### PR TITLE
campaigns: Display a legend under burndown charts

### DIFF
--- a/web/src/enterprise/campaigns/detail/BurndownChart.tsx
+++ b/web/src/enterprise/campaigns/detail/BurndownChart.tsx
@@ -4,6 +4,7 @@ import {
     Area,
     ComposedChart,
     LabelFormatter,
+    Legend,
     ResponsiveContainer,
     Tooltip,
     XAxis,
@@ -38,15 +39,21 @@ const commonAreaProps = {
     type: 'stepBefore',
 } as const
 
-const tooltipItemOrder: Record<string, number> = {
-    'Open & awaiting review': 4,
-    'Open & changes requested': 3,
-    'Open & approved': 2,
-    Closed: 1,
-    Merged: 0,
+interface StateDefinition {
+    fill: string
+    label: string
+    sortOrder: number
 }
 
-const tooltipItemSorter = (item: TooltipPayload): number => tooltipItemOrder[item.name]
+const states: Record<string, StateDefinition> = {
+    openPending: { fill: 'var(--warning)', label: 'Open & awaiting review', sortOrder: 4 },
+    openChangesRequested: { fill: 'var(--danger)', label: 'Open & changes requested', sortOrder: 3 },
+    openApproved: { fill: 'var(--success)', label: 'Open & approved', sortOrder: 2 },
+    closed: { fill: 'var(--secondary)', label: 'Closed', sortOrder: 1 },
+    merged: { fill: 'var(--merged)', label: 'Merged', sortOrder: 0 },
+}
+
+const tooltipItemSorter = ({ dataKey }: TooltipPayload): number => states[dataKey as string].sortOrder
 
 /**
  * A burndown chart showing progress of the campaigns changesets.
@@ -72,6 +79,7 @@ export const CampaignBurndownChart: React.FunctionComponent<Props> = ({ changese
             <ComposedChart
                 data={changesetCountsOverTime.map(snapshot => ({ ...snapshot, date: Date.parse(snapshot.date) }))}
             >
+                <Legend verticalAlign="bottom" iconType="square" />
                 <XAxis
                     dataKey="date"
                     domain={[
@@ -101,16 +109,20 @@ export const CampaignBurndownChart: React.FunctionComponent<Props> = ({ changese
                     itemSorter={tooltipItemSorter}
                 />
 
-                <Area dataKey="openPending" name="Open & awaiting review" fill="var(--warning)" {...commonAreaProps} />
-                <Area
-                    dataKey="openChangesRequested"
-                    name="Open & changes requested"
-                    fill="var(--danger)"
-                    {...commonAreaProps}
-                />
-                <Area dataKey="openApproved" name="Open & approved" fill="var(--success)" {...commonAreaProps} />
-                <Area dataKey="closed" name="Closed" fill="var(--secondary)" {...commonAreaProps} />
-                <Area dataKey="merged" name="Merged" fill="var(--merged)" {...commonAreaProps} />
+                {Object.entries(states)
+                    .sort(([, aDef], [, bDef]) => bDef.sortOrder - aDef.sortOrder)
+                    .map(([dataKey, area]) => (
+                        <Area
+                            key={area.sortOrder}
+                            dataKey={dataKey}
+                            name={area.label}
+                            fill={area.fill}
+                            // The stroke is used to colour the legend, which we
+                            // want to match the fill colour for each area.
+                            stroke={area.fill}
+                            {...commonAreaProps}
+                        />
+                    ))}
             </ComposedChart>
         </ResponsiveContainer>
     )

--- a/web/src/enterprise/campaigns/detail/BurndownChart.tsx
+++ b/web/src/enterprise/campaigns/detail/BurndownChart.tsx
@@ -110,16 +110,16 @@ export const CampaignBurndownChart: React.FunctionComponent<Props> = ({ changese
                 />
 
                 {Object.entries(states)
-                    .sort(([, aDef], [, bDef]) => bDef.sortOrder - aDef.sortOrder)
-                    .map(([dataKey, area]) => (
+                    .sort(([, a], [, b]) => b.sortOrder - a.sortOrder)
+                    .map(([dataKey, state]) => (
                         <Area
-                            key={area.sortOrder}
+                            key={state.sortOrder}
                             dataKey={dataKey}
-                            name={area.label}
-                            fill={area.fill}
+                            name={state.label}
+                            fill={state.fill}
                             // The stroke is used to colour the legend, which we
                             // want to match the fill colour for each area.
-                            stroke={area.fill}
+                            stroke={state.fill}
                             {...commonAreaProps}
                         />
                     ))}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/BurndownChart.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/BurndownChart.test.tsx.snap
@@ -334,7 +334,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
             fill="none"
             fillOpacity={0.6}
             height={260}
-            stroke="#3182bd"
+            stroke="var(--warning)"
             strokeWidth={0}
             width={430}
           />
@@ -363,7 +363,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
             fill="none"
             fillOpacity={0.6}
             height={260}
-            stroke="#3182bd"
+            stroke="var(--danger)"
             strokeWidth={0}
             width={430}
           />
@@ -392,7 +392,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
             fill="none"
             fillOpacity={0.6}
             height={260}
-            stroke="#3182bd"
+            stroke="var(--success)"
             strokeWidth={0}
             width={430}
           />
@@ -421,7 +421,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
             fill="none"
             fillOpacity={0.6}
             height={260}
-            stroke="#3182bd"
+            stroke="var(--secondary)"
             strokeWidth={0}
             width={430}
           />
@@ -450,13 +450,217 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
             fill="none"
             fillOpacity={0.6}
             height={260}
-            stroke="#3182bd"
+            stroke="var(--merged)"
             strokeWidth={0}
             width={430}
           />
         </g>
       </g>
     </svg>
+    <div
+      className="recharts-legend-wrapper"
+      style={
+        Object {
+          "bottom": 5,
+          "height": "auto",
+          "left": 5,
+          "position": "absolute",
+          "width": 490,
+        }
+      }
+    >
+      <ul
+        className="recharts-default-legend"
+        style={
+          Object {
+            "margin": 0,
+            "padding": 0,
+            "textAlign": "center",
+          }
+        }
+      >
+        <li
+          className="recharts-legend-item legend-item-0"
+          style={
+            Object {
+              "display": "inline-block",
+              "marginRight": 10,
+            }
+          }
+        >
+          <svg
+            className="recharts-surface"
+            height={14}
+            style={
+              Object {
+                "display": "inline-block",
+                "marginRight": 4,
+                "verticalAlign": "middle",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 32 32"
+            width={14}
+          >
+            <path
+              className="recharts-symbols"
+              d="M-16,-16h32v32h-32Z"
+              fill="var(--warning)"
+              transform="translate(16, 16)"
+            />
+          </svg>
+          <span
+            className="recharts-legend-item-text"
+          >
+            Open & awaiting review
+          </span>
+        </li>
+        <li
+          className="recharts-legend-item legend-item-1"
+          style={
+            Object {
+              "display": "inline-block",
+              "marginRight": 10,
+            }
+          }
+        >
+          <svg
+            className="recharts-surface"
+            height={14}
+            style={
+              Object {
+                "display": "inline-block",
+                "marginRight": 4,
+                "verticalAlign": "middle",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 32 32"
+            width={14}
+          >
+            <path
+              className="recharts-symbols"
+              d="M-16,-16h32v32h-32Z"
+              fill="var(--danger)"
+              transform="translate(16, 16)"
+            />
+          </svg>
+          <span
+            className="recharts-legend-item-text"
+          >
+            Open & changes requested
+          </span>
+        </li>
+        <li
+          className="recharts-legend-item legend-item-2"
+          style={
+            Object {
+              "display": "inline-block",
+              "marginRight": 10,
+            }
+          }
+        >
+          <svg
+            className="recharts-surface"
+            height={14}
+            style={
+              Object {
+                "display": "inline-block",
+                "marginRight": 4,
+                "verticalAlign": "middle",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 32 32"
+            width={14}
+          >
+            <path
+              className="recharts-symbols"
+              d="M-16,-16h32v32h-32Z"
+              fill="var(--success)"
+              transform="translate(16, 16)"
+            />
+          </svg>
+          <span
+            className="recharts-legend-item-text"
+          >
+            Open & approved
+          </span>
+        </li>
+        <li
+          className="recharts-legend-item legend-item-3"
+          style={
+            Object {
+              "display": "inline-block",
+              "marginRight": 10,
+            }
+          }
+        >
+          <svg
+            className="recharts-surface"
+            height={14}
+            style={
+              Object {
+                "display": "inline-block",
+                "marginRight": 4,
+                "verticalAlign": "middle",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 32 32"
+            width={14}
+          >
+            <path
+              className="recharts-symbols"
+              d="M-16,-16h32v32h-32Z"
+              fill="var(--secondary)"
+              transform="translate(16, 16)"
+            />
+          </svg>
+          <span
+            className="recharts-legend-item-text"
+          >
+            Closed
+          </span>
+        </li>
+        <li
+          className="recharts-legend-item legend-item-4"
+          style={
+            Object {
+              "display": "inline-block",
+              "marginRight": 10,
+            }
+          }
+        >
+          <svg
+            className="recharts-surface"
+            height={14}
+            style={
+              Object {
+                "display": "inline-block",
+                "marginRight": 4,
+                "verticalAlign": "middle",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 32 32"
+            width={14}
+          >
+            <path
+              className="recharts-symbols"
+              d="M-16,-16h32v32h-32Z"
+              fill="var(--merged)"
+              transform="translate(16, 16)"
+            />
+          </svg>
+          <span
+            className="recharts-legend-item-text"
+          >
+            Merged
+          </span>
+        </li>
+      </ul>
+    </div>
     <div
       className="recharts-tooltip-wrapper"
       style={


### PR DESCRIPTION
I found the burndown charts a little hard to read without hovering. This PR adds a legend to make the colour mapping more obvious. It looks like this:

![image](https://user-images.githubusercontent.com/229984/83058623-84b9a780-a00d-11ea-94cb-3583eab8336d.png)

On a technical level, Recharts legends use the area's stroke colour, so we also need to duplicate the fill colour into the stroke. The only effect this has on the rendered chart is that the dots that appear when you mouseover are now in the area colour, which is arguably better anyway.