### PR TITLE
campaigns: Add locales to BurndownChart props

### DIFF
--- a/web/src/enterprise/campaigns/detail/BurndownChart.test.tsx
+++ b/web/src/enterprise/campaigns/detail/BurndownChart.test.tsx
@@ -47,6 +47,7 @@ describe('CampaignBurndownChart', () => {
                             },
                         ]}
                         history={history}
+                        locales="en-US"
                     />,
                     { createNodeMock }
                 )

--- a/web/src/enterprise/campaigns/detail/BurndownChart.tsx
+++ b/web/src/enterprise/campaigns/detail/BurndownChart.tsx
@@ -1,5 +1,5 @@
 import H from 'history'
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import {
     Area,
     ComposedChart,
@@ -14,16 +14,8 @@ import { ICampaign } from '../../../../../shared/src/graphql/schema'
 
 interface Props extends Pick<ICampaign, 'changesetCountsOverTime'> {
     history: H.History
+    locales?: string | string[]
 }
-
-const dateTickFormat = new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric' })
-const dateTickFormatter = (timestamp: number): string => dateTickFormat.format(timestamp)
-
-// const tooltipLabelFormat = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' })
-const tooltipLabelFormat = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
-const tooltipLabelFormatter = (date: number): string => tooltipLabelFormat.format(date)
-
-const toLocaleString = (value: number): string => value.toLocaleString()
 
 const tooltipStyle: React.CSSProperties = {
     color: 'var(--body-color)',
@@ -51,7 +43,21 @@ const tooltipItemSorter = (item: TooltipPayload): number => tooltipItemOrder[ite
 /**
  * A burndown chart showing progress of the campaigns changesets.
  */
-export const CampaignBurndownChart: React.FunctionComponent<Props> = ({ changesetCountsOverTime }) => {
+export const CampaignBurndownChart: React.FunctionComponent<Props> = ({ changesetCountsOverTime, locales }) => {
+    const dateTickFormat = useMemo(() => new Intl.DateTimeFormat(locales, { month: 'long', day: 'numeric' }), [locales])
+    const dateTickFormatter = useCallback((timestamp: number): string => dateTickFormat.format(timestamp), [
+        dateTickFormat,
+    ])
+    // const tooltipLabelFormat = useMemo(() => new Intl.DateTimeFormat(locales, { dateStyle: 'medium' }), [locales])
+    const tooltipLabelFormat = useMemo(
+        () => new Intl.DateTimeFormat(locales, { month: 'short', day: 'numeric', year: 'numeric' }),
+        [locales]
+    )
+    const tooltipLabelFormatter = useCallback((date: number): string => tooltipLabelFormat.format(date), [
+        tooltipLabelFormat,
+    ])
+    const toLocaleString = useCallback((value: number): string => value.toLocaleString(locales), [locales])
+
     if (changesetCountsOverTime.length <= 1) {
         return (
             <p>


### PR DESCRIPTION
This was something I noticed while updating the snapshots in #11035.

We use `Intl.DateTimeFormat` to localise dates when displaying them in the burndown chart X axis, but date order is inconsistent in different locales: for example, "November 13" in en-US becomes "13 November" in en-AU. To make the snapshot tests more robust, we should be able to control which locale is used, while falling back to the system locale by default.

I'm not really convinced that this is the actual best approach, and would appreciate feedback as a relative dilettante in the world of TypeScript and React: localisation feels like a cross cutting concern that might need a more global approach, and I don't really like the React hooks to make the callbacks work, but this was the minimal set of changes I needed to get things to work reliably in my home locale of `en_AU.UTF-8`.