### PR TITLE
campaigns: Attempt to republish failed changesets

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -616,9 +616,9 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 		return nil, ErrIDIsZero
 	}
 
-	// 🚨 SECURITY: CreateChangesetJobForPatch checks whether current user is authorized.
+	// 🚨 SECURITY: QueueChangesetJobForPatch checks whether current user is authorized.
 	svc := ee.NewService(r.store, r.httpFactory)
-	if err = svc.CreateChangesetJobForPatch(ctx, patchID); err != nil {
+	if err = svc.QueueChangesetJobForPatch(ctx, patchID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -616,9 +616,9 @@ func (r *Resolver) PublishChangeset(ctx context.Context, args *graphqlbackend.Pu
 		return nil, ErrIDIsZero
 	}
 
-	// 🚨 SECURITY: QueueChangesetJobForPatch checks whether current user is authorized.
+	// 🚨 SECURITY: EnqueueChangesetJobForPatch checks whether current user is authorized.
 	svc := ee.NewService(r.store, r.httpFactory)
-	if err = svc.QueueChangesetJobForPatch(ctx, patchID); err != nil {
+	if err = svc.EnqueueChangesetJobForPatch(ctx, patchID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -550,12 +550,12 @@ func (s *Service) RetryPublishCampaign(ctx context.Context, id int64) (campaign 
 	return campaign, nil
 }
 
-// QueueChangesetJobForPatch queues a ChangesetJob for the Patch with the given
-// ID, creating it if necessary. The Patch has to belong to a PatchSet that was
-// attached to a Campaign.
-func (s *Service) QueueChangesetJobForPatch(ctx context.Context, patchID int64) (err error) {
+// EnqueueChangesetJobForPatch queues a ChangesetJob for the Patch with the
+// given ID, creating it if necessary. The Patch has to belong to a PatchSet
+// that was attached to a Campaign.
+func (s *Service) EnqueueChangesetJobForPatch(ctx context.Context, patchID int64) (err error) {
 	traceTitle := fmt.Sprintf("patch: %d", patchID)
-	tr, ctx := trace.New(ctx, "service.QueueChangesetJobForPatch", traceTitle)
+	tr, ctx := trace.New(ctx, "service.EnqueueChangesetJobForPatch", traceTitle)
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -550,12 +550,12 @@ func (s *Service) RetryPublishCampaign(ctx context.Context, id int64) (campaign 
 	return campaign, nil
 }
 
-// CreateChangesetJobForPatch creates a ChangesetJob for the
-// Patch with the given ID. The Patch has to belong to a
-// PatchSet that was attached to a Campaign.
-func (s *Service) CreateChangesetJobForPatch(ctx context.Context, patchID int64) (err error) {
+// QueueChangesetJobForPatch queues a ChangesetJob for the Patch with the given
+// ID, creating it if necessary. The Patch has to belong to a PatchSet that was
+// attached to a Campaign.
+func (s *Service) QueueChangesetJobForPatch(ctx context.Context, patchID int64) (err error) {
 	traceTitle := fmt.Sprintf("patch: %d", patchID)
-	tr, ctx := trace.New(ctx, "service.CreateChangesetJobForPatch", traceTitle)
+	tr, ctx := trace.New(ctx, "service.QueueChangesetJobForPatch", traceTitle)
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -174,9 +174,9 @@ func TestServicePermissionLevels(t *testing.T) {
 				tc.assertFunc(t, err)
 			})
 
-			t.Run("QueueChangesetJobForPatch", func(t *testing.T) {
+			t.Run("EnqueueChangesetJobForPatch", func(t *testing.T) {
 				for _, p := range patches {
-					err = svc.QueueChangesetJobForPatch(currentUserCtx, p.ID)
+					err = svc.EnqueueChangesetJobForPatch(currentUserCtx, p.ID)
 					tc.assertFunc(t, err)
 				}
 			})
@@ -513,7 +513,7 @@ func TestService(t *testing.T) {
 		}
 	})
 
-	t.Run("QueueChangesetJobForPatch", func(t *testing.T) {
+	t.Run("EnqueueChangesetJobForPatch", func(t *testing.T) {
 		patchSet := &campaigns.PatchSet{UserID: user.ID}
 		err = store.CreatePatchSet(ctx, patchSet)
 		if err != nil {
@@ -533,7 +533,7 @@ func TestService(t *testing.T) {
 		}
 
 		svc := NewServiceWithClock(store, cf, clock)
-		err = svc.QueueChangesetJobForPatch(ctx, patch.ID)
+		err = svc.EnqueueChangesetJobForPatch(ctx, patch.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -547,7 +547,7 @@ func TestService(t *testing.T) {
 		}
 
 		// Try to create again, check that it's the same one
-		err = svc.QueueChangesetJobForPatch(ctx, patch.ID)
+		err = svc.EnqueueChangesetJobForPatch(ctx, patch.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -564,7 +564,7 @@ func TestService(t *testing.T) {
 		}
 
 		// Error out the changeset job and verify that
-		// QueueChangesetJobForPatch updates the job to force a retry.
+		// EnqueueChangesetJobForPatch updates the job to force a retry.
 		haveJob.Error = "ruh roh"
 		haveJob.StartedAt = time.Now()
 		haveJob.FinishedAt = time.Now()
@@ -576,7 +576,7 @@ func TestService(t *testing.T) {
 		if !haveJob.UnsuccessfullyCompleted() {
 			t.Error("tried to error out the changesetJob and failed")
 		}
-		if err := svc.QueueChangesetJobForPatch(ctx, patch.ID); err != nil {
+		if err := svc.EnqueueChangesetJobForPatch(ctx, patch.ID); err != nil {
 			t.Fatal(err)
 		}
 		haveJob3, err := store.GetChangesetJob(ctx, GetChangesetJobOpts{
@@ -1121,7 +1121,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 						if j.RepoID == repo.ID {
 							toPublish[j.ID] = j
 
-							err = svc.QueueChangesetJobForPatch(ctx, j.ID)
+							err = svc.EnqueueChangesetJobForPatch(ctx, j.ID)
 							if err != nil {
 								t.Fatalf("Failed to individually created ChangesetJob: %s", err)
 							}

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -174,9 +174,9 @@ func TestServicePermissionLevels(t *testing.T) {
 				tc.assertFunc(t, err)
 			})
 
-			t.Run("CreateChangesetJobForPatch", func(t *testing.T) {
+			t.Run("QueueChangesetJobForPatch", func(t *testing.T) {
 				for _, p := range patches {
-					err = svc.CreateChangesetJobForPatch(currentUserCtx, p.ID)
+					err = svc.QueueChangesetJobForPatch(currentUserCtx, p.ID)
 					tc.assertFunc(t, err)
 				}
 			})
@@ -513,7 +513,7 @@ func TestService(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateChangesetJobForPatch", func(t *testing.T) {
+	t.Run("QueueChangesetJobForPatch", func(t *testing.T) {
 		patchSet := &campaigns.PatchSet{UserID: user.ID}
 		err = store.CreatePatchSet(ctx, patchSet)
 		if err != nil {
@@ -533,7 +533,7 @@ func TestService(t *testing.T) {
 		}
 
 		svc := NewServiceWithClock(store, cf, clock)
-		err = svc.CreateChangesetJobForPatch(ctx, patch.ID)
+		err = svc.QueueChangesetJobForPatch(ctx, patch.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -547,7 +547,7 @@ func TestService(t *testing.T) {
 		}
 
 		// Try to create again, check that it's the same one
-		err = svc.CreateChangesetJobForPatch(ctx, patch.ID)
+		err = svc.QueueChangesetJobForPatch(ctx, patch.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -564,7 +564,7 @@ func TestService(t *testing.T) {
 		}
 
 		// Error out the changeset job and verify that
-		// CreateChangesetJobForPatch updates the job to force a retry.
+		// QueueChangesetJobForPatch updates the job to force a retry.
 		haveJob.Error = "ruh roh"
 		haveJob.StartedAt = time.Now()
 		haveJob.FinishedAt = time.Now()
@@ -576,7 +576,7 @@ func TestService(t *testing.T) {
 		if !haveJob.UnsuccessfullyCompleted() {
 			t.Error("tried to error out the changesetJob and failed")
 		}
-		if err := svc.CreateChangesetJobForPatch(ctx, patch.ID); err != nil {
+		if err := svc.QueueChangesetJobForPatch(ctx, patch.ID); err != nil {
 			t.Fatal(err)
 		}
 		haveJob3, err := store.GetChangesetJob(ctx, GetChangesetJobOpts{
@@ -1121,7 +1121,7 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 						if j.RepoID == repo.ID {
 							toPublish[j.ID] = j
 
-							err = svc.CreateChangesetJobForPatch(ctx, j.ID)
+							err = svc.QueueChangesetJobForPatch(ctx, j.ID)
 							if err != nil {
 								t.Fatalf("Failed to individually created ChangesetJob: %s", err)
 							}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -316,9 +316,20 @@ func (c *ChangesetJob) Clone() *ChangesetJob {
 	return &cc
 }
 
+// Completed returns true for jobs that have completed, regardless of whether
+// that was successful or not.
+func (c *ChangesetJob) Completed() bool {
+	return !c.FinishedAt.IsZero()
+}
+
 // SuccessfullyCompleted returns true for jobs that have already successfully run
 func (c *ChangesetJob) SuccessfullyCompleted() bool {
-	return c.Error == "" && !c.FinishedAt.IsZero() && c.ChangesetID != 0
+	return c.Error == "" && c.ChangesetID != 0 && c.Completed()
+}
+
+// UnsuccessfullyCompleted returns true for jobs that have run, but failed.
+func (c *ChangesetJob) UnsuccessfullyCompleted() bool {
+	return c.Error != "" && c.ChangesetID == 0 && c.Completed()
 }
 
 // Reset sets the Error, StartedAt and FinishedAt fields to their respective


### PR DESCRIPTION
A couple of random thoughts that occurred while I was working on this that I'd appreciate feedback on:

1. `CreateChangesetJobForPatch` arguably doesn't capture what the function now does, but I'm not sure what verb is more appropriate. `QueueChangesetJobForPatch`, maybe? _I've updated it to `Queue...`, but would still welcome feedback on this._
2. More broadly, I'm not sure that having [a unique constraint on `changeset_jobs` over `campaign_id, patch_id`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@24ce1ba7e95836a05aa85ff49f1dd4d52fb55282/-/blob/cmd/frontend/db/schema.md#L100:55) makes total sense — is there any value to retaining failed jobs and their associated errors, or is this transient enough that we're OK with the "reset the fields and try again" approach in this PR?

Fixes #10795.