### PR TITLE
Don't produce unparseable diff

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -232,7 +232,10 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 			rdr, err = git.ExecReader(ctx, *cachedRepo, []string{
 				"diff",
 				"--find-renames",
-				"--find-copies",
+				// Todo: Enable once we have support for copy detection in go-diff
+				// and actually expose a `isCopy` field in the api, otherwise this
+				// information is thrown away anyways.
+				// "--find-copies",
 				"--full-index",
 				"--inter-hunk-context=3",
 				"--no-prefix",

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -232,7 +232,7 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 			rdr, err = git.ExecReader(ctx, *cachedRepo, []string{
 				"diff",
 				"--find-renames",
-				// Todo: Enable once we have support for copy detection in go-diff
+				// TODO(eseliger): Enable once we have support for copy detection in go-diff
 				// and actually expose a `isCopy` field in the api, otherwise this
 				// information is thrown away anyways.
 				// "--find-copies",

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -45,7 +45,7 @@ func TestRepositoryComparison(t *testing.T) {
 		if len(args) < 1 && args[0] != "diff" {
 			t.Fatalf("gitserver.ExecReader received wrong args: %v", args)
 		}
-		return ioutil.NopCloser(strings.NewReader(testDiff)), nil
+		return ioutil.NopCloser(strings.NewReader(testDiff + testCopyDiff)), nil
 	}
 	defer func() { git.Mocks.ExecReader = nil }()
 
@@ -469,6 +469,14 @@ index 9bd8209..d2acfa9 100644
  Line 9
  Line 10
 +Another line
+`
+
+// This is unparseable by go-diff. Once it isn't anymore, the test should fail, reminding
+// us of the TODO comment in repository_comparison to reenable it.
+const testCopyDiff = `diff --git a/test.txt b/test2.txt
+similarity index 100%
+copy from test.txt
+copy to test2.txt
 `
 const testDiffFirstHunk = ` Line 1
  Line 2


### PR DESCRIPTION
The go-diff library currently has no support
for copy detection. In addition, we don't use
that information anywhere, so we can save
the computational effort here until we do.

Closes https://github.com/sourcegraph/sourcegraph/issues/2169
