### PR TITLE
search: use heuristic signal choose pattern interpretation

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -971,7 +971,7 @@ func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver,
 	var queryInfo query.QueryInfo
 	var err error
 	if conf.AndOrQueryEnabled() {
-		andOrQuery, err := query.ParseAndOr(plainQuery)
+		andOrQuery, _, err := query.ParseAndOr(plainQuery)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -871,12 +871,12 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopePar
 			return r.evaluateOperator(ctx, scopeParameters, term)
 		} else if term.Kind == query.Concat {
 			q := append(scopeParameters, term)
-			r.query = query.AndOrQuery{Query: q}
+			r.query.(*query.AndOrQuery).Query = q
 			return r.evaluateLeaf(ctx)
 		}
 	case query.Pattern:
 		q := append(scopeParameters, term)
-		r.query = query.AndOrQuery{Query: q}
+		r.query.(*query.AndOrQuery).Query = q
 		return r.evaluateLeaf(ctx)
 	case query.Parameter:
 		// evaluatePatternExpression does not process Parameter nodes.
@@ -893,7 +893,7 @@ func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchR
 		return &SearchResultsResolver{alert: alertForQuery("", err)}, nil
 	}
 	if pattern == nil {
-		r.query = query.AndOrQuery{Query: scopeParameters}
+		r.query.(*query.AndOrQuery).Query = scopeParameters
 		return r.evaluateLeaf(ctx)
 	}
 	result, err := r.evaluatePatternExpression(ctx, scopeParameters, pattern)

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -913,9 +913,9 @@ func tryFallbackParser(in string) ([]Node, error) {
 }
 
 // ParseAndOr a raw input string into a parse tree comprising Nodes.
-func ParseAndOr(in string) ([]Node, error) {
+func ParseAndOr(in string) ([]Node, map[heuristic]bool, error) {
 	if strings.TrimSpace(in) == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	parser := &parser{
 		buf:               []byte(in),
@@ -926,15 +926,15 @@ func ParseAndOr(in string) ([]Node, error) {
 	nodes, err := parser.parseOr()
 	if err != nil {
 		if nodes, err := tryFallbackParser(in); err == nil {
-			return nodes, nil
+			return nodes, parser.heuristicsApplied, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	if parser.balanced != 0 {
 		if nodes, err := tryFallbackParser(in); err == nil {
-			return nodes, nil
+			return nodes, parser.heuristicsApplied, nil
 		}
-		return nil, errors.New("unbalanced expression")
+		return nil, nil, errors.New("unbalanced expression")
 	}
 	if !parser.heuristic[unambiguated] {
 		// Hoist or expressions if this query is potential ambiguous.
@@ -942,7 +942,7 @@ func ParseAndOr(in string) ([]Node, error) {
 			nodes = hoistedNodes
 		}
 	}
-	return newOperator(nodes, And), nil
+	return newOperator(nodes, And), nil, nil
 }
 
 func ParseLiteralSearch(in string) ([]Node, error) {
@@ -971,7 +971,7 @@ func ParseLiteralSearch(in string) ([]Node, error) {
 
 // ProcessAndOr query parses and validates an and/or query for a given search type.
 func ProcessAndOr(in string) (QueryInfo, error) {
-	query, err := ParseAndOr(in)
+	query, heuristicsApplied, err := ParseAndOr(in)
 	if err != nil {
 		return nil, err
 	}
@@ -981,5 +981,5 @@ func ProcessAndOr(in string) (QueryInfo, error) {
 		return nil, err
 	}
 
-	return &AndOrQuery{Query: query}, nil
+	return &AndOrQuery{Query: query, HeuristicsApplied: heuristicsApplied}, nil
 }

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -896,7 +896,7 @@ func (p *parser) parseOr() ([]Node, error) {
 	return newOperator(append(left, right...), Or), nil
 }
 
-func tryFallbackParser(in string) ([]Node, error) {
+func tryFallbackParser(in string) ([]Node, map[heuristic]bool, error) {
 	parser := &parser{
 		buf:               []byte(in),
 		heuristic:         map[heuristic]bool{allowDanglingParens: true},
@@ -904,18 +904,18 @@ func tryFallbackParser(in string) ([]Node, error) {
 	}
 	nodes, err := parser.parseOr()
 	if err != nil {
-		return nil, err
+		return nil, parser.heuristicsApplied, err
 	}
 	if hoistedNodes, err := Hoist(nodes); err == nil {
-		return newOperator(hoistedNodes, And), nil
+		return newOperator(hoistedNodes, And), parser.heuristicsApplied, nil
 	}
-	return newOperator(nodes, And), nil
+	return newOperator(nodes, And), parser.heuristicsApplied, nil
 }
 
 // ParseAndOr a raw input string into a parse tree comprising Nodes.
 func ParseAndOr(in string) ([]Node, map[heuristic]bool, error) {
 	if strings.TrimSpace(in) == "" {
-		return nil, nil, nil
+		return nil, map[heuristic]bool{}, nil
 	}
 	parser := &parser{
 		buf:               []byte(in),
@@ -925,14 +925,14 @@ func ParseAndOr(in string) ([]Node, map[heuristic]bool, error) {
 
 	nodes, err := parser.parseOr()
 	if err != nil {
-		if nodes, err := tryFallbackParser(in); err == nil {
-			return nodes, parser.heuristicsApplied, nil
+		if nodes, heuristicsApplied, err := tryFallbackParser(in); err == nil {
+			return nodes, heuristicsApplied, nil
 		}
 		return nil, nil, err
 	}
 	if parser.balanced != 0 {
-		if nodes, err := tryFallbackParser(in); err == nil {
-			return nodes, parser.heuristicsApplied, nil
+		if nodes, heuristicsApplied, err := tryFallbackParser(in); err == nil {
+			return nodes, heuristicsApplied, nil
 		}
 		return nil, nil, errors.New("unbalanced expression")
 	}
@@ -942,7 +942,7 @@ func ParseAndOr(in string) ([]Node, map[heuristic]bool, error) {
 			nodes = hoistedNodes
 		}
 	}
-	return newOperator(nodes, And), nil, nil
+	return newOperator(nodes, And), parser.heuristicsApplied, nil
 }
 
 func ParseLiteralSearch(in string) ([]Node, error) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -662,7 +662,7 @@ func TestParse(t *testing.T) {
 			var err error
 			result, err = parseAndOrGrammar(tt.Input) // Parse without heuristic.
 			check(result, err, string(tt.WantGrammar))
-			result, err = ParseAndOr(tt.Input)
+			result, _, err = ParseAndOr(tt.Input)
 			if tt.WantHeuristic == Same {
 				check(result, err, string(tt.WantGrammar))
 			} else {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -18,7 +18,7 @@ func prettyPrint(nodes []Node) string {
 func TestSubstituteAliases(t *testing.T) {
 	input := "r:repo g:repogroup f:file"
 	want := `(and "repo:repo" "repogroup:repogroup" "file:file")`
-	query, _ := ParseAndOr(input)
+	query, _, _ := ParseAndOr(input)
 	got := prettyPrint(SubstituteAliases(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -28,7 +28,7 @@ func TestSubstituteAliases(t *testing.T) {
 func TestLowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`
-	query, _ := ParseAndOr(input)
+	query, _, _ := ParseAndOr(input)
 	got := prettyPrint(LowercaseFieldNames(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -175,7 +175,7 @@ func TestSearchUppercase(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("searchUppercase", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _, _ := ParseAndOr(c.input)
 			got := prettyPrint(SearchUppercase(SubstituteAliases(query)))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -203,7 +203,7 @@ func TestMap(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _, _ := ParseAndOr(c.input)
 			got := prettyPrint(Map(query, c.fns...))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -218,7 +218,7 @@ func TestPartitionSearchPattern(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run("partition search pattern", func(t *testing.T) {
-			q, _ := ParseAndOr(tt.input)
+			q, _, _ := ParseAndOr(tt.input)
 			scopeParameters, pattern, err := PartitionSearchPattern(q)
 			if err != nil {
 				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {


### PR DESCRIPTION
Stacked on #11059.

Long description because these are changes around complex behaviors that need a trail :-) Feel free to skip to the one inline comment to see why this PR exists.

---

This PR uses the heuristic signals to fix a regression introduced in https://github.com/sourcegraph/sourcegraph/pull/9846. What happened is that we originally applied a heuristic to treat a pattern like `foo() or bar()` literally even in regexp mode, similar to how we do this heuristic today for `foo()` (note that normally, `()` would imply empty string in regexp syntax). #9846 added the logic to interpret quoted strings as literal patterns and regexp otherwise for and/or queries, similar to the behavior we have today. Except, this introduced behavior where we would interpret syntactically valid regexp strings like `foo()` as regexp still (i.e., the fact that we applied the heuristic was thrown away at the point we converted this value). 

This PR uses that knowledge to mimic exactly what we do today. I was particular about how to do this by tracking heuristic signals. The alternative hack could have been to set `Quoted: true` when this heuristic fires, but:
- `Quoted: true` is intended to mean (only) "quoted is true iff the search pattern was quoted", which drives logic to treat it literally in certain context
- Thus, I don't want to entangle (abuse) the above to say "this heuristic implies this pattern should be treated literally, so let's quote it to get that behavior".