### PR TITLE
Override $LANG when running Jest tests

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -2,6 +2,17 @@
 
 const path = require('path')
 
+// Use the same locale for test runs so that snapshots generated using code that
+// uses Intl or toLocaleString() are consistent.
+//
+// We have to do this at this point instead of in the normal Jest setup hooks
+// because ICU (and therefore Intl) only reads the environment once:
+// specifically, at the point any Intl object is instantiated. Jest indirectly
+// uses a locale-sensitive sort while setting up test suites _before_ invoking
+// the setup hooks, so we have no opportunity to change $LANG outside of this
+// ugly side effect. (This is especially evident when running tests in-band.)
+process.env.LANG = 'en_US.UTF-8'
+
 /** @type {jest.InitialOptions} */
 const config = {
   // uses latest jsdom and exposes jsdom as a global,


### PR DESCRIPTION
This is an alternative approach to fixing the issue in #11037, [as suggested by @felixfbecker](https://github.com/sourcegraph/sourcegraph/pull/11037#issuecomment-635483200): instead of modifying the `<CampaignBurndownChart />` component to allow overridding the locale, we instead override `$LANG` unconditionally when running tests in Jest to ensure that we don't have snapshot test breakage due to different locales.

This ended up being uglier than I would have liked (specifically, it's a side effect in the Jest config module): we have code in `shared/dev/jestGlobalState.js` to override `$TZ` for similar reasons, but `$LANG` is read _very_ early, and only once per process, [after which it's memoised](https://sourcegraph.com/github.com/unicode-org/icu@ec7e29f2b697188e5a667db2b235a3d0db8a5d20/-/blob/icu4c/source/common/locid.cpp#L925-936). Having the `process.env.LANG` set in `jestGlobalState.js` worked when the tests were being run in the default child process pool mode, but did not work when the tests were being run in-band, and I decided I preferred the ugly side effect to modal non-determinism.