### PR TITLE
codeintel: Infer go module version via git tags during auto indexing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -230,6 +230,7 @@ Dockerfile @sourcegraph/distribution
 # Precise code intel
 /cmd/precise-code-intel-bundle-manager/ @sourcegraph/code-intel
 /cmd/precise-code-intel-worker/ @sourcegraph/code-intel
+/cmd/precise-code-intel-indexer/ @sourcegraph/code-intel
 /internal/cmd/precise-code-intel-test @sourcegraph/code-intel
 /internal/codeintel @sourcegraph/code-intel
 /enterprise/internal/codeintel @sourcegraph/code-intel

--- a/cmd/precise-code-intel-indexer/internal/indexer/processor.go
+++ b/cmd/precise-code-intel-indexer/internal/indexer/processor.go
@@ -41,9 +41,17 @@ func (p *processor) Process(ctx context.Context, index db.Index) error {
 }
 
 func (p *processor) index(ctx context.Context, repoDir string, index db.Index) error {
+	tag, exact, err := p.gitserverClient.Tags(ctx, p.db, index.RepositoryID, index.Commit)
+	if err != nil {
+		return err
+	}
+	if !exact {
+		tag = fmt.Sprintf("%s-%s", tag, index.Commit[:12])
+	}
+
 	args := []string{
 		"--repositoryRoot=.",
-		"--moduleVersion=NONE", // TODO - find git tags on this commit to support module version
+		fmt.Sprintf("--moduleVersion=%s", tag),
 	}
 
 	return command(repoDir, "lsif-go", args...)

--- a/internal/codeintel/gitserver/client.go
+++ b/internal/codeintel/gitserver/client.go
@@ -27,6 +27,11 @@ type Client interface {
 
 	// FileExists determines whether a file exists in a particular commit of a repository.
 	FileExists(ctx context.Context, db db.DB, repositoryID int, commit, file string) (bool, error)
+
+	// Tags returns the git tags associated with the given commit along with a boolean indicating whether
+	// or not the tag was attached directly to the commit. If no tags exist at or before this commit, the
+	// tag is an empty string.
+	Tags(ctx context.Context, db db.DB, repositoryID int, commit string) (string, bool, error)
 }
 
 type defaultClient struct{}
@@ -51,4 +56,8 @@ func (c *defaultClient) Archive(ctx context.Context, db db.DB, repositoryID int,
 
 func (c *defaultClient) FileExists(ctx context.Context, db db.DB, repositoryID int, commit, file string) (bool, error) {
 	return FileExists(ctx, db, repositoryID, commit, file)
+}
+
+func (c *defaultClient) Tags(ctx context.Context, db db.DB, repositoryID int, commit string) (string, bool, error) {
+	return Tags(ctx, db, repositoryID, commit)
 }

--- a/internal/codeintel/gitserver/tags.go
+++ b/internal/codeintel/gitserver/tags.go
@@ -1,0 +1,38 @@
+package gitserver
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+)
+
+// Tags returns the git tags associated with the given commit along with a boolean indicating whether
+// or not the tag was attached directly to the commit. If no tags exist at or before this commit, the
+// tag is an empty string.
+func Tags(ctx context.Context, db db.DB, repositoryID int, commit string) (string, bool, error) {
+	tag, err := execGitCommand(ctx, db, repositoryID, "tag", "-l", "--points-at", commit)
+	if err != nil {
+		return "", false, err
+	}
+	if tag != "" {
+		return tag, true, nil
+	}
+
+	// git describe --tags will exit with status 128 (fatal: No names found, cannot describe anything)
+	// when there are no tags known to the given repo. In order to prevent a gitserver error from
+	// occurring, we first check to see if there are any tags and early-exit.
+	tags, err := execGitCommand(ctx, db, repositoryID, "tag", commit)
+	if err != nil {
+		return "", false, err
+	}
+	if tags == "" {
+		return "", false, nil
+	}
+
+	tag, err = execGitCommand(ctx, db, repositoryID, "describe", "--tags", "--abbrev=0", commit)
+	if err != nil {
+		return "", false, err
+	}
+
+	return tag, false, nil
+}


### PR DESCRIPTION
This does the same basic thing lsif-go does in order to determine the module version when indexing with git information on-disk.