### PR TITLE
campaigns: Fix publishing campaigns w/ failed jobs

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -157,10 +157,10 @@ func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store
 	}
 
 	jobs, _, err := store.ListPatches(ctx, ListPatchesOpts{
-		PatchSetID:        c.PatchSetID,
-		Limit:             -1,
-		OnlyWithDiff:      true,
-		OnlyNotInCampaign: c.ID,
+		PatchSetID:              c.PatchSetID,
+		Limit:                   -1,
+		OnlyWithDiff:            true,
+		OnlyWithoutChangesetJob: c.ID,
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -157,10 +157,10 @@ func (s *Service) createChangesetJobsWithStore(ctx context.Context, store *Store
 	}
 
 	jobs, _, err := store.ListPatches(ctx, ListPatchesOpts{
-		PatchSetID:                c.PatchSetID,
-		Limit:                     -1,
-		OnlyWithDiff:              true,
-		OnlyUnpublishedInCampaign: c.ID,
+		PatchSetID:        c.PatchSetID,
+		Limit:             -1,
+		OnlyWithDiff:      true,
+		OnlyNotInCampaign: c.ID,
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -2135,12 +2135,12 @@ type ListPatchesOpts struct {
 	// associated with that Campaign are returned. The state of the
 	// ChangesetJobs is not checked. This is mutually exclusive with
 	// OnlyUnpublishedInCampaign.
-	OnlyNotInCampaign int64
+	OnlyWithoutChangesetJob int64
 
 	// If this is set to a Campaign ID only the Patches are returned that are
 	// _not_ associated with a successfully completed ChangesetJob (meaning that
 	// a Changeset on the codehost was created) for the given Campaign. This is
-	// mutually exclusive with OnlyNotInCampaign.
+	// mutually exclusive with OnlyWithoutChangesetJob.
 	OnlyUnpublishedInCampaign int64
 
 	// If this is set only the Patches where diff_stat_added OR
@@ -2210,8 +2210,8 @@ func listPatchesQuery(opts *ListPatchesOpts) *sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("patches.patch_set_id = %s", opts.PatchSetID))
 	}
 
-	if opts.OnlyNotInCampaign != 0 {
-		preds = append(preds, notInCampaignQuery(opts.OnlyNotInCampaign))
+	if opts.OnlyWithoutChangesetJob != 0 {
+		preds = append(preds, notInCampaignQuery(opts.OnlyWithoutChangesetJob))
 	}
 
 	if opts.OnlyWithDiff {

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -2131,9 +2131,16 @@ type ListPatchesOpts struct {
 	Limit        int
 	OnlyWithDiff bool
 
-	// If this is set to a Campaign ID only the Patches are returned that
-	// are _not_ associated with a successfully completed ChangesetJob (meaning
-	// that a Changeset on the codehost was created) for the given Campaign.
+	// When set to a Campaign ID, only patches that do not have ChangesetJobs
+	// associated with that Campaign are returned. The state of the
+	// ChangesetJobs is not checked. This is mutually exclusive with
+	// OnlyUnpublishedInCampaign.
+	OnlyNotInCampaign int64
+
+	// If this is set to a Campaign ID only the Patches are returned that are
+	// _not_ associated with a successfully completed ChangesetJob (meaning that
+	// a Changeset on the codehost was created) for the given Campaign. This is
+	// mutually exclusive with OnlyNotInCampaign.
 	OnlyUnpublishedInCampaign int64
 
 	// If this is set only the Patches where diff_stat_added OR
@@ -2203,6 +2210,10 @@ func listPatchesQuery(opts *ListPatchesOpts) *sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("patches.patch_set_id = %s", opts.PatchSetID))
 	}
 
+	if opts.OnlyNotInCampaign != 0 {
+		preds = append(preds, notInCampaignQuery(opts.OnlyNotInCampaign))
+	}
+
 	if opts.OnlyWithDiff {
 		preds = append(preds, sqlf.Sprintf("patches.diff != ''"))
 	}
@@ -2219,6 +2230,21 @@ func listPatchesQuery(opts *ListPatchesOpts) *sqlf.Query {
 		listPatchesQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
 	)
+}
+
+const onlyNotInCampaignQueryFmtstr = `
+NOT EXISTS (
+	SELECT 1
+	FROM changeset_jobs
+	WHERE
+	  changeset_jobs.patch_id = patches.id
+	AND
+	  changeset_jobs.campaign_id = %s
+)
+`
+
+func notInCampaignQuery(campaignID int64) *sqlf.Query {
+	return sqlf.Sprintf(onlyNotInCampaignQueryFmtstr, campaignID)
 }
 
 var onlyUnpublishedInCampaignQueryFmtstr = `

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1853,6 +1853,76 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, reposStore re
 		})
 	})
 
+	t.Run("Listing OnlyNotInCampaign", func(t *testing.T) {
+		// Define a fake campaign.
+		campaignID := int64(1220)
+
+		// Set up two changeset jobs within the campaign: one successful, one
+		// failed.
+		jobSuccess := &cmpgn.ChangesetJob{
+			PatchID:     patches[0].ID,
+			CampaignID:  campaignID,
+			ChangesetID: 1220,
+			StartedAt:   clock.now(),
+			FinishedAt:  clock.now(),
+		}
+		if err := s.CreateChangesetJob(ctx, jobSuccess); err != nil {
+			t.Fatal(err)
+		}
+
+		jobFailed := &cmpgn.ChangesetJob{
+			PatchID:    patches[1].ID,
+			CampaignID: campaignID,
+			StartedAt:  clock.now(),
+			FinishedAt: clock.now(),
+			Error:      "Octocat knocked pull request off desk",
+		}
+		if err := s.CreateChangesetJob(ctx, jobFailed); err != nil {
+			t.Fatal(err)
+		}
+
+		// List the patches and see what we get back.
+		opts := ListPatchesOpts{OnlyNotInCampaign: campaignID}
+		have, _, err := s.ListPatches(ctx, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Since patches[0] and patches[1] exist in the changeset jobs created
+		// above, we only expect to see patches[2] in the results.
+		want := patches[2:]
+		if len(have) != len(want) {
+			t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+		}
+
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("opts: %+v, diff: %s", opts, diff)
+		}
+
+		// Update the changeset jobs to change the campaign IDs and try again.
+		// This time, we should get all three elements of patches back.
+		for _, job := range []*cmpgn.ChangesetJob{jobSuccess, jobFailed} {
+			job.CampaignID = 0
+			if err = s.UpdateChangesetJob(ctx, job); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		have, _, err = s.ListPatches(ctx, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want = patches
+		if len(have) != len(want) {
+			t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+		}
+
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("opts: %+v, diff: %s", opts, diff)
+		}
+	})
+
 	t.Run("Listing OnlyWithoutDiffStats", func(t *testing.T) {
 		listOpts := ListPatchesOpts{OnlyWithoutDiffStats: true}
 		have, _, err := s.ListPatches(ctx, listOpts)

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1853,7 +1853,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, reposStore re
 		})
 	})
 
-	t.Run("Listing OnlyNotInCampaign", func(t *testing.T) {
+	t.Run("Listing OnlyWithoutChangesetJob", func(t *testing.T) {
 		// Define a fake campaign.
 		campaignID := int64(1220)
 
@@ -1882,7 +1882,7 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, reposStore re
 		}
 
 		// List the patches and see what we get back.
-		opts := ListPatchesOpts{OnlyNotInCampaign: campaignID}
+		opts := ListPatchesOpts{OnlyWithoutChangesetJob: campaignID}
 		have, _, err := s.ListPatches(ctx, opts)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
I took a slightly different technical approach to the one @eseliger suggested in #10797: instead of adding a flag to omit failed jobs, I've instead extended `ListPatchesOpts` with a field called `OnlyNotInCampaign` that is essentially a peer to the existing `OnlyUnpublishedInCampaign`: it returns patches that have no corresponding `changeset_jobs` record in that campaign, regardless of state.

Otherwise, this implements the behaviour suggested in #10797: namely, that publishing a campaign with one or more failed jobs should _not_ result in the jobs being retried. Since #10795 will soon be fixed, users can do that themselves after publishing the campaign via the UI.

Fixes #10797.