### PR TITLE
search: short-circuit quantifiers over queries

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -670,22 +670,18 @@ func (p *parser) ParseParameter() (Parameter, bool, error) {
 
 // containsPattern returns true if any descendent of nodes is a search pattern.
 func containsPattern(node Node) bool {
-	var result bool
-	VisitPattern([]Node{node}, func(_ string, _, _ bool) {
-		result = true
+	return exists([]Node{node}, func(node Node) bool {
+		_, ok := node.(Pattern)
+		return ok
 	})
-	return result
 }
 
 // returns true if descendent of node contains and/or expressions.
 func containsAndOrExpression(nodes []Node) bool {
-	var result bool
-	VisitOperator(nodes, func(kind operatorKind, _ []Node) {
-		if kind == And || kind == Or {
-			result = true
-		}
+	return exists(nodes, func(node Node) bool {
+		term, ok := node.(Operator)
+		return ok && (term.Kind == And || term.Kind == Or)
 	})
-	return result
 }
 
 // partitionParameters constructs a parse tree to distinguish terms where

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -668,22 +668,6 @@ func (p *parser) ParseParameter() (Parameter, bool, error) {
 	return Parameter{Field: field, Value: value, Negated: negated}, true, nil
 }
 
-// containsPattern returns true if any descendent of nodes is a search pattern.
-func containsPattern(node Node) bool {
-	return exists([]Node{node}, func(node Node) bool {
-		_, ok := node.(Pattern)
-		return ok
-	})
-}
-
-// returns true if descendent of node contains and/or expressions.
-func containsAndOrExpression(nodes []Node) bool {
-	return exists(nodes, func(node Node) bool {
-		term, ok := node.(Operator)
-		return ok && (term.Kind == And || term.Kind == Or)
-	})
-}
-
 // partitionParameters constructs a parse tree to distinguish terms where
 // ordering is insignificant (e.g., "repo:foo file:bar") versus terms where
 // ordering may be significant (e.g., search patterns like "foo bar").

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -17,8 +17,7 @@ func (e *UnsupportedError) Error() string {
 	return e.Msg
 }
 
-// exists traverses every node in nodes and returns early as soon as fn is
-// satisfied.
+// exists traverses every node in nodes and returns early as soon as fn is satisfied.
 func exists(nodes []Node, fn func(node Node) bool) bool {
 	found := false
 	for _, node := range nodes {
@@ -32,8 +31,7 @@ func exists(nodes []Node, fn func(node Node) bool) bool {
 	return found
 }
 
-// forAll traverses every node in nodes and returns whether all nodes satisfy
-// fn.
+// forAll traverses every node in nodes and returns whether all nodes satisfy fn.
 func forAll(nodes []Node, fn func(node Node) bool) bool {
 	return exists(nodes, func(node Node) bool {
 		return !fn(node)
@@ -47,6 +45,22 @@ func isPatternExpression(nodes []Node) bool {
 		// Any non-pattern leaf, i.e., Parameter, falsifies the condition.
 		_, ok := node.(Parameter)
 		return ok
+	})
+}
+
+// containsPattern returns true if any descendent of nodes is a search pattern.
+func containsPattern(node Node) bool {
+	return exists([]Node{node}, func(node Node) bool {
+		_, ok := node.(Pattern)
+		return ok
+	})
+}
+
+// returns true if descendent of node contains and/or expressions.
+func containsAndOrExpression(nodes []Node) bool {
+	return exists(nodes, func(node Node) bool {
+		term, ok := node.(Operator)
+		return ok && (term.Kind == And || term.Kind == Or)
 	})
 }
 

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -33,9 +33,16 @@ func exists(nodes []Node, fn func(node Node) bool) bool {
 
 // forAll traverses every node in nodes and returns whether all nodes satisfy fn.
 func forAll(nodes []Node, fn func(node Node) bool) bool {
-	return exists(nodes, func(node Node) bool {
-		return !fn(node)
-	})
+	sat := true
+	for _, node := range nodes {
+		if !fn(node) {
+			return false
+		}
+		if operator, ok := node.(Operator); ok {
+			return forAll(operator.Operands, fn)
+		}
+	}
+	return sat
 }
 
 // isPatternExpression returns true if every leaf node in nodes is a search

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -253,3 +253,17 @@ func TestContainsAndOrKeyword(t *testing.T) {
 		t.Errorf("Did not expect query to contain keyword")
 	}
 }
+
+func TestForAll(t *testing.T) {
+	nodes := []Node{
+		Parameter{Field: "repo", Value: "foo"},
+		Parameter{Field: "repo", Value: "bar"},
+	}
+	result := forAll(nodes, func(node Node) bool {
+		_, ok := node.(Parameter)
+		return ok
+	})
+	if !result {
+		t.Errorf("Expected all nodes to be parameters.")
+	}
+}


### PR DESCRIPTION
There are a couple of functions that check existential properties on queries, so this PR adds `exists` and `forAll` quantifiers. The previous checks did a full traversal of the tree, the added benefit of exists/forAll is it shortcircuits when the condition is satisfied/falsified.

Existing tests cover these.