### PR TITLE
repo-updater: Use per HTTP request timeouts

### DIFF
--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"golang.org/x/time/rate"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 // A Sourcer converts the given ExternalServices to Sources
@@ -92,9 +92,6 @@ func newSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limiter) (Sou
 		panic(fmt.Sprintf("source not implemented for external service kind %q", svc.Kind))
 	}
 }
-
-// sourceTimeout is the default timeout to use on Source.ListRepos
-const sourceTimeout = 30 * time.Minute
 
 // A Source yields repositories to be stored and analysed by Sourcegraph.
 // Successive calls to its ListRepos method may yield different results.

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -362,9 +362,6 @@ func (s *Syncer) sourced(ctx context.Context, observe ...func(*Repo)) ([]*Repo, 
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, sourceTimeout)
-	defer cancel()
-
 	return listAll(ctx, srcs, observe...)
 }
 

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -65,6 +65,7 @@ func NewExternalHTTPClientFactory() *Factory {
 		NewMiddleware(
 			ContextErrorMiddleware,
 		),
+		NewTimeoutOpt(60*time.Second),
 		// ExternalTransportOpt needs to be before TracedTransportOpt and
 		// NewCachedTransportOpt since it wants to extract a http.Transport,
 		// not a generic http.RoundTripper.
@@ -256,6 +257,14 @@ func NewIdleConnTimeoutOpt(timeout time.Duration) Opt {
 
 		tr.IdleConnTimeout = timeout
 
+		return nil
+	}
+}
+
+// NewTimeoutOpt returns a Opt that sets the Timeout field of an http.Client.
+func NewTimeoutOpt(timeout time.Duration) Opt {
+	return func(cli *http.Client) error {
+		cli.Timeout = timeout
 		return nil
 	}
 }

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -262,6 +262,20 @@ func TestNewIdleConnTimeoutOpt(t *testing.T) {
 	}
 }
 
+func TestNewTimeoutOpt(t *testing.T) {
+	var cli http.Client
+
+	timeout := 42 * time.Second
+	err := NewTimeoutOpt(timeout)(&cli)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if have, want := cli.Timeout, timeout; have != want {
+		t.Errorf("have Timeout %s, want %s", have, want)
+	}
+}
+
 func newFakeClient(code int, body []byte, err error) Doer {
 	return DoerFunc(func(r *http.Request) (*http.Response, error) {
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
This commit removes the global 30 minutes sourcing timeout and replaces
it with per HTTP request timeout of 60 seconds which is set in
`NewExternalHTTPClientFactory`.

This per request timeout will apply to all external HTTP requests we do
(i.e. beyond repo-updater), which seems appropriate.

A global timeout for sourcing repos in the code host isn't necessary
since this is a background operation. As it turns out, just listing
repos can be very slow if there are enough repos to be listed.

As seen in the logs in Stackdriver, each page of repos is taking between
900ms and 3 seconds, which quickly adds up to more than the previously
set 30 minutes timeout.