### PR TITLE
codeintel: Replace DefinitionReferenceRow type with MonikerLocations

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/database/database.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/database.go
@@ -251,7 +251,7 @@ func (db *databaseImpl) MonikersByPosition(ctx context.Context, path string, lin
 // also returns the size of the complete result set to aid in pagination (along with skip and take).
 func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) ([]Location, int, error) {
 	// TODO(efritz) - gross
-	var rows []types.DefinitionReferenceRow
+	var rows []types.Location
 	var totalCount int
 	var err error
 	if tableName == "definitions" {

--- a/cmd/precise-code-intel-worker/internal/correlation/group.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/group.go
@@ -1,7 +1,6 @@
 package correlation
 
 import (
-	"fmt"
 	"math"
 	"strings"
 
@@ -42,8 +41,8 @@ func groupBundleData(state *State, dumpID int) (*GroupedBundleData, error) {
 
 	documents := serializeBundleDocuments(state)
 	resultChunks := serializeResultChunks(state, numResultChunks)
-	definitionRows := gatherMonikersByResult(state, state.DefinitionData, getDefinitionResultID)
-	referenceRows := gatherMonikersByResult(state, state.ReferenceData, getReferenceResultID)
+	definitionRows := gatherMonikersLocations(state, state.DefinitionData, getDefinitionResultID)
+	referenceRows := gatherMonikersLocations(state, state.ReferenceData, getReferenceResultID)
 	packages := gatherPackages(state, dumpID)
 	packageReferences, err := gatherPackageReferences(state, dumpID)
 	if err != nil {
@@ -184,12 +183,10 @@ var (
 	getReferenceResultID  = func(r lsif.Range) string { return r.ReferenceResultID }
 )
 
-func gatherMonikersByResult(state *State, data map[string]datastructures.DefaultIDSetMap, xr func(r lsif.Range) string) []types.MonikerLocations {
-	var rows []types.MonikerLocations
-
+func gatherMonikersLocations(state *State, data map[string]datastructures.DefaultIDSetMap, getResultID func(r lsif.Range) string) []types.MonikerLocations {
 	monikers := datastructures.DefaultIDSetMap{}
 	for _, r := range state.RangeData {
-		resultID := xr(r)
+		resultID := getResultID(r)
 		if resultID != "" && len(r.MonikerIDs) > 0 {
 			s := monikers.GetOrCreate(resultID)
 			for id := range r.MonikerIDs {
@@ -198,6 +195,7 @@ func gatherMonikersByResult(state *State, data map[string]datastructures.Default
 		}
 	}
 
+	uniques := map[string]types.MonikerLocations{}
 	for id, documentRanges := range data {
 		monikerIDs, ok := monikers[id]
 		if !ok {
@@ -206,10 +204,8 @@ func gatherMonikersByResult(state *State, data map[string]datastructures.Default
 
 		for monikerID := range monikerIDs {
 			var locations []types.Location
-
 			for documentID, rangeIDs := range documentRanges {
 				document := state.DocumentData[documentID]
-
 				if strings.HasPrefix(document.URI, "..") {
 					continue
 				}
@@ -227,16 +223,24 @@ func gatherMonikersByResult(state *State, data map[string]datastructures.Default
 				}
 			}
 
-			// TODO - deduplicate
-			rows = append(rows, types.MonikerLocations{
-				Scheme:     state.MonikerData[monikerID].Scheme,
-				Identifier: state.MonikerData[monikerID].Identifier,
-				Locations:  locations,
-			})
+			moniker := state.MonikerData[monikerID]
+			key := makeKey(moniker.Scheme, moniker.Identifier)
+			uniques[key] = types.MonikerLocations{
+				Scheme:     moniker.Scheme,
+				Identifier: moniker.Identifier,
+				Locations:  append(uniques[key].Locations, locations...),
+			}
 		}
 	}
 
-	return rows
+	monikerLocations := make([]types.MonikerLocations, 0, len(uniques))
+	for _, v := range uniques {
+		if len(v.Locations) > 0 {
+			monikerLocations = append(monikerLocations, v)
+		}
+	}
+
+	return monikerLocations
 }
 
 // TODO(efritz) - document
@@ -246,7 +250,7 @@ func gatherPackages(state *State, dumpID int) []types.Package {
 		source := state.MonikerData[id]
 		packageInfo := state.PackageInformationData[source.PackageInformationID]
 
-		uniques[fmt.Sprintf("%s:%s:%s", source.Scheme, packageInfo.Name, packageInfo.Version)] = types.Package{
+		uniques[makeKey(source.Scheme, packageInfo.Name, packageInfo.Version)] = types.Package{
 			DumpID:  dumpID,
 			Scheme:  source.Scheme,
 			Name:    packageInfo.Name,
@@ -254,7 +258,7 @@ func gatherPackages(state *State, dumpID int) []types.Package {
 		}
 	}
 
-	var packages []types.Package
+	packages := make([]types.Package, 0, len(uniques))
 	for _, v := range uniques {
 		packages = append(packages, v)
 	}
@@ -276,7 +280,7 @@ func gatherPackageReferences(state *State, dumpID int) ([]types.PackageReference
 		source := state.MonikerData[id]
 		packageInfo := state.PackageInformationData[source.PackageInformationID]
 
-		key := fmt.Sprintf("%s:%s:%s", source.Scheme, packageInfo.Name, packageInfo.Version)
+		key := makeKey(source.Scheme, packageInfo.Name, packageInfo.Version)
 		uniques[key] = ExpandedPackageReference{
 			Scheme:      source.Scheme,
 			Name:        packageInfo.Name,
@@ -285,7 +289,7 @@ func gatherPackageReferences(state *State, dumpID int) ([]types.PackageReference
 		}
 	}
 
-	var packageReferences []types.PackageReference
+	packageReferences := make([]types.PackageReference, 0, len(uniques))
 	for _, v := range uniques {
 		filter, err := bloomfilter.CreateFilter(v.Identifiers)
 		if err != nil {
@@ -302,4 +306,8 @@ func gatherPackageReferences(state *State, dumpID int) ([]types.PackageReference
 	}
 
 	return packageReferences, nil
+}
+
+func makeKey(parts ...string) string {
+	return strings.Join(parts, ":")
 }

--- a/cmd/precise-code-intel-worker/internal/correlation/group_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/group_test.go
@@ -161,21 +161,45 @@ func TestConvert(t *testing.T) {
 				},
 			},
 		},
-		Definitions: []types.DefinitionReferenceRow{
-			{Scheme: "scheme A", Identifier: "ident A", URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-			{Scheme: "scheme B", Identifier: "ident B", URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-			{Scheme: "scheme A", Identifier: "ident A", URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-			{Scheme: "scheme B", Identifier: "ident B", URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-			{Scheme: "scheme A", Identifier: "ident A", URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
-			{Scheme: "scheme B", Identifier: "ident B", URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+		Definitions: []types.MonikerLocations{
+			{
+				Scheme:     "scheme A",
+				Identifier: "ident A",
+				Locations: []types.Location{
+					{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				},
+			},
+			{
+				Scheme:     "scheme B",
+				Identifier: "ident B",
+				Locations: []types.Location{
+					{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				},
+			},
 		},
-		References: []types.DefinitionReferenceRow{
-			{Scheme: "scheme C", Identifier: "ident C", URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-			{Scheme: "scheme C", Identifier: "ident C", URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-			{Scheme: "scheme D", Identifier: "ident D", URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-			{Scheme: "scheme D", Identifier: "ident D", URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-			{Scheme: "scheme C", Identifier: "ident C", URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
-			{Scheme: "scheme D", Identifier: "ident D", URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+		References: []types.MonikerLocations{
+			{
+				Scheme:     "scheme C",
+				Identifier: "ident C",
+				Locations: []types.Location{
+					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+					{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				},
+			},
+			{
+				Scheme:     "scheme D",
+				Identifier: "ident D",
+				Locations: []types.Location{
+					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+					{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				},
+			},
 		},
 		Packages: []types.Package{
 			{DumpID: 42, Scheme: "scheme C", Name: "pkg B", Version: "1.2.3"},
@@ -206,8 +230,8 @@ func normalizeGroupedBundleData(groupedBundleData *GroupedBundleData) {
 		}
 	}
 
-	sortDefinitionReferenceRows(groupedBundleData.Definitions)
-	sortDefinitionReferenceRows(groupedBundleData.References)
+	sortMonikerLocations(groupedBundleData.Definitions)
+	sortMonikerLocations(groupedBundleData.References)
 }
 
 func sortMonikerIDs(s []types.ID) {
@@ -226,14 +250,27 @@ func sortDocumentIDRangeIDs(s []types.DocumentIDRangeID) {
 	})
 }
 
-func sortDefinitionReferenceRows(s []types.DefinitionReferenceRow) {
-	sort.Slice(s, func(i, j int) bool {
-		if cmp := strings.Compare(s[i].URI, s[j].URI); cmp != 0 {
+func sortMonikerLocations(monikerLocations []types.MonikerLocations) {
+	sort.Slice(monikerLocations, func(i, j int) bool {
+		if cmp := strings.Compare(monikerLocations[i].Scheme, monikerLocations[j].Scheme); cmp != 0 {
 			return cmp < 0
-		} else if cmp := strings.Compare(s[i].Identifier, s[j].Identifier); cmp != 0 {
+		} else if cmp := strings.Compare(monikerLocations[i].Identifier, monikerLocations[j].Identifier); cmp != 0 {
 			return cmp < 0
-		} else {
-			return s[i].StartLine < s[j].StartLine
 		}
+		return false
+	})
+
+	for _, ml := range monikerLocations {
+		sortLocations(ml.Locations)
+	}
+}
+
+func sortLocations(locations []types.Location) {
+	sort.Slice(locations, func(i, j int) bool {
+		if cmp := strings.Compare(locations[i].URI, locations[j].URI); cmp != 0 {
+			return cmp < 0
+		}
+
+		return locations[i].StartLine < locations[j].StartLine
 	})
 }

--- a/internal/codeintel/bundles/persistence/mocks/mock_reader.go
+++ b/internal/codeintel/bundles/persistence/mocks/mock_reader.go
@@ -44,7 +44,7 @@ func NewMockReader() *MockReader {
 			},
 		},
 		ReadDefinitionsFunc: &ReaderReadDefinitionsFunc{
-			defaultHook: func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+			defaultHook: func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
@@ -59,7 +59,7 @@ func NewMockReader() *MockReader {
 			},
 		},
 		ReadReferencesFunc: &ReaderReadReferencesFunc{
-			defaultHook: func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+			defaultHook: func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
@@ -198,15 +198,15 @@ func (c ReaderCloseFuncCall) Results() []interface{} {
 // ReaderReadDefinitionsFunc describes the behavior when the ReadDefinitions
 // method of the parent MockReader instance is invoked.
 type ReaderReadDefinitionsFunc struct {
-	defaultHook func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)
-	hooks       []func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)
+	defaultHook func(context.Context, string, string, int, int) ([]types.Location, int, error)
+	hooks       []func(context.Context, string, string, int, int) ([]types.Location, int, error)
 	history     []ReaderReadDefinitionsFuncCall
 	mutex       sync.Mutex
 }
 
 // ReadDefinitions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockReader) ReadDefinitions(v0 context.Context, v1 string, v2 string, v3 int, v4 int) ([]types.DefinitionReferenceRow, int, error) {
+func (m *MockReader) ReadDefinitions(v0 context.Context, v1 string, v2 string, v3 int, v4 int) ([]types.Location, int, error) {
 	r0, r1, r2 := m.ReadDefinitionsFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.ReadDefinitionsFunc.appendCall(ReaderReadDefinitionsFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
@@ -215,7 +215,7 @@ func (m *MockReader) ReadDefinitions(v0 context.Context, v1 string, v2 string, v
 // SetDefaultHook sets function that is called when the ReadDefinitions
 // method of the parent MockReader instance is invoked and the hook queue is
 // empty.
-func (f *ReaderReadDefinitionsFunc) SetDefaultHook(hook func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)) {
+func (f *ReaderReadDefinitionsFunc) SetDefaultHook(hook func(context.Context, string, string, int, int) ([]types.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -223,7 +223,7 @@ func (f *ReaderReadDefinitionsFunc) SetDefaultHook(hook func(context.Context, st
 // ReadDefinitions method of the parent MockReader instance inovkes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ReaderReadDefinitionsFunc) PushHook(hook func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)) {
+func (f *ReaderReadDefinitionsFunc) PushHook(hook func(context.Context, string, string, int, int) ([]types.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -231,21 +231,21 @@ func (f *ReaderReadDefinitionsFunc) PushHook(hook func(context.Context, string, 
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *ReaderReadDefinitionsFunc) SetDefaultReturn(r0 []types.DefinitionReferenceRow, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+func (f *ReaderReadDefinitionsFunc) SetDefaultReturn(r0 []types.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *ReaderReadDefinitionsFunc) PushReturn(r0 []types.DefinitionReferenceRow, r1 int, r2 error) {
-	f.PushHook(func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+func (f *ReaderReadDefinitionsFunc) PushReturn(r0 []types.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *ReaderReadDefinitionsFunc) nextHook() func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+func (f *ReaderReadDefinitionsFunc) nextHook() func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -295,7 +295,7 @@ type ReaderReadDefinitionsFuncCall struct {
 	Arg4 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.DefinitionReferenceRow
+	Result0 []types.Location
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 int
@@ -541,15 +541,15 @@ func (c ReaderReadMetaFuncCall) Results() []interface{} {
 // ReaderReadReferencesFunc describes the behavior when the ReadReferences
 // method of the parent MockReader instance is invoked.
 type ReaderReadReferencesFunc struct {
-	defaultHook func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)
-	hooks       []func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)
+	defaultHook func(context.Context, string, string, int, int) ([]types.Location, int, error)
+	hooks       []func(context.Context, string, string, int, int) ([]types.Location, int, error)
 	history     []ReaderReadReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // ReadReferences delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockReader) ReadReferences(v0 context.Context, v1 string, v2 string, v3 int, v4 int) ([]types.DefinitionReferenceRow, int, error) {
+func (m *MockReader) ReadReferences(v0 context.Context, v1 string, v2 string, v3 int, v4 int) ([]types.Location, int, error) {
 	r0, r1, r2 := m.ReadReferencesFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.ReadReferencesFunc.appendCall(ReaderReadReferencesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
@@ -558,7 +558,7 @@ func (m *MockReader) ReadReferences(v0 context.Context, v1 string, v2 string, v3
 // SetDefaultHook sets function that is called when the ReadReferences
 // method of the parent MockReader instance is invoked and the hook queue is
 // empty.
-func (f *ReaderReadReferencesFunc) SetDefaultHook(hook func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)) {
+func (f *ReaderReadReferencesFunc) SetDefaultHook(hook func(context.Context, string, string, int, int) ([]types.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -566,7 +566,7 @@ func (f *ReaderReadReferencesFunc) SetDefaultHook(hook func(context.Context, str
 // ReadReferences method of the parent MockReader instance inovkes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ReaderReadReferencesFunc) PushHook(hook func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error)) {
+func (f *ReaderReadReferencesFunc) PushHook(hook func(context.Context, string, string, int, int) ([]types.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -574,21 +574,21 @@ func (f *ReaderReadReferencesFunc) PushHook(hook func(context.Context, string, s
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *ReaderReadReferencesFunc) SetDefaultReturn(r0 []types.DefinitionReferenceRow, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+func (f *ReaderReadReferencesFunc) SetDefaultReturn(r0 []types.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *ReaderReadReferencesFunc) PushReturn(r0 []types.DefinitionReferenceRow, r1 int, r2 error) {
-	f.PushHook(func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+func (f *ReaderReadReferencesFunc) PushReturn(r0 []types.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *ReaderReadReferencesFunc) nextHook() func(context.Context, string, string, int, int) ([]types.DefinitionReferenceRow, int, error) {
+func (f *ReaderReadReferencesFunc) nextHook() func(context.Context, string, string, int, int) ([]types.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -638,7 +638,7 @@ type ReaderReadReferencesFuncCall struct {
 	Arg4 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []types.DefinitionReferenceRow
+	Result0 []types.Location
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 int

--- a/internal/codeintel/bundles/persistence/mocks/mock_writer.go
+++ b/internal/codeintel/bundles/persistence/mocks/mock_writer.go
@@ -52,7 +52,7 @@ func NewMockWriter() *MockWriter {
 			},
 		},
 		WriteDefinitionsFunc: &WriterWriteDefinitionsFunc{
-			defaultHook: func(context.Context, []types.DefinitionReferenceRow) error {
+			defaultHook: func(context.Context, []types.MonikerLocations) error {
 				return nil
 			},
 		},
@@ -67,7 +67,7 @@ func NewMockWriter() *MockWriter {
 			},
 		},
 		WriteReferencesFunc: &WriterWriteReferencesFunc{
-			defaultHook: func(context.Context, []types.DefinitionReferenceRow) error {
+			defaultHook: func(context.Context, []types.MonikerLocations) error {
 				return nil
 			},
 		},
@@ -311,15 +311,15 @@ func (c WriterFlushFuncCall) Results() []interface{} {
 // WriterWriteDefinitionsFunc describes the behavior when the
 // WriteDefinitions method of the parent MockWriter instance is invoked.
 type WriterWriteDefinitionsFunc struct {
-	defaultHook func(context.Context, []types.DefinitionReferenceRow) error
-	hooks       []func(context.Context, []types.DefinitionReferenceRow) error
+	defaultHook func(context.Context, []types.MonikerLocations) error
+	hooks       []func(context.Context, []types.MonikerLocations) error
 	history     []WriterWriteDefinitionsFuncCall
 	mutex       sync.Mutex
 }
 
 // WriteDefinitions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockWriter) WriteDefinitions(v0 context.Context, v1 []types.DefinitionReferenceRow) error {
+func (m *MockWriter) WriteDefinitions(v0 context.Context, v1 []types.MonikerLocations) error {
 	r0 := m.WriteDefinitionsFunc.nextHook()(v0, v1)
 	m.WriteDefinitionsFunc.appendCall(WriterWriteDefinitionsFuncCall{v0, v1, r0})
 	return r0
@@ -328,7 +328,7 @@ func (m *MockWriter) WriteDefinitions(v0 context.Context, v1 []types.DefinitionR
 // SetDefaultHook sets function that is called when the WriteDefinitions
 // method of the parent MockWriter instance is invoked and the hook queue is
 // empty.
-func (f *WriterWriteDefinitionsFunc) SetDefaultHook(hook func(context.Context, []types.DefinitionReferenceRow) error) {
+func (f *WriterWriteDefinitionsFunc) SetDefaultHook(hook func(context.Context, []types.MonikerLocations) error) {
 	f.defaultHook = hook
 }
 
@@ -336,7 +336,7 @@ func (f *WriterWriteDefinitionsFunc) SetDefaultHook(hook func(context.Context, [
 // WriteDefinitions method of the parent MockWriter instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *WriterWriteDefinitionsFunc) PushHook(hook func(context.Context, []types.DefinitionReferenceRow) error) {
+func (f *WriterWriteDefinitionsFunc) PushHook(hook func(context.Context, []types.MonikerLocations) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -345,7 +345,7 @@ func (f *WriterWriteDefinitionsFunc) PushHook(hook func(context.Context, []types
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *WriterWriteDefinitionsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, []types.DefinitionReferenceRow) error {
+	f.SetDefaultHook(func(context.Context, []types.MonikerLocations) error {
 		return r0
 	})
 }
@@ -353,12 +353,12 @@ func (f *WriterWriteDefinitionsFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *WriterWriteDefinitionsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, []types.DefinitionReferenceRow) error {
+	f.PushHook(func(context.Context, []types.MonikerLocations) error {
 		return r0
 	})
 }
 
-func (f *WriterWriteDefinitionsFunc) nextHook() func(context.Context, []types.DefinitionReferenceRow) error {
+func (f *WriterWriteDefinitionsFunc) nextHook() func(context.Context, []types.MonikerLocations) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -396,7 +396,7 @@ type WriterWriteDefinitionsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 []types.DefinitionReferenceRow
+	Arg1 []types.MonikerLocations
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -631,15 +631,15 @@ func (c WriterWriteMetaFuncCall) Results() []interface{} {
 // WriterWriteReferencesFunc describes the behavior when the WriteReferences
 // method of the parent MockWriter instance is invoked.
 type WriterWriteReferencesFunc struct {
-	defaultHook func(context.Context, []types.DefinitionReferenceRow) error
-	hooks       []func(context.Context, []types.DefinitionReferenceRow) error
+	defaultHook func(context.Context, []types.MonikerLocations) error
+	hooks       []func(context.Context, []types.MonikerLocations) error
 	history     []WriterWriteReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // WriteReferences delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockWriter) WriteReferences(v0 context.Context, v1 []types.DefinitionReferenceRow) error {
+func (m *MockWriter) WriteReferences(v0 context.Context, v1 []types.MonikerLocations) error {
 	r0 := m.WriteReferencesFunc.nextHook()(v0, v1)
 	m.WriteReferencesFunc.appendCall(WriterWriteReferencesFuncCall{v0, v1, r0})
 	return r0
@@ -648,7 +648,7 @@ func (m *MockWriter) WriteReferences(v0 context.Context, v1 []types.DefinitionRe
 // SetDefaultHook sets function that is called when the WriteReferences
 // method of the parent MockWriter instance is invoked and the hook queue is
 // empty.
-func (f *WriterWriteReferencesFunc) SetDefaultHook(hook func(context.Context, []types.DefinitionReferenceRow) error) {
+func (f *WriterWriteReferencesFunc) SetDefaultHook(hook func(context.Context, []types.MonikerLocations) error) {
 	f.defaultHook = hook
 }
 
@@ -656,7 +656,7 @@ func (f *WriterWriteReferencesFunc) SetDefaultHook(hook func(context.Context, []
 // WriteReferences method of the parent MockWriter instance inovkes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WriterWriteReferencesFunc) PushHook(hook func(context.Context, []types.DefinitionReferenceRow) error) {
+func (f *WriterWriteReferencesFunc) PushHook(hook func(context.Context, []types.MonikerLocations) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -665,7 +665,7 @@ func (f *WriterWriteReferencesFunc) PushHook(hook func(context.Context, []types.
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *WriterWriteReferencesFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, []types.DefinitionReferenceRow) error {
+	f.SetDefaultHook(func(context.Context, []types.MonikerLocations) error {
 		return r0
 	})
 }
@@ -673,12 +673,12 @@ func (f *WriterWriteReferencesFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *WriterWriteReferencesFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, []types.DefinitionReferenceRow) error {
+	f.PushHook(func(context.Context, []types.MonikerLocations) error {
 		return r0
 	})
 }
 
-func (f *WriterWriteReferencesFunc) nextHook() func(context.Context, []types.DefinitionReferenceRow) error {
+func (f *WriterWriteReferencesFunc) nextHook() func(context.Context, []types.MonikerLocations) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -716,7 +716,7 @@ type WriterWriteReferencesFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 []types.DefinitionReferenceRow
+	Arg1 []types.MonikerLocations
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error

--- a/internal/codeintel/bundles/persistence/observability.go
+++ b/internal/codeintel/bundles/persistence/observability.go
@@ -88,16 +88,16 @@ func (r *ObservedReader) ReadResultChunk(ctx context.Context, id int) (_ types.R
 }
 
 // ReadDefinitions calls into the inner Reader and registers the observed results.
-func (r *ObservedReader) ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) (definitions []types.DefinitionReferenceRow, _ int, err error) {
+func (r *ObservedReader) ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) (locations []types.Location, _ int, err error) {
 	ctx, endObservation := r.readDefinitionsOperation.With(ctx, &err, observation.Args{})
-	defer func() { endObservation(float64(len(definitions)), observation.Args{}) }()
+	defer func() { endObservation(float64(len(locations)), observation.Args{}) }()
 	return r.reader.ReadDefinitions(ctx, scheme, identifier, skip, take)
 }
 
 // ReadReferences calls into the inner Reader and registers the observed results.
-func (r *ObservedReader) ReadReferences(ctx context.Context, scheme, identifier string, skip, take int) (references []types.DefinitionReferenceRow, _ int, err error) {
+func (r *ObservedReader) ReadReferences(ctx context.Context, scheme, identifier string, skip, take int) (locations []types.Location, _ int, err error) {
 	ctx, endObservation := r.readReferencesOperation.With(ctx, &err, observation.Args{})
-	defer func() { endObservation(float64(len(references)), observation.Args{}) }()
+	defer func() { endObservation(float64(len(locations)), observation.Args{}) }()
 	return r.reader.ReadReferences(ctx, scheme, identifier, skip, take)
 }
 

--- a/internal/codeintel/bundles/persistence/reader.go
+++ b/internal/codeintel/bundles/persistence/reader.go
@@ -10,7 +10,7 @@ type Reader interface {
 	ReadMeta(ctx context.Context) (string, string, int, error)
 	ReadDocument(ctx context.Context, path string) (types.DocumentData, bool, error)
 	ReadResultChunk(ctx context.Context, id int) (types.ResultChunkData, bool, error)
-	ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) ([]types.DefinitionReferenceRow, int, error)
-	ReadReferences(ctx context.Context, scheme, identifier string, skip, take int) ([]types.DefinitionReferenceRow, int, error)
+	ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) ([]types.Location, int, error)
+	ReadReferences(ctx context.Context, scheme, identifier string, skip, take int) ([]types.Location, int, error)
 	Close() error
 }

--- a/internal/codeintel/bundles/persistence/sqlite/migrations/migration.go
+++ b/internal/codeintel/bundles/persistence/sqlite/migrations/migration.go
@@ -1,0 +1,3 @@
+package migrations
+
+// TODO

--- a/internal/codeintel/bundles/persistence/sqlite/migrations/migration.go
+++ b/internal/codeintel/bundles/persistence/sqlite/migrations/migration.go
@@ -1,3 +1,0 @@
-package migrations
-
-// TODO

--- a/internal/codeintel/bundles/persistence/sqlite/reader_test.go
+++ b/internal/codeintel/bundles/persistence/sqlite/reader_test.go
@@ -106,11 +106,11 @@ func TestReadDefinitions(t *testing.T) {
 		t.Errorf("unexpected total count. want=%d have=%d", 11, totalCount)
 	}
 
-	expectedDefinitions := []types.DefinitionReferenceRow{
-		{Scheme: "gomod", Identifier: "github.com/sourcegraph/lsif-go/protocol:Vertex", URI: "protocol/protocol.go", StartLine: 334, StartCharacter: 1, EndLine: 334, EndCharacter: 7},
-		{Scheme: "gomod", Identifier: "github.com/sourcegraph/lsif-go/protocol:Vertex", URI: "protocol/protocol.go", StartLine: 139, StartCharacter: 1, EndLine: 139, EndCharacter: 7},
-		{Scheme: "gomod", Identifier: "github.com/sourcegraph/lsif-go/protocol:Vertex", URI: "protocol/protocol.go", StartLine: 384, StartCharacter: 1, EndLine: 384, EndCharacter: 7},
-		{Scheme: "gomod", Identifier: "github.com/sourcegraph/lsif-go/protocol:Vertex", URI: "protocol/protocol.go", StartLine: 357, StartCharacter: 1, EndLine: 357, EndCharacter: 7},
+	expectedDefinitions := []types.Location{
+		{URI: "protocol/protocol.go", StartLine: 334, StartCharacter: 1, EndLine: 334, EndCharacter: 7},
+		{URI: "protocol/protocol.go", StartLine: 139, StartCharacter: 1, EndLine: 139, EndCharacter: 7},
+		{URI: "protocol/protocol.go", StartLine: 384, StartCharacter: 1, EndLine: 384, EndCharacter: 7},
+		{URI: "protocol/protocol.go", StartLine: 357, StartCharacter: 1, EndLine: 357, EndCharacter: 7},
 	}
 	if diff := cmp.Diff(expectedDefinitions, definitions); diff != "" {
 		t.Errorf("unexpected definitions (-want +got):\n%s", diff)
@@ -126,11 +126,11 @@ func TestReadReferences(t *testing.T) {
 		t.Errorf("unexpected total count. want=%d have=%d", 25, totalCount)
 	}
 
-	expectedReferences := []types.DefinitionReferenceRow{
-		{Scheme: "gomod", Identifier: "golang.org/x/tools/go/packages:Package", URI: "internal/index/helper.go", StartLine: 184, StartCharacter: 56, EndLine: 184, EndCharacter: 63},
-		{Scheme: "gomod", Identifier: "golang.org/x/tools/go/packages:Package", URI: "internal/index/helper.go", StartLine: 35, StartCharacter: 56, EndLine: 35, EndCharacter: 63},
-		{Scheme: "gomod", Identifier: "golang.org/x/tools/go/packages:Package", URI: "internal/index/helper.go", StartLine: 184, StartCharacter: 35, EndLine: 184, EndCharacter: 42},
-		{Scheme: "gomod", Identifier: "golang.org/x/tools/go/packages:Package", URI: "internal/index/helper.go", StartLine: 48, StartCharacter: 44, EndLine: 48, EndCharacter: 51},
+	expectedReferences := []types.Location{
+		{URI: "internal/index/helper.go", StartLine: 184, StartCharacter: 56, EndLine: 184, EndCharacter: 63},
+		{URI: "internal/index/helper.go", StartLine: 35, StartCharacter: 56, EndLine: 35, EndCharacter: 63},
+		{URI: "internal/index/helper.go", StartLine: 184, StartCharacter: 35, EndLine: 184, EndCharacter: 42},
+		{URI: "internal/index/helper.go", StartLine: 48, StartCharacter: 44, EndLine: 48, EndCharacter: 51},
 	}
 	if diff := cmp.Diff(expectedReferences, references); diff != "" {
 		t.Errorf("unexpected references (-want +got):\n%s", diff)

--- a/internal/codeintel/bundles/persistence/sqlite/writer.go
+++ b/internal/codeintel/bundles/persistence/sqlite/writer.go
@@ -105,19 +105,23 @@ func (w *sqliteWriter) WriteResultChunks(ctx context.Context, resultChunks map[i
 	return nil
 }
 
-func (w *sqliteWriter) WriteDefinitions(ctx context.Context, definitions []types.DefinitionReferenceRow) error {
-	for _, r := range definitions {
-		if err := w.definitionInserter.Insert(ctx, r.Scheme, r.Identifier, r.URI, r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter); err != nil {
-			return errors.Wrap(err, "definitionInserter.Insert")
+func (w *sqliteWriter) WriteDefinitions(ctx context.Context, monikerLocations []types.MonikerLocations) error {
+	for _, ml := range monikerLocations {
+		for _, l := range ml.Locations {
+			if err := w.definitionInserter.Insert(ctx, ml.Scheme, ml.Identifier, l.URI, l.StartLine, l.StartCharacter, l.EndLine, l.EndCharacter); err != nil {
+				return errors.Wrap(err, "definitionInserter.Insert")
+			}
 		}
 	}
 	return nil
 }
 
-func (w *sqliteWriter) WriteReferences(ctx context.Context, references []types.DefinitionReferenceRow) error {
-	for _, r := range references {
-		if err := w.referenceInserter.Insert(ctx, r.Scheme, r.Identifier, r.URI, r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter); err != nil {
-			return errors.Wrap(err, "referenceInserter.Insert")
+func (w *sqliteWriter) WriteReferences(ctx context.Context, monikerLocations []types.MonikerLocations) error {
+	for _, ml := range monikerLocations {
+		for _, l := range ml.Locations {
+			if err := w.referenceInserter.Insert(ctx, ml.Scheme, ml.Identifier, l.URI, l.StartLine, l.StartCharacter, l.EndLine, l.EndCharacter); err != nil {
+				return errors.Wrap(err, "referenceInserter.Insert")
+			}
 		}
 	}
 	return nil

--- a/internal/codeintel/bundles/persistence/sqlite/writer_test.go
+++ b/internal/codeintel/bundles/persistence/sqlite/writer_test.go
@@ -80,21 +80,37 @@ func TestWrite(t *testing.T) {
 		t.Fatalf("unexpected error while writing result chunks: %s", err)
 	}
 
-	expectedDefinitions := []types.DefinitionReferenceRow{
-		{Scheme: "scheme A", Identifier: "ident A", URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-		{Scheme: "scheme A", Identifier: "ident A", URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-		{Scheme: "scheme A", Identifier: "ident A", URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+	expectedDefinitions := []types.Location{
+		{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+		{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+		{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 	}
-	if err := writer.WriteDefinitions(ctx, expectedDefinitions); err != nil {
+
+	definitionMonikerLocations := []types.MonikerLocations{
+		{
+			Scheme:     "scheme A",
+			Identifier: "ident A",
+			Locations:  expectedDefinitions,
+		},
+	}
+	if err := writer.WriteDefinitions(ctx, definitionMonikerLocations); err != nil {
 		t.Fatalf("unexpected error while writing definitions: %s", err)
 	}
 
-	expectedReferences := []types.DefinitionReferenceRow{
-		{Scheme: "scheme C", Identifier: "ident C", URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-		{Scheme: "scheme C", Identifier: "ident C", URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-		{Scheme: "scheme C", Identifier: "ident C", URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+	expectedReferences := []types.Location{
+		{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+		{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+		{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 	}
-	if err := writer.WriteReferences(ctx, expectedReferences); err != nil {
+
+	referenceMonikerLocations := []types.MonikerLocations{
+		{
+			Scheme:     "scheme C",
+			Identifier: "ident C",
+			Locations:  expectedReferences,
+		},
+	}
+	if err := writer.WriteReferences(ctx, referenceMonikerLocations); err != nil {
 		t.Fatalf("unexpected error while writing references: %s", err)
 	}
 

--- a/internal/codeintel/bundles/persistence/writer.go
+++ b/internal/codeintel/bundles/persistence/writer.go
@@ -10,8 +10,8 @@ type Writer interface {
 	WriteMeta(ctx context.Context, lsifVersion string, numResultChunks int) error
 	WriteDocuments(ctx context.Context, documents map[string]types.DocumentData) error
 	WriteResultChunks(ctx context.Context, resultChunks map[int]types.ResultChunkData) error
-	WriteDefinitions(ctx context.Context, definitions []types.DefinitionReferenceRow) error
-	WriteReferences(ctx context.Context, references []types.DefinitionReferenceRow) error
+	WriteDefinitions(ctx context.Context, monikerLocations []types.MonikerLocations) error
+	WriteReferences(ctx context.Context, monikerLocations []types.MonikerLocations) error
 	Flush(ctx context.Context) error
 	Close() error
 }

--- a/internal/codeintel/bundles/types/types.go
+++ b/internal/codeintel/bundles/types/types.go
@@ -70,6 +70,23 @@ type DocumentIDRangeID struct {
 	RangeID ID
 }
 
+// Loocation represents a range within a particular document relative to its
+// containing bundle.
+type Location struct {
+	URI            string
+	StartLine      int
+	StartCharacter int
+	EndLine        int
+	EndCharacter   int
+}
+
+// TODO
+type MonikerLocations struct {
+	Scheme     string
+	Identifier string
+	Locations  []Location
+}
+
 // Package pairs a package name and the dump that provides it.
 type Package struct {
 	DumpID  int
@@ -85,17 +102,4 @@ type PackageReference struct {
 	Name    string
 	Version string
 	Filter  []byte // a bloom filter of identifiers imported by this dependent
-}
-
-// DefinitionReferenceRow represents a linking between a definition of a symbol or
-// a reference of an externally defined symbol the source location in which the
-// symbol definition or use can be found within a particular bundle.
-type DefinitionReferenceRow struct {
-	Scheme         string
-	Identifier     string
-	URI            string
-	StartLine      int
-	StartCharacter int
-	EndLine        int
-	EndCharacter   int
 }

--- a/internal/codeintel/bundles/types/types.go
+++ b/internal/codeintel/bundles/types/types.go
@@ -80,7 +80,8 @@ type Location struct {
 	EndCharacter   int
 }
 
-// TODO
+// MonikerLocations pairs a moniker scheme and identifier with the set of locations
+// with that within a particular bundle.
 type MonikerLocations struct {
 	Scheme     string
 	Identifier string


### PR DESCRIPTION
Replace the DefinitonReferenceRow type to decouple it from a row-based storage engine.
