### PR TITLE
codeintel: Swallow deleted repos during auto indexing

### DIFF
--- a/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
+++ b/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 type Updater struct {
@@ -64,6 +65,10 @@ func (u *Updater) update(ctx context.Context) error {
 
 	for _, stat := range stats {
 		if err := u.queueRepository(ctx, stat); err != nil {
+			if vcs.IsRepoNotExist(err) {
+				continue
+			}
+
 			return err
 		}
 	}

--- a/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
+++ b/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 type Scheduler struct {
@@ -85,6 +86,10 @@ func (s *Scheduler) update(ctx context.Context) error {
 
 	for _, indexableRepository := range indexableRepositories {
 		if err := s.queueIndex(ctx, indexableRepository); err != nil {
+			if vcs.IsRepoNotExist(err) {
+				continue
+			}
+
 			return err
 		}
 	}

--- a/internal/codeintel/db/repo_usage.go
+++ b/internal/codeintel/db/repo_usage.go
@@ -35,6 +35,7 @@ func (db *dbImpl) RepoUsageStatistics(ctx context.Context) ([]RepoUsageStatistic
 		) counts
 		-- Cast allows use of the uri btree index
 		JOIN repo r ON r.uri = counts.repo_name::citext
+		WHERE r.deleted_at IS NULL
 		ORDER BY search_count DESC, precise_count DESC
 	`)))
 }


### PR DESCRIPTION
Requesting data for deleted repositories from gitserver will result in an error, but we shouldn't stop processing due to this. This PR changes the behavior so these repos are simply skipped.