### PR TITLE
codeintel: Install go into precise-code-intel-indexer dockerfile

### DIFF
--- a/cmd/precise-code-intel-indexer/Dockerfile
+++ b/cmd/precise-code-intel-indexer/Dockerfile
@@ -11,7 +11,10 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
-    tini
+    tini musl-dev go
+
+ENV GOROOT=/usr/lib/go GOPATH=/go PATH=/go/bin:$PATH
+RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
 RUN mkdir temp && \
     curl -L https://github.com/sourcegraph/src-cli/releases/download/3.12.0/src-cli_3.12.0_linux_amd64.tar.gz -o src-cli.tar.gz && \


### PR DESCRIPTION
This is currently Go 1.12, which will help us with our proof of concept, but we should keep this as current as possible by installing from source during build.