### PR TITLE
Remove repo count from the Explore page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Forks and archived repositories at a specific commit are searched without the need to specify "fork:yes" or "archived:yes" in the query. [#10864](https://github.com/sourcegraph/sourcegraph/pull/10864)
 - The git history for binary files is now correctly shown. [#11034](https://github.com/sourcegraph/sourcegraph/pull/11034)
 - Links to AWS Code Commit repositories have been fixed after the URL schema has been changed. [#11019](https://github.com/sourcegraph/sourcegraph/pull/11019)
-- Links to view all repositories will now always appear on the Explore page
+- Links to view all repositories will now always appear on the Explore page. [#11113](https://github.com/sourcegraph/sourcegraph/pull/11113)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Forks and archived repositories at a specific commit are searched without the need to specify "fork:yes" or "archived:yes" in the query. [#10864](https://github.com/sourcegraph/sourcegraph/pull/10864)
 - The git history for binary files is now correctly shown. [#11034](https://github.com/sourcegraph/sourcegraph/pull/11034)
 - Links to AWS Code Commit repositories have been fixed after the URL schema has been changed. [#11019](https://github.com/sourcegraph/sourcegraph/pull/11019)
-- Links to view all repositories will now always appear on the Explore page. [#11113](https://github.com/sourcegraph/sourcegraph/pull/11113)
+- A link to view all repositories will now always appear on the Explore page. [#11113](https://github.com/sourcegraph/sourcegraph/pull/11113)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Forks and archived repositories at a specific commit are searched without the need to specify "fork:yes" or "archived:yes" in the query. [#10864](https://github.com/sourcegraph/sourcegraph/pull/10864)
 - The git history for binary files is now correctly shown. [#11034](https://github.com/sourcegraph/sourcegraph/pull/11034)
 - Links to AWS Code Commit repositories have been fixed after the URL schema has been changed. [#11019](https://github.com/sourcegraph/sourcegraph/pull/11019)
+- Links to view all repositories will now always appear on the Explore page
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -213,11 +213,9 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 }
 
 func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error) {
-	// 🚨 SECURITY: Only site admins can perform precise counts, because it is a slow operation.
+	// 🚨 SECURITY: Only site admins can do this, because a total repository count does not respect repository permissions.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		if args.Precise {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	i32ptr := func(v int32) *int32 {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -215,7 +215,8 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error) {
 	// 🚨 SECURITY: Only site admins can do this, because a total repository count does not respect repository permissions.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
+		// TODO this should return err instead of null
+		return nil, nil
 	}
 
 	i32ptr := func(v int32) *int32 {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -218,7 +218,6 @@ func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *Tot
 		if args.Precise {
 			return nil, err
 		}
-		return nil, nil
 	}
 
 	i32ptr := func(v int32) *int32 {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -32,7 +32,7 @@ func TestRepositories(t *testing.T) {
 							{ "name": "repo2" },
 							{ "name": "repo3" }
 						],
-						"totalCount": 3,
+						"totalCount": null,
 						"pageInfo": {"hasNextPage": false}
 					}
 				}

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -32,7 +32,7 @@ func TestRepositories(t *testing.T) {
 							{ "name": "repo2" },
 							{ "name": "repo3" }
 						],
-						"totalCount": null,
+						"totalCount": 3,
 						"pageInfo": {"hasNextPage": false}
 					}
 				}

--- a/web/src/repo/explore/RepositoriesExploreSection.tsx
+++ b/web/src/repo/explore/RepositoriesExploreSection.tsx
@@ -107,10 +107,17 @@ export class RepositoriesExploreSection extends React.PureComponent<Props, State
                         )
                     )}
                 </div>
-                {typeof totalCount === 'number' && totalCount > 0 && (
+                {typeof totalCount === 'number' && totalCount > 0 ? (
                     <div className="card-footer">
                         <Link to={`/search?${buildSearchURLQuery('repo:', this.props.patternType, false)}`}>
                             View all {totalCount} {pluralize('repository', totalCount, 'repositories')}
+                            <ChevronRightIcon className="icon-inline" />
+                        </Link>
+                    </div>
+                ) : (
+                    <div className="card-footer">
+                        <Link to={`/search?${buildSearchURLQuery('repo:', this.props.patternType, false)}`}>
+                            View all repositories
                             <ChevronRightIcon className="icon-inline" />
                         </Link>
                     </div>

--- a/web/src/repo/explore/RepositoriesExploreSection.tsx
+++ b/web/src/repo/explore/RepositoriesExploreSection.tsx
@@ -7,7 +7,6 @@ import { RepoLink } from '../../../../shared/src/components/RepoLink'
 import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
-import { pluralize } from '../../../../shared/src/util/strings'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { queryGraphQL } from '../../backend/graphql'
 import { PatternTypeProps } from '../../search'
@@ -68,16 +67,6 @@ export class RepositoriesExploreSection extends React.PureComponent<Props, State
 
         const itemClass = 'py-2'
 
-        // Only show total count if it is counting *all* repositories (i.e., no filter args are specified).
-        const queryingAllRepositories = RepositoriesExploreSection.QUERY_REPOSITORIES_ARGS.names === null
-        const totalCount =
-            queryingAllRepositories &&
-            this.state.repositoriesOrError !== LOADING &&
-            !isErrorLike(this.state.repositoriesOrError) &&
-            typeof this.state.repositoriesOrError.totalCount === 'number'
-                ? this.state.repositoriesOrError.totalCount
-                : undefined
-
         return (
             <div className="card">
                 <h3 className="card-header">Repositories</h3>
@@ -107,21 +96,12 @@ export class RepositoriesExploreSection extends React.PureComponent<Props, State
                         )
                     )}
                 </div>
-                {typeof totalCount === 'number' && totalCount > 0 ? (
-                    <div className="card-footer">
-                        <Link to={`/search?${buildSearchURLQuery('repo:', this.props.patternType, false)}`}>
-                            View all {totalCount} {pluralize('repository', totalCount, 'repositories')}
-                            <ChevronRightIcon className="icon-inline" />
-                        </Link>
-                    </div>
-                ) : (
-                    <div className="card-footer">
-                        <Link to={`/search?${buildSearchURLQuery('repo:', this.props.patternType, false)}`}>
-                            View all repositories
-                            <ChevronRightIcon className="icon-inline" />
-                        </Link>
-                    </div>
-                )}
+                <div className="card-footer">
+                    <Link to={`/search?${buildSearchURLQuery('repo:', this.props.patternType, false)}`}>
+                        View all repositories
+                        <ChevronRightIcon className="icon-inline" />
+                    </Link>
+                </div>
             </div>
         )
     }
@@ -139,7 +119,6 @@ function queryRepositories(
                         description
                         url
                     }
-                    totalCount(precise: false)
                 }
             }
         `,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/10461

Turns out we do usually show this, but there are a few issues:

~1) currently, non-admins will never see it, due to an error~
**edit**: this was intentional: see history at https://github.com/sourcegraph/sourcegraph/issues/1860!

2) sometimes, the handler will return nil for various reasons

~I fixed the former case, and in the latter case I added a fallback.~

edit: I removed the total count from the explore page entirely and added a link that will always appear