### PR TITLE
Add prometheus and grafana to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,15 @@
     {
       "packageNames": ["@octokit/rest", "@slack/web-api", "googleapis"],
       "reviewers": ["beyang"]
+    },
+    {
+      "packageNames": ["index.docker.io/sourcegraph/grafana", "index.docker.io/sourcegraph/prometheus"],
+      "groupName": "Sourcegraph Prometheus / Grafana Docker images",
+      "allowedVersions": "<10.0",
+      "versionScheme": "semver",
+      "ignoreUnstable": false,
+      "semanticCommits": false,
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Changing renovate to handle automatic upgrades of Prometheus and Grafana

Fixes https://github.com/sourcegraph/sourcegraph/issues/9983
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
