### PR TITLE
Fix wrong file revision chosen in file diff

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -105,9 +105,9 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 
 	// Find the common merge-base for the diff. That's what the diff will actually need to be applied to,
 	// not the baseRevspec.
-	mergeBaseCommit, _, _, err := git.ExecSafe(ctx, *grepo, []string{"merge-base", baseRevspec, headRevspec})
+	mergeBaseCommit, stderr, _, err := git.ExecSafe(ctx, *grepo, []string{"merge-base", baseRevspec, headRevspec})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("git merge-base failed: %v - %s", err, stderr)
 	}
 
 	wg.Add(2)

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -106,7 +106,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		// Find the common merge-base for the diff. That's what the diff will actually need to be applied to,
+		// Find the common merge-base for the diff. That's the revision the diff applies to,
 		// not the baseRevspec.
 		mergeBaseCommit, err := git.MergeBase(ctx, *grepo, api.CommitID(baseRevspec), api.CommitID(headRevspec))
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -51,7 +51,7 @@ func TestRepositoryComparison(t *testing.T) {
 	defer func() { git.Mocks.ExecReader = nil }()
 
 	git.Mocks.ExecSafe = func(args []string) (stdout, stderr []byte, exitCode int, err error) {
-		if len(args) < 3 && args[0] != "merge-base" && args[1] != wantBaseRevision && args[2] != wantHeadRevision {
+		if len(args) < 3 || args[0] != "merge-base" || args[1] != wantBaseRevision || args[2] != wantHeadRevision {
 			t.Fatalf("gitserver.ExecSafe received wrong args: %v", args)
 		}
 		return []byte(wantMergeBaseRevision), []byte{}, 0, nil

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -48,7 +48,7 @@ func TestRepositoryComparison(t *testing.T) {
 		}
 		return ioutil.NopCloser(strings.NewReader(testDiff)), nil
 	}
-	defer func() { git.Mocks.ExecReader = nil }()
+	t.Cleanup(func() { git.Mocks.ExecReader = nil })
 
 	git.Mocks.MergeBase = func(repo gitserver.Repo, a, b api.CommitID) (api.CommitID, error) {
 		if string(a) != wantBaseRevision || string(b) != wantHeadRevision {
@@ -56,7 +56,7 @@ func TestRepositoryComparison(t *testing.T) {
 		}
 		return api.CommitID(wantMergeBaseRevision), nil
 	}
-	defer func() { git.Mocks.MergeBase = nil }()
+	t.Cleanup(func() { git.Mocks.MergeBase = nil })
 
 	input := &RepositoryComparisonInput{Base: &wantBaseRevision, Head: &wantHeadRevision}
 	repoResolver := NewRepositoryResolver(repo)

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -50,13 +50,13 @@ func TestRepositoryComparison(t *testing.T) {
 	}
 	defer func() { git.Mocks.ExecReader = nil }()
 
-	git.Mocks.ExecSafe = func(args []string) (stdout, stderr []byte, exitCode int, err error) {
-		if len(args) < 3 || args[0] != "merge-base" || args[1] != wantBaseRevision || args[2] != wantHeadRevision {
-			t.Fatalf("gitserver.ExecSafe received wrong args: %v", args)
+	git.Mocks.MergeBase = func(repo gitserver.Repo, a, b api.CommitID) (api.CommitID, error) {
+		if string(a) != wantBaseRevision || string(b) != wantHeadRevision {
+			t.Fatalf("gitserver.MergeBase received wrong args: %s %s", a, b)
 		}
-		return []byte(wantMergeBaseRevision), []byte{}, 0, nil
+		return api.CommitID(wantMergeBaseRevision), nil
 	}
-	defer func() { git.Mocks.ExecSafe = nil }()
+	defer func() { git.Mocks.MergeBase = nil }()
 
 	input := &RepositoryComparisonInput{Base: &wantBaseRevision, Head: &wantHeadRevision}
 	repoResolver := NewRepositoryResolver(repo)

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -25,6 +25,7 @@ func TestRepositoryComparison(t *testing.T) {
 	ctx := context.Background()
 
 	wantBaseRevision := "24f7ca7c1190835519e261d7eefa09df55ceea4f"
+	wantMergeBaseRevision := "a7985dde7f92ad3490ec513be78fa2b365c7534c"
 	wantHeadRevision := "b69072d5f687b31b9f6ae3ceafdc24c259c4b9ec"
 
 	repo := &types.Repo{
@@ -33,7 +34,7 @@ func TestRepositoryComparison(t *testing.T) {
 	}
 
 	git.Mocks.GetCommit = func(id api.CommitID) (*git.Commit, error) {
-		if string(id) != wantBaseRevision && string(id) != wantHeadRevision {
+		if string(id) != wantMergeBaseRevision && string(id) != wantHeadRevision {
 			t.Fatalf("GetCommit received wrong ID: %s", id)
 		}
 
@@ -48,6 +49,14 @@ func TestRepositoryComparison(t *testing.T) {
 		return ioutil.NopCloser(strings.NewReader(testDiff)), nil
 	}
 	defer func() { git.Mocks.ExecReader = nil }()
+
+	git.Mocks.ExecSafe = func(args []string) (stdout, stderr []byte, exitCode int, err error) {
+		if len(args) < 3 && args[0] != "merge-base" && args[1] != wantBaseRevision && args[2] != wantHeadRevision {
+			t.Fatalf("gitserver.ExecSafe received wrong args: %v", args)
+		}
+		return []byte(wantMergeBaseRevision), []byte{}, 0, nil
+	}
+	defer func() { git.Mocks.ExecSafe = nil }()
 
 	input := &RepositoryComparisonInput{Base: &wantBaseRevision, Head: &wantHeadRevision}
 	repoResolver := NewRepositoryResolver(repo)
@@ -183,8 +192,16 @@ func TestRepositoryComparison(t *testing.T) {
 				t.Fatalf("wrong diffstat. want=%q, have=%q", wantStat, have)
 			}
 
-			if n.OldFile() == nil {
+			oldFile := n.OldFile()
+			if oldFile == nil {
 				t.Fatalf("OldFile() is nil")
+			}
+			gitBlob, ok := oldFile.ToGitBlob()
+			if !ok {
+				t.Fatalf("OldFile() is no GitBlob")
+			}
+			if have, want := string(gitBlob.Commit().OID()), wantMergeBaseRevision; have != want {
+				t.Fatalf("Got wrong commit ID for OldFile(): want=%s have=%s", want, have)
 			}
 			newFile := n.NewFile()
 			if newFile == nil {

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/pkg/errors"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1234,7 +1234,7 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 		}
 		return api.CommitID(testBaseRevision), nil
 	}
-	defer func() { git.Mocks.MergeBase = nil }()
+	t.Cleanup(func() { git.Mocks.MergeBase = nil })
 
 	// repo & external service setup
 	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -118,6 +118,7 @@ var (
 		"rev-list":     {"--max-parents", "--reverse", "--max-count"},
 		"ls-remote":    {"--get-url"},
 		"symbolic-ref": {"--short"},
+		"merge-base":   {},
 	}
 
 	// `git log`, `git show`, `git diff`, etc., share a large common set of whitelisted args.

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -118,7 +118,6 @@ var (
 		"rev-list":     {"--max-parents", "--reverse", "--max-count"},
 		"ls-remote":    {"--get-url"},
 		"symbolic-ref": {"--short"},
-		"merge-base":   {},
 	}
 
 	// `git log`, `git show`, `git diff`, etc., share a large common set of whitelisted args.

--- a/internal/vcs/git/merge_base.go
+++ b/internal/vcs/git/merge_base.go
@@ -13,6 +13,9 @@ import (
 
 // MergeBase returns the merge base commit for the specified commits.
 func MergeBase(ctx context.Context, repo gitserver.Repo, a, b api.CommitID) (api.CommitID, error) {
+	if Mocks.MergeBase != nil {
+		return Mocks.MergeBase(repo, a, b)
+	}
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: MergeBase")
 	span.SetTag("A", a)
 	span.SetTag("B", b)

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -24,6 +24,7 @@ var Mocks, emptyMocks struct {
 	Stat             func(commit api.CommitID, name string) (os.FileInfo, error)
 	GetObject        func(objectName string) (OID, ObjectType, error)
 	Commits          func(repo gitserver.Repo, opt CommitsOptions) ([]*Commit, error)
+	MergeBase        func(repo gitserver.Repo, a, b api.CommitID) (api.CommitID, error)
 }
 
 // ResetMocks clears the mock functions set on Mocks (so that subsequent tests don't inadvertently


### PR DESCRIPTION
The merge base is the commit that the diff applies to, not the specified base OID. Hence, we need to find the merge-base and use that as the base in the file.