### PR TITLE
campaigns: Reload after toggling the feature flag

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -356,7 +356,7 @@ type Mutation {
         # A JSON object containing the entire site configuration. The previous site configuration will be replaced
         # with this new value.
         input: String!
-    ): SiteConfigurationActions!
+    ): OverwriteSiteConfigurationResult!
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.
@@ -3386,7 +3386,7 @@ type SiteConfiguration {
 }
 
 # The actions to be taken after the site configuration has been updated.
-type SiteConfigurationActions {
+type OverwriteSiteConfigurationResult {
     # Whether the frontend needs to be reloaded.
     frontendReloadRequired: Boolean!
     # Whether a server restart is required.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3387,8 +3387,8 @@ type SiteConfiguration {
 
 # The actions to be taken after the site configuration has been updated.
 type OverwriteSiteConfigurationResult {
-    # Whether the frontend needs to be reloaded.
-    frontendReloadRequired: Boolean!
+    # Whether the client UI needs to be reloaded.
+    clientReloadRequired: Boolean!
     # Whether a server restart is required.
     serverRestartRequired: Boolean!
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -334,6 +334,8 @@ type Mutation {
     # Updates the site configuration. Returns whether or not a restart is required for the update to be applied.
     #
     # Only site admins may perform this mutation.
+    #
+    # DEPRECATED: Use overwriteSiteConfiguration instead. This mutation will be removed in a future release.
     updateSiteConfiguration(
         # The last ID of the site configuration that is known by the client, to
         # prevent race conditions. An error will be returned if someone else
@@ -342,7 +344,19 @@ type Mutation {
         # A JSON object containing the entire site configuration. The previous site configuration will be replaced
         # with this new value.
         input: String!
-    ): Boolean!
+    ): Boolean! @deprecated(reason: "use overwriteSiteConfiguration instead")
+    # Overwrites the site configuration. Returns the actions required for the update to be applied.
+    #
+    # Only site admins may perform this mutation.
+    overwriteSiteConfiguration(
+        # The last ID of the site configuration that is known by the client, to
+        # prevent race conditions. An error will be returned if someone else
+        # has already written a new update.
+        lastID: Int!
+        # A JSON object containing the entire site configuration. The previous site configuration will be replaced
+        # with this new value.
+        input: String!
+    ): SiteConfigurationActions!
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.
@@ -3369,6 +3383,14 @@ type SiteConfiguration {
     # This includes both JSON Schema validation problems and other messages that perform more advanced checks
     # on the configuration (that can't be expressed in the JSON Schema).
     validationMessages: [String!]!
+}
+
+# The actions to be taken after the site configuration has been updated.
+type SiteConfigurationActions {
+    # Whether the frontend needs to be reloaded.
+    frontendReloadRequired: Boolean!
+    # Whether a server restart is required.
+    serverRestartRequired: Boolean!
 }
 
 # The critical configuration for a site.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -358,7 +358,7 @@ type Mutation {
         # A JSON object containing the entire site configuration. The previous site configuration will be replaced
         # with this new value.
         input: String!
-    ): SiteConfigurationActions!
+    ): OverwriteSiteConfigurationResult!
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.
@@ -3393,7 +3393,7 @@ type SiteConfiguration {
 }
 
 # The actions to be taken after the site configuration has been updated.
-type SiteConfigurationActions {
+type OverwriteSiteConfigurationResult {
     # Whether the frontend needs to be reloaded.
     frontendReloadRequired: Boolean!
     # Whether a server restart is required.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3394,8 +3394,8 @@ type SiteConfiguration {
 
 # The actions to be taken after the site configuration has been updated.
 type OverwriteSiteConfigurationResult {
-    # Whether the frontend needs to be reloaded.
-    frontendReloadRequired: Boolean!
+    # Whether the client UI needs to be reloaded.
+    clientReloadRequired: Boolean!
     # Whether a server restart is required.
     serverRestartRequired: Boolean!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -336,6 +336,8 @@ type Mutation {
     # Updates the site configuration. Returns whether or not a restart is required for the update to be applied.
     #
     # Only site admins may perform this mutation.
+    #
+    # DEPRECATED: Use overwriteSiteConfiguration instead. This mutation will be removed in a future release.
     updateSiteConfiguration(
         # The last ID of the site configuration that is known by the client, to
         # prevent race conditions. An error will be returned if someone else
@@ -344,7 +346,19 @@ type Mutation {
         # A JSON object containing the entire site configuration. The previous site configuration will be replaced
         # with this new value.
         input: String!
-    ): Boolean!
+    ): Boolean! @deprecated(reason: "use overwriteSiteConfiguration instead")
+    # Overwrites the site configuration. Returns the actions required for the update to be applied.
+    #
+    # Only site admins may perform this mutation.
+    overwriteSiteConfiguration(
+        # The last ID of the site configuration that is known by the client, to
+        # prevent race conditions. An error will be returned if someone else
+        # has already written a new update.
+        lastID: Int!
+        # A JSON object containing the entire site configuration. The previous site configuration will be replaced
+        # with this new value.
+        input: String!
+    ): SiteConfigurationActions!
     # Sets whether the user with the specified user ID is a site admin.
     #
     # Only site admins may perform this mutation.
@@ -3376,6 +3390,14 @@ type SiteConfiguration {
     # This includes both JSON Schema validation problems and other messages that perform more advanced checks
     # on the configuration (that can't be expressed in the JSON Schema).
     validationMessages: [String!]!
+}
+
+# The actions to be taken after the site configuration has been updated.
+type SiteConfigurationActions {
+    # Whether the frontend needs to be reloaded.
+    frontendReloadRequired: Boolean!
+    # Whether a server restart is required.
+    serverRestartRequired: Boolean!
 }
 
 # The critical configuration for a site.

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -189,12 +189,12 @@ func (r *schemaResolver) overwriteSiteConfiguration(ctx context.Context, args *s
 }
 
 type overwriteSiteConfigurationResult struct {
-	frontendReloadRequired bool
-	serverRestartRequired  bool
+	clientReloadRequired  bool
+	serverRestartRequired bool
 }
 
-func (sca *overwriteSiteConfigurationResult) FrontendReloadRequired() bool {
-	return sca.frontendReloadRequired
+func (sca *overwriteSiteConfigurationResult) ClientReloadRequired() bool {
+	return sca.clientReloadRequired
 }
 func (sca *overwriteSiteConfigurationResult) ServerRestartRequired() bool {
 	return sca.serverRestartRequired
@@ -209,8 +209,8 @@ func (r *schemaResolver) OverwriteSiteConfiguration(ctx context.Context, args *s
 		return nil, err
 	}
 	return &overwriteSiteConfigurationResult{
-		frontendReloadRequired: result.FrontendReloadRequired,
-		serverRestartRequired:  result.ServerRestartRequired,
+		clientReloadRequired:  result.ClientReloadRequired,
+		serverRestartRequired: result.ServerRestartRequired,
 	}, nil
 }
 

--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -44,8 +44,8 @@ func ParseConfig(data conftypes.RawUnified) (*Unified, error) {
 // ConfigWriteResult defines the actions that should be performed after a config
 // property is changed in order for the user to see the change take effect.
 type ConfigWriteResult struct {
-	FrontendReloadRequired bool
-	ServerRestartRequired  bool
+	ClientReloadRequired  bool
+	ServerRestartRequired bool
 }
 
 type configPropertyResultSchema map[string]ConfigWriteResult
@@ -61,7 +61,7 @@ var configPropertiesRequiringAction = configPropertyResultSchema{
 	"auth.sessionExpiry":               {ServerRestartRequired: true},
 	"auth.userOrgMap":                  {ServerRestartRequired: true},
 	"disablePublicRepoRedirects":       {ServerRestartRequired: true},
-	"experimentalFeatures::automation": {FrontendReloadRequired: true},
+	"experimentalFeatures::automation": {ClientReloadRequired: true},
 	"extensions":                       {ServerRestartRequired: true},
 	"externalURL":                      {ServerRestartRequired: true},
 	"git.cloneURLToRepositoryName":     {ServerRestartRequired: true},
@@ -79,8 +79,8 @@ func calculateConfigChangeResult(before, after *Unified, schema configPropertyRe
 	// should be set.
 	for option := range diff(before, after) {
 		if optionResult, ok := schema[option]; ok {
-			if optionResult.FrontendReloadRequired {
-				result.FrontendReloadRequired = true
+			if optionResult.ClientReloadRequired {
+				result.ClientReloadRequired = true
 			}
 			if optionResult.ServerRestartRequired {
 				result.ServerRestartRequired = true

--- a/internal/conf/parse_test.go
+++ b/internal/conf/parse_test.go
@@ -1,0 +1,94 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+)
+
+func TestPropertyActions(t *testing.T) {
+	// Set up a fake schema that covers the required scenarios.
+	schema := configPropertyActionSchema{
+		"experimentalFeatures::automation": {FrontendReloadRequired: true},
+		"externalURL":                      {FrontendReloadRequired: true, ServerRestartRequired: true},
+		"email.address":                    {},
+		"licenseKey":                       {ServerRestartRequired: true},
+	}
+
+	// Set up an empty configuration to use as the "before" in our tests.
+	empty, err := ParseConfig(conftypes.RawUnified{
+		Site: `{}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("empty configurations", func(t *testing.T) {
+		have := needActionToApply(empty, empty, schema)
+		want := PostConfigWriteActions{FrontendReloadRequired: false, ServerRestartRequired: false}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("unexpected actions: %s", diff)
+		}
+	})
+
+	t.Run("no action required", func(t *testing.T) {
+		config, err := ParseConfig(conftypes.RawUnified{
+			Site: `{"email.address":"foo@bar.quux"}`,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have := needActionToApply(empty, config, schema)
+		want := PostConfigWriteActions{FrontendReloadRequired: false, ServerRestartRequired: false}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("unexpected actions: %s", diff)
+		}
+	})
+
+	t.Run("frontend reload required", func(t *testing.T) {
+		config, err := ParseConfig(conftypes.RawUnified{
+			Site: `{"email.address":"foo@bar.quux", "experimentalFeatures": {"automation": "enabled"}}`,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have := needActionToApply(empty, config, schema)
+		want := PostConfigWriteActions{FrontendReloadRequired: true, ServerRestartRequired: false}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("unexpected actions: %s", diff)
+		}
+	})
+
+	t.Run("server restart required", func(t *testing.T) {
+		config, err := ParseConfig(conftypes.RawUnified{
+			Site: `{"email.address":"foo@bar.quux", "licenseKey": "foo"}`,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have := needActionToApply(empty, config, schema)
+		want := PostConfigWriteActions{FrontendReloadRequired: false, ServerRestartRequired: true}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("unexpected actions: %s", diff)
+		}
+	})
+
+	t.Run("frontend reload and server restart required", func(t *testing.T) {
+		config, err := ParseConfig(conftypes.RawUnified{
+			Site: `{"email.address":"foo@bar.quux", "experimentalFeatures": {"automation": "enabled"}, "licenseKey": "foo"}`,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have := needActionToApply(empty, config, schema)
+		want := PostConfigWriteActions{FrontendReloadRequired: true, ServerRestartRequired: true}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("unexpected actions: %s", diff)
+		}
+	})
+}

--- a/internal/conf/parse_test.go
+++ b/internal/conf/parse_test.go
@@ -10,8 +10,8 @@ import (
 func TestCalculateConfigChangeResult(t *testing.T) {
 	// Set up a fake schema that covers the required scenarios.
 	schema := configPropertyResultSchema{
-		"experimentalFeatures::automation": {FrontendReloadRequired: true},
-		"externalURL":                      {FrontendReloadRequired: true, ServerRestartRequired: true},
+		"experimentalFeatures::automation": {ClientReloadRequired: true},
+		"externalURL":                      {ClientReloadRequired: true, ServerRestartRequired: true},
 		"email.address":                    {},
 		"licenseKey":                       {ServerRestartRequired: true},
 	}
@@ -26,7 +26,7 @@ func TestCalculateConfigChangeResult(t *testing.T) {
 
 	t.Run("empty configurations", func(t *testing.T) {
 		have := calculateConfigChangeResult(empty, empty, schema)
-		want := ConfigWriteResult{FrontendReloadRequired: false, ServerRestartRequired: false}
+		want := ConfigWriteResult{ClientReloadRequired: false, ServerRestartRequired: false}
 		if diff := cmp.Diff(have, want); diff != "" {
 			t.Fatalf("unexpected result: %s", diff)
 		}
@@ -41,7 +41,7 @@ func TestCalculateConfigChangeResult(t *testing.T) {
 		}
 
 		have := calculateConfigChangeResult(empty, config, schema)
-		want := ConfigWriteResult{FrontendReloadRequired: false, ServerRestartRequired: false}
+		want := ConfigWriteResult{ClientReloadRequired: false, ServerRestartRequired: false}
 		if diff := cmp.Diff(have, want); diff != "" {
 			t.Fatalf("unexpected result: %s", diff)
 		}
@@ -56,7 +56,7 @@ func TestCalculateConfigChangeResult(t *testing.T) {
 		}
 
 		have := calculateConfigChangeResult(empty, config, schema)
-		want := ConfigWriteResult{FrontendReloadRequired: true, ServerRestartRequired: false}
+		want := ConfigWriteResult{ClientReloadRequired: true, ServerRestartRequired: false}
 		if diff := cmp.Diff(have, want); diff != "" {
 			t.Fatalf("unexpected result: %s", diff)
 		}
@@ -71,7 +71,7 @@ func TestCalculateConfigChangeResult(t *testing.T) {
 		}
 
 		have := calculateConfigChangeResult(empty, config, schema)
-		want := ConfigWriteResult{FrontendReloadRequired: false, ServerRestartRequired: true}
+		want := ConfigWriteResult{ClientReloadRequired: false, ServerRestartRequired: true}
 		if diff := cmp.Diff(have, want); diff != "" {
 			t.Fatalf("unexpected result: %s", diff)
 		}
@@ -86,7 +86,7 @@ func TestCalculateConfigChangeResult(t *testing.T) {
 		}
 
 		have := calculateConfigChangeResult(empty, config, schema)
-		want := ConfigWriteResult{FrontendReloadRequired: true, ServerRestartRequired: true}
+		want := ConfigWriteResult{ClientReloadRequired: true, ServerRestartRequired: true}
 		if diff := cmp.Diff(have, want); diff != "" {
 			t.Fatalf("unexpected result: %s", diff)
 		}

--- a/internal/conf/parse_test.go
+++ b/internal/conf/parse_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
-func TestConfigChangeResult(t *testing.T) {
+func TestCalculateConfigChangeResult(t *testing.T) {
 	// Set up a fake schema that covers the required scenarios.
 	schema := configPropertyResultSchema{
 		"experimentalFeatures::automation": {FrontendReloadRequired: true},

--- a/internal/conf/parse_test.go
+++ b/internal/conf/parse_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
-func TestPropertyActions(t *testing.T) {
+func TestConfigChangeResult(t *testing.T) {
 	// Set up a fake schema that covers the required scenarios.
-	schema := configPropertyActionSchema{
+	schema := configPropertyResultSchema{
 		"experimentalFeatures::automation": {FrontendReloadRequired: true},
 		"externalURL":                      {FrontendReloadRequired: true, ServerRestartRequired: true},
 		"email.address":                    {},
@@ -25,10 +25,10 @@ func TestPropertyActions(t *testing.T) {
 	}
 
 	t.Run("empty configurations", func(t *testing.T) {
-		have := needActionToApply(empty, empty, schema)
-		want := PostConfigWriteActions{FrontendReloadRequired: false, ServerRestartRequired: false}
+		have := calculateConfigChangeResult(empty, empty, schema)
+		want := ConfigWriteResult{FrontendReloadRequired: false, ServerRestartRequired: false}
 		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatalf("unexpected actions: %s", diff)
+			t.Fatalf("unexpected result: %s", diff)
 		}
 	})
 
@@ -40,10 +40,10 @@ func TestPropertyActions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		have := needActionToApply(empty, config, schema)
-		want := PostConfigWriteActions{FrontendReloadRequired: false, ServerRestartRequired: false}
+		have := calculateConfigChangeResult(empty, config, schema)
+		want := ConfigWriteResult{FrontendReloadRequired: false, ServerRestartRequired: false}
 		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatalf("unexpected actions: %s", diff)
+			t.Fatalf("unexpected result: %s", diff)
 		}
 	})
 
@@ -55,10 +55,10 @@ func TestPropertyActions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		have := needActionToApply(empty, config, schema)
-		want := PostConfigWriteActions{FrontendReloadRequired: true, ServerRestartRequired: false}
+		have := calculateConfigChangeResult(empty, config, schema)
+		want := ConfigWriteResult{FrontendReloadRequired: true, ServerRestartRequired: false}
 		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatalf("unexpected actions: %s", diff)
+			t.Fatalf("unexpected result: %s", diff)
 		}
 	})
 
@@ -70,10 +70,10 @@ func TestPropertyActions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		have := needActionToApply(empty, config, schema)
-		want := PostConfigWriteActions{FrontendReloadRequired: false, ServerRestartRequired: true}
+		have := calculateConfigChangeResult(empty, config, schema)
+		want := ConfigWriteResult{FrontendReloadRequired: false, ServerRestartRequired: true}
 		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatalf("unexpected actions: %s", diff)
+			t.Fatalf("unexpected result: %s", diff)
 		}
 	})
 
@@ -85,10 +85,10 @@ func TestPropertyActions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		have := needActionToApply(empty, config, schema)
-		want := PostConfigWriteActions{FrontendReloadRequired: true, ServerRestartRequired: true}
+		have := calculateConfigChangeResult(empty, config, schema)
+		want := ConfigWriteResult{FrontendReloadRequired: true, ServerRestartRequired: true}
 		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatalf("unexpected actions: %s", diff)
+			t.Fatalf("unexpected result: %s", diff)
 		}
 	})
 }

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -194,6 +194,9 @@ func (s *Server) updateFromSource(ctx context.Context) (PostConfigWriteActions, 
 	if actions.ServerRestartRequired {
 		s.markNeedServerRestart()
 	}
+	// We don't persist the frontend reload state here because we can't monitor
+	// if the user has actually done it: instead, we'll just report that
+	// synchronously now in the return value, but otherwise drop it.
 
 	return actions, nil
 }

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -512,7 +512,7 @@ export class Driver {
             request: gql`
                 mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
                     overwriteSiteConfiguration(lastID: $lastID, input: $input) {
-                        frontendReloadRequired
+                        clientReloadRequired
                         serverRestartRequired
                     }
                 }

--- a/shared/src/e2e/driver.ts
+++ b/shared/src/e2e/driver.ts
@@ -508,15 +508,18 @@ export class Driver {
         const { site } = dataOrThrowErrors(currentConfigResponse)
         const currentConfig = site.configuration.effectiveContents
         const newConfig = modifyJSONC(currentConfig, path, f)
-        const updateConfigResponse = await this.makeGraphQLRequest<IMutation>({
+        const overwriteConfigResponse = await this.makeGraphQLRequest<IMutation>({
             request: gql`
-                mutation UpdateSiteConfiguration($lastID: Int!, $input: String!) {
-                    updateSiteConfiguration(lastID: $lastID, input: $input)
+                mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
+                    overwriteSiteConfiguration(lastID: $lastID, input: $input) {
+                        frontendReloadRequired
+                        serverRestartRequired
+                    }
                 }
             `,
             variables: { lastID: site.configuration.id, input: newConfig },
         })
-        dataOrThrowErrors(updateConfigResponse)
+        dataOrThrowErrors(overwriteConfigResponse)
     }
 
     public async ensureHasCORSOrigin({ corsOriginURL }: { corsOriginURL: string }): Promise<void> {

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -854,31 +854,6 @@ export function fetchSiteConfiguration({
 }
 
 /**
- * Updates the site's configuration.
- *
- * @returns An observable indicating whether or not a service restart is
- * required for the update to be applied.
- */
-export function updateSiteConfiguration(
-    { requestGraphQL }: Pick<PlatformContext, 'requestGraphQL'>,
-    lastID: number,
-    input: string
-): Observable<boolean> {
-    return requestGraphQL<GQL.IMutation>({
-        request: gql`
-            mutation UpdateSiteConfiguration($lastID: Int!, $input: String!) {
-                updateSiteConfiguration(lastID: $lastID, input: $input)
-            }
-        `,
-        variables: { lastID, input },
-        mightContainPrivateInfo: true,
-    }).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.updateSiteConfiguration)
-    )
-}
-
-/**
  * Overwrites the site's configuration.
  *
  * @returns An observable indicating whether a service restart and/or frontend

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -877,3 +877,28 @@ export function updateSiteConfiguration(
         map(data => data.updateSiteConfiguration)
     )
 }
+
+/**
+ * Overwrites the site's configuration.
+ *
+ * @returns An observable indicating whether a service restart and/or frontend
+ * reload is required for the update to be applied.
+ */
+export function overwriteSiteConfiguration(
+    { requestGraphQL }: Pick<PlatformContext, 'requestGraphQL'>,
+    lastID: number,
+    input: string
+): Observable<GQL.ISiteConfigurationActions> {
+    return requestGraphQL<GQL.IMutation>({
+        request: gql`
+            mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
+                overwriteSiteConfiguration(lastID: $lastID, input: $input)
+            }
+        `,
+        variables: { lastID, input },
+        mightContainPrivateInfo: true,
+    }).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.overwriteSiteConfiguration)
+    )
+}

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -868,7 +868,7 @@ export function overwriteSiteConfiguration(
         request: gql`
             mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
                 overwriteSiteConfiguration(lastID: $lastID, input: $input) {
-                    frontendReloadRequired
+                    clientReloadRequired
                     serverRestartRequired
                 }
             }

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -892,7 +892,10 @@ export function overwriteSiteConfiguration(
     return requestGraphQL<GQL.IMutation>({
         request: gql`
             mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
-                overwriteSiteConfiguration(lastID: $lastID, input: $input)
+                overwriteSiteConfiguration(lastID: $lastID, input: $input) {
+                    frontendReloadRequired
+                    serverRestartRequired
+                }
             }
         `,
         variables: { lastID, input },

--- a/web/src/regression/util/api.ts
+++ b/web/src/regression/util/api.ts
@@ -863,7 +863,7 @@ export function overwriteSiteConfiguration(
     { requestGraphQL }: Pick<PlatformContext, 'requestGraphQL'>,
     lastID: number,
     input: string
-): Observable<GQL.ISiteConfigurationActions> {
+): Observable<GQL.IOverwriteSiteConfigurationResult> {
     return requestGraphQL<GQL.IMutation>({
         request: gql`
             mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {

--- a/web/src/regression/util/helpers.ts
+++ b/web/src/regression/util/helpers.ts
@@ -227,7 +227,7 @@ export async function editGlobalSettings(
 export async function editSiteConfig(
     gqlClient: GraphQLClient,
     ...edits: ((contents: string) => jsonc.Edit[])[]
-): Promise<{ destroy: ResourceDestructor; result: GQL.ISiteConfigurationActions }> {
+): Promise<{ destroy: ResourceDestructor; result: GQL.IOverwriteSiteConfigurationResult }> {
     const origConfig = await fetchSiteConfiguration(gqlClient).toPromise()
     let newContents = origConfig.configuration.effectiveContents
     for (const editFn of edits) {

--- a/web/src/regression/util/helpers.ts
+++ b/web/src/regression/util/helpers.ts
@@ -15,7 +15,7 @@ import {
     deleteOrganization,
     getViewerSettings,
     fetchSiteConfiguration,
-    updateSiteConfiguration,
+    overwriteSiteConfiguration,
 } from './api'
 import { Config } from '../../../../shared/src/e2e/config'
 import { ResourceDestructor } from './TestResourceManager'
@@ -227,17 +227,17 @@ export async function editGlobalSettings(
 export async function editSiteConfig(
     gqlClient: GraphQLClient,
     ...edits: ((contents: string) => jsonc.Edit[])[]
-): Promise<{ destroy: ResourceDestructor; result: boolean }> {
+): Promise<{ destroy: ResourceDestructor; result: GQL.ISiteConfigurationActions }> {
     const origConfig = await fetchSiteConfiguration(gqlClient).toPromise()
     let newContents = origConfig.configuration.effectiveContents
     for (const editFn of edits) {
         newContents = jsonc.applyEdits(newContents, editFn(newContents))
     }
     return {
-        result: await updateSiteConfiguration(gqlClient, origConfig.configuration.id, newContents).toPromise(),
+        result: await overwriteSiteConfiguration(gqlClient, origConfig.configuration.id, newContents).toPromise(),
         destroy: async () => {
             const c = await fetchSiteConfiguration(gqlClient).toPromise()
-            await updateSiteConfiguration(
+            await overwriteSiteConfiguration(
                 gqlClient,
                 c.configuration.id,
                 origConfig.configuration.effectiveContents

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -254,14 +254,14 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                             })
                         )
                     }),
-                    tap(({ frontendReloadRequired, serverRestartRequired }) => {
+                    tap(({ clientReloadRequired, serverRestartRequired }) => {
                         // If the frontend has to be reloaded, let's just do it
                         // now: we know that the user just saved and has no
                         // local state that isn't persisted somewhere, so it's a
                         // good opportunity to do it. If they also need to
                         // restart the server, that message is persistent and
                         // will come back after the reload via the JSContext.
-                        if (frontendReloadRequired) {
+                        if (clientReloadRequired) {
                             window.location.reload()
                         }
 

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -461,26 +461,6 @@ export function fetchAllConfigAndSettings(): Observable<AllConfig> {
 }
 
 /**
- * Updates the site's configuration.
- *
- * @returns An observable indicating whether or not a service restart is
- * required for the update to be applied.
- */
-export function updateSiteConfiguration(lastID: number, input: string): Observable<boolean> {
-    return mutateGraphQL(
-        gql`
-            mutation UpdateSiteConfiguration($lastID: Int!, $input: String!) {
-                updateSiteConfiguration(lastID: $lastID, input: $input)
-            }
-        `,
-        { lastID, input }
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.updateSiteConfiguration)
-    )
-}
-
-/**
  * Overwrites the site's configuration.
  *
  * @returns An observable indicating whether a service restart and/or frontend

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -474,7 +474,7 @@ export function overwriteSiteConfiguration(
         gql`
             mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
                 overwriteSiteConfiguration(lastID: $lastID, input: $input) {
-                    frontendReloadRequired
+                    clientReloadRequired
                     serverRestartRequired
                 }
             }

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -466,7 +466,10 @@ export function fetchAllConfigAndSettings(): Observable<AllConfig> {
  * @returns An observable indicating whether a service restart and/or frontend
  * reload is required for the update to be applied.
  */
-export function overwriteSiteConfiguration(lastID: number, input: string): Observable<GQL.ISiteConfigurationActions> {
+export function overwriteSiteConfiguration(
+    lastID: number,
+    input: string
+): Observable<GQL.IOverwriteSiteConfigurationResult> {
     return mutateGraphQL(
         gql`
             mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -481,6 +481,29 @@ export function updateSiteConfiguration(lastID: number, input: string): Observab
 }
 
 /**
+ * Overwrites the site's configuration.
+ *
+ * @returns An observable indicating whether a service restart and/or frontend
+ * reload is required for the update to be applied.
+ */
+export function overwriteSiteConfiguration(lastID: number, input: string): Observable<GQL.ISiteConfigurationActions> {
+    return mutateGraphQL(
+        gql`
+            mutation OverwriteSiteConfiguration($lastID: Int!, $input: String!) {
+                overwriteSiteConfiguration(lastID: $lastID, input: $input) {
+                    frontendReloadRequired
+                    serverRestartRequired
+                }
+            }
+        `,
+        { lastID, input }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.overwriteSiteConfiguration)
+    )
+}
+
+/**
  * Reloads the site.
  */
 export function reloadSite(): Observable<void> {


### PR DESCRIPTION
This PR will reload the user's frontend if they've just toggled the Campaigns feature flag. Simple, right?

Interesting bits:

1. We can now define whether the frontend should be reloaded on a per configuration setting basis.
2. Configuration change results are now reported on a per-change basis, rather than relying on global site state.
3. As the previous `updateSiteConfiguration` mutation couldn't be extended to report more than a `Boolean!`, a new `overwriteSiteConfiguration` mutation has been added with similar semantics, but a more extensible return value. We should remove `updateSiteConfiguration` in a couple of versions, per [the GraphQL making breaking changes documentation](https://docs.sourcegraph.com/dev/graphql_api#making-breaking-changes). (What's our process there? File an issue?)

Fixes #10715.