### PR TITLE
codeintel: Add scheme to frontend URL in indexer

### DIFF
--- a/cmd/precise-code-intel-indexer/internal/indexer/processor.go
+++ b/cmd/precise-code-intel-indexer/internal/indexer/processor.go
@@ -64,7 +64,7 @@ func (p *processor) upload(ctx context.Context, repoDir string, index db.Index) 
 	}
 
 	args := []string{
-		fmt.Sprintf("-endpoint=%s", p.frontendURL),
+		fmt.Sprintf("-endpoint=http://%s", p.frontendURL),
 		"lsif",
 		"upload",
 		fmt.Sprintf("-repo=%s", repoName),


### PR DESCRIPTION
Dotcom is seeing a lot of errors like 

```
Post sourcegraph-frontend-internal/.api/lsif/upload?commit=6a8421bcff44c2a9889075724070baaebf8dcd72&indexerName=lsif-go&repository=github.com%2Frobfig%2Fcron: unsupported protocol scheme ""+
```

because the SRC_FRONTEND_URL is a host/port pair only. 