### PR TITLE
search: disable parentheses heuristic for recognized operators

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -480,7 +480,7 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	start := p.pos
 	pieces, advance, ok := ScanSearchPatternHeuristic(p.buf[p.pos:])
 	end := start + advance
-	if !ok || len(p.buf[start:end]) == 0 || !isPureSearchPattern(p.buf[start:end]) {
+	if !ok || len(p.buf[start:end]) == 0 || !isPureSearchPattern(p.buf[start:end]) || ContainsAndOrKeyword(string(p.buf[start:end])) {
 		// We tried validating the pattern but it is either unbalanced
 		// or malformed, empty, or an invalid and/or expression.
 		return Pattern{}, false

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -531,6 +531,12 @@ func TestParse(t *testing.T) {
 			WantGrammar:   Spec(`(concat "x" (or "y" "f"))`),
 			WantHeuristic: Diff(`(concat "()" "x" "()" (or "y" "()" "f") "()")`),
 		},
+		{
+			Name:          "disable parens as patterns heuristic if containing recognized operator",
+			Input:         "(() or ())",
+			WantGrammar:   Spec(`""`),
+			WantHeuristic: Diff(`(or "()" "()")`),
+		},
 		// Escaping.
 		{
 			Input:         `\(\)`,


### PR DESCRIPTION
We want a pattern like `(() main func())` to be treated literally according to the heuristic that recognizes this input. This same heuristic will interpret `(() or main())` literally, but in this case, the subexpression is a valid or-expression that we should parse rather than apply this heuristic.

This PR fixes the above, but really it is a stopgap because as I'm introducing more complex testing cases, I'm realizing that this heuristic doesn't really cut it for the behaviors we care about, and I will rework this logic soon.