### PR TITLE
search: interpret escaped parentheses in heuristic

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -480,7 +480,7 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	start := p.pos
 	pieces, advance, ok := ScanSearchPatternHeuristic(p.buf[p.pos:])
 	end := start + advance
-	if !ok || len(p.buf[start:end]) == 0 || !isPureSearchPattern(p.buf[start:end]) {
+	if !ok || len(p.buf[start:end]) == 0 || !isPureSearchPattern(p.buf[start:end]) || ContainsAndOrKeyword(string(p.buf[start:end])) {
 		// We tried validating the pattern but it is either unbalanced
 		// or malformed, empty, or an invalid and/or expression.
 		return Pattern{}, false

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -432,9 +432,9 @@ loop:
 					continue
 				}
 				switch r {
-				case 'a', 'b', 'f', 'v', '(', ')':
+				case 'a', 'b', 'f', 'v':
 					piece = append(piece, '\\', r)
-				case ':', '\\', '"', '\'':
+				case ':', '\\', '"', '\'', '(', ')':
 					piece = append(piece, r)
 				case 'n':
 					piece = append(piece, '\n')

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -531,6 +531,12 @@ func TestParse(t *testing.T) {
 			WantGrammar:   Spec(`(concat "x" (or "y" "f"))`),
 			WantHeuristic: Diff(`(concat "()" "x" "()" (or "y" "()" "f") "()")`),
 		},
+		{
+			Name:          "disable parens as patterns heuristic if containing recognized operator",
+			Input:         "(() or ())",
+			WantGrammar:   Spec(`""`),
+			WantHeuristic: Diff(`(or "()" "()")`),
+		},
 		// Escaping.
 		{
 			Input:         `\(\)`,

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -540,13 +540,13 @@ func TestParse(t *testing.T) {
 		// Escaping.
 		{
 			Input:         `\(\)`,
-			WantGrammar:   `"\\(\\)"`,
-			WantHeuristic: Same,
+			WantGrammar:   Spec(`"\\(\\)"`),
+			WantHeuristic: Diff(`"()"`),
 		},
 		{
 			Input:         `\( \) ()`,
 			WantGrammar:   Spec(`(concat "\\(" "\\)")`),
-			WantHeuristic: Diff(`(concat "\\(" "\\)" "()")`),
+			WantHeuristic: Diff(`(concat "(" ")" "()")`),
 		},
 		{
 			Input:         `\ `,


### PR DESCRIPTION
DO NOT REVIEW, WIP. Description is for myself.

Stacked on #11128.

This PR changes a function that controls a heuristic when interpreting syntax like `()` as patterns versus expression groups. When this heuristic encounters escaped parentheses, like `\(\)`, it will interpret these (including slashes). We want to actually interpret this escape sequence here, since if this heuristic fires, it implies that the string is literal.
