### PR TITLE
Register LSIF upload endpoint in internal frontend

### DIFF
--- a/cmd/frontend/enterprise/codeintel_upload.go
+++ b/cmd/frontend/enterprise/codeintel_upload.go
@@ -14,6 +14,5 @@ var defaultHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Reques
 
 // NewCodeIntelUploadHandler is re-assigned by the enterprise frontend
 var NewCodeIntelUploadHandler CodeIntelUploadHandlerFactory = func(_ bool) http.Handler {
-	fmt.Printf("GOT DEFAULT HANDLER?\n")
 	return defaultHandler
 }

--- a/cmd/frontend/enterprise/codeintel_upload.go
+++ b/cmd/frontend/enterprise/codeintel_upload.go
@@ -1,7 +1,6 @@
 package enterprise
 
 import (
-	"fmt"
 	"net/http"
 )
 

--- a/cmd/frontend/enterprise/codeintel_upload.go
+++ b/cmd/frontend/enterprise/codeintel_upload.go
@@ -1,0 +1,19 @@
+package enterprise
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type CodeIntelUploadHandlerFactory func(internal bool) http.Handler
+
+var defaultHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte("codeintel upload is only available in enterprise"))
+})
+
+// NewCodeIntelUploadHandler is re-assigned by the enterprise frontend
+var NewCodeIntelUploadHandler CodeIntelUploadHandlerFactory = func(_ bool) http.Handler {
+	fmt.Printf("GOT DEFAULT HANDLER?\n")
+	return defaultHandler
+}

--- a/cmd/frontend/httpapi/proxy.go
+++ b/cmd/frontend/httpapi/proxy.go
@@ -1,8 +1,0 @@
-package httpapi
-
-import (
-	"net/http"
-)
-
-// NewCodeIntelUploadHandler is set by the enterprise frontend
-var NewCodeIntelUploadHandler func() http.Handler

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -18,9 +18,9 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/httpapi"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/pkg/updatecheck"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/loghandlers"
@@ -224,20 +224,14 @@ func Main(githubWebhook, bitbucketServerWebhook http.Handler) error {
 		return err
 	}
 
-	// httpapi.NewCodeIntelUploadHandler is set by the enterprise frontend
-	var codeintelUploadHandler http.Handler
-	if httpapi.NewCodeIntelUploadHandler != nil {
-		codeintelUploadHandler = httpapi.NewCodeIntelUploadHandler()
-	}
-
 	// Create the external HTTP handler.
-	externalHandler, err := newExternalHTTPHandler(schema, githubWebhook, bitbucketServerWebhook, codeintelUploadHandler)
+	externalHandler, err := newExternalHTTPHandler(schema, githubWebhook, bitbucketServerWebhook, enterprise.NewCodeIntelUploadHandler)
 	if err != nil {
 		return err
 	}
 
 	// The internal HTTP handler does not include the auth handlers.
-	internalHandler := newInternalHTTPHandler(schema)
+	internalHandler := newInternalHTTPHandler(schema, enterprise.NewCodeIntelUploadHandler)
 
 	// serve will serve externalHandler on l. It additionally handles graceful restarts.
 	srv := &httpServers{}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inconshreveable/log15"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/pkg/updatecheck"
 	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
@@ -30,7 +31,7 @@ import (
 //
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
-func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, bitbucketServerWebhook, codeintelUploadHandler http.Handler) http.Handler {
+func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, bitbucketServerWebhook http.Handler, newCodeIntelUploadHandler enterprise.CodeIntelUploadHandlerFactory) http.Handler {
 	if m == nil {
 		m = apirouter.New(nil)
 	}
@@ -61,15 +62,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, bitbucketS
 	}
 
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
-
-	if codeintelUploadHandler != nil {
-		m.Get(apirouter.LSIFUpload).Handler(trace.TraceRoute(codeintelUploadHandler))
-	} else {
-		m.Get(apirouter.LSIFUpload).Handler(trace.TraceRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte("codeintel upload is only available in enterprise"))
-		})))
-	}
+	m.Get(apirouter.LSIFUpload).Handler(trace.TraceRoute(newCodeIntelUploadHandler(false)))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCliVersion).Handler(trace.TraceRoute(handler(srcCliVersionServe)))
@@ -91,7 +84,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, bitbucketS
 // 🚨 SECURITY: This handler should not be served on a publicly exposed port. 🚨
 // This handler is not guaranteed to provide the same authorization checks as
 // public API handlers.
-func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
+func NewInternalHandler(m *mux.Router, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.CodeIntelUploadHandlerFactory) http.Handler {
 	if m == nil {
 		m = apirouter.New(nil)
 	}
@@ -138,6 +131,7 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema) http.Handler {
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
 	m.Get(apirouter.Configuration).Handler(trace.TraceRoute(handler(serveConfiguration)))
 	m.Get(apirouter.SearchConfiguration).Handler(trace.TraceRoute(handler(serveSearchConfiguration)))
+	m.Get(apirouter.LSIFUpload).Handler(trace.TraceRoute(newCodeIntelUploadHandler(true)))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -120,6 +120,7 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/configuration").Methods("POST").Name(Configuration)
 	base.Path("/search/configuration").Methods("GET").Name(SearchConfiguration)
 	base.Path("/telemetry").Methods("POST").Name(Telemetry)
+	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
 

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -19,8 +19,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/httpapi"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
@@ -184,8 +184,8 @@ func initCodeIntel() {
 		)
 	}
 
-	httpapi.NewCodeIntelUploadHandler = func() http.Handler {
-		return codeintelhttpapi.NewUploadHandler(db, bundleManagerClient)
+	enterprise.NewCodeIntelUploadHandler = func(internal bool) http.Handler {
+		return codeintelhttpapi.NewUploadHandler(db, bundleManagerClient, internal)
 	}
 }
 

--- a/enterprise/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler.go
@@ -24,14 +24,17 @@ import (
 type UploadHandler struct {
 	db                  db.DB
 	bundleManagerClient bundles.BundleManagerClient
+	internal            bool
 }
 
-func NewUploadHandler(db db.DB, bundleManagerClient bundles.BundleManagerClient) http.Handler {
+func NewUploadHandler(db db.DB, bundleManagerClient bundles.BundleManagerClient, internal bool) http.Handler {
 	handler := &UploadHandler{
 		db:                  db,
 		bundleManagerClient: bundleManagerClient,
+		internal:            internal,
 	}
 
+	fmt.Printf("MAKING REAL HANDLER...\n")
 	return http.HandlerFunc(handler.handleEnqueue)
 }
 
@@ -53,7 +56,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 		// 🚨 SECURITY: Ensure we return before proxying to the precise-code-intel-api-server upload
 		// endpoint. This endpoint is unprotected, so we need to make sure the user provides a valid
 		// token proving contributor access to the repository.
-		if conf.Get().LsifEnforceAuth && !isSiteAdmin(ctx) && !enforceAuth(ctx, w, r, repoName) {
+		if !h.internal && conf.Get().LsifEnforceAuth && !isSiteAdmin(ctx) && !enforceAuth(ctx, w, r, repoName) {
 			return
 		}
 	}

--- a/enterprise/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler.go
@@ -34,7 +34,6 @@ func NewUploadHandler(db db.DB, bundleManagerClient bundles.BundleManagerClient,
 		internal:            internal,
 	}
 
-	fmt.Printf("MAKING REAL HANDLER...\n")
 	return http.HandlerFunc(handler.handleEnqueue)
 }
 


### PR DESCRIPTION
The auto-indexer accesses the frontend via SRC_FRONTEND_INTERNAL, but that API does not have the lsif/upload endpoint registered.

Instead of adding a new envvar to access the _public_ port (which would also require generating a sudo access token for the app to use), we register the codeintel upload endpoint in the internal API in a way that can bypass the upload auth mechanism.

This renames a package {httpapi}->{enterprise}, which contains a hook for the enterprise code to update the code intel upload handler. There are some other globals in the frontend package which I think should be consolidated here over time (such as campaign resolvers cc @mrnugget ).