### PR TITLE
db: add tests to external services

### DIFF
--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -376,14 +376,14 @@ func (e *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.E
 		sqlf.Sprintf("deleted_at IS NULL"),
 		sqlf.Sprintf("id=%d", id),
 	}
-	ExternalServicesStore, err := e.list(ctx, conds, nil)
+	ess, err := e.list(ctx, conds, nil)
 	if err != nil {
 		return nil, err
 	}
-	if len(ExternalServicesStore) == 0 {
+	if len(ess) == 0 {
 		return nil, externalServiceNotFoundError{id: id}
 	}
-	return ExternalServicesStore[0], nil
+	return ess[0], nil
 }
 
 // List returns all external services.

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -266,9 +266,9 @@ func (e *ExternalServicesStore) validateDuplicateRateLimits(ctx context.Context,
 // determines a deadlock occurred.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error {
+func (e *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error {
 	ps := confGet().AuthProviders
-	if err := c.ValidateConfig(ctx, 0, externalService.Kind, externalService.Config, ps); err != nil {
+	if err := e.ValidateConfig(ctx, 0, externalService.Kind, externalService.Config, ps); err != nil {
 		return err
 	}
 
@@ -291,15 +291,15 @@ type ExternalServiceUpdate struct {
 // Update updates a external service.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error {
+func (e *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error {
 	if update.Config != nil {
 		// Query to get the kind (which is immutable) so we can validate the new config.
-		externalService, err := c.GetByID(ctx, id)
+		externalService, err := e.GetByID(ctx, id)
 		if err != nil {
 			return err
 		}
 
-		if err := c.ValidateConfig(ctx, id, externalService.Kind, *update.Config, ps); err != nil {
+		if err := e.ValidateConfig(ctx, id, externalService.Kind, *update.Config, ps); err != nil {
 			return err
 		}
 	}
@@ -367,13 +367,13 @@ func (*ExternalServicesStore) Delete(ctx context.Context, id int64) error {
 // GetByID returns the external service for id.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.ExternalService, error) {
+func (e *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.ExternalService, error) {
 	if Mocks.ExternalServices.GetByID != nil {
 		return Mocks.ExternalServices.GetByID(id)
 	}
 
 	conds := []*sqlf.Query{sqlf.Sprintf("id=%d", id)}
-	ExternalServicesStore, err := c.list(ctx, conds, nil)
+	ExternalServicesStore, err := e.list(ctx, conds, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -386,18 +386,18 @@ func (c *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.E
 // List returns all external services.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
+func (e *ExternalServicesStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
 	if Mocks.ExternalServices.List != nil {
 		return Mocks.ExternalServices.List(opt)
 	}
-	return c.list(ctx, opt.sqlConditions(), opt.LimitOffset)
+	return e.list(ctx, opt.sqlConditions(), opt.LimitOffset)
 }
 
 // listConfigs decodes the list configs into result.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) listConfigs(ctx context.Context, kind string, result interface{}) error {
-	services, err := c.List(ctx, ExternalServicesListOptions{Kinds: []string{kind}})
+func (e *ExternalServicesStore) listConfigs(ctx context.Context, kind string, result interface{}) error {
+	services, err := e.List(ctx, ExternalServicesListOptions{Kinds: []string{kind}})
 	if err != nil {
 		return err
 	}
@@ -426,9 +426,9 @@ func (c *ExternalServicesStore) listConfigs(ctx context.Context, kind string, re
 // ListAWSCodeCommitConnections returns a list of AWSCodeCommit configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context) ([]*schema.AWSCodeCommitConnection, error) {
+func (e *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context) ([]*schema.AWSCodeCommitConnection, error) {
 	var connections []*schema.AWSCodeCommitConnection
-	if err := c.listConfigs(ctx, "AWSCODECOMMIT", &connections); err != nil {
+	if err := e.listConfigs(ctx, "AWSCODECOMMIT", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -437,9 +437,9 @@ func (c *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context
 // ListBitbucketCloudConnections returns a list of BitbucketCloud configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Context) ([]*schema.BitbucketCloudConnection, error) {
+func (e *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Context) ([]*schema.BitbucketCloudConnection, error) {
 	var connections []*schema.BitbucketCloudConnection
-	if err := c.listConfigs(ctx, "BITBUCKETCLOUD", &connections); err != nil {
+	if err := e.listConfigs(ctx, "BITBUCKETCLOUD", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -448,9 +448,9 @@ func (c *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Contex
 // ListBitbucketServerConnections returns a list of BitbucketServer configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
+func (e *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
 	var connections []*schema.BitbucketServerConnection
-	if err := c.listConfigs(ctx, "BITBUCKETSERVER", &connections); err != nil {
+	if err := e.listConfigs(ctx, "BITBUCKETSERVER", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -459,9 +459,9 @@ func (c *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Conte
 // ListGitHubConnections returns a list of GitHubConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*schema.GitHubConnection, error) {
+func (e *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*schema.GitHubConnection, error) {
 	var connections []*schema.GitHubConnection
-	if err := c.listConfigs(ctx, "GITHUB", &connections); err != nil {
+	if err := e.listConfigs(ctx, "GITHUB", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -470,9 +470,9 @@ func (c *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*s
 // ListGitLabConnections returns a list of GitLabConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*schema.GitLabConnection, error) {
+func (e *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*schema.GitLabConnection, error) {
 	var connections []*schema.GitLabConnection
-	if err := c.listConfigs(ctx, "GITLAB", &connections); err != nil {
+	if err := e.listConfigs(ctx, "GITLAB", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -481,9 +481,9 @@ func (c *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*s
 // ListGitoliteConnections returns a list of GitoliteConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]*schema.GitoliteConnection, error) {
+func (e *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]*schema.GitoliteConnection, error) {
 	var connections []*schema.GitoliteConnection
-	if err := c.listConfigs(ctx, "GITOLITE", &connections); err != nil {
+	if err := e.listConfigs(ctx, "GITOLITE", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -492,9 +492,9 @@ func (c *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]
 // ListPhabricatorConnections returns a list of PhabricatorConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
+func (e *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
 	var connections []*schema.PhabricatorConnection
-	if err := c.listConfigs(ctx, "PHABRICATOR", &connections); err != nil {
+	if err := e.listConfigs(ctx, "PHABRICATOR", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
@@ -503,15 +503,15 @@ func (c *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) 
 // ListOtherExternalServicesConnections returns a list of OtherExternalServiceConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) ListOtherExternalServicesConnections(ctx context.Context) ([]*schema.OtherExternalServiceConnection, error) {
+func (e *ExternalServicesStore) ListOtherExternalServicesConnections(ctx context.Context) ([]*schema.OtherExternalServiceConnection, error) {
 	var connections []*schema.OtherExternalServiceConnection
-	if err := c.listConfigs(ctx, "OTHER", &connections); err != nil {
+	if err := e.listConfigs(ctx, "OTHER", &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil
 }
 
-func (c *ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*types.ExternalService, error) {
+func (*ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*types.ExternalService, error) {
 	q := sqlf.Sprintf(`
 		SELECT id, kind, display_name, config, created_at, updated_at
 		FROM external_services
@@ -542,7 +542,7 @@ func (c *ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, l
 // Count counts all external services that satisfy the options (ignoring limit and offset).
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (c *ExternalServicesStore) Count(ctx context.Context, opt ExternalServicesListOptions) (int, error) {
+func (*ExternalServicesStore) Count(ctx context.Context, opt ExternalServicesListOptions) (int, error) {
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM external_services WHERE (%s)", sqlf.Join(opt.sqlConditions(), ") AND ("))
 	var count int
 	if err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -372,13 +372,16 @@ func (e *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.E
 		return Mocks.ExternalServices.GetByID(id)
 	}
 
-	conds := []*sqlf.Query{sqlf.Sprintf("id=%d", id)}
+	conds := []*sqlf.Query{
+		sqlf.Sprintf("deleted_at IS NULL"),
+		sqlf.Sprintf("id=%d", id),
+	}
 	ExternalServicesStore, err := e.list(ctx, conds, nil)
 	if err != nil {
 		return nil, err
 	}
 	if len(ExternalServicesStore) == 0 {
-		return nil, fmt.Errorf("external service not found: id=%d", id)
+		return nil, externalServiceNotFoundError{id: id}
 	}
 	return ExternalServicesStore[0], nil
 }

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -272,7 +272,7 @@ func (e *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf
 		return err
 	}
 
-	externalService.CreatedAt = time.Now()
+	externalService.CreatedAt = time.Now().UTC().Truncate(time.Microsecond)
 	externalService.UpdatedAt = externalService.CreatedAt
 
 	return dbconn.Global.QueryRowContext(

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -62,11 +62,11 @@ type ExternalServicesListOptions struct {
 func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	conds := []*sqlf.Query{sqlf.Sprintf("deleted_at IS NULL")}
 	if len(o.Kinds) > 0 {
-		kinds := []*sqlf.Query{}
+		kinds := make([]*sqlf.Query, 0, len(o.Kinds))
 		for _, kind := range o.Kinds {
 			kinds = append(kinds, sqlf.Sprintf("%s", kind))
 		}
-		conds = append(conds, sqlf.Sprintf("kind IN (%s)", sqlf.Join(kinds, ", ")))
+		conds = append(conds, sqlf.Sprintf("kind IN (%s)", sqlf.Join(kinds, ",")))
 	}
 	return conds
 }

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -539,6 +539,10 @@ func (*ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, lim
 		}
 		results = append(results, &h)
 	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return results, nil
 }
 

--- a/cmd/frontend/db/external_services.go
+++ b/cmd/frontend/db/external_services.go
@@ -115,14 +115,14 @@ func (e *ExternalServicesStore) ValidateConfig(ctx context.Context, id int64, ki
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = e.validateGithubConnection(ctx, id, &c)
+		err = e.validateGitHubConnection(ctx, id, &c)
 
 	case "GITLAB":
 		var c schema.GitLabConnection
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = e.validateGitlabConnection(ctx, id, &c, ps)
+		err = e.validateGitLabConnection(ctx, id, &c, ps)
 
 	case "BITBUCKETSERVER":
 		var c schema.BitbucketServerConnection
@@ -178,7 +178,7 @@ func validateOtherExternalServiceConnection(c *schema.OtherExternalServiceConnec
 	return nil
 }
 
-func (e *ExternalServicesStore) validateGithubConnection(ctx context.Context, id int64, c *schema.GitHubConnection) error {
+func (e *ExternalServicesStore) validateGitHubConnection(ctx context.Context, id int64, c *schema.GitHubConnection) error {
 	err := new(multierror.Error)
 	for _, validate := range e.GitHubValidators {
 		err = multierror.Append(err, validate(c))
@@ -193,7 +193,7 @@ func (e *ExternalServicesStore) validateGithubConnection(ctx context.Context, id
 	return err.ErrorOrNil()
 }
 
-func (e *ExternalServicesStore) validateGitlabConnection(ctx context.Context, id int64, c *schema.GitLabConnection, ps []schema.AuthProviders) error {
+func (e *ExternalServicesStore) validateGitLabConnection(ctx context.Context, id int64, c *schema.GitLabConnection, ps []schema.AuthProviders) error {
 	err := new(multierror.Error)
 	for _, validate := range e.GitLabValidators {
 		err = multierror.Append(err, validate(c, ps))

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -20,6 +20,10 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 		wantArgs  []interface{}
 	}{
 		{
+			name:      "no kind",
+			wantQuery: "deleted_at IS NULL",
+		},
+		{
 			name:      "only one kind: GitHub",
 			kinds:     []string{"GITHUB"},
 			wantQuery: "deleted_at IS NULL AND kind IN ($1)",

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -201,3 +201,39 @@ func TestExternalServicesStore_Update(t *testing.T) {
 		t.Fatalf("UpdateAt: want to be updated but not")
 	}
 }
+
+func TestExternalServicesStore_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es := &types.ExternalService{
+		Kind:        "GITHUB",
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := (&ExternalServicesStore{}).Create(ctx, confGet, es)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete this external service
+	err = (&ExternalServicesStore{}).Delete(ctx, es.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete again should get externalServiceNotFoundError
+	err = (&ExternalServicesStore{}).Delete(ctx, es.ID)
+	gotErr := fmt.Sprintf("%v", err)
+	wantErr := fmt.Sprintf("external service not found: %v", es.ID)
+	if gotErr != wantErr {
+		t.Errorf("error: want %q but got %q", wantErr, gotErr)
+	}
+}

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -312,3 +312,33 @@ func TestExternalServicesStore_List(t *testing.T) {
 		t.Fatalf("(-want +got):\n%s", diff)
 	}
 }
+func TestExternalServicesStore_Count(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es := &types.ExternalService{
+		Kind:        "GITHUB",
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := (&ExternalServicesStore{}).Create(ctx, confGet, es)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := (&ExternalServicesStore{}).Count(ctx, ExternalServicesListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count != 1 {
+		t.Fatalf("Want 1 external service but got %d", count)
+	}
+}

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -237,3 +237,45 @@ func TestExternalServicesStore_Delete(t *testing.T) {
 		t.Errorf("error: want %q but got %q", wantErr, gotErr)
 	}
 }
+
+func TestExternalServicesStore_GetByID(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es := &types.ExternalService{
+		Kind:        "GITHUB",
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := (&ExternalServicesStore{}).Create(ctx, confGet, es)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be able to get back by its ID
+	_, err = (&ExternalServicesStore{}).GetByID(ctx, es.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete this external service
+	err = (&ExternalServicesStore{}).Delete(ctx, es.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should now get externalServiceNotFoundError
+	_, err = (&ExternalServicesStore{}).GetByID(ctx, es.ID)
+	gotErr := fmt.Sprintf("%v", err)
+	wantErr := fmt.Sprintf("external service not found: %v", es.ID)
+	if gotErr != wantErr {
+		t.Errorf("error: want %q but got %q", wantErr, gotErr)
+	}
+}

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -312,6 +312,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 		t.Fatalf("(-want +got):\n%s", diff)
 	}
 }
+
 func TestExternalServicesStore_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/cmd/frontend/db/external_services_test.go
+++ b/cmd/frontend/db/external_services_test.go
@@ -279,3 +279,36 @@ func TestExternalServicesStore_GetByID(t *testing.T) {
 		t.Errorf("error: want %q but got %q", wantErr, gotErr)
 	}
 }
+
+func TestExternalServicesStore_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es := &types.ExternalService{
+		Kind:        "GITHUB",
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := (&ExternalServicesStore{}).Create(ctx, confGet, es)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ess, err := (&ExternalServicesStore{}).List(ctx, ExternalServicesListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ess) != 1 {
+		t.Fatalf("Want 1 external service but got %d", len(ess))
+	} else if diff := cmp.Diff(es, ess[0]); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add tests for external services in DB layer.

Please review by commit. Inline comments are added for necessary elaboration.

Part of #10067