### PR TITLE
campaigns: Order changeset jobs by updated_at time

### DIFF
--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -101,7 +101,7 @@ UPDATE changeset_jobs j SET started_at = now() WHERE id = (
 	SELECT j.id FROM changeset_jobs j
 	JOIN campaigns c ON c.id = j.campaign_id
 	WHERE j.started_at IS NULL AND c.patch_set_id IS NOT NULL
-	ORDER BY j.id ASC
+	ORDER BY j.updated_at ASC
 	FOR UPDATE SKIP LOCKED LIMIT 1
 )
 RETURNING j.id,


### PR DESCRIPTION
This ensures that after a job has been updated it goes to the back of
the queue.

This ensures that problematic jobs don't gather at the front of the
queue.

Closes: https://github.com/sourcegraph/sourcegraph/issues/10798



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
