### PR TITLE
Make syncSubscription function clearer

### DIFF
--- a/shared/src/api/client/api/common.ts
+++ b/shared/src/api/client/api/common.ts
@@ -4,7 +4,7 @@ import { from, Observable, observable as symbolObservable, Subscription, Unsubsc
 import { mergeMap, finalize } from 'rxjs/operators'
 import { Subscribable } from 'sourcegraph'
 import { ProxySubscribable } from '../../extension/api/common'
-import { syncSubscription } from '../../util'
+import { synchronousSubscription } from '../../util'
 import { asError } from '../../../util/errors'
 import { FeatureProviderRegistry } from '../services/registry'
 
@@ -88,7 +88,7 @@ export const wrapRemoteObservable = <T>(
                                 complete: partialObserver.complete ? () => partialObserver.complete() : noop,
                             }
                         }
-                        return syncSubscription(proxySubscribable.subscribe(proxyObserver))
+                        return synchronousSubscription(proxySubscribable.subscribe(proxyObserver))
                     },
                 }
             }

--- a/shared/src/api/extension/api/commands.ts
+++ b/shared/src/api/extension/api/commands.ts
@@ -1,7 +1,7 @@
 import * as comlink from 'comlink'
 import { Unsubscribable } from 'rxjs'
 import { ClientCommandsAPI } from '../../client/api/commands'
-import { syncSubscription } from '../../util'
+import { synchronousSubscription } from '../../util'
 
 interface CommandEntry {
     command: string
@@ -22,6 +22,6 @@ export class ExtCommands {
     }
 
     public registerCommand(entry: CommandEntry): Unsubscribable {
-        return syncSubscription(this.proxy.$registerCommand(entry.command, comlink.proxy(entry.callback)))
+        return synchronousSubscription(this.proxy.$registerCommand(entry.command, comlink.proxy(entry.callback)))
     }
 }

--- a/shared/src/api/extension/api/content.ts
+++ b/shared/src/api/extension/api/content.ts
@@ -2,7 +2,7 @@ import * as comlink from 'comlink'
 import { Unsubscribable } from 'rxjs'
 import { LinkPreviewProvider } from 'sourcegraph'
 import { ClientContentAPI } from '../../client/api/content'
-import { syncSubscription } from '../../util'
+import { synchronousSubscription } from '../../util'
 import { toProxyableSubscribable } from './common'
 
 /** @internal */
@@ -15,6 +15,6 @@ export class ExtContent {
         > = comlink.proxy((url: string) =>
             toProxyableSubscribable(provider.provideLinkPreview(new URL(url)), preview => preview)
         )
-        return syncSubscription(this.proxy.$registerLinkPreviewProvider(urlMatchPattern, providerFunction))
+        return synchronousSubscription(this.proxy.$registerLinkPreviewProvider(urlMatchPattern, providerFunction))
     }
 }

--- a/shared/src/api/extension/api/languageFeatures.ts
+++ b/shared/src/api/extension/api/languageFeatures.ts
@@ -13,7 +13,7 @@ import {
 } from 'sourcegraph'
 import { ClientLanguageFeaturesAPI } from '../../client/api/languageFeatures'
 import { ReferenceParams, TextDocumentPositionParams } from '../../protocol'
-import { syncSubscription } from '../../util'
+import { synchronousSubscription } from '../../util'
 import { toProxyableSubscribable } from './common'
 import { ExtDocuments } from './documents'
 import { fromHover, fromLocation, toPosition, fromDocumentSelector } from './types'
@@ -31,7 +31,9 @@ export class ExtLanguageFeatures {
                 hover => (hover ? fromHover(hover) : hover)
             )
         )
-        return syncSubscription(this.proxy.$registerHoverProvider(fromDocumentSelector(selector), providerFunction))
+        return synchronousSubscription(
+            this.proxy.$registerHoverProvider(fromDocumentSelector(selector), providerFunction)
+        )
     }
 
     public registerDefinitionProvider(selector: DocumentSelector, provider: DefinitionProvider): Unsubscribable {
@@ -43,7 +45,7 @@ export class ExtLanguageFeatures {
                 toLocations
             )
         )
-        return syncSubscription(
+        return synchronousSubscription(
             this.proxy.$registerDefinitionProvider(fromDocumentSelector(selector), providerFunction)
         )
     }
@@ -61,7 +63,9 @@ export class ExtLanguageFeatures {
                 toLocations
             )
         )
-        return syncSubscription(this.proxy.$registerReferenceProvider(fromDocumentSelector(selector), providerFunction))
+        return synchronousSubscription(
+            this.proxy.$registerReferenceProvider(fromDocumentSelector(selector), providerFunction)
+        )
     }
 
     public registerLocationProvider(
@@ -77,7 +81,7 @@ export class ExtLanguageFeatures {
                 toLocations
             )
         )
-        return syncSubscription(
+        return synchronousSubscription(
             this.proxy.$registerLocationProvider(idStr, fromDocumentSelector(selector), comlink.proxy(providerFunction))
         )
     }
@@ -94,7 +98,7 @@ export class ExtLanguageFeatures {
                 items => items
             )
         )
-        return syncSubscription(
+        return synchronousSubscription(
             this.proxy.$registerCompletionItemProvider(fromDocumentSelector(selector), providerFunction)
         )
     }

--- a/shared/src/api/extension/api/search.ts
+++ b/shared/src/api/extension/api/search.ts
@@ -2,12 +2,12 @@ import * as comlink from 'comlink'
 import { Unsubscribable } from 'rxjs'
 import { QueryTransformer } from 'sourcegraph'
 import { ClientSearchAPI } from '../../client/api/search'
-import { syncSubscription } from '../../util'
+import { synchronousSubscription } from '../../util'
 
 export class ExtSearch {
     constructor(private proxy: comlink.Remote<ClientSearchAPI>) {}
 
     public registerQueryTransformer(provider: QueryTransformer): Unsubscribable {
-        return syncSubscription(this.proxy.$registerQueryTransformer(comlink.proxy(provider)))
+        return synchronousSubscription(this.proxy.$registerQueryTransformer(comlink.proxy(provider)))
     }
 }

--- a/shared/src/api/extension/api/views.ts
+++ b/shared/src/api/extension/api/views.ts
@@ -1,7 +1,7 @@
 import * as comlink from 'comlink'
 import * as sourcegraph from 'sourcegraph'
 import { ClientViewsAPI, PanelUpdater, PanelViewData } from '../../client/api/views'
-import { syncSubscription } from '../../util'
+import { synchronousSubscription } from '../../util'
 import { Unsubscribable } from 'rxjs'
 import { toProxyableSubscribable } from './common'
 import { ContributableViewContainer } from '../../protocol'
@@ -77,7 +77,7 @@ export class ExtViews implements comlink.ProxyMarked {
     public registerViewProvider(id: string, provider: sourcegraph.ViewProvider): Unsubscribable {
         switch (provider.where) {
             case ContributableViewContainer.Directory: {
-                return syncSubscription(
+                return synchronousSubscription(
                     this.proxy.$registerDirectoryViewProvider(
                         id,
                         comlink.proxy((context: ViewContexts[typeof ContributableViewContainer.Directory]) =>
@@ -101,7 +101,7 @@ export class ExtViews implements comlink.ProxyMarked {
                 )
             }
             case ContributableViewContainer.GlobalPage: {
-                return syncSubscription(
+                return synchronousSubscription(
                     this.proxy.$registerGlobalPageViewProvider(
                         id,
                         comlink.proxy((context: ViewContexts[typeof ContributableViewContainer.GlobalPage]) =>

--- a/shared/src/api/util.ts
+++ b/shared/src/api/util.ts
@@ -44,7 +44,9 @@ export function registerComlinkTransferHandlers(): void {
  *
  * @param subscriptionPromise A Promise for a Subscription proxied from the other thread
  */
-export const syncSubscription = (subscriptionPromise: Promise<Remote<Unsubscribable & ProxyMarked>>): Subscription =>
+export const synchronousSubscription = (
+    subscriptionPromise: Promise<Remote<Unsubscribable & ProxyMarked>>
+): Subscription =>
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     new Subscription(async function (this: any) {
         // Wait to retrieve the proxy


### PR DESCRIPTION
@twop expressed in https://github.com/sourcegraph/sourcegraph/pull/11033#discussion_r432609208 that he found `syncSubscription` hard to understand. This PR adds a more elaborate description (instead of just the one-liner) and also renames the function to disambiguate the abbreviation.

@twop - if you have any more questions on this, please ask in a comment on the diff and I'll respond by changing/extending the comments 😊 