### PR TITLE
codeintel: Call upload routine extracted from src-cli

### DIFF
--- a/cmd/precise-code-intel-indexer/Dockerfile
+++ b/cmd/precise-code-intel-indexer/Dockerfile
@@ -17,13 +17,10 @@ ENV GOROOT=/usr/lib/go GOPATH=/go PATH=/go/bin:$PATH
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
 RUN mkdir temp && \
-    curl -L https://github.com/sourcegraph/src-cli/releases/download/3.12.0/src-cli_3.12.0_linux_amd64.tar.gz -o src-cli.tar.gz && \
-    tar -C temp -zvxf src-cli.tar.gz && \
-    mv temp/src /usr/local/bin && \
     curl -L https://github.com/sourcegraph/lsif-go/releases/download/v0.8.0/lsif-go_0.8.0_linux_amd64.tar.gz -o lsif-go.tar.gz && \
     tar -C temp -zvxf lsif-go.tar.gz && \
     mv temp/lsif-go /usr/local/bin && \
-    rm -rf temp src-cli.tar.gz lsif-go.tar.gz
+    rm -rf temp lsif-go.tar.gz
 
 USER sourcegraph
 EXPOSE 3189

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/sirupsen/logrus v1.5.0 // indirect
 	github.com/sloonz/go-qprintable v0.0.0-20160203160305-775b3a4592d5 // indirect
 	github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d // indirect
-	github.com/sourcegraph/codeintelutils v0.0.0-20200528142143-a2f46204e2e9
+	github.com/sourcegraph/codeintelutils v0.0.0-20200602000243-9543a4b9c9f8
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
 	github.com/sourcegraph/go-diff v0.5.3
 	github.com/sourcegraph/go-jsonschema v0.0.0-20191222043427-cdbee60427af

--- a/go.sum
+++ b/go.sum
@@ -878,6 +878,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/codeintelutils v0.0.0-20200528142143-a2f46204e2e9 h1:AUUSD/me2hphB7WyWGuljtUEdFBpgWjDII3wd9CmeX8=
 github.com/sourcegraph/codeintelutils v0.0.0-20200528142143-a2f46204e2e9/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
+github.com/sourcegraph/codeintelutils v0.0.0-20200602000243-9543a4b9c9f8 h1:W0oFiF6o3iRzdiJSKcfhxAi93tQDaVYC5hKA6VYOnSA=
+github.com/sourcegraph/codeintelutils v0.0.0-20200602000243-9543a4b9c9f8/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWifxmICRqgXK7khThjw03RfdGhyeA2S4EQ=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
 github.com/sourcegraph/go-diff v0.5.1 h1:gO6i5zugwzo1RVTvgvfwCOSVegNuvnNi6bAD1QCmkHs=


### PR DESCRIPTION
Do not shell out to src-cli - call the upload code directly. The shared logic has been extracted into the sourcegraph/codeintelutils repo.