### PR TITLE
codeintel: Fix nil deref in db layer

### DIFF
--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -201,7 +201,11 @@ func (db *dbImpl) query(ctx context.Context, query *sqlf.Query) (*sql.Rows, erro
 
 // queryForEffect performs a query and throws away the result.
 func (db *dbImpl) queryForEffect(ctx context.Context, query *sqlf.Query) error {
-	return closeRows(db.query(ctx, query))
+	rows, err := db.query(ctx, query)
+	if err != nil {
+		return err
+	}
+	return closeRows(rows, nil)
 }
 
 // scanStrings scans a slice of strings from the return value of `*dbImpl.query`.


### PR DESCRIPTION
Do not try to close rows if the query returns a non-nil err value.