### PR TITLE
codeintel: Stop creating git tags when checking if tags exist

### DIFF
--- a/internal/codeintel/gitserver/tags.go
+++ b/internal/codeintel/gitserver/tags.go
@@ -21,7 +21,7 @@ func Tags(ctx context.Context, db db.DB, repositoryID int, commit string) (strin
 	// git describe --tags will exit with status 128 (fatal: No names found, cannot describe anything)
 	// when there are no tags known to the given repo. In order to prevent a gitserver error from
 	// occurring, we first check to see if there are any tags and early-exit.
-	tags, err := execGitCommand(ctx, db, repositoryID, "tag", commit)
+	tags, err := execGitCommand(ctx, db, repositoryID, "tag")
 	if err != nil {
 		return "", false, err
 	}


### PR DESCRIPTION
Run `git tag` in order to determine if any tags exist; do not run `git tag {commit}`, as that's an unnecessary check that will happen to **create** a tag instead. Not what we want!