### PR TITLE
search: fix indexed search match count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Links to AWS Code Commit repositories have been fixed after the URL schema has been changed. [#11019](https://github.com/sourcegraph/sourcegraph/pull/11019)
 - A link to view all repositories will now always appear on the Explore page. [#11113](https://github.com/sourcegraph/sourcegraph/pull/11113)
 - The Site-admin > Pings page no longer incorrectly indicates that pings are disabled when they aren't. [#11229](https://github.com/sourcegraph/sourcegraph/pull/11229)
+- Match counts are now accurately reported for indexed search [#11242](https://github.com/sourcegraph/sourcegraph/pull/11242)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Links to AWS Code Commit repositories have been fixed after the URL schema has been changed. [#11019](https://github.com/sourcegraph/sourcegraph/pull/11019)
 - A link to view all repositories will now always appear on the Explore page. [#11113](https://github.com/sourcegraph/sourcegraph/pull/11113)
 - The Site-admin > Pings page no longer incorrectly indicates that pings are disabled when they aren't. [#11229](https://github.com/sourcegraph/sourcegraph/pull/11229)
-- Match counts are now accurately reported for indexed search [#11242](https://github.com/sourcegraph/sourcegraph/pull/11242)
+- Match counts are now accurately reported for indexed search. [#11242](https://github.com/sourcegraph/sourcegraph/pull/11242)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -539,6 +539,7 @@ func TestZoektSearchHEAD(t *testing.T) {
 		name              string
 		args              args
 		wantFm            []*FileMatchResolver
+		wantMatchCount    int
 		wantLimitHit      bool
 		wantReposLimitHit map[string]struct{}
 		wantErr           bool
@@ -603,6 +604,73 @@ func TestZoektSearchHEAD(t *testing.T) {
 			wantReposLimitHit: nil,
 			wantErr:           true,
 		},
+		{
+			name: "returns accurate match count of 5 line fragment matches across two files",
+			args: args{
+				ctx:             context.Background(),
+				query:           &search.TextPatternInfo{PathPatternsAreRegExps: true, FileMatchLimit: 100},
+				repos:           makeRepositoryRevisions("foo/bar@master", "foo/foobar@master"),
+				useFullDeadline: false,
+				searcher: &fakeSearcher{
+					repos: &zoekt.RepoList{
+						Repos: []*zoekt.RepoListEntry{
+							{
+								Repository: zoekt.Repository{
+									Name: "foo/bar",
+								},
+							},
+							{
+								Repository: zoekt.Repository{
+									Name: "foo/foobar",
+								},
+							},
+						},
+					},
+					result: &zoekt.SearchResult{
+						Files: []zoekt.FileMatch{
+							{
+								Repository: "foo/bar",
+								FileName:   "baz.go",
+								LineMatches: []zoekt.LineMatch{
+									{
+										Line: []byte("I'm like 1.5+ hours into writing this test :'("),
+										LineFragments: []zoekt.LineFragmentMatch{
+											{LineOffset: 0, MatchLength: 5},
+										},
+									},
+									{
+										Line: []byte("I'm ready for the rain to stop."),
+										LineFragments: []zoekt.LineFragmentMatch{
+											{LineOffset: 0, MatchLength: 5},
+											{LineOffset: 5, MatchLength: 10},
+										},
+									},
+								},
+							},
+							{
+								Repository: "foo/foobar",
+								FileName:   "baz.go",
+								LineMatches: []zoekt.LineMatch{
+									{
+										Line: []byte("s/rain/pain"),
+										LineFragments: []zoekt.LineFragmentMatch{
+											{LineOffset: 0, MatchLength: 5},
+											{LineOffset: 5, MatchLength: 2},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				since: func(time.Time) time.Duration { return 0 },
+			},
+			wantFm:            nil,
+			wantLimitHit:      false,
+			wantReposLimitHit: map[string]struct{}{},
+			wantMatchCount:    5,
+			wantErr:           false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -616,14 +684,24 @@ func TestZoektSearchHEAD(t *testing.T) {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotFm, tt.wantFm) {
-				t.Errorf("zoektSearchHEAD() gotFm = %v, want %v", gotFm, tt.wantFm)
+			if tt.wantFm != nil {
+				if !reflect.DeepEqual(gotFm, tt.wantFm) {
+					t.Errorf("zoektSearchHEAD() gotFm = %v, want %v", gotFm, tt.wantFm)
+				}
 			}
 			if gotLimitHit != tt.wantLimitHit {
 				t.Errorf("zoektSearchHEAD() gotLimitHit = %v, want %v", gotLimitHit, tt.wantLimitHit)
 			}
 			if !reflect.DeepEqual(gotReposLimitHit, tt.wantReposLimitHit) {
 				t.Errorf("zoektSearchHEAD() gotReposLimitHit = %v, want %v", gotReposLimitHit, tt.wantReposLimitHit)
+			}
+
+			var gotMatchCount int
+			for _, m := range gotFm {
+				gotMatchCount += m.MatchCount
+			}
+			if gotMatchCount != tt.wantMatchCount {
+				t.Errorf("zoektSearchHEAD() gotMatchCount = %v, want %v", gotMatchCount, tt.wantMatchCount)
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -251,7 +251,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 			JPath:        file.FileName,
 			JLineMatches: lines,
 			JLimitHit:    fileLimitHit,
-			MatchCount:   matchCount,
+			MatchCount:   matchCount, // We do not use resp.MatchCount because it counts the number of lines matched, not the number of fragments.
 			uri:          fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 			symbols:      symbols,
 			Repo:         repoRev.Repo,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -204,6 +204,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 		baseURI := &gituri.URI{URL: url.URL{Scheme: "git://", Host: string(repoRev.Repo.Name), RawQuery: "?" + url.QueryEscape(inputRev)}}
 		lines := make([]*lineMatch, 0, len(file.LineMatches))
 		symbols := []*searchSymbolResult{}
+		var matchCount int
 		for _, l := range file.LineMatches {
 			if !l.FileName {
 				if len(l.LineFragments) > maxLineFragmentMatches {
@@ -237,6 +238,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 					}
 				}
 				if !isSymbol {
+					matchCount += len(offsets)
 					lines = append(lines, &lineMatch{
 						JPreview:          string(l.Line),
 						JLineNumber:       int32(l.LineNumber - 1),
@@ -249,6 +251,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 			JPath:        file.FileName,
 			JLineMatches: lines,
 			JLimitHit:    fileLimitHit,
+			MatchCount:   matchCount,
 			uri:          fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 			symbols:      symbols,
 			Repo:         repoRev.Repo,


### PR DESCRIPTION
This fixes #11236, a regression introduced by https://github.com/sourcegraph/sourcegraph/pull/9541. The `MatchCount` value should be set on the Zoekt path.

While investigating this I discovered an interesting match count discrepancy. Irrespective of the regression, and prior to the bug I introduced, we had been calculating the number of matches returned by Zoekt by counting the number of _lines_. This stems from returning `lines` [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d11e4dc7567c7f453ffd46cdabe1d6c58a2ebf06/-/blob/cmd/frontend/graphqlbackend/zoekt.go#L250) on the Zoekt path, and using [`len(fm.LinesMatches)` prior to using the `MatchCount` member that I introduced](https://github.com/sourcegraph/sourcegraph/pull/9541/files#diff-4c0e5adb9c777d181fac5c74474f820cL150). 


So three matches of `foo` on a line like `foo foo foo` would only count as one match on the indexed search path. To count the three separate `foo`s, we need to calculate the number based off of [`offsets`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d11e4dc7567c7f453ffd46cdabe1d6c58a2ebf06/-/blob/cmd/frontend/graphqlbackend/zoekt.go#L243) AKA fragments (which is what this PR does). Now this prompted the question of whether we intended to report the number of line matches, or the number of fragments. I believe we really do mean to report the number of fragments (since that seems reasonable), but also because that's what the [unindexed search part did before the change](https://github.com/sourcegraph/sourcegraph/pull/9541/files#diff-12aa12435865df936cc98d2d3dd0d510R292) (and this behavior is preserved, with `MatchCount`) _but only because the logic in the unindexed search path always adds only one fragment per line match_, as you can see [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d11e4dc7567c7f453ffd46cdabe1d6c58a2ebf06/-/blob/cmd/searcher/search/search_regex.go#L271).

So, there is/was a discrepancy of match count in the indexed/unindexed search paths before the regression, and this PR addresses that bug as well. If we really mean to report the number of lines, and not fragments, then it implies that the unindexed search part contains a bug (reports more matches than number of lines). I do think we mean to report the number of fragments. 

But there's another interesting tidbit: Zoekt returns a `MatchCount` member, for example, we access it here: [`resp.MatchCount`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d11e4dc7567c7f453ffd46cdabe1d6c58a2ebf06/-/blob/cmd/frontend/graphqlbackend/zoekt.go#L146-150). I thought that I could use that `MatchCount` value to return the number of matches, because the docstring says:

> // Number of non-overlapping matches [ref](https://sourcegraph.com/github.com/sourcegraph/zoekt/-/blob/api.go#L135)

And from this description I assumed it meant it counts multiple matches on a line, since I'm not sure what "non-overlapping matches" would mean if they are separated by lines, which are already discrete, non-overlapping data. Maybe it means something entirely different, because this `MatchCount` only counts the number of lines, not the number of matches in a line. It's also possible that's a bug, but I am not familiar enough with what this data member of Zoekt is trying to say, so CC @keegancsmith, take from it what you will.

---

It took me ~15 minutes to verify a fix, and 1.5+ hours to write the test, and that's really frustrating. I had to keep adding data to the test case so the function wouldn't nil panic all over the place until finally I wound up with a ~60 line struct :/. This would be better as an integration test, but the infra isn't ready yet. CC @unknwon I'm just pointing out this is important and a real pain point, I'm hoping it comes soon 🤞 

