### PR TITLE
src-cli: bump minimum to 3.13.0

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.12.0"
+const MinimumVersion = "3.13.0"


### PR DESCRIPTION
I'm following the directions here: https://github.com/sourcegraph/src-cli/blob/master/DEVELOPMENT.md#releasing

I see that the release is built (https://github.com/sourcegraph/src-cli/releases/tag/3.13.0), but the curl commands in the README is still giving me 3.12.0 from sourcegraph.com 🤔 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
