### PR TITLE
handlerutil: add test for checking `URLMovedError`

### DIFF
--- a/cmd/frontend/internal/pkg/handlerutil/repo_test.go
+++ b/cmd/frontend/internal/pkg/handlerutil/repo_test.go
@@ -1,0 +1,26 @@
+package handlerutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func TestGetRepo(t *testing.T) {
+	t.Run("URLMovedError", func(t *testing.T) {
+		backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
+			return &types.Repo{Name: name + name}, nil
+		}
+		t.Cleanup(func() {
+			backend.Mocks.Repos = backend.MockRepos{}
+		})
+
+		_, err := GetRepo(context.Background(), map[string]string{"Repo": "repo1"})
+		if _, ok := err.(*URLMovedError); !ok {
+			t.Fatalf("err: want type *URLMovedError but got %T", err)
+		}
+	})
+}


### PR DESCRIPTION
Adds a test case to test for `URLMovedError` when the requested repository name is "outdated". This is happens when a repository is renamed on code host or the external config has `repositoryPathPattern` configured.