### PR TITLE
Add argument field to BigQuery event logs

### DIFF
--- a/cmd/frontend/internal/usagestats/event_handlers.go
+++ b/cmd/frontend/internal/usagestats/event_handlers.go
@@ -60,6 +60,7 @@ type bigQueryEvent struct {
 	Source          string `json:"source"`
 	Timestamp       string `json:"timestamp"`
 	Version         string `json:"version"`
+	Argument        string `json:"argument"`
 }
 
 // publishSourcegraphDotComEvent publishes Sourcegraph.com events to BigQuery.
@@ -78,6 +79,7 @@ func publishSourcegraphDotComEvent(args Event) error {
 		Source:          args.Source,
 		Timestamp:       time.Now().UTC().Format(time.RFC3339),
 		Version:         version.Version(),
+		Argument:        args.Argument,
 	})
 	if err != nil {
 		return err

--- a/cmd/frontend/internal/usagestats/event_handlers.go
+++ b/cmd/frontend/internal/usagestats/event_handlers.go
@@ -79,7 +79,7 @@ func publishSourcegraphDotComEvent(args Event) error {
 		Source:          args.Source,
 		Timestamp:       time.Now().UTC().Format(time.RFC3339),
 		Version:         version.Version(),
-		Argument:        args.Argument,
+		Argument:        string(args.Argument),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
@ebrodymoore before this is merged, we need to test that this doesn't break anything with events that actually contain JSON argument data... My #1 concern is that we wouldn't be properly escaping the characters, so an arguments field that looks like 
`{"query_data": { "combined": "<SEARCH STRING>", ... } }`
would break things if `<SEARCH STRING>` itself contained `{`s and `,`s and etc.

Would you be able to do that test? Let me know if I can help here!

Note that we are already capturing search query data at https://sourcegraph.com/github.com/sourcegraph/sourcegraph@89f9e5f0889ae3966fe76f65c06ef1f743785386/-/blob/web/src/search/queryTelemetry.tsx#L10:9