### PR TITLE
Add viewerCanAdminister flag to campaigns connection

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -53,9 +53,10 @@ type PatchInput struct {
 }
 
 type ListCampaignArgs struct {
-	First       *int32
-	State       *string
-	HasPatchSet *bool
+	First               *int32
+	State               *string
+	HasPatchSet         *bool
+	ViewerCanAdminister *bool
 }
 
 type DeleteCampaignArgs struct {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -821,6 +821,8 @@ type ExternalChangeset implements Node & Changeset {
         state: CampaignState
         # Only return campaigns that have a patchset.
         hasPatchSet: Boolean
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
     ): CampaignConnection!
 
     # The events belonging to this changeset.
@@ -1097,6 +1099,8 @@ type Query {
         state: CampaignState
         # Only return campaigns that have a patchset.
         hasPatchSet: Boolean
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
     ): CampaignConnection!
 
     # Looks up a repository by either name or cloneURL.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -828,6 +828,8 @@ type ExternalChangeset implements Node & Changeset {
         state: CampaignState
         # Only return campaigns that have a patchset.
         hasPatchSet: Boolean
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
     ): CampaignConnection!
 
     # The events belonging to this changeset.
@@ -1104,6 +1106,8 @@ type Query {
         state: CampaignState
         # Only return campaigns that have a patchset.
         hasPatchSet: Boolean
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
     ): CampaignConnection!
 
     # Looks up a repository by either name or cloneURL.

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -42,7 +42,7 @@ func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacke
 }
 
 func (r *campaignsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	opts := ee.CountCampaignsOpts{ChangesetID: r.opts.ChangesetID, State: r.opts.State, HasPatchSet: r.opts.HasPatchSet}
+	opts := ee.CountCampaignsOpts{ChangesetID: r.opts.ChangesetID, State: r.opts.State, HasPatchSet: r.opts.HasPatchSet, OnlyForAuthor: r.opts.OnlyForAuthor}
 	count, err := r.store.CountCampaigns(ctx, opts)
 	return int32(count), err
 }

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -223,7 +224,7 @@ func (r *changesetResolver) Repository(ctx context.Context) (*graphqlbackend.Rep
 }
 
 func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
-	return newChangesetCampaignsConnectionsResolver(r.store, r.httpFactory, r.Changeset.ID, args)
+	return newChangesetCampaignsConnectionsResolver(ctx, r.store, r.httpFactory, r.Changeset.ID, args)
 }
 
 func (r *changesetResolver) CreatedAt() graphqlbackend.DateTime {
@@ -492,7 +493,7 @@ func (r *hiddenChangesetResolver) ToHiddenExternalChangeset() (graphqlbackend.Hi
 func (r *hiddenChangesetResolver) ID() graphql.ID { return marshalHiddenChangesetID(r.Changeset.ID) }
 
 func (r *hiddenChangesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
-	return newChangesetCampaignsConnectionsResolver(r.store, r.httpFactory, r.Changeset.ID, args)
+	return newChangesetCampaignsConnectionsResolver(ctx, r.store, r.httpFactory, r.Changeset.ID, args)
 }
 
 func (r *hiddenChangesetResolver) CreatedAt() graphqlbackend.DateTime {
@@ -515,6 +516,7 @@ func (r *hiddenChangesetResolver) State() campaigns.ChangesetState {
 }
 
 func newChangesetCampaignsConnectionsResolver(
+	ctx context.Context,
 	s *ee.Store,
 	cf *httpcli.Factory,
 	changeset int64,
@@ -532,6 +534,18 @@ func newChangesetCampaignsConnectionsResolver(
 	opts.State = state
 	if args.First != nil {
 		opts.Limit = int(*args.First)
+	}
+
+	authErr := backend.CheckCurrentUserIsSiteAdmin(ctx)
+	if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
+		return nil, err
+	}
+	isSiteAdmin := authErr != backend.ErrMustBeSiteAdmin
+	if !isSiteAdmin {
+		if args.ViewerCanAdminister != nil && *args.ViewerCanAdminister {
+			actor := actor.FromContext(ctx)
+			opts.OnlyForAuthor = actor.UID
+		}
 	}
 
 	return &campaignsConnectionResolver{store: s, httpFactory: cf, opts: opts}, nil

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1734,6 +1734,79 @@ func TestPermissionLevels(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("Campaigns", func(t *testing.T) {
+			tests := []struct {
+				name                string
+				currentUser         int32
+				viewerCanAdminister bool
+				wantCampaigns       []int64
+			}{
+				{
+					name:                "admin listing viewerCanAdminister: true",
+					currentUser:         adminID,
+					viewerCanAdminister: true,
+					wantCampaigns:       []int64{adminCampaign, userCampaign},
+				},
+				{
+					name:                "user listing viewerCanAdminister: true",
+					currentUser:         userID,
+					viewerCanAdminister: true,
+					wantCampaigns:       []int64{userCampaign},
+				},
+				{
+					name:                "admin listing viewerCanAdminister: false",
+					currentUser:         adminID,
+					viewerCanAdminister: false,
+					wantCampaigns:       []int64{adminCampaign, userCampaign},
+				},
+				{
+					name:                "user listing viewerCanAdminister: false",
+					currentUser:         userID,
+					viewerCanAdminister: false,
+					wantCampaigns:       []int64{adminCampaign, userCampaign},
+				},
+			}
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					actorCtx := actor.WithActor(context.Background(), actor.FromUser(tc.currentUser))
+					expectedIDs := make(map[string]bool, len(tc.wantCampaigns))
+					for _, c := range tc.wantCampaigns {
+						graphqlID := string(campaigns.MarshalCampaignID(c))
+						expectedIDs[graphqlID] = true
+					}
+
+					query := fmt.Sprintf(`
+				query {
+					campaigns(viewerCanAdminister: %t) { totalCount, nodes { id } }
+					node(id: %q) {
+						id
+						... on ExternalChangeset {
+							campaigns(viewerCanAdminister: %t) { totalCount, nodes { id } }
+						}
+					}
+					}`, tc.viewerCanAdminister, marshalChangesetID(changeset.ID), tc.viewerCanAdminister)
+					var res struct {
+						Campaigns apitest.CampaignConnection
+						Node      apitest.Changeset
+					}
+					apitest.MustExec(actorCtx, t, s, nil, &res, query)
+					for _, conn := range []apitest.CampaignConnection{res.Campaigns, res.Node.Campaigns} {
+						if have, want := conn.TotalCount, len(tc.wantCampaigns); have != want {
+							t.Fatalf("wrong count of campaigns returned, want=%d have=%d", want, have)
+						}
+						if have, want := conn.TotalCount, len(conn.Nodes); have != want {
+							t.Fatalf("totalCount and nodes length don't match, want=%d have=%d", want, have)
+						}
+						for _, node := range conn.Nodes {
+							if _, ok := expectedIDs[node.ID]; !ok {
+								t.Fatalf("received wrong campaign with id %q", node.ID)
+							}
+						}
+					}
+				})
+			}
+		})
 	})
 
 	t.Run("mutations", func(t *testing.T) {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1785,7 +1785,7 @@ func TestPermissionLevels(t *testing.T) {
 							campaigns(viewerCanAdminister: %t) { totalCount, nodes { id } }
 						}
 					}
-					}`, tc.viewerCanAdminister, marshalChangesetID(changeset.ID), tc.viewerCanAdminister)
+					}`, tc.viewerCanAdminister, marshalExternalChangesetID(changeset.ID), tc.viewerCanAdminister)
 					var res struct {
 						Campaigns apitest.CampaignConnection
 						Node      apitest.Changeset

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1335,6 +1335,8 @@ type CountCampaignsOpts struct {
 	ChangesetID int64
 	State       campaigns.CampaignState
 	HasPatchSet *bool
+	// Only return campaigns where author_id is the given.
+	OnlyForAuthor int32
 }
 
 // CountCampaigns returns the number of campaigns in the database.
@@ -1372,6 +1374,10 @@ func countCampaignsQuery(opts *CountCampaignsOpts) *sqlf.Query {
 		} else {
 			preds = append(preds, sqlf.Sprintf("patch_set_id IS NULL"))
 		}
+	}
+
+	if opts.OnlyForAuthor != 0 {
+		preds = append(preds, sqlf.Sprintf("author_id = %d", opts.OnlyForAuthor))
 	}
 
 	if len(preds) == 0 {
@@ -1451,6 +1457,8 @@ type ListCampaignsOpts struct {
 	Limit       int
 	State       campaigns.CampaignState
 	HasPatchSet *bool
+	// Only return campaigns where author_id is the given.
+	OnlyForAuthor int32
 }
 
 // ListCampaigns lists Campaigns with the given filters.
@@ -1523,6 +1531,10 @@ func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
 		} else {
 			preds = append(preds, sqlf.Sprintf("patch_set_id IS NULL"))
 		}
+	}
+
+	if opts.OnlyForAuthor != 0 {
+		preds = append(preds, sqlf.Sprintf("author_id = %d", opts.OnlyForAuthor))
 	}
 
 	return sqlf.Sprintf(


### PR DESCRIPTION
This is required for making https://github.com/sourcegraph/sourcegraph/issues/10982 work, as the campaign update selection screen needs it.