### PR TITLE
Bump src-cli version to 3.14

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.13.0"
+const MinimumVersion = "3.14.0"


### PR DESCRIPTION
This version includes the fix in
https://github.com/sourcegraph/src-cli/pull/213 which is required for
https://github.com/sourcegraph/sourcegraph/pull/11071.
