### PR TITLE
codeintel: Add index resetter process

### DIFF
--- a/cmd/precise-code-intel-indexer/env.go
+++ b/cmd/precise-code-intel-indexer/env.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	rawFrontendURL, _                   = os.LookupEnv("SRC_FRONTEND_INTERNAL")
+	rawResetInterval                    = env.Get("PRECISE_CODE_INTEL_RESET_INTERVAL", "1m", "How often to reset stalled indexes.")
 	rawIndexerPollInterval              = env.Get("PRECISE_CODE_INTEL_INDEXER_POLL_INTERVAL", "1s", "Interval between queries to the index queue.")
 	rawIndexabilityUpdaterInterval      = env.Get("PRECISE_CODE_INTEL_INDEXABILITY_UPDATER_INTERVAL", "30m", "Interval between scheduled indexability updates.")
 	rawSchedulerInterval                = env.Get("PRECISE_CODE_INTEL_SCHEDULER_INTERVAL", "30m", "Interval between scheduled index updates.")

--- a/cmd/precise-code-intel-indexer/internal/resetter/metrics.go
+++ b/cmd/precise-code-intel-indexer/internal/resetter/metrics.go
@@ -1,0 +1,27 @@
+package resetter
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type ResetterMetrics struct {
+	Count  prometheus.Counter
+	Errors prometheus.Counter
+}
+
+func NewResetterMetrics(r prometheus.Registerer) ResetterMetrics {
+	count := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_index_queue_resets_total",
+		Help: "Total number of indexes put back into queued state",
+	})
+	r.MustRegister(count)
+
+	errors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_index_queue_reset_errors_total",
+		Help: "Total number of errors when running the index resetter",
+	})
+	r.MustRegister(errors)
+
+	return ResetterMetrics{
+		Count:  count,
+		Errors: errors,
+	}
+}

--- a/cmd/precise-code-intel-indexer/internal/resetter/resetter.go
+++ b/cmd/precise-code-intel-indexer/internal/resetter/resetter.go
@@ -1,0 +1,35 @@
+package resetter
+
+import (
+	"context"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/db"
+)
+
+type IndexResetter struct {
+	DB            db.DB
+	ResetInterval time.Duration
+	Metrics       ResetterMetrics
+}
+
+// Run periodically moves all indexes that have been in the PROCESSING state for a
+// while back to QUEUED. For each updated index record, the indexer process that
+// was responsible for handling the index did not hold a row lock, indicating that
+// it has died.
+func (ur *IndexResetter) Run() {
+	for {
+		ids, err := ur.DB.ResetStalledIndexes(context.Background(), time.Now())
+		if err != nil {
+			ur.Metrics.Errors.Inc()
+			log15.Error("Failed to reset stalled indexes", "error", err)
+		}
+		for _, id := range ids {
+			log15.Debug("Reset stalled index", "indexID", id)
+		}
+
+		ur.Metrics.Count.Add(float64(len(ids)))
+		time.Sleep(ur.ResetInterval)
+	}
+}

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -161,6 +161,10 @@ type DB interface {
 	// false valued flag. This method must not be called from within a transaction.
 	DequeueIndex(ctx context.Context) (Index, DB, bool, error)
 
+	// ResetStalledIndexes moves all unlocked indexes processing for more than `StalledIndexMaxAge` back to the
+	// queued state. This method returns a list of updated index identifiers.
+	ResetStalledIndexes(ctx context.Context, now time.Time) ([]int, error)
+
 	// RepoUsageStatistics reads recent event log records and returns the number of search-based and precise
 	// code intelligence activity within the last week grouped by repository. The resulting slice is ordered
 	// by search then precise event counts.

--- a/internal/codeintel/db/observability.go
+++ b/internal/codeintel/db/observability.go
@@ -49,6 +49,7 @@ type ObservedDB struct {
 	markIndexCompleteOperation         *observation.Operation
 	markIndexErroredOperation          *observation.Operation
 	dequeueIndexOperation              *observation.Operation
+	resetStalledIndexesOperation       *observation.Operation
 	repoUsageStatisticsOperation       *observation.Operation
 	repoNameOperation                  *observation.Operation
 }
@@ -251,6 +252,11 @@ func NewObserved(db DB, observationContext *observation.Context) DB {
 			MetricLabels: []string{"dequeue_index"},
 			Metrics:      metrics,
 		}),
+		resetStalledIndexesOperation: observationContext.Operation(observation.Op{
+			Name:         "DB.ResetStalledIndexes",
+			MetricLabels: []string{"reset_stalled_indexes"},
+			Metrics:      metrics,
+		}),
 		repoUsageStatisticsOperation: observationContext.Operation(observation.Op{
 			Name:         "DB.RepoUsageStatistics",
 			MetricLabels: []string{"repo_usage_statistics"},
@@ -309,6 +315,7 @@ func (db *ObservedDB) wrap(other DB) DB {
 		markIndexCompleteOperation:         db.markIndexCompleteOperation,
 		markIndexErroredOperation:          db.markIndexErroredOperation,
 		dequeueIndexOperation:              db.dequeueIndexOperation,
+		resetStalledIndexesOperation:       db.resetStalledIndexesOperation,
 		repoUsageStatisticsOperation:       db.repoUsageStatisticsOperation,
 		repoNameOperation:                  db.repoNameOperation,
 	}
@@ -590,6 +597,13 @@ func (db *ObservedDB) DequeueIndex(ctx context.Context) (_ Index, _ DB, _ bool, 
 	ctx, endObservation := db.dequeueIndexOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 	return db.db.DequeueIndex(ctx)
+}
+
+// ResetStalledIndexes calls into the inner DB and registers the observed results.
+func (db *ObservedDB) ResetStalledIndexes(ctx context.Context, now time.Time) (_ []int, err error) {
+	ctx, endObservation := db.resetStalledIndexesOperation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+	return db.db.ResetStalledIndexes(ctx, now)
 }
 
 // RepoUsageStatistics calls into the inner DB and registers the observed results.


### PR DESCRIPTION
This is symmetric to the upload resetter process to move "stuck" processing indexes back to queued when the indexer that was working on them died unexpectedly.