### PR TITLE
web: Reload after toggling the Campaigns flag

### DIFF
--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -15,6 +15,7 @@ import { ErrorAlert } from '../components/alerts'
 import * as jsonc from '@sqs/jsonc-parser'
 import { setProperty } from '@sqs/jsonc-parser/lib/edit'
 import * as H from 'history'
+import { SiteConfiguration } from '../schema/site.schema'
 
 const defaultFormattingOptions: jsonc.FormattingOptions = {
     eol: '\n',
@@ -251,6 +252,24 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                                 console.error(error)
                                 this.setState({ saving: false, error })
                                 return []
+                            }),
+                            tap(() => {
+                                // Flipping the Campaigns feature flag
+                                // ("automation") requires a reload for the
+                                // Campaigns UI to be correctly rendered.
+                                //
+                                // This should be removed once the feature flag
+                                // is removed.
+                                const lastAutomationEnabled = lastConfiguration
+                                    ? (jsonc.parse(lastConfiguration.effectiveContents) as SiteConfiguration)
+                                          .experimentalFeatures?.automation
+                                    : undefined
+                                const newAutomationEnabled = (jsonc.parse(newContents) as SiteConfiguration)
+                                    .experimentalFeatures?.automation
+
+                                if (lastAutomationEnabled !== newAutomationEnabled) {
+                                    window.location.reload()
+                                }
                             })
                         )
                     }),

--- a/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -260,12 +260,13 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                                 //
                                 // This should be removed once the feature flag
                                 // is removed.
-                                const lastAutomationEnabled = lastConfiguration
-                                    ? (jsonc.parse(lastConfiguration.effectiveContents) as SiteConfiguration)
-                                          .experimentalFeatures?.automation
-                                    : undefined
-                                const newAutomationEnabled = (jsonc.parse(newContents) as SiteConfiguration)
-                                    .experimentalFeatures?.automation
+                                const lastAutomationEnabled =
+                                    (lastConfiguration &&
+                                        (jsonc.parse(lastConfiguration.effectiveContents) as SiteConfiguration)
+                                            ?.experimentalFeatures?.automation) === 'enabled'
+                                const newAutomationEnabled =
+                                    (jsonc.parse(newContents) as SiteConfiguration)?.experimentalFeatures
+                                        ?.automation === 'enabled'
 
                                 if (lastAutomationEnabled !== newAutomationEnabled) {
                                     window.location.reload()


### PR DESCRIPTION
This implements the approach suggested by @felixfbecker in #11118: instead of having the server tell us when a reload is required, let's just parse and pull apart the before and after configuration blobs and figure out if we need to reload from that.

My assumption is that we'll revert this PR in full as part of removing the feature flag, when the time comes.

Fixes #10715.