### PR TITLE
codeintel: Perform bundle migrations concurrently

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/paths/paths.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/paths/paths.go
@@ -10,6 +10,7 @@ const uploadDir = "uploads"
 const uploadPartsDir = "upload-parts"
 const dbsDir = "dbs"
 const dbPartsDir = "db-parts"
+const migrationMarkersDir = "migration-markers"
 
 // PrepDirectories creates the root directories within the given bundle dir.
 func PrepDirectories(bundleDir string) error {
@@ -18,6 +19,7 @@ func PrepDirectories(bundleDir string) error {
 		uploadPartsDir,
 		dbsDir,
 		dbPartsDir,
+		migrationMarkersDir,
 	}
 
 	for _, dir := range rootDirs {
@@ -72,4 +74,9 @@ func DBPartsDir(bundleDir string) string {
 // DBPartFilename returns the path of the db with the given identifier and part index.
 func DBPartFilename(bundleDir string, id, index int64) string {
 	return filepath.Join(bundleDir, dbPartsDir, fmt.Sprintf("%d.%d.gz", id, index))
+}
+
+// MigrationMarkerFilename returns the path to the file that marks a migration has been performed.
+func MigrationMarkerFilename(bundleDir string, version int) string {
+	return filepath.Join(bundleDir, migrationMarkersDir, fmt.Sprintf("v%d", version))
 }

--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -307,13 +307,15 @@ var ErrUnknownDatabase = errors.New("unknown database")
 // route's id value and serializes the resulting value to the response writer. If an
 // error occurs it will be written to the body of a 500-level response.
 func (s *Server) dbQuery(w http.ResponseWriter, r *http.Request, handler dbQueryHandlerFn) {
+	id := idFromRequest(r)
+
 	if err := s.dbQueryErr(w, r, handler); err != nil {
 		if err == ErrUnknownDatabase {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
 
-		log15.Error("Failed to handle query", "err", err)
+		log15.Error("Failed to handle query", "err", err, "id", id)
 		http.Error(w, fmt.Sprintf("failed to handle query: %s", err.Error()), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
This processes multiple migrations in a background process at once. This also marks a file so that the same migration version does not need to be run multiple times (although it would be fast to do a second time, it still requires opening _every_ database on disk).