### PR TITLE
campaigns: Cache external changeset diffstats

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -129,6 +129,10 @@ Foreign-key constraints:
  external_check_state  | text                     | 
  created_by_campaign   | boolean                  | not null default false
  added_to_campaign     | boolean                  | not null default false
+ diff_stat_added       | integer                  | 
+ diff_stat_changed     | integer                  | 
+ diff_stat_deleted     | integer                  | 
+ sync_state            | jsonb                    | not null default '{}'::jsonb
 Indexes:
     "changesets_pkey" PRIMARY KEY, btree (id)
     "changesets_repo_external_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_id)

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -278,6 +278,7 @@ type ExternalChangesetResolver interface {
 
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)
 	Diff(ctx context.Context) (*RepositoryComparisonResolver, error)
+	DiffStat(ctx context.Context) (*DiffStat, error)
 	Head(ctx context.Context) (*GitRefResolver, error)
 	Base(ctx context.Context) (*GitRefResolver, error)
 	Labels(ctx context.Context) ([]ChangesetLabelResolver, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -872,6 +872,12 @@ type ExternalChangeset implements Node & Changeset {
     # The diff of this changeset, or null if the changeset is closed (without merging) or is already merged.
     diff: RepositoryComparison
 
+    # The diffstat of this changeset, or null if the changeset is closed
+    # (without merging) or is already merged. This data is also available
+    # indirectly through the diff field above, but if only the diffStat is
+    # required, this field is cheaper to access.
+    diffStat: DiffStat
+
     # The state of the checks (e.g., for continuous integration) on this changeset, or null if no
     # checks have been configured.
     checkState: ChangesetCheckState

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -879,6 +879,12 @@ type ExternalChangeset implements Node & Changeset {
     # The diff of this changeset, or null if the changeset is closed (without merging) or is already merged.
     diff: RepositoryComparison
 
+    # The diffstat of this changeset, or null if the changeset is closed
+    # (without merging) or is already merged. This data is also available
+    # indirectly through the diff field above, but if only the diffStat is
+    # required, this field is cheaper to access.
+    diffStat: DiffStat
+
     # The state of the checks (e.g., for continuous integration) on this changeset, or null if no
     # checks have been configured.
     checkState: ChangesetCheckState

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -1,6 +1,9 @@
 package apitest
 
-import "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+import (
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
 
 type GitTarget struct {
 	OID            string
@@ -22,6 +25,10 @@ type GitRef struct {
 type DiffRange struct{ StartLine, Lines int }
 
 type DiffStat struct{ Added, Deleted, Changed int32 }
+
+func (ds DiffStat) ToDiffStat() *diff.Stat {
+	return &diff.Stat{Added: ds.Added, Deleted: ds.Deleted, Changed: ds.Changed}
+}
 
 type FileDiffHunk struct {
 	Body, Section      string

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -406,6 +406,13 @@ func (r *changesetResolver) Diff(ctx context.Context) (*graphqlbackend.Repositor
 	})
 }
 
+func (r *changesetResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffStat, error) {
+	if stat := r.Changeset.DiffStat(); stat != nil {
+		return graphqlbackend.NewDiffStat(*stat), nil
+	}
+	return nil, nil
+}
+
 func (r *changesetResolver) Head(ctx context.Context) (*graphqlbackend.GitRefResolver, error) {
 	name, err := r.Changeset.HeadRef()
 	if err != nil {

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -485,6 +485,7 @@ func TestRepositoryPermissions(t *testing.T) {
 				HeadRefOid: changesetHeadRefOid,
 			},
 		}
+		c.SetDiffStat(changesetDiffStat.ToDiffStat())
 		if err := store.CreateChangesets(ctx, c); err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -600,9 +600,7 @@ func TestCampaigns(t *testing.T) {
 
 	{
 		have := addChangesetsResult.Campaign.DiffStat
-		// Expected DiffStat is zeros, because we don't return diffstats for
-		// closed changesets
-		want := apitest.DiffStat{Added: 0, Changed: 0, Deleted: 0}
+		want := apitest.DiffStat{Added: 2, Changed: 2, Deleted: 6}
 		if have != want {
 			t.Errorf("wrong campaign combined diffstat. want=%v, have=%v", want, have)
 		}

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -1156,7 +1157,7 @@ func TestService(t *testing.T) {
 		}
 		t.Cleanup(func() { db.MockAuthzFilter = nil })
 
-		fakeSource := &FakeChangesetSource{Err: nil}
+		fakeSource := &ct.FakeChangesetSource{Err: nil}
 		sourcer := repos.NewFakeSourcer(nil, fakeSource)
 
 		svc := NewServiceWithClock(store, cf, clock)

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -1,22 +1,28 @@
 package campaigns
 
 import (
+	"context"
+	"io"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 // SetDerivedState will update the external state fields on the Changeset based
-// on the current  state of the changeset and associated events.
-func SetDerivedState(c *cmpgn.Changeset, es []*cmpgn.ChangesetEvent) {
+// on the current state of the changeset and associated events.
+func SetDerivedState(ctx context.Context, c *cmpgn.Changeset, es []*cmpgn.ChangesetEvent) {
 	// Copy so that we can sort without mutating the argument
 	events := make(ChangesetEvents, len(es))
 	copy(events, es)
@@ -39,6 +45,40 @@ func SetDerivedState(c *cmpgn.Changeset, es []*cmpgn.ChangesetEvent) {
 		log15.Warn("Computing changeset review state", "err", err)
 	} else {
 		c.ExternalReviewState = state
+	}
+
+	// Some of the fields on changesets are dependent on the SyncState: this
+	// encapsulates fields that we want to cache based on our current
+	// understanding of the changeset's state on the external provider that are
+	// not part of the metadata that we get from the provider's API.
+	//
+	// To update this, first we need gitserver's view of the repo.
+	repo, err := changesetGitserverRepo(ctx, c)
+	if err != nil {
+		log15.Warn("Retrieving gitserver repo for changeset", "err", err)
+		return
+	}
+
+	// Now we can update the state. Since we'll want to only perform some
+	// actions based on how the state changes, we'll keep references to the old
+	// and new states for the duration of this function, although we'll update
+	// c.SyncState as soon as we can.
+	oldState := c.SyncState
+	newState, err := computeSyncState(ctx, c, *repo)
+	if err != nil {
+		log15.Warn("Computing sync state", "err", err)
+		return
+	}
+	c.SyncState = *newState
+
+	// Now we can update fields that are invalidated when the sync state
+	// changes.
+	if !oldState.Equals(newState) {
+		if stat, err := computeDiffStat(ctx, c, *repo); err != nil {
+			log15.Warn("Computing diffstat", "err", err)
+		} else {
+			c.SetDiffStat(stat)
+		}
 	}
 }
 
@@ -386,6 +426,92 @@ func computeReviewState(statesByAuthor map[string]campaigns.ChangesetReviewState
 		states[s] = true
 	}
 	return selectReviewState(states)
+}
+
+// computeDiffStat computes the up to date diffstat for the changeset, based on
+// the values in c.SyncState.
+func computeDiffStat(ctx context.Context, c *cmpgn.Changeset, repo gitserver.Repo) (*diff.Stat, error) {
+	iter, err := git.Diff(ctx, git.DiffOptions{
+		Repo: repo,
+		Base: c.SyncState.BaseRefOid,
+		Head: c.SyncState.HeadRefOid,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	stat := &diff.Stat{}
+	for {
+		file, err := iter.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		fs := file.Stat()
+		log15.Info("file diff", "file", file.NewName, "stat", fs)
+		stat.Added += fs.Added
+		stat.Changed += fs.Changed
+		stat.Deleted += fs.Deleted
+	}
+
+	log15.Info("total diff stat", "stat", stat)
+
+	return stat, nil
+}
+
+// computeSyncState computes the up to date sync state based on the changeset as
+// it currently exists on the external provider.
+func computeSyncState(ctx context.Context, c *cmpgn.Changeset, repo gitserver.Repo) (*cmpgn.ChangesetSyncState, error) {
+	// If the changeset type can return the OIDs directly, then we can use that
+	// for the new state. Otherwise, we need to try to resolve the ref to a
+	// revision.
+	base, err := computeRev(ctx, c, repo, func(c *cmpgn.Changeset) (string, error) {
+		return c.BaseRefOid()
+	}, func(c *cmpgn.Changeset) (string, error) {
+		return c.BaseRef()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	head, err := computeRev(ctx, c, repo, func(c *cmpgn.Changeset) (string, error) {
+		return c.HeadRefOid()
+	}, func(c *cmpgn.Changeset) (string, error) {
+		return c.HeadRef()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &cmpgn.ChangesetSyncState{BaseRefOid: base, HeadRefOid: head}, nil
+}
+
+func computeRev(ctx context.Context, c *cmpgn.Changeset, repo gitserver.Repo, getOid, getRef func(*cmpgn.Changeset) (string, error)) (string, error) {
+	if rev, err := getOid(c); err != nil {
+		return "", err
+	} else if rev != "" {
+		return rev, nil
+	}
+
+	ref, err := getRef(c)
+	if err != nil {
+		return "", err
+	}
+
+	rev, err := git.ResolveRevision(ctx, repo, nil, ref, nil)
+	return string(rev), err
+}
+
+// changesetGitserverRepo looks up a gitserver.Repo based on the RepoID within a
+// changeset.
+func changesetGitserverRepo(ctx context.Context, c *cmpgn.Changeset) (*gitserver.Repo, error) {
+	repo, err := db.Repos.Get(ctx, c.RepoID)
+	if err != nil {
+		return nil, err
+	}
+	return &gitserver.Repo{Name: repo.Name, URL: repo.URI}, nil
 }
 
 func unixMilliToTime(ms int64) time.Time {

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -270,7 +270,11 @@ WITH batch AS (
       external_review_state text,
       external_check_state  text,
       created_by_campaign   boolean,
-      added_to_campaign     boolean
+      added_to_campaign     boolean,
+      diff_stat_added       integer,
+      diff_stat_changed     integer,
+	  diff_stat_deleted     integer,
+	  sync_state            jsonb
     )
   )
   WITH ORDINALITY
@@ -295,7 +299,11 @@ changed AS (
     external_review_state,
     external_check_state,
     created_by_campaign,
-    added_to_campaign
+	added_to_campaign,
+	diff_stat_added,
+	diff_stat_changed,
+	diff_stat_deleted,
+	sync_state
   )
   SELECT
     repo_id,
@@ -312,7 +320,11 @@ changed AS (
     external_review_state,
     external_check_state,
     created_by_campaign,
-    added_to_campaign
+	added_to_campaign,
+	diff_stat_added,
+	diff_stat_changed,
+	diff_stat_deleted,
+	sync_state
   FROM batch
   ON CONFLICT ON CONSTRAINT
     changesets_repo_external_id_unique
@@ -338,7 +350,11 @@ SELECT
   COALESCE(changed.external_review_state, existing.external_review_state) AS external_review_state,
   COALESCE(changed.external_check_state, existing.external_check_state) AS external_check_state,
   COALESCE(changed.created_by_campaign, existing.created_by_campaign) AS created_by_campaign,
-  COALESCE(changed.added_to_campaign, existing.added_to_campaign) AS added_to_campaign
+  COALESCE(changed.added_to_campaign, existing.added_to_campaign) AS added_to_campaign,
+  COALESCE(changed.diff_stat_added, existing.diff_stat_added) AS diff_stat_added,
+  COALESCE(changed.diff_stat_changed, existing.diff_stat_changed) AS diff_stat_changed,
+  COALESCE(changed.diff_stat_deleted, existing.diff_stat_deleted) AS diff_stat_deleted,
+  COALESCE(changed.sync_state, existing.sync_state) AS sync_state
 FROM changed
 RIGHT JOIN batch ON batch.repo_id = changed.repo_id
 AND batch.external_id = changed.external_id
@@ -379,6 +395,10 @@ func batchChangesetsQuery(fmtstr string, cs []*campaigns.Changeset) (*sqlf.Query
 		ExternalCheckState  *campaigns.ChangesetCheckState  `json:"external_check_state"`
 		CreatedByCampaign   bool                            `json:"created_by_campaign"`
 		AddedToCampaign     bool                            `json:"added_to_campaign"`
+		DiffStatAdded       *int32                          `json:"diff_stat_added"`
+		DiffStatChanged     *int32                          `json:"diff_stat_changed"`
+		DiffStatDeleted     *int32                          `json:"diff_stat_deleted"`
+		SyncState           json.RawMessage                 `json:"sync_state"`
 	}
 
 	records := make([]record, 0, len(cs))
@@ -390,6 +410,11 @@ func batchChangesetsQuery(fmtstr string, cs []*campaigns.Changeset) (*sqlf.Query
 		}
 
 		campaignIDs, err := jsonSetColumn(c.CampaignIDs)
+		if err != nil {
+			return nil, err
+		}
+
+		syncState, err := json.Marshal(c.SyncState)
 		if err != nil {
 			return nil, err
 		}
@@ -408,6 +433,10 @@ func batchChangesetsQuery(fmtstr string, cs []*campaigns.Changeset) (*sqlf.Query
 			ExternalUpdatedAt:   nullTimeColumn(c.ExternalUpdatedAt),
 			CreatedByCampaign:   c.CreatedByCampaign,
 			AddedToCampaign:     c.AddedToCampaign,
+			DiffStatAdded:       c.DiffStatAdded,
+			DiffStatChanged:     c.DiffStatChanged,
+			DiffStatDeleted:     c.DiffStatDeleted,
+			SyncState:           syncState,
 		}
 		if len(c.ExternalState) > 0 {
 			r.ExternalState = &c.ExternalState
@@ -540,7 +569,11 @@ SELECT
   changesets.external_review_state,
   changesets.external_check_state,
   changesets.created_by_campaign,
-  changesets.added_to_campaign
+  changesets.added_to_campaign,
+  changesets.diff_stat_added,
+  changesets.diff_stat_changed,
+  changesets.diff_stat_deleted,
+  changesets.sync_state
 FROM changesets
 INNER JOIN repo ON repo.id = changesets.repo_id
 WHERE %s
@@ -656,14 +689,15 @@ func listChangesetSyncData(opts ListChangesetSyncDataOpts) *sqlf.Query {
 // ListChangesetsOpts captures the query options needed for
 // listing changesets.
 type ListChangesetsOpts struct {
-	Cursor              int64
-	Limit               int
-	CampaignID          int64
-	IDs                 []int64
-	WithoutDeleted      bool
-	ExternalState       *campaigns.ChangesetState
-	ExternalReviewState *campaigns.ChangesetReviewState
-	ExternalCheckState  *campaigns.ChangesetCheckState
+	Cursor               int64
+	Limit                int
+	CampaignID           int64
+	IDs                  []int64
+	WithoutDeleted       bool
+	ExternalState        *campaigns.ChangesetState
+	ExternalReviewState  *campaigns.ChangesetReviewState
+	ExternalCheckState   *campaigns.ChangesetCheckState
+	OnlyWithoutDiffStats bool
 }
 
 // ListChangesets lists Changesets with the given filters.
@@ -706,7 +740,11 @@ SELECT
   changesets.external_review_state,
   changesets.external_check_state,
   changesets.created_by_campaign,
-  changesets.added_to_campaign
+  changesets.added_to_campaign,
+  changesets.diff_stat_added,
+  changesets.diff_stat_changed,
+  changesets.diff_stat_deleted,
+  changesets.sync_state
 FROM changesets
 INNER JOIN repo ON repo.id = changesets.repo_id
 WHERE %s
@@ -759,6 +797,10 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("changesets.external_check_state = %s", *opts.ExternalCheckState))
 	}
 
+	if opts.OnlyWithoutDiffStats {
+		preds = append(preds, sqlf.Sprintf("(changesets.diff_stat_added IS NULL OR changesets.diff_stat_changed IS NULL OR changesets.diff_stat_deleted IS NULL)"))
+	}
+
 	return sqlf.Sprintf(
 		listChangesetsQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
@@ -799,7 +841,11 @@ changed AS (
     external_review_state = batch.external_review_state,
     external_check_state  = batch.external_check_state,
     created_by_campaign   = batch.created_by_campaign,
-    added_to_campaign     = batch.added_to_campaign
+	added_to_campaign     = batch.added_to_campaign,
+	diff_stat_added       = batch.diff_stat_added,
+	diff_stat_changed     = batch.diff_stat_changed,
+	diff_stat_deleted     = batch.diff_stat_deleted,
+	sync_state            = batch.sync_state
   FROM batch
   WHERE changesets.id = batch.id
   RETURNING changesets.*
@@ -823,7 +869,11 @@ SELECT
   changed.external_review_state,
   changed.external_check_state,
   changed.created_by_campaign,
-  changed.added_to_campaign
+  changed.added_to_campaign,
+  changed.diff_stat_added,
+  changed.diff_stat_changed,
+  changed.diff_stat_deleted,
+  changed.sync_state
 FROM changed
 LEFT JOIN batch ON batch.repo_id = changed.repo_id
 AND batch.external_id = changed.external_id
@@ -2829,7 +2879,7 @@ func closeErr(c io.Closer, err *error) {
 }
 
 func scanChangeset(t *campaigns.Changeset, s scanner) error {
-	var metadata json.RawMessage
+	var metadata, syncState json.RawMessage
 
 	var (
 		externalState       string
@@ -2853,6 +2903,10 @@ func scanChangeset(t *campaigns.Changeset, s scanner) error {
 		&dbutil.NullString{S: &externalCheckState},
 		&t.CreatedByCampaign,
 		&t.AddedToCampaign,
+		&t.DiffStatAdded,
+		&t.DiffStatChanged,
+		&t.DiffStatDeleted,
+		&syncState,
 	)
 	if err != nil {
 		return errors.Wrap(err, "scanning changeset")
@@ -2873,6 +2927,9 @@ func scanChangeset(t *campaigns.Changeset, s scanner) error {
 
 	if err = json.Unmarshal(metadata, t.Metadata); err != nil {
 		return errors.Wrapf(err, "scanChangeset: failed to unmarshal %q metadata", t.ExternalServiceType)
+	}
+	if err = json.Unmarshal(syncState, &t.SyncState); err != nil {
+		return errors.Wrapf(err, "scanChangeset: failed to unmarshal sync state: %s", syncState)
 	}
 
 	return nil

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -273,8 +273,8 @@ WITH batch AS (
       added_to_campaign     boolean,
       diff_stat_added       integer,
       diff_stat_changed     integer,
-	  diff_stat_deleted     integer,
-	  sync_state            jsonb
+      diff_stat_deleted     integer,
+      sync_state            jsonb
     )
   )
   WITH ORDINALITY
@@ -299,11 +299,11 @@ changed AS (
     external_review_state,
     external_check_state,
     created_by_campaign,
-	added_to_campaign,
-	diff_stat_added,
-	diff_stat_changed,
-	diff_stat_deleted,
-	sync_state
+    added_to_campaign,
+    diff_stat_added,
+    diff_stat_changed,
+    diff_stat_deleted,
+    sync_state
   )
   SELECT
     repo_id,
@@ -320,11 +320,11 @@ changed AS (
     external_review_state,
     external_check_state,
     created_by_campaign,
-	added_to_campaign,
-	diff_stat_added,
-	diff_stat_changed,
-	diff_stat_deleted,
-	sync_state
+    added_to_campaign,
+    diff_stat_added,
+    diff_stat_changed,
+    diff_stat_deleted,
+    sync_state
   FROM batch
   ON CONFLICT ON CONSTRAINT
     changesets_repo_external_id_unique
@@ -835,17 +835,17 @@ changed AS (
     external_id           = batch.external_id,
     external_service_type = batch.external_service_type,
     external_branch       = batch.external_branch,
-	external_deleted_at   = batch.external_deleted_at,
-	external_updated_at   = batch.external_updated_at,
+    external_deleted_at   = batch.external_deleted_at,
+    external_updated_at   = batch.external_updated_at,
     external_state        = batch.external_state,
     external_review_state = batch.external_review_state,
     external_check_state  = batch.external_check_state,
     created_by_campaign   = batch.created_by_campaign,
-	added_to_campaign     = batch.added_to_campaign,
-	diff_stat_added       = batch.diff_stat_added,
-	diff_stat_changed     = batch.diff_stat_changed,
-	diff_stat_deleted     = batch.diff_stat_deleted,
-	sync_state            = batch.sync_state
+    added_to_campaign     = batch.added_to_campaign,
+    diff_stat_added       = batch.diff_stat_added,
+    diff_stat_changed     = batch.diff_stat_changed,
+    diff_stat_deleted     = batch.diff_stat_deleted,
+    sync_state            = batch.sync_state
   FROM batch
   WHERE changesets.id = batch.id
   RETURNING changesets.*

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -466,6 +466,12 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		ExternalServiceType: extsvc.TypeGitHub,
 	}
 
+	var (
+		added   int32 = 77
+		deleted int32 = 88
+		changed int32 = 99
+	)
+
 	t.Run("Create", func(t *testing.T) {
 		var i int
 		for i = 0; i < cap(changesets); i++ {
@@ -482,6 +488,14 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				ExternalState:       cmpgn.ChangesetStateOpen,
 				ExternalReviewState: cmpgn.ChangesetReviewStateApproved,
 				ExternalCheckState:  cmpgn.ChangesetCheckStatePassed,
+			}
+
+			// Only set the diff stats on a subset to make sure that
+			// we handle nil pointers correctly
+			if i != cap(changesets)-1 {
+				th.DiffStatAdded = &added
+				th.DiffStatChanged = &changed
+				th.DiffStatDeleted = &deleted
 			}
 
 			changesets = append(changesets, th)
@@ -755,6 +769,22 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 
 			if len(have) != 0 {
 				t.Fatalf("have %d changesets. want 0", len(changesets))
+			}
+		}
+
+		{
+			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{OnlyWithoutDiffStats: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := 1
+			if len(have) != want {
+				t.Fatalf("have %d changesets; want %d", len(have), want)
+			}
+
+			if have[0].ID != changesets[cap(changesets)-1].ID {
+				t.Fatalf("unexpected changeset: have %+v; want %+v", have[0], changesets[cap(changesets)-1])
 			}
 		}
 

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -308,9 +308,9 @@ func (s *ChangesetSyncer) Run(ctx context.Context) {
 		s.queue.Upsert(sched...)
 	}
 
-	// Prioritise changesets without diffstats on startup.
-	if err := s.prioritiseChangesetsWithoutDiffStats(ctx); err != nil {
-		log15.Error("Prioritising changesets", "err", err)
+	// Prioritize changesets without diffstats on startup.
+	if err := s.prioritizeChangesetsWithoutDiffStats(ctx); err != nil {
+		log15.Error("Prioritizing changesets", "err", err)
 	}
 
 	var next scheduledSync
@@ -481,7 +481,7 @@ func (s *ChangesetSyncer) computeSchedule(ctx context.Context) ([]scheduledSync,
 	return ss, nil
 }
 
-func (s *ChangesetSyncer) prioritiseChangesetsWithoutDiffStats(ctx context.Context) error {
+func (s *ChangesetSyncer) prioritizeChangesetsWithoutDiffStats(ctx context.Context) error {
 	changesets, _, err := s.SyncStore.ListChangesets(ctx, ListChangesetsOpts{OnlyWithoutDiffStats: true, Limit: -1})
 	if err != nil {
 		return err

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -287,9 +287,7 @@ func TestSyncerRun(t *testing.T) {
 		defer cancel()
 		now := time.Now()
 		store := MockSyncStore{
-			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
-				return nil, 0, nil
-			},
+			listChangesets: mockListChangesets,
 			listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) ([]campaigns.ChangesetSyncData, error) {
 				return []campaigns.ChangesetSyncData{
 					{
@@ -321,9 +319,7 @@ func TestSyncerRun(t *testing.T) {
 		// Empty schedule but then we add an item
 		ctx, cancel := context.WithCancel(context.Background())
 		store := MockSyncStore{
-			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
-				return nil, 0, nil
-			},
+			listChangesets: mockListChangesets,
 			listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) ([]campaigns.ChangesetSyncData, error) {
 				return []campaigns.ChangesetSyncData{}, nil
 			},
@@ -450,9 +446,7 @@ func TestSyncRegistry(t *testing.T) {
 	}
 
 	syncStore := MockSyncStore{
-		listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
-			return nil, 0, nil
-		},
+		listChangesets: mockListChangesets,
 		listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) (data []campaigns.ChangesetSyncData, err error) {
 			return []campaigns.ChangesetSyncData{
 				{
@@ -590,4 +584,8 @@ func (m MockRepoStore) ListExternalServices(ctx context.Context, args repos.Stor
 
 func (m MockRepoStore) ListRepos(ctx context.Context, args repos.StoreListReposArgs) ([]*repos.Repo, error) {
 	return m.listRepos(ctx, args)
+}
+
+func mockListChangesets(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+	return nil, 0, nil
 }

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -176,7 +176,7 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	}
 }
 
-func TestPrioritiseChangesetsWithoutDiffStats(t *testing.T) {
+func TestPrioritizeChangesetsWithoutDiffStats(t *testing.T) {
 	for name, tc := range map[string]struct {
 		listChangesets func(context.Context, ListChangesetsOpts) (campaigns.Changesets, int64, error)
 		wantError      bool
@@ -231,7 +231,7 @@ func TestPrioritiseChangesetsWithoutDiffStats(t *testing.T) {
 				}
 			}()
 
-			err := syncer.prioritiseChangesetsWithoutDiffStats(context.Background())
+			err := syncer.prioritizeChangesetsWithoutDiffStats(context.Background())
 			if tc.wantError && err == nil {
 				t.Error("expected an error; got nil")
 			} else if !tc.wantError && err != nil {

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -3,10 +3,12 @@ package campaigns
 import (
 	"container/heap"
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -174,11 +176,84 @@ func TestChangesetPriorityQueue(t *testing.T) {
 	}
 }
 
+func TestPrioritiseChangesetsWithoutDiffStats(t *testing.T) {
+	for name, tc := range map[string]struct {
+		listChangesets func(context.Context, ListChangesetsOpts) (campaigns.Changesets, int64, error)
+		wantError      bool
+		wantIDs        []int64
+	}{
+		"ListChangesets error": {
+			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+				return nil, 0, errors.New("hello!")
+			},
+			wantError: true,
+		},
+		"empty list": {
+			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+				return []*campaigns.Changeset{}, 0, nil
+			},
+		},
+		"non-empty list": {
+			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+				return []*campaigns.Changeset{
+					{ID: 1},
+					{ID: 2},
+				}, 0, nil
+			},
+			wantIDs: []int64{1, 2},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var wg sync.WaitGroup
+
+			syncer := &ChangesetSyncer{
+				SyncStore:      MockSyncStore{listChangesets: tc.listChangesets},
+				priorityNotify: make(chan []int64),
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				var (
+					ids  []int64
+					seen bool
+				)
+
+				for ids = range syncer.priorityNotify {
+					if seen {
+						t.Error("received more than one message on priorityNotify")
+					}
+					seen = true
+				}
+
+				if diff := cmp.Diff(ids, tc.wantIDs); diff != "" {
+					t.Errorf("invalid IDs received on the priorityNotify channel: have %+v; want %+v", ids, tc.wantIDs)
+				}
+			}()
+
+			err := syncer.prioritiseChangesetsWithoutDiffStats(context.Background())
+			if tc.wantError && err == nil {
+				t.Error("expected an error; got nil")
+			} else if !tc.wantError && err != nil {
+				t.Errorf("got unexpected error: %+v", err)
+			}
+
+			// We have to wait for the goroutine to exit lest we fail after this
+			// function is complete.
+			close(syncer.priorityNotify)
+			wg.Wait()
+		})
+	}
+}
+
 func TestSyncerRun(t *testing.T) {
 	t.Run("Sync due", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		now := time.Now()
 		store := MockSyncStore{
+			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+				return nil, 0, nil
+			},
 			listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) ([]campaigns.ChangesetSyncData, error) {
 				return []campaigns.ChangesetSyncData{
 					{
@@ -212,6 +287,9 @@ func TestSyncerRun(t *testing.T) {
 		defer cancel()
 		now := time.Now()
 		store := MockSyncStore{
+			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+				return nil, 0, nil
+			},
 			listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) ([]campaigns.ChangesetSyncData, error) {
 				return []campaigns.ChangesetSyncData{
 					{
@@ -243,6 +321,9 @@ func TestSyncerRun(t *testing.T) {
 		// Empty schedule but then we add an item
 		ctx, cancel := context.WithCancel(context.Background())
 		store := MockSyncStore{
+			listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+				return nil, 0, nil
+			},
 			listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) ([]campaigns.ChangesetSyncData, error) {
 				return []campaigns.ChangesetSyncData{}, nil
 			},
@@ -369,6 +450,9 @@ func TestSyncRegistry(t *testing.T) {
 	}
 
 	syncStore := MockSyncStore{
+		listChangesets: func(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
+			return nil, 0, nil
+		},
 		listChangesetSyncData: func(ctx context.Context, opts ListChangesetSyncDataOpts) (data []campaigns.ChangesetSyncData, err error) {
 			return []campaigns.ChangesetSyncData{
 				{

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -1,4 +1,4 @@
-package campaigns
+package testing
 
 import (
 	"context"

--- a/enterprise/internal/campaigns/testing/mock_github.go
+++ b/enterprise/internal/campaigns/testing/mock_github.go
@@ -1,0 +1,80 @@
+package testing
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+type MockedGitHubChangesetSyncState struct {
+	execReader      func([]string) (io.ReadCloser, error)
+	mockRepoLookup  func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
+	resolveRevision func(string, *git.ResolveRevisionOptions) (api.CommitID, error)
+}
+
+// MockGitHubChangesetSync sets up mocks such that invoking LoadChangesets() on
+// one or more GitHub changesets will always return succeed, and return the same
+// diff (+1, ~1, -3).
+//
+// state.Unmock() must called to clean up, usually via defer.
+func MockGitHubChangesetSync(repo *protocol.RepoInfo) *MockedGitHubChangesetSyncState {
+	state := &MockedGitHubChangesetSyncState{
+		execReader:      git.Mocks.ExecReader,
+		mockRepoLookup:  repoupdater.MockRepoLookup,
+		resolveRevision: git.Mocks.ResolveRevision,
+	}
+
+	repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
+		return &protocol.RepoLookupResult{
+			Repo: repo,
+		}, nil
+	}
+
+	git.Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+		// This provides a diff that will resolve to 1 added line, 1 changed
+		// line, and 3 deleted lines.
+		const testGitHubDiff = `
+diff --git a/test.py b/test.py
+index 884601b..c4886d5 100644
+--- a/test.py
++++ b/test.py
+@@ -1,6 +1,4 @@
++# square makes a value squarer.
+ def square(a):
+-    """
+-    square makes a value squarer.
+-    """
+
+-    return a * a
++    return pow(a, 2)
+
+`
+
+		if len(args) < 1 && args[0] != "diff" {
+			if state.execReader != nil {
+				return state.execReader(args)
+			}
+			return nil, errors.New("cannot handle non-diff command in mock ExecReader")
+		}
+		return ioutil.NopCloser(strings.NewReader(testGitHubDiff)), nil
+	}
+
+	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+		return api.CommitID("mockcommitid"), nil
+	}
+
+	return state
+}
+
+// Unmock resets the mocks set up by MockGitHubChangesetSync.
+func (state *MockedGitHubChangesetSyncState) Unmock() {
+	git.Mocks.ExecReader = state.execReader
+	git.Mocks.ResolveRevision = state.resolveRevision
+	repoupdater.MockRepoLookup = state.mockRepoLookup
+}

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -167,7 +167,7 @@ func (h Webhook) upsertChangesetEvent(
 		ChangesetIDs: []int64{cs.ID},
 		Limit:        -1,
 	})
-	SetDerivedState(cs, events)
+	SetDerivedState(ctx, cs, events)
 	if err := tx.UpdateChangesets(ctx, cs); err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +27,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -107,6 +111,25 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Set up mocks to prevent the diffstat computation from trying to
+		// use a real gitserver, and so we can control what diff is used to
+		// create the diffstat.
+		repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
+			return &protocol.RepoLookupResult{
+				Repo: &protocol.RepoInfo{
+					Name: "repo",
+					VCS:  protocol.VCSInfo{URL: "https://example.com/repo/"},
+				},
+			}, nil
+		}
+		git.Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+			return ioutil.NopCloser(strings.NewReader("")), nil
+		}
+		defer func() {
+			repoupdater.MockRepoLookup = nil
+			git.ResetMocks()
+		}()
 
 		err = SyncChangesets(ctx, repoStore, store, cf, changesets...)
 		if err != nil {

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -23,13 +22,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -115,21 +113,11 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		// Set up mocks to prevent the diffstat computation from trying to
 		// use a real gitserver, and so we can control what diff is used to
 		// create the diffstat.
-		repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
-			return &protocol.RepoLookupResult{
-				Repo: &protocol.RepoInfo{
-					Name: "repo",
-					VCS:  protocol.VCSInfo{URL: "https://example.com/repo/"},
-				},
-			}, nil
-		}
-		git.Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader("")), nil
-		}
-		defer func() {
-			repoupdater.MockRepoLookup = nil
-			git.ResetMocks()
-		}()
+		state := ct.MockGitHubChangesetSync(&protocol.RepoInfo{
+			Name: "repo",
+			VCS:  protocol.VCSInfo{URL: "https://example.com/repo/"},
+		})
+		defer state.Unmock()
 
 		err = SyncChangesets(ctx, repoStore, store, cf, changesets...)
 		if err != nil {

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -308,7 +308,7 @@ func ExecChangesetJob(
 	// with outdated metadata.
 	clone := cs.Changeset.Clone()
 	events := clone.Events()
-	SetDerivedState(clone, events)
+	SetDerivedState(ctx, clone, events)
 	if err = opts.Store.CreateChangesets(ctx, clone); err != nil {
 		if _, ok := err.(AlreadyExistError); !ok {
 			return err
@@ -324,7 +324,7 @@ func ExecChangesetJob(
 			return errors.Wrap(err, "setting changeset metadata")
 		}
 		events = clone.Events()
-		SetDerivedState(clone, events)
+		SetDerivedState(ctx, clone, events)
 
 		clone.CampaignIDs = append(clone.CampaignIDs, job.CampaignID)
 		clone.CreatedByCampaign = true

--- a/enterprise/internal/campaigns/workers_test.go
+++ b/enterprise/internal/campaigns/workers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
@@ -114,9 +115,9 @@ func TestExecChangesetJob(t *testing.T) {
 				}
 			}
 
-			gitClient := &FakeGitserverClient{Response: headRef, ResponseErr: nil}
+			gitClient := &ct.FakeGitserverClient{Response: headRef, ResponseErr: nil}
 
-			sourcer := repos.NewFakeSourcer(nil, &FakeChangesetSource{
+			sourcer := repos.NewFakeSourcer(nil, &ct.FakeChangesetSource{
 				Svc:             extSvc,
 				Err:             nil,
 				ChangesetExists: tc.existsOnCodehost,

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -632,7 +632,7 @@ func (c *Changeset) HeadRefOid() (string, error) {
 	case *github.PullRequest:
 		return m.HeadRefOid, nil
 	case *bitbucketserver.PullRequest:
-		return m.FromRefRev, nil
+		return "", nil
 	default:
 		return "", errors.New("unknown changeset type")
 	}
@@ -659,7 +659,7 @@ func (c *Changeset) BaseRefOid() (string, error) {
 	case *github.PullRequest:
 		return m.BaseRefOid, nil
 	case *bitbucketserver.PullRequest:
-		return m.ToRefRev, nil
+		return "", nil
 	default:
 		return "", errors.New("unknown changeset type")
 	}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -698,10 +698,15 @@ func (c *Changeset) Labels() []ChangesetLabel {
 type ChangesetSyncState struct {
 	BaseRefOid string
 	HeadRefOid string
+
+	// This is essentially the result of c.ExternalState != CampaignStateOpen
+	// the last time a sync occured. We use this to short circuit computing the
+	// sync state if the changeset remains closed.
+	IsComplete bool
 }
 
 func (state *ChangesetSyncState) Equals(old *ChangesetSyncState) bool {
-	return state.BaseRefOid == old.BaseRefOid && state.HeadRefOid == old.HeadRefOid
+	return state.BaseRefOid == old.BaseRefOid && state.HeadRefOid == old.HeadRefOid && state.IsComplete == old.IsComplete
 }
 
 // A ChangesetEvent is an event that happened in the lifetime

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -360,6 +360,10 @@ type Changeset struct {
 	ExternalCheckState  ChangesetCheckState
 	CreatedByCampaign   bool
 	AddedToCampaign     bool
+	DiffStatAdded       *int32
+	DiffStatChanged     *int32
+	DiffStatDeleted     *int32
+	SyncState           ChangesetSyncState
 }
 
 // Clone returns a clone of a Changeset.
@@ -367,6 +371,37 @@ func (c *Changeset) Clone() *Changeset {
 	tt := *c
 	tt.CampaignIDs = c.CampaignIDs[:len(c.CampaignIDs):len(c.CampaignIDs)]
 	return &tt
+}
+
+// DiffStat returns a *diff.Stat if DiffStatAdded, DiffStatChanged, and
+// DiffStatDeleted are set, or nil if one or more is not.
+func (c *Changeset) DiffStat() *diff.Stat {
+	if c.DiffStatAdded == nil || c.DiffStatChanged == nil || c.DiffStatDeleted == nil {
+		return nil
+	}
+
+	return &diff.Stat{
+		Added:   *c.DiffStatAdded,
+		Changed: *c.DiffStatChanged,
+		Deleted: *c.DiffStatDeleted,
+	}
+}
+
+func (c *Changeset) SetDiffStat(stat *diff.Stat) {
+	if stat == nil {
+		c.DiffStatAdded = nil
+		c.DiffStatChanged = nil
+		c.DiffStatDeleted = nil
+	} else {
+		added := stat.Added
+		c.DiffStatAdded = &added
+
+		changed := stat.Changed
+		c.DiffStatChanged = &changed
+
+		deleted := stat.Deleted
+		c.DiffStatDeleted = &deleted
+	}
 }
 
 func (c *Changeset) SetMetadata(meta interface{}) error {
@@ -597,7 +632,7 @@ func (c *Changeset) HeadRefOid() (string, error) {
 	case *github.PullRequest:
 		return m.HeadRefOid, nil
 	case *bitbucketserver.PullRequest:
-		return "", nil
+		return m.FromRefRev, nil
 	default:
 		return "", errors.New("unknown changeset type")
 	}
@@ -624,7 +659,7 @@ func (c *Changeset) BaseRefOid() (string, error) {
 	case *github.PullRequest:
 		return m.BaseRefOid, nil
 	case *bitbucketserver.PullRequest:
-		return "", nil
+		return m.ToRefRev, nil
 	default:
 		return "", errors.New("unknown changeset type")
 	}
@@ -658,6 +693,15 @@ func (c *Changeset) Labels() []ChangesetLabel {
 	default:
 		return []ChangesetLabel{}
 	}
+}
+
+type ChangesetSyncState struct {
+	BaseRefOid string
+	HeadRefOid string
+}
+
+func (state *ChangesetSyncState) Equals(old *ChangesetSyncState) bool {
+	return state.BaseRefOid == old.BaseRefOid && state.HeadRefOid == old.HeadRefOid
 }
 
 // A ChangesetEvent is an event that happened in the lifetime

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -1,6 +1,8 @@
 package campaigns
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -356,5 +358,56 @@ func TestChangesetDiffStat(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+type changesetSyncStateTestCase struct {
+	state [2]ChangesetSyncState
+	want  bool
+}
+
+func TestChangesetSyncStateEquals(t *testing.T) {
+	testCases := make(map[string]changesetSyncStateTestCase)
+
+	for baseName, basePairs := range map[string][2]string{
+		"base equal":     {"abc", "abc"},
+		"base different": {"abc", "def"},
+	} {
+		for headName, headPairs := range map[string][2]string{
+			"head equal":     {"abc", "abc"},
+			"head different": {"abc", "def"},
+		} {
+			for completeName, completePairs := range map[string][2]bool{
+				"complete both true":  {true, true},
+				"complete both false": {false, false},
+				"complete different":  {true, false},
+			} {
+				key := fmt.Sprintf("%s; %s; %s", baseName, headName, completeName)
+
+				testCases[key] = changesetSyncStateTestCase{
+					state: [2]ChangesetSyncState{
+						{
+							BaseRefOid: basePairs[0],
+							HeadRefOid: headPairs[0],
+							IsComplete: completePairs[0],
+						},
+						{
+							BaseRefOid: basePairs[1],
+							HeadRefOid: headPairs[1],
+							IsComplete: completePairs[1],
+						},
+					},
+					// This is icky, but works, and means we're not just
+					// repeating the implementation of Equals().
+					want: strings.HasPrefix(key, "base equal; head equal; complete both"),
+				}
+			}
+		}
+	}
+
+	for name, tc := range testCases {
+		if have := tc.state[0].Equals(&tc.state[1]); have != tc.want {
+			t.Errorf("%s: unexpected Equals result: have %v; want %v", name, have, tc.want)
+		}
 	}
 }

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1087,10 +1087,6 @@ type PullRequest struct {
 	Commits      []*Commit       `json:"commits,omitempty"`
 	CommitStatus []*CommitStatus `json:"commit_status,omitempty"`
 
-	// Computed fields.
-	FromRefRev string `json:"fromRefRev,omitempty"`
-	ToRefRev   string `json:"toRefRev,omitempty"`
-
 	// Deprecated, use CommitStatus instead. BuildStatus was not tied to individual commits
 	BuildStatuses []*BuildStatus `json:"buildstatuses,omitempty"`
 }

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1087,6 +1087,10 @@ type PullRequest struct {
 	Commits      []*Commit       `json:"commits,omitempty"`
 	CommitStatus []*CommitStatus `json:"commit_status,omitempty"`
 
+	// Computed fields.
+	FromRefRev string `json:"fromRefRev,omitempty"`
+	ToRefRev   string `json:"toRefRev,omitempty"`
+
 	// Deprecated, use CommitStatus instead. BuildStatus was not tied to individual commits
 	BuildStatuses []*BuildStatus `json:"buildstatuses,omitempty"`
 }

--- a/migrations/1528395685_add_diffstat_fields_to_changesets.down.sql
+++ b/migrations/1528395685_add_diffstat_fields_to_changesets.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE changesets DROP COLUMN IF EXISTS diff_stat_added;
+ALTER TABLE changesets DROP COLUMN IF EXISTS diff_stat_changed;
+ALTER TABLE changesets DROP COLUMN IF EXISTS diff_stat_deleted;
+ALTER TABLE changesets DROP COLUMN IF EXISTS sync_state;
+
+COMMIT;

--- a/migrations/1528395685_add_diffstat_fields_to_changesets.up.sql
+++ b/migrations/1528395685_add_diffstat_fields_to_changesets.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE changesets ADD COLUMN IF NOT EXISTS diff_stat_added integer;
+ALTER TABLE changesets ADD COLUMN IF NOT EXISTS diff_stat_changed integer;
+ALTER TABLE changesets ADD COLUMN IF NOT EXISTS diff_stat_deleted integer;
+ALTER TABLE changesets ADD COLUMN IF NOT EXISTS sync_state jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -70,6 +70,8 @@
 // 1528395683_empty.up.sql (159B)
 // 1528395684_lsif_num_resets.down.sql (293B)
 // 1528395684_lsif_num_resets.up.sql (340B)
+// 1528395685_add_diffstat_fields_to_changesets.down.sql (264B)
+// 1528395685_add_diffstat_fields_to_changesets.up.sql (335B)
 
 package migrations
 
@@ -1538,6 +1540,46 @@ func _1528395684_lsif_num_resetsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395685_add_diffstat_fields_to_changesetsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x29\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\xc9\x4c\x4b\x8b\x2f\x2e\x49\x2c\x89\x4f\x4c\x49\x49\x4d\xb1\x26\x57\x37\x44\x29\xf9\xfa\x53\x52\x73\x52\x4b\x48\xd6\x5f\x5c\x99\x97\x0c\xd6\x9f\x6a\xcd\xc5\xe5\xec\xef\xeb\xeb\x19\x62\xcd\x05\x08\x00\x00\xff\xff\x96\x3f\x2c\x95\x08\x01\x00\x00")
+
+func _1528395685_add_diffstat_fields_to_changesetsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395685_add_diffstat_fields_to_changesetsDownSql,
+		"1528395685_add_diffstat_fields_to_changesets.down.sql",
+	)
+}
+
+func _1528395685_add_diffstat_fields_to_changesetsDownSql() (*asset, error) {
+	bytes, err := _1528395685_add_diffstat_fields_to_changesetsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395685_add_diffstat_fields_to_changesets.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe6, 0xc6, 0x90, 0x7d, 0x7d, 0x84, 0x80, 0xa6, 0x91, 0x63, 0x6c, 0xc2, 0x66, 0xaf, 0x16, 0xf9, 0x28, 0x49, 0x20, 0xeb, 0x1e, 0x96, 0xd9, 0x26, 0xb8, 0xe1, 0x13, 0x1e, 0xab, 0xf, 0xe3, 0x2d}}
+	return a, nil
+}
+
+var __1528395685_add_diffstat_fields_to_changesetsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\xcc\xc1\x0a\x82\x30\x1c\xc7\xf1\xfb\x9e\xe2\x77\xf3\x1d\xdc\x69\xea\x8c\xc1\x9c\x90\x7f\xa1\x9b\x98\xfb\x6b\x46\x2c\x68\xbb\x44\xf4\xee\x51\x3e\x82\x5d\xbf\x7c\xf9\x14\xfa\x60\x9c\x14\x42\x59\xd2\x47\x90\x2a\xac\xc6\x74\x19\xc3\xc2\x91\x53\x84\xaa\x2a\x94\xad\xed\x1b\x07\x53\xc3\xb5\x04\x7d\x32\x1d\x75\xf0\xeb\x3c\x0f\x31\x8d\x69\x18\xbd\x67\x8f\x35\x24\x5e\xf8\x21\x77\x40\xdb\xfd\x17\xca\xf3\x8d\xd3\x1e\x2a\x3e\xc3\xf4\xa3\x18\xd7\x78\x0f\x67\x54\xba\x56\xbd\x25\x64\xaf\x77\x96\xe7\x5b\xfb\xfe\xae\xb7\x56\x0a\x51\xb6\x4d\x63\x48\x8a\x4f\x00\x00\x00\xff\xff\xc7\xd8\xde\x90\x4f\x01\x00\x00")
+
+func _1528395685_add_diffstat_fields_to_changesetsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395685_add_diffstat_fields_to_changesetsUpSql,
+		"1528395685_add_diffstat_fields_to_changesets.up.sql",
+	)
+}
+
+func _1528395685_add_diffstat_fields_to_changesetsUpSql() (*asset, error) {
+	bytes, err := _1528395685_add_diffstat_fields_to_changesetsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395685_add_diffstat_fields_to_changesets.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x68, 0x3b, 0x46, 0x62, 0xdb, 0x3b, 0x6a, 0x6f, 0x93, 0xcf, 0xc3, 0xcc, 0x4, 0x8f, 0x1, 0xd8, 0x5, 0xd3, 0xc1, 0x9c, 0xdf, 0x84, 0x63, 0x24, 0xca, 0x24, 0x7e, 0xe, 0xde, 0x15, 0x1f, 0x72}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1699,6 +1741,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395683_empty.up.sql":                                                 _1528395683_emptyUpSql,
 	"1528395684_lsif_num_resets.down.sql":                                     _1528395684_lsif_num_resetsDownSql,
 	"1528395684_lsif_num_resets.up.sql":                                       _1528395684_lsif_num_resetsUpSql,
+	"1528395685_add_diffstat_fields_to_changesets.down.sql":                   _1528395685_add_diffstat_fields_to_changesetsDownSql,
+	"1528395685_add_diffstat_fields_to_changesets.up.sql":                     _1528395685_add_diffstat_fields_to_changesetsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -1815,6 +1859,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395683_empty.up.sql":                                                 {_1528395683_emptyUpSql, map[string]*bintree{}},
 	"1528395684_lsif_num_resets.down.sql":                                     {_1528395684_lsif_num_resetsDownSql, map[string]*bintree{}},
 	"1528395684_lsif_num_resets.up.sql":                                       {_1528395684_lsif_num_resetsUpSql, map[string]*bintree{}},
+	"1528395685_add_diffstat_fields_to_changesets.down.sql":                   {_1528395685_add_diffstat_fields_to_changesetsDownSql, map[string]*bintree{}},
+	"1528395685_add_diffstat_fields_to_changesets.up.sql":                     {_1528395685_add_diffstat_fields_to_changesetsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -283,6 +283,11 @@ export const queryChangesets = (
                                             }
                                         }
                                     }
+                                    diffStat {
+                                        added
+                                        changed
+                                        deleted
+                                    }
                                 }
                             }
                         }

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.test.tsx
@@ -50,6 +50,11 @@ describe('ExternalChangesetNode', () => {
                                 nodes: [{ __typename: 'FileDiff' }],
                             },
                         },
+                        diffStat: {
+                            added: 100,
+                            changed: 200,
+                            deleted: 100,
+                        },
                         labels: [
                             {
                                 __typename: 'ChangesetLabel',

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -120,7 +120,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                 </div>
             </div>
             <div className="flex-shrink-0 flex-grow-0 ml-1 align-items-end">
-                {node.diff?.fileDiffs && <DiffStat {...node.diff.fileDiffs.diffStat} expandedCounts={true} />}
+                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} />}
             </div>
             <div className="flex-shrink-0 flex-grow-0 ml-1 align-items-end">
                 <ReviewStateIcon

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
@@ -101,6 +101,11 @@ Object {
                         ],
                       },
                     },
+                    "diffStat": Object {
+                      "added": 100,
+                      "changed": 200,
+                      "deleted": 100,
+                    },
                     "externalID": "123",
                     "externalURL": Object {
                       "url": "https://github.com/sourcegraph/sourcegraph/pull/111111",


### PR DESCRIPTION
Fixes #11075.

The general approach here is to cache the changeset diffstat if the base or head OID has changed when we sync the changeset, then use that cached changeset when a GraphQL query is made that requires a campaign or changeset diffstat.

There is one observable behaviour change: closed changesets previously returned zero diffstats, but now return their actual diffstat. I think this is OK, and it simplifies the implementation, but we could force the syncer to cache zeroes for closed changesets to return to the old behaviour. I've kept the relevant test change in a separate commit for now to make it easier to change this if necessary.

Since campaign diffstats require knowledge of which changesets are accessible to the user, I've elected to use the simple approach for now of continuing to use the GraphQL connection. (See the discussion below between @mrnugget and I for more detail.) This is technically suboptimal, as we're pulling in sync data that we don't need to, but I think that's likely OK pending further work on being able to resolve permissions at the store level. I'm also happy to attempt @mrnugget's suggested optimisation in a future PR.