### PR TITLE
search: introduce annotations for terms

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -971,7 +971,7 @@ func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver,
 	var queryInfo query.QueryInfo
 	var err error
 	if conf.AndOrQueryEnabled() {
-		andOrQuery, _, err := query.ParseAndOr(plainQuery)
+		andOrQuery, err := query.ParseAndOr(plainQuery)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -7,7 +7,7 @@ type Mapper interface {
 	MapNodes(m Mapper, node []Node) []Node
 	MapOperator(m Mapper, kind operatorKind, operands []Node) []Node
 	MapParameter(m Mapper, field, value string, negated bool) Node
-	MapPattern(m Mapper, value string, negated, quoted bool) Node
+	MapPattern(m Mapper, value string, negated bool, annotation annotation) Node
 }
 
 // The BaseMapper is a mapper that recursively visits each node in a query and
@@ -20,7 +20,7 @@ func (*BaseMapper) MapNodes(mapper Mapper, nodes []Node) []Node {
 	for _, node := range nodes {
 		switch v := node.(type) {
 		case Pattern:
-			mapped = append(mapped, mapper.MapPattern(mapper, v.Value, v.Negated, v.Quoted))
+			mapped = append(mapped, mapper.MapPattern(mapper, v.Value, v.Negated, v.Annotation))
 		case Parameter:
 			mapped = append(mapped, mapper.MapParameter(mapper, v.Field, v.Value, v.Negated))
 		case Operator:
@@ -41,8 +41,8 @@ func (*BaseMapper) MapParameter(mapper Mapper, field, value string, negated bool
 }
 
 // Base mapper for Patterns. It is the identity function.
-func (*BaseMapper) MapPattern(mapper Mapper, value string, negated, quoted bool) Node {
-	return Pattern{Value: value, Negated: negated, Quoted: quoted}
+func (*BaseMapper) MapPattern(mapper Mapper, value string, negated bool, annotation annotation) Node {
+	return Pattern{Value: value, Negated: negated, Annotation: annotation}
 }
 
 // OperatorMapper is a helper mapper that maps operators in a query. It takes as
@@ -78,11 +78,11 @@ func (s *ParameterMapper) MapParameter(mapper Mapper, field, value string, negat
 // the return value.
 type PatternMapper struct {
 	BaseMapper
-	callback func(value string, negated, quoted bool) Node
+	callback func(value string, negated bool, annotation annotation) Node
 }
 
-func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated, quoted bool) Node {
-	return s.callback(value, negated, quoted)
+func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated bool, annotation annotation) Node {
+	return s.callback(value, negated, annotation)
 }
 
 // FieldMapper is a helper mapper that only maps patterns in a query, for a
@@ -120,7 +120,7 @@ func MapParameter(nodes []Node, callback func(field, value string, negated bool)
 // MapPattern is a convenience function that calls callback on all pattern
 // nodes, substituting them for callback's return value. callback supplies the
 // node's field, value, and whether the value is negated.
-func MapPattern(nodes []Node, callback func(value string, negated, quoted bool) Node) []Node {
+func MapPattern(nodes []Node, callback func(value string, negated bool, annotation annotation) Node) []Node {
 	mapper := &PatternMapper{callback: callback}
 	return mapper.MapNodes(mapper, nodes)
 }

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -7,7 +7,7 @@ type Mapper interface {
 	MapNodes(m Mapper, node []Node) []Node
 	MapOperator(m Mapper, kind operatorKind, operands []Node) []Node
 	MapParameter(m Mapper, field, value string, negated bool) Node
-	MapPattern(m Mapper, value string, negated bool, annotation annotation) Node
+	MapPattern(m Mapper, value string, negated bool, Annotation Annotation) Node
 }
 
 // The BaseMapper is a mapper that recursively visits each node in a query and
@@ -41,8 +41,8 @@ func (*BaseMapper) MapParameter(mapper Mapper, field, value string, negated bool
 }
 
 // Base mapper for Patterns. It is the identity function.
-func (*BaseMapper) MapPattern(mapper Mapper, value string, negated bool, annotation annotation) Node {
-	return Pattern{Value: value, Negated: negated, Annotation: annotation}
+func (*BaseMapper) MapPattern(mapper Mapper, value string, negated bool, Annotation Annotation) Node {
+	return Pattern{Value: value, Negated: negated, Annotation: Annotation}
 }
 
 // OperatorMapper is a helper mapper that maps operators in a query. It takes as
@@ -78,11 +78,11 @@ func (s *ParameterMapper) MapParameter(mapper Mapper, field, value string, negat
 // the return value.
 type PatternMapper struct {
 	BaseMapper
-	callback func(value string, negated bool, annotation annotation) Node
+	callback func(value string, negated bool, Annotation Annotation) Node
 }
 
-func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated bool, annotation annotation) Node {
-	return s.callback(value, negated, annotation)
+func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated bool, Annotation Annotation) Node {
+	return s.callback(value, negated, Annotation)
 }
 
 // FieldMapper is a helper mapper that only maps patterns in a query, for a
@@ -120,7 +120,7 @@ func MapParameter(nodes []Node, callback func(field, value string, negated bool)
 // MapPattern is a convenience function that calls callback on all pattern
 // nodes, substituting them for callback's return value. callback supplies the
 // node's field, value, and whether the value is negated.
-func MapPattern(nodes []Node, callback func(value string, negated bool, annotation annotation) Node) []Node {
+func MapPattern(nodes []Node, callback func(value string, negated bool, Annotation Annotation) Node) []Node {
 	mapper := &PatternMapper{callback: callback}
 	return mapper.MapNodes(mapper, nodes)
 }

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -154,32 +154,34 @@ func skipSpace(buf []byte) int {
 	return count
 }
 
-type heuristic string
+type heuristics uint8
 
 const (
-	// If present, balanced parentheses, which would normally be treated as
-	// delimiting expression groups, are treated as literal search patterns
-	// instead.
-	parensAsPatterns heuristic = "ParensAsPatterns"
-	// If present, all parentheses, whether balanced or unbalanced, are
-	// treated as literal search patterns (i.e., interpreting parentheses as
+	// If set, balanced parentheses, which would normally be treated as
+	// delimiting expression groups, may in select cases be parsed as
+	// literal search patterns instead.
+	parensAsPatterns heuristics = 1 << iota
+	// If set, all parentheses, whether balanced or unbalanced, are parsed
+	// as literal search patterns (i.e., interpreting parentheses as
 	// expression groups is completely disabled).
-	allowDanglingParens = "AllowDanglingParens"
-	// If present, quotes and escape sequences, which would normally be
+	allowDanglingParens
+	// If set, quotes and escape sequences, which would normally be
 	// interpreted, are treated literally in search patterns instead.
 	// Balanced quotes remain expected for non-empty fields like repo:"foo",
 	// if specified.
-	literalSearchPatterns = "LiteralSearchPatterns"
-	// If present, implies that at least one expression was disambiguated by
+	literalSearchPatterns
+	// If set, implies that at least one expression was disambiguated by
 	// explicit parentheses.
-	disambiguated = "Disambiguated"
+	disambiguated
 )
 
+func isSet(h, heuristic heuristics) bool { return h&heuristic != 0 }
+
 type parser struct {
-	buf       []byte
-	heuristic map[heuristic]bool
-	pos       int
-	balanced  int
+	buf        []byte
+	heuristics heuristics
+	pos        int
+	balanced   int
 }
 
 func (p *parser) done() bool {
@@ -485,7 +487,7 @@ loop:
 // parentheses as part of the pattern. It only succeeds if the value parsed can
 // be interpreted as a pattern, and not, e.g., as a filter:value parameter.
 func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
-	if !p.heuristic[parensAsPatterns] || p.heuristic[allowDanglingParens] {
+	if !isSet(p.heuristics, parensAsPatterns) || isSet(p.heuristics, allowDanglingParens) {
 		return Pattern{}, false
 	}
 	if value, ok := p.TryParseDelimiter(); ok {
@@ -623,7 +625,7 @@ func (p *parser) ParseFieldValue() (string, error) {
 	if p.match(DQUOTE) {
 		return delimited('"')
 	}
-	value, advance, _ := ScanValue(p.buf[p.pos:], p.heuristic[allowDanglingParens])
+	value, advance, _ := ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
 	p.pos += advance
 	return value, nil
 }
@@ -632,7 +634,7 @@ func (p *parser) ParseFieldValue() (string, error) {
 // Note that ParsePattern may be called multiple times (a query can have
 // multiple Patterns concatenated together).
 func (p *parser) ParsePattern() Pattern {
-	if p.heuristic[literalSearchPatterns] {
+	if isSet(p.heuristics, literalSearchPatterns) {
 		// Accept unconditionally as pattern, even if the pattern
 		// contains dangling quotes like " or ', and do not interpret
 		// quoted strings as quoted, but interpret them literally.
@@ -647,7 +649,7 @@ func (p *parser) ParsePattern() Pattern {
 		return Pattern{Value: value, Negated: false, Annotation: annotation{Labels: Literal | Quoted}}
 	}
 
-	value, advance, sawDanglingParen := ScanValue(p.buf[p.pos:], p.heuristic[allowDanglingParens])
+	value, advance, sawDanglingParen := ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
 	var labels labels
 	if sawDanglingParen {
 		labels = HeuristicDanglingParens
@@ -729,7 +731,7 @@ loop:
 			break loop
 		}
 		switch {
-		case p.match(LPAREN) && !p.heuristic[allowDanglingParens]:
+		case p.match(LPAREN) && !isSet(p.heuristics, allowDanglingParens):
 			// First try parse a parameter as a search pattern containing parens.
 			if patterns, ok := p.ParseSearchPatternHeuristic(); ok {
 				nodes = append(nodes, patterns)
@@ -738,19 +740,19 @@ loop:
 				// group as part of an and/or expression.
 				_ = p.expect(LPAREN) // Guaranteed to succeed.
 				p.balanced++
-				p.heuristic[disambiguated] = true
+				p.heuristics = p.heuristics | disambiguated
 				result, err := p.parseOr()
 				if err != nil {
 					return nil, err
 				}
 				nodes = append(nodes, result...)
 			}
-		case p.expect(RPAREN) && !p.heuristic[allowDanglingParens]:
+		case p.expect(RPAREN) && !isSet(p.heuristics, allowDanglingParens):
 			p.balanced--
-			p.heuristic[disambiguated] = true
+			p.heuristics = p.heuristics | disambiguated
 			if len(nodes) == 0 {
 				// We parsed "()".
-				if p.heuristic[parensAsPatterns] {
+				if isSet(p.heuristics, parensAsPatterns) {
 					// Interpret literally.
 					nodes = []Node{Pattern{Value: "()", Annotation: annotation{Labels: Literal | HeuristicParensAsPatterns}}}
 				} else {
@@ -894,8 +896,8 @@ func (p *parser) parseOr() ([]Node, error) {
 
 func tryFallbackParser(in string) ([]Node, error) {
 	parser := &parser{
-		buf:       []byte(in),
-		heuristic: map[heuristic]bool{allowDanglingParens: true},
+		buf:        []byte(in),
+		heuristics: allowDanglingParens,
 	}
 	nodes, err := parser.parseOr()
 	if err != nil {
@@ -913,8 +915,8 @@ func ParseAndOr(in string) ([]Node, error) {
 		return nil, nil
 	}
 	parser := &parser{
-		buf:       []byte(in),
-		heuristic: map[heuristic]bool{parensAsPatterns: true},
+		buf:        []byte(in),
+		heuristics: parensAsPatterns,
 	}
 
 	nodes, err := parser.parseOr()
@@ -930,7 +932,7 @@ func ParseAndOr(in string) ([]Node, error) {
 		}
 		return nil, errors.New("unbalanced expression")
 	}
-	if !parser.heuristic[disambiguated] {
+	if !isSet(parser.heuristics, disambiguated) {
 		// Hoist or expressions if this query is potential ambiguous.
 		if hoistedNodes, err := Hoist(nodes); err == nil {
 			nodes = hoistedNodes
@@ -944,11 +946,8 @@ func ParseLiteralSearch(in string) ([]Node, error) {
 		return nil, nil
 	}
 	parser := &parser{
-		buf: []byte(in),
-		heuristic: map[heuristic]bool{
-			allowDanglingParens:   true,
-			literalSearchPatterns: true,
-		},
+		buf:        []byte(in),
+		heuristics: allowDanglingParens | literalSearchPatterns,
 	}
 	nodes, err := parser.parseOr()
 	if err != nil {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -49,7 +49,7 @@ const (
 )
 
 // An annotation stores information associated with a node.
-type annotation struct {
+type Annotation struct {
 	Labels labels
 }
 
@@ -57,7 +57,7 @@ type annotation struct {
 type Pattern struct {
 	Value      string     `json:"value"`   // The pattern value.
 	Negated    bool       `json:"negated"` // True if this pattern is negated.
-	Annotation annotation `json:"-"`       // An annotation attached to this pattern.
+	Annotation Annotation `json:"-"`       // An annotation attached to this pattern.
 }
 
 // Parameter is a leaf node of expressions representing a parameter of format "repo:foo".
@@ -491,7 +491,7 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 		return Pattern{}, false
 	}
 	if value, ok := p.TryParseDelimiter(); ok {
-		return Pattern{Value: value, Annotation: annotation{Labels: Literal | Quoted}}, true
+		return Pattern{Value: value, Annotation: Annotation{Labels: Literal | Quoted}}, true
 	}
 
 	start := p.pos
@@ -505,11 +505,11 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	// The heuristic succeeds: we can process the string as a pure search pattern.
 	p.pos += advance
 	if len(pieces) == 1 {
-		return Pattern{Value: pieces[0], Annotation: annotation{Labels: Literal | HeuristicParensAsPatterns}}, true
+		return Pattern{Value: pieces[0], Annotation: Annotation{Labels: Literal | HeuristicParensAsPatterns}}, true
 	}
 	patterns := []Node{}
 	for _, piece := range pieces {
-		patterns = append(patterns, Pattern{Value: piece, Annotation: annotation{Labels: Literal | HeuristicParensAsPatterns}})
+		patterns = append(patterns, Pattern{Value: piece, Annotation: Annotation{Labels: Literal | HeuristicParensAsPatterns}})
 	}
 	return Operator{Kind: Concat, Operands: patterns}, true
 }
@@ -640,13 +640,13 @@ func (p *parser) ParsePattern() Pattern {
 		// quoted strings as quoted, but interpret them literally.
 		value, advance := ScanSearchPatternLiteral(p.buf[p.pos:])
 		p.pos += advance
-		return Pattern{Value: value, Negated: false, Annotation: annotation{Labels: Literal}}
+		return Pattern{Value: value, Negated: false, Annotation: Annotation{Labels: Literal}}
 	}
 
 	// If we can parse a well-delimited value, that takes precedence, and we
 	// denote it with Quoted set to true.
 	if value, ok := p.TryParseDelimiter(); ok {
-		return Pattern{Value: value, Negated: false, Annotation: annotation{Labels: Literal | Quoted}}
+		return Pattern{Value: value, Negated: false, Annotation: Annotation{Labels: Literal | Quoted}}
 	}
 
 	value, advance, sawDanglingParen := ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
@@ -656,7 +656,7 @@ func (p *parser) ParsePattern() Pattern {
 	}
 	p.pos += advance
 	// Invariant: the pattern can't be quoted since we checked for that.
-	return Pattern{Value: value, Negated: false, Annotation: annotation{Labels: labels}} // FIXME: make literal?
+	return Pattern{Value: value, Negated: false, Annotation: Annotation{Labels: labels}} // FIXME: make literal?
 }
 
 // ParseParameter returns a leaf node corresponding to the syntax
@@ -754,7 +754,7 @@ loop:
 				// We parsed "()".
 				if isSet(p.heuristics, parensAsPatterns) {
 					// Interpret literally.
-					nodes = []Node{Pattern{Value: "()", Annotation: annotation{Labels: Literal | HeuristicParensAsPatterns}}}
+					nodes = []Node{Pattern{Value: "()", Annotation: Annotation{Labels: Literal | HeuristicParensAsPatterns}}}
 				} else {
 					// Interpret as a group: return an empty non-nil node.
 					nodes = []Node{Parameter{}}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -37,18 +37,18 @@ func (Pattern) node()   {}
 func (Parameter) node() {}
 func (Operator) node()  {}
 
-// A label is a general-purpose annotation that stores information about a node.
-type label uint8
+// Labels are general-purpose annotations that store information about a node.
+type labels uint8
 
 const (
-	None          = 0
-	Literal label = 1 << iota
+	None    labels = 0
+	Literal        = 1 << iota
 	Quoted
 )
 
 // An annotation stores information associated with a node.
 type annotation struct {
-	Labels label
+	Labels labels
 }
 
 // Pattern is a leaf node of expressions representing a search pattern fragment.

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestScanParameter(t *testing.T) {
+func TestParseParameterList(t *testing.T) {
 	cases := []struct {
 		Name  string
 		Input string

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -14,7 +14,7 @@ func TestParseParameterList(t *testing.T) {
 		Name       string
 		Input      string
 		Want       string
-		WantLabels label
+		WantLabels labels
 	}{
 		{
 			Name:       "Normal field:value",

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -220,8 +220,8 @@ func parseAndOrGrammar(in string) ([]Node, error) {
 		return nil, nil
 	}
 	parser := &parser{
-		buf:       []byte(in),
-		heuristic: map[heuristic]bool{parensAsPatterns: false},
+		buf: []byte(in),
+		// heuristics: map[heuristic]bool{parensAsPatterns: false},
 	}
 	nodes, err := parser.parseOr()
 	if err != nil {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -83,7 +83,7 @@ func TestParseParameterList(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			parser := &parser{buf: []byte(tt.Input), heuristicsApplied: map[heuristic]bool{}}
+			parser := &parser{buf: []byte(tt.Input)}
 			result, err := parser.parseParameterList()
 			if err != nil {
 				t.Fatal("Unexpected error")
@@ -220,9 +220,8 @@ func parseAndOrGrammar(in string) ([]Node, error) {
 		return nil, nil
 	}
 	parser := &parser{
-		buf:               []byte(in),
-		heuristic:         map[heuristic]bool{parensAsPatterns: false},
-		heuristicsApplied: map[heuristic]bool{},
+		buf:       []byte(in),
+		heuristic: map[heuristic]bool{parensAsPatterns: false},
 	}
 	nodes, err := parser.parseOr()
 	if err != nil {
@@ -686,7 +685,7 @@ func TestParse(t *testing.T) {
 			var err error
 			result, err = parseAndOrGrammar(tt.Input) // Parse without heuristic.
 			check(result, err, string(tt.WantGrammar))
-			result, _, err = ParseAndOr(tt.Input)
+			result, err = ParseAndOr(tt.Input)
 			if tt.WantHeuristic == Same {
 				check(result, err, string(tt.WantGrammar))
 			} else {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -11,62 +11,74 @@ import (
 
 func TestParseParameterList(t *testing.T) {
 	cases := []struct {
-		Name  string
-		Input string
-		Want  string
+		Name       string
+		Input      string
+		Want       string
+		WantLabels label
 	}{
 		{
-			Name:  "Normal field:value",
-			Input: `file:README.md`,
-			Want:  `[{"field":"file","value":"README.md","negated":false}]`,
+			Name:       "Normal field:value",
+			Input:      `file:README.md`,
+			Want:       `{"field":"file","value":"README.md","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "First char is colon",
-			Input: `:foo`,
-			Want:  `[{"value":":foo","negated":false,"quoted":false}]`,
+			Name:       "First char is colon",
+			Input:      `:foo`,
+			Want:       `{"value":":foo","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "Last char is colon",
-			Input: `foo:`,
-			Want:  `[{"value":"foo:","negated":false,"quoted":false}]`,
+			Name:       "Last char is colon",
+			Input:      `foo:`,
+			Want:       `{"value":"foo:","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "Match first colon",
-			Input: `file:bar:baz`,
-			Want:  `[{"field":"file","value":"bar:baz","negated":false}]`,
+			Name:       "Match first colon",
+			Input:      `file:bar:baz`,
+			Want:       `{"field":"file","value":"bar:baz","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "No field, start with minus",
-			Input: `-:foo`,
-			Want:  `[{"value":"-:foo","negated":false,"quoted":false}]`,
+			Name:       "No field, start with minus",
+			Input:      `-:foo`,
+			Want:       `{"value":"-:foo","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "Minus prefix on field",
-			Input: `-file:README.md`,
-			Want:  `[{"field":"file","value":"README.md","negated":true}]`,
+			Name:       "Minus prefix on field",
+			Input:      `-file:README.md`,
+			Want:       `{"field":"file","value":"README.md","negated":true}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "Double minus prefix on field",
-			Input: `--foo:bar`,
-			Want:  `[{"value":"--foo:bar","negated":false,"quoted":false}]`,
+			Name:       "Double minus prefix on field",
+			Input:      `--foo:bar`,
+			Want:       `{"value":"--foo:bar","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "Minus in the middle is not a valid field",
-			Input: `fie-ld:bar`,
-			Want:  `[{"value":"fie-ld:bar","negated":false,"quoted":false}]`,
+			Name:       "Minus in the middle is not a valid field",
+			Input:      `fie-ld:bar`,
+			Want:       `{"value":"fie-ld:bar","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Name:  "Interpret escaped whitespace",
-			Input: `a\ pattern`,
-			Want:  `[{"value":"a pattern","negated":false,"quoted":false}]`,
+			Name:       "Interpret escaped whitespace",
+			Input:      `a\ pattern`,
+			Want:       `{"value":"a pattern","negated":false}`,
+			WantLabels: None,
 		},
 		{
-			Input: `"quoted"`,
-			Want:  `[{"value":"quoted","negated":false,"quoted":true}]`,
+			Input:      `"quoted"`,
+			Want:       `{"value":"quoted","negated":false}`,
+			WantLabels: Literal | Quoted,
 		},
 		{
-			Input: `'\''`,
-			Want:  `[{"value":"'","negated":false,"quoted":true}]`,
+			Input:      `'\''`,
+			Want:       `{"value":"'","negated":false}`,
+			WantLabels: Literal | Quoted,
 		},
 	}
 	for _, tt := range cases {
@@ -74,11 +86,17 @@ func TestParseParameterList(t *testing.T) {
 			parser := &parser{buf: []byte(tt.Input), heuristicsApplied: map[heuristic]bool{}}
 			result, err := parser.parseParameterList()
 			if err != nil {
-				panic("ruh roh")
+				t.Fatal("Unexpected error")
 			}
-			got, _ := json.Marshal(result)
+			resultNode := result[0]
+			got, _ := json.Marshal(resultNode)
 			if diff := cmp.Diff(tt.Want, string(got)); diff != "" {
 				t.Error(diff)
+			}
+			if patternNode, ok := resultNode.(Pattern); ok {
+				if diff := cmp.Diff(tt.WantLabels, patternNode.Annotation.Labels); diff != "" {
+					t.Error(diff)
+				}
 			}
 		})
 	}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -91,7 +91,7 @@ func Hoist(nodes []Node) ([]Node, error) {
 // SearchUppercase adds case:yes to queries if any pattern is mixed-case.
 func SearchUppercase(nodes []Node) []Node {
 	var foundMixedCase bool
-	VisitPattern(nodes, func(value string, _, _ bool) {
+	VisitPattern(nodes, func(value string, _, _ bool, _ annotation) {
 		// FIXME: make sure query maps content before calling this.
 		if match := containsUppercase(value); match {
 			foundMixedCase = true

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -91,7 +91,7 @@ func Hoist(nodes []Node) ([]Node, error) {
 // SearchUppercase adds case:yes to queries if any pattern is mixed-case.
 func SearchUppercase(nodes []Node) []Node {
 	var foundMixedCase bool
-	VisitPattern(nodes, func(value string, _ bool, _ annotation) {
+	VisitPattern(nodes, func(value string, _ bool, _ Annotation) {
 		// FIXME: make sure query maps content before calling this.
 		if match := containsUppercase(value); match {
 			foundMixedCase = true

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -22,8 +22,8 @@ func SubstituteAliases(nodes []Node) []Node {
 	}
 	return MapParameter(nodes, func(field, value string, negated bool) Node {
 		if field == "content" {
-			// Assume quoted is false if content is specified.
-			return Pattern{Value: value, Negated: negated, Quoted: false}
+			// The Quoted label is unset if content is specified.
+			return Pattern{Value: value, Negated: negated}
 		}
 		if canonical, ok := aliases[field]; ok {
 			field = canonical
@@ -91,7 +91,7 @@ func Hoist(nodes []Node) ([]Node, error) {
 // SearchUppercase adds case:yes to queries if any pattern is mixed-case.
 func SearchUppercase(nodes []Node) []Node {
 	var foundMixedCase bool
-	VisitPattern(nodes, func(value string, _, _ bool, _ annotation) {
+	VisitPattern(nodes, func(value string, _ bool, _ annotation) {
 		// FIXME: make sure query maps content before calling this.
 		if match := containsUppercase(value); match {
 			foundMixedCase = true

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -104,8 +104,8 @@ func TestHoist(t *testing.T) {
 			// does not perform the heuristic.
 			parse := func(in string) []Node {
 				parser := &parser{
-					buf:       []byte(in),
-					heuristic: map[heuristic]bool{parensAsPatterns: true},
+					buf:        []byte(in),
+					heuristics: parensAsPatterns,
 				}
 				nodes, _ := parser.parseOr()
 				return newOperator(nodes, And)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -18,7 +18,7 @@ func prettyPrint(nodes []Node) string {
 func TestSubstituteAliases(t *testing.T) {
 	input := "r:repo g:repogroup f:file"
 	want := `(and "repo:repo" "repogroup:repogroup" "file:file")`
-	query, _, _ := ParseAndOr(input)
+	query, _ := ParseAndOr(input)
 	got := prettyPrint(SubstituteAliases(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -28,7 +28,7 @@ func TestSubstituteAliases(t *testing.T) {
 func TestLowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`
-	query, _, _ := ParseAndOr(input)
+	query, _ := ParseAndOr(input)
 	got := prettyPrint(LowercaseFieldNames(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -104,9 +104,8 @@ func TestHoist(t *testing.T) {
 			// does not perform the heuristic.
 			parse := func(in string) []Node {
 				parser := &parser{
-					buf:               []byte(in),
-					heuristic:         map[heuristic]bool{parensAsPatterns: true},
-					heuristicsApplied: map[heuristic]bool{},
+					buf:       []byte(in),
+					heuristic: map[heuristic]bool{parensAsPatterns: true},
 				}
 				nodes, _ := parser.parseOr()
 				return newOperator(nodes, And)
@@ -175,7 +174,7 @@ func TestSearchUppercase(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("searchUppercase", func(t *testing.T) {
-			query, _, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input)
 			got := prettyPrint(SearchUppercase(SubstituteAliases(query)))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -203,7 +202,7 @@ func TestMap(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input)
 			got := prettyPrint(Map(query, c.fns...))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -172,14 +172,19 @@ func parseRegexpOrPanic(field, value string) *regexp.Regexp {
 // valueToTypedValue approximately preserves the field validation for
 // OrdinaryQuery processing. It does not check the validity of field negation or
 // if the same field is specified more than once.
-func (q AndOrQuery) valueToTypedValue(field, value string, labels labels) []*types.Value {
+func (q AndOrQuery) valueToTypedValue(field, value string, label labels) []*types.Value {
+
+	// Can't call the above parameter "labels" because then Go complains the
+	// type annotation here is "not a type".
+	isSet := func(l, label labels) bool { return l&label != 0 }
+
 	switch field {
 	case
 		FieldDefault:
 		// If a pattern is quoted, or we applied heuristics to interpret
 		// valid regexp metasyntax literally instead, this pattern is a
 		// string.
-		if (labels&Quoted != 0) || (labels&HeuristicParensAsPatterns != 0) {
+		if isSet(label, Quoted) || isSet(label, HeuristicParensAsPatterns) {
 			return []*types.Value{{String: &value}}
 		}
 		if regexp, err := regexp.Compile(value); err == nil {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -103,7 +103,7 @@ func (q AndOrQuery) StringValue(field string) (value, negatedValue string) {
 func (q AndOrQuery) Values(field string) []*types.Value {
 	var values []*types.Value
 	if field == "" {
-		VisitPattern(q.Query, func(value string, _ bool, annotation annotation) {
+		VisitPattern(q.Query, func(value string, _ bool, annotation Annotation) {
 			values = append(values, q.valueToTypedValue(field, value, annotation.Labels)...)
 		})
 	} else {
@@ -116,7 +116,7 @@ func (q AndOrQuery) Values(field string) []*types.Value {
 
 func (q AndOrQuery) Fields() map[string][]*types.Value {
 	fields := make(map[string][]*types.Value)
-	VisitPattern(q.Query, func(value string, _ bool, _ annotation) {
+	VisitPattern(q.Query, func(value string, _ bool, _ Annotation) {
 		fields[""] = q.Values("")
 	})
 	VisitParameter(q.Query, func(field, _ string, _ bool) {
@@ -130,7 +130,7 @@ func (q AndOrQuery) Fields() map[string][]*types.Value {
 // not is significant for surfacing suggestions.
 func (q AndOrQuery) ParseTree() syntax.ParseTree {
 	var tree syntax.ParseTree
-	VisitPattern(q.Query, func(value string, negated bool, _ annotation) {
+	VisitPattern(q.Query, func(value string, negated bool, _ Annotation) {
 		expr := &syntax.Expr{
 			Field: "",
 			Value: value,

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -173,7 +173,7 @@ func parseRegexpOrPanic(field, value string) *regexp.Regexp {
 // valueToTypedValue approximately preserves the field validation for
 // OrdinaryQuery processing. It does not check the validity of field negation or
 // if the same field is specified more than once.
-func (q AndOrQuery) valueToTypedValue(field, value string, labels label) []*types.Value {
+func (q AndOrQuery) valueToTypedValue(field, value string, labels labels) []*types.Value {
 	switch field {
 	case
 		FieldDefault:

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -104,7 +104,7 @@ func (q AndOrQuery) StringValue(field string) (value, negatedValue string) {
 func (q AndOrQuery) Values(field string) []*types.Value {
 	var values []*types.Value
 	if field == "" {
-		VisitPattern(q.Query, func(value string, _, quoted bool) {
+		VisitPattern(q.Query, func(value string, _, quoted bool, _ annotation) {
 			values = append(values, q.valueToTypedValue(field, value, quoted)...)
 		})
 	} else {
@@ -117,7 +117,7 @@ func (q AndOrQuery) Values(field string) []*types.Value {
 
 func (q AndOrQuery) Fields() map[string][]*types.Value {
 	fields := make(map[string][]*types.Value)
-	VisitPattern(q.Query, func(value string, _, quoted bool) {
+	VisitPattern(q.Query, func(value string, _, quoted bool, _ annotation) {
 		fields[""] = q.Values("")
 	})
 	VisitParameter(q.Query, func(field, _ string, _ bool) {
@@ -131,7 +131,7 @@ func (q AndOrQuery) Fields() map[string][]*types.Value {
 // not is significant for surfacing suggestions.
 func (q AndOrQuery) ParseTree() syntax.ParseTree {
 	var tree syntax.ParseTree
-	VisitPattern(q.Query, func(value string, negated, _ bool) {
+	VisitPattern(q.Query, func(value string, negated, _ bool, _ annotation) {
 		expr := &syntax.Expr{
 			Field: "",
 			Value: value,

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -38,8 +38,7 @@ type OrdinaryQuery struct {
 
 // A query containing and/or expressions.
 type AndOrQuery struct {
-	Query             []Node
-	HeuristicsApplied map[heuristic]bool
+	Query []Node
 }
 
 func (q OrdinaryQuery) RegexpPatterns(field string) (values, negatedValues []string) {
@@ -180,7 +179,7 @@ func (q AndOrQuery) valueToTypedValue(field, value string, labels labels) []*typ
 		// If a pattern is quoted, or we applied heuristics to interpret
 		// valid regexp metasyntax literally instead, this pattern is a
 		// string.
-		if (labels&Quoted != 0) || q.HeuristicsApplied[parensAsPatterns] {
+		if (labels&Quoted != 0) || (labels&HeuristicParensAsPatterns != 0) {
 			return []*types.Value{{String: &value}}
 		}
 		if regexp, err := regexp.Compile(value); err == nil {

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -10,18 +10,16 @@ import (
 func TestValueToTypedValue(t *testing.T) {
 	value := ".*"
 	t.Run("is quoted is string", func(t *testing.T) {
-		inputQuoted := true
 		q := &AndOrQuery{}
-		got := q.valueToTypedValue("", value, inputQuoted)
+		got := q.valueToTypedValue("", value, Quoted)
 		want := types.Value{String: &value}
 		if *got[0].String != *want.String {
 			t.Errorf("got %v, want %v", *got[0].String, *want.String)
 		}
 	})
 	t.Run("is not quoted is regex", func(t *testing.T) {
-		inputQuoted := false
 		q := &AndOrQuery{}
-		got := q.valueToTypedValue("", value, inputQuoted)
+		got := q.valueToTypedValue("", value, None)
 		regexValue, _ := regexp.Compile(value)
 		want := types.Value{Regexp: regexValue}
 		if got[0].Regexp.String() != want.Regexp.String() {
@@ -31,9 +29,8 @@ func TestValueToTypedValue(t *testing.T) {
 
 	value = ".*("
 	t.Run("uncompilable regex is string", func(t *testing.T) {
-		inputQuoted := false
 		q := &AndOrQuery{}
-		got := q.valueToTypedValue("", value, inputQuoted)
+		got := q.valueToTypedValue("", value, None)
 		want := types.Value{String: &value}
 		if *got[0].String != *want.String {
 			t.Errorf("got %v, want %v", *got[0].String, *want.String)
@@ -42,11 +39,10 @@ func TestValueToTypedValue(t *testing.T) {
 
 	value = "foo()"
 	t.Run("compilable regex becomes a literal string pattern when parensAsPatterns heuristic is applied", func(t *testing.T) {
-		inputQuoted := false
 		q := &AndOrQuery{
 			HeuristicsApplied: map[heuristic]bool{parensAsPatterns: true},
 		}
-		got := q.valueToTypedValue("", value, inputQuoted)
+		got := q.valueToTypedValue("", value, None)
 		want := types.Value{String: &value}
 		if *got[0].String != *want.String {
 			t.Errorf("got %v, want %v", *got[0].String, *want.String)

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -39,10 +39,8 @@ func TestValueToTypedValue(t *testing.T) {
 
 	value = "foo()"
 	t.Run("compilable regex becomes a literal string pattern when parensAsPatterns heuristic is applied", func(t *testing.T) {
-		q := &AndOrQuery{
-			HeuristicsApplied: map[heuristic]bool{parensAsPatterns: true},
-		}
-		got := q.valueToTypedValue("", value, None)
+		q := &AndOrQuery{}
+		got := q.valueToTypedValue("", value, HeuristicParensAsPatterns)
 		want := types.Value{String: &value}
 		if *got[0].String != *want.String {
 			t.Errorf("got %v, want %v", *got[0].String, *want.String)

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -137,9 +137,8 @@ func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err 
 func isPureSearchPattern(buf []byte) bool {
 	// Check if the balanced string we scanned is perhaps an and/or expression by parsing without the heuristic.
 	try := &parser{
-		buf:               buf,
-		heuristic:         map[heuristic]bool{parensAsPatterns: false},
-		heuristicsApplied: map[heuristic]bool{},
+		buf:       buf,
+		heuristic: map[heuristic]bool{parensAsPatterns: false},
 	}
 	result, err := try.parseOr()
 	if err != nil {

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -135,11 +135,8 @@ func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err 
 // containing whitespace or balanced parentheses, can be treated as a search
 // pattern in the and/or grammar.
 func isPureSearchPattern(buf []byte) bool {
-	// Check if the balanced string we scanned is perhaps an and/or expression by parsing without the heuristic.
-	try := &parser{
-		buf:       buf,
-		heuristic: map[heuristic]bool{parensAsPatterns: false},
-	}
+	// Check if the balanced string we scanned is perhaps an and/or expression by parsing without the parensAsPatterns heuristic.
+	try := &parser{buf: buf}
 	result, err := try.parseOr()
 	if err != nil {
 		// This is not an and/or expression, but it is balanced. It

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -218,7 +218,7 @@ func TestPartitionSearchPattern(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run("partition search pattern", func(t *testing.T) {
-			q, _, _ := ParseAndOr(tt.input)
+			q, _ := ParseAndOr(tt.input)
 			scopeParameters, pattern, err := PartitionSearchPattern(q)
 			if err != nil {
 				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -6,7 +6,7 @@ type Visitor interface {
 	VisitNodes(v Visitor, node []Node)
 	VisitOperator(v Visitor, kind operatorKind, operands []Node)
 	VisitParameter(v Visitor, field, value string, negated bool)
-	VisitPattern(v Visitor, value string, negated bool, annotation annotation)
+	VisitPattern(v Visitor, value string, negated bool, Annotation Annotation)
 }
 
 // BaseVisitor is a visitor that recursively visits each node in a query. A
@@ -35,7 +35,7 @@ func (*BaseVisitor) VisitOperator(visitor Visitor, kind operatorKind, operands [
 
 func (*BaseVisitor) VisitParameter(visitor Visitor, field, value string, negated bool) {}
 
-func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated bool, annotation annotation) {
+func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated bool, Annotation Annotation) {
 }
 
 // ParameterVisitor is a helper visitor that only visits operators in a query,
@@ -65,11 +65,11 @@ func (s *ParameterVisitor) VisitParameter(visitor Visitor, field, value string, 
 // and supplies the pattern members via a callback.
 type PatternVisitor struct {
 	BaseVisitor
-	callback func(value string, negated bool, annotation annotation)
+	callback func(value string, negated bool, Annotation Annotation)
 }
 
-func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated bool, annotation annotation) {
-	s.callback(value, negated, annotation)
+func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated bool, Annotation Annotation) {
+	s.callback(value, negated, Annotation)
 }
 
 // FieldVisitor is a helper visitor that only visits parameter fields in a
@@ -105,7 +105,7 @@ func VisitParameter(nodes []Node, callback func(field, value string, negated boo
 // VisitPattern is a convenience function that calls callback on all pattern
 // nodes. callback supplies the node's value value, and whether the value is
 // negated or quoted.
-func VisitPattern(nodes []Node, callback func(value string, negated bool, annotation annotation)) {
+func VisitPattern(nodes []Node, callback func(value string, negated bool, Annotation Annotation)) {
 	visitor := &PatternVisitor{callback: callback}
 	visitor.VisitNodes(visitor, nodes)
 }

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -6,7 +6,7 @@ type Visitor interface {
 	VisitNodes(v Visitor, node []Node)
 	VisitOperator(v Visitor, kind operatorKind, operands []Node)
 	VisitParameter(v Visitor, field, value string, negated bool)
-	VisitPattern(v Visitor, value string, negated, quoted bool, annotation annotation)
+	VisitPattern(v Visitor, value string, negated bool, annotation annotation)
 }
 
 // BaseVisitor is a visitor that recursively visits each node in a query. A
@@ -18,7 +18,7 @@ func (*BaseVisitor) VisitNodes(visitor Visitor, nodes []Node) {
 	for _, node := range nodes {
 		switch v := node.(type) {
 		case Pattern:
-			visitor.VisitPattern(visitor, v.Value, v.Negated, v.Quoted, v.Annotation)
+			visitor.VisitPattern(visitor, v.Value, v.Negated, v.Annotation)
 		case Parameter:
 			visitor.VisitParameter(visitor, v.Field, v.Value, v.Negated)
 		case Operator:
@@ -35,7 +35,7 @@ func (*BaseVisitor) VisitOperator(visitor Visitor, kind operatorKind, operands [
 
 func (*BaseVisitor) VisitParameter(visitor Visitor, field, value string, negated bool) {}
 
-func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated, quoted bool, annotation annotation) {
+func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated bool, annotation annotation) {
 }
 
 // ParameterVisitor is a helper visitor that only visits operators in a query,
@@ -65,11 +65,11 @@ func (s *ParameterVisitor) VisitParameter(visitor Visitor, field, value string, 
 // and supplies the pattern members via a callback.
 type PatternVisitor struct {
 	BaseVisitor
-	callback func(value string, negated, quoted bool, annotation annotation)
+	callback func(value string, negated bool, annotation annotation)
 }
 
-func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated, quoted bool, annotation annotation) {
-	s.callback(value, negated, quoted, annotation)
+func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated bool, annotation annotation) {
+	s.callback(value, negated, annotation)
 }
 
 // FieldVisitor is a helper visitor that only visits parameter fields in a
@@ -105,7 +105,7 @@ func VisitParameter(nodes []Node, callback func(field, value string, negated boo
 // VisitPattern is a convenience function that calls callback on all pattern
 // nodes. callback supplies the node's value value, and whether the value is
 // negated or quoted.
-func VisitPattern(nodes []Node, callback func(value string, negated, quoted bool, annotation annotation)) {
+func VisitPattern(nodes []Node, callback func(value string, negated bool, annotation annotation)) {
 	visitor := &PatternVisitor{callback: callback}
 	visitor.VisitNodes(visitor, nodes)
 }

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -6,7 +6,7 @@ type Visitor interface {
 	VisitNodes(v Visitor, node []Node)
 	VisitOperator(v Visitor, kind operatorKind, operands []Node)
 	VisitParameter(v Visitor, field, value string, negated bool)
-	VisitPattern(v Visitor, value string, negated, quoted bool)
+	VisitPattern(v Visitor, value string, negated, quoted bool, annotation annotation)
 }
 
 // BaseVisitor is a visitor that recursively visits each node in a query. A
@@ -18,7 +18,7 @@ func (*BaseVisitor) VisitNodes(visitor Visitor, nodes []Node) {
 	for _, node := range nodes {
 		switch v := node.(type) {
 		case Pattern:
-			visitor.VisitPattern(visitor, v.Value, v.Negated, v.Quoted)
+			visitor.VisitPattern(visitor, v.Value, v.Negated, v.Quoted, v.Annotation)
 		case Parameter:
 			visitor.VisitParameter(visitor, v.Field, v.Value, v.Negated)
 		case Operator:
@@ -35,7 +35,8 @@ func (*BaseVisitor) VisitOperator(visitor Visitor, kind operatorKind, operands [
 
 func (*BaseVisitor) VisitParameter(visitor Visitor, field, value string, negated bool) {}
 
-func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated, quoted bool) {}
+func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated, quoted bool, annotation annotation) {
+}
 
 // ParameterVisitor is a helper visitor that only visits operators in a query,
 // and supplies the operator members via a callback.
@@ -64,11 +65,11 @@ func (s *ParameterVisitor) VisitParameter(visitor Visitor, field, value string, 
 // and supplies the pattern members via a callback.
 type PatternVisitor struct {
 	BaseVisitor
-	callback func(value string, negated, quoted bool)
+	callback func(value string, negated, quoted bool, annotation annotation)
 }
 
-func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated, quoted bool) {
-	s.callback(value, negated, quoted)
+func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated, quoted bool, annotation annotation) {
+	s.callback(value, negated, quoted, annotation)
 }
 
 // FieldVisitor is a helper visitor that only visits parameter fields in a
@@ -104,7 +105,7 @@ func VisitParameter(nodes []Node, callback func(field, value string, negated boo
 // VisitPattern is a convenience function that calls callback on all pattern
 // nodes. callback supplies the node's value value, and whether the value is
 // negated or quoted.
-func VisitPattern(nodes []Node, callback func(value string, negated, quoted bool)) {
+func VisitPattern(nodes []Node, callback func(value string, negated, quoted bool, annotation annotation)) {
 	visitor := &PatternVisitor{callback: callback}
 	visitor.VisitNodes(visitor, nodes)
 }


### PR DESCRIPTION
This PR introduces a type to attach information as "annotation" to individual nodes in a query. The only `annotation` type introduced in this PR is `Labels`, which allows to attach general-purpose information to a query. The `annotation` type is expected to expand, as we will certainly find other annotations useful, for example location `Range`s of terms in a query, errors, or suggestions specific to a term. For simplicity this PR only adds `Annotation` to Pattern nodes, but will later be a member of all query nodes.

I've added a labels that help drive the parser logic and interpretation (about quoting and heuristics). This is more elegant than the previous ad-hoc pattern type with `Quoted` member, and I've refactored everything around the changes. This comes after thinking more about managing bookkeeping and parser options (I think @keegancsmith asked about a more 'direct' or simpler way, and I think this helps with it).

Review this PR by commit.

---

You may be curious what guides the type definitions of nodes. I.e., whether information about a node is an "annotation" versus a top-level member in the definitions below. The gist is that all parts of the abstract syntax should be exposed at the top level, and associated information (location ranges, and other labels) are annotations. This is why "Negated" is not, for example, a label.

```
// Pattern is a leaf node of expressions representing a search pattern fragment. 
type Pattern struct {                                                                                                                                                                 
        Value      string
        Negated    bool
        Annotation annotation
} 

// Parameter is a leaf node of expressions representing a parameter of format "repo:foo".                                                                                             
type Parameter struct {                                                                                                                                                               
        Field   string `json:"field"`
        Value   string `json:"value"`
        Negated bool   `json:"negated"`
        Annotation annotation
} 
```

These definitions lead to visitor interfaces that can distinctly expose what forms part of the tree structure, versus other information that is (only) associated with it. So the intent is to create clearer ways of interacting with the query rather than bundling all information into one struct.
