### PR TITLE
txemail: make gophermail types unexported

### DIFF
--- a/internal/txemail/template.go
+++ b/internal/txemail/template.go
@@ -1,14 +1,17 @@
 package txemail
 
 import (
+	"bytes"
 	"html"
 	htmltemplate "html/template"
+	"io"
 	"strings"
 	texttemplate "text/template"
 
 	"github.com/microcosm-cc/bluemonday"
 	gfm "github.com/shurcooL/github_flavored_markdown"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
+	gophermail "gopkg.in/jpoehls/gophermail.v0"
 )
 
 // MustParseTemplate calls ParseTemplate and panics if an error is returned.
@@ -48,6 +51,33 @@ func ParseTemplate(input txtypes.Templates) (*txtypes.ParsedTemplates, error) {
 	}
 
 	return &txtypes.ParsedTemplates{Subj: st, Text: tt, Html: ht}, nil
+}
+
+func renderTemplate(t *txtypes.ParsedTemplates, data interface{}, m *gophermail.Message) error {
+	render := func(tmpl interface {
+		Execute(io.Writer, interface{}) error
+	}) (string, error) {
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, data); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	}
+
+	var err error
+	m.Subject, err = render(t.Subj)
+	if err != nil {
+		return err
+	}
+	m.Body, err = render(t.Text)
+	if err != nil {
+		return err
+	}
+	m.HTMLBody, err = render(t.Html)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 var (

--- a/internal/txemail/template_test.go
+++ b/internal/txemail/template_test.go
@@ -22,7 +22,7 @@ func TestParseTemplate(t *testing.T) {
 	}
 
 	var m gophermail.Message
-	if err := pt.Render(struct {
+	if err := renderTemplate(pt, struct {
 		A string
 		B string
 	}{

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -60,7 +60,7 @@ func render(message Message) (*gophermail.Message, error) {
 		return nil, err
 	}
 
-	if err := parsed.Render(message.Data, &m); err != nil {
+	if err := renderTemplate(parsed, message.Data, &m); err != nil {
 		return nil, err
 	}
 

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -27,8 +27,8 @@ type Message struct {
 	Data     interface{}       // template data
 }
 
-// Render returns the rendered message contents without sending email.
-func Render(message Message) (*gophermail.Message, error) {
+// render returns the rendered message contents without sending email.
+func render(message Message) (*gophermail.Message, error) {
 	m := gophermail.Message{
 		From: mail.Address{
 			Name: "Sourcegraph",
@@ -99,7 +99,7 @@ func Send(ctx context.Context, message Message) error {
 		return errors.New("no SMTP server configured (in email.smtp)")
 	}
 
-	m, err := Render(message)
+	m, err := render(message)
 	if err != nil {
 		return err
 	}

--- a/internal/txemail/txtypes/types.go
+++ b/internal/txemail/txtypes/types.go
@@ -1,12 +1,8 @@
 package txtypes
 
 import (
-	"bytes"
 	htmltemplate "html/template"
-	"io"
 	texttemplate "text/template"
-
-	gophermail "gopkg.in/jpoehls/gophermail.v0"
 )
 
 // Message describes an email message to be sent.
@@ -33,31 +29,4 @@ type ParsedTemplates struct {
 	Subj *texttemplate.Template
 	Text *texttemplate.Template
 	Html *htmltemplate.Template
-}
-
-func (t ParsedTemplates) Render(data interface{}, m *gophermail.Message) error {
-	render := func(tmpl interface {
-		Execute(io.Writer, interface{}) error
-	}) (string, error) {
-		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, data); err != nil {
-			return "", err
-		}
-		return buf.String(), nil
-	}
-
-	var err error
-	m.Subject, err = render(t.Subj)
-	if err != nil {
-		return err
-	}
-	m.Body, err = render(t.Text)
-	if err != nil {
-		return err
-	}
-	m.HTMLBody, err = render(t.Html)
-	if err != nil {
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
We unnecessarily exposed gophermail types in our txemail/... packages. This change moves all use of gophermail into just the txemail package. Additionally it avoids using it in the exported API.

This makes it easier to change the package we use for email. Currently gophermail is archived and unmaintained.

Part of https://github.com/sourcegraph/sourcegraph/issues/10703