### PR TITLE
extsvc: Replace raw strings with constants for external service "kind"

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 func TestLatestDockerVersionPushed(t *testing.T) {
@@ -135,7 +136,7 @@ func TestSerializeBasic(t *testing.T) {
 		DeployType:           "server",
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
-		ExternalServices:     []string{"GITHUB", "GITLAB"},
+		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,
@@ -239,7 +240,7 @@ func TestSerializeAutomationUsage(t *testing.T) {
 		DeployType:           "server",
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
-		ExternalServices:     []string{"GITHUB", "GITLAB"},
+		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,
@@ -311,7 +312,7 @@ func TestSerializeCodeIntelUsage(t *testing.T) {
 		DeployType:           "server",
 		ClientVersionString:  "3.12.6",
 		AuthProviders:        []string{"foo", "bar"},
-		ExternalServices:     []string{"GITHUB", "GITLAB"},
+		ExternalServices:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		BuiltinSignupAllowed: true,
 		HasExtURL:            false,
 		UniqueUsers:          123,

--- a/cmd/repo-updater/repos/awscodecommit_test.go
+++ b/cmd/repo-updater/repos/awscodecommit_test.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -21,7 +22,7 @@ func TestAWSCodeCommitSource_Exclude(t *testing.T) {
 	}
 
 	fact := httpcli.NewFactory(httpcli.NewMiddleware())
-	svc := ExternalService{Kind: "AWSCODECOMMIT"}
+	svc := ExternalService{Kind: extsvc.KindAWSCodeCommit}
 	conn, err := newAWSCodeCommitSource(&svc, config, fact)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/repo-updater/repos/bitbucketcloud_test.go
+++ b/cmd/repo-updater/repos/bitbucketcloud_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -86,7 +87,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind:   "BITBUCKETCLOUD",
+				Kind:   extsvc.KindBitbucketCloud,
 				Config: marshalJSON(t, tc.conf),
 			}
 
@@ -118,7 +119,7 @@ func TestBitbucketCloudSource_makeRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETCLOUD"}
+	svc := ExternalService{ID: 1, Kind: extsvc.KindBitbucketCloud}
 
 	tests := []struct {
 		name   string
@@ -219,7 +220,7 @@ func TestBitbucketCloudSource_Exclude(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETCLOUD"}
+	svc := ExternalService{ID: 1, Kind: extsvc.KindBitbucketCloud}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -51,7 +52,7 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETSERVER"}
+	svc := ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -124,7 +125,7 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 		},
 	}
 
-	svc := ExternalService{ID: 1, Kind: "BITBUCKETSERVER"}
+	svc := ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -205,7 +206,7 @@ func TestBitbucketServerSource_LoadChangesets(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "BITBUCKETSERVER",
+				Kind: extsvc.KindBitbucketServer,
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,
 					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
@@ -315,7 +316,7 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "BITBUCKETSERVER",
+				Kind: extsvc.KindBitbucketServer,
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,
 					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
@@ -388,7 +389,7 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "BITBUCKETSERVER",
+				Kind: extsvc.KindBitbucketServer,
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,
 					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
@@ -462,7 +463,7 @@ func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "BITBUCKETSERVER",
+				Kind: extsvc.KindBitbucketServer,
 				Config: marshalJSON(t, &schema.BitbucketServerConnection{
 					Url:   instanceURL,
 					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -93,7 +94,7 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "GITHUB",
+				Kind: extsvc.KindGitHub,
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
 					Token: os.Getenv("GITHUB_TOKEN"),
@@ -168,7 +169,7 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "GITHUB",
+				Kind: extsvc.KindGitHub,
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
 					Token: os.Getenv("GITHUB_TOKEN"),
@@ -238,7 +239,7 @@ func TestGithubSource_UpdateChangeset(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "GITHUB",
+				Kind: extsvc.KindGitHub,
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
 					Token: os.Getenv("GITHUB_TOKEN"),
@@ -312,7 +313,7 @@ func TestGithubSource_LoadChangesets(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "GITHUB",
+				Kind: extsvc.KindGitHub,
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url:   "https://github.com",
 					Token: os.Getenv("GITHUB_TOKEN"),
@@ -420,7 +421,7 @@ func TestGithubSource_GetRepo(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "GITHUB",
+				Kind: extsvc.KindGitHub,
 				Config: marshalJSON(t, &schema.GitHubConnection{
 					Url: "https://github.com",
 				}),
@@ -453,7 +454,7 @@ func TestGithubSource_makeRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc := ExternalService{ID: 1, Kind: "GITHUB"}
+	svc := ExternalService{ID: 1, Kind: extsvc.KindGitHub}
 
 	tests := []struct {
 		name   string
@@ -680,7 +681,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind:   "GITHUB",
+				Kind:   extsvc.KindGitHub,
 				Config: marshalJSON(t, tc.conf),
 			}
 

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -134,7 +135,7 @@ func TestGitLabSource_GetRepo(t *testing.T) {
 			lg.SetHandler(log15.DiscardHandler())
 
 			svc := &ExternalService{
-				Kind: "GITLAB",
+				Kind: extsvc.KindGitLab,
 				Config: marshalJSON(t, &schema.GitLabConnection{
 					Url: "https://gitlab.com",
 				}),
@@ -167,7 +168,7 @@ func TestGitLabSource_makeRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc := ExternalService{ID: 1, Kind: "GITLAB"}
+	svc := ExternalService{ID: 1, Kind: extsvc.KindGitLab}
 
 	tests := []struct {
 		name   string

--- a/cmd/repo-updater/repos/other_test.go
+++ b/cmd/repo-updater/repos/other_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 func TestSrcExpose(t *testing.T) {
@@ -114,7 +115,7 @@ func TestSrcExpose(t *testing.T) {
 
 	source, err := NewOtherSource(&ExternalService{
 		ID:     1,
-		Kind:   "OTHER",
+		Kind:   extsvc.KindOther,
 		Config: fmt.Sprintf(`{"url": %q}`, s.URL),
 	}, nil)
 	if err != nil {

--- a/cmd/repo-updater/repos/phabricator.go
+++ b/cmd/repo-updater/repos/phabricator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -184,7 +185,7 @@ func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
 
 	for {
 		phabs, err := s.ListExternalServices(ctx, StoreListExternalServicesArgs{
-			Kinds: []string{"PHABRICATOR"},
+			Kinds: []string{extsvc.KindPhabricator},
 		})
 		if err != nil {
 			log15.Error("unable to fetch Phabricator connections", "err", err)

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"golang.org/x/time/rate"
-
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"golang.org/x/time/rate"
 )
 
 // A Sourcer converts the given ExternalServices to Sources
@@ -71,22 +71,22 @@ func NewChangesetSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limi
 }
 
 func newSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limiter) (Source, error) {
-	switch strings.ToLower(svc.Kind) {
-	case "github":
+	switch strings.ToUpper(svc.Kind) {
+	case extsvc.KindGitHub:
 		return NewGithubSource(svc, cf, rl)
-	case "gitlab":
+	case extsvc.KindGitLab:
 		return NewGitLabSource(svc, cf)
-	case "bitbucketserver":
+	case extsvc.KindBitbucketServer:
 		return NewBitbucketServerSource(svc, cf, rl)
-	case "bitbucketcloud":
+	case extsvc.KindBitbucketCloud:
 		return NewBitbucketCloudSource(svc, cf)
-	case "gitolite":
+	case extsvc.KindGitolite:
 		return NewGitoliteSource(svc, cf)
-	case "phabricator":
+	case extsvc.KindPhabricator:
 		return NewPhabricatorSource(svc, cf)
-	case "awscodecommit":
+	case extsvc.KindAWSCodeCommit:
 		return NewAWSCodeCommitSource(svc, cf)
-	case "other":
+	case extsvc.KindOther:
 		return NewOtherSource(svc, cf)
 	default:
 		panic(fmt.Sprintf("source not implemented for external service kind %q", svc.Kind))

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -90,7 +91,7 @@ func TestSyncer_Sync(t *testing.T) {
 func testSyncerSync(s repos.Store) func(*testing.T) {
 	githubService := &repos.ExternalService{
 		ID:   1,
-		Kind: "GITHUB",
+		Kind: extsvc.KindGitHub,
 	}
 
 	githubRepo := (&repos.Repo{
@@ -107,7 +108,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 	gitlabService := &repos.ExternalService{
 		ID:   10,
-		Kind: "GITLAB",
+		Kind: extsvc.KindGitLab,
 	}
 
 	gitlabRepo := (&repos.Repo{
@@ -124,7 +125,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 	bitbucketServerService := &repos.ExternalService{
 		ID:   20,
-		Kind: "BITBUCKETSERVER",
+		Kind: extsvc.KindBitbucketServer,
 	}
 
 	bitbucketServerRepo := (&repos.Repo{
@@ -141,7 +142,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 	awsCodeCommitService := &repos.ExternalService{
 		ID:   30,
-		Kind: "AWSCODECOMMIT",
+		Kind: extsvc.KindAWSCodeCommit,
 	}
 
 	awsCodeCommitRepo := (&repos.Repo{
@@ -158,7 +159,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 	otherService := &repos.ExternalService{
 		ID:   40,
-		Kind: "OTHER",
+		Kind: extsvc.KindOther,
 	}
 
 	otherRepo := (&repos.Repo{
@@ -174,7 +175,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 	gitoliteService := &repos.ExternalService{
 		ID:   50,
-		Kind: "GITOLITE",
+		Kind: extsvc.KindGitolite,
 	}
 
 	gitoliteRepo := (&repos.Repo{
@@ -191,7 +192,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 
 	bitbucketCloudService := &repos.ExternalService{
 		ID:   60,
-		Kind: "BITBUCKETCLOUD",
+		Kind: extsvc.KindBitbucketCloud,
 	}
 
 	bitbucketCloudRepo := (&repos.Repo{

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -133,18 +133,18 @@ func (e ExternalService) BaseURL() (*url.URL, error) {
 // Exclude changes the configuration of an external service to exclude the given
 // repos from being synced.
 func (e *ExternalService) Exclude(rs ...*Repo) error {
-	switch strings.ToLower(e.Kind) {
-	case "github":
+	switch strings.ToUpper(e.Kind) {
+	case extsvc.KindGitHub:
 		return e.excludeGithubRepos(rs...)
-	case "gitlab":
+	case extsvc.KindGitLab:
 		return e.excludeGitLabRepos(rs...)
-	case "bitbucketserver":
+	case extsvc.KindBitbucketServer:
 		return e.excludeBitbucketServerRepos(rs...)
-	case "awscodecommit":
+	case extsvc.KindAWSCodeCommit:
 		return e.excludeAWSCodeCommitRepos(rs...)
-	case "gitolite":
+	case extsvc.KindGitolite:
 		return e.excludeGitoliteRepos(rs...)
-	case "other":
+	case extsvc.KindOther:
 		return e.excludeOtherRepos(rs...)
 	default:
 		return errors.Errorf("external service kind %q doesn't have an exclude list", e.Kind)
@@ -479,20 +479,20 @@ func (e *ExternalService) config(kind string, opt func(c interface{}) (string, i
 }
 
 func (e ExternalService) schema() string {
-	switch strings.ToLower(e.Kind) {
-	case "awscodecommit":
+	switch strings.ToUpper(e.Kind) {
+	case extsvc.KindAWSCodeCommit:
 		return schema.AWSCodeCommitSchemaJSON
-	case "bitbucketserver":
+	case extsvc.KindBitbucketServer:
 		return schema.BitbucketServerSchemaJSON
-	case "github":
+	case extsvc.KindGitHub:
 		return schema.GitHubSchemaJSON
-	case "gitlab":
+	case extsvc.KindGitLab:
 		return schema.GitLabSchemaJSON
-	case "gitolite":
+	case extsvc.KindGitolite:
 		return schema.GitoliteSchemaJSON
-	case "phabricator":
+	case extsvc.KindPhabricator:
 		return schema.PhabricatorSchemaJSON
-	case "other":
+	case extsvc.KindOther:
 		return schema.OtherExternalServiceSchemaJSON
 	default:
 		return ""

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -3,18 +3,19 @@ package repos
 import (
 	"context"
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/schema"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/schema"
 	"golang.org/x/time/rate"
 )
 
@@ -29,7 +30,7 @@ func TestExternalService_Exclude(t *testing.T) {
 	}
 
 	githubService := ExternalService{
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github",
 		Config: `{
 			// Some comment
@@ -42,7 +43,7 @@ func TestExternalService_Exclude(t *testing.T) {
 	}
 
 	gitlabService := ExternalService{
-		Kind:        "GITLAB",
+		Kind:        extsvc.KindGitLab,
 		DisplayName: "GitLab",
 		Config: `{
 			// Some comment
@@ -55,7 +56,7 @@ func TestExternalService_Exclude(t *testing.T) {
 	}
 
 	bitbucketServerService := ExternalService{
-		Kind:        "BITBUCKETSERVER",
+		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server",
 		Config: `{
 			// Some comment
@@ -70,7 +71,7 @@ func TestExternalService_Exclude(t *testing.T) {
 
 	awsCodeCommitService := ExternalService{
 		ID:          9,
-		Kind:        "AWSCODECOMMIT",
+		Kind:        extsvc.KindAWSCodeCommit,
 		DisplayName: "AWS CodeCommit",
 		Config: `{
 			"region": "us-west-1",
@@ -83,7 +84,7 @@ func TestExternalService_Exclude(t *testing.T) {
 	}
 
 	gitoliteService := ExternalService{
-		Kind:        "GITOLITE",
+		Kind:        extsvc.KindGitolite,
 		DisplayName: "Gitolite",
 		Config: `{
 			// Some comment
@@ -95,7 +96,7 @@ func TestExternalService_Exclude(t *testing.T) {
 	}
 
 	otherService := ExternalService{
-		Kind:        "OTHER",
+		Kind:        extsvc.KindOther,
 		DisplayName: "Other code hosts",
 		Config: formatJSON(t, `{
 			"url": "https://git-host.mycorp.com",

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -134,7 +135,7 @@ func TestServer_handleRepoLookup(t *testing.T) {
 func TestServer_SetRepoEnabled(t *testing.T) {
 	githubService := &repos.ExternalService{
 		ID:          1,
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - test",
 		Config: formatJSON(`
 		{
@@ -161,7 +162,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 
 	gitlabService := &repos.ExternalService{
 		ID:          1,
-		Kind:        "GITLAB",
+		Kind:        extsvc.KindGitLab,
 		DisplayName: "gitlab.com - test",
 		Config: formatJSON(`
 		{
@@ -190,7 +191,7 @@ func TestServer_SetRepoEnabled(t *testing.T) {
 
 	bitbucketServerService := &repos.ExternalService{
 		ID:          1,
-		Kind:        "BITBUCKETSERVER",
+		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server - Test",
 		Config: formatJSON(`
 		{
@@ -452,7 +453,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 func TestServer_RepoExternalServices(t *testing.T) {
 	service1 := &repos.ExternalService{
 		ID:          1,
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - test",
 		Config: formatJSON(`
 		{
@@ -463,7 +464,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 	}
 	service2 := &repos.ExternalService{
 		ID:          2,
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - test2",
 		Config: formatJSON(`
 		{
@@ -544,7 +545,7 @@ func TestServer_RepoExternalServices(t *testing.T) {
 func TestServer_StatusMessages(t *testing.T) {
 	githubService := &repos.ExternalService{
 		ID:          1,
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - test",
 	}
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -127,7 +128,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		server.SourcegraphDotComMode = true
 
 		es, err := store.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
-			Kinds: []string{"GITHUB", "GITLAB"},
+			Kinds: []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		})
 
 		if err != nil {

--- a/enterprise/cmd/frontend/db/external_services_test.go
+++ b/enterprise/cmd/frontend/db/external_services_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -72,7 +73,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		assert func(testing.TB, []string)
 	}{
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "without region, accessKeyID, secretAccessKey, gitCredentials",
 			config: `{}`,
 			assert: includes(
@@ -83,7 +84,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid region",
 			config: `{"region": "foo", "accessKeyID": "bar", "secretAccessKey": "baz", "gitCredentials": {"username": "user", "password": "pw"}}`,
 			assert: includes(
@@ -91,7 +92,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid gitCredentials",
 			config: `{"region": "eu-west-2", "accessKeyID": "bar", "secretAccessKey": "baz", "gitCredentials": {"username": "", "password": ""}}`,
 			assert: includes(
@@ -100,13 +101,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "valid",
 			config: `{"region": "eu-west-2", "accessKeyID": "bar", "secretAccessKey": "baz", "gitCredentials": {"username": "user", "password": "pw"}}`,
 			assert: equals("<nil>"),
 		},
 		{
-			kind: "AWSCODECOMMIT",
+			kind: extsvc.KindAWSCodeCommit,
 			desc: "valid exclude",
 			config: `
 			{
@@ -122,37 +123,37 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid empty exclude",
 			config: `{"exclude": []}`,
 			assert: includes(`exclude: Array must have at least 1 items`),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid empty exclude item",
 			config: `{"exclude": [{}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid exclude item",
 			config: `{"exclude": [{"foo": "bar"}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "f o o b a r"}]}`,
 			assert: includes(`exclude.0.name: Does not match pattern '^[\w.-]+$'`),
 		},
 		{
-			kind:   "AWSCODECOMMIT",
+			kind:   extsvc.KindAWSCodeCommit,
 			desc:   "invalid exclude item id",
 			config: `{"exclude": [{"id": "b$a$r"}]}`,
 			assert: includes(`exclude.0.id: Does not match pattern '^[\w-]+$'`),
 		},
 		{
-			kind: "AWSCODECOMMIT",
+			kind: extsvc.KindAWSCodeCommit,
 			desc: "invalid additional exclude item properties",
 			config: `{"exclude": [{
 				"id": "d111baff-3450-46fd-b7d2-a0ae41f1c5bb",
@@ -161,7 +162,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes(`exclude.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "AWSCODECOMMIT",
+			kind: extsvc.KindAWSCodeCommit,
 			desc: "both name and id can be specified in exclude",
 			config: `
 			{
@@ -183,7 +184,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "witout prefix nor host",
 			config: `{}`,
 			assert: includes(
@@ -192,7 +193,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "with example.com defaults",
 			config: `{"prefix": "gitolite.example.com/", "host": "git@gitolite.example.com"}`,
 			assert: includes(
@@ -201,7 +202,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "witout prefix nor host",
 			config: `{}`,
 			assert: includes(
@@ -210,13 +211,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "bad blacklist regex",
 			config: `{"blacklist": "]["}`,
 			assert: includes("blacklist: Does not match format 'regex'"),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "phabricator without url nor callsignCommand",
 			config: `{"phabricator": {}}`,
 			assert: includes(
@@ -225,43 +226,43 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "phabricator with invalid url",
 			config: `{"phabricator": {"url": "not-a-url"}}`,
 			assert: includes("phabricator.url: Does not match format 'uri'"),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "invalid empty exclude",
 			config: `{"exclude": []}`,
 			assert: includes(`exclude: Array must have at least 1 items`),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "invalid empty exclude item",
 			config: `{"exclude": [{}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "invalid exclude item",
 			config: `{"exclude": [{"foo": "bar"}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": ""}]}`,
 			assert: includes(`exclude.0.name: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "GITOLITE",
+			kind:   extsvc.KindGitolite,
 			desc:   "invalid additional exclude item properties",
 			config: `{"exclude": [{"name": "foo", "bar": "baz"}]}`,
 			assert: includes(`exclude.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "GITOLITE",
+			kind: extsvc.KindGitolite,
 			desc: "name can be specified in exclude",
 			config: `
 			{
@@ -274,7 +275,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind: "BITBUCKETCLOUD",
+			kind: extsvc.KindBitbucketCloud,
 			desc: "valid with url, username, appPassword",
 			config: `
 			{
@@ -285,7 +286,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind: "BITBUCKETCLOUD",
+			kind: extsvc.KindBitbucketCloud,
 			desc: "valid with url, username, appPassword, teams",
 			config: `
 			{
@@ -297,7 +298,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "without url, username nor appPassword",
 			config: `{}`,
 			assert: includes(
@@ -307,25 +308,25 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "bad url scheme",
 			config: `{"url": "badscheme://bitbucket.org"}`,
 			assert: includes("url: Does not match pattern '^https?://'"),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "bad apiURL scheme",
 			config: `{"apiURL": "badscheme://api.bitbucket.org"}`,
 			assert: includes("apiURL: Does not match pattern '^https?://'"),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid gitURLType",
 			config: `{"gitURLType": "bad"}`,
 			assert: includes(`gitURLType: gitURLType must be one of the following: "http", "ssh"`),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid team name",
 			config: `{"teams": ["sg local"]}`,
 			assert: includes(
@@ -333,7 +334,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind: "BITBUCKETCLOUD",
+			kind: extsvc.KindBitbucketCloud,
 			desc: "empty exclude",
 			config: `
 			{
@@ -345,31 +346,31 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid empty exclude item",
 			config: `{"exclude": [{}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid exclude item",
 			config: `{"exclude": [{"foo": "bar"}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
 			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid additional exclude item properties",
 			config: `{"exclude": [{"id": 1234, "bar": "baz"}]}`,
 			assert: includes(`exclude.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "BITBUCKETCLOUD",
+			kind: extsvc.KindBitbucketCloud,
 			desc: "both name and uuid can be specified in exclude",
 			config: `
 			{
@@ -383,13 +384,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "BITBUCKETCLOUD",
+			kind:   extsvc.KindBitbucketCloud,
 			desc:   "invalid exclude pattern",
 			config: `{"exclude": [{"pattern": "["}]}`,
 			assert: includes(`exclude.0.pattern: Does not match format 'regex'`),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "valid with url, username, token, repositoryQuery",
 			config: `
 			{
@@ -401,7 +402,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "valid with url, username, token, repos",
 			config: `
 			{
@@ -413,7 +414,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "without url, username, repositoryQuery nor repos",
 			config: `{}`,
 			assert: includes(
@@ -423,25 +424,25 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "without username",
 			config: `{}`,
 			assert: includes("username is required"),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "example url",
 			config: `{"url": "https://bitbucket.example.com"}`,
 			assert: includes("url: Must not validate the schema (not)"),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "bad url scheme",
 			config: `{"url": "badscheme://bitbucket.com"}`,
 			assert: includes("url: Does not match pattern '^https?://'"),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "with token AND password",
 			config: `{"token": "foo", "password": "bar"}`,
 			assert: includes(
@@ -450,67 +451,67 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid token",
 			config: `{"token": ""}`,
 			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid git url type",
 			config: `{"gitURLType": "bad"}`,
 			assert: includes(`gitURLType: gitURLType must be one of the following: "http", "ssh"`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid certificate",
 			config: `{"certificate": ""}`,
 			assert: includes("certificate: Does not match pattern '^-----BEGIN CERTIFICATE-----\n'"),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "empty repositoryQuery",
 			config: `{"repositoryQuery": []}`,
 			assert: includes(`repositoryQuery: Array must have at least 1 items`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "empty repositoryQuery item",
 			config: `{"repositoryQuery": [""]}`,
 			assert: includes(`repositoryQuery.0: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid empty exclude",
 			config: `{"exclude": []}`,
 			assert: includes(`exclude: Array must have at least 1 items`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid empty exclude item",
 			config: `{"exclude": [{}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid exclude item",
 			config: `{"exclude": [{"foo": "bar"}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
 			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid additional exclude item properties",
 			config: `{"exclude": [{"id": 1234, "bar": "baz"}]}`,
 			assert: includes(`exclude.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "both name and id can be specified in exclude",
 			config: `
 			{
@@ -526,19 +527,19 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid empty repos",
 			config: `{"repos": []}`,
 			assert: includes(`repos: Array must have at least 1 items`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid empty repos item",
 			config: `{"repos": [""]}`,
 			assert: includes(`repos.0: Does not match pattern '^[\w-]+/[\w.-]+$'`),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "invalid exclude pattern",
 			config: `
 			{
@@ -553,7 +554,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes(`exclude.0.pattern: Does not match format 'regex'`),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "valid repos",
 			config: `
 			{
@@ -569,25 +570,25 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid authorization ttl",
 			config: `{"authorization": {"ttl": "foo"}}`,
 			assert: includes(`authorization.ttl: time: invalid duration foo`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid authorization hardTTL",
 			config: `{"authorization": {"ttl": "3h", "hardTTL": "1h"}}`,
 			assert: includes(`authorization.hardTTL: must be larger than ttl`),
 		},
 		{
-			kind:   "BITBUCKETSERVER",
+			kind:   extsvc.KindBitbucketServer,
 			desc:   "valid authorization ttl 0",
 			config: `{"authorization": {"ttl": "0"}}`,
 			assert: excludes(`authorization.ttl: time: invalid duration 0`),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "missing oauth in authorization",
 			config: `
 			{
@@ -597,7 +598,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes("authorization: oauth is required"),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "missing oauth fields",
 			config: `
 			{
@@ -612,7 +613,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "invalid oauth fields",
 			config: `
 			{
@@ -630,7 +631,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "invalid oauth signingKey",
 			config: `
 			{
@@ -645,7 +646,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes("authorization.oauth.signingKey: illegal base64 data at input byte 3"),
 		},
 		{
-			kind: "BITBUCKETSERVER",
+			kind: extsvc.KindBitbucketServer,
 			desc: "username identity provider",
 			config: fmt.Sprintf(`
 			{
@@ -665,7 +666,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "without url, token, repositoryQuery, repos nor orgs",
 			config: `{}`,
 			assert: includes(
@@ -675,7 +676,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind: "GITHUB",
+			kind: extsvc.KindGitHub,
 			desc: "with url, token, repositoryQuery",
 			config: `
 			{
@@ -686,7 +687,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind: "GITHUB",
+			kind: extsvc.KindGitHub,
 			desc: "with url, token, repos",
 			config: `
 			{
@@ -697,7 +698,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind: "GITHUB",
+			kind: extsvc.KindGitHub,
 			desc: "with url, token, orgs",
 			config: `
 			{
@@ -708,7 +709,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "with example.com url and badscheme",
 			config: `{"url": "badscheme://github-enterprise.example.com"}`,
 			assert: includes(
@@ -717,91 +718,91 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "with invalid gitURLType",
 			config: `{"gitURLType": "git"}`,
 			assert: includes(`gitURLType: gitURLType must be one of the following: "http", "ssh"`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid token",
 			config: `{"token": ""}`,
 			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid certificate",
 			config: `{"certificate": ""}`,
 			assert: includes("certificate: Does not match pattern '^-----BEGIN CERTIFICATE-----\n'"),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "empty repositoryQuery",
 			config: `{"repositoryQuery": []}`,
 			assert: includes(`repositoryQuery: Array must have at least 1 items`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "empty repositoryQuery item",
 			config: `{"repositoryQuery": [""]}`,
 			assert: includes(`repositoryQuery.0: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid repos",
 			config: `{"repos": [""]}`,
 			assert: includes(`repos.0: Does not match pattern '^[\w-]+/[\w.-]+$'`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid authorization ttl",
 			config: `{"authorization": {"ttl": "foo"}}`,
 			assert: includes(`authorization.ttl: time: invalid duration foo`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "valid authorization ttl 0",
 			config: `{"authorization": {"ttl": "0"}}`,
 			assert: excludes(`authorization.ttl: time: invalid duration 0`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid empty exclude",
 			config: `{"exclude": []}`,
 			assert: includes(`exclude: Array must have at least 1 items`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid empty exclude item",
 			config: `{"exclude": [{}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid exclude item",
 			config: `{"exclude": [{"foo": "bar"}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
 			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid empty exclude item id",
 			config: `{"exclude": [{"id": ""}]}`,
 			assert: includes(`exclude.0.id: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "GITHUB",
+			kind:   extsvc.KindGitHub,
 			desc:   "invalid additional exclude item properties",
 			config: `{"exclude": [{"id": "foo", "bar": "baz"}]}`,
 			assert: includes(`exclude.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "GITHUB",
+			kind: extsvc.KindGitHub,
 			desc: "both name and id can be specified in exclude",
 			config: `
 			{
@@ -815,43 +816,43 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "empty projectQuery",
 			config: `{"projectQuery": []}`,
 			assert: includes(`projectQuery: Array must have at least 1 items`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "empty projectQuery item",
 			config: `{"projectQuery": [""]}`,
 			assert: includes(`projectQuery.0: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid empty exclude item",
 			config: `{"exclude": [{}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid exclude item",
 			config: `{"exclude": [{"foo": "bar"}]}`,
 			assert: includes(`exclude.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
 			assert: includes(`exclude.0.name: Does not match pattern '^[\w.-]+(/[\w.-]+)+$'`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid additional exclude item properties",
 			config: `{"exclude": [{"id": 1234, "bar": "baz"}]}`,
 			assert: includes(`exclude.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "both name and id can be specified in exclude",
 			config: `
 			{
@@ -865,7 +866,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "subgroup paths are valid for exclude",
 			config: `
 			{
@@ -879,7 +880,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "paths containing . in the first part of the path are valid for exclude",
 			config: `
 			{
@@ -893,37 +894,37 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid empty projects",
 			config: `{"projects": []}`,
 			assert: includes(`projects: Array must have at least 1 items`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid empty projects item",
 			config: `{"projects": [{}]}`,
 			assert: includes(`projects.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid projects item",
 			config: `{"projects": [{"foo": "bar"}]}`,
 			assert: includes(`projects.0: Must validate at least one schema (anyOf)`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid projects item name",
 			config: `{"projects": [{"name": "bar"}]}`,
 			assert: includes(`projects.0.name: Does not match pattern '^[\w.-]+(/[\w.-]+)+$'`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid additional projects item properties",
 			config: `{"projects": [{"id": 1234, "bar": "baz"}]}`,
 			assert: includes(`projects.0: Additional property bar is not allowed`),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "both name and id can be specified in projects",
 			config: `
 			{
@@ -937,7 +938,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "without url, token nor projectQuery",
 			config: `{}`,
 			assert: includes(
@@ -947,7 +948,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "with example.com url and badscheme",
 			config: `{"url": "badscheme://github-enterprise.example.com"}`,
 			assert: includes(
@@ -956,37 +957,37 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "with invalid gitURLType",
 			config: `{"gitURLType": "git"}`,
 			assert: includes(`gitURLType: gitURLType must be one of the following: "http", "ssh"`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid token",
 			config: `{"token": ""}`,
 			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid certificate",
 			config: `{"certificate": ""}`,
 			assert: includes("certificate: Does not match pattern '^-----BEGIN CERTIFICATE-----\n'"),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "invalid authorization ttl",
 			config: `{"authorization": {"ttl": "foo"}}`,
 			assert: includes(`authorization.ttl: time: invalid duration foo`),
 		},
 		{
-			kind:   "GITLAB",
+			kind:   extsvc.KindGitLab,
 			desc:   "valid authorization ttl 0",
 			config: `{"authorization": {"ttl": "0"}}`,
 			assert: excludes(`authorization.ttl: time: invalid duration 0`),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "missing oauth provider",
 			config: `
 			{
@@ -997,7 +998,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes("Did not find authentication provider matching \"https://gitlab.foo.bar\". Check the [**site configuration**](/site-admin/configuration) to verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for https://gitlab.foo.bar."),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "valid oauth provider",
 			config: `
 			{
@@ -1011,7 +1012,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: excludes("Did not find authentication provider matching \"https://gitlab.foo.bar\". Check the [**site configuration**](/site-admin/configuration) to verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for https://gitlab.foo.bar."),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "missing external provider",
 			config: `
 			{
@@ -1029,7 +1030,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes("Did not find authentication provider matching type bar and configID foo. Check the [**site configuration**](/site-admin/configuration) to verify that an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) matches the type and configID."),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "valid external provider with SAML",
 			config: `
 			{
@@ -1055,7 +1056,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: excludes("Did not find authentication provider matching type bar and configID foo. Check the [**site configuration**](/site-admin/configuration) to verify that an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) matches the type and configID."),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "valid external provider with OIDC",
 			config: `
 			{
@@ -1081,7 +1082,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: excludes("Did not find authentication provider matching type bar and configID foo. Check the [**site configuration**](/site-admin/configuration) to verify that an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) matches the type and configID."),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "username identity provider",
 			config: `
 			{
@@ -1098,7 +1099,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "missing properties in name transformations",
 			config: `
 			{
@@ -1116,7 +1117,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "invalid properties in name transformations",
 			config: `
 			{
@@ -1131,7 +1132,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: includes(`nameTransformations.0.regex: Does not match format 'regex'`),
 		},
 		{
-			kind: "GITLAB",
+			kind: extsvc.KindGitLab,
 			desc: "valid name transformations",
 			config: `
 			{
@@ -1153,7 +1154,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 		{
-			kind:   "PHABRICATOR",
+			kind:   extsvc.KindPhabricator,
 			desc:   "without repos nor token",
 			config: `{}`,
 			assert: includes(
@@ -1162,103 +1163,103 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			),
 		},
 		{
-			kind:   "PHABRICATOR",
+			kind:   extsvc.KindPhabricator,
 			desc:   "with empty repos",
 			config: `{"repos": []}`,
 			assert: includes(`repos: Array must have at least 1 items`),
 		},
 		{
-			kind:   "PHABRICATOR",
+			kind:   extsvc.KindPhabricator,
 			desc:   "with repos",
 			config: `{"repos": [{"path": "gitolite/my/repo", "callsign": "MUX"}]}`,
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "PHABRICATOR",
+			kind:   extsvc.KindPhabricator,
 			desc:   "invalid token",
 			config: `{"token": ""}`,
 			assert: includes(`token: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "PHABRICATOR",
+			kind:   extsvc.KindPhabricator,
 			desc:   "with token",
 			config: `{"token": "a given token"}`,
 			assert: equals(`<nil>`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without url nor repos array",
 			config: `{}`,
 			assert: includes(`repos is required`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without URL but with null repos array",
 			config: `{"repos": null}`,
 			assert: includes(`repos: Invalid type. Expected: array, given: null`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without URL but with empty repos array",
 			config: `{"repos": []}`,
 			assert: excludes(`repos: Array must have at least 1 items`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without URL and empty repo array item",
 			config: `{"repos": [""]}`,
 			assert: includes(`repos.0: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without URL and invalid repo array item",
 			config: `{"repos": ["https://github.com/%%%%malformed"]}`,
 			assert: includes(`repos.0: Does not match format 'uri-reference'`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without URL and invalid scheme in repo array item",
 			config: `{"repos": ["badscheme://github.com/my/repo"]}`,
 			assert: includes(`repos.0: scheme "badscheme" not one of git, http, https or ssh`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "without URL and valid repos",
 			config: `{"repos": ["http://git.hub/repo", "https://git.hub/repo", "git://user@hub.com:3233/repo.git/", "ssh://user@hub.com/repo.git/"]}`,
 			assert: equals("<nil>"),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "with URL but null repos array",
 			config: `{"url": "http://github.com/", "repos": null}`,
 			assert: includes(`repos: Invalid type. Expected: array, given: null`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "with URL but empty repos array",
 			config: `{"url": "http://github.com/", "repos": []}`,
 			assert: excludes(`repos: Array must have at least 1 items`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "with URL and empty repo array item",
 			config: `{"url": "http://github.com/", "repos": [""]}`,
 			assert: includes(`repos.0: String length must be greater than or equal to 1`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "with URL and invalid repo array item",
 			config: `{"url": "https://github.com/", "repos": ["foo/%%%%malformed"]}`,
 			assert: includes(`repos.0: Does not match format 'uri-reference'`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "with invalid scheme URL",
 			config: `{"url": "badscheme://github.com/", "repos": ["my/repo"]}`,
 			assert: includes(`url: Does not match pattern '^(git|ssh|https?)://'`),
 		},
 		{
-			kind:   "OTHER",
+			kind:   extsvc.KindOther,
 			desc:   "with URL and valid repos",
 			config: `{"url": "https://github.com/", "repos": ["foo/", "bar", "/baz", "bam.git"]}`,
 			assert: equals("<nil>"),

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -284,7 +284,7 @@ func (*fakeExternalServiceLister) ListExternalServices(context.Context, repos.St
 	return []*repos.ExternalService{
 		{
 			ID:          1,
-			Kind:        "GITHUB",
+			Kind:        extsvc.KindGitHub,
 			DisplayName: "GitHub.com",
 			Config:      `{"url": "https://github.com"}`,
 		},

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -43,7 +44,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -232,7 +232,7 @@ func TestCampaigns(t *testing.T) {
 
 	store := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	githubExtSvc := &repos.ExternalService{
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "GitHub",
 		Config: marshalJSON(t, &schema.GitHubConnection{
 			Url:   "https://github.com",
@@ -249,7 +249,7 @@ func TestCampaigns(t *testing.T) {
 	}
 
 	bbsExtSvc := &repos.ExternalService{
-		Kind:        "BITBUCKETSERVER",
+		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server",
 		Config: marshalJSON(t, &schema.BitbucketServerConnection{
 			Url:   bbsURL,
@@ -647,7 +647,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 
 	repoStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	githubExtSvc := &repos.ExternalService{
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "GitHub",
 		Config: marshalJSON(t, &schema.GitHubConnection{
 			Url:   "https://github.com",

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"golang.org/x/time/rate"
 )
@@ -83,7 +84,7 @@ func (s *SyncRegistry) Add(extServiceID int64) {
 	service := services[0]
 
 	switch service.Kind {
-	case "GITHUB", "BITBUCKETSERVER":
+	case extsvc.KindGitHub, extsvc.KindBitbucketServer:
 	// Supported by campaigns
 	default:
 		log15.Debug("Campaigns syncer not started for unsupported code host", "kind", service.Kind)

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
-
-	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
-
-	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 func TestNextSync(t *testing.T) {
@@ -360,7 +358,7 @@ func TestSyncRegistry(t *testing.T) {
 			return []*repos.ExternalService{
 				{
 					ID:          1,
-					Kind:        "GITHUB",
+					Kind:        extsvc.KindGitHub,
 					DisplayName: "",
 					Config:      "",
 					CreatedAt:   time.Time{},
@@ -401,7 +399,7 @@ func TestSyncRegistry(t *testing.T) {
 	// Simulate a service being removed
 	r.HandleExternalServiceSync(api.ExternalService{
 		ID:        1,
-		Kind:      "GITHUB",
+		Kind:      extsvc.KindGitHub,
 		DeletedAt: &now,
 	})
 	assertSyncerCount(0)
@@ -409,7 +407,7 @@ func TestSyncRegistry(t *testing.T) {
 	// And added again
 	r.HandleExternalServiceSync(api.ExternalService{
 		ID:        1,
-		Kind:      "GITHUB",
+		Kind:      extsvc.KindGitHub,
 		DeletedAt: nil,
 	})
 	assertSyncerCount(1)

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -242,7 +242,7 @@ func (h *GitHubWebhook) parseEvent(r *http.Request) (interface{}, *repos.Externa
 	// it's ok for this to be have linear complexity.
 	// If there are no secrets or no secret managed to authenticate the request,
 	// we return a 401 to the client.
-	args := repos.StoreListExternalServicesArgs{Kinds: []string{"GITHUB"}}
+	args := repos.StoreListExternalServicesArgs{Kinds: []string{extsvc.KindGitHub}}
 	es, err := h.Repos.ListExternalServices(r.Context(), args)
 	if err != nil {
 		return nil, nil, &httpError{http.StatusInternalServerError, err}
@@ -834,7 +834,7 @@ func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *repo
 		}
 	}
 
-	args := repos.StoreListExternalServicesArgs{Kinds: []string{"BITBUCKETSERVER"}}
+	args := repos.StoreListExternalServicesArgs{Kinds: []string{extsvc.KindBitbucketServer}}
 	if externalServiceID != 0 {
 		args.IDs = append(args.IDs, externalServiceID)
 	}

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -19,16 +19,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
-
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -55,7 +53,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		secret := "secret"
 		repoStore := repos.NewDBStore(db, sql.TxOptions{})
 		extSvc := &repos.ExternalService{
-			Kind:        "GITHUB",
+			Kind:        extsvc.KindGitHub,
 			DisplayName: "GitHub",
 			Config: marshalJSON(t, &schema.GitHubConnection{
 				Url:      "https://github.com",
@@ -205,7 +203,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		secret := "secret"
 		repoStore := repos.NewDBStore(db, sql.TxOptions{})
 		extSvc := &repos.ExternalService{
-			Kind:        "BITBUCKETSERVER",
+			Kind:        extsvc.KindBitbucketServer,
 			DisplayName: "Bitbucket",
 			Config: marshalJSON(t, &schema.BitbucketServerConnection{
 				Url:   "https://bitbucket.sgdev.org",

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -38,7 +39,7 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 
 func AWSCodeCommitConfigs(ctx context.Context) ([]*schema.AWSCodeCommitConnection, error) {
 	var config []*schema.AWSCodeCommitConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "AWSCODECOMMIT", &config); err != nil {
+	if err := api.InternalClient.ExternalServiceConfigs(ctx, extsvc.KindAWSCodeCommit, &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -46,7 +47,7 @@ func AWSCodeCommitConfigs(ctx context.Context) ([]*schema.AWSCodeCommitConnectio
 
 func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
 	var config []*schema.BitbucketServerConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "BITBUCKETSERVER", &config); err != nil {
+	if err := api.InternalClient.ExternalServiceConfigs(ctx, extsvc.KindBitbucketServer, &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -54,7 +55,7 @@ func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConne
 
 func GitHubConfigs(ctx context.Context) ([]*schema.GitHubConnection, error) {
 	var config []*schema.GitHubConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "GITHUB", &config); err != nil {
+	if err := api.InternalClient.ExternalServiceConfigs(ctx, extsvc.KindGitHub, &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -62,7 +63,7 @@ func GitHubConfigs(ctx context.Context) ([]*schema.GitHubConnection, error) {
 
 func GitLabConfigs(ctx context.Context) ([]*schema.GitLabConnection, error) {
 	var config []*schema.GitLabConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "GITLAB", &config); err != nil {
+	if err := api.InternalClient.ExternalServiceConfigs(ctx, extsvc.KindGitLab, &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -70,7 +71,7 @@ func GitLabConfigs(ctx context.Context) ([]*schema.GitLabConnection, error) {
 
 func GitoliteConfigs(ctx context.Context) ([]*schema.GitoliteConnection, error) {
 	var config []*schema.GitoliteConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "GITOLITE", &config); err != nil {
+	if err := api.InternalClient.ExternalServiceConfigs(ctx, extsvc.KindGitolite, &config); err != nil {
 		return nil, err
 	}
 	return config, nil
@@ -78,7 +79,7 @@ func GitoliteConfigs(ctx context.Context) ([]*schema.GitoliteConnection, error) 
 
 func PhabricatorConfigs(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
 	var config []*schema.PhabricatorConnection
-	if err := api.InternalClient.ExternalServiceConfigs(ctx, "PHABRICATOR", &config); err != nil {
+	if err := api.InternalClient.ExternalServiceConfigs(ctx, extsvc.KindPhabricator, &config); err != nil {
 		return nil, err
 	}
 	return config, nil

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -91,22 +91,22 @@ type RepoID string
 
 // ParseConfig attempts to unmarshal the given JSON config into a configuration struct defined in the schema package.
 func ParseConfig(kind, config string) (cfg interface{}, _ error) {
-	switch strings.ToLower(kind) {
-	case "awscodecommit":
+	switch strings.ToUpper(kind) {
+	case KindAWSCodeCommit:
 		cfg = &schema.AWSCodeCommitConnection{}
-	case "bitbucketserver":
+	case KindBitbucketServer:
 		cfg = &schema.BitbucketServerConnection{}
-	case "bitbucketcloud":
+	case KindBitbucketCloud:
 		cfg = &schema.BitbucketCloudConnection{}
-	case "github":
+	case KindGitHub:
 		cfg = &schema.GitHubConnection{}
-	case "gitlab":
+	case KindGitLab:
 		cfg = &schema.GitLabConnection{}
-	case "gitolite":
+	case KindGitolite:
 		cfg = &schema.GitoliteConnection{}
-	case "phabricator":
+	case KindPhabricator:
 		cfg = &schema.PhabricatorConnection{}
-	case "other":
+	case KindOther:
 		cfg = &schema.OtherExternalServiceConnection{}
 	default:
 		return nil, fmt.Errorf("unknown external service kind %q", kind)
@@ -118,10 +118,10 @@ const IDParam = "externalServiceID"
 
 func WebhookURL(kind string, externalServiceID int64, externalURL string) string {
 	var path string
-	switch strings.ToLower(kind) {
-	case "github":
+	switch strings.ToUpper(kind) {
+	case KindGitHub:
 		path = "github-webhooks"
-	case "bitbucketserver":
+	case KindBitbucketServer:
 		path = "bitbucket-server-webhooks"
 	default:
 		return ""

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -68,6 +68,17 @@ func (s *Accounts) TracingFields() []otlog.Field {
 	}
 }
 
+const (
+	KindAWSCodeCommit   = "AWSCODECOMMIT"
+	KindBitbucketServer = "BITBUCKETSERVER"
+	KindBitbucketCloud  = "BITBUCKETCLOUD"
+	KindGitHub          = "GITHUB"
+	KindGitLab          = "GITLAB"
+	KindGitolite        = "GITOLITE"
+	KindPhabricator     = "PHABRICATOR"
+	KindOther           = "OTHER"
+)
+
 // AccountID is a descriptive type for the external identifier of an external account on the
 // code host. It can be the string representation of an integer (e.g. GitLab), a GraphQL ID
 // (e.g. GitHub), or a username (e.g. Bitbucket Server) depends on the code host type.

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -16,7 +16,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "GitLab default",
 			config:      `{"url": "https://example.com/"}`,
-			kind:        "GITLAB",
+			kind:        KindGitLab,
 			displayName: "GitLab 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -28,7 +28,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "GitHub default",
 			config:      `{"url": "https://example.com/"}`,
-			kind:        "GITHUB",
+			kind:        KindGitHub,
 			displayName: "GitHub 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -40,7 +40,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "Bitbucket Server default",
 			config:      `{"url": "https://example.com/"}`,
-			kind:        "BITBUCKETSERVER",
+			kind:        KindBitbucketServer,
 			displayName: "BitbucketServer 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -52,7 +52,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "Bitbucket Cloud default",
 			config:      `{"url": "https://example.com/"}`,
-			kind:        "BITBUCKETCLOUD",
+			kind:        KindBitbucketCloud,
 			displayName: "BitbucketCloud 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -64,7 +64,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "GitLab non-default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        "GITLAB",
+			kind:        KindGitLab,
 			displayName: "GitLab 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -76,7 +76,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "GitHub default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        "GITHUB",
+			kind:        KindGitHub,
 			displayName: "GitHub 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -88,7 +88,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "Bitbucket Server default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        "BITBUCKETSERVER",
+			kind:        KindBitbucketServer,
 			displayName: "BitbucketServer 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
@@ -100,7 +100,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		{
 			name:        "Bitbucket Cloud default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        "BITBUCKETCLOUD",
+			kind:        KindBitbucketCloud,
 			displayName: "BitbucketCloud 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",


### PR DESCRIPTION
This change replaces all uppercase occurrences and places where we were doing a switch on 'string.ToLower(kind)`

I've not made changes to occurrences of lowercase strings yet apart from where they were obviously referring to 'kind' as we also use those to represent `repo.ServiceType` and I'm not clear on how they interact yet. 

For example: https://github.com/sourcegraph/sourcegraph/blob/8bea5eb42c72423a163932d6f31d9b5cf9ebb21d/internal/api/api.go#L48-L51

Part of: https://github.com/sourcegraph/sourcegraph/issues/10296