### PR TITLE
Fix HasUnpublishedPatches for errored changeset jobs

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -182,8 +182,9 @@ func (r *campaignResolver) HasUnpublishedPatches(ctx context.Context) (bool, err
 	}
 
 	unpublishedCount, err := r.store.CountPatches(ctx, ee.CountPatchesOpts{
-		PatchSetID:                r.Campaign.PatchSetID,
-		OnlyUnpublishedInCampaign: r.Campaign.ID,
+		PatchSetID:                   r.Campaign.PatchSetID,
+		OnlyNeverPublishedInCampaign: r.Campaign.ID,
+		OnlyWithDiff:                 true,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "getting unpublished patches count")

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -182,9 +182,9 @@ func (r *campaignResolver) HasUnpublishedPatches(ctx context.Context) (bool, err
 	}
 
 	unpublishedCount, err := r.store.CountPatches(ctx, ee.CountPatchesOpts{
-		PatchSetID:                   r.Campaign.PatchSetID,
-		OnlyNeverPublishedInCampaign: r.Campaign.ID,
-		OnlyWithDiff:                 true,
+		PatchSetID:                        r.Campaign.PatchSetID,
+		OnlyWithoutChangesetJobInCampaign: r.Campaign.ID,
+		OnlyWithDiff:                      true,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "getting unpublished patches count")

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -2066,7 +2066,7 @@ type CountPatchesOpts struct {
 	// If this is set to a Campaign ID only the Patches are returned that are
 	// _not_ associated with any ChangesetJob (meaning
 	// that a Changeset on the codehost was created) for the given Campaign.
-	OnlyNeverPublishedInCampaign int64
+	OnlyWithoutChangesetJobInCampaign int64
 }
 
 // CountPatches returns the number of Patches in the database.
@@ -2103,8 +2103,8 @@ func countPatchesQuery(opts *CountPatchesOpts) *sqlf.Query {
 		preds = append(preds, onlyUnpublishedInCampaignQuery(opts.OnlyUnpublishedInCampaign))
 	}
 
-	if opts.OnlyNeverPublishedInCampaign != 0 {
-		preds = append(preds, onlyNeverPublishedInCampaignQuery(opts.OnlyNeverPublishedInCampaign))
+	if opts.OnlyWithoutChangesetJobInCampaign != 0 {
+		preds = append(preds, onlyWithoutChangesetJobInCampaignQuery(opts.OnlyWithoutChangesetJobInCampaign))
 	}
 
 	return sqlf.Sprintf(countPatchesQueryFmtstr, sqlf.Join(preds, "\n AND "))
@@ -2188,7 +2188,7 @@ type ListPatchesOpts struct {
 	// If this is set to a Campaign ID only the Patches are returned that are
 	// _not_ associated with any ChangesetJob (meaning
 	// that a Changeset on the codehost was created) for the given Campaign.
-	OnlyNeverPublishedInCampaign int64
+	OnlyWithoutChangesetJobInCampaign int64
 
 	// If this is set only the Patches where diff_stat_added OR
 	// diff_stat_changed OR diff_stat_deleted are NULL.
@@ -2269,8 +2269,8 @@ func listPatchesQuery(opts *ListPatchesOpts) *sqlf.Query {
 		preds = append(preds, onlyUnpublishedInCampaignQuery(opts.OnlyUnpublishedInCampaign))
 	}
 
-	if opts.OnlyNeverPublishedInCampaign != 0 {
-		preds = append(preds, onlyNeverPublishedInCampaignQuery(opts.OnlyNeverPublishedInCampaign))
+	if opts.OnlyWithoutChangesetJobInCampaign != 0 {
+		preds = append(preds, onlyWithoutChangesetJobInCampaignQuery(opts.OnlyWithoutChangesetJobInCampaign))
 	}
 
 	if opts.OnlyWithoutDiffStats {
@@ -2315,7 +2315,7 @@ func onlyUnpublishedInCampaignQuery(campaignID int64) *sqlf.Query {
 	return sqlf.Sprintf(onlyUnpublishedInCampaignQueryFmtstr, campaignID)
 }
 
-var onlyNeverPublishedInCampaignQueryFmtstr = `
+var onlyWithoutChangesetJobInCampaignQueryFmtstr = `
 NOT EXISTS (
   SELECT 1
   FROM changeset_jobs
@@ -2326,8 +2326,8 @@ NOT EXISTS (
 )
 `
 
-func onlyNeverPublishedInCampaignQuery(campaignID int64) *sqlf.Query {
-	return sqlf.Sprintf(onlyNeverPublishedInCampaignQueryFmtstr, campaignID)
+func onlyWithoutChangesetJobInCampaignQuery(campaignID int64) *sqlf.Query {
+	return sqlf.Sprintf(onlyWithoutChangesetJobInCampaignQueryFmtstr, campaignID)
 }
 
 // CreateChangesetJob creates the given ChangesetJob.

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -2062,6 +2062,11 @@ type CountPatchesOpts struct {
 	// _not_ associated with a successfully completed ChangesetJob (meaning
 	// that a Changeset on the codehost was created) for the given Campaign.
 	OnlyUnpublishedInCampaign int64
+
+	// If this is set to a Campaign ID only the Patches are returned that are
+	// _not_ associated with any ChangesetJob (meaning
+	// that a Changeset on the codehost was created) for the given Campaign.
+	OnlyNeverPublishedInCampaign int64
 }
 
 // CountPatches returns the number of Patches in the database.
@@ -2096,6 +2101,10 @@ func countPatchesQuery(opts *CountPatchesOpts) *sqlf.Query {
 
 	if opts.OnlyUnpublishedInCampaign != 0 {
 		preds = append(preds, onlyUnpublishedInCampaignQuery(opts.OnlyUnpublishedInCampaign))
+	}
+
+	if opts.OnlyNeverPublishedInCampaign != 0 {
+		preds = append(preds, onlyNeverPublishedInCampaignQuery(opts.OnlyNeverPublishedInCampaign))
 	}
 
 	return sqlf.Sprintf(countPatchesQueryFmtstr, sqlf.Join(preds, "\n AND "))
@@ -2176,6 +2185,11 @@ type ListPatchesOpts struct {
 	// mutually exclusive with OnlyWithoutChangesetJob.
 	OnlyUnpublishedInCampaign int64
 
+	// If this is set to a Campaign ID only the Patches are returned that are
+	// _not_ associated with any ChangesetJob (meaning
+	// that a Changeset on the codehost was created) for the given Campaign.
+	OnlyNeverPublishedInCampaign int64
+
 	// If this is set only the Patches where diff_stat_added OR
 	// diff_stat_changed OR diff_stat_deleted are NULL.
 	OnlyWithoutDiffStats bool
@@ -2255,6 +2269,10 @@ func listPatchesQuery(opts *ListPatchesOpts) *sqlf.Query {
 		preds = append(preds, onlyUnpublishedInCampaignQuery(opts.OnlyUnpublishedInCampaign))
 	}
 
+	if opts.OnlyNeverPublishedInCampaign != 0 {
+		preds = append(preds, onlyNeverPublishedInCampaignQuery(opts.OnlyNeverPublishedInCampaign))
+	}
+
 	if opts.OnlyWithoutDiffStats {
 		preds = append(preds, sqlf.Sprintf("(patches.diff_stat_added IS NULL OR patches.diff_stat_deleted IS NULL OR patches.diff_stat_changed IS NULL)"))
 	}
@@ -2295,6 +2313,21 @@ NOT EXISTS (
 
 func onlyUnpublishedInCampaignQuery(campaignID int64) *sqlf.Query {
 	return sqlf.Sprintf(onlyUnpublishedInCampaignQueryFmtstr, campaignID)
+}
+
+var onlyNeverPublishedInCampaignQueryFmtstr = `
+NOT EXISTS (
+  SELECT 1
+  FROM changeset_jobs
+  WHERE
+    changeset_jobs.patch_id = patches.id
+  AND
+    changeset_jobs.campaign_id = %s
+)
+`
+
+func onlyNeverPublishedInCampaignQuery(campaignID int64) *sqlf.Query {
+	return sqlf.Sprintf(onlyNeverPublishedInCampaignQueryFmtstr, campaignID)
 }
 
 // CreateChangesetJob creates the given ChangesetJob.

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -2035,6 +2035,109 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, reposStore re
 		}
 	})
 
+	t.Run("Listing and Counting OnlyNeverPublishedInCampaign", func(t *testing.T) {
+		campaignID := int64(999)
+
+		listOpts := ListPatchesOpts{OnlyNeverPublishedInCampaign: campaignID}
+		countOpts := CountPatchesOpts{OnlyNeverPublishedInCampaign: campaignID}
+
+		have, _, err := s.ListPatches(ctx, listOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have, want := have, patches
+		if len(have) != len(want) {
+			t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+		}
+
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("opts: %+v, diff: %s", listOpts, diff)
+		}
+
+		count, err := s.CountPatches(ctx, countOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if int(count) != len(want) {
+			t.Errorf("jobs counted: %d", count)
+		}
+
+		// Create successful job
+		changesetJob := &cmpgn.ChangesetJob{
+			PatchID:     patches[0].ID,
+			CampaignID:  campaignID,
+			ChangesetID: 789,
+			StartedAt:   clock.now(),
+			FinishedAt:  clock.now(),
+		}
+		err = s.CreateChangesetJob(ctx, changesetJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have, _, err = s.ListPatches(ctx, listOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want = patches[1:] // Exclude the first patch.
+		if len(have) != len(want) {
+			t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+		}
+
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("opts: %+v, diff: %s", listOpts, diff)
+		}
+
+		count, err = s.CountPatches(ctx, countOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if int(count) != len(want) {
+			t.Errorf("jobs counted: %d", count)
+		}
+
+		// Set ChangesetJob to errored.
+		changesetJob.ChangesetID = 0
+		changesetJob.Error = "Very bad."
+		err = s.UpdateChangesetJob(ctx, changesetJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have, _, err = s.ListPatches(ctx, listOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want = patches[1:] // Exclude the first patch.
+		if len(have) != len(want) {
+			t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+		}
+
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Fatalf("opts: %+v, diff: %s", listOpts, diff)
+		}
+
+		count, err = s.CountPatches(ctx, countOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if int(count) != len(want) {
+			t.Errorf("jobs counted: %d", count)
+		}
+
+		// Reset state for other tests.
+		err = s.DeleteChangesetJob(ctx, changesetJob.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("Listing and Counting OnlyUnpublishedInCampaign", func(t *testing.T) {
 		campaignID := int64(999)
 		changesetJob := &cmpgn.ChangesetJob{

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -2035,11 +2035,11 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, reposStore re
 		}
 	})
 
-	t.Run("Listing and Counting OnlyNeverPublishedInCampaign", func(t *testing.T) {
+	t.Run("Listing and Counting OnlyWithoutChangesetJobInCampaign", func(t *testing.T) {
 		campaignID := int64(999)
 
-		listOpts := ListPatchesOpts{OnlyNeverPublishedInCampaign: campaignID}
-		countOpts := CountPatchesOpts{OnlyNeverPublishedInCampaign: campaignID}
+		listOpts := ListPatchesOpts{OnlyWithoutChangesetJobInCampaign: campaignID}
+		countOpts := CountPatchesOpts{OnlyWithoutChangesetJobInCampaign: campaignID}
 
 		have, _, err := s.ListPatches(ctx, listOpts)
 		if err != nil {


### PR DESCRIPTION
We still included changeset jobs that errored or are currently running, which also won't run on publish, so they should not contribute to this flag.