### PR TITLE
search: function to convert or-operators on patterns to regexp

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -126,7 +126,7 @@ func partition(nodes []Node, fn func(node Node) bool) (left, right []Node) {
 	return left, right
 }
 
-func convertOrToRegexp(nodes []Node) []Node {
+func substituteOrForRegexp(nodes []Node) []Node {
 	isPattern := func(node Node) bool {
 		if pattern, ok := node.(Pattern); ok && !pattern.Negated {
 			return true
@@ -145,10 +145,10 @@ func convertOrToRegexp(nodes []Node) []Node {
 				}
 				valueString := strings.Join(values, "|")
 				new = append(new, Pattern{Value: valueString})
-				rest = convertOrToRegexp(rest)
+				rest = substituteOrForRegexp(rest)
 				new = newOperator(append(new, rest...), Or)
 			} else {
-				new = append(new, newOperator(convertOrToRegexp(v.Operands), v.Kind)...)
+				new = append(new, newOperator(substituteOrForRegexp(v.Operands), v.Kind)...)
 			}
 		case Parameter, Pattern:
 			new = append(new, node)

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -113,6 +113,50 @@ func containsUppercase(s string) bool {
 	return false
 }
 
+// partition partitions nodes into left and right groups. A node is put in the
+// left group if fn evaluates to true, or in the right group if fn evaluates to false.
+func partition(nodes []Node, fn func(node Node) bool) (left, right []Node) {
+	for _, node := range nodes {
+		if fn(node) {
+			left = append(left, node)
+		} else {
+			right = append(right, node)
+		}
+	}
+	return left, right
+}
+
+func convertOrToRegexp(nodes []Node) []Node {
+	isPattern := func(node Node) bool {
+		if pattern, ok := node.(Pattern); ok && !pattern.Negated {
+			return true
+		}
+		return false
+	}
+	new := []Node{}
+	for _, node := range nodes {
+		switch v := node.(type) {
+		case Operator:
+			if v.Kind == Or {
+				patterns, other := partition(v.Operands, isPattern)
+				var values []string
+				for _, node := range patterns {
+					values = append(values, node.(Pattern).Value)
+				}
+				valueString := strings.Join(values, "|")
+				new = append(new, Pattern{Value: valueString})
+				rest := convertOrToRegexp(other)
+				new = newOperator(append(new, rest...), Or)
+			} else {
+				new = append(new, newOperator(convertOrToRegexp(v.Operands), v.Kind)...)
+			}
+		case Parameter, Pattern:
+			new = append(new, node)
+		}
+	}
+	return new
+}
+
 // Map pipes query through one or more query transformer functions.
 func Map(query []Node, fns ...func([]Node) []Node) []Node {
 	for _, fn := range fns {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -138,14 +138,14 @@ func convertOrToRegexp(nodes []Node) []Node {
 		switch v := node.(type) {
 		case Operator:
 			if v.Kind == Or {
-				patterns, other := partition(v.Operands, isPattern)
+				patterns, rest := partition(v.Operands, isPattern)
 				var values []string
 				for _, node := range patterns {
 					values = append(values, node.(Pattern).Value)
 				}
 				valueString := strings.Join(values, "|")
 				new = append(new, Pattern{Value: valueString})
-				rest := convertOrToRegexp(other)
+				rest = convertOrToRegexp(rest)
 				new = newOperator(append(new, rest...), Or)
 			} else {
 				new = append(new, newOperator(convertOrToRegexp(v.Operands), v.Kind)...)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -183,7 +183,7 @@ func TestSearchUppercase(t *testing.T) {
 	}
 }
 
-func TestOrOperator(t *testing.T) {
+func TestSubstituteOrForRegexp(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -183,6 +183,47 @@ func TestSearchUppercase(t *testing.T) {
 	}
 }
 
+func TestOrOperator(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "foo or bar",
+			want:  `"foo|bar"`,
+		},
+		{
+			input: "(foo or (bar or baz))",
+			want:  `"foo|bar|baz"`,
+		},
+		{
+			input: "repo:foobar foo or (bar or baz)",
+			want:  `(or "bar|baz" (and "repo:foobar" "foo"))`,
+		},
+		{
+			input: "(foo or (bar or baz)) and foobar",
+			want:  `(and "foo|bar|baz" "foobar")`,
+		},
+		{
+			input: "(foo or (bar and baz))",
+			want:  `(or "foo" (and "bar" "baz"))`,
+		},
+		{
+			input: "foo or (bar and baz) or foobar",
+			want:  `(or "foo|foobar" (and "bar" "baz"))`,
+		},
+	}
+	for _, c := range cases {
+		t.Run("Map query", func(t *testing.T) {
+			query, _ := ParseAndOr(c.input)
+			got := prettyPrint(convertOrToRegexp(query))
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
 func TestMap(t *testing.T) {
 	cases := []struct {
 		input string

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -216,7 +216,7 @@ func TestOrOperator(t *testing.T) {
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input)
-			got := prettyPrint(convertOrToRegexp(query))
+			got := prettyPrint(substituteOrForRegexp(query))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Optimization for regexp (basically makes `or` syntactic sugar for `|`). Partly addresses #11299 (for regexp). A couple of checks will make this work for `repo:` and `file:` as well (tracked in #11009). 

Not used anywhere yet, I will add this to the query processing along with integration tests in a subsequent PR.