### PR TITLE
authz: ignore 404 API error for GitHub

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -276,9 +276,8 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 				log15.Debug("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError", "repoID", repo.ID, "err", err)
 				return []extsvc.AccountID{}, nil
 			}
-			return nil, err
 		}
-		return ids, nil
+		return ids, err
 	}()
 	if err != nil {
 		// Process partial results if this is an initial fetch.

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -13,12 +14,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -260,10 +263,23 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(err, "wait for rate limiter")
 	}
 
-	extAccountIDs, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
-		URI:              repo.URI,
-		ExternalRepoSpec: repo.ExternalRepo,
-	})
+	extAccountIDs, err := func() ([]extsvc.AccountID, error) {
+		ids, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
+			URI:              repo.URI,
+			ExternalRepoSpec: repo.ExternalRepo,
+		})
+		if err != nil {
+			// Detect 404 error (i.e. not authorized to call given APIs) that often happens with GitHub.com
+			// when the owner of the token only has READ access. However, we don't want to fail entirely
+			// so the scheduler won't keep trying to fetch permissions of this same repository.
+			if apiErr, ok := err.(*github.APIError); ok && apiErr.Code == http.StatusNotFound {
+				log15.Debug("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError", "repoID", repo.ID, "err", err)
+				return []extsvc.AccountID{}, nil
+			}
+			return nil, err
+		}
+		return ids, nil
+	}()
 	if err != nil {
 		// Process partial results if this is an initial fetch.
 		if !noPerms {
@@ -335,7 +351,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(err, "set repository pending permissions")
 	}
 
-	log15.Info("PermsSyncer.syncRepoPerms.synced", "repoID", repo.ID, "name", repo.Name)
+	log15.Info("PermsSyncer.syncRepoPerms.synced", "repoID", repo.ID, "name", repo.Name, "count", len(extAccountIDs))
 	return nil
 }
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"


### PR DESCRIPTION
- Detects and ignores 404 API error returned by GitHub client. 
- Also adds an additional debugging argument "count" to indicate how many users are actually found during the permissions syncing, will be useful to spot token problems.

Fixes #11007