### PR TITLE
authz: move permissions sidebaritem to enterprise

### DIFF
--- a/web/src/enterprise/repo/settings/sidebaritems.ts
+++ b/web/src/enterprise/repo/settings/sidebaritems.ts
@@ -7,4 +7,10 @@ export const enterpriseRepoSettingsSidebarItems: RepoSettingsSideBarItems = [
         to: '/code-intelligence',
         label: 'Code intelligence',
     },
+    {
+        to: '/permissions',
+        exact: true,
+        label: 'Permissions',
+        condition: () => !!window.context.site['permissions.backgroundSync']?.enabled,
+    },
 ]

--- a/web/src/repo/settings/sidebaritems.ts
+++ b/web/src/repo/settings/sidebaritems.ts
@@ -16,10 +16,4 @@ export const repoSettingsSidebarItems: RepoSettingsSideBarItems = [
         exact: true,
         label: 'Mirroring',
     },
-    {
-        to: '/permissions',
-        exact: true,
-        label: 'Permissions',
-        condition: () => !!window.context.site['permissions.backgroundSync']?.enabled,
-    },
 ]


### PR DESCRIPTION
This sidebaritem was overlooked when move pages to enterprise namespace.