### PR TITLE
authz: bypass private repos without authz provider configured for the code host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A link to view all repositories will now always appear on the Explore page. [#11113](https://github.com/sourcegraph/sourcegraph/pull/11113)
 - The Site-admin > Pings page no longer incorrectly indicates that pings are disabled when they aren't. [#11229](https://github.com/sourcegraph/sourcegraph/pull/11229)
 - Match counts are now accurately reported for indexed search. [#11242](https://github.com/sourcegraph/sourcegraph/pull/11242)
+- When background permissions syncing is enabled, it is now possible to only enforce permissions for repositories from selected code hosts (instead of enforcing permissions for repositories from all code hosts). [#11336](https://github.com/sourcegraph/sourcegraph/pull/11336)
 
 ### Removed
 


### PR DESCRIPTION
Previously, we had the following assumption (accidentally taken from working on explicit permissions APIs):

- When background permissions syncing is enabled, the site admin would want to enforce permissions for all repositories from all code hosts.

This PR removes this _false_ assumption, and allows access to private repos that from code hosts which do not have authz provider configured.

Fixes #11318