### PR TITLE
Remove duplication of GitHub redirect middleware and recorder in tests

### DIFF
--- a/cmd/repo-updater/repos/sources_test.go
+++ b/cmd/repo-updater/repos/sources_test.go
@@ -760,20 +760,10 @@ func TestSources_ListRepos(t *testing.T) {
 func newClientFactory(t testing.TB, name string, mws ...httpcli.Middleware) (*httpcli.Factory, func(testing.TB)) {
 	cassete := filepath.Join("testdata", "sources", strings.Replace(name, " ", "-", -1))
 	rec := newRecorder(t, cassete, update(name))
-	mws = append(mws, githubProxyRedirectMiddleware, gitserverRedirectMiddleware)
+	mws = append(mws, httpcli.GitHubProxyRedirectMiddleware, gitserverRedirectMiddleware)
 	mw := httpcli.NewMiddleware(mws...)
 	return httpcli.NewFactory(mw, httptestutil.NewRecorderOpt(rec)),
 		func(t testing.TB) { save(t, rec) }
-}
-
-func githubProxyRedirectMiddleware(cli httpcli.Doer) httpcli.Doer {
-	return httpcli.DoerFunc(func(req *http.Request) (*http.Response, error) {
-		if req.URL.Hostname() == "github-proxy" {
-			req.URL.Host = "api.github.com"
-			req.URL.Scheme = "https"
-		}
-		return cli.Do(req)
-	})
 }
 
 func gitserverRedirectMiddleware(cli httpcli.Doer) httpcli.Doer {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -46,7 +47,7 @@ func TestCampaigns(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	rcache.SetupForTest(t)
 
-	cf, save := newGithubClientFactory(t, "test-campaigns")
+	cf, save := httptestutil.NewGitHubRecorderFactory(t, *update, "test-campaigns")
 	defer save()
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
@@ -618,7 +619,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	rcache.SetupForTest(t)
 
-	cf, save := newGithubClientFactory(t, "test-changeset-counts-over-time")
+	cf, save := httptestutil.NewGitHubRecorderFactory(t, *update, "test-changeset-counts-over-time")
 	defer save()
 
 	userID := insertTestUser(t, dbconn.Global, "changeset-counts-over-time", false)

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -156,6 +156,18 @@ func ContextErrorMiddleware(cli Doer) Doer {
 	})
 }
 
+// GitHubProxyRedirectMiddleware rewrites requests to the "github-proxy" host
+// to "https://api.github.com".
+func GitHubProxyRedirectMiddleware(cli Doer) Doer {
+	return DoerFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Hostname() == "github-proxy" {
+			req.URL.Host = "api.github.com"
+			req.URL.Scheme = "https"
+		}
+		return cli.Do(req)
+	})
+}
+
 //
 // Common Opts
 //


### PR DESCRIPTION
(Stacked on https://github.com/sourcegraph/sourcegraph/pull/11340/files)

I think we should use `httptestutil` more and put little helpers like these in there.

The GitHubProxyRedirectMiddleware I put in `httpcli` next to the other middlewares.
