### PR TITLE
extsvc: Add ParseServiceType

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -840,15 +840,18 @@ func scanRepo(r *Repo, s scanner) error {
 		return errors.Wrap(err, "scanRepo: failed to unmarshal sources")
 	}
 
-	typ := strings.ToLower(r.ExternalRepo.ServiceType)
+	typ, ok := extsvc.ParseServiceType(r.ExternalRepo.ServiceType)
+	if !ok {
+		return nil
+	}
 	switch typ {
 	case extsvc.TypeGitHub:
 		r.Metadata = new(github.Repository)
 	case extsvc.TypeGitLab:
 		r.Metadata = new(gitlab.Project)
-	case "bitbucketserver":
+	case extsvc.TypeBitbucketServer:
 		r.Metadata = new(bitbucketserver.Repo)
-	case "bitbucketcloud":
+	case extsvc.TypeBitbucketCloud:
 		r.Metadata = new(bitbucketcloud.Repo)
 	case extsvc.TypeAWSCodeCommit:
 		r.Metadata = new(awscodecommit.Repository)

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -471,14 +471,18 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 			},
 			func() testCase {
 				var update interface{}
-				switch strings.ToLower(tc.repo.ExternalRepo.ServiceType) {
+				typ, ok := extsvc.ParseServiceType(tc.repo.ExternalRepo.ServiceType)
+				if !ok {
+					panic(fmt.Sprintf("test must be extended with new external service kind: %q", strings.ToLower(tc.repo.ExternalRepo.ServiceType)))
+				}
+				switch typ {
 				case extsvc.TypeGitHub:
 					update = &github.Repository{IsArchived: true}
 				case extsvc.TypeGitLab:
 					update = &gitlab.Project{Archived: true}
-				case "bitbucketserver":
+				case extsvc.TypeBitbucketServer:
 					update = &bitbucketserver.Repo{Public: true}
-				case "bitbucketcloud":
+				case extsvc.TypeBitbucketCloud:
 					update = &bitbucketcloud.Repo{IsPrivate: true}
 				case extsvc.TypeAWSCodeCommit:
 					update = &awscodecommit.Repository{Description: "new description"}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -670,7 +670,8 @@ func newRepoInfo(r *repos.Repo) (*protocol.RepoInfo, error) {
 		ExternalRepo: r.ExternalRepo,
 	}
 
-	switch strings.ToLower(r.ExternalRepo.ServiceType) {
+	typ, _ := extsvc.ParseServiceType(r.ExternalRepo.ServiceType)
+	switch typ {
 	case extsvc.TypeGitHub:
 		ghrepo := r.Metadata.(*github.Repository)
 		info.Links = &protocol.RepoLinks{
@@ -687,7 +688,7 @@ func newRepoInfo(r *repos.Repo) (*protocol.RepoInfo, error) {
 			Blob:   pathAppend(proj.WebURL, "/blob/{rev}/{path}"),
 			Commit: pathAppend(proj.WebURL, "/commit/{commit}"),
 		}
-	case "bitbucketserver":
+	case extsvc.TypeBitbucketServer:
 		repo := r.Metadata.(*bitbucketserver.Repo)
 		if len(repo.Links.Self) == 0 {
 			break

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -116,6 +116,32 @@ const (
 	TypeOther = "other"
 )
 
+// ParseServiceType will return a ServiceType constant after doing a case insensitive match on s.
+// It returns ("", false) if no match was found.
+func ParseServiceType(s string) (string, bool) {
+	// Note the special cases for Bitbucket because the constants need to be mixed case
+	switch strings.ToLower(s) {
+	case TypeAWSCodeCommit:
+		return TypeAWSCodeCommit, true
+	case strings.ToLower(TypeBitbucketServer):
+		return TypeBitbucketServer, true
+	case strings.ToLower(TypeBitbucketCloud):
+		return TypeBitbucketCloud, true
+	case TypeGitHub:
+		return TypeGitHub, true
+	case TypeGitLab:
+		return TypeGitLab, true
+	case TypeGitolite:
+		return TypeGitolite, true
+	case TypePhabricator:
+		return TypePhabricator, true
+	case TypeOther:
+		return TypeOther, true
+	default:
+		return "", false
+	}
+}
+
 // AccountID is a descriptive type for the external identifier of an external account on the
 // code host. It can be the string representation of an integer (e.g. GitLab), a GraphQL ID
 // (e.g. GitHub), or a username (e.g. Bitbucket Server) depends on the code host type.

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -116,16 +116,21 @@ const (
 	TypeOther = "other"
 )
 
+var (
+	// Precompute these for use in ParseServiceType below since the constants are mixed case
+	bbsLower = strings.ToLower(TypeBitbucketServer)
+	bbcLower = strings.ToLower(TypeBitbucketCloud)
+)
+
 // ParseServiceType will return a ServiceType constant after doing a case insensitive match on s.
 // It returns ("", false) if no match was found.
 func ParseServiceType(s string) (string, bool) {
-	// Note the special cases for Bitbucket because the constants need to be mixed case
 	switch strings.ToLower(s) {
 	case TypeAWSCodeCommit:
 		return TypeAWSCodeCommit, true
-	case strings.ToLower(TypeBitbucketServer):
+	case bbsLower:
 		return TypeBitbucketServer, true
-	case strings.ToLower(TypeBitbucketCloud):
+	case bbcLower:
 		return TypeBitbucketCloud, true
 	case TypeGitHub:
 		return TypeGitHub, true


### PR DESCRIPTION
Bitbucket ServiceType constants are mixed case so we still had places
that were matching on raw strings after lowercasing.

This change moves the knowledge of how to parse ServiceType constants
to the extsvc package.

Closes: https://github.com/sourcegraph/sourcegraph/issues/10296
