### PR TITLE
dev: codecov only shows CI status on PRs

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -21,6 +21,7 @@ coverage:
           - go
     patch:
       default:
+        only_pulls: true
         target: 5%
 comment:
   require_changes: yes


### PR DESCRIPTION
Noticed a bunch of failing CI status on master. It seems to be due to
codecov and not passing the patch threshold. This removes the noise from
master branch. Now codecov will only report on pull requests (allowing
the PR developer to respond to the status).

Relevant codecov documentation: https://docs.codecov.io/docs/commit-status#branches
> Only post a status to pull requests, defaults to false. If true no status will be posted for commits not on a pull request