### PR TITLE
Do not include hidden changesets if inclusion would leak data

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -134,14 +134,15 @@ func (r *campaignResolver) Changesets(
 	ctx context.Context,
 	args *graphqlbackend.ListChangesetsArgs,
 ) (graphqlbackend.ChangesetsConnectionResolver, error) {
-	opts, err := listChangesetOptsFromArgs(args)
+	opts, safe, err := listChangesetOptsFromArgs(args)
 	if err != nil {
 		return nil, err
 	}
 	opts.CampaignID = r.Campaign.ID
 	return &changesetsConnectionResolver{
-		store: r.store,
-		opts:  opts,
+		store:    r.store,
+		opts:     opts,
+		optsSafe: safe,
 	}, nil
 }
 
@@ -154,6 +155,7 @@ func (r *campaignResolver) OpenChangesets(ctx context.Context) (graphqlbackend.C
 			ExternalState: &state,
 			Limit:         -1,
 		},
+		optsSafe: true,
 	}, nil
 }
 
@@ -273,6 +275,7 @@ func (r *campaignResolver) RepositoryDiffs(
 			CampaignID: r.Campaign.ID,
 			Limit:      int(args.GetFirst()),
 		},
+		optsSafe: true,
 	}
 	return &changesetDiffsConnectionResolver{changesetsConnection}, nil
 }
@@ -284,6 +287,7 @@ func (r *campaignResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffSt
 			CampaignID: r.Campaign.ID,
 			Limit:      -1, // Get all changesets
 		},
+		optsSafe: true,
 	}
 
 	changesetDiffs := &changesetDiffsConnectionResolver{changesetsConnection}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -478,6 +478,8 @@ func TestRepositoryPermissions(t *testing.T) {
 			ExternalServiceType: extsvc.TypeGitHub,
 			ExternalID:          fmt.Sprintf("external-%d", r.ID),
 			ExternalState:       campaigns.ChangesetStateOpen,
+			ExternalCheckState:  campaigns.ChangesetCheckStatePassed,
+			ExternalReviewState: campaigns.ChangesetReviewStateChangesRequested,
 			Metadata: &github.PullRequest{
 				BaseRefOid: changesetBaseRefOid,
 				HeadRefOid: changesetHeadRefOid,
@@ -555,8 +557,13 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	// Query campaign and check that we get all changesets and all patches
 	userCtx := actor.WithActor(ctx, actor.FromUser(userID))
-	testCampaignResponse(t, s, userCtx, campaign.ID, wantCampaignResponse{
+
+	input := map[string]interface{}{
+		"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
+	}
+	testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
 		changesetTypes:     map[string]int{"ExternalChangeset": 2},
+		changesetsCount:    2,
 		openChangesetTypes: map[string]int{"ExternalChangeset": 2},
 		errors: []string{
 			fmt.Sprintf("error patch %d", patches[0].ID),
@@ -604,11 +611,15 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	// Send query again and check that for each filtered repository we get a
 	// HiddenChangeset/HiddenPatch and that errors are filtered out
-	testCampaignResponse(t, s, userCtx, campaign.ID, wantCampaignResponse{
+	input = map[string]interface{}{
+		"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
+	}
+	want := wantCampaignResponse{
 		changesetTypes: map[string]int{
 			"ExternalChangeset":       1,
 			"HiddenExternalChangeset": 1,
 		},
+		changesetsCount: 2,
 		openChangesetTypes: map[string]int{
 			"ExternalChangeset":       1,
 			"HiddenExternalChangeset": 1,
@@ -631,7 +642,8 @@ func TestRepositoryPermissions(t *testing.T) {
 			Changed: 1 * patchesDiffStat.Changed,
 			Deleted: 1 * patchesDiffStat.Deleted,
 		},
-	})
+	}
+	testCampaignResponse(t, s, userCtx, input, want)
 
 	for _, c := range changesets {
 		// The changeset whose repository has been filtered should be hidden
@@ -650,31 +662,61 @@ func TestRepositoryPermissions(t *testing.T) {
 			testPatchResponse(t, s, userCtx, p.ID, "Patch")
 		}
 	}
+
+	// Now we query with more filters for the changesets. The hidden changesets
+	// should not be returned, since that would leak information about the
+	// hidden changesets.
+	input = map[string]interface{}{
+		"campaign":   string(campaigns.MarshalCampaignID(campaign.ID)),
+		"checkState": string(campaigns.ChangesetCheckStatePassed),
+	}
+	wantCheckStateResponse := want
+	wantCheckStateResponse.changesetsCount = 1
+	wantCheckStateResponse.changesetTypes = map[string]int{
+		"ExternalChangeset": 1,
+		// No HiddenExternalChangeset
+	}
+	testCampaignResponse(t, s, userCtx, input, wantCheckStateResponse)
+
+	input = map[string]interface{}{
+		"campaign":    string(campaigns.MarshalCampaignID(campaign.ID)),
+		"reviewState": string(campaigns.ChangesetReviewStateChangesRequested),
+	}
+	wantReviewStateResponse := want
+	wantReviewStateResponse.changesetsCount = 1
+	wantReviewStateResponse.changesetTypes = map[string]int{
+		"ExternalChangeset": 1,
+		// No HiddenExternalChangeset
+	}
+	testCampaignResponse(t, s, userCtx, input, wantReviewStateResponse)
 }
 
 type wantCampaignResponse struct {
 	patchTypes         map[string]int
 	changesetTypes     map[string]int
+	changesetsCount    int
 	openChangesetTypes map[string]int
 	errors             []string
 	campaignDiffStat   apitest.DiffStat
 	patchSetDiffStat   apitest.DiffStat
 }
 
-func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, id int64, w wantCampaignResponse) {
+func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, in map[string]interface{}, w wantCampaignResponse) {
 	t.Helper()
 
 	var response struct{ Node apitest.Campaign }
-	query := fmt.Sprintf(queryCampaignPermLevels, campaigns.MarshalCampaignID(id))
+	apitest.MustExec(ctx, t, s, in, &response, queryCampaignPermLevels)
 
-	apitest.MustExec(ctx, t, s, nil, &response, query)
-
-	if have, want := response.Node.ID, string(campaigns.MarshalCampaignID(id)); have != want {
+	if have, want := response.Node.ID, in["campaign"]; have != want {
 		t.Fatalf("campaign id is wrong. have %q, want %q", have, want)
 	}
 
 	if diff := cmp.Diff(w.errors, response.Node.Status.Errors); diff != "" {
 		t.Fatalf("unexpected status errors (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(w.changesetsCount, response.Node.Changesets.TotalCount); diff != "" {
+		t.Fatalf("unexpected changesets total count (-want +got):\n%s", diff)
 	}
 
 	changesetTypes := map[string]int{}
@@ -718,8 +760,8 @@ func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, 
 }
 
 const queryCampaignPermLevels = `
-query {
-  node(id: %q) {
+query($campaign: ID!, $state: ChangesetState, $reviewState: ChangesetReviewState, $checkState: ChangesetCheckState) {
+  node(id: $campaign) {
     ... on Campaign {
       id
 
@@ -728,7 +770,8 @@ query {
 		errors
 	  }
 
-      changesets(first: 100) {
+      changesets(first: 100, state: $state, reviewState: $reviewState, checkState: $checkState) {
+        totalCount
         nodes {
           __typename
           ... on HiddenExternalChangeset {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -506,8 +506,12 @@ func (r *Resolver) CreateChangesets(ctx context.Context, args *graphqlbackend.Cr
 	return csr, nil
 }
 
-func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs) (ee.ListChangesetsOpts, bool, error) {
-	var opts ee.ListChangesetsOpts
+// listChangesetOptsFromArgs turns the graphqlbackend.ListChangesetsArgs into
+// ListChangesetsOpts.
+// If the args do not include a filter that would reveal sensitive information
+// about a changeset the user doesn't have access to, the second return value
+// is false.
+func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs) (opts ee.ListChangesetsOpts, optsSafe bool, err error) {
 	if args == nil {
 		return opts, true, nil
 	}
@@ -524,6 +528,8 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs) (ee.List
 			return opts, false, errors.New("changeset state not valid")
 		}
 		opts.ExternalState = &state
+		// hiddenChangesetResolver has a State property so filtering based on
+		// that is safe.
 	}
 	if args.ReviewState != nil {
 		state := campaigns.ChangesetReviewState(*args.ReviewState)


### PR DESCRIPTION
This is another part of #10809 and makes sure that we don't include
`HiddenChangesets` in the `changesets()` query if the user specified
filters for `ExternalCheckState` or `ExternalReviewState`.

Why? Because if we include the hidden changesets in the response that
would leak information about their state (e.g.: a user could tell that
"out of 10 hidden changesets, only 1 is in 'changes requested' state, I
know which one it is now")

TODO:
- [x] Excluding hidden changesets in the total count. I'm still thinking about how to do that without loading everything into memory.
