### PR TITLE
codeintel: Add optional indexer arg to LSIF resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -93,6 +93,7 @@ type LSIFQueryArgs struct {
 	Repository *RepositoryResolver
 	Commit     api.CommitID
 	Path       string
+	Indexer    string
 	UploadID   int64
 }
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -291,12 +291,19 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	return len(entries) == 1, nil
 }
 
-func (r *GitTreeEntryResolver) LSIF(ctx context.Context) (LSIFQueryResolver, error) {
+func (r *GitTreeEntryResolver) LSIF(ctx context.Context, args *struct{ Indexer *string }) (LSIFQueryResolver, error) {
 	codeIntelRequests.WithLabelValues(trace.RequestOrigin(ctx)).Inc()
+
+	var indexer string
+	if args.Indexer != nil {
+		indexer = *args.Indexer
+	}
+
 	return EnterpriseResolvers.codeIntelResolver.LSIF(ctx, &LSIFQueryArgs{
 		Repository: r.Repository(),
 		Commit:     api.CommitID(r.Commit().OID()),
 		Path:       r.Path(),
+		Indexer:    indexer,
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2795,7 +2795,7 @@ type GitBlob implements TreeEntry & File2 {
     # CHANGELOG during this time.
     # A wrapper around LSIF query methods. If no LSIF upload can be used to answer code
     # intelligence queries for this path-at-revision, this resolves to null.
-    lsif: LSIFQueryResolver
+    lsif(indexer: String): LSIFQueryResolver
 }
 
 # A wrapper object around LSIF query methods for a particular path-at-revision. When this node is

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2802,7 +2802,7 @@ type GitBlob implements TreeEntry & File2 {
     # CHANGELOG during this time.
     # A wrapper around LSIF query methods. If no LSIF upload can be used to answer code
     # intelligence queries for this path-at-revision, this resolves to null.
-    lsif: LSIFQueryResolver
+    lsif(indexer: String): LSIFQueryResolver
 }
 
 # A wrapper object around LSIF query methods for a particular path-at-revision. When this node is

--- a/enterprise/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/internal/codeintel/resolvers/resolver.go
@@ -100,7 +100,7 @@ func (r *Resolver) LSIFUploads(ctx context.Context, args *graphqlbackend.LSIFRep
 }
 
 func (r *Resolver) LSIF(ctx context.Context, args *graphqlbackend.LSIFQueryArgs) (graphqlbackend.LSIFQueryResolver, error) {
-	dumps, err := r.codeIntelAPI.FindClosestDumps(ctx, int(args.Repository.Type().ID), string(args.Commit), args.Path)
+	dumps, err := r.codeIntelAPI.FindClosestDumps(ctx, int(args.Repository.Type().ID), string(args.Commit), args.Path, args.Indexer)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/api/api.go
+++ b/internal/codeintel/api/api.go
@@ -14,7 +14,7 @@ type CodeIntelAPI interface {
 	// FindClosestDumps returns the set of dumps that can most accurately answer code intelligence
 	// queries for the given file. These dump IDs should be subsequently passed to invocations of
 	// Definitions, References, and Hover.
-	FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) ([]db.Dump, error)
+	FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) ([]db.Dump, error)
 
 	// Definitions returns the list of source locations that define the symbol at the given position.
 	// This may include remote definitions if the remote repository is also indexed.

--- a/internal/codeintel/api/exists.go
+++ b/internal/codeintel/api/exists.go
@@ -13,14 +13,14 @@ import (
 // FindClosestDumps returns the set of dumps that can most accurately answer code intelligence
 // queries for the given file. These dump IDs should be subsequently passed to invocations of
 // Definitions, References, and Hover.
-func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) ([]db.Dump, error) {
+func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) ([]db.Dump, error) {
 	// See if we know about this commit. If not, we need to update our commits table
 	// and the visibility of the dumps in this repository.
 	if err := api.updateCommitsAndVisibility(ctx, repositoryID, commit); err != nil {
 		return nil, err
 	}
 
-	candidates, err := api.db.FindClosestDumps(ctx, repositoryID, commit, file)
+	candidates, err := api.db.FindClosestDumps(ctx, repositoryID, commit, file, indexer)
 	if err != nil {
 		return nil, errors.Wrap(err, "db.FindClosestDumps")
 	}

--- a/internal/codeintel/api/exists_test.go
+++ b/internal/codeintel/api/exists_test.go
@@ -22,7 +22,7 @@ func TestFindClosestDatabase(t *testing.T) {
 	mockBundleClient4 := bundlemocks.NewMockBundleClient()
 	mockGitserverClient := gitservermocks.NewMockClient()
 
-	setMockDBFindClosestDumps(t, mockDB, 42, testCommit, "s1/main.go", []db.Dump{
+	setMockDBFindClosestDumps(t, mockDB, 42, testCommit, "s1/main.go", "idx", []db.Dump{
 		{ID: 50, Root: "s1/"},
 		{ID: 51, Root: "s1/"},
 		{ID: 52, Root: "s1/"},
@@ -58,7 +58,7 @@ func TestFindClosestDatabase(t *testing.T) {
 	})
 
 	api := testAPI(mockDB, mockBundleManagerClient, mockGitserverClient)
-	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "s1/main.go")
+	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "s1/main.go", "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest database: %s", err)
 	}
@@ -97,7 +97,7 @@ func TestFindClosestSkipsGitserverIfCommitIsKnown(t *testing.T) {
 	mockGitserverClient := gitservermocks.NewMockClient()
 
 	setMockDBHasCommit(t, mockDB, 42, testCommit, true)
-	setMockDBFindClosestDumps(t, mockDB, 42, testCommit, "main.go", []db.Dump{
+	setMockDBFindClosestDumps(t, mockDB, 42, testCommit, "main.go", "idx", []db.Dump{
 		{ID: 50, Root: ""},
 	})
 	setMockBundleManagerClientBundleClient(t, mockBundleManagerClient, map[int]bundles.BundleClient{
@@ -106,7 +106,7 @@ func TestFindClosestSkipsGitserverIfCommitIsKnown(t *testing.T) {
 	setMockBundleClientExists(t, mockBundleClient, "main.go", true)
 
 	api := New(mockDB, mockBundleManagerClient, mockGitserverClient)
-	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "main.go")
+	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "main.go", "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest database: %s", err)
 	}

--- a/internal/codeintel/api/helpers_test.go
+++ b/internal/codeintel/api/helpers_test.go
@@ -75,8 +75,8 @@ func setMockDBGetPackage(t *testing.T, mockDB *dbmocks.MockDB, expectedScheme, e
 	})
 }
 
-func setMockDBFindClosestDumps(t *testing.T, mockDB *dbmocks.MockDB, expectedRepositoryID int, expectedCommit, expectedFile string, dumps []db.Dump) {
-	mockDB.FindClosestDumpsFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit, file string) ([]db.Dump, error) {
+func setMockDBFindClosestDumps(t *testing.T, mockDB *dbmocks.MockDB, expectedRepositoryID int, expectedCommit, expectedFile, expectedIndexer string, dumps []db.Dump) {
+	mockDB.FindClosestDumpsFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit, file, indexer string) ([]db.Dump, error) {
 		if repositoryID != expectedRepositoryID {
 			t.Errorf("unexpected repository id for FindClosestDumps. want=%d have=%d", expectedRepositoryID, repositoryID)
 		}
@@ -85,6 +85,9 @@ func setMockDBFindClosestDumps(t *testing.T, mockDB *dbmocks.MockDB, expectedRep
 		}
 		if file != expectedFile {
 			t.Errorf("unexpected file for FindClosestDumps. want=%s have=%s", expectedFile, file)
+		}
+		if indexer != expectedIndexer {
+			t.Errorf("unexpected indexer for FindClosestDumps. want=%s have=%s", expectedIndexer, indexer)
 		}
 		return dumps, nil
 	})

--- a/internal/codeintel/api/observability.go
+++ b/internal/codeintel/api/observability.go
@@ -51,11 +51,6 @@ func NewObserved(codeIntelAPI CodeIntelAPI, observationContext *observation.Cont
 			MetricLabels: []string{"hover"},
 			Metrics:      metrics,
 		}),
-		diagnosticsOperation: observationContext.Operation(observation.Op{
-			Name:         "CodeIntelAPI.Diagnostics",
-			MetricLabels: []string{"diagnostics"},
-			Metrics:      metrics,
-		}),
 	}
 }
 

--- a/internal/codeintel/api/observability.go
+++ b/internal/codeintel/api/observability.go
@@ -51,14 +51,19 @@ func NewObserved(codeIntelAPI CodeIntelAPI, observationContext *observation.Cont
 			MetricLabels: []string{"hover"},
 			Metrics:      metrics,
 		}),
+		diagnosticsOperation: observationContext.Operation(observation.Op{
+			Name:         "CodeIntelAPI.Diagnostics",
+			MetricLabels: []string{"diagnostics"},
+			Metrics:      metrics,
+		}),
 	}
 }
 
 // FindClosestDumps calls into the inner CodeIntelAPI and registers the observed results.
-func (api *ObservedCodeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) (dumps []db.Dump, err error) {
+func (api *ObservedCodeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) (dumps []db.Dump, err error) {
 	ctx, endObservation := api.findClosestDumpsOperation.With(ctx, &err, observation.Args{})
 	defer func() { endObservation(float64(len(dumps)), observation.Args{}) }()
-	return api.codeIntelAPI.FindClosestDumps(ctx, repositoryID, commit, file)
+	return api.codeIntelAPI.FindClosestDumps(ctx, repositoryID, commit, file, indexer)
 }
 
 // Definitions calls into the inner CodeIntelAPI and registers the observed results.

--- a/internal/codeintel/db/db.go
+++ b/internal/codeintel/db/db.go
@@ -91,8 +91,8 @@ type DB interface {
 	// GetDumpByID returns a dump by its identifier and boolean flag indicating its existence.
 	GetDumpByID(ctx context.Context, id int) (Dump, bool, error)
 
-	// FindClosestDumps returns the set of dumps that can most accurately answer queries for the given repository, commit, and file.
-	FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) ([]Dump, error)
+	// FindClosestDumps returns the set of dumps that can most accurately answer queries for the given repository, commit, file, and optional indexer.
+	FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) ([]Dump, error)
 
 	// DeleteOldestDump deletes the oldest dump that is not currently visible at the tip of its repository's default branch.
 	// This method returns the deleted dump's identifier and a flag indicating its (previous) existence.

--- a/internal/codeintel/db/mocks/mock_db.go
+++ b/internal/codeintel/db/mocks/mock_db.go
@@ -181,7 +181,7 @@ func NewMockDB() *MockDB {
 			},
 		},
 		FindClosestDumpsFunc: &DBFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string) ([]db.Dump, error) {
+			defaultHook: func(context.Context, int, string, string, string) ([]db.Dump, error) {
 				return nil, nil
 			},
 		},
@@ -1254,24 +1254,24 @@ func (c DBDoneFuncCall) Results() []interface{} {
 // DBFindClosestDumpsFunc describes the behavior when the FindClosestDumps
 // method of the parent MockDB instance is invoked.
 type DBFindClosestDumpsFunc struct {
-	defaultHook func(context.Context, int, string, string) ([]db.Dump, error)
-	hooks       []func(context.Context, int, string, string) ([]db.Dump, error)
+	defaultHook func(context.Context, int, string, string, string) ([]db.Dump, error)
+	hooks       []func(context.Context, int, string, string, string) ([]db.Dump, error)
 	history     []DBFindClosestDumpsFuncCall
 	mutex       sync.Mutex
 }
 
 // FindClosestDumps delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockDB) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string) ([]db.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3)
-	m.FindClosestDumpsFunc.appendCall(DBFindClosestDumpsFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockDB) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 string) ([]db.Dump, error) {
+	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.FindClosestDumpsFunc.appendCall(DBFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the FindClosestDumps
 // method of the parent MockDB instance is invoked and the hook queue is
 // empty.
-func (f *DBFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string) ([]db.Dump, error)) {
+func (f *DBFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) ([]db.Dump, error)) {
 	f.defaultHook = hook
 }
 
@@ -1279,7 +1279,7 @@ func (f *DBFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, 
 // FindClosestDumps method of the parent MockDB instance inovkes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *DBFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string) ([]db.Dump, error)) {
+func (f *DBFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, string) ([]db.Dump, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1288,7 +1288,7 @@ func (f *DBFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *DBFindClosestDumpsFunc) SetDefaultReturn(r0 []db.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string) ([]db.Dump, error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, string) ([]db.Dump, error) {
 		return r0, r1
 	})
 }
@@ -1296,12 +1296,12 @@ func (f *DBFindClosestDumpsFunc) SetDefaultReturn(r0 []db.Dump, r1 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *DBFindClosestDumpsFunc) PushReturn(r0 []db.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string) ([]db.Dump, error) {
+	f.PushHook(func(context.Context, int, string, string, string) ([]db.Dump, error) {
 		return r0, r1
 	})
 }
 
-func (f *DBFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string) ([]db.Dump, error) {
+func (f *DBFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, string) ([]db.Dump, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1346,6 +1346,9 @@ type DBFindClosestDumpsFuncCall struct {
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []db.Dump
@@ -1357,7 +1360,7 @@ type DBFindClosestDumpsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c DBFindClosestDumpsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/db/observability.go
+++ b/internal/codeintel/db/observability.go
@@ -460,10 +460,10 @@ func (db *ObservedDB) GetDumpByID(ctx context.Context, id int) (_ Dump, _ bool, 
 }
 
 // FindClosestDumps calls into the inner DB and registers the observed results.
-func (db *ObservedDB) FindClosestDumps(ctx context.Context, repositoryID int, commit, file string) (dumps []Dump, err error) {
+func (db *ObservedDB) FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) (dumps []Dump, err error) {
 	ctx, endObservation := db.findClosestDumpsOperation.With(ctx, &err, observation.Args{})
 	defer func() { endObservation(float64(len(dumps)), observation.Args{}) }()
-	return db.db.FindClosestDumps(ctx, repositoryID, commit, file)
+	return db.db.FindClosestDumps(ctx, repositoryID, commit, file, indexer)
 }
 
 // DeleteOldestDump calls into the inner DB and registers the observed results.


### PR DESCRIPTION
Add an optional `indexer` argument to the LSIF resolver which limits the definition/reference/hover results by the name of the tool that indexed that data.