### PR TITLE
codeintel: Add PathsWithPrefix to bundle reader

### DIFF
--- a/internal/codeintel/bundles/persistence/observability.go
+++ b/internal/codeintel/bundles/persistence/observability.go
@@ -12,6 +12,7 @@ import (
 type ObservedReader struct {
 	reader                   Reader
 	readMetaOperation        *observation.Operation
+	pathsWithPrefixOperation *observation.Operation
 	readDocumentOperation    *observation.Operation
 	readResultChunkOperation *observation.Operation
 	readDefinitionsOperation *observation.Operation
@@ -43,6 +44,11 @@ func NewObserved(reader Reader, observationContext *observation.Context) Reader 
 			MetricLabels: []string{"read_meta"},
 			Metrics:      metrics,
 		}),
+		pathsWithPrefixOperation: observationContext.Operation(observation.Op{
+			Name:         "Reader.PathsWithPrefix",
+			MetricLabels: []string{"paths_with_prefix"},
+			Metrics:      metrics,
+		}),
 		readDocumentOperation: observationContext.Operation(observation.Op{
 			Name:         "Reader.ReadDocument",
 			MetricLabels: []string{"read_document"},
@@ -71,6 +77,13 @@ func (r *ObservedReader) ReadMeta(ctx context.Context) (_ types.MetaData, err er
 	ctx, endObservation := r.readMetaOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 	return r.reader.ReadMeta(ctx)
+}
+
+// PathsWithPrefix calls into the inner Reader and registers the observed results.
+func (r *ObservedReader) PathsWithPrefix(ctx context.Context, prefix string) (_ []string, err error) {
+	ctx, endObservation := r.pathsWithPrefixOperation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+	return r.reader.PathsWithPrefix(ctx, prefix)
 }
 
 // ReadDocument calls into the inner Reader and registers the observed results.

--- a/internal/codeintel/bundles/persistence/reader.go
+++ b/internal/codeintel/bundles/persistence/reader.go
@@ -8,6 +8,7 @@ import (
 
 type Reader interface {
 	ReadMeta(ctx context.Context) (types.MetaData, error)
+	PathsWithPrefix(ctx context.Context, prefix string) ([]string, error)
 	ReadDocument(ctx context.Context, path string) (types.DocumentData, bool, error)
 	ReadResultChunk(ctx context.Context, id int) (types.ResultChunkData, bool, error)
 	ReadDefinitions(ctx context.Context, scheme, identifier string, skip, take int) ([]types.Location, int, error)

--- a/internal/codeintel/bundles/persistence/sqlite/reader.go
+++ b/internal/codeintel/bundles/persistence/sqlite/reader.go
@@ -74,6 +74,10 @@ func (r *sqliteReader) ReadMeta(ctx context.Context) (types.MetaData, error) {
 	}, nil
 }
 
+func (r *sqliteReader) PathsWithPrefix(ctx context.Context, prefix string) ([]string, error) {
+	return store.ScanStrings(r.store.Query(ctx, sqlf.Sprintf(`SELECT path FROM documents WHERE path LIKE %s`, prefix+"%")))
+}
+
 func (r *sqliteReader) ReadDocument(ctx context.Context, path string) (types.DocumentData, bool, error) {
 	key := r.makeCacheKey("document", path)
 	if documentData, ok := r.getFromCache(key).(types.DocumentData); ok {

--- a/internal/codeintel/bundles/persistence/sqlite/reader_v0_test.go
+++ b/internal/codeintel/bundles/persistence/sqlite/reader_v0_test.go
@@ -20,6 +20,23 @@ func TestReadMetaV0(t *testing.T) {
 	}
 }
 
+func TestPathsWithPrefixV0(t *testing.T) {
+	paths, err := testReader(t, v0TestFile).PathsWithPrefix(context.Background(), "internal/")
+	if err != nil {
+		t.Fatalf("unexpected error fetching paths with prefix: %s", err)
+	}
+
+	expectedPaths := []string{
+		"internal/gomod/module.go",
+		"internal/index/helper.go",
+		"internal/index/indexer.go",
+		"internal/index/types.go",
+	}
+	if diff := cmp.Diff(expectedPaths, paths); diff != "" {
+		t.Errorf("unexpected paths (-want +got):\n%s", diff)
+	}
+}
+
 func TestReadDocumentV0(t *testing.T) {
 	data, exists, err := testReader(t, v0TestFile).ReadDocument(context.Background(), "protocol/writer.go")
 	if err != nil {

--- a/internal/codeintel/bundles/persistence/sqlite/reader_v4_test.go
+++ b/internal/codeintel/bundles/persistence/sqlite/reader_v4_test.go
@@ -20,6 +20,22 @@ func TestReadMetaV4(t *testing.T) {
 	}
 }
 
+func TestPathsWithPrefixV4(t *testing.T) {
+	paths, err := testReader(t, v4TestFile).PathsWithPrefix(context.Background(), "internal/")
+	if err != nil {
+		t.Fatalf("unexpected error fetching paths with prefix: %s", err)
+	}
+
+	expectedPaths := []string{
+		"internal/gomod/module.go",
+		"internal/index/helper.go",
+		"internal/index/indexer.go",
+		"internal/index/types.go",
+	}
+	if diff := cmp.Diff(expectedPaths, paths); diff != "" {
+		t.Errorf("unexpected paths (-want +got):\n%s", diff)
+	}
+}
 func TestReadDocumentV4(t *testing.T) {
 	data, exists, err := testReader(t, v4TestFile).ReadDocument(context.Background(), "protocol/writer.go")
 	if err != nil {

--- a/internal/codeintel/bundles/persistence/sqlite/reader_v5_test.go
+++ b/internal/codeintel/bundles/persistence/sqlite/reader_v5_test.go
@@ -20,6 +20,23 @@ func TestReadMetaV5(t *testing.T) {
 	}
 }
 
+func TestPathsWithPrefixV5(t *testing.T) {
+	paths, err := testReader(t, v5TestFile).PathsWithPrefix(context.Background(), "internal/")
+	if err != nil {
+		t.Fatalf("unexpected error fetching paths with prefix: %s", err)
+	}
+
+	expectedPaths := []string{
+		"internal/gomod/module.go",
+		"internal/index/helper.go",
+		"internal/index/indexer.go",
+		"internal/index/types.go",
+	}
+	if diff := cmp.Diff(expectedPaths, paths); diff != "" {
+		t.Errorf("unexpected paths (-want +got):\n%s", diff)
+	}
+}
+
 func TestReadDocumentV5(t *testing.T) {
 	data, exists, err := testReader(t, v5TestFile).ReadDocument(context.Background(), "protocol/writer.go")
 	if err != nil {
@@ -28,12 +45,6 @@ func TestReadDocumentV5(t *testing.T) {
 	if !exists {
 		t.Errorf("expected document to exist")
 	}
-
-	// for k, v := range data.Ranges {
-	// 	if v.HoverResultID == types.ID("3463") {
-	// 		fmt.Printf("%s -> %v\n", k, v)
-	// 	}
-	// }
 
 	expectedRange := types.RangeData{
 		StartLine:          140,


### PR DESCRIPTION
This will be necessary for code insights, which needs to be able to query diagnostics for all files within a given file tree.