### PR TITLE
codeintel: Bundle manager database references existing types

### DIFF
--- a/cmd/precise-code-intel-bundle-manager/internal/database/database.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/database.go
@@ -30,9 +30,6 @@ type Database interface {
 	// Hover returns the hover text of the symbol at the given position.
 	Hover(ctx context.Context, path string, line, character int) (string, client.Range, bool, error)
 
-	// Diagnostics returns the diagnostics for the documents that have the given path prefix.
-	Diagnostics(ctx context.Context, prefix string) ([]client.Diagnostic, error)
-
 	// MonikersByPosition returns all monikers attached ranges containing the given position. If multiple
 	// ranges contain the position, then this method will return multiple sets of monikers. Each slice
 	// of monikers are attached to a single range. The order of the output slice is "outside-in", so that
@@ -195,41 +192,6 @@ func (db *databaseImpl) Hover(ctx context.Context, path string, line, character 
 	return "", client.Range{}, false, nil
 }
 
-// Diagnostics returns the diagnostics for the documents that have the given path prefix.
-func (db *databaseImpl) Diagnostics(ctx context.Context, prefix string) ([]client.Diagnostic, error) {
-	paths, err := db.getPathsWithPrefix(ctx, prefix)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "db.getPathsWithPrefix")
-	}
-
-	var diagnostics []client.Diagnostic
-	for _, path := range paths {
-		documentData, exists, err := db.getDocumentData(ctx, prefix)
-		if err != nil {
-			return nil, pkgerrors.Wrap(err, "db.getDocumentData")
-		}
-		if !exists {
-			return nil, nil
-		}
-
-		for _, diagnostic := range documentData.Diagnostics {
-			diagnostics = append(diagnostics, client.Diagnostic{
-				Path:           path,
-				Severity:       diagnostic.Severity,
-				Code:           diagnostic.Code,
-				Message:        diagnostic.Message,
-				Source:         diagnostic.Source,
-				StartLine:      diagnostic.StartLine,
-				StartCharacter: diagnostic.StartCharacter,
-				EndLine:        diagnostic.EndLine,
-				EndCharacter:   diagnostic.EndCharacter,
-			})
-		}
-	}
-
-	return diagnostics, nil
-}
-
 // MonikersByPosition returns all monikers attached ranges containing the given position. If multiple
 // ranges contain the position, then this method will return multiple sets of monikers. Each slice
 // of monikers are attached to a single range. The order of the output slice is "outside-in", so that
@@ -267,10 +229,10 @@ func (db *databaseImpl) MonikersByPosition(ctx context.Context, path string, lin
 
 	return monikerData, nil
 }
-i
+
 // MonikerResults returns the locations that define or reference the given moniker. This method
 // also returns the size of the complete result set to aid in pagination (along with skip and take).
-func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) ([]client.Location, int, error) {
+func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) (_ []client.Location, _ int, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "getResultChunkByResultID")
 	span.SetTag("filename", db.filename)
 	span.SetTag("tableName", tableName)
@@ -330,21 +292,6 @@ func (db *databaseImpl) PackageInformation(ctx context.Context, path string, pac
 	}
 
 	return client.PackageInformationData{}, false, nil
-}
-
-func (db *databaseImpl) getPathsWithPrefix(ctx context.Context, prefix string) (_ []string, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "getPathsWithPrefix")
-	span.SetTag("filename", db.filename)
-	span.SetTag("prefix", prefix)
-	defer func() {
-		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
-		}
-		span.Finish()
-	}()
-
-	return db.reader.PathsWithPrefix(ctx, prefix)
 }
 
 // getDocumentData fetches and unmarshals the document data or the given path. This method caches

--- a/cmd/precise-code-intel-bundle-manager/internal/database/database.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/database.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/ext"
 	pkgerrors "github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/persistence"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -21,26 +22,29 @@ type Database interface {
 	Exists(ctx context.Context, path string) (bool, error)
 
 	// Definitions returns the set of locations defining the symbol at the given position.
-	Definitions(ctx context.Context, path string, line, character int) ([]Location, error)
+	Definitions(ctx context.Context, path string, line, character int) ([]client.Location, error)
 
 	// References returns the set of locations referencing the symbol at the given position.
-	References(ctx context.Context, path string, line, character int) ([]Location, error)
+	References(ctx context.Context, path string, line, character int) ([]client.Location, error)
 
 	// Hover returns the hover text of the symbol at the given position.
-	Hover(ctx context.Context, path string, line, character int) (string, Range, bool, error)
+	Hover(ctx context.Context, path string, line, character int) (string, client.Range, bool, error)
+
+	// Diagnostics returns the diagnostics for the documents that have the given path prefix.
+	Diagnostics(ctx context.Context, prefix string) ([]client.Diagnostic, error)
 
 	// MonikersByPosition returns all monikers attached ranges containing the given position. If multiple
 	// ranges contain the position, then this method will return multiple sets of monikers. Each slice
 	// of monikers are attached to a single range. The order of the output slice is "outside-in", so that
 	// the range attached to earlier monikers enclose the range attached to later monikers.
-	MonikersByPosition(ctx context.Context, path string, line, character int) ([][]types.MonikerData, error)
+	MonikersByPosition(ctx context.Context, path string, line, character int) ([][]client.MonikerData, error)
 
 	// MonikerResults returns the locations that define or reference the given moniker. This method
 	// also returns the size of the complete result set to aid in pagination (along with skip and take).
-	MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) ([]Location, int, error)
+	MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) ([]client.Location, int, error)
 
 	// PackageInformation looks up package information data by identifier.
-	PackageInformation(ctx context.Context, path string, packageInformationID types.ID) (types.PackageInformationData, bool, error)
+	PackageInformation(ctx context.Context, path string, packageInformationID string) (client.PackageInformationData, bool, error)
 }
 
 type databaseImpl struct {
@@ -51,36 +55,21 @@ type databaseImpl struct {
 
 var _ Database = &databaseImpl{}
 
-type Location struct {
-	Path  string `json:"path"`
-	Range Range  `json:"range"`
-}
-
-type Range struct {
-	Start Position `json:"start"`
-	End   Position `json:"end"`
-}
-
-type Position struct {
-	Line      int `json:"line"`
-	Character int `json:"character"`
-}
-
-func newRange(startLine, startCharacter, endLine, endCharacter int) Range {
-	return Range{
-		Start: Position{
+func newRange(startLine, startCharacter, endLine, endCharacter int) client.Range {
+	return client.Range{
+		Start: client.Position{
 			Line:      startLine,
 			Character: startCharacter,
 		},
-		End: Position{
+		End: client.Position{
 			Line:      endLine,
 			Character: endCharacter,
 		},
 	}
 }
 
-// documentPathRangeID denotes a range qualified by its containing document.
-type documentPathRangeID struct {
+// DocumentPathRangeID denotes a range qualified by its containing document.
+type DocumentPathRangeID struct {
 	Path    string
 	RangeID types.ID
 }
@@ -122,7 +111,7 @@ func (db *databaseImpl) Exists(ctx context.Context, path string) (bool, error) {
 }
 
 // Definitions returns the set of locations defining the symbol at the given position.
-func (db *databaseImpl) Definitions(ctx context.Context, path string, line, character int) ([]Location, error) {
+func (db *databaseImpl) Definitions(ctx context.Context, path string, line, character int) ([]client.Location, error) {
 	_, ranges, exists, err := db.getRangeByPosition(ctx, path, line, character)
 	if err != nil || !exists {
 		return nil, pkgerrors.Wrap(err, "db.getRangeByPosition")
@@ -146,17 +135,17 @@ func (db *databaseImpl) Definitions(ctx context.Context, path string, line, char
 		return locations, nil
 	}
 
-	return []Location{}, nil
+	return []client.Location{}, nil
 }
 
 // References returns the set of locations referencing the symbol at the given position.
-func (db *databaseImpl) References(ctx context.Context, path string, line, character int) ([]Location, error) {
+func (db *databaseImpl) References(ctx context.Context, path string, line, character int) ([]client.Location, error) {
 	_, ranges, exists, err := db.getRangeByPosition(ctx, path, line, character)
 	if err != nil || !exists {
 		return nil, pkgerrors.Wrap(err, "db.getRangeByPosition")
 	}
 
-	var allLocations []Location
+	var allLocations []client.Location
 	for _, r := range ranges {
 		if r.ReferenceResultID == "" {
 			continue
@@ -179,10 +168,10 @@ func (db *databaseImpl) References(ctx context.Context, path string, line, chara
 }
 
 // Hover returns the hover text of the symbol at the given position.
-func (db *databaseImpl) Hover(ctx context.Context, path string, line, character int) (string, Range, bool, error) {
+func (db *databaseImpl) Hover(ctx context.Context, path string, line, character int) (string, client.Range, bool, error) {
 	documentData, ranges, exists, err := db.getRangeByPosition(ctx, path, line, character)
 	if err != nil || !exists {
-		return "", Range{}, false, pkgerrors.Wrap(err, "db.getRangeByPosition")
+		return "", client.Range{}, false, pkgerrors.Wrap(err, "db.getRangeByPosition")
 	}
 
 	for _, r := range ranges {
@@ -192,7 +181,7 @@ func (db *databaseImpl) Hover(ctx context.Context, path string, line, character 
 
 		text, exists := documentData.HoverResults[r.HoverResultID]
 		if !exists {
-			return "", Range{}, false, ErrMalformedBundle{
+			return "", client.Range{}, false, ErrMalformedBundle{
 				Filename: db.filename,
 				Name:     "hoverResult",
 				Key:      string(r.HoverResultID),
@@ -203,22 +192,57 @@ func (db *databaseImpl) Hover(ctx context.Context, path string, line, character 
 		return text, newRange(r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter), true, nil
 	}
 
-	return "", Range{}, false, nil
+	return "", client.Range{}, false, nil
+}
+
+// Diagnostics returns the diagnostics for the documents that have the given path prefix.
+func (db *databaseImpl) Diagnostics(ctx context.Context, prefix string) ([]client.Diagnostic, error) {
+	paths, err := db.getPathsWithPrefix(ctx, prefix)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "db.getPathsWithPrefix")
+	}
+
+	var diagnostics []client.Diagnostic
+	for _, path := range paths {
+		documentData, exists, err := db.getDocumentData(ctx, prefix)
+		if err != nil {
+			return nil, pkgerrors.Wrap(err, "db.getDocumentData")
+		}
+		if !exists {
+			return nil, nil
+		}
+
+		for _, diagnostic := range documentData.Diagnostics {
+			diagnostics = append(diagnostics, client.Diagnostic{
+				Path:           path,
+				Severity:       diagnostic.Severity,
+				Code:           diagnostic.Code,
+				Message:        diagnostic.Message,
+				Source:         diagnostic.Source,
+				StartLine:      diagnostic.StartLine,
+				StartCharacter: diagnostic.StartCharacter,
+				EndLine:        diagnostic.EndLine,
+				EndCharacter:   diagnostic.EndCharacter,
+			})
+		}
+	}
+
+	return diagnostics, nil
 }
 
 // MonikersByPosition returns all monikers attached ranges containing the given position. If multiple
 // ranges contain the position, then this method will return multiple sets of monikers. Each slice
 // of monikers are attached to a single range. The order of the output slice is "outside-in", so that
 // the range attached to earlier monikers enclose the range attached to later monikers.
-func (db *databaseImpl) MonikersByPosition(ctx context.Context, path string, line, character int) ([][]types.MonikerData, error) {
+func (db *databaseImpl) MonikersByPosition(ctx context.Context, path string, line, character int) ([][]client.MonikerData, error) {
 	documentData, ranges, exists, err := db.getRangeByPosition(ctx, path, line, character)
 	if err != nil || !exists {
 		return nil, pkgerrors.Wrap(err, "db.getRangeByPosition")
 	}
 
-	var monikerData [][]types.MonikerData
+	var monikerData [][]client.MonikerData
 	for _, r := range ranges {
-		var batch []types.MonikerData
+		var batch []client.MonikerData
 		for _, monikerID := range r.MonikerIDs {
 			moniker, exists := documentData.Monikers[monikerID]
 			if !exists {
@@ -230,7 +254,12 @@ func (db *databaseImpl) MonikersByPosition(ctx context.Context, path string, lin
 				}
 			}
 
-			batch = append(batch, moniker)
+			batch = append(batch, client.MonikerData{
+				Kind:                 moniker.Kind,
+				Scheme:               moniker.Scheme,
+				Identifier:           moniker.Identifier,
+				PackageInformationID: string(moniker.PackageInformationID),
+			})
 		}
 
 		monikerData = append(monikerData, batch)
@@ -238,10 +267,10 @@ func (db *databaseImpl) MonikersByPosition(ctx context.Context, path string, lin
 
 	return monikerData, nil
 }
-
+i
 // MonikerResults returns the locations that define or reference the given moniker. This method
 // also returns the size of the complete result set to aid in pagination (along with skip and take).
-func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) (_ []Location, _ int, err error) {
+func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) ([]client.Location, int, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "getResultChunkByResultID")
 	span.SetTag("filename", db.filename)
 	span.SetTag("tableName", tableName)
@@ -255,7 +284,6 @@ func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, i
 		span.Finish()
 	}()
 
-	// TODO(efritz) - gross
 	var rows []types.Location
 	var totalCount int
 	if tableName == "definitions" {
@@ -272,9 +300,9 @@ func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, i
 		return nil, 0, err
 	}
 
-	var locations []Location
+	var locations []client.Location
 	for _, row := range rows {
-		locations = append(locations, Location{
+		locations = append(locations, client.Location{
 			Path:  row.URI,
 			Range: newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
 		})
@@ -284,18 +312,39 @@ func (db *databaseImpl) MonikerResults(ctx context.Context, tableName, scheme, i
 }
 
 // PackageInformation looks up package information data by identifier.
-func (db *databaseImpl) PackageInformation(ctx context.Context, path string, packageInformationID types.ID) (types.PackageInformationData, bool, error) {
+func (db *databaseImpl) PackageInformation(ctx context.Context, path string, packageInformationID string) (client.PackageInformationData, bool, error) {
 	documentData, exists, err := db.getDocumentData(ctx, path)
 	if err != nil {
-		return types.PackageInformationData{}, false, pkgerrors.Wrap(err, "db.getDocumentData")
+		return client.PackageInformationData{}, false, pkgerrors.Wrap(err, "db.getDocumentData")
 	}
-
 	if !exists {
-		return types.PackageInformationData{}, false, nil
+		return client.PackageInformationData{}, false, nil
 	}
 
-	packageInformationData, exists := documentData.PackageInformation[packageInformationID]
-	return packageInformationData, exists, nil
+	packageInformationData, exists := documentData.PackageInformation[types.ID(packageInformationID)]
+	if exists {
+		return client.PackageInformationData{
+			Name:    packageInformationData.Name,
+			Version: packageInformationData.Version,
+		}, true, nil
+	}
+
+	return client.PackageInformationData{}, false, nil
+}
+
+func (db *databaseImpl) getPathsWithPrefix(ctx context.Context, prefix string) (_ []string, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "getPathsWithPrefix")
+	span.SetTag("filename", db.filename)
+	span.SetTag("prefix", prefix)
+	defer func() {
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.SetTag("err", err.Error())
+		}
+		span.Finish()
+	}()
+
+	return db.reader.PathsWithPrefix(ctx, prefix)
 }
 
 // getDocumentData fetches and unmarshals the document data or the given path. This method caches
@@ -326,7 +375,6 @@ func (db *databaseImpl) getRangeByPosition(ctx context.Context, path string, lin
 	if err != nil {
 		return types.DocumentData{}, nil, false, pkgerrors.Wrap(err, "db.getDocumentData")
 	}
-
 	if !exists {
 		return types.DocumentData{}, nil, false, nil
 	}
@@ -336,12 +384,11 @@ func (db *databaseImpl) getRangeByPosition(ctx context.Context, path string, lin
 
 // getResultByID fetches and unmarshals a definition or reference result by identifier.
 // This method caches result chunk data by a unique key prefixed by the database filename.
-func (db *databaseImpl) getResultByID(ctx context.Context, id types.ID) ([]documentPathRangeID, error) {
+func (db *databaseImpl) getResultByID(ctx context.Context, id types.ID) ([]DocumentPathRangeID, error) {
 	resultChunkData, exists, err := db.getResultChunkByResultID(ctx, id)
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "db.getResultChunkByResultID")
 	}
-
 	if !exists {
 		return nil, ErrMalformedBundle{
 			Filename: db.filename,
@@ -360,7 +407,7 @@ func (db *databaseImpl) getResultByID(ctx context.Context, id types.ID) ([]docum
 		}
 	}
 
-	var resultData []documentPathRangeID
+	var resultData []DocumentPathRangeID
 	for _, documentIDRangeID := range documentIDRangeIDs {
 		path, ok := resultChunkData.DocumentPaths[documentIDRangeID.DocumentID]
 		if !ok {
@@ -372,7 +419,7 @@ func (db *databaseImpl) getResultByID(ctx context.Context, id types.ID) ([]docum
 			}
 		}
 
-		resultData = append(resultData, documentPathRangeID{
+		resultData = append(resultData, DocumentPathRangeID{
 			Path:    path,
 			RangeID: documentIDRangeID.RangeID,
 		})
@@ -404,7 +451,7 @@ func (db *databaseImpl) getResultChunkByResultID(ctx context.Context, id types.I
 
 // convertRangesToLocations converts pairs of document paths and range identifiers
 // to a list of locations.
-func (db *databaseImpl) convertRangesToLocations(ctx context.Context, resultData []documentPathRangeID) ([]Location, error) {
+func (db *databaseImpl) convertRangesToLocations(ctx context.Context, resultData []DocumentPathRangeID) ([]client.Location, error) {
 	// We potentially have to open a lot of documents. Reduce possible pressure on the
 	// cache by ordering our queries so we only have to read and unmarshal each document
 	// once.
@@ -420,7 +467,7 @@ func (db *databaseImpl) convertRangesToLocations(ctx context.Context, resultData
 	}
 	sort.Strings(paths)
 
-	var locations []Location
+	var locations []client.Location
 	for _, path := range paths {
 		documentData, exists, err := db.getDocumentData(ctx, path)
 		if err != nil {
@@ -446,7 +493,7 @@ func (db *databaseImpl) convertRangesToLocations(ctx context.Context, resultData
 				}
 			}
 
-			locations = append(locations, Location{
+			locations = append(locations, client.Location{
 				Path:  path,
 				Range: newRange(r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter),
 			})

--- a/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	sqlitereader "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/persistence/sqlite"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 )
@@ -47,7 +47,7 @@ func TestDatabaseDefinitions(t *testing.T) {
 	if actual, err := db.Definitions(context.Background(), "cmd/lsif-go/main.go", 110, 22); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	} else {
-		expected := []Location{
+		expected := []client.Location{
 			{
 				Path:  "internal/index/indexer.go",
 				Range: newRange(20, 1, 20, 6),
@@ -74,7 +74,7 @@ func TestDatabaseReferences(t *testing.T) {
 	if actual, err := db.References(context.Background(), "protocol/writer.go", 85, 20); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	} else {
-		expected := []Location{
+		expected := []client.Location{
 			{
 				Path:  "internal/index/indexer.go",
 				Range: newRange(529, 22, 529, 31),
@@ -127,13 +127,13 @@ func TestDatabaseMonikersByPosition(t *testing.T) {
 	if actual, err := db.MonikersByPosition(context.Background(), "protocol/protocol.go", 92, 10); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	} else {
-		expected := [][]types.MonikerData{
+		expected := [][]client.MonikerData{
 			{
 				{
 					Kind:                 "export",
 					Scheme:               "gomod",
 					Identifier:           "github.com/sourcegraph/lsif-go/protocol:NewMetaData",
-					PackageInformationID: types.ID("213"),
+					PackageInformationID: "213",
 				},
 			},
 		}
@@ -145,7 +145,7 @@ func TestDatabaseMonikersByPosition(t *testing.T) {
 }
 
 func TestDatabaseMonikerResults(t *testing.T) {
-	edgeLocations := []Location{
+	edgeLocations := []client.Location{
 		{
 			Path:  "protocol/protocol.go",
 			Range: newRange(600, 1, 600, 5),
@@ -188,7 +188,7 @@ func TestDatabaseMonikerResults(t *testing.T) {
 		},
 	}
 
-	markdownLocations := []Location{
+	markdownLocations := []client.Location{
 		{
 			Path:  "internal/index/helper.go",
 			Range: newRange(78, 6, 78, 16),
@@ -201,7 +201,7 @@ func TestDatabaseMonikerResults(t *testing.T) {
 		identifier         string
 		skip               int
 		take               int
-		expectedLocations  []Location
+		expectedLocations  []client.Location
 		expectedTotalCount int
 	}{
 		{"definitions", "gomod", "github.com/sourcegraph/lsif-go/protocol:Edge", 0, 100, edgeLocations, 10},
@@ -227,12 +227,12 @@ func TestDatabaseMonikerResults(t *testing.T) {
 
 func TestDatabasePackageInformation(t *testing.T) {
 	db := openTestDatabase(t)
-	if actual, exists, err := db.PackageInformation(context.Background(), "protocol/protocol.go", types.ID("213")); err != nil {
+	if actual, exists, err := db.PackageInformation(context.Background(), "protocol/protocol.go", "213"); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	} else if !exists {
 		t.Errorf("no package information")
 	} else {
-		expected := types.PackageInformationData{
+		expected := client.PackageInformationData{
 			Name:    "github.com/sourcegraph/lsif-go",
 			Version: "v0.0.0-ad3507cbeb18",
 		}

--- a/cmd/precise-code-intel-bundle-manager/internal/database/mock_database_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/mock_database_test.go
@@ -4,7 +4,7 @@ package database
 
 import (
 	"context"
-	types "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
+	client "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"sync"
 )
 
@@ -19,6 +19,9 @@ type MockDatabase struct {
 	// DefinitionsFunc is an instance of a mock function object controlling
 	// the behavior of the method Definitions.
 	DefinitionsFunc *DatabaseDefinitionsFunc
+	// DiagnosticsFunc is an instance of a mock function object controlling
+	// the behavior of the method Diagnostics.
+	DiagnosticsFunc *DatabaseDiagnosticsFunc
 	// ExistsFunc is an instance of a mock function object controlling the
 	// behavior of the method Exists.
 	ExistsFunc *DatabaseExistsFunc
@@ -49,7 +52,12 @@ func NewMockDatabase() *MockDatabase {
 			},
 		},
 		DefinitionsFunc: &DatabaseDefinitionsFunc{
-			defaultHook: func(context.Context, string, int, int) ([]Location, error) {
+			defaultHook: func(context.Context, string, int, int) ([]client.Location, error) {
+				return nil, nil
+			},
+		},
+		DiagnosticsFunc: &DatabaseDiagnosticsFunc{
+			defaultHook: func(context.Context, string) ([]client.Diagnostic, error) {
 				return nil, nil
 			},
 		},
@@ -59,27 +67,27 @@ func NewMockDatabase() *MockDatabase {
 			},
 		},
 		HoverFunc: &DatabaseHoverFunc{
-			defaultHook: func(context.Context, string, int, int) (string, Range, bool, error) {
-				return "", Range{}, false, nil
+			defaultHook: func(context.Context, string, int, int) (string, client.Range, bool, error) {
+				return "", client.Range{}, false, nil
 			},
 		},
 		MonikerResultsFunc: &DatabaseMonikerResultsFunc{
-			defaultHook: func(context.Context, string, string, string, int, int) ([]Location, int, error) {
+			defaultHook: func(context.Context, string, string, string, int, int) ([]client.Location, int, error) {
 				return nil, 0, nil
 			},
 		},
 		MonikersByPositionFunc: &DatabaseMonikersByPositionFunc{
-			defaultHook: func(context.Context, string, int, int) ([][]types.MonikerData, error) {
+			defaultHook: func(context.Context, string, int, int) ([][]client.MonikerData, error) {
 				return nil, nil
 			},
 		},
 		PackageInformationFunc: &DatabasePackageInformationFunc{
-			defaultHook: func(context.Context, string, types.ID) (types.PackageInformationData, bool, error) {
-				return types.PackageInformationData{}, false, nil
+			defaultHook: func(context.Context, string, string) (client.PackageInformationData, bool, error) {
+				return client.PackageInformationData{}, false, nil
 			},
 		},
 		ReferencesFunc: &DatabaseReferencesFunc{
-			defaultHook: func(context.Context, string, int, int) ([]Location, error) {
+			defaultHook: func(context.Context, string, int, int) ([]client.Location, error) {
 				return nil, nil
 			},
 		},
@@ -95,6 +103,9 @@ func NewMockDatabaseFrom(i Database) *MockDatabase {
 		},
 		DefinitionsFunc: &DatabaseDefinitionsFunc{
 			defaultHook: i.Definitions,
+		},
+		DiagnosticsFunc: &DatabaseDiagnosticsFunc{
+			defaultHook: i.Diagnostics,
 		},
 		ExistsFunc: &DatabaseExistsFunc{
 			defaultHook: i.Exists,
@@ -219,15 +230,15 @@ func (c DatabaseCloseFuncCall) Results() []interface{} {
 // DatabaseDefinitionsFunc describes the behavior when the Definitions
 // method of the parent MockDatabase instance is invoked.
 type DatabaseDefinitionsFunc struct {
-	defaultHook func(context.Context, string, int, int) ([]Location, error)
-	hooks       []func(context.Context, string, int, int) ([]Location, error)
+	defaultHook func(context.Context, string, int, int) ([]client.Location, error)
+	hooks       []func(context.Context, string, int, int) ([]client.Location, error)
 	history     []DatabaseDefinitionsFuncCall
 	mutex       sync.Mutex
 }
 
 // Definitions delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockDatabase) Definitions(v0 context.Context, v1 string, v2 int, v3 int) ([]Location, error) {
+func (m *MockDatabase) Definitions(v0 context.Context, v1 string, v2 int, v3 int) ([]client.Location, error) {
 	r0, r1 := m.DefinitionsFunc.nextHook()(v0, v1, v2, v3)
 	m.DefinitionsFunc.appendCall(DatabaseDefinitionsFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -236,7 +247,7 @@ func (m *MockDatabase) Definitions(v0 context.Context, v1 string, v2 int, v3 int
 // SetDefaultHook sets function that is called when the Definitions method
 // of the parent MockDatabase instance is invoked and the hook queue is
 // empty.
-func (f *DatabaseDefinitionsFunc) SetDefaultHook(hook func(context.Context, string, int, int) ([]Location, error)) {
+func (f *DatabaseDefinitionsFunc) SetDefaultHook(hook func(context.Context, string, int, int) ([]client.Location, error)) {
 	f.defaultHook = hook
 }
 
@@ -244,7 +255,7 @@ func (f *DatabaseDefinitionsFunc) SetDefaultHook(hook func(context.Context, stri
 // Definitions method of the parent MockDatabase instance inovkes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *DatabaseDefinitionsFunc) PushHook(hook func(context.Context, string, int, int) ([]Location, error)) {
+func (f *DatabaseDefinitionsFunc) PushHook(hook func(context.Context, string, int, int) ([]client.Location, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -252,21 +263,21 @@ func (f *DatabaseDefinitionsFunc) PushHook(hook func(context.Context, string, in
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DatabaseDefinitionsFunc) SetDefaultReturn(r0 []Location, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, int, int) ([]Location, error) {
+func (f *DatabaseDefinitionsFunc) SetDefaultReturn(r0 []client.Location, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, int, int) ([]client.Location, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DatabaseDefinitionsFunc) PushReturn(r0 []Location, r1 error) {
-	f.PushHook(func(context.Context, string, int, int) ([]Location, error) {
+func (f *DatabaseDefinitionsFunc) PushReturn(r0 []client.Location, r1 error) {
+	f.PushHook(func(context.Context, string, int, int) ([]client.Location, error) {
 		return r0, r1
 	})
 }
 
-func (f *DatabaseDefinitionsFunc) nextHook() func(context.Context, string, int, int) ([]Location, error) {
+func (f *DatabaseDefinitionsFunc) nextHook() func(context.Context, string, int, int) ([]client.Location, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -313,7 +324,7 @@ type DatabaseDefinitionsFuncCall struct {
 	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []Location
+	Result0 []client.Location
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -328,6 +339,115 @@ func (c DatabaseDefinitionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DatabaseDefinitionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// DatabaseDiagnosticsFunc describes the behavior when the Diagnostics
+// method of the parent MockDatabase instance is invoked.
+type DatabaseDiagnosticsFunc struct {
+	defaultHook func(context.Context, string) ([]client.Diagnostic, error)
+	hooks       []func(context.Context, string) ([]client.Diagnostic, error)
+	history     []DatabaseDiagnosticsFuncCall
+	mutex       sync.Mutex
+}
+
+// Diagnostics delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockDatabase) Diagnostics(v0 context.Context, v1 string) ([]client.Diagnostic, error) {
+	r0, r1 := m.DiagnosticsFunc.nextHook()(v0, v1)
+	m.DiagnosticsFunc.appendCall(DatabaseDiagnosticsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the Diagnostics method
+// of the parent MockDatabase instance is invoked and the hook queue is
+// empty.
+func (f *DatabaseDiagnosticsFunc) SetDefaultHook(hook func(context.Context, string) ([]client.Diagnostic, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Diagnostics method of the parent MockDatabase instance inovkes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DatabaseDiagnosticsFunc) PushHook(hook func(context.Context, string) ([]client.Diagnostic, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DatabaseDiagnosticsFunc) SetDefaultReturn(r0 []client.Diagnostic, r1 error) {
+	f.SetDefaultHook(func(context.Context, string) ([]client.Diagnostic, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DatabaseDiagnosticsFunc) PushReturn(r0 []client.Diagnostic, r1 error) {
+	f.PushHook(func(context.Context, string) ([]client.Diagnostic, error) {
+		return r0, r1
+	})
+}
+
+func (f *DatabaseDiagnosticsFunc) nextHook() func(context.Context, string) ([]client.Diagnostic, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DatabaseDiagnosticsFunc) appendCall(r0 DatabaseDiagnosticsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DatabaseDiagnosticsFuncCall objects
+// describing the invocations of this function.
+func (f *DatabaseDiagnosticsFunc) History() []DatabaseDiagnosticsFuncCall {
+	f.mutex.Lock()
+	history := make([]DatabaseDiagnosticsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DatabaseDiagnosticsFuncCall is an object that describes an invocation of
+// method Diagnostics on an instance of MockDatabase.
+type DatabaseDiagnosticsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []client.Diagnostic
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DatabaseDiagnosticsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DatabaseDiagnosticsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -442,15 +562,15 @@ func (c DatabaseExistsFuncCall) Results() []interface{} {
 // DatabaseHoverFunc describes the behavior when the Hover method of the
 // parent MockDatabase instance is invoked.
 type DatabaseHoverFunc struct {
-	defaultHook func(context.Context, string, int, int) (string, Range, bool, error)
-	hooks       []func(context.Context, string, int, int) (string, Range, bool, error)
+	defaultHook func(context.Context, string, int, int) (string, client.Range, bool, error)
+	hooks       []func(context.Context, string, int, int) (string, client.Range, bool, error)
 	history     []DatabaseHoverFuncCall
 	mutex       sync.Mutex
 }
 
 // Hover delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDatabase) Hover(v0 context.Context, v1 string, v2 int, v3 int) (string, Range, bool, error) {
+func (m *MockDatabase) Hover(v0 context.Context, v1 string, v2 int, v3 int) (string, client.Range, bool, error) {
 	r0, r1, r2, r3 := m.HoverFunc.nextHook()(v0, v1, v2, v3)
 	m.HoverFunc.appendCall(DatabaseHoverFuncCall{v0, v1, v2, v3, r0, r1, r2, r3})
 	return r0, r1, r2, r3
@@ -458,7 +578,7 @@ func (m *MockDatabase) Hover(v0 context.Context, v1 string, v2 int, v3 int) (str
 
 // SetDefaultHook sets function that is called when the Hover method of the
 // parent MockDatabase instance is invoked and the hook queue is empty.
-func (f *DatabaseHoverFunc) SetDefaultHook(hook func(context.Context, string, int, int) (string, Range, bool, error)) {
+func (f *DatabaseHoverFunc) SetDefaultHook(hook func(context.Context, string, int, int) (string, client.Range, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -466,7 +586,7 @@ func (f *DatabaseHoverFunc) SetDefaultHook(hook func(context.Context, string, in
 // Hover method of the parent MockDatabase instance inovkes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DatabaseHoverFunc) PushHook(hook func(context.Context, string, int, int) (string, Range, bool, error)) {
+func (f *DatabaseHoverFunc) PushHook(hook func(context.Context, string, int, int) (string, client.Range, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -474,21 +594,21 @@ func (f *DatabaseHoverFunc) PushHook(hook func(context.Context, string, int, int
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DatabaseHoverFunc) SetDefaultReturn(r0 string, r1 Range, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, string, int, int) (string, Range, bool, error) {
+func (f *DatabaseHoverFunc) SetDefaultReturn(r0 string, r1 client.Range, r2 bool, r3 error) {
+	f.SetDefaultHook(func(context.Context, string, int, int) (string, client.Range, bool, error) {
 		return r0, r1, r2, r3
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DatabaseHoverFunc) PushReturn(r0 string, r1 Range, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, string, int, int) (string, Range, bool, error) {
+func (f *DatabaseHoverFunc) PushReturn(r0 string, r1 client.Range, r2 bool, r3 error) {
+	f.PushHook(func(context.Context, string, int, int) (string, client.Range, bool, error) {
 		return r0, r1, r2, r3
 	})
 }
 
-func (f *DatabaseHoverFunc) nextHook() func(context.Context, string, int, int) (string, Range, bool, error) {
+func (f *DatabaseHoverFunc) nextHook() func(context.Context, string, int, int) (string, client.Range, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -538,7 +658,7 @@ type DatabaseHoverFuncCall struct {
 	Result0 string
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 Range
+	Result1 client.Range
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
 	Result2 bool
@@ -562,15 +682,15 @@ func (c DatabaseHoverFuncCall) Results() []interface{} {
 // DatabaseMonikerResultsFunc describes the behavior when the MonikerResults
 // method of the parent MockDatabase instance is invoked.
 type DatabaseMonikerResultsFunc struct {
-	defaultHook func(context.Context, string, string, string, int, int) ([]Location, int, error)
-	hooks       []func(context.Context, string, string, string, int, int) ([]Location, int, error)
+	defaultHook func(context.Context, string, string, string, int, int) ([]client.Location, int, error)
+	hooks       []func(context.Context, string, string, string, int, int) ([]client.Location, int, error)
 	history     []DatabaseMonikerResultsFuncCall
 	mutex       sync.Mutex
 }
 
 // MonikerResults delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockDatabase) MonikerResults(v0 context.Context, v1 string, v2 string, v3 string, v4 int, v5 int) ([]Location, int, error) {
+func (m *MockDatabase) MonikerResults(v0 context.Context, v1 string, v2 string, v3 string, v4 int, v5 int) ([]client.Location, int, error) {
 	r0, r1, r2 := m.MonikerResultsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
 	m.MonikerResultsFunc.appendCall(DatabaseMonikerResultsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
 	return r0, r1, r2
@@ -579,7 +699,7 @@ func (m *MockDatabase) MonikerResults(v0 context.Context, v1 string, v2 string, 
 // SetDefaultHook sets function that is called when the MonikerResults
 // method of the parent MockDatabase instance is invoked and the hook queue
 // is empty.
-func (f *DatabaseMonikerResultsFunc) SetDefaultHook(hook func(context.Context, string, string, string, int, int) ([]Location, int, error)) {
+func (f *DatabaseMonikerResultsFunc) SetDefaultHook(hook func(context.Context, string, string, string, int, int) ([]client.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -587,7 +707,7 @@ func (f *DatabaseMonikerResultsFunc) SetDefaultHook(hook func(context.Context, s
 // MonikerResults method of the parent MockDatabase instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *DatabaseMonikerResultsFunc) PushHook(hook func(context.Context, string, string, string, int, int) ([]Location, int, error)) {
+func (f *DatabaseMonikerResultsFunc) PushHook(hook func(context.Context, string, string, string, int, int) ([]client.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -595,21 +715,21 @@ func (f *DatabaseMonikerResultsFunc) PushHook(hook func(context.Context, string,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DatabaseMonikerResultsFunc) SetDefaultReturn(r0 []Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, string, string, int, int) ([]Location, int, error) {
+func (f *DatabaseMonikerResultsFunc) SetDefaultReturn(r0 []client.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, string, string, int, int) ([]client.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DatabaseMonikerResultsFunc) PushReturn(r0 []Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, string, string, string, int, int) ([]Location, int, error) {
+func (f *DatabaseMonikerResultsFunc) PushReturn(r0 []client.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string, string, string, int, int) ([]client.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *DatabaseMonikerResultsFunc) nextHook() func(context.Context, string, string, string, int, int) ([]Location, int, error) {
+func (f *DatabaseMonikerResultsFunc) nextHook() func(context.Context, string, string, string, int, int) ([]client.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -662,7 +782,7 @@ type DatabaseMonikerResultsFuncCall struct {
 	Arg5 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []Location
+	Result0 []client.Location
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 int
@@ -686,15 +806,15 @@ func (c DatabaseMonikerResultsFuncCall) Results() []interface{} {
 // DatabaseMonikersByPositionFunc describes the behavior when the
 // MonikersByPosition method of the parent MockDatabase instance is invoked.
 type DatabaseMonikersByPositionFunc struct {
-	defaultHook func(context.Context, string, int, int) ([][]types.MonikerData, error)
-	hooks       []func(context.Context, string, int, int) ([][]types.MonikerData, error)
+	defaultHook func(context.Context, string, int, int) ([][]client.MonikerData, error)
+	hooks       []func(context.Context, string, int, int) ([][]client.MonikerData, error)
 	history     []DatabaseMonikersByPositionFuncCall
 	mutex       sync.Mutex
 }
 
 // MonikersByPosition delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockDatabase) MonikersByPosition(v0 context.Context, v1 string, v2 int, v3 int) ([][]types.MonikerData, error) {
+func (m *MockDatabase) MonikersByPosition(v0 context.Context, v1 string, v2 int, v3 int) ([][]client.MonikerData, error) {
 	r0, r1 := m.MonikersByPositionFunc.nextHook()(v0, v1, v2, v3)
 	m.MonikersByPositionFunc.appendCall(DatabaseMonikersByPositionFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -703,7 +823,7 @@ func (m *MockDatabase) MonikersByPosition(v0 context.Context, v1 string, v2 int,
 // SetDefaultHook sets function that is called when the MonikersByPosition
 // method of the parent MockDatabase instance is invoked and the hook queue
 // is empty.
-func (f *DatabaseMonikersByPositionFunc) SetDefaultHook(hook func(context.Context, string, int, int) ([][]types.MonikerData, error)) {
+func (f *DatabaseMonikersByPositionFunc) SetDefaultHook(hook func(context.Context, string, int, int) ([][]client.MonikerData, error)) {
 	f.defaultHook = hook
 }
 
@@ -711,7 +831,7 @@ func (f *DatabaseMonikersByPositionFunc) SetDefaultHook(hook func(context.Contex
 // MonikersByPosition method of the parent MockDatabase instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *DatabaseMonikersByPositionFunc) PushHook(hook func(context.Context, string, int, int) ([][]types.MonikerData, error)) {
+func (f *DatabaseMonikersByPositionFunc) PushHook(hook func(context.Context, string, int, int) ([][]client.MonikerData, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -719,21 +839,21 @@ func (f *DatabaseMonikersByPositionFunc) PushHook(hook func(context.Context, str
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DatabaseMonikersByPositionFunc) SetDefaultReturn(r0 [][]types.MonikerData, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, int, int) ([][]types.MonikerData, error) {
+func (f *DatabaseMonikersByPositionFunc) SetDefaultReturn(r0 [][]client.MonikerData, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, int, int) ([][]client.MonikerData, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DatabaseMonikersByPositionFunc) PushReturn(r0 [][]types.MonikerData, r1 error) {
-	f.PushHook(func(context.Context, string, int, int) ([][]types.MonikerData, error) {
+func (f *DatabaseMonikersByPositionFunc) PushReturn(r0 [][]client.MonikerData, r1 error) {
+	f.PushHook(func(context.Context, string, int, int) ([][]client.MonikerData, error) {
 		return r0, r1
 	})
 }
 
-func (f *DatabaseMonikersByPositionFunc) nextHook() func(context.Context, string, int, int) ([][]types.MonikerData, error) {
+func (f *DatabaseMonikersByPositionFunc) nextHook() func(context.Context, string, int, int) ([][]client.MonikerData, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -780,7 +900,7 @@ type DatabaseMonikersByPositionFuncCall struct {
 	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 [][]types.MonikerData
+	Result0 [][]client.MonikerData
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -801,15 +921,15 @@ func (c DatabaseMonikersByPositionFuncCall) Results() []interface{} {
 // DatabasePackageInformationFunc describes the behavior when the
 // PackageInformation method of the parent MockDatabase instance is invoked.
 type DatabasePackageInformationFunc struct {
-	defaultHook func(context.Context, string, types.ID) (types.PackageInformationData, bool, error)
-	hooks       []func(context.Context, string, types.ID) (types.PackageInformationData, bool, error)
+	defaultHook func(context.Context, string, string) (client.PackageInformationData, bool, error)
+	hooks       []func(context.Context, string, string) (client.PackageInformationData, bool, error)
 	history     []DatabasePackageInformationFuncCall
 	mutex       sync.Mutex
 }
 
 // PackageInformation delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockDatabase) PackageInformation(v0 context.Context, v1 string, v2 types.ID) (types.PackageInformationData, bool, error) {
+func (m *MockDatabase) PackageInformation(v0 context.Context, v1 string, v2 string) (client.PackageInformationData, bool, error) {
 	r0, r1, r2 := m.PackageInformationFunc.nextHook()(v0, v1, v2)
 	m.PackageInformationFunc.appendCall(DatabasePackageInformationFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
@@ -818,7 +938,7 @@ func (m *MockDatabase) PackageInformation(v0 context.Context, v1 string, v2 type
 // SetDefaultHook sets function that is called when the PackageInformation
 // method of the parent MockDatabase instance is invoked and the hook queue
 // is empty.
-func (f *DatabasePackageInformationFunc) SetDefaultHook(hook func(context.Context, string, types.ID) (types.PackageInformationData, bool, error)) {
+func (f *DatabasePackageInformationFunc) SetDefaultHook(hook func(context.Context, string, string) (client.PackageInformationData, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -826,7 +946,7 @@ func (f *DatabasePackageInformationFunc) SetDefaultHook(hook func(context.Contex
 // PackageInformation method of the parent MockDatabase instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *DatabasePackageInformationFunc) PushHook(hook func(context.Context, string, types.ID) (types.PackageInformationData, bool, error)) {
+func (f *DatabasePackageInformationFunc) PushHook(hook func(context.Context, string, string) (client.PackageInformationData, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -834,21 +954,21 @@ func (f *DatabasePackageInformationFunc) PushHook(hook func(context.Context, str
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DatabasePackageInformationFunc) SetDefaultReturn(r0 types.PackageInformationData, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, types.ID) (types.PackageInformationData, bool, error) {
+func (f *DatabasePackageInformationFunc) SetDefaultReturn(r0 client.PackageInformationData, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, string) (client.PackageInformationData, bool, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DatabasePackageInformationFunc) PushReturn(r0 types.PackageInformationData, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, string, types.ID) (types.PackageInformationData, bool, error) {
+func (f *DatabasePackageInformationFunc) PushReturn(r0 client.PackageInformationData, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, string, string) (client.PackageInformationData, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *DatabasePackageInformationFunc) nextHook() func(context.Context, string, types.ID) (types.PackageInformationData, bool, error) {
+func (f *DatabasePackageInformationFunc) nextHook() func(context.Context, string, string) (client.PackageInformationData, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -889,10 +1009,10 @@ type DatabasePackageInformationFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 types.ID
+	Arg2 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 types.PackageInformationData
+	Result0 client.PackageInformationData
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 bool
@@ -916,15 +1036,15 @@ func (c DatabasePackageInformationFuncCall) Results() []interface{} {
 // DatabaseReferencesFunc describes the behavior when the References method
 // of the parent MockDatabase instance is invoked.
 type DatabaseReferencesFunc struct {
-	defaultHook func(context.Context, string, int, int) ([]Location, error)
-	hooks       []func(context.Context, string, int, int) ([]Location, error)
+	defaultHook func(context.Context, string, int, int) ([]client.Location, error)
+	hooks       []func(context.Context, string, int, int) ([]client.Location, error)
 	history     []DatabaseReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // References delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockDatabase) References(v0 context.Context, v1 string, v2 int, v3 int) ([]Location, error) {
+func (m *MockDatabase) References(v0 context.Context, v1 string, v2 int, v3 int) ([]client.Location, error) {
 	r0, r1 := m.ReferencesFunc.nextHook()(v0, v1, v2, v3)
 	m.ReferencesFunc.appendCall(DatabaseReferencesFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -932,7 +1052,7 @@ func (m *MockDatabase) References(v0 context.Context, v1 string, v2 int, v3 int)
 
 // SetDefaultHook sets function that is called when the References method of
 // the parent MockDatabase instance is invoked and the hook queue is empty.
-func (f *DatabaseReferencesFunc) SetDefaultHook(hook func(context.Context, string, int, int) ([]Location, error)) {
+func (f *DatabaseReferencesFunc) SetDefaultHook(hook func(context.Context, string, int, int) ([]client.Location, error)) {
 	f.defaultHook = hook
 }
 
@@ -940,7 +1060,7 @@ func (f *DatabaseReferencesFunc) SetDefaultHook(hook func(context.Context, strin
 // References method of the parent MockDatabase instance inovkes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *DatabaseReferencesFunc) PushHook(hook func(context.Context, string, int, int) ([]Location, error)) {
+func (f *DatabaseReferencesFunc) PushHook(hook func(context.Context, string, int, int) ([]client.Location, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -948,21 +1068,21 @@ func (f *DatabaseReferencesFunc) PushHook(hook func(context.Context, string, int
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DatabaseReferencesFunc) SetDefaultReturn(r0 []Location, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, int, int) ([]Location, error) {
+func (f *DatabaseReferencesFunc) SetDefaultReturn(r0 []client.Location, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, int, int) ([]client.Location, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DatabaseReferencesFunc) PushReturn(r0 []Location, r1 error) {
-	f.PushHook(func(context.Context, string, int, int) ([]Location, error) {
+func (f *DatabaseReferencesFunc) PushReturn(r0 []client.Location, r1 error) {
+	f.PushHook(func(context.Context, string, int, int) ([]client.Location, error) {
 		return r0, r1
 	})
 }
 
-func (f *DatabaseReferencesFunc) nextHook() func(context.Context, string, int, int) ([]Location, error) {
+func (f *DatabaseReferencesFunc) nextHook() func(context.Context, string, int, int) ([]client.Location, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1009,7 +1129,7 @@ type DatabaseReferencesFuncCall struct {
 	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []Location
+	Result0 []client.Location
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/cmd/precise-code-intel-bundle-manager/internal/database/mock_database_test.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/mock_database_test.go
@@ -19,9 +19,6 @@ type MockDatabase struct {
 	// DefinitionsFunc is an instance of a mock function object controlling
 	// the behavior of the method Definitions.
 	DefinitionsFunc *DatabaseDefinitionsFunc
-	// DiagnosticsFunc is an instance of a mock function object controlling
-	// the behavior of the method Diagnostics.
-	DiagnosticsFunc *DatabaseDiagnosticsFunc
 	// ExistsFunc is an instance of a mock function object controlling the
 	// behavior of the method Exists.
 	ExistsFunc *DatabaseExistsFunc
@@ -53,11 +50,6 @@ func NewMockDatabase() *MockDatabase {
 		},
 		DefinitionsFunc: &DatabaseDefinitionsFunc{
 			defaultHook: func(context.Context, string, int, int) ([]client.Location, error) {
-				return nil, nil
-			},
-		},
-		DiagnosticsFunc: &DatabaseDiagnosticsFunc{
-			defaultHook: func(context.Context, string) ([]client.Diagnostic, error) {
 				return nil, nil
 			},
 		},
@@ -103,9 +95,6 @@ func NewMockDatabaseFrom(i Database) *MockDatabase {
 		},
 		DefinitionsFunc: &DatabaseDefinitionsFunc{
 			defaultHook: i.Definitions,
-		},
-		DiagnosticsFunc: &DatabaseDiagnosticsFunc{
-			defaultHook: i.Diagnostics,
 		},
 		ExistsFunc: &DatabaseExistsFunc{
 			defaultHook: i.Exists,
@@ -339,115 +328,6 @@ func (c DatabaseDefinitionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DatabaseDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// DatabaseDiagnosticsFunc describes the behavior when the Diagnostics
-// method of the parent MockDatabase instance is invoked.
-type DatabaseDiagnosticsFunc struct {
-	defaultHook func(context.Context, string) ([]client.Diagnostic, error)
-	hooks       []func(context.Context, string) ([]client.Diagnostic, error)
-	history     []DatabaseDiagnosticsFuncCall
-	mutex       sync.Mutex
-}
-
-// Diagnostics delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockDatabase) Diagnostics(v0 context.Context, v1 string) ([]client.Diagnostic, error) {
-	r0, r1 := m.DiagnosticsFunc.nextHook()(v0, v1)
-	m.DiagnosticsFunc.appendCall(DatabaseDiagnosticsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Diagnostics method
-// of the parent MockDatabase instance is invoked and the hook queue is
-// empty.
-func (f *DatabaseDiagnosticsFunc) SetDefaultHook(hook func(context.Context, string) ([]client.Diagnostic, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Diagnostics method of the parent MockDatabase instance inovkes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *DatabaseDiagnosticsFunc) PushHook(hook func(context.Context, string) ([]client.Diagnostic, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *DatabaseDiagnosticsFunc) SetDefaultReturn(r0 []client.Diagnostic, r1 error) {
-	f.SetDefaultHook(func(context.Context, string) ([]client.Diagnostic, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *DatabaseDiagnosticsFunc) PushReturn(r0 []client.Diagnostic, r1 error) {
-	f.PushHook(func(context.Context, string) ([]client.Diagnostic, error) {
-		return r0, r1
-	})
-}
-
-func (f *DatabaseDiagnosticsFunc) nextHook() func(context.Context, string) ([]client.Diagnostic, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *DatabaseDiagnosticsFunc) appendCall(r0 DatabaseDiagnosticsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of DatabaseDiagnosticsFuncCall objects
-// describing the invocations of this function.
-func (f *DatabaseDiagnosticsFunc) History() []DatabaseDiagnosticsFuncCall {
-	f.mutex.Lock()
-	history := make([]DatabaseDiagnosticsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// DatabaseDiagnosticsFuncCall is an object that describes an invocation of
-// method Diagnostics on an instance of MockDatabase.
-type DatabaseDiagnosticsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []client.Diagnostic
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c DatabaseDiagnosticsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c DatabaseDiagnosticsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
@@ -17,7 +17,6 @@ type ObservedDatabase struct {
 	definitionsOperation        *observation.Operation
 	referencesOperation         *observation.Operation
 	hoverOperation              *observation.Operation
-	diagnosticsOperation        *observation.Operation
 	monikersByPositionOperation *observation.Operation
 	monikerResultsOperation     *observation.Operation
 	packageInformationOperation *observation.Operation
@@ -62,11 +61,6 @@ func NewObserved(database Database, filename string, observationContext *observa
 		hoverOperation: observationContext.Operation(observation.Op{
 			Name:         "Database.Hover",
 			MetricLabels: []string{"hover"},
-			Metrics:      metrics,
-		}),
-		diagnosticsOperation: observationContext.Operation(observation.Op{
-			Name:         "Database.Diagnostics",
-			MetricLabels: []string{"diagnostics"},
 			Metrics:      metrics,
 		}),
 		monikersByPositionOperation: observationContext.Operation(observation.Op{
@@ -142,18 +136,6 @@ func (db *ObservedDatabase) Hover(ctx context.Context, path string, line, charac
 	})
 	defer endObservation(1, observation.Args{})
 	return db.database.Hover(ctx, path, line, character)
-}
-
-// Diagnostics calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) Diagnostics(ctx context.Context, pathPrefix string) (diagnostics []client.Diagnostic, err error) {
-	ctx, endObservation := db.hoverOperation.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{
-			log.String("filename", db.filename),
-			log.String("pathPrefix", pathPrefix),
-		},
-	})
-	defer func() { endObservation(float64(len(diagnostics)), observation.Args{}) }()
-	return db.database.Diagnostics(ctx, pathPrefix)
 }
 
 // MonikersByPosition calls into the inner Database and registers the observed results.

--- a/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/database/observability.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/client"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -17,6 +17,7 @@ type ObservedDatabase struct {
 	definitionsOperation        *observation.Operation
 	referencesOperation         *observation.Operation
 	hoverOperation              *observation.Operation
+	diagnosticsOperation        *observation.Operation
 	monikersByPositionOperation *observation.Operation
 	monikerResultsOperation     *observation.Operation
 	packageInformationOperation *observation.Operation
@@ -63,6 +64,11 @@ func NewObserved(database Database, filename string, observationContext *observa
 			MetricLabels: []string{"hover"},
 			Metrics:      metrics,
 		}),
+		diagnosticsOperation: observationContext.Operation(observation.Op{
+			Name:         "Database.Diagnostics",
+			MetricLabels: []string{"diagnostics"},
+			Metrics:      metrics,
+		}),
 		monikersByPositionOperation: observationContext.Operation(observation.Op{
 			Name:         "Database.MonikersByPosition",
 			MetricLabels: []string{"monikers_by_position"},
@@ -97,7 +103,7 @@ func (db *ObservedDatabase) Exists(ctx context.Context, path string) (_ bool, er
 }
 
 // Definitions calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) Definitions(ctx context.Context, path string, line, character int) (definitions []Location, err error) {
+func (db *ObservedDatabase) Definitions(ctx context.Context, path string, line, character int) (definitions []client.Location, err error) {
 	ctx, endObservation := db.definitionsOperation.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.String("filename", db.filename),
@@ -111,7 +117,7 @@ func (db *ObservedDatabase) Definitions(ctx context.Context, path string, line, 
 }
 
 // References calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) References(ctx context.Context, path string, line, character int) (references []Location, err error) {
+func (db *ObservedDatabase) References(ctx context.Context, path string, line, character int) (references []client.Location, err error) {
 	ctx, endObservation := db.referencesOperation.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.String("filename", db.filename),
@@ -125,7 +131,7 @@ func (db *ObservedDatabase) References(ctx context.Context, path string, line, c
 }
 
 // Hover calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) Hover(ctx context.Context, path string, line, character int) (_ string, _ Range, _ bool, err error) {
+func (db *ObservedDatabase) Hover(ctx context.Context, path string, line, character int) (_ string, _ client.Range, _ bool, err error) {
 	ctx, endObservation := db.hoverOperation.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.String("filename", db.filename),
@@ -138,8 +144,20 @@ func (db *ObservedDatabase) Hover(ctx context.Context, path string, line, charac
 	return db.database.Hover(ctx, path, line, character)
 }
 
+// Diagnostics calls into the inner Database and registers the observed results.
+func (db *ObservedDatabase) Diagnostics(ctx context.Context, pathPrefix string) (diagnostics []client.Diagnostic, err error) {
+	ctx, endObservation := db.hoverOperation.With(ctx, &err, observation.Args{
+		LogFields: []log.Field{
+			log.String("filename", db.filename),
+			log.String("pathPrefix", pathPrefix),
+		},
+	})
+	defer func() { endObservation(float64(len(diagnostics)), observation.Args{}) }()
+	return db.database.Diagnostics(ctx, pathPrefix)
+}
+
 // MonikersByPosition calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) MonikersByPosition(ctx context.Context, path string, line, character int) (monikers [][]types.MonikerData, err error) {
+func (db *ObservedDatabase) MonikersByPosition(ctx context.Context, path string, line, character int) (monikers [][]client.MonikerData, err error) {
 	ctx, endObservation := db.monikersByPositionOperation.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.String("filename", db.filename),
@@ -161,7 +179,7 @@ func (db *ObservedDatabase) MonikersByPosition(ctx context.Context, path string,
 }
 
 // MonikerResults calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) (locations []Location, _ int, err error) {
+func (db *ObservedDatabase) MonikerResults(ctx context.Context, tableName, scheme, identifier string, skip, take int) (locations []client.Location, _ int, err error) {
 	ctx, endObservation := db.monikerResultsOperation.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.String("filename", db.filename),
@@ -175,7 +193,7 @@ func (db *ObservedDatabase) MonikerResults(ctx context.Context, tableName, schem
 }
 
 // PackageInformation calls into the inner Database and registers the observed results.
-func (db *ObservedDatabase) PackageInformation(ctx context.Context, path string, packageInformationID types.ID) (_ types.PackageInformationData, _ bool, err error) {
+func (db *ObservedDatabase) PackageInformation(ctx context.Context, path string, packageInformationID string) (_ client.PackageInformationData, _ bool, err error) {
 	ctx, endObservation := db.packageInformationOperation.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.String("filename", db.filename),

--- a/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-bundle-manager/internal/paths"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/persistence"
 	sqlitereader "github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/persistence/sqlite"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/tar"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -253,7 +252,7 @@ func (s *Server) handlePackageInformation(w http.ResponseWriter, r *http.Request
 		packageInformationData, exists, err := db.PackageInformation(
 			ctx,
 			getQuery(r, "path"),
-			types.ID(getQuery(r, "packageInformationId")),
+			getQuery(r, "packageInformationId"),
 		)
 		if err != nil {
 			return nil, pkgerrors.Wrap(err, "db.PackageInformation")

--- a/internal/codeintel/bundles/client/types.go
+++ b/internal/codeintel/bundles/client/types.go
@@ -2,7 +2,7 @@ package client
 
 // Location is an LSP-like location scoped to a dump.
 type Location struct {
-	DumpID int    `json:"dumpId"`
+	DumpID int
 	Path   string `json:"path"`
 	Range  Range  `json:"range"`
 }
@@ -24,7 +24,7 @@ type MonikerData struct {
 	Kind                 string `json:"kind"`
 	Scheme               string `json:"scheme"`
 	Identifier           string `json:"identifier"`
-	PackageInformationID string `json:"packageInformationID"`
+	PackageInformationID string `json:"packageInformationId"`
 }
 
 // PackageInformationData describes a package within a package manager system.


### PR DESCRIPTION
The bundle manager JSON return types should use the same types that are used by the bundle manager client to interpret those types.