### PR TITLE
codeintel: Parse and write diagnostic results to bundles

### DIFF
--- a/cmd/precise-code-intel-worker/internal/correlation/correlate_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/correlate_test.go
@@ -25,8 +25,16 @@ func TestCorrelate(t *testing.T) {
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///test/root",
 		DocumentData: map[string]lsif.Document{
-			"02": {URI: "foo.go", Contains: datastructures.IDSet{"04": {}, "05": {}, "06": {}}},
-			"03": {URI: "bar.go", Contains: datastructures.IDSet{"07": {}, "08": {}, "09": {}}},
+			"02": {
+				URI:         "foo.go",
+				Contains:    datastructures.IDSet{"04": {}, "05": {}, "06": {}},
+				Diagnostics: datastructures.IDSet{"49": {}},
+			},
+			"03": {
+				URI:         "bar.go",
+				Contains:    datastructures.IDSet{"07": {}, "08": {}, "09": {}},
+				Diagnostics: datastructures.IDSet{},
+			},
 		},
 		RangeData: map[string]lsif.Range{
 			"04": {
@@ -111,6 +119,22 @@ func TestCorrelate(t *testing.T) {
 			"22": {Name: "pkg A", Version: "v0.1.0"},
 			"23": {Name: "pkg B", Version: "v1.2.3"},
 		},
+		Diagnostics: map[string]lsif.DiagnosticResult{
+			"49": {
+				Result: []lsif.Diagnostic{
+					{
+						Severity:       1,
+						Code:           "2322",
+						Message:        "Type '10' is not assignable to type 'string'.",
+						Source:         "eslint",
+						StartLine:      1,
+						StartCharacter: 5,
+						EndLine:        1,
+						EndCharacter:   6,
+					},
+				},
+			},
+		},
 		NextData: map[string]string{
 			"09": "10",
 			"10": "11",
@@ -141,7 +165,11 @@ func TestCorrelateMetaDataRoot(t *testing.T) {
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///test/root/",
 		DocumentData: map[string]lsif.Document{
-			"02": {URI: "foo.go", Contains: datastructures.IDSet{}},
+			"02": {
+				URI:         "foo.go",
+				Contains:    datastructures.IDSet{},
+				Diagnostics: datastructures.IDSet{},
+			},
 		},
 		RangeData:              map[string]lsif.Range{},
 		ResultSetData:          map[string]lsif.ResultSet{},
@@ -150,6 +178,7 @@ func TestCorrelateMetaDataRoot(t *testing.T) {
 		HoverData:              map[string]string{},
 		MonikerData:            map[string]lsif.Moniker{},
 		PackageInformationData: map[string]lsif.PackageInformation{},
+		Diagnostics:            map[string]lsif.DiagnosticResult{},
 		NextData:               map[string]string{},
 		ImportedMonikers:       datastructures.IDSet{},
 		ExportedMonikers:       datastructures.IDSet{},
@@ -177,7 +206,11 @@ func TestCorrelateMetaDataRootX(t *testing.T) {
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///__w/sourcegraph/sourcegraph/shared/",
 		DocumentData: map[string]lsif.Document{
-			"02": {URI: "../node_modules/@types/history/index.d.ts", Contains: datastructures.IDSet{}},
+			"02": {
+				URI:         "../node_modules/@types/history/index.d.ts",
+				Contains:    datastructures.IDSet{},
+				Diagnostics: datastructures.IDSet{},
+			},
 		},
 		RangeData:              map[string]lsif.Range{},
 		ResultSetData:          map[string]lsif.ResultSet{},
@@ -186,6 +219,7 @@ func TestCorrelateMetaDataRootX(t *testing.T) {
 		HoverData:              map[string]string{},
 		MonikerData:            map[string]lsif.Moniker{},
 		PackageInformationData: map[string]lsif.PackageInformation{},
+		Diagnostics:            map[string]lsif.DiagnosticResult{},
 		NextData:               map[string]string{},
 		ImportedMonikers:       datastructures.IDSet{},
 		ExportedMonikers:       datastructures.IDSet{},

--- a/cmd/precise-code-intel-worker/internal/correlation/group.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/group.go
@@ -79,6 +79,7 @@ func serializeDocument(state *State, doc lsif.Document) types.DocumentData {
 		HoverResults:       map[types.ID]string{},
 		Monikers:           map[types.ID]types.MonikerData{},
 		PackageInformation: map[types.ID]types.PackageInformationData{},
+		Diagnostics:        []types.DiagnosticData{},
 	}
 
 	for rangeID := range doc.Contains {
@@ -122,6 +123,21 @@ func serializeDocument(state *State, doc lsif.Document) types.DocumentData {
 					Version: packageInformation.Version,
 				}
 			}
+		}
+	}
+
+	for diagnosticID := range doc.Diagnostics {
+		for _, diagnostic := range state.Diagnostics[diagnosticID].Result {
+			document.Diagnostics = append(document.Diagnostics, types.DiagnosticData{
+				Severity:       diagnostic.Severity,
+				Code:           diagnostic.Code,
+				Message:        diagnostic.Message,
+				Source:         diagnostic.Source,
+				StartLine:      diagnostic.StartLine,
+				StartCharacter: diagnostic.StartCharacter,
+				EndLine:        diagnostic.EndLine,
+				EndCharacter:   diagnostic.EndCharacter,
+			})
 		}
 	}
 

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/jsonlines/unmarshal_test.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/jsonlines/unmarshal_test.go
@@ -97,8 +97,9 @@ func TestUnmarshalDocument(t *testing.T) {
 	}
 
 	expectedDocument := lsif.Document{
-		URI:      "file:///test/root/foo.go",
-		Contains: datastructures.IDSet{},
+		URI:         "file:///test/root/foo.go",
+		Contains:    datastructures.IDSet{},
+		Diagnostics: datastructures.IDSet{},
 	}
 	if diff := cmp.Diff(expectedDocument, document); diff != "" {
 		t.Errorf("unexpected document (-want +got):\n%s", diff)
@@ -193,5 +194,30 @@ func TestUnmarshalPackageInformation(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedPackageInformation, packageInformation); diff != "" {
 		t.Errorf("unexpected package information (-want +got):\n%s", diff)
+	}
+}
+
+func TestUnmarshalDiagnosticResult(t *testing.T) {
+	diagnosticResult, err := unmarshalDiagnosticResult([]byte(`{"id": 18, "type": "vertex", "label": "diagnosticResult", "result": [{"severity": 1, "code": 2322, "source": "eslint", "message": "Type '10' is not assignable to type 'string'.", "range": {"start": {"line": 1, "character": 5}, "end": {"line": 1, "character": 6}}}]}`))
+	if err != nil {
+		t.Fatalf("unexpected error unmarshalling diagnostic result data: %s", err)
+	}
+
+	expectedDiagnosticResult := lsif.DiagnosticResult{
+		Result: []lsif.Diagnostic{
+			{
+				Severity:       1,
+				Code:           "2322",
+				Message:        "Type '10' is not assignable to type 'string'.",
+				Source:         "eslint",
+				StartLine:      1,
+				StartCharacter: 5,
+				EndLine:        1,
+				EndCharacter:   6,
+			},
+		},
+	}
+	if diff := cmp.Diff(expectedDiagnosticResult, diagnosticResult); diff != "" {
+		t.Errorf("unexpected diagnostic result (-want +got):\n%s", diff)
 	}
 }

--- a/cmd/precise-code-intel-worker/internal/correlation/lsif/types.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/lsif/types.go
@@ -22,8 +22,9 @@ type MetaData struct {
 }
 
 type Document struct {
-	URI      string
-	Contains datastructures.IDSet
+	URI         string
+	Contains    datastructures.IDSet
+	Diagnostics datastructures.IDSet
 }
 
 type Range struct {
@@ -151,4 +152,19 @@ func (d Moniker) SetPackageInformationID(id string) Moniker {
 type PackageInformation struct {
 	Name    string
 	Version string
+}
+
+type DiagnosticResult struct {
+	Result []Diagnostic
+}
+
+type Diagnostic struct {
+	Severity       int
+	Code           string
+	Message        string
+	Source         string
+	StartLine      int
+	StartCharacter int
+	EndLine        int
+	EndCharacter   int
 }

--- a/cmd/precise-code-intel-worker/internal/correlation/state.go
+++ b/cmd/precise-code-intel-worker/internal/correlation/state.go
@@ -17,6 +17,7 @@ type State struct {
 	HoverData              map[string]string
 	MonikerData            map[string]lsif.Moniker
 	PackageInformationData map[string]lsif.PackageInformation
+	Diagnostics            map[string]lsif.DiagnosticResult
 	NextData               map[string]string            // maps vertices related via next edges
 	ImportedMonikers       datastructures.IDSet         // moniker ids that have kind "import"
 	ExportedMonikers       datastructures.IDSet         // moniker ids that have kind "export"
@@ -35,6 +36,7 @@ func newState() *State {
 		HoverData:              map[string]string{},
 		MonikerData:            map[string]lsif.Moniker{},
 		PackageInformationData: map[string]lsif.PackageInformation{},
+		Diagnostics:            map[string]lsif.DiagnosticResult{},
 		NextData:               map[string]string{},
 		ImportedMonikers:       datastructures.IDSet{},
 		ExportedMonikers:       datastructures.IDSet{},

--- a/cmd/precise-code-intel-worker/testdata/dump1.lsif
+++ b/cmd/precise-code-intel-worker/testdata/dump1.lsif
@@ -46,3 +46,5 @@
 {"id": "46", "type": "edge", "label": "packageInformation", "outV": "19", "inV": "23"}
 {"id": "47", "type": "edge", "label": "contains", "outV": "02", "inVs": ["04", "05", "06"]}
 {"id": "48", "type": "edge", "label": "contains", "outV": "03", "inVs": ["07", "08", "09"]}
+{"id": "49", "type": "vertex", "label": "diagnosticResult", "result": [{"severity": 1, "code": 2322, "message": "Type '10' is not assignable to type 'string'.", "source": "eslint", "range": {"start": {"line": 1, "character": 5}, "end": {"line": 1, "character": 6}}}]}
+{"id": "50", "type": "edge", "label": "textDocument/diagnostic", "outV": "02", "inV": "49"}

--- a/internal/codeintel/bundles/types/types.go
+++ b/internal/codeintel/bundles/types/types.go
@@ -15,6 +15,7 @@ type DocumentData struct {
 	HoverResults       map[ID]string // hover text normalized to markdown string
 	Monikers           map[ID]MonikerData
 	PackageInformation map[ID]PackageInformationData
+	Diagnostics        []DiagnosticData
 }
 
 // RangeData represents a range vertex within an index. It contains the same relevant
@@ -47,6 +48,19 @@ type PackageInformationData struct {
 
 	// Version of the package.
 	Version string
+}
+
+// DiagnosticData carries diagnostic information attached to a range within its
+// containing document.
+type DiagnosticData struct {
+	Severity       int
+	Code           string
+	Message        string
+	Source         string
+	StartLine      int // 0-indexed, inclusive
+	StartCharacter int // 0-indexed, inclusive
+	EndLine        int // 0-indexed, inclusive
+	EndCharacter   int // 0-indexed, inclusive
 }
 
 // ResultChunkData represents a row of the resultChunk table. Each row is a subset


### PR DESCRIPTION
Parse diagnostic results from LSIF input and add them to the document payload.