### PR TITLE
docker-images(cadvisor): bake in a set of default args

### DIFF
--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,0 +1,27 @@
+FROM gcr.io/google-containers/cadvisor:v0.35.0@sha256:4074c8bc608b78af3ca3d6e60b3794369a190ab2efd992e31b3079b075401efa
+LABEL com.sourcegraph.cadvisor.version=v0.35.0
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.url=https://sourcegraph.com/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
+LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
+
+# Reflects cAdvisor Dockerfile at https://github.com/google/cadvisor/blob/master/deploy/Dockerfile
+# alongside additional Sourcegraph defaults.
+ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr", \
+    # sourcegraph cAdvisor custom port
+    "-port=48080", \
+    # only enable certain metrics, based on kubelet master
+    "-disable_metrics=percpu,sched,tcp,udp", \
+    # other kubelet defaults (v0.35.0)
+    # see https://sourcegraph.com/github.com/google/cadvisor@v0.35.0/-/blob/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+    "-housekeeping_interval=10s", \
+    "-max_housekeeping_interval=15s", \
+    "-event_storage_event_limit=default=0", \
+    "-event_storage_age_limit=default=0"]

--- a/docker-images/cadvisor/build.sh
+++ b/docker-images/cadvisor/build.sh
@@ -2,6 +2,8 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
-# This merely re-tags the image to match our official versioning scheme.
-docker pull gcr.io/google-containers/cadvisor:v0.35.0@sha256:4074c8bc608b78af3ca3d6e60b3794369a190ab2efd992e31b3079b075401efa
-docker tag gcr.io/google-containers/cadvisor:v0.35.0@sha256:4074c8bc608b78af3ca3d6e60b3794369a190ab2efd992e31b3079b075401efa "$IMAGE"
+docker build --no-cache -t "${IMAGE:-'sourcegraph/cadvisor'}" . \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION


### PR DESCRIPTION
This bakes in the set of arguments used to reduce memory usage and prometheus load on our clusters into our cAdvisor image.

There are two additional arguments we use:

```
-store_container_labels=false -whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid
```

opting not to bake these in because they are k8s-specific. From what I understand, adding the args when running will append (not override) flags so this should set the correct flags (inspect seems to imply as much):

```
docker run -d sourcegraph/cadvisor:dev -store_container_labels=false -whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid
```

Will update https://github.com/sourcegraph/deploy-sourcegraph/pull/722, https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/118 with the reduced arg set

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
