### PR TITLE
search: refine or-expression converter

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -143,10 +143,12 @@ func substituteOrForRegexp(nodes []Node) []Node {
 				for _, node := range patterns {
 					values = append(values, node.(Pattern).Value)
 				}
-				valueString := strings.Join(values, "|")
+				valueString := "(" + strings.Join(values, ")|(") + ")"
 				new = append(new, Pattern{Value: valueString})
-				rest = substituteOrForRegexp(rest)
-				new = newOperator(append(new, rest...), Or)
+				if len(rest) > 0 {
+					rest = substituteOrForRegexp(rest)
+					new = newOperator(append(new, rest...), Or)
+				}
 			} else {
 				new = append(new, newOperator(substituteOrForRegexp(v.Operands), v.Kind)...)
 			}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -190,27 +190,31 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 	}{
 		{
 			input: "foo or bar",
-			want:  `"foo|bar"`,
+			want:  `"(foo)|(bar)"`,
 		},
 		{
 			input: "(foo or (bar or baz))",
-			want:  `"foo|bar|baz"`,
+			want:  `"(foo)|(bar)|(baz)"`,
 		},
 		{
 			input: "repo:foobar foo or (bar or baz)",
-			want:  `(or "bar|baz" (and "repo:foobar" "foo"))`,
+			want:  `(or "(bar)|(baz)" (and "repo:foobar" "foo"))`,
 		},
 		{
 			input: "(foo or (bar or baz)) and foobar",
-			want:  `(and "foo|bar|baz" "foobar")`,
+			want:  `(and "(foo)|(bar)|(baz)" "foobar")`,
 		},
 		{
 			input: "(foo or (bar and baz))",
-			want:  `(or "foo" (and "bar" "baz"))`,
+			want:  `(or "(foo)" (and "bar" "baz"))`,
 		},
 		{
 			input: "foo or (bar and baz) or foobar",
-			want:  `(or "foo|foobar" (and "bar" "baz"))`,
+			want:  `(or "(foo)|(foobar)" (and "bar" "baz"))`,
+		},
+		{
+			input: "repo:foo a or b",
+			want:  `(and "repo:foo" "(a)|(b)")`,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
- Fixes a case where `repo:foo a or b` converts to `(or (a|b)` instead of `(and (a|b)`
- Groups expressions `(...`) that are concatted by `|`. I don't have a concrete example for when this breaks, but since regex has different operator precedence, not grouping `|` will probably be wrong for some patterns.