### PR TITLE
search: allow mixed regexp patterns and quoted patterns

### DIFF
--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -18,42 +18,38 @@ var tests = []test{
 	// Repo search (part 1).
 	{
 		Name:  `Global search, repo search by name, nonzero result`,
-		Query: `repo:auth0/go-jwt-middleware$`,
+		Query: `repo:auth0-go-jwt-middleware$`,
 	},
 	{
 		Name:  `Global search, repo search by name, case yes, nonzero result`,
-		Query: `String repo:^github.com/adjust/go-wrk$ case:yes count:1 stable:yes`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ String case:yes count:1 stable:yes`,
 	},
 	// Text search, focused to repo.
 	{
-		Name:  `Global search, non-master branch, large repo, nonzero result`,
+		Name:  `Repo search, non-master branch, nonzero result`,
 		Query: `repo:^github.com/facebook/react$@0.3-stable var ExecutionEnvironment = require('ExecutionEnvironment'); patterntype:literal count:1 stable:yes`,
 	},
 	{
-		Name:  `Global search, indexed multiline search, nonzero result`,
-		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this patterntype:regexp count:1 stable:yes`,
+		Name:  `Repo search, indexed multiline search, nonzero result`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \nimport index:only count:1 stable:yes`,
 	},
 	{
-		Name:  `Global search, indexed multiline search, zero results`,
-		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this\.props\.sourcegraph\(`,
+		Name:  `Repo search, unindexed multiline search, nonzero result`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \nimport index:no count:1 stable:yes`,
 	},
 	{
-		Name:  `Global search, unindexed multiline search, nonzero result`,
-		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this index:no count:1 stable:yes`,
-	},
-	{
-		Name:  `Global search, unindexed multiline search, zero results`,
-		Query: `repo:^github\.com/facebook/react$ componentDidMount\(\) {\n\s*this\.props\.sourcegraph\( index:no`,
+		Name:  `Repo search, zero results`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ doesnot734734743734743exist`,
 	},
 	// Commit search.
 	{
 		Name:  `Commit search, nonzero result`,
-		Query: `repo:^github\.com/facebook/react$ type:commit hello world count:1`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ type:commit count:1`,
 	},
 	// Diff search.
 	{
 		Name:  `Diff search, nonzero result`,
-		Query: `repo:^github\.com/sgtest/mux$ type:diff main count:1`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ type:diff os.Args count:1`,
 	},
 	// Timeout search options.
 	{
@@ -67,17 +63,13 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, double-quoted pattern, nonzero result`,
-		Query: `"error type:\n" count:1 stable:yes`,
+		Query: `"error type:\n" patterntype:regexp count:1 stable:yes`,
 	},
 	{
 		Name:  `Global search, exclude repo, nonzero result`,
-		Query: `"error type:\n" count:1 -repo:DirectXMan12 stable:yes`,
+		Query: `"error type:\n" -repo:DirectXMan12 patterntype:regexp count:1 stable:yes`,
 	},
 	// Repohascommitafter.
-	{
-		Name:  `Global search, repohascommitafter, nonzero result`,
-		Query: `repohascommitafter:"5 months ago" test patterntype:literal count:1 stable:yes`,
-	},
 	{
 		Name:  `Global search, repohascommitafter, nonzero result`,
 		Query: `repohascommitafter:"5 months ago" test patterntype:literal count:1 stable:yes`,
@@ -85,7 +77,7 @@ var tests = []test{
 	// Global regex text search.
 	{
 		Name:  `Global search, regex, unindexed, nonzero result`,
-		Query: `^func.*$ index:only count:1 stable:yes`,
+		Query: `^func.*$ patterntype:regexp index:only count:1 stable:yes`,
 	},
 	{
 		Name:  `Global search, fork only, nonzero result`,
@@ -93,7 +85,7 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, filter by language`,
-		Query: `\bfunc\b lang:js count:1 stable:yes`,
+		Query: `\bfunc\b lang:go count:1 stable:yes`,
 	},
 	{
 		Name:  `Global search, filename, zero results`,
@@ -111,7 +103,7 @@ var tests = []test{
 	// Structural search.
 	{
 		Name:  `Global search, structural, index only, nonzero result`,
-		Query: `repo:^github\.com/facebook/react$ index:only patterntype:structural toHaveYielded(:[args]) count:5`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ make(:[1]) index:only patterntype:structural count:3`,
 	},
 	// Repo search (part 2).
 	{
@@ -128,15 +120,15 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, fork excluded, zero results`,
-		Query: `type:repo sgtest/mux`,
+		Query: `type:repo sgtest-mux`,
 	},
 	{
 		Name:  `Global search, fork included, nonzero result`,
-		Query: `type:repo sgtest/mux fork:yes`,
+		Query: `type:repo sgtest-mux fork:yes`,
 	},
 	{
 		Name:  `Global search, fork included if exact without option, nonzero result`,
-		Query: `repo:^github\.com/sgtest/mux$`,
+		Query: `repo:^github\.com/rvantonderp/sgtest-mux$`,
 	},
 	{
 		Name:  `Global search, exclude counts for fork and archive`,
@@ -145,27 +137,27 @@ var tests = []test{
 	// And/Or queries.
 	{
 		Name:  `And operator, basic`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ func and main type:file stable:yes count:1 lang:go file:^cmd/frontend/auth/user_test\.go$ patterntype:regexp`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ func and main count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Or operator, single and double quoted`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ 'Search()' or "generate" type:file stable:yes lang:go file:^cmd/frontend/graphqlbackend/codeintel_usage_stats\.go$|^cmd/frontend/authz/perms.go$ patterntype:regexp`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ "readConfig()" or 'buildHeaders' stable:yes type:file count:1 patterntype:regexp`,
 	},
 	{
 		Name:  `Literals, grouped parens with parens-as-patterns heuristic`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ (() or ()) stable:yes type:file count:1 file:^\.buildkite/hooks/pre-command$ patterntype:regexp`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ (() or ()) stable:yes type:file count:1 patterntype:regexp`,
 	},
 	{
 		Name:  `Literals, no grouped parens`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ () or () stable:yes type:file count:1 file:^\.buildkite/hooks/pre-command$ patterntype:regexp`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ () or () stable:yes type:file count:1 patterntype:regexp`,
 	},
 	{
 		Name:  `Literals, escaped parens`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ \(\) or \(\) stable:yes type:file count:1 file:^\.buildkite/hooks/pre-command$ patterntype:regexp`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \(\) or \(\) stable:yes type:file count:1 patterntype:regexp`,
 	},
 	{
 		Name:  `Literals, escaped and unescaped parens`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ (() or \(\)) stable:yes type:file count:1 file:^\.buildkite/hooks/pre-command$`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ (() or \(\)) stable:yes type:file count:1 patterntype:regexp`,
 	},
 	{
 		Name:  `Literals, escaped and unescaped parens, no group`,
@@ -173,27 +165,35 @@ var tests = []test{
 	},
 	{
 		Name:  `Literals, double paren`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ ()() or ()()`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ ()() or ()()`,
 	},
 	{
 		Name:  `Literals, double paren, dangling paren right side`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ ()() or main()(`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ ()() or main()(`,
 	},
 	{
 		Name:  `Literals, double paren, dangling paren left side`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ ()( or ()()`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ ()( or ()()`,
 	},
 	{
 		Name:  `Mixed regexp and literal`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ func(.*) or does_not_exist_3744`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ func(.*) or does_not_exist_3744 count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Mixed regexp and literal heuristic`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ func(.*) or func(`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ func( or func(.*) count:1 stable:yes type:file`,
+	},
+	{
+		Name:  `Mixed regexp and quoted literal`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ "*" and cert.*Load count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Escape sequences`,
-		Query: `repo:^github\.com/sourcegraph/sourcegraph$ \' and \" and \\ and / file:^\.buildkite/hooks/pre-command$`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \' and \" and \\ and /`,
+	},
+	{
+		Name:  `Escaped whitespace sequences with 'and'`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \ and /`,
 	},
 }
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -504,12 +504,18 @@ func (p *parser) ParseSearchPatternHeuristic() (Node, bool) {
 	}
 	// The heuristic succeeds: we can process the string as a pure search pattern.
 	p.pos += advance
+
+	var labels labels
+	if !ContainsRegexpMetasyntax(string(p.buf[start:end])) {
+		labels = Literal | HeuristicParensAsPatterns
+	}
+
 	if len(pieces) == 1 {
-		return Pattern{Value: pieces[0], Annotation: Annotation{Labels: Literal | HeuristicParensAsPatterns}}, true
+		return Pattern{Value: pieces[0], Annotation: Annotation{Labels: labels}}, true
 	}
 	patterns := []Node{}
 	for _, piece := range pieces {
-		patterns = append(patterns, Pattern{Value: piece, Annotation: Annotation{Labels: Literal | HeuristicParensAsPatterns}})
+		patterns = append(patterns, Pattern{Value: piece, Annotation: Annotation{labels}})
 	}
 	return Operator{Kind: Concat, Operands: patterns}, true
 }

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -79,6 +79,19 @@ func ContainsAndOrKeyword(input string) bool {
 	return strings.Contains(lower, " and ") || strings.Contains(lower, " or ")
 }
 
+// ContainsRegexpMetasyntax returns true if a string is a valid regular
+// expression and contains regex metasyntax (i.e., it is not a literal).
+func ContainsRegexpMetasyntax(input string) bool {
+	_, err := regexp.Compile(input)
+	if err == nil {
+		// It is a regexp. But does it contain metasyntax, or is it literal?
+		if len(regexp.QuoteMeta(input)) != len(input) {
+			return true
+		}
+	}
+	return false
+}
+
 // processTopLevel processes the top level of a query. It validates that we can
 // process the query with respect to and/or expressions on file content, but not
 // otherwise for nested parameters.


### PR DESCRIPTION
Review by commit--

The first commit just makes it possible to do things like `reg.*p or "quoted literal thing"` by disallowing a heuristic interpretation of a pattern. The exact mechanism (see inline comment) that does this is a workaround that I'll restructure after I've pinned down the behavior by tests.

The second commit helps pin down the behavior with updated tests :-) For my test purposes, I've changed the repos to test against so that they are smaller and frozen to an exact commit, on another GH account.

