### PR TITLE
github: update VCR for `ListRepositoryCollaborators`

### DIFF
--- a/internal/extsvc/github/testdata/vcr/ListRepositoryCollaborators_private-repo.yaml
+++ b/internal/extsvc/github/testdata/vcr/ListRepositoryCollaborators_private-repo.yaml
@@ -13,14 +13,12 @@ interactions:
     url: https://api.github.com/repos/sourcegraph-vcr-repos/private-org-repo-1/collaborators?page=1&per_page=100
     method: GET
   response:
-    body: '[{"login":"sourcegraph-dogfood-user","id":39098008,"node_id":"MDQ6VXNlcjM5MDk4MDA4","avatar_url":"https://avatars2.githubusercontent.com/u/39098008?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph-dogfood-user","html_url":"https://github.com/sourcegraph-dogfood-user","followers_url":"https://api.github.com/users/sourcegraph-dogfood-user/followers","following_url":"https://api.github.com/users/sourcegraph-dogfood-user/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph-dogfood-user/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph-dogfood-user/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph-dogfood-user/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph-dogfood-user/orgs","repos_url":"https://api.github.com/users/sourcegraph-dogfood-user/repos","events_url":"https://api.github.com/users/sourcegraph-dogfood-user/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph-dogfood-user/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":false,"pull":true}},{"login":"sourcegraph-vcr","id":63290851,"node_id":"MDQ6VXNlcjYzMjkwODUx","avatar_url":"https://avatars3.githubusercontent.com/u/63290851?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph-vcr","html_url":"https://github.com/sourcegraph-vcr","followers_url":"https://api.github.com/users/sourcegraph-vcr/followers","following_url":"https://api.github.com/users/sourcegraph-vcr/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph-vcr/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph-vcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph-vcr/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph-vcr/orgs","repos_url":"https://api.github.com/users/sourcegraph-vcr/repos","events_url":"https://api.github.com/users/sourcegraph-vcr/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph-vcr/received_events","type":"User","site_admin":false,"permissions":{"admin":true,"push":true,"pull":true}},{"login":"sourcegraph-vcr-amy","id":66464773,"node_id":"MDQ6VXNlcjY2NDY0Nzcz","avatar_url":"https://avatars3.githubusercontent.com/u/66464773?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph-vcr-amy","html_url":"https://github.com/sourcegraph-vcr-amy","followers_url":"https://api.github.com/users/sourcegraph-vcr-amy/followers","following_url":"https://api.github.com/users/sourcegraph-vcr-amy/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph-vcr-amy/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph-vcr-amy/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph-vcr-amy/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph-vcr-amy/orgs","repos_url":"https://api.github.com/users/sourcegraph-vcr-amy/repos","events_url":"https://api.github.com/users/sourcegraph-vcr-amy/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph-vcr-amy/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":false,"pull":true}}]'
+    body: '[{"login":"sourcegraph-vcr","id":63290851,"node_id":"MDQ6VXNlcjYzMjkwODUx","avatar_url":"https://avatars3.githubusercontent.com/u/63290851?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph-vcr","html_url":"https://github.com/sourcegraph-vcr","followers_url":"https://api.github.com/users/sourcegraph-vcr/followers","following_url":"https://api.github.com/users/sourcegraph-vcr/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph-vcr/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph-vcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph-vcr/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph-vcr/orgs","repos_url":"https://api.github.com/users/sourcegraph-vcr/repos","events_url":"https://api.github.com/users/sourcegraph-vcr/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph-vcr/received_events","type":"User","site_admin":false,"permissions":{"admin":true,"push":true,"pull":true}},{"login":"sourcegraph-vcr-amy","id":66464773,"node_id":"MDQ6VXNlcjY2NDY0Nzcz","avatar_url":"https://avatars3.githubusercontent.com/u/66464773?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph-vcr-amy","html_url":"https://github.com/sourcegraph-vcr-amy","followers_url":"https://api.github.com/users/sourcegraph-vcr-amy/followers","following_url":"https://api.github.com/users/sourcegraph-vcr-amy/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph-vcr-amy/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph-vcr-amy/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph-vcr-amy/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph-vcr-amy/orgs","repos_url":"https://api.github.com/users/sourcegraph-vcr-amy/repos","events_url":"https://api.github.com/users/sourcegraph-vcr-amy/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph-vcr-amy/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":false,"pull":true}},{"login":"sourcegraph-vcr-bob","id":66464926,"node_id":"MDQ6VXNlcjY2NDY0OTI2","avatar_url":"https://avatars1.githubusercontent.com/u/66464926?v=4","gravatar_id":"","url":"https://api.github.com/users/sourcegraph-vcr-bob","html_url":"https://github.com/sourcegraph-vcr-bob","followers_url":"https://api.github.com/users/sourcegraph-vcr-bob/followers","following_url":"https://api.github.com/users/sourcegraph-vcr-bob/following{/other_user}","gists_url":"https://api.github.com/users/sourcegraph-vcr-bob/gists{/gist_id}","starred_url":"https://api.github.com/users/sourcegraph-vcr-bob/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/sourcegraph-vcr-bob/subscriptions","organizations_url":"https://api.github.com/users/sourcegraph-vcr-bob/orgs","repos_url":"https://api.github.com/users/sourcegraph-vcr-bob/repos","events_url":"https://api.github.com/users/sourcegraph-vcr-bob/events{/privacy}","received_events_url":"https://api.github.com/users/sourcegraph-vcr-bob/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":false,"pull":true}}]'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Security-Policy:
@@ -28,9 +26,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 08 Jun 2020 02:39:08 GMT
+      - Tue, 09 Jun 2020 06:49:46 GMT
       Etag:
-      - W/"a8df8a086bbe78a516cf1a7626a9b962"
+      - W/"345db0dbe2756279da7ccb42eec57bbe"
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -49,20 +47,17 @@ interactions:
       X-Frame-Options:
       - deny
       X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json, github.machine-man-preview; format=json
       X-Github-Request-Id:
-      - B80B:3850:3A1F99:9BDCF9:5EDDA4CB
+      - 88DF:243E:2A8F630:489B579:5EDF310A
       X-Oauth-Scopes:
-      - admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-        admin:repo_hook, delete:packages, delete_repo, gist, notifications, read:packages,
-        repo, user, workflow, write:discussion, write:packages
+      - admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist, notifications, read:packages, repo, user, workflow, write:discussion, write:packages
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
       - "4998"
       X-Ratelimit-Reset:
-      - "1591587547"
+      - "1591688986"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/internal/extsvc/github/testdata/vcr/ListRepositoryCollaborators_public-repo.yaml
+++ b/internal/extsvc/github/testdata/vcr/ListRepositoryCollaborators_public-repo.yaml
@@ -18,9 +18,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Security-Policy:
@@ -28,7 +26,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 08 Jun 2020 02:39:07 GMT
+      - Tue, 09 Jun 2020 06:49:46 GMT
       Etag:
       - W/"1875c98197830a53e3c5425d7920d302"
       Referrer-Policy:
@@ -49,20 +47,17 @@ interactions:
       X-Frame-Options:
       - deny
       X-Github-Media-Type:
-      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json,
-        github.machine-man-preview; format=json
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; format=json, github.machine-man-preview; format=json
       X-Github-Request-Id:
-      - B80B:3850:3A1F8F:9BDCF0:5EDDA4CB
+      - 88DF:243E:2A8F600:489B567:5EDF3109
       X-Oauth-Scopes:
-      - admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-        admin:repo_hook, delete:packages, delete_repo, gist, notifications, read:packages,
-        repo, user, workflow, write:discussion, write:packages
+      - admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist, notifications, read:packages, repo, user, workflow, write:discussion, write:packages
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
       - "4999"
       X-Ratelimit-Reset:
-      - "1591587547"
+      - "1591688986"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/internal/extsvc/github/user_test.go
+++ b/internal/extsvc/github/user_test.go
@@ -36,14 +36,14 @@ func TestClient_ListRepositoryCollaborators(t *testing.T) {
 			repo:  "private-org-repo-1",
 			wantUsers: []*Collaborator{
 				{
-					ID:         "MDQ6VXNlcjM5MDk4MDA4", // sourcegraph-dogfood-user as outside collaborator
-					DatabaseID: 39098008,
-				}, {
 					ID:         "MDQ6VXNlcjYzMjkwODUx", // sourcegraph-vcr as owner
 					DatabaseID: 63290851,
 				}, {
 					ID:         "MDQ6VXNlcjY2NDY0Nzcz", // sourcegraph-vcr-amy as organization member
 					DatabaseID: 66464773,
+				}, {
+					ID:         "MDQ6VXNlcjY2NDY0OTI2", // sourcegraph-vcr-bob as outside collaborator
+					DatabaseID: 66464926,
 				},
 			},
 		},


### PR DESCRIPTION
Follow up PR of https://github.com/sourcegraph/sourcegraph/pull/11304.

Previously using `sourcegraph-dogfood-user` because `sourcegraph-vcr-bob` was flagged. Now it is resolved by contacting GitHub Support. So updating.