### PR TITLE
e2e: add tests for access token

### DIFF
--- a/dev/e2e/access_token_test.go
+++ b/dev/e2e/access_token_test.go
@@ -1,0 +1,39 @@
+// +build e2e
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestAccessToken(t *testing.T) {
+	t.Run("create a token and test it", func(t *testing.T) {
+		token, err := client.CreateAccessToken("TestAccessToken", []string{"user:all"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := client.DeleteAccessToken(token)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		_, err = client.CurrentUserID(token)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("use an invalid token gets 401", func(t *testing.T) {
+		_, err := client.CurrentUserID("a bad token")
+		gotErr := fmt.Sprintf("%v", errors.Cause(err))
+		wantErr := "401: Invalid access token.\n"
+		if gotErr != wantErr {
+			t.Fatalf("err: want %q but got %q", wantErr, gotErr)
+		}
+	})
+}

--- a/internal/e2eutil/access_token.go
+++ b/internal/e2eutil/access_token.go
@@ -1,0 +1,53 @@
+package e2eutil
+
+import (
+	"github.com/pkg/errors"
+)
+
+// CreateAccessToken creates a new access token with given note and scopes for the
+// authenticated user. It returns the new access token created.
+func (c *Client) CreateAccessToken(note string, scopes []string) (string, error) {
+	const query = `
+mutation CreateAccessToken($user: ID!, $scopes: [String!]!, $note: String!) {
+	createAccessToken(user: $user, scopes: $scopes, note: $note) {
+		token
+	}
+}
+`
+	variables := map[string]interface{}{
+		"user":   c.userID,
+		"scopes": scopes,
+		"note":   note,
+	}
+	var resp struct {
+		Data struct {
+			CreateAccessToken struct {
+				Token string `json:"token"`
+			} `json:"createAccessToken"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "request GraphQL")
+	}
+	return resp.Data.CreateAccessToken.Token, nil
+}
+
+// DeleteAccessToken deletes the given access token of the authenticated user.
+func (c *Client) DeleteAccessToken(token string) error {
+	const query = `
+mutation DeleteAccessToken($token: String!) {
+	deleteAccessToken(byToken: $token) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]interface{}{
+		"token": token,
+	}
+	err := c.GraphQL("", query, variables, nil)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
+}

--- a/internal/e2eutil/client.go
+++ b/internal/e2eutil/client.go
@@ -252,8 +252,8 @@ func (c *Client) GraphQL(token, query string, variables map[string]interface{}, 
 		return errors.Wrap(err, "read response body")
 	}
 
-	// Quick check if the response is a JSON
-	if len(body) > 0 && body[0] == '{' {
+	// Check if the response format should be JSON
+	if strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
 		// Try and see unmarshalling to errors
 		var errResp struct {
 			Errors []struct {

--- a/internal/e2eutil/client.go
+++ b/internal/e2eutil/client.go
@@ -182,7 +182,7 @@ func (c *Client) authenticate(path string, body interface{}) error {
 	}
 	c.sessionCookie = sessionCookie
 
-	userID, err := c.currentUserID()
+	userID, err := c.CurrentUserID("")
 	if err != nil {
 		return errors.Wrap(err, "get current user")
 	}
@@ -190,8 +190,9 @@ func (c *Client) authenticate(path string, body interface{}) error {
 	return nil
 }
 
-// currentUserID returns the current user's GraphQL node ID.
-func (c *Client) currentUserID() (string, error) {
+// CurrentUserID returns the current authenticated user's GraphQL node ID.
+// An optional token can be passed to impersonate other users.
+func (c *Client) CurrentUserID(token string) (string, error) {
 	const query = `
 	query {
 		currentUser {
@@ -206,7 +207,7 @@ func (c *Client) currentUserID() (string, error) {
 			} `json:"currentUser"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", query, nil, &resp)
+	err := c.GraphQL(token, query, nil, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}


### PR DESCRIPTION
Adds e2e tests for access token, which covers ([source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f3c0274598f5cba73256a8a55db75519be58a7c5/-/blob/web/src/regression/core.test.ts#L203:1)):

- Create, test and delete a valid access token.
- Use of an invalid token gets 401.

Easier to review by commit.

Part of #10068