### PR TITLE
In campaign update without patchset ID, skip changesets where permissions are missing

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -932,8 +932,7 @@ func (s *Service) UpdateCampaign(ctx context.Context, args UpdateCampaignArgs) (
 			return campaign, nil, err
 		}
 
-		opts := ResetChangesetJobsOpts{CampaignID: campaign.ID, OnlyFailed: false}
-		return campaign, nil, tx.ResetChangesetJobs(ctx, opts)
+		return campaign, nil, resetAccessibleChangesetJobs(ctx, tx, campaign)
 	}
 
 	diff, err := computeCampaignUpdateDiff(ctx, tx, campaign, oldPatchSetID, updateAttributes)
@@ -1015,6 +1014,41 @@ type repoGroup struct {
 	patch        *campaigns.Patch
 	newPatch     *campaigns.Patch
 	changeset    *campaigns.Changeset
+}
+
+func resetAccessibleChangesetJobs(ctx context.Context, tx *Store, campaign *campaigns.Campaign) error {
+	patches, _, err := tx.ListPatches(ctx, ListPatchesOpts{
+		PatchSetID:   campaign.PatchSetID,
+		Limit:        -1,
+		OnlyWithDiff: true,
+	})
+	if err != nil {
+		return errors.Wrap(err, "listing patches")
+	}
+
+	repoIDs := make([]api.RepoID, 0, len(patches))
+	for _, p := range patches {
+		repoIDs = append(repoIDs, p.RepoID)
+	}
+
+	accessibleRepoIDs, err := accessibleRepos(ctx, repoIDs)
+	if err != nil {
+		return err
+	}
+
+	var resetPatchIDs []int64
+	for _, p := range patches {
+		if _, ok := accessibleRepoIDs[p.RepoID]; !ok {
+			continue
+		}
+
+		resetPatchIDs = append(resetPatchIDs, p.ID)
+	}
+
+	return tx.ResetChangesetJobs(ctx, ResetChangesetJobsOpts{
+		CampaignID: campaign.ID,
+		PatchIDs:   resetPatchIDs,
+	})
 }
 
 func computeCampaignUpdateDiff(

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -1346,6 +1346,22 @@ func TestService_UpdateCampaignWithNewPatchSetID(t *testing.T) {
 			wantModified:      repoNames{"repo-0"},
 		},
 		{
+			name:             "no new patch set but name update, missing repo permissions",
+			updateName:       true,
+			oldPatches:       repoNames{"repo-0", "repo-1"},
+			missingRepoPerms: repoNames{"repo-1"},
+			wantModified:     repoNames{"repo-0"},
+			wantUnmodified:   repoNames{"repo-1"},
+		},
+		{
+			name:              "no new patch set but description update, missing repo permissions",
+			updateDescription: true,
+			oldPatches:        repoNames{"repo-0", "repo-1"},
+			missingRepoPerms:  repoNames{"repo-1"},
+			wantModified:      repoNames{"repo-0"},
+			wantUnmodified:    repoNames{"repo-1"},
+		},
+		{
 			name:           "1 modified diff",
 			updatePatchSet: true,
 			oldPatches:     repoNames{"repo-0"},


### PR DESCRIPTION
This is the bit I was missing in the previous PR: if we update a campaign without updating its patchset, we previously reset all changesets jobs so that all those changesets are updated.

Now we can only reset those changeset jobs the user has access to.
