### PR TITLE
codeintel: Add exact path to FindClosestDumps

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -303,6 +303,7 @@ func (r *GitTreeEntryResolver) LSIF(ctx context.Context, args *struct{ Indexer *
 		Repository: r.Repository(),
 		Commit:     api.CommitID(r.Commit().OID()),
 		Path:       r.Path(),
+		ExactPath:  !r.stat.IsDir(),
 		Indexer:    indexer,
 	})
 }

--- a/enterprise/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/internal/codeintel/resolvers/resolver.go
@@ -156,8 +156,8 @@ func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*graphql
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
-func (r *Resolver) LSIF(ctx context.Context, args *graphqlbackend.LSIFQueryArgs) (graphqlbackend.LSIFQueryResolver, error) {
-	dumps, err := r.codeIntelAPI.FindClosestDumps(ctx, int(args.Repository.Type().ID), string(args.Commit), args.Path, args.Indexer)
+func (r *Resolver) GitBlobLSIFData(ctx context.Context, args *graphqlbackend.GitBlobLSIFDataArgs) (graphqlbackend.GitBlobLSIFDataResolver, error) {
+	dumps, err := r.codeIntelAPI.FindClosestDumps(ctx, int(args.Repository.Type().ID), string(args.Commit), args.Path, args.ExactPath, args.Indexer)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/api/api.go
+++ b/internal/codeintel/api/api.go
@@ -12,9 +12,11 @@ import (
 // CodeIntelAPI is the main interface into precise code intelligence data.
 type CodeIntelAPI interface {
 	// FindClosestDumps returns the set of dumps that can most accurately answer code intelligence
-	// queries for the given file. These dump IDs should be subsequently passed to invocations of
+	// queries for the given path. If exactPath is true, then only dumps that definitely contain the
+	// exact document path are returned. Otherwise, dumps containing any document for which the given
+	// path is a prefix are returned. These dump IDs should be subsequently passed to invocations of
 	// Definitions, References, and Hover.
-	FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) ([]db.Dump, error)
+	FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) ([]db.Dump, error)
 
 	// Definitions returns the list of source locations that define the symbol at the given position.
 	// This may include remote definitions if the remote repository is also indexed.

--- a/internal/codeintel/api/exists.go
+++ b/internal/codeintel/api/exists.go
@@ -11,32 +11,39 @@ import (
 )
 
 // FindClosestDumps returns the set of dumps that can most accurately answer code intelligence
-// queries for the given file. These dump IDs should be subsequently passed to invocations of
+// queries for the given path. If exactPath is true, then only dumps that definitely contain the
+// exact document path are returned. Otherwise, dumps containing any document for which the given
+// path is a prefix are returned. These dump IDs should be subsequently passed to invocations of
 // Definitions, References, and Hover.
-func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) ([]db.Dump, error) {
+func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) ([]db.Dump, error) {
 	// See if we know about this commit. If not, we need to update our commits table
 	// and the visibility of the dumps in this repository.
 	if err := api.updateCommitsAndVisibility(ctx, repositoryID, commit); err != nil {
 		return nil, err
 	}
 
-	candidates, err := api.db.FindClosestDumps(ctx, repositoryID, commit, file, indexer)
+	candidates, err := api.db.FindClosestDumps(ctx, repositoryID, commit, path, indexer)
 	if err != nil {
 		return nil, errors.Wrap(err, "db.FindClosestDumps")
 	}
 
 	var dumps []db.Dump
 	for _, dump := range candidates {
-		exists, err := api.bundleManagerClient.BundleClient(dump.ID).Exists(ctx, strings.TrimPrefix(file, dump.Root))
-		if err != nil {
-			if err == client.ErrNotFound {
-				log15.Warn("Bundle does not exist")
-				return nil, nil
+		// TODO(efritz) - ensure there's a valid document path
+		// for the other condition. This should probably look like
+		// an additional parameter on the following exists query.
+		if exactPath {
+			exists, err := api.bundleManagerClient.BundleClient(dump.ID).Exists(ctx, strings.TrimPrefix(path, dump.Root))
+			if err != nil {
+				if err == client.ErrNotFound {
+					log15.Warn("Bundle does not exist")
+					return nil, nil
+				}
+				return nil, errors.Wrap(err, "bundleManagerClient.BundleClient")
 			}
-			return nil, errors.Wrap(err, "bundleManagerClient.BundleClient")
-		}
-		if !exists {
-			continue
+			if !exists {
+				continue
+			}
 		}
 
 		dumps = append(dumps, dump)

--- a/internal/codeintel/api/exists_test.go
+++ b/internal/codeintel/api/exists_test.go
@@ -58,7 +58,7 @@ func TestFindClosestDatabase(t *testing.T) {
 	})
 
 	api := testAPI(mockDB, mockBundleManagerClient, mockGitserverClient)
-	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "s1/main.go", "idx")
+	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest database: %s", err)
 	}
@@ -106,7 +106,7 @@ func TestFindClosestSkipsGitserverIfCommitIsKnown(t *testing.T) {
 	setMockBundleClientExists(t, mockBundleClient, "main.go", true)
 
 	api := New(mockDB, mockBundleManagerClient, mockGitserverClient)
-	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "main.go", "idx")
+	dumps, err := api.FindClosestDumps(context.Background(), 42, testCommit, "main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest database: %s", err)
 	}

--- a/internal/codeintel/api/observability.go
+++ b/internal/codeintel/api/observability.go
@@ -61,10 +61,10 @@ func NewObserved(codeIntelAPI CodeIntelAPI, observationContext *observation.Cont
 }
 
 // FindClosestDumps calls into the inner CodeIntelAPI and registers the observed results.
-func (api *ObservedCodeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) (dumps []db.Dump, err error) {
+func (api *ObservedCodeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (dumps []db.Dump, err error) {
 	ctx, endObservation := api.findClosestDumpsOperation.With(ctx, &err, observation.Args{})
 	defer func() { endObservation(float64(len(dumps)), observation.Args{}) }()
-	return api.codeIntelAPI.FindClosestDumps(ctx, repositoryID, commit, file, indexer)
+	return api.codeIntelAPI.FindClosestDumps(ctx, repositoryID, commit, path, exactPath, indexer)
 }
 
 // Definitions calls into the inner CodeIntelAPI and registers the observed results.


### PR DESCRIPTION
This will be a necessary change once we query all documents within a given tree for diagnostics. This parameter basically acts as a prefix-allowed flag.