### PR TITLE
Add OpenGrok to Sourcegraph search syntax guide

### DIFF
--- a/doc/admin/migration/opengrok.md
+++ b/doc/admin/migration/opengrok.md
@@ -1,5 +1,7 @@
 # Migrating from Oracle OpenGrok to Sourcegraph for code search
 
+> NOTE: This guide helps Sourcegraph admins migrate from deploying Oracle OpenGrok to Sourcegraph. See our [Oracle OpenGrok end user migration guide](../../../user/search/opengrok.md) to learn how to switch from OpenGrok's search syntax to Sourcegraph's.
+
 You can migrate from Oracle's [OpenGrok](https://oracle.github.io/opengrok/) to [Sourcegraph](https://about.sourcegraph.com) for code search by following the steps in this document.
 
 - [Background](opengrok.md#background)

--- a/doc/user/search/opengrok.md
+++ b/doc/user/search/opengrok.md
@@ -65,7 +65,7 @@ Both Sourcegraph and OpenGrok allow users to add keywords for scoping searches. 
 | Search symbol references | `def:pattern` | Available through hover tooltips and `Find references` panels on code pages |
 | Search for repository names | Not supported | `pattern type:repo` |
 | Search for file names | `file:pattern` | `pattern type:repo` |
-| Search commit messages | `hist:pattern` | `pattern type:path` |
+| Search commit messages | `hist:pattern` | `pattern type:commit` |
 | Search code changes (diff search) | Not supported | `pattern type:diff` |
 | Scope searches to a language | `pattern type:c` | `pattern lang:c` |
 | Case sensitivity | Not supported | `case:yes` or `case:no` |
@@ -81,5 +81,4 @@ To see an exhaustive list of Sourcegraph's search keywords, see the [search quer
 **Negating search keywords**
 
 Sourcegraph allows users to negate any search keyword by appending a `-` character to the name. For example, `pattern -repo:foo` will search across all repositories except for those that contain "foo". `pattern -lang:javascript` will search across all non-JavaScript files.
-
 

--- a/doc/user/search/opengrok.md
+++ b/doc/user/search/opengrok.md
@@ -1,0 +1,85 @@
+# Switching from Oracle OpenGrok to Sourcegraph
+
+> NOTE: This guide helps Sourcegraph users switch from using Oracle OpenGrok's search syntax to Sourcegraph's. See our [Oracle OpenGrok admin migration guide](../../admin/migration/opengrok.md) for instructions on switching from an OpenGrok deployment to Sourcegraph.
+
+## Related pages
+
+- [All Sourcegraph search documentation](index.md)
+  - [Sourcegraph query syntax](queries.md)
+- [Search product feature comparisons](https://about.sourcegraph.com/workflow)
+- [OpenGrok to Sourcegraph admin migration guide](../../admin/migration/opengrok.md)
+
+## Switching to Sourcegraph's query syntax
+
+### Wildcards vs. regular expressions
+
+Oracle OpenGrok provides wildcard support for searches. For example, to find all strings beginning with `foo`, you can use the wildcard search `foo*`. Similarly, OpenGrok provides the `?` operator for single character wildcards.
+
+Sourcegraph, [provides full regular expression search](queries.md#regexp-search), with support for the [RE2 syntax](https://golang.org/s/re2syntax). The same search above would take the form `foo.*` (or in this case, just `foo`, since Sourcegraph automatically supports partial matches). Much more powerful regexp expressions are available.
+
+(Note that Sourcegraph also provides a [literal search mode](queries.md#Literal-search--default-) by default, in which there's no need to escape special characters. This simplifies searches such a `foo(`, which would result in an error in regexp mode.)
+
+### Selecting repositories and branches
+
+Oracle OpenGrok provides a multi-select dropdown box to allow users to select which repositories to include in a search. This scope is stored across sessions, until the user changes it.
+
+Sourcegraph provides a search keyword (`repo:`) that supports regexp and partial matches for selecting repositories. As examples: 
+- To search for the string "pattern" in all repositories in the github.com/org org, search for `pattern repo:github.com/org`. 
+- To search in a distinct list of repositories, you can use a `|` character as a regexp OR operator: `pattern repo:github.com/org/repository1|github.com/org/repository2`.
+  - Note this query could be simplified further using more advanced regexp matching if the two repos share part of their names, such as: `pattern repo:github.com/org/repository(1|2)`.
+
+Sourcegraph also allows site admins to create pre-defined repository groupings, using [version contexts](index.md#version-contexts-experimental).
+
+### Searching in non-master (unindexed) branches, tags, and commits
+
+Oracle OpenGrok can only search in the version of code that is stored on disk. To search across multiple revisions or branches, an OpenGrok administrator must explicitly add each of those copies of the code to OpenGrok.
+
+Sourcegraph allows users to search on any Git revision, even if it is not indexed. Users can append `@<git rev>` to the end of any `repo:` keyword to specify which version to search. For example, to search on `feature-branch`, use `pattern repo:github.com/org/repo@feature-branch`, and to search on a commit `abc123`, use `pattern repo:github.com/org/repo@abc123`.
+
+Sourcegraph also provides the ability to search on multiple Git revisions in a single repository at once, using `:` characters to separate revision names in the `repo:` field. For example, search both `feature-branch` and `abc123` in a single query using `pattern repo:github.com/org/repo@feature-branch:abc123`.
+
+### Special characters
+
+Oracle OpenGrok doesn't index most single-character strings (such as for special characters like `{`, `}`, `[`, `]`, `+`, `-`, and more), and non-alpha-numeric characters generally.
+
+Sourcegraph indexes all characters, and can search for strings of any length. Using the default [literal search mode](queries.md#Literal-search--default-), any search (including those with special characters like `foo.bar`, `try {`, `i++`, `i-=1`, `foo->bar`, and more), will all be searchable without special handling. Using [regexp mode](queries.md#regexp-search) would require escaping special charactes.
+
+The only exceptions are colon characters, which are by default used for specifying a search keyword on Sourcegraph (see below). Any search containing colons can be done using the `content:"pattern"` keyword to explicitly mark it as the search string.
+
+### Boolean operators
+
+Oracle OpenGrok provides three boolean operators — `AND`, `OR`, and `NOT` — for scoping searches to files that contain strings that match multiple patterns.
+
+Sourcegraph provides [`AND` and `OR` operators](queries.md#operators).
+
+> NOTE: Operators are available as of Sourcegraph 3.15 and enabled with `{"experimentalFeatures": {"andOrQuery": "enabled"}}` in the site configuration. Built-in operator support is planned for an upcoming release.
+
+### Search keywords
+
+Both Sourcegraph and OpenGrok allow users to add keywords for scoping searches. Below is a mapping from OpenGrok syntax to Sourcegraph.
+
+| | OpenGrok | Sourcegraph |
+|-------------------|------------|--------|
+| Search text | `full:pattern` | `pattern` |
+| Search symbol definitions | `def:pattern` | `pattern type:symbol` |
+| Search symbol references | `def:pattern` | Available through hover tooltips and `Find references` panels on code pages |
+| Search for repository names | Not supported | `pattern type:repo` |
+| Search for file names | `file:pattern` | `pattern type:repo` |
+| Search commit messages | `hist:pattern` | `pattern type:path` |
+| Search code changes (diff search) | Not supported | `pattern type:diff` |
+| Scope searches to a language | `pattern type:c` | `pattern lang:c` |
+| Case sensitivity | Not supported | `case:yes` or `case:no` |
+| Scope searches to forked repositories | Supported through the repository selector | `fork:yes`, `fork:no`, or `fork:only` |
+| Scope searches to archived repositories | Supported through the repository selector | `archived:yes`, `archived:no`, or `archived:only` |
+| Scope searches to repositories that contain a file | Not supported | `pattern repohasfile:foo` |
+| Scope searches to recently updated repositories | Not supported | `pattern repohascommitafter:"3 months"` or `pattern repohascommitafter:"june 25 2017"` |
+
+Sourcegraph also provides keywords to [scope commit message and diff searches](queries.md#keywords--diff-and-commit-searches-only-) to specific authors or timeframes in which a change was made.
+
+To see an exhaustive list of Sourcegraph's search keywords, see the [search query syntax](queries.md#keywords--all-searches-) page.
+
+**Negating search keywords**
+
+Sourcegraph allows users to negate any search keyword by appending a `-` character to the name. For example, `pattern -repo:foo` will search across all repositories except for those that contain "foo". `pattern -lang:javascript` will search across all non-JavaScript files.
+
+

--- a/doc/user/search/opengrok.md
+++ b/doc/user/search/opengrok.md
@@ -44,7 +44,7 @@ Oracle OpenGrok doesn't index most single-character strings (such as for special
 
 Sourcegraph indexes all characters, and can search for strings of any length. Using the default [literal search mode](queries.md#Literal-search--default-), any search (including those with special characters like `foo.bar`, `try {`, `i++`, `i-=1`, `foo->bar`, and more), will all be searchable without special handling. Using [regexp mode](queries.md#regexp-search) would require escaping special charactes.
 
-The only exceptions are colon characters, which are by default used for specifying a search keyword on Sourcegraph (see below). Any search containing colons can be done using the `content:"pattern"` keyword to explicitly mark it as the search string.
+The only exceptions are colon characters, which are by default used for specifying a search keyword on Sourcegraph (see below). Any search containing colons can be done using, for example, `content:"foo::bar"` keyword to explicitly mark it as the search string.
 
 ### Boolean operators
 
@@ -81,4 +81,3 @@ To see an exhaustive list of Sourcegraph's search keywords, see the [search quer
 **Negating search keywords**
 
 Sourcegraph allows users to negate any search keyword by appending a `-` character to the name. For example, `pattern -repo:foo` will search across all repositories except for those that contain "foo". `pattern -lang:javascript` will search across all non-JavaScript files.
-

--- a/doc/user/search/opengrok.md
+++ b/doc/user/search/opengrok.md
@@ -80,4 +80,6 @@ To see an exhaustive list of Sourcegraph's search keywords, see the [search quer
 
 **Negating search keywords**
 
-Sourcegraph allows users to negate any search keyword by appending a `-` character to the name. For example, `pattern -repo:foo` will search across all repositories except for those that contain "foo". `pattern -lang:javascript` will search across all non-JavaScript files.
+Oracle OpenGrok allows users to negate any search keyword, or to negate file results that contain a given search pattern, by appending a `-` character to the start of the term.
+
+Sourcegraph also allows users to negate search keywords by appending a `-` character to the name. For example, `pattern -repo:foo` will search across all repositories except for those that contain "foo". `pattern -lang:javascript` will search across all non-JavaScript files. Sourcegraph cannot currently exclude files based on text that they don't contain, but this will be available using [operators](queries.md#operators) soon.

--- a/doc/user/search/opengrok.md
+++ b/doc/user/search/opengrok.md
@@ -64,7 +64,7 @@ Both Sourcegraph and OpenGrok allow users to add keywords for scoping searches. 
 | Search symbol definitions | `def:pattern` | `pattern type:symbol` |
 | Search symbol references | `def:pattern` | Available through hover tooltips and `Find references` panels on code pages |
 | Search for repository names | Not supported | `pattern type:repo` |
-| Search for file names | `file:pattern` | `pattern type:repo` |
+| Search for file names | `file:pattern` | `file:pattern` |
 | Search commit messages | `hist:pattern` | `pattern type:commit` |
 | Search code changes (diff search) | Not supported | `pattern type:diff` |
 | Scope searches to a language | `pattern type:c` | `pattern lang:c` |

--- a/doc/user/search/queries.md
+++ b/doc/user/search/queries.md
@@ -93,7 +93,7 @@ Multiple or combined **repo:** and **file:** keywords are intersected. For examp
 
 Use operators to create more expressive searches.
 
-> NOTE: Operators are available as of 3.15 and enabled with `{"experimentalFeatures": {"andOrQuery": "enabled"}}` in site settings. Built-in operator support is planned for the upcoming 3.16 release and onwards.
+> NOTE: Operators are available as of 3.15 and enabled with `{"experimentalFeatures": {"andOrQuery": "enabled"}}` in the site configuration. Built-in operator support is planned for an upcoming release.
 
 | Operator | Example |
 | --- | --- |


### PR DESCRIPTION
Sources include:

- OpenGrok official docs: https://oracle.github.io/opengrok/
- Live OpenGrok demo: http://www.midnightbsd.org/opengrok/help.jsp

Goal here isn't to be 100% comprehensive (though any additions/changes are welcome). Rather, the goal is to be _useful_ to OpenGrok users who are trying Sourcegraph. 
