### PR TITLE
Update patchset TTL to be 1 week

### DIFF
--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1645,7 +1645,7 @@ var deletePatchSetQueryFmtstr = `
 DELETE FROM patch_sets WHERE id = %s
 `
 
-const PatchSetTTL = 1 * time.Hour
+const PatchSetTTL = 7 * 24 * time.Hour
 
 // DeleteExpiredPatchSets deletes PatchSets that have not been attached to a Campaign within PatchSetTTL.
 func (s *Store) DeleteExpiredPatchSets(ctx context.Context) error {

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -2231,7 +2231,7 @@ func testStorePatchSetsDeleteExpired(t *testing.T, ctx context.Context, s *Store
 		},
 		{
 			hasCampaign: false,
-			createdAt:   clock.now().Add(-500 * time.Minute),
+			createdAt:   clock.now().Add(-8 * 24 * time.Hour),
 			wantDeleted: true,
 		},
 		{
@@ -2241,12 +2241,12 @@ func testStorePatchSetsDeleteExpired(t *testing.T, ctx context.Context, s *Store
 		},
 		{
 			hasCampaign: true,
-			createdAt:   clock.now().Add(-500 * time.Minute),
+			createdAt:   clock.now().Add(-8 * 24 * time.Hour),
 			wantDeleted: false,
 		},
 		{
 			hasCampaign: false,
-			createdAt:   clock.now().Add(-500 * time.Minute),
+			createdAt:   clock.now().Add(-8 * 24 * time.Hour),
 
 			patchesAttachedToOtherCampaign: true,
 			patches: []*cmpgn.Patch{


### PR DESCRIPTION
Patchsets can take a while to create. I think they should survive at least a weekend, and it seems harmless to allow them to last for a week.
