### PR TITLE
Reject campaign update if lacking permission for any of new patches

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -1129,7 +1129,7 @@ func computeCampaignUpdateDiff(
 	}
 
 	for _, j := range newPatches {
-		// If the user is missing permissions for any if the new patches, we
+		// If the user is missing permissions for any of the new patches, we
 		// return an error instead of skipping patches, so we don't end up with
 		// an unfixable state (i.e. unpublished patch + changeset for same
 		// repo).

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -1135,7 +1135,6 @@ func computeCampaignUpdateDiff(
 		// repo).
 		if _, ok := accessibleRepoIDs[j.RepoID]; !ok {
 			return nil, &db.RepoNotFoundErr{ID: j.RepoID}
-
 		}
 
 		if group, ok := byRepoID[j.RepoID]; ok {


### PR DESCRIPTION
Previously we simply skipped the patches and didn't publish them if the
user lost permissions for a repo in between creating the patchset and
updating the campaign.

That could lead to an unfixable state where a campaign had a patch and a
changeset for the same repository.

We decided that the best solution is to simply return an error and
reject the update.

