### PR TITLE
dev: remove code-intel from dev/start.sh install targets

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -6,7 +6,7 @@
 # This will install binaries into the `.bin` directory under the repository root.
 #
 
-all_oss_commands=" gitserver query-runner github-proxy searcher replacer frontend repo-updater symbols precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-worker "
+all_oss_commands=" gitserver query-runner github-proxy searcher replacer frontend repo-updater symbols "
 
 # handle options
 verbose=false


### PR DESCRIPTION
looks like https://github.com/sourcegraph/sourcegraph/pull/11419 removed code-intel services from vanilla sourcegraph, so these install targets were causing startup to fail with `./dev/start.sh` - from what I understand the workflow to start those services now should be to use `./enterprise/dev/start.sh`?

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
