### PR TITLE
fixed race condition for settings being unavailable for extension

### DIFF
--- a/shared/src/api/client/client.ts
+++ b/shared/src/api/client/client.ts
@@ -22,7 +22,7 @@ export interface ExtensionHostClient extends Unsubscribable {
 export function createExtensionHostClient(
     services: Services,
     extensionHostEndpoint: Observable<EndpointPair>,
-    initData: InitData,
+    initData: Omit<InitData, 'initialSettings'>,
     platformContext: PlatformContext
 ): ExtensionHostClient {
     const client = extensionHostEndpoint.pipe(

--- a/shared/src/api/extension/api/configuration.test.ts
+++ b/shared/src/api/extension/api/configuration.test.ts
@@ -2,18 +2,20 @@ import { initNewExtensionAPI } from '../flatExtensionApi'
 import { SettingsEdit } from '../../client/services/settings'
 import { pretendRemote } from '../../util'
 import { MainThreadAPI } from '../../contract'
+import { SettingsCascade } from '../../../settings/settings'
+
+const initialSettings = (value: { a: string }): SettingsCascade<{ a: string }> => ({
+    subjects: [],
+    final: value,
+})
 
 describe('ConfigurationService', () => {
     describe('get()', () => {
-        test("throws if initial settings haven't been received", () => {
-            const { configuration } = initNewExtensionAPI(pretendRemote({}))
-            expect(() => configuration.get()).toThrow('unexpected internal error: settings data is not yet available')
-        })
         test('returns the latest settings', () => {
             const {
                 configuration,
                 exposedToMain: { syncSettingsData },
-            } = initNewExtensionAPI(pretendRemote({}))
+            } = initNewExtensionAPI(pretendRemote({}), initialSettings({ a: 'a' }))
             syncSettingsData({ subjects: [], final: { a: 'b' } })
             syncSettingsData({ subjects: [], final: { a: 'c' } })
             expect(configuration.get<{ a: string }>().get('a')).toBe('c')
@@ -21,24 +23,9 @@ describe('ConfigurationService', () => {
     })
 
     describe('changes', () => {
-        test('emits as soon as initial settings are received', () => {
-            const {
-                configuration,
-                exposedToMain: { syncSettingsData },
-            } = initNewExtensionAPI(pretendRemote({}))
+        test('emits immediately on subscription with initial settings (why btw?)', () => {
+            const { configuration } = initNewExtensionAPI(pretendRemote({}), initialSettings({ a: 'a' }))
             let calledTimes = 0
-            configuration.subscribe(() => calledTimes++)
-            expect(calledTimes).toBe(0)
-            syncSettingsData({ subjects: [], final: { a: 'b' } })
-            expect(calledTimes).toBe(1)
-        })
-        test('emits immediately on subscription if initial settings have already been received', () => {
-            const {
-                configuration,
-                exposedToMain: { syncSettingsData },
-            } = initNewExtensionAPI(pretendRemote({}))
-            let calledTimes = 0
-            syncSettingsData({ subjects: [], final: { a: 'b' } })
             configuration.subscribe(() => calledTimes++)
             expect(calledTimes).toBe(1)
         })
@@ -47,21 +34,19 @@ describe('ConfigurationService', () => {
             const {
                 configuration,
                 exposedToMain: { syncSettingsData },
-            } = initNewExtensionAPI(pretendRemote({}))
+            } = initNewExtensionAPI(pretendRemote({}), initialSettings({ a: 'a' }))
             let calledTimes = 0
             configuration.subscribe(() => calledTimes++)
             syncSettingsData({ subjects: [], final: { a: 'b' } })
-            syncSettingsData({ subjects: [], final: { a: 'c' } })
-            syncSettingsData({ subjects: [], final: { a: 'd' } })
-            expect(calledTimes).toBe(3)
+            // one initial and one update
+            expect(calledTimes).toBe(2)
         })
 
         test('config objects freezes in time??!?!', () => {
             const {
                 configuration,
                 exposedToMain: { syncSettingsData },
-            } = initNewExtensionAPI(pretendRemote({}))
-            syncSettingsData({ subjects: [], final: { a: 'b' } })
+            } = initNewExtensionAPI(pretendRemote({}), initialSettings({ a: 'b' }))
             const config = configuration.get<{ a: string }>()
             expect(config.get('a')).toBe('b')
             syncSettingsData({ subjects: [], final: { a: 'c' } })
@@ -72,18 +57,15 @@ describe('ConfigurationService', () => {
     describe('talks to the client api', () => {
         test('talks to the client when an update is requested', async () => {
             const requestedEdits: SettingsEdit[] = []
-            const {
-                configuration,
-                exposedToMain: { syncSettingsData },
-            } = initNewExtensionAPI(
+            const { configuration } = initNewExtensionAPI(
                 pretendRemote<MainThreadAPI>({
                     applySettingsEdit: edit =>
                         Promise.resolve().then(() => {
                             requestedEdits.push(edit)
                         }),
-                })
+                }),
+                initialSettings({ a: 'b' })
             )
-            syncSettingsData({ subjects: [], final: { a: 'b' } })
             const config = configuration.get<{ a: string }>()
             await config.update('a', 'aha!')
             expect(requestedEdits).toEqual<SettingsEdit[]>([{ path: ['a'], value: 'aha!' }])

--- a/shared/src/api/extension/api/configuration.test.ts
+++ b/shared/src/api/extension/api/configuration.test.ts
@@ -23,7 +23,7 @@ describe('ConfigurationService', () => {
     })
 
     describe('changes', () => {
-        test('emits immediately on subscription with initial settings (why btw?)', () => {
+        test('emits immediately on subscription', () => {
             const { configuration } = initNewExtensionAPI(pretendRemote({}), initialSettings({ a: 'a' }))
             let calledTimes = 0
             configuration.subscribe(() => calledTimes++)

--- a/shared/src/api/extension/extensionHost.ts
+++ b/shared/src/api/extension/extensionHost.ts
@@ -17,6 +17,7 @@ import { ExtensionViewsApi } from './api/views'
 import { ExtensionWindows } from './api/windows'
 import { registerComlinkTransferHandlers } from '../util'
 import { initNewExtensionAPI } from './flatExtensionApi'
+import { SettingsCascade } from '../../settings/settings'
 
 /**
  * Required information when initializing an extension host.
@@ -27,6 +28,9 @@ export interface InitData {
 
     /** @see {@link module:sourcegraph.internal.clientApplication} */
     clientApplication: 'sourcegraph' | 'other'
+
+    /** fetched initial settings object */
+    initialSettings: Readonly<SettingsCascade<object>>
 }
 
 /**
@@ -137,7 +141,10 @@ function createExtensionAPI(
     const search = new ExtensionSearch(proxy.search)
     const content = new ExtensionContent(proxy.content)
 
-    const { configuration, exposedToMain, workspace, state, commands } = initNewExtensionAPI(proxy)
+    const { configuration, exposedToMain, workspace, state, commands } = initNewExtensionAPI(
+        proxy,
+        initData.initialSettings
+    )
 
     // Expose the extension host API to the client (main thread)
     const extensionHostAPI: ExtensionHostAPI = {

--- a/shared/src/api/extension/flatExtensionApi.ts
+++ b/shared/src/api/extension/flatExtensionApi.ts
@@ -1,7 +1,7 @@
 import { SettingsCascade } from '../../settings/settings'
 import { Remote, proxy } from 'comlink'
 import * as sourcegraph from 'sourcegraph'
-import { ReplaySubject, Subject } from 'rxjs'
+import { BehaviorSubject, Subject } from 'rxjs'
 import { FlatExtHostAPI, MainThreadAPI } from '../contract'
 import { syncSubscription } from '../util'
 

--- a/shared/src/api/extension/flatExtensionApi.ts
+++ b/shared/src/api/extension/flatExtensionApi.ts
@@ -46,13 +46,10 @@ export const initNewExtensionAPI = (
 ): InitResult => {
     const state: ExtState = { roots: [], versionContext: undefined, settings: initialSettings }
 
-    const configChanges = new ReplaySubject<void>(1)
-    // TODO (simon) why it is needed?
-    // the idea here is to emit immediately after listening to changes
-    // because initial settings were not passed in as a parameter but via syncSettingsData
-    // but we ALREADY have settings available? I think it will result in unneeded update
-    // for original version see https://github.com/sourcegraph/sourcegraph/pull/10874/files
-    configChanges.next()
+    const configChanges = new BehaviorSubject<void>(undefined)
+    // Most extensions never call `configuration.get()` synchronously in `activate()` to get
+    // the initial settings data, and instead only subscribe to configuration changes.
+    // In order for these extensions to be able to access settings, make sure `configuration` emits on subscription.
 
     const rootChanges = new Subject<void>()
     const versionContextChanges = new Subject<string | undefined>()

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -1,6 +1,6 @@
 import 'message-port-polyfill'
 
-import { BehaviorSubject, from, NEVER, throwError } from 'rxjs'
+import { BehaviorSubject, from, NEVER, throwError, of } from 'rxjs'
 import { filter, first, switchMap, take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { EndpointPair, PlatformContext } from '../../platform/context'
@@ -50,7 +50,7 @@ interface Mocks
     > {}
 
 const NOOP_MOCKS: Mocks = {
-    settings: NEVER,
+    settings: of({ final: {}, subjects: [] }),
     updateSettings: () => Promise.reject(new Error('Mocks#updateSettings not implemented')),
     requestGraphQL: () => throwError(new Error('Mocks#queryGraphQL not implemented')),
     getScriptURLForExtension: scriptURL => scriptURL,
@@ -87,7 +87,7 @@ export async function integrationTestContext(
     const extensionHost = startExtensionHost(extensionHostEndpoints)
 
     const services = new Services(mocks)
-    const initData: InitData = {
+    const initData: Omit<InitData, 'initialSettings'> = {
         sourcegraphURL: 'https://example.com/',
         clientApplication: 'sourcegraph',
     }

--- a/shared/src/api/integration-test/testHelpers.ts
+++ b/shared/src/api/integration-test/testHelpers.ts
@@ -1,6 +1,6 @@
 import 'message-port-polyfill'
 
-import { BehaviorSubject, from, NEVER, throwError, of } from 'rxjs'
+import { BehaviorSubject, from, throwError, of } from 'rxjs'
 import { filter, first, switchMap, take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { EndpointPair, PlatformContext } from '../../platform/context'

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -69,7 +69,7 @@ export function createController(context: PlatformContext): Controller {
 
     const services = new Services(context)
     const extensionHostEndpoint = context.createExtensionHost()
-    const initData: InitData = {
+    const initData: Omit<InitData, 'initialSettings'> = {
         sourcegraphURL: context.sourcegraphURL,
         clientApplication: context.clientApplication,
     }


### PR DESCRIPTION
This ensures that initialized settings object is available for all extensions.

Added waiting for settings objects before initializing extension host api

fixes: https://github.com/sourcegraph/sourcegraph/issues/11235