### PR TITLE
Correct err check

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -204,8 +204,8 @@ func outOfDateAlert(args AlertFuncArgs) []*Alert {
 		return nil
 	}
 	offline := globalUpdateStatus.Err != nil // Whether or not instance can connect to Sourcegraph.com for update checks
-	monthsOutOfDate, err := version.HowLongOutOfDate(version.Version())
-	if err == nil {
+	monthsOutOfDate, err := version.HowLongOutOfDate()
+	if err != nil {
 		log15.Error("failed to determine how out of date Sourcegraph is", "error", err)
 		return nil
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -39,7 +39,7 @@ var timestamp = devTimestamp
 
 // HowLongOutOfDate returns a time in months since this build of Sourcegraph was created. It is
 // based on a constant baked into the Go binary at build time.
-func HowLongOutOfDate(currentVersion string) (int, error) {
+func HowLongOutOfDate() (int, error) {
 	buildUnixTimestamp, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("unable to parse version build timestamp: %w", err)


### PR DESCRIPTION
This fixes an error check that would return if the err was nil. 
Fixes       `frontend | ERROR failed to determine how out of date Sourcegraph is, error: <nil>` 

Part of https://github.com/sourcegraph/sourcegraph/issues/9708




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->