### PR TITLE
repo-updater: Move rate limiters into code host clients

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"net/url"
 	"strconv"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/time/rate"
 )
 
 // A BitbucketServerSource yields repositories from a single BitbucketServer connection configured
@@ -28,25 +28,19 @@ type BitbucketServerSource struct {
 	config  *schema.BitbucketServerConnection
 	exclude excludeFunc
 	client  *bitbucketserver.Client
-
-	// rateLimiter should be used to limit requests made to the external service
-	rateLimiter *rate.Limiter
 }
 
 // NewBitbucketServerSource returns a new BitbucketServerSource from the given external service.
 // rl is optional
-func NewBitbucketServerSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limiter) (*BitbucketServerSource, error) {
+func NewBitbucketServerSource(svc *ExternalService, cf *httpcli.Factory, rl ratelimit.Limiter) (*BitbucketServerSource, error) {
 	var c schema.BitbucketServerConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	if rl == nil {
-		rl = rate.NewLimiter(rate.Inf, 0)
-	}
 	return newBitbucketServerSource(svc, &c, cf, rl)
 }
 
-func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerConnection, cf *httpcli.Factory, rl *rate.Limiter) (*BitbucketServerSource, error) {
+func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerConnection, cf *httpcli.Factory, rl ratelimit.Limiter) (*BitbucketServerSource, error) {
 	if cf == nil {
 		cf = httpcli.NewExternalHTTPClientFactory()
 	}
@@ -72,17 +66,16 @@ func newBitbucketServerSource(svc *ExternalService, c *schema.BitbucketServerCon
 		return nil, err
 	}
 
-	client, err := bitbucketserver.NewClient(c, cli)
+	client, err := bitbucketserver.NewClient(c, cli, rl)
 	if err != nil {
 		return nil, err
 	}
 
 	return &BitbucketServerSource{
-		svc:         svc,
-		config:      c,
-		exclude:     exclude,
-		client:      client,
-		rateLimiter: rl,
+		svc:     svc,
+		config:  c,
+		exclude: exclude,
+		client:  client,
 	}, nil
 }
 
@@ -109,10 +102,6 @@ func (s BitbucketServerSource) CreateChangeset(ctx context.Context, c *Changeset
 	pr.FromRef.Repository.Slug = repo.Slug
 	pr.FromRef.Repository.Project.Key = repo.Project.Key
 	pr.FromRef.ID = git.EnsureRefPrefix(c.HeadRef)
-
-	if err := s.rateLimiter.Wait(ctx); err != nil {
-		return false, errors.Wrap(err, "waiting for rate limiter")
-	}
 
 	err := s.client.CreatePullRequest(ctx, pr)
 	if err != nil {
@@ -146,9 +135,6 @@ func (s BitbucketServerSource) CloseChangeset(ctx context.Context, c *Changeset)
 		return errors.New("Changeset is not a Bitbucket Server pull request")
 	}
 
-	if err := s.rateLimiter.Wait(ctx); err != nil {
-		return errors.Wrap(err, "waiting for rate limiter")
-	}
 	err := s.client.DeclinePullRequest(ctx, pr)
 	if err != nil {
 		return err
@@ -174,9 +160,6 @@ func (s BitbucketServerSource) LoadChangesets(ctx context.Context, cs ...*Change
 		pr.ToRef.Repository.Slug = repo.Slug
 		pr.ToRef.Repository.Project.Key = repo.Project.Key
 
-		if err := s.rateLimiter.Wait(ctx); err != nil {
-			return errors.Wrap(err, "waiting for rate limiter")
-		}
 		err = s.client.LoadPullRequest(ctx, pr)
 		if err != nil {
 			if bitbucketserver.IsNotFound(err) {
@@ -207,21 +190,12 @@ func (s BitbucketServerSource) LoadChangesets(ctx context.Context, cs ...*Change
 }
 
 func (s BitbucketServerSource) loadPullRequestData(ctx context.Context, pr *bitbucketserver.PullRequest) error {
-	// Each request below asks for items in pages of 1000 so it's safe to assume we'll only be requesting
-	// one page per request for now.
-	// We make 3 API calls, so wait until the rate limiter allows them.
-	if err := s.rateLimiter.WaitN(ctx, 3); err != nil {
-		return errors.Wrap(err, "waiting for rate limiter")
-	}
-
 	if err := s.client.LoadPullRequestActivities(ctx, pr); err != nil {
 		return errors.Wrap(err, "loading pr activities")
 	}
-
 	if err := s.client.LoadPullRequestCommits(ctx, pr); err != nil {
 		return errors.Wrap(err, "loading pr commits")
 	}
-
 	if err := s.client.LoadPullRequestBuildStatuses(ctx, pr); err != nil {
 		return errors.Wrap(err, "loading pr build status")
 	}
@@ -245,9 +219,6 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 	update.ToRef.Repository.Slug = pr.ToRef.Repository.Slug
 	update.ToRef.Repository.Project.Key = pr.ToRef.Repository.Project.Key
 
-	if err := s.rateLimiter.Wait(ctx); err != nil {
-		return errors.Wrap(err, "waiting for rate limiter")
-	}
 	updated, err := s.client.UpdatePullRequest(ctx, update)
 	if err != nil {
 		return err

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -389,7 +389,7 @@ func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult,
 		}
 
 		if hasNext && cost > 0 {
-			time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(cost))
+			time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(cost))
 		}
 	}
 }
@@ -411,7 +411,7 @@ func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *gi
 				}
 			}
 
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimitMonitor.Get()
 			log15.Debug(
 				"github sync: ListOrgRepositories",
 				"repos", len(repos),
@@ -443,7 +443,7 @@ func (s *GithubSource) listUser(ctx context.Context, user string, results chan *
 				fail, err = err, nil
 			}
 
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimitMonitor.Get()
 			log15.Debug(
 				"github sync: ListUserRepositories",
 				"repos", len(repos),
@@ -505,7 +505,7 @@ func (s *GithubSource) listRepos(ctx context.Context, repos []string, results ch
 
 		results <- &githubResult{repo: repo}
 
-		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
+		time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
 }
 
@@ -550,7 +550,7 @@ func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResul
 func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult) {
 	s.paginate(ctx, results, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
 		defer func() {
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimitMonitor.Get()
 			log15.Debug(
 				"github sync: ListAffiliated",
 				"repos", len(repos),
@@ -583,7 +583,7 @@ func (s *GithubSource) listSearch(ctx context.Context, query string, results cha
 		}
 
 		repos, hasNext := reposPage.Repos, reposPage.HasNextPage
-		remaining, reset, retry, ok := s.searchClient.RateLimit.Get()
+		remaining, reset, retry, ok := s.searchClient.RateLimitMonitor.Get()
 		log15.Debug(
 			"github sync: ListRepositoriesForSearch",
 			"searchString", query,
@@ -721,7 +721,7 @@ func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, result
 			results <- &githubResult{repo: r}
 		}
 
-		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
+		time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
 
 	return nil

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -968,7 +968,7 @@ type RateLimiterRegistry struct {
 }
 
 // NewRateLimitRegistry returns a new registry and attempts to populate it. On error, an
-// empty registry is returned which can still to handle syncs.
+// empty registry is returned which can still handle syncs.
 func NewRateLimiterRegistry(ctx context.Context, serviceLister externalServiceLister) (*RateLimiterRegistry, error) {
 	r := &RateLimiterRegistry{
 		serviceLister: serviceLister,

--- a/enterprise/cmd/frontend/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session.go
@@ -128,7 +128,7 @@ func derefInt64(i *int64) int64 {
 
 func (s *sessionIssuerHelper) newClient(token string) *githubsvc.Client {
 	apiURL, _ := githubsvc.APIRoot(s.BaseURL)
-	return githubsvc.NewClient(apiURL, token, nil)
+	return githubsvc.NewClient(apiURL, token, nil, nil)
 }
 
 // getVerifiedEmails returns the list of user emails that are verified. If the primary email is verified,

--- a/enterprise/cmd/frontend/internal/authz/bitbucketserver/authz.go
+++ b/enterprise/cmd/frontend/internal/authz/bitbucketserver/authz.go
@@ -66,7 +66,7 @@ func newAuthzProvider(
 		errs = multierror.Append(errs, errors.Errorf("authorization.hardTTL: must be larger than ttl"))
 	}
 
-	cli, err := bitbucketserver.NewClient(c, nil)
+	cli, err := bitbucketserver.NewClient(c, nil, nil)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		return nil, errs.ErrorOrNil()

--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -27,7 +27,7 @@ type Provider struct {
 
 func NewProvider(githubURL *url.URL, baseToken string, cacheTTL time.Duration, mockCache cache) *Provider {
 	apiURL, _ := github.APIRoot(githubURL)
-	client := &clientAdapter{Client: github.NewClient(apiURL, baseToken, nil)}
+	client := &clientAdapter{Client: github.NewClient(apiURL, baseToken, nil, nil)}
 
 	p := &Provider{
 		codeHost: extsvc.NewCodeHost(githubURL, extsvc.TypeGitHub),

--- a/enterprise/internal/codeintel/httpapi/auth_github.go
+++ b/enterprise/internal/codeintel/httpapi/auth_github.go
@@ -27,7 +27,7 @@ func enforceAuthGithub(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		return http.StatusUnauthorized, errors.New("must provide github_token")
 	}
 
-	client := github.NewClient(&githubURL, githubToken, nil)
+	client := github.NewClient(&githubURL, githubToken, nil, nil)
 
 	// There are 2 supported ways to authenticate the upload:
 	//

--- a/internal/extsvc/bitbucketserver/testing.go
+++ b/internal/extsvc/bitbucketserver/testing.go
@@ -41,7 +41,7 @@ func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
 		Url:   instanceURL,
 	}
 
-	cli, err := NewClient(c, hc)
+	cli, err := NewClient(c, hc, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -451,7 +451,7 @@ func newClient(t testing.TB, name string) (*Client, func()) {
 		t.Fatal(err)
 	}
 
-	cli := NewClient(uri, os.Getenv("GITHUB_TOKEN"), doer)
+	cli := NewClient(uri, os.Getenv("GITHUB_TOKEN"), doer, nil)
 
 	return cli, save
 }

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -77,7 +77,7 @@ func newTestClientWithToken(t *testing.T, token string, cli httpcli.Doer) *Clien
 	rcache.SetupForTest(t)
 
 	apiURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/"}
-	return NewClient(apiURL, token, cli)
+	return NewClient(apiURL, token, cli, nil)
 }
 
 // TestClient_GetRepository tests the behavior of GetRepository.

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -50,7 +50,7 @@ func NewMiddleware(mws ...Middleware) Middleware {
 type Opt func(*http.Client) error
 
 // A Factory constructs an http.Client with the given functional
-// options applied, returning an aggreagte error of the errors returned by
+// options applied, returning an aggregate error of the errors returned by
 // all those options.
 type Factory struct {
 	stack  Middleware

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -16,6 +16,8 @@ type Limiter interface {
 	Limit(ctx context.Context, n int) error
 }
 
+// NewBlockingLimiter returns a rate limiter that will block when
+// the rate limit has been exceeded
 func NewBlockingLimiter(r *rate.Limiter) *BlockingLimiter {
 	return &BlockingLimiter{
 		r: r,
@@ -34,6 +36,8 @@ func (bl *BlockingLimiter) Limit(ctx context.Context, n int) error {
 	return bl.r.WaitN(ctx, n)
 }
 
+// NewNonBlockingLimiter returns a rate limiter that will not block when
+// the rate limit has been exceeded and will instead return an error.
 func NewNonBlockingLimiter(r *rate.Limiter) *NonBlockingLimiter {
 	return &NonBlockingLimiter{
 		r: r,


### PR DESCRIPTION
This change introduces a new 'Limiter' interface in the the 'ratelimit' package with both a blocking and non blocking implementation.

The underlying rate limiter should still be acquired from the rate limit registry to ensure they are shared across different clients in the same instance. Once acquired, it can be used to create either a blocking or non blocking version which is then passed to our GitHub and Bitbucket clients and will be checked before making any client requests.

The goal of this change is to remove the need to manually check the rate limiter and opens up the path to enable rate limiter for all our other `Source` implementations here:

https://github.com/sourcegraph/sourcegraph/blob/0f893caf2d091c8ebdef49d35cc5a29e30d113d1/cmd/repo-updater/repos/sources.go#L78

Part of: https://github.com/sourcegraph/sourcegraph/issues/9953