### PR TITLE
e2e: add tests for `auth.userOrgMap`

### DIFF
--- a/dev/e2e/main_test.go
+++ b/dev/e2e/main_test.go
@@ -34,10 +34,6 @@ var (
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	if len(*githubToken) == 0 {
-		log.Fatal("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	*baseURL = strings.TrimSuffix(*baseURL, "/")
 
 	needsSiteInit, err := e2eutil.NeedsSiteInit(*baseURL)

--- a/dev/e2e/organization_test.go
+++ b/dev/e2e/organization_test.go
@@ -4,15 +4,18 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestOrganization(t *testing.T) {
-	orgID, err := client.CreateOrganization("e2e-test-org", "e2e-test-org")
+	const testOrgName = "e2e-test-org"
+	orgID, err := client.CreateOrganization(testOrgName, testOrgName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,6 +31,12 @@ func TestOrganization(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer func() {
+			err := client.OverwriteSettings(orgID, `{}`)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
 
 		{
 			contents, err := client.ViewerSettings()
@@ -75,10 +84,89 @@ func TestOrganization(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var wantQuickLinks []schema.QuickLink
-			if diff := cmp.Diff(wantQuickLinks, got.QuickLinks); diff != "" {
+			if diff := cmp.Diff([]schema.QuickLink{}, got.QuickLinks); diff != "" {
 				t.Fatalf("QuickLinks mismatch (-want +got):\n%s", diff)
 			}
+		}
+	})
+
+	// Docs: https://docs.sourcegraph.com/user/organizations
+	t.Run("auth.userOrgMap", func(t *testing.T) {
+		// Create a test user (test-org-user-1) without settings "auth.userOrgMap",
+		// the user should not be added to the organization (e2e-test-org) automatically.
+		const testUsername1 = "test-org-user-1"
+		testUserID1, err := client.CreateUser(testUsername1, testUsername1+"@sourcegraph.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := client.DeleteUser(testUserID1, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		orgs, err := client.UserOrganizations(testUsername1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff([]string{}, orgs); diff != "" {
+			t.Fatalf("Organizations mismatch (-want +got):\n%s", diff)
+		}
+
+		// Update site configuration to set "auth.userOrgMap" which makes new user join
+		// the organization (e2e-test-org) automatically.
+		siteConfig, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldSiteConfig := new(schema.SiteConfiguration)
+		*oldSiteConfig = *siteConfig
+		defer func() {
+			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		siteConfig.AuthUserOrgMap = map[string][]string{"*": {testOrgName}}
+		err = client.UpdateSiteConfiguration(siteConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var lastOrgs []string
+		// Retry because the configuration update endpoint is eventually consistent
+		err = e2eutil.Retry(5*time.Second, func() error {
+			// Create another test user (test-org-user-2) and the user should be added to
+			// the organization (e2e-test-org) automatically.
+			const testUsername2 = "test-org-user-2"
+			testUserID2, err := client.CreateUser(testUsername2, testUsername2+"@sourcegraph.com")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				err := client.DeleteUser(testUserID2, true)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			orgs, err = client.UserOrganizations(testUsername2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lastOrgs = orgs
+
+			wantOrgs := []string{testOrgName}
+			if cmp.Diff(wantOrgs, orgs) != "" {
+				return e2eutil.ErrContinueRetry
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err, "lastOrgs:", lastOrgs)
 		}
 	})
 }

--- a/dev/e2e/organization_test.go
+++ b/dev/e2e/organization_test.go
@@ -115,7 +115,7 @@ func TestOrganization(t *testing.T) {
 			t.Fatalf("Organizations mismatch (-want +got):\n%s", diff)
 		}
 
-		// Update site configuration to set "auth.userOrgMap" which makes new user join
+		// Update site configuration to set "auth.userOrgMap" which makes the new user join
 		// the organization (e2e-test-org) automatically.
 		siteConfig, err := client.SiteConfiguration()
 		if err != nil {

--- a/dev/e2e/search_test.go
+++ b/dev/e2e/search_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
 )
 
-func TestSearch_VisibilityFilter(t *testing.T) {
+func TestSearch(t *testing.T) {
+	if len(*githubToken) == 0 {
+		t.Fatal("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	// Set up external service
 	esID, err := client.AddExternalService(e2eutil.AddExternalServiceInput{
 		Kind:        "GITHUB",

--- a/internal/e2eutil/helper.go
+++ b/internal/e2eutil/helper.go
@@ -9,7 +9,7 @@ import (
 
 var ErrContinueRetry = errors.New("continue Retry")
 
-// Retry retries the given function until reached timeout. The function should
+// Retry retries the given function until the timeout is reached. The function should
 // return ErrContinueRetry to indicate another retry.
 func Retry(timeout time.Duration, fn func() error) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/e2eutil/helper.go
+++ b/internal/e2eutil/helper.go
@@ -1,0 +1,34 @@
+package e2eutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var ErrContinueRetry = errors.New("continue Retry")
+
+// Retry retries the given function until reached timeout. The function should
+// return ErrContinueRetry to indicate another retry.
+func Retry(timeout time.Duration, fn func() error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				return errors.Errorf("Retry timed out in %s", timeout)
+			}
+			return ctx.Err()
+		default:
+			err := fn()
+			if err != ErrContinueRetry {
+				return err
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/internal/e2eutil/settings.go
+++ b/internal/e2eutil/settings.go
@@ -1,7 +1,11 @@
 package e2eutil
 
 import (
+	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // OverwriteSettings overwrites settings for given subject ID with contents.
@@ -49,4 +53,64 @@ query ViewerSettings {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
 	return resp.Data.ViewerSettings.Final, nil
+}
+
+// SiteConfiguration returns current effective site configuration.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) SiteConfiguration() (*schema.SiteConfiguration, error) {
+	const query = `
+query Site {
+	site {
+		configuration {
+			effectiveContents
+		}
+	}
+}
+`
+
+	var resp struct {
+		Data struct {
+			Site struct {
+				Configuration struct {
+					EffectiveContents string `json:"effectiveContents"`
+				} `json:"configuration"`
+			} `json:"site"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, nil, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	config := new(schema.SiteConfiguration)
+	err = jsonc.Unmarshal(resp.Data.Site.Configuration.EffectiveContents, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal configuration")
+	}
+	return config, nil
+}
+
+// UpdateSiteConfiguration updates site configuration.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) UpdateSiteConfiguration(config *schema.SiteConfiguration) error {
+	input, err := jsoniter.Marshal(config)
+	if err != nil {
+		return errors.Wrap(err, "marshal configuration")
+	}
+
+	const query = `
+mutation UpdateSiteConfiguration($input: String!) {
+	updateSiteConfiguration(lastID: 0, input: $input)
+}
+`
+	variables := map[string]interface{}{
+		"input": string(input),
+	}
+	err = c.GraphQL("", query, variables, nil)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
 }

--- a/internal/e2eutil/user.go
+++ b/internal/e2eutil/user.go
@@ -4,8 +4,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CreateUser creates a new user with given username and email.
-// It returns GraphQL node ID of newly created user.
+// CreateUser creates a new user with the given username and email.
+// It returns the GraphQL node ID of newly created user.
 //
 // This method requires the authenticated user to be a site admin.
 func (c *Client) CreateUser(username, email string) (string, error) {

--- a/internal/e2eutil/user.go
+++ b/internal/e2eutil/user.go
@@ -1,0 +1,101 @@
+package e2eutil
+
+import (
+	"github.com/pkg/errors"
+)
+
+// CreateUser creates a new user with given username and email.
+// It returns GraphQL node ID of newly created user.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) CreateUser(username, email string) (string, error) {
+	const query = `
+mutation CreateUser($username: String!, $email: String) {
+	createUser(username: $username, email: $email) {
+		user {
+			id
+		}
+	}
+}
+`
+	variables := map[string]interface{}{
+		"username": username,
+		"email":    email,
+	}
+	var resp struct {
+		Data struct {
+			CreateUser struct {
+				User struct {
+					ID string `json:"id"`
+				} `json:"user"`
+			} `json:"createUser"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.CreateUser.User.ID, nil
+}
+
+// DeleteUser deletes a user by given GraphQL node ID.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) DeleteUser(id string, hard bool) error {
+	const query = `
+mutation DeleteUser($user: ID!, $hard: Boolean) {
+	 deleteUser(user: $user, hard: $hard) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]interface{}{
+		"user": id,
+		"hard": hard,
+	}
+	err := c.GraphQL("", query, variables, nil)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
+}
+
+// UserOrganizations returns organizations name the given user belongs to.
+func (c *Client) UserOrganizations(username string) ([]string, error) {
+	const query = `
+query User($username: String) {
+	user(username: $username) {
+		organizations {
+			nodes {
+				name
+			}
+		}
+	}
+}
+`
+	variables := map[string]interface{}{
+		"username": username,
+	}
+	var resp struct {
+		Data struct {
+			User struct {
+				Organizations struct {
+					Nodes []struct {
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"organizations"`
+			} `json:"user"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	names := make([]string, 0, len(resp.Data.User.Organizations.Nodes))
+	for _, node := range resp.Data.User.Organizations.Nodes {
+		names = append(names, node.Name)
+	}
+	return names, nil
+}


### PR DESCRIPTION
Adds e2e tests for organization settings cascade, which covers ([source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@57c1c6f9474d6929917b7de783a8e7ce3d8c6f45/-/blob/web/src/regression/org.test.ts#L182:1)):

- Site configuration `auth.userOrgMap`, which automatically adds new user to specified organizations.

Easier to review by commit.

Part of #10068