### PR TITLE
POC/Draft: Add dev/deps visualization tool

### DIFF
--- a/dev/deps/main.go
+++ b/dev/deps/main.go
@@ -13,7 +13,7 @@ import (
 const concurrency = 50
 const ignoreDescendantImports = true
 const ignoreSiblingDescendantImports = true
-const Root = "github.com/sourcegraph/sourcegraph/enterprise/cmd"
+const root = "github.com/sourcegraph/sourcegraph/enterprise/cmd"
 
 func main() {
 	if err := mainErr(); err != nil {

--- a/dev/deps/main.go
+++ b/dev/deps/main.go
@@ -23,7 +23,7 @@ func main() {
 }
 
 func mainErr() error {
-	cmd := exec.Command("go", "list", fmt.Sprintf("%s/...", Root))
+	cmd := exec.Command("go", "list", fmt.Sprintf("%s/...", root))
 	out, err := cmd.Output()
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func mainErr() error {
 
 	var pkgs []string
 	for _, pkg := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		pkgs = append(pkgs, strings.TrimPrefix(strings.TrimPrefix(pkg, Root), "/"))
+		pkgs = append(pkgs, strings.TrimPrefix(strings.TrimPrefix(pkg, root), "/"))
 	}
 
 	imports, err := getAllImports(pkgs)
@@ -126,7 +126,7 @@ func getAllImports(pkgs []string) (map[string][]string, error) {
 	var wg sync.WaitGroup
 	pairs := make(chan pair, len(pkgs))
 
-	for i := 0; i < Concurrency; i++ {
+	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 
 		go func() {
@@ -154,7 +154,7 @@ func getAllImports(pkgs []string) (map[string][]string, error) {
 }
 
 func getImports(pkg string) ([]string, error) {
-	cmd := exec.Command("go", "list", "-f", `{{ join .Imports "\n" }}`, fmt.Sprintf("%s/%s", Root, pkg))
+	cmd := exec.Command("go", "list", "-f", `{{ join .Imports "\n" }}`, fmt.Sprintf("%s/%s", root, pkg))
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -162,8 +162,8 @@ func getImports(pkg string) ([]string, error) {
 
 	var importPackages []string
 	for _, importPkg := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if strings.HasPrefix(importPkg, Root) {
-			importPackages = append(importPackages, strings.TrimPrefix(importPkg, Root+"/"))
+		if strings.HasPrefix(importPkg, root) {
+			importPackages = append(importPackages, strings.TrimPrefix(importPkg, root+"/"))
 		}
 	}
 
@@ -251,14 +251,14 @@ var replacer = strings.NewReplacer("/", "_", "-", "_", ".", "_")
 
 func labelize(pkg string) string {
 	if pkg == "" {
-		pkg = Root
+		pkg = root
 	}
 	return filepath.Base(pkg)
 }
 
 func normalize(pkg string) string {
 	if pkg == "" {
-		pkg = Root
+		pkg = root
 	}
 	return replacer.Replace(pkg)
 }

--- a/dev/deps/main.go
+++ b/dev/deps/main.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-const Concurrency = 50
+const concurrency = 50
 const ignoreDescendantImports = true
 const ignoreSiblingDescendantImports = true
 const Root = "github.com/sourcegraph/sourcegraph/enterprise/cmd"

--- a/dev/deps/main.go
+++ b/dev/deps/main.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const Concurrency = 50
+const ignoreDescendantImports = true
+const ignoreSiblingDescendantImports = true
+const Root = "github.com/sourcegraph/sourcegraph/enterprise/cmd"
+
+func main() {
+	if err := mainErr(); err != nil {
+		fmt.Printf("error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func mainErr() error {
+	cmd := exec.Command("go", "list", fmt.Sprintf("%s/...", Root))
+	out, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	var pkgs []string
+	for _, pkg := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		pkgs = append(pkgs, strings.TrimPrefix(strings.TrimPrefix(pkg, Root), "/"))
+	}
+
+	imports, err := getAllImports(pkgs)
+	if err != nil {
+		return err
+	}
+
+	intermediatePaths := getAllIntermediatePaths(pkgs)
+	sort.Strings(intermediatePaths)
+	pathTree := &treeNode{
+		children: map[string]*treeNode{
+			"": nestPaths("", intermediatePaths),
+		},
+	}
+
+	fmt.Printf("digraph deps {\n")
+	fmt.Printf("    newrank=true;\n")
+	writeNodes(pathTree, imports, 1)
+	writeEdges(imports)
+	fmt.Printf("}\n")
+
+	return nil
+}
+
+func getAllIntermediatePaths(pkgs []string) []string {
+	uniques := map[string]struct{}{}
+	for _, pkg := range pkgs {
+		for _, pkg := range getIntermediatePaths(pkg) {
+			uniques[pkg] = struct{}{}
+		}
+	}
+
+	var flattened []string
+	for key := range uniques {
+		flattened = append(flattened, key)
+	}
+	return flattened
+}
+
+func getIntermediatePaths(pkg string) []string {
+	if dirname := filepath.Dir(pkg); dirname != "." {
+		return append([]string{pkg}, getIntermediatePaths(dirname)...)
+	}
+
+	return []string{pkg}
+}
+
+type treeNode struct {
+	children map[string]*treeNode
+}
+
+func nestPaths(prefix string, pkgs []string) *treeNode {
+	nodes := map[string]*treeNode{}
+
+outer:
+	for _, pkg := range pkgs {
+		// Skip self and anything not within the current prefix
+		if pkg == prefix || !isParent(pkg, prefix) {
+			continue
+		}
+
+		// Skip anything already claimed by this level
+		for prefix := range nodes {
+			if isParent(pkg, prefix) {
+				continue outer
+			}
+		}
+
+		nodes[pkg] = nestPaths(pkg, pkgs)
+	}
+
+	return &treeNode{nodes}
+}
+
+func isParent(child, parent string) bool {
+	return parent == "" || strings.HasPrefix(child, parent+"/")
+}
+
+func getAllImports(pkgs []string) (map[string][]string, error) {
+	ch := make(chan string, len(pkgs))
+	for _, pkg := range pkgs {
+		ch <- pkg
+	}
+	close(ch)
+
+	type pair struct {
+		pkg     string
+		imports []string
+		err     error
+	}
+
+	var wg sync.WaitGroup
+	pairs := make(chan pair, len(pkgs))
+
+	for i := 0; i < Concurrency; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for pkg := range ch {
+				imports, err := getImports(pkg)
+				pairs <- pair{pkg, imports, err}
+			}
+		}()
+	}
+	wg.Wait()
+	close(pairs)
+
+	allImports := map[string][]string{}
+	for pair := range pairs {
+		if err := pair.err; err != nil {
+			return nil, err
+		}
+
+		allImports[pair.pkg] = pair.imports
+	}
+
+	return allImports, nil
+}
+
+func getImports(pkg string) ([]string, error) {
+	cmd := exec.Command("go", "list", "-f", `{{ join .Imports "\n" }}`, fmt.Sprintf("%s/%s", Root, pkg))
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var importPackages []string
+	for _, importPkg := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if strings.HasPrefix(importPkg, Root) {
+			importPackages = append(importPackages, strings.TrimPrefix(importPkg, Root+"/"))
+		}
+	}
+
+	return importPackages, nil
+}
+
+func writeNodes(node *treeNode, imports map[string][]string, level int) {
+	for pkg, children := range node.children {
+		if len(children.children) == 0 {
+			if pkgVisible(pkg, imports) {
+				fmt.Printf("%s%s [label=\"%s\"]\n", indent(level), normalize(pkg), labelize(pkg))
+			}
+		} else {
+			fmt.Printf("%ssubgraph cluster_%s {\n", indent(level), normalize(pkg))
+			fmt.Printf("%slabel=\"%s\"\n", indent(level+1), labelize(pkg))
+
+			if pkgVisible(pkg, imports) {
+				fmt.Printf("%s%s [label=\"%s\"]\n", indent(level+1), normalize(pkg), ".")
+			}
+
+			writeNodes(children, imports, level+1)
+			fmt.Printf("%s}\n", indent(level))
+		}
+	}
+}
+
+func writeEdges(imports map[string][]string) {
+	for pkg, importPkgs := range imports {
+		for _, importPkg := range importPkgs {
+			if !edgeVisible(pkg, importPkg) {
+				continue
+			}
+
+			fmt.Printf("    %s -> %s\n", normalize(pkg), normalize(importPkg))
+		}
+	}
+}
+
+func pkgVisible(importPkg string, imports map[string][]string) bool {
+	for _, pkg := range imports[importPkg] {
+		if edgeVisible(importPkg, pkg) {
+			return true
+		}
+	}
+
+	for _, pkg := range importedBy(importPkg, imports) {
+		if edgeVisible(pkg, importPkg) {
+			return true
+		}
+	}
+	return false
+}
+
+func edgeVisible(pkg, importPkg string) bool {
+	if ignoreDescendantImports && strings.HasPrefix(importPkg, pkg) {
+		return false
+	}
+
+	if ignoreSiblingDescendantImports && strings.HasPrefix(importPkg, filepath.Dir(pkg)) {
+		return false
+	}
+
+	return true
+}
+
+func importedBy(pkg string, imports map[string][]string) []string {
+	var deps []string
+	for k, vs := range imports {
+		for _, v := range vs {
+			if v == pkg {
+				deps = append(deps, k)
+				break
+			}
+		}
+	}
+
+	return deps
+}
+
+func indent(level int) string {
+	return strings.Repeat(" ", level*4)
+}
+
+var replacer = strings.NewReplacer("/", "_", "-", "_", ".", "_")
+
+func labelize(pkg string) string {
+	if pkg == "" {
+		pkg = Root
+	}
+	return filepath.Base(pkg)
+}
+
+func normalize(pkg string) string {
+	if pkg == "" {
+		pkg = Root
+	}
+	return replacer.Replace(pkg)
+}


### PR DESCRIPTION
Our imports can be very confusing! I've made a tool to try to visualize what package import other packages. After a cursory glance at things like godepgraph, I didn't find something that adequately visualizes what I'm trying to look for.

The tool committed here is a very **very** rough draft a package-import visualizer that:

- visualizes packages only within the given target (e.g. will only show sourcegraph packages, not vendors or stdlib)
- shows package nesting via subgraph organization
- can optionally ignore classes of edges (ignore imports of descendants)

It can be run via: 

```
go run ./dev/deps/main.go > sample.dot && dot -Tsvg sample.dot > sample.svg
```

Currently there are no flags and just package-declared globals.

Here is the output for the enterprise/cmd package:

![c](https://user-images.githubusercontent.com/103087/84400930-4654e880-abc8-11ea-9dbc-36ef2d58b243.png)

The same package ignoring imports of packages that are descendants of siblings (which should never indicate a smell):

![b](https://user-images.githubusercontent.com/103087/84400928-45bc5200-abc8-11ea-9379-4a04c90f9b1e.png)

The same package also ignoring imports of descendant packages (which shoudl also never indicate a smell):

![a](https://user-images.githubusercontent.com/103087/84400924-4523bb80-abc8-11ea-8d1d-b58c943c08ea.png)

From this, we can see that enterprise/cmd/repo-updater imports the db package from enterprise/cmd/frontend, which I think indicates some incorrect organization (the OSS packages have a symmetric smell).

Looking for suggestions on how to improve this tool to catch these kind of high-level tech debt issues / organizational yuckies.

I plan to extend this tool a bit to visualize different things such as "show all dependents of this particular package up to depth N"

Looking for suggestions on other use cases and suggestions for output rendering (if there's a dot wizard in the company please show yourself).