### PR TITLE
ratelimit: Move registry and make it global

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -53,7 +53,7 @@ type Server struct {
 	}
 	RateLimitSyncer interface {
 		// SyncRateLimiters should be called when an external service changes so that
-		// our internal rate limiter are kept in sync
+		// our internal rate limiters are kept in sync
 		SyncRateLimiters(ctx context.Context) error
 	}
 	PermsSyncer interface {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -51,7 +51,7 @@ type Server struct {
 		// the registry can start or stop the syncer associated with the service
 		HandleExternalServiceSync(es api.ExternalService)
 	}
-	RateLimiterRegistry interface {
+	RateLimitSyncer interface {
 		// SyncRateLimiters should be called when an external service changes so that
 		// our internal rate limiter are kept in sync
 		SyncRateLimiters(ctx context.Context) error
@@ -347,8 +347,8 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if s.RateLimiterRegistry != nil {
-		err = s.RateLimiterRegistry.SyncRateLimiters(ctx)
+	if s.RateLimitSyncer != nil {
+		err = s.RateLimitSyncer.SyncRateLimiters(ctx)
 		if err != nil {
 			log15.Warn("Handling rate limiter sync", "err", err)
 		}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -39,7 +40,7 @@ type PermsSyncer struct {
 	// The mockable function to return the current time.
 	clock func() time.Time
 	// The rate limit registry for code hosts.
-	rateLimiterRegistry *repos.RateLimiterRegistry
+	rateLimiterRegistry *ratelimit.Registry
 	// The time duration of how often to re-compute schedule for users and repositories.
 	scheduleInterval time.Duration
 	// The metrics that are exposed to Prometheus.
@@ -58,7 +59,7 @@ func NewPermsSyncer(
 	reposStore repos.Store,
 	permsStore *edb.PermsStore,
 	clock func() time.Time,
-	rateLimiterRegistry *repos.RateLimiterRegistry,
+	rateLimiterRegistry *ratelimit.Registry,
 ) *PermsSyncer {
 	s := &PermsSyncer{
 		queue:               newRequestQueue(),

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"context"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 )
 
 func TestPermsSyncer_ScheduleUsers(t *testing.T) {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -318,19 +318,6 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	}
 }
 
-type fakeExternalServiceLister struct{}
-
-func (*fakeExternalServiceLister) ListExternalServices(context.Context, repos.StoreListExternalServicesArgs) ([]*repos.ExternalService, error) {
-	return []*repos.ExternalService{
-		{
-			ID:          1,
-			Kind:        extsvc.KindGitHub,
-			DisplayName: "GitHub.com",
-			Config:      `{"url": "https://github.com"}`,
-		},
-	}, nil
-}
-
 func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 	ctx := context.Background()
 	t.Run("no rate limit registry", func(t *testing.T) {

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 )
 
 func main() {
@@ -44,14 +45,14 @@ func enterpriseInit(
 	ctx := context.Background()
 	campaignsStore := campaigns.NewStore(db)
 
-	rateLimiterRegistry, err := repos.NewRateLimiterRegistry(ctx, repoStore)
+	rateLimitSyncer, err := repos.NewRateLimitSyncer(ctx, ratelimit.DefaultRegistry, repoStore)
 	if err != nil {
 		log15.Error("Creating rate limit registry", "err", err)
 	} else if server != nil {
-		server.RateLimiterRegistry = rateLimiterRegistry
+		server.RateLimitSyncer = rateLimitSyncer
 	}
 
-	syncRegistry := campaigns.NewSyncRegistry(ctx, campaignsStore, repoStore, cf, rateLimiterRegistry)
+	syncRegistry := campaigns.NewSyncRegistry(ctx, campaignsStore, repoStore, cf, ratelimit.DefaultRegistry)
 	if server != nil {
 		server.ChangesetSyncRegistry = syncRegistry
 	}
@@ -77,7 +78,7 @@ func enterpriseInit(
 	// TODO(jchen): This is an unfortunate compromise to not rewrite ossDB.ExternalServices for now.
 	dbconn.Global = db
 	permsStore := frontendDB.NewPermsStore(db, clock)
-	permsSyncer := authz.NewPermsSyncer(repoStore, permsStore, clock, rateLimiterRegistry)
+	permsSyncer := authz.NewPermsSyncer(repoStore, permsStore, clock, ratelimit.DefaultRegistry)
 	go startBackgroundPermsSync(ctx, permsSyncer, db)
 	debugDumpers = append(debugDumpers, permsSyncer)
 	if server != nil {

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -148,8 +148,11 @@ func (c *Monitor) now() time.Time {
 	return time.Now()
 }
 
+// DefaultRegistry is the default global rate limit registry. It will hold rate limit mappings
+// for each instance of our services.
 var DefaultRegistry = NewRegistry()
 
+// NewRegistry creates a new empty registry.
 func NewRegistry() *Registry {
 	return &Registry{
 		rateLimiters: make(map[string]*rate.Limiter),


### PR DESCRIPTION
This change separates the rate limit registry and syncer. In most cases
the DefaultRegistry in the ratelimit package should now be used.

A followup PR will update our code host clients to find the appropriate
rate limiter and use it.

Part of: https://github.com/sourcegraph/sourcegraph/issues/9953

