### PR TITLE
github: Move rate limiting into client

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/time/rate"
 )
 
 // A GithubSource yields repositories from a single Github connection configured
@@ -41,24 +40,18 @@ type GithubSource struct {
 	// originalHostname is the hostname of config.Url (differs from client APIURL, whose host is api.github.com
 	// for an originalHostname of github.com).
 	originalHostname string
-
-	// rateLimiter should be used to limit requests made to the external service
-	rateLimiter *rate.Limiter
 }
 
 // NewGithubSource returns a new GithubSource from the given external service.
-func NewGithubSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limiter) (*GithubSource, error) {
+func NewGithubSource(svc *ExternalService, cf *httpcli.Factory) (*GithubSource, error) {
 	var c schema.GitHubConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	if rl == nil {
-		rl = rate.NewLimiter(rate.Inf, 0)
-	}
-	return newGithubSource(svc, &c, cf, rl)
+	return newGithubSource(svc, &c, cf)
 }
 
-func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory, rl *rate.Limiter) (*GithubSource, error) {
+func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error) {
 	baseURL, err := url.Parse(c.Url)
 	if err != nil {
 		return nil, err
@@ -123,7 +116,6 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 		client:           github.NewClient(apiURL, c.Token, cli),
 		searchClient:     github.NewClient(apiURL, c.Token, cli),
 		originalHostname: originalHostname,
-		rateLimiter:      rl,
 	}, nil
 }
 
@@ -166,10 +158,6 @@ func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, 
 	var exists bool
 	repo := c.Repo.Metadata.(*github.Repository)
 
-	if err := s.rateLimiter.Wait(ctx); err != nil {
-		return false, errors.Wrap(err, "waiting for rate limiter")
-	}
-
 	pr, err := s.client.CreatePullRequest(ctx, &github.CreatePullRequestInput{
 		RepositoryID: repo.ID,
 		Title:        c.Title,
@@ -208,9 +196,6 @@ func (s GithubSource) CloseChangeset(ctx context.Context, c *Changeset) error {
 		return errors.New("Changeset is not a GitHub pull request")
 	}
 
-	if err := s.rateLimiter.Wait(ctx); err != nil {
-		return errors.Wrap(err, "waiting for rate limiter")
-	}
 	err := s.client.ClosePullRequest(ctx, pr)
 	if err != nil {
 		return err
@@ -237,12 +222,6 @@ func (s GithubSource) LoadChangesets(ctx context.Context, cs ...*Changeset) erro
 		}
 	}
 
-	// Each LoadPullRequest call uses 3 tokens. This was calculated by manually calling the query
-	// and asking for the cost as described here:
-	// https://developer.github.com/v4/guides/resource-limitations/#returning-a-calls-rate-limit-status
-	if err := s.rateLimiter.WaitN(ctx, len(prs)*3); err != nil {
-		return errors.Wrap(err, "waiting for rate limiter")
-	}
 	err := s.client.LoadPullRequests(ctx, prs...)
 	if err != nil {
 		return err
@@ -264,9 +243,6 @@ func (s GithubSource) UpdateChangeset(ctx context.Context, c *Changeset) error {
 		return errors.New("Changeset is not a GitHub pull request")
 	}
 
-	if err := s.rateLimiter.Wait(ctx); err != nil {
-		return errors.Wrap(err, "waiting for rate limiter")
-	}
 	updated, err := s.client.UpdatePullRequest(ctx, &github.UpdatePullRequestInput{
 		PullRequestID: pr.ID,
 		Title:         c.Title,
@@ -389,7 +365,7 @@ func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult,
 		}
 
 		if hasNext && cost > 0 {
-			time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(cost))
+			time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(cost))
 		}
 	}
 }
@@ -411,7 +387,7 @@ func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *gi
 				}
 			}
 
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimitMonitor.Get()
 			log15.Debug(
 				"github sync: ListOrgRepositories",
 				"repos", len(repos),
@@ -443,7 +419,7 @@ func (s *GithubSource) listUser(ctx context.Context, user string, results chan *
 				fail, err = err, nil
 			}
 
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimitMonitor.Get()
 			log15.Debug(
 				"github sync: ListUserRepositories",
 				"repos", len(repos),
@@ -505,7 +481,7 @@ func (s *GithubSource) listRepos(ctx context.Context, repos []string, results ch
 
 		results <- &githubResult{repo: repo}
 
-		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
+		time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
 }
 
@@ -550,7 +526,7 @@ func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResul
 func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult) {
 	s.paginate(ctx, results, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
 		defer func() {
-			remaining, reset, retry, _ := s.client.RateLimit.Get()
+			remaining, reset, retry, _ := s.client.RateLimitMonitor.Get()
 			log15.Debug(
 				"github sync: ListAffiliated",
 				"repos", len(repos),
@@ -583,7 +559,7 @@ func (s *GithubSource) listSearch(ctx context.Context, query string, results cha
 		}
 
 		repos, hasNext := reposPage.Repos, reposPage.HasNextPage
-		remaining, reset, retry, ok := s.searchClient.RateLimit.Get()
+		remaining, reset, retry, ok := s.searchClient.RateLimitMonitor.Get()
 		log15.Debug(
 			"github sync: ListRepositoriesForSearch",
 			"searchString", query,
@@ -721,7 +697,7 @@ func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, result
 			results <- &githubResult{repo: r}
 		}
 
-		time.Sleep(s.client.RateLimit.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
+		time.Sleep(s.client.RateLimitMonitor.RecommendedWaitForBackgroundOp(1)) // 0-duration sleep unless nearing rate limit exhaustion
 	}
 
 	return nil

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -101,7 +101,7 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 				}),
 			}
 
-			githubSrc, err := NewGithubSource(svc, cf, nil)
+			githubSrc, err := NewGithubSource(svc, cf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -176,7 +176,7 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 				}),
 			}
 
-			githubSrc, err := NewGithubSource(svc, cf, nil)
+			githubSrc, err := NewGithubSource(svc, cf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -246,7 +246,7 @@ func TestGithubSource_UpdateChangeset(t *testing.T) {
 				}),
 			}
 
-			githubSrc, err := NewGithubSource(svc, cf, nil)
+			githubSrc, err := NewGithubSource(svc, cf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -320,7 +320,7 @@ func TestGithubSource_LoadChangesets(t *testing.T) {
 				}),
 			}
 
-			githubSrc, err := NewGithubSource(svc, cf, nil)
+			githubSrc, err := NewGithubSource(svc, cf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -427,7 +427,7 @@ func TestGithubSource_GetRepo(t *testing.T) {
 				}),
 			}
 
-			githubSrc, err := NewGithubSource(svc, cf, nil)
+			githubSrc, err := NewGithubSource(svc, cf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -485,7 +485,7 @@ func TestGithubSource_makeRepo(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			s, err := newGithubSource(&svc, test.schmea, nil, nil)
+			s, err := newGithubSource(&svc, test.schmea, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -685,7 +685,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 				Config: marshalJSON(t, tc.conf),
 			}
 
-			githubSrc, err := NewGithubSource(svc, cf, nil)
+			githubSrc, err := NewGithubSource(svc, cf)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -73,7 +73,7 @@ func NewChangesetSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limi
 func newSource(svc *ExternalService, cf *httpcli.Factory, rl *rate.Limiter) (Source, error) {
 	switch strings.ToUpper(svc.Kind) {
 	case extsvc.KindGitHub:
-		return NewGithubSource(svc, cf, rl)
+		return NewGithubSource(svc, cf)
 	case extsvc.KindGitLab:
 		return NewGitLabSource(svc, cf)
 	case extsvc.KindBitbucketServer:

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -144,7 +144,7 @@ func Main(enterpriseInit EnterpriseInit) {
 			switch c := cfg.(type) {
 			case *schema.GitHubConnection:
 				if strings.HasPrefix(c.Url, "https://github.com") && c.Token != "" {
-					server.GithubDotComSource, err = repos.NewGithubSource(e, cf, nil)
+					server.GithubDotComSource, err = repos.NewGithubSource(e, cf)
 				}
 			case *schema.GitLabConnection:
 				if strings.HasPrefix(c.Url, "https://gitlab.com") && c.Token != "" {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -247,7 +247,7 @@ func TestCampaigns(t *testing.T) {
 		t.Fatal(t)
 	}
 
-	githubSrc, err := repos.NewGithubSource(githubExtSvc, cf, nil)
+	githubSrc, err := repos.NewGithubSource(githubExtSvc, cf)
 	if err != nil {
 		t.Fatal(t)
 	}
@@ -684,7 +684,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 		t.Fatal(t)
 	}
 
-	githubSrc, err := repos.NewGithubSource(githubExtSvc, cf, nil)
+	githubSrc, err := repos.NewGithubSource(githubExtSvc, cf)
 	if err != nil {
 		t.Fatal(t)
 	}

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -64,7 +64,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			t.Fatal(t)
 		}
 
-		githubSrc, err := repos.NewGithubSource(extSvc, cf, nil)
+		githubSrc, err := repos.NewGithubSource(extSvc, cf)
 		if err != nil {
 			t.Fatal(t)
 		}

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -7,8 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"golang.org/x/time/rate"
 	"io"
 	"io/ioutil"
 	"log"
@@ -24,11 +22,13 @@ import (
 	"github.com/graphql-go/graphql/language/visitor"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"golang.org/x/time/rate"
 )
 
 var (


### PR DESCRIPTION
Now that we are using a global rate limit registry in the `ratelimit` package we can use it to find the appropriate rate limiter when we create a client.

Part of: https://github.com/sourcegraph/sourcegraph/issues/9953
