### PR TITLE
Fix enterprise startup

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -7,6 +7,7 @@
 #
 
 all_oss_commands=" gitserver query-runner github-proxy searcher replacer frontend repo-updater symbols "
+all_commands="${all_oss_commands}${ENTERPRISE_ONLY_COMMANDS}"
 
 # handle options
 verbose=false
@@ -25,11 +26,11 @@ shift "$(expr $OPTIND - 1)"
 # check provided commands
 ok=true
 case $# in
-  0) commands=$all_oss_commands ;;
+  0) commands=$all_commands ;;
   *)
     commands=" $* "
     for cmd in $commands; do
-      case $all_oss_commands in
+      case $all_commands in
         *" $cmd "*) ;;
         *)
           echo >&2 "unknown command: $cmd"

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -40,6 +40,17 @@ for i; do
           ;;
       esac
       ;;
+    enterprise/cmd/*)
+      cmd=${i#enterprise/cmd/}
+      cmd=${cmd%%/*}
+      case " ${cmdlist[*]} " in
+        " $cmd ") ;;
+
+        *)
+          cmdlist+=("$cmd")
+          ;;
+      esac
+      ;;
     *)
       all_cmds=true
       ;;

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -132,8 +132,9 @@ trap 'kill $build_ts_pid; exit' EXIT
 (yarn run build-ts || true) &
 build_ts_pid="$!"
 
+export PROCFILE=${PROCFILE:-dev/Procfile}
 printf >&2 "\nStarting all binaries...\n\n"
-export GOREMAN="goreman --set-ports=false --exit-on-error -f dev/Procfile"
+export GOREMAN="goreman --set-ports=false --exit-on-error -f ${PROCFILE}"
 
 if ! [ "$(id -u)" = 0 ] && command -v authbind; then
   # ignoring because $GOREMAN is used in other handle-change.sh

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -1,0 +1,28 @@
+gitserver: gitserver
+query-runner: query-runner
+repo-updater: repo-updater
+searcher: searcher
+replacer: replacer
+symbols: symbols
+github-proxy: github-proxy
+frontend: env CONFIGURATION_MODE=server SITE_CONFIG_ESCAPE_HATCH_PATH=$HOME/.sourcegraph/site-config.json frontend
+watch: ./dev/changewatch.sh
+nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf 2>&1 | grep -v 'could not open error log file'
+caddy: ./dev/caddy.sh run --watch --config=dev/Caddyfile
+web: ./node_modules/.bin/gulp --color watch
+syntect_server: ./dev/syntect_server.sh
+zoekt-indexserver-0: ./dev/zoekt/wrapper indexserver 0
+zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
+zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
+zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
+keycloak: ./dev/auth-provider/keycloak.sh
+jaeger: ./dev/jaeger.sh
+docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080
+prometheus: ./dev/prometheus.sh
+grafana: ./dev/grafana.sh
+postgres_exporter: ./dev/postgres_exporter.sh
+
+# Additional enterprise services
+precise-code-intel-bundle-manager: precise-code-intel-bundle-manager
+precise-code-intel-indexer: precise-code-intel-indexer
+precise-code-intel-worker: precise-code-intel-worker

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -38,7 +38,9 @@ export SOURCEGRAPH_LICENSE_GENERATION_KEY
 export PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187
 export PRECISE_CODE_INTEL_BUNDLE_DIR=$HOME/.sourcegraph/lsif-storage
 
-export WATCH_ADDITIONAL_GO_DIRS="$PWD/cmd $PWD/dev $PWD/internal"
-export ENTERPRISE_COMMANDS="frontend repo-updater precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-worker"
+export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"
+export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-worker "
+export ENTERPRISE_COMMANDS="frontend repo-updater ${ENTERPRISE_ONLY_COMMANDS}"
 export ENTERPRISE=1
+export PROCFILE=enterprise/dev/procfile
 ../dev/start.sh


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/11424 had removed the precise-code-intel services (which are defined **only** in enterprise) from procfile, making it so that they never run in dev.

Fixing this also surfaced another set of issues:

- Any change in enterprise/cmd restarts all services (fixed by adding a case to dev/handle-change.sh)
- There's only one Procfile, which means if there's an enterprise-only service, you either need to always build and launch it in the OSS version, or you need to launch them separately in enterprise (fixed by having an enterprise-defined Procfile)
- Removing the enterprise-only commands from all_oss_commands makes it so that the enterprise-commands are never built - this does not affect the enterprise version of frontend/repo-updater, which are already defined in the oss commands list (fixed by adding ENTERPRISE_ONLY_COMMANDS)
- Enterprise watch dirs did not match OSS watch dirs (the former used absolute paths while the latter used relative paths) - fixed by making enterprise watch dirs relative to repo root