### PR TITLE
src-expose: clearer warning log message

### DIFF
--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -156,7 +156,7 @@ func configureRepos(logger *log.Logger, root string) []string {
 
 	err := filepath.Walk(root, func(path string, fi os.FileInfo, fileErr error) error {
 		if fileErr != nil {
-			logger.Printf("error encountered on %s: %v", path, fileErr)
+			logger.Printf("WARN: ignoring error searching %s: %v", path, fileErr)
 			return nil
 		}
 		if !fi.IsDir() {


### PR DESCRIPTION
If you see this log message you may think something is broken. We still
want to show it because it may contain useful information if a setup is
misconfigured.