### PR TITLE
search: fix caps on annotation variable

### DIFF
--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -7,7 +7,7 @@ type Mapper interface {
 	MapNodes(m Mapper, node []Node) []Node
 	MapOperator(m Mapper, kind operatorKind, operands []Node) []Node
 	MapParameter(m Mapper, field, value string, negated bool) Node
-	MapPattern(m Mapper, value string, negated bool, Annotation Annotation) Node
+	MapPattern(m Mapper, value string, negated bool, annotation Annotation) Node
 }
 
 // The BaseMapper is a mapper that recursively visits each node in a query and
@@ -41,8 +41,8 @@ func (*BaseMapper) MapParameter(mapper Mapper, field, value string, negated bool
 }
 
 // Base mapper for Patterns. It is the identity function.
-func (*BaseMapper) MapPattern(mapper Mapper, value string, negated bool, Annotation Annotation) Node {
-	return Pattern{Value: value, Negated: negated, Annotation: Annotation}
+func (*BaseMapper) MapPattern(mapper Mapper, value string, negated bool, annotation Annotation) Node {
+	return Pattern{Value: value, Negated: negated, Annotation: annotation}
 }
 
 // OperatorMapper is a helper mapper that maps operators in a query. It takes as
@@ -78,11 +78,11 @@ func (s *ParameterMapper) MapParameter(mapper Mapper, field, value string, negat
 // the return value.
 type PatternMapper struct {
 	BaseMapper
-	callback func(value string, negated bool, Annotation Annotation) Node
+	callback func(value string, negated bool, annotation Annotation) Node
 }
 
-func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated bool, Annotation Annotation) Node {
-	return s.callback(value, negated, Annotation)
+func (s *PatternMapper) MapPattern(mapper Mapper, value string, negated bool, annotation Annotation) Node {
+	return s.callback(value, negated, annotation)
 }
 
 // FieldMapper is a helper mapper that only maps patterns in a query, for a
@@ -120,7 +120,7 @@ func MapParameter(nodes []Node, callback func(field, value string, negated bool)
 // MapPattern is a convenience function that calls callback on all pattern
 // nodes, substituting them for callback's return value. callback supplies the
 // node's field, value, and whether the value is negated.
-func MapPattern(nodes []Node, callback func(value string, negated bool, Annotation Annotation) Node) []Node {
+func MapPattern(nodes []Node, callback func(value string, negated bool, annotation Annotation) Node) []Node {
 	mapper := &PatternMapper{callback: callback}
 	return mapper.MapNodes(mapper, nodes)
 }

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -6,7 +6,7 @@ type Visitor interface {
 	VisitNodes(v Visitor, node []Node)
 	VisitOperator(v Visitor, kind operatorKind, operands []Node)
 	VisitParameter(v Visitor, field, value string, negated bool)
-	VisitPattern(v Visitor, value string, negated bool, Annotation Annotation)
+	VisitPattern(v Visitor, value string, negated bool, annotation Annotation)
 }
 
 // BaseVisitor is a visitor that recursively visits each node in a query. A
@@ -35,7 +35,7 @@ func (*BaseVisitor) VisitOperator(visitor Visitor, kind operatorKind, operands [
 
 func (*BaseVisitor) VisitParameter(visitor Visitor, field, value string, negated bool) {}
 
-func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated bool, Annotation Annotation) {
+func (*BaseVisitor) VisitPattern(visitor Visitor, value string, negated bool, annotation Annotation) {
 }
 
 // ParameterVisitor is a helper visitor that only visits operators in a query,
@@ -65,11 +65,11 @@ func (s *ParameterVisitor) VisitParameter(visitor Visitor, field, value string, 
 // and supplies the pattern members via a callback.
 type PatternVisitor struct {
 	BaseVisitor
-	callback func(value string, negated bool, Annotation Annotation)
+	callback func(value string, negated bool, annotation Annotation)
 }
 
-func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated bool, Annotation Annotation) {
-	s.callback(value, negated, Annotation)
+func (s *PatternVisitor) VisitPattern(visitor Visitor, value string, negated bool, annotation Annotation) {
+	s.callback(value, negated, annotation)
 }
 
 // FieldVisitor is a helper visitor that only visits parameter fields in a
@@ -105,7 +105,7 @@ func VisitParameter(nodes []Node, callback func(field, value string, negated boo
 // VisitPattern is a convenience function that calls callback on all pattern
 // nodes. callback supplies the node's value value, and whether the value is
 // negated or quoted.
-func VisitPattern(nodes []Node, callback func(value string, negated bool, Annotation Annotation)) {
+func VisitPattern(nodes []Node, callback func(value string, negated bool, annotation Annotation)) {
 	visitor := &PatternVisitor{callback: callback}
 	visitor.VisitNodes(visitor, nodes)
 }


### PR DESCRIPTION
A previous find-replace operation I did capitalized some variable names by accident, just undoing that.

Will merge without review.