### PR TITLE
search: refactor error types

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -10,14 +10,6 @@ import (
 	"unicode/utf8"
 )
 
-type ExpectedOperand struct {
-	Msg string
-}
-
-func (e *ExpectedOperand) Error() string {
-	return e.Msg
-}
-
 /*
 Parser implements a parser for the following grammar:
 
@@ -868,7 +860,7 @@ func (p *parser) parseAnd() ([]Node, error) {
 		return nil, err
 	}
 	if left == nil {
-		return nil, &UnsupportedError{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
+		return nil, &ExpectedOperand{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
 	}
 	if !p.expect(AND) {
 		return left, nil
@@ -888,7 +880,7 @@ func (p *parser) parseOr() ([]Node, error) {
 		return nil, err
 	}
 	if left == nil {
-		return nil, &UnsupportedError{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
+		return nil, &ExpectedOperand{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
 	}
 	if !p.expect(OR) {
 		return left, nil

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -8,6 +8,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
 )
 
+type ExpectedOperand struct {
+	Msg string
+}
+
+func (e *ExpectedOperand) Error() string {
+	return e.Msg
+}
+
+type UnsupportedError struct {
+	Msg string
+}
+
+func (e *UnsupportedError) Error() string {
+	return e.Msg
+}
+
 type SearchType int
 
 const (

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -9,14 +9,6 @@ import (
 	"github.com/src-d/enry/v2"
 )
 
-type UnsupportedError struct {
-	Msg string
-}
-
-func (e *UnsupportedError) Error() string {
-	return e.Msg
-}
-
 // exists traverses every node in nodes and returns early as soon as fn is satisfied.
 func exists(nodes []Node, fn func(node Node) bool) bool {
 	found := false


### PR DESCRIPTION
Part 1 of stack for literal search with and/or operators. Splitting things up so that some of the easy PRs can be approved by anyone, not just search team.

This moves dedicated error types to `types.go` and corrects the return type for some parser errors.