### PR TITLE
search: expose search type to new parser

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -93,7 +93,7 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 		// To process the input as an and/or query, the flag must be enabled, not be a
 		// literal search, and must contain either an 'and' or 'or' expression.
 		// Else, fallback to the older existing parser.
-		queryInfo, err = query.ProcessAndOr(args.Query)
+		queryInfo, err = query.ProcessAndOr(args.Query, searchType)
 		if err != nil {
 			return alertForQuery(args.Query, err), nil
 		}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1109,7 +1109,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 }
 
 func TestSearchResolver_evaluateWarning(t *testing.T) {
-	q, _ := query.ProcessAndOr("file:foo or file:bar")
+	q, _ := query.ProcessAndOr("file:foo or file:bar", query.SearchTypeRegex)
 	wantPrefix := "I'm having trouble understanding that query."
 	andOrQuery, _ := q.(*query.AndOrQuery)
 	got, _ := (&searchResolver{}).evaluate(context.Background(), andOrQuery.Query)
@@ -1119,7 +1119,7 @@ func TestSearchResolver_evaluateWarning(t *testing.T) {
 		}
 	})
 
-	_, err := query.ProcessAndOr("file:foo or or or")
+	_, err := query.ProcessAndOr("file:foo or or or", query.SearchTypeRegex)
 	gotAlert := alertForQuery("", err)
 	t.Run("warn for unsupported ambiguous and/or query", func(t *testing.T) {
 		if !strings.HasPrefix(gotAlert.description, wantPrefix) {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -960,16 +960,23 @@ func ParseLiteralSearch(in string) ([]Node, error) {
 }
 
 // ProcessAndOr query parses and validates an and/or query for a given search type.
-func ProcessAndOr(in string) (QueryInfo, error) {
-	query, err := ParseAndOr(in)
-	if err != nil {
-		return nil, err
-	}
-	query = Map(query, LowercaseFieldNames, SubstituteAliases)
-	err = validate(query)
-	if err != nil {
-		return nil, err
-	}
+func ProcessAndOr(in string, searchType SearchType) (QueryInfo, error) {
+	var query []Node
+	var err error
 
+	switch searchType {
+	case SearchTypeLiteral:
+		// SearchTypeLiteral is not supported yet.
+	case SearchTypeRegex, SearchTypeStructural:
+		query, err = ParseAndOr(in)
+		if err != nil {
+			return nil, err
+		}
+		query = Map(query, LowercaseFieldNames, SubstituteAliases)
+		err = validate(query)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &AndOrQuery{Query: query}, nil
 }

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -48,7 +48,7 @@ func TestAndOrQuery_Validation(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
-			_, err := ProcessAndOr(c.input)
+			_, err := ProcessAndOr(c.input, SearchTypeRegex)
 			if err == nil {
 				t.Fatal("expected test to fail")
 			}
@@ -85,7 +85,7 @@ func TestAndOrQuery_IsCaseSensitive(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			query, err := ProcessAndOr(c.input)
+			query, err := ProcessAndOr(c.input, SearchTypeRegex)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -115,7 +115,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 		},
 	}
 	t.Run("for regexp field", func(t *testing.T) {
-		query, err := ProcessAndOr(c.query)
+		query, err := ProcessAndOr(c.query, SearchTypeRegex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +130,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 }
 
 func TestAndOrQuery_CaseInsensitiveFields(t *testing.T) {
-	query, err := ProcessAndOr("repoHasFile:foo")
+	query, err := ProcessAndOr("repoHasFile:foo", SearchTypeRegex)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Stacked PR no. 2. Easy PR: this just exposes `searchType` to the new parser so that I can add the code path that is specific to literal search. No functional changes.