### PR TITLE
search: pull labels out of parser

### DIFF
--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -1,0 +1,38 @@
+package query
+
+import "sort"
+
+// Labels are general-purpose annotations that store information about a node.
+type labels uint8
+
+const (
+	None    labels = 0
+	Literal        = 1 << iota
+	Quoted
+	HeuristicParensAsPatterns
+	HeuristicDanglingParens
+	HeuristicHoisted
+)
+
+var allLabels = map[labels]string{
+	None:                      "None",
+	Literal:                   "Literal",
+	Quoted:                    "Quoted",
+	HeuristicParensAsPatterns: "HeuristicParensAsPatterns",
+	HeuristicDanglingParens:   "HeuristicDanglingParens",
+	HeuristicHoisted:          "HeuristicHoisted",
+}
+
+func Strings(labels labels) []string {
+	if labels == 0 {
+		return []string{"None"}
+	}
+	var s []string
+	for k, v := range allLabels {
+		if k&labels != 0 {
+			s = append(s, v)
+		}
+	}
+	sort.Strings(s)
+	return s
+}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -29,17 +29,6 @@ func (Pattern) node()   {}
 func (Parameter) node() {}
 func (Operator) node()  {}
 
-// Labels are general-purpose annotations that store information about a node.
-type labels uint8
-
-const (
-	None    labels = 0
-	Literal        = 1 << iota
-	Quoted
-	HeuristicParensAsPatterns
-	HeuristicDanglingParens
-)
-
 // An annotation stores information associated with a node.
 type Annotation struct {
 	Labels labels


### PR DESCRIPTION
Stacked PR no. 3. Easy PR: just pulls out some `labels` type member and adds helper functions for pretty printing the bitmap values. No tests for the helper functions here since they are unused, and are only useful in subsequent tests.