### PR TITLE
docker-images(grafana): manually create additional dir

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -44,6 +44,7 @@ COPY home.json /usr/share/grafana/public/dashboards/home.json
 
 COPY --from=builder /dashboards/*.json /sg_config_grafana/provisioning/dashboards/sourcegraph_internal/
 COPY --from=builder /generated/grafana/* /sg_config_grafana/provisioning/dashboards/sourcegraph/
+RUN mkdir /sg_grafana_additional_dashboards
 
 # hadolint ignore=DL3020
 ADD --chown=grafana:grafana entry.sh /


### PR DESCRIPTION
Grafana seems to be crash-loop-backoffing on `dot-com` trying to find`/sg_grafana_additional_dashboards` - looking at the diff of https://github.com/sourcegraph/sourcegraph/commit/8451bb7fa365b3d406fe51c6d447085978a7c322, I can't find anything that might cause this. 

This change tries to create the dir manually in the image to avoid it being nonexisting, since on `dot-com` we don't seem to mount anything to `/sg_grafana_additional_dashboards`


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
