### PR TITLE
search: convert concat operator to spaces for literal search

### DIFF
--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -195,6 +195,14 @@ var tests = []test{
 		Name:  `Escaped whitespace sequences with 'and'`,
 		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \ and /`,
 	},
+	{
+		Name:  `Concat converted to spaces for literal search`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go caCertPool := or x509 Pool patterntype:literal`,
+	},
+	{
+		Name:  `Concat converted to .* for regexp search`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go ca Pool or x509 Pool stable:yes type:file`,
+	},
 }
 
 func sanitizeFilename(s string) string {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -905,6 +905,7 @@ func ProcessAndOr(in string, searchType SearchType) (QueryInfo, error) {
 		if err != nil {
 			return nil, err
 		}
+		query = substituteConcat(query, " ")
 	case SearchTypeRegex, SearchTypeStructural:
 		query, err = ParseAndOr(in)
 		if err != nil {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -163,6 +163,62 @@ func substituteOrForRegexp(nodes []Node) []Node {
 	return new
 }
 
+// substituteConcat reduces a concatenation of patterns to a separator-separated string.
+func substituteConcat(nodes []Node, separator string) []Node {
+	isPattern := func(node Node) bool {
+		if pattern, ok := node.(Pattern); ok && !pattern.Negated {
+			return true
+		}
+		return false
+	}
+	new := []Node{}
+	for _, node := range nodes {
+		switch v := node.(type) {
+		case Parameter, Pattern:
+			new = append(new, node)
+		case Operator:
+			if v.Kind == Concat {
+				// Merge consecutive patterns.
+				previous := v.Operands[0]
+				merged := Pattern{}
+				if p, ok := previous.(Pattern); ok {
+					merged = p
+				}
+				for _, node := range v.Operands[1:] {
+					if isPattern(node) && isPattern(previous) {
+						p := node.(Pattern)
+						if merged.Value != "" {
+							merged.Annotation.Labels |= p.Annotation.Labels
+							merged = Pattern{
+								Value:      merged.Value + separator + p.Value,
+								Annotation: merged.Annotation,
+							}
+						} else {
+							// Base case.
+							merged = Pattern{Value: p.Value}
+						}
+						previous = node
+						continue
+					}
+					if merged.Value != "" {
+						new = append(new, merged)
+						merged = Pattern{}
+					}
+					new = append(new, substituteConcat([]Node{node}, separator)...)
+				}
+				if merged.Value != "" {
+					new = append(new, merged)
+					merged = Pattern{}
+				}
+			} else {
+				new = append(new, newOperator(substituteConcat(v.Operands, separator), v.Kind)...)
+			}
+		}
+
+	}
+	return new
+}
+
 // Map pipes query through one or more query transformer functions.
 func Map(query []Node, fns ...func([]Node) []Node) []Node {
 	for _, fn := range fns {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -228,6 +228,39 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 	}
 }
 
+func TestSubstituteConcat(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "a b c d e f",
+			want:  `"a b c d e f"`,
+		},
+		{
+			input: "a (b and c) d",
+			want:  `"a" (and "b" "c") "d"`,
+		},
+		{
+			input: "a b (c and d) e f (g or h) (i j k)",
+			want:  `"a b" (and "c" "d") "e f" (or "g" "h") "(i j k)"`,
+		},
+		{
+			input: "(((a b c))) and d",
+			want:  `(and "(((a b c)))" "d")`,
+		},
+	}
+	for _, c := range cases {
+		t.Run("Map query", func(t *testing.T) {
+			query, _ := ParseAndOr(c.input)
+			got := prettyPrint(substituteConcat(query, " "))
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
 func TestMap(t *testing.T) {
 	cases := []struct {
 		input string


### PR DESCRIPTION
Our [existing code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e9fddd6fd0d99576532b04f54f284b072bd2139/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1806:38) will substitute `concat` operators with `.*?`, but for literal search we want this to be spaces. This PR simply converts `concat` operators for literal search before the existing code can affect it. Once all the desired behavior and test are in place, we can concentrate the existing code logic in the new parser code.
