### PR TITLE
search: structural search uses literal search parser

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -89,7 +89,7 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	}
 
 	var queryInfo query.QueryInfo
-	if conf.AndOrQueryEnabled() && query.ContainsAndOrKeyword(args.Query) {
+	if (conf.AndOrQueryEnabled() && query.ContainsAndOrKeyword(args.Query)) || searchType == query.SearchTypeStructural {
 		// To process the input as an and/or query, the flag must be enabled
 		// and must contain either an 'and' or 'or' expression.
 		// Else, fallback to the older existing parser.

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -105,6 +105,10 @@ var tests = []test{
 		Name:  `Global search, structural, index only, nonzero result`,
 		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ make(:[1]) index:only patterntype:structural count:3`,
 	},
+	{
+		Name:  `Structural search quotes are interpreted literally`,
+		Query: `repo:^github\.com/rvantonderp/auth0-go-jwt-middleware$ file:^README\.md "This :[_] authenticated :[_]" patterntype:structural`,
+	},
 	// Repo search (part 2).
 	{
 		Name:  `Global search, archived excluded, zero results`,
@@ -202,6 +206,10 @@ var tests = []test{
 	{
 		Name:  `Concat converted to .* for regexp search`,
 		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go ca Pool or x509 Pool stable:yes type:file`,
+	},
+	{
+		Name:  `Structural search uses literal search parser`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go :[[v]] := x509 and AppendCertsFromPEM(:[_]) patterntype:structural`,
 	},
 }
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -900,13 +900,13 @@ func ProcessAndOr(in string, searchType SearchType) (QueryInfo, error) {
 	var err error
 
 	switch searchType {
-	case SearchTypeLiteral:
+	case SearchTypeLiteral, SearchTypeStructural:
 		query, err = ParseAndOrLiteral(in)
 		if err != nil {
 			return nil, err
 		}
 		query = substituteConcat(query, " ")
-	case SearchTypeRegex, SearchTypeStructural:
+	case SearchTypeRegex:
 		query, err = ParseAndOr(in)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Similar to #11480, structural search expects concatenated patterns to also be space-separated search patterns, so now uses the same parser as literal search before being handed off to comby. 

Because the literal search parser interprets quotes literally (which is what we want), but the parser without and/or queries does not, I am activating the new parser unconditionally for structural search queries, and cover this behavior with integration tests.