### PR TITLE
search: merge line matches for union operation

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -660,6 +660,37 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 	return rr, err
 }
 
+// unionMerge performs a merge of file match results, merging line matches when
+// they occur in the same file, and taking care to update match counts.
+func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
+	for _, leftMatch := range left.SearchResults {
+		for _, rightMatch := range right.SearchResults {
+			rightFileMatch, ok := rightMatch.ToFileMatch()
+			if !ok {
+				left.SearchResults = append(left.SearchResults, rightMatch)
+				continue
+			}
+
+			leftFileMatch, ok := leftMatch.ToFileMatch()
+			if !ok {
+				left.SearchResults = append(left.SearchResults, rightMatch)
+			}
+
+			if leftFileMatch.uri == rightFileMatch.uri {
+				leftFileMatch.JLineMatches = append(leftFileMatch.JLineMatches, rightFileMatch.JLineMatches...)
+				leftFileMatch.MatchCount += rightFileMatch.MatchCount
+				leftFileMatch.JLimitHit = leftFileMatch.JLimitHit || rightFileMatch.JLimitHit
+			} else {
+				left.SearchResults = append(left.SearchResults, rightMatch)
+			}
+
+		}
+	}
+	// merge common search data.
+	left.searchResultsCommon.update(right.searchResultsCommon)
+	return left
+}
+
 // union returns the union of two sets of search results and merges common search data.
 func union(left, right *SearchResultsResolver) *SearchResultsResolver {
 	if right == nil {
@@ -668,72 +699,54 @@ func union(left, right *SearchResultsResolver) *SearchResultsResolver {
 	if left == nil {
 		return right
 	}
+
 	if left.SearchResults != nil && right.SearchResults != nil {
-		rightFileMatches := make(map[string]*FileMatchResolver)
-		for _, r := range right.SearchResults {
-			if fileMatch, ok := r.ToFileMatch(); ok {
-				rightFileMatches[fileMatch.uri] = fileMatch
-			}
-		}
-
-		for _, leftMatch := range left.SearchResults {
-			leftFileMatch, ok := leftMatch.ToFileMatch()
-			if !ok {
-				continue
-			}
-
-			if rightFileMatch := rightFileMatches[leftFileMatch.uri]; rightFileMatch != nil {
-				// Merge line matches for the same file.
-				leftFileMatch.JLineMatches = append(leftFileMatch.JLineMatches, rightFileMatch.JLineMatches...)
-			}
-		}
-
-		left.SearchResults = append(left.SearchResults, right.SearchResults...)
-		// merge common search data.
-		left.searchResultsCommon.update(right.searchResultsCommon)
-		return left
+		return unionMerge(left, right)
 	} else if right.SearchResults != nil {
 		return right
 	}
 	return left
 }
 
-// intersect returns the intersection of two sets of search result content
-// matches, based on whether a single file path contains content matches in both
-// sets.
-func intersect(left, right *SearchResultsResolver) (*SearchResultsResolver, error) {
-	if left == nil || right == nil {
-		return nil, nil
-	}
-
-	rFileMatches := make(map[string]*FileMatchResolver)
-
+// intersectMerge performs a merge of file match results, merging line matches
+// for files contained in both result sets, and updating counts.
+func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
+	rightFileMatches := make(map[string]*FileMatchResolver)
 	for _, r := range right.SearchResults {
 		if fileMatch, ok := r.ToFileMatch(); ok {
-			rFileMatches[fileMatch.uri] = fileMatch
+			rightFileMatches[fileMatch.uri] = fileMatch
 		}
 	}
 
 	var merged []SearchResultResolver
-	for _, ltmp := range left.SearchResults {
-		ltmpFileMatch, ok := ltmp.ToFileMatch()
+	for _, leftMatch := range left.SearchResults {
+		leftFileMatch, ok := leftMatch.ToFileMatch()
 		if !ok {
 			continue
 		}
 
-		rtmpFileMatch := rFileMatches[ltmpFileMatch.uri]
-		if rtmpFileMatch == nil {
+		rightFileMatch := rightFileMatches[leftFileMatch.uri]
+		if rightFileMatch == nil {
 			continue
 		}
 
-		ltmpFileMatch.JLineMatches = append(ltmpFileMatch.JLineMatches, rtmpFileMatch.JLineMatches...)
-		merged = append(merged, ltmp)
+		leftFileMatch.JLineMatches = append(leftFileMatch.JLineMatches, rightFileMatch.JLineMatches...)
+		leftFileMatch.MatchCount += rightFileMatch.MatchCount
+		leftFileMatch.JLimitHit = leftFileMatch.JLimitHit || rightFileMatch.JLimitHit
+		merged = append(merged, leftMatch)
 	}
 	left.SearchResults = merged
 	left.searchResultsCommon.update(right.searchResultsCommon)
-	// for intersect we want the newly computed intersection size.
-	left.searchResultsCommon.resultCount = int32(len(merged))
-	return left, nil
+	return left
+}
+
+// intersect returns the intersection of two sets of search result content
+// matches, based on whether a single file path contains content matches in both sets.
+func intersect(left, right *SearchResultsResolver) *SearchResultsResolver {
+	if left == nil || right == nil {
+		return nil
+	}
+	return intersectMerge(left, right)
 }
 
 // evaluateAnd performs set intersection on result sets. It collects results for
@@ -796,10 +809,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 			}
 			if new != nil {
 				exhausted = exhausted && !new.limitHit
-				result, err = intersect(result, new)
-				if err != nil {
-					return nil, err
-				}
+				result = intersect(result, new)
 			}
 		}
 		if exhausted {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -669,6 +669,25 @@ func union(left, right *SearchResultsResolver) *SearchResultsResolver {
 		return right
 	}
 	if left.SearchResults != nil && right.SearchResults != nil {
+		rightFileMatches := make(map[string]*FileMatchResolver)
+		for _, r := range right.SearchResults {
+			if fileMatch, ok := r.ToFileMatch(); ok {
+				rightFileMatches[fileMatch.uri] = fileMatch
+			}
+		}
+
+		for _, leftMatch := range left.SearchResults {
+			leftFileMatch, ok := leftMatch.ToFileMatch()
+			if !ok {
+				continue
+			}
+
+			if rightFileMatch := rightFileMatches[leftFileMatch.uri]; rightFileMatch != nil {
+				// Merge line matches for the same file.
+				leftFileMatch.JLineMatches = append(leftFileMatch.JLineMatches, rightFileMatch.JLineMatches...)
+			}
+		}
+
 		left.SearchResults = append(left.SearchResults, right.SearchResults...)
 		// merge common search data.
 		left.searchResultsCommon.update(right.searchResultsCommon)

--- a/doc/user/search/queries.md
+++ b/doc/user/search/queries.md
@@ -99,7 +99,7 @@ Use operators to create more expressive searches.
 | --- | --- |
 | `and`, `AND` | [`conf.Get( and log15.Error(`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+conf.Get%28+and+log15.Error%28&patternType=regexp), [`conf.Get( and log15.Error( and after`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+conf.Get%28+and+log15.Error%28+and+after&patternType=regexp) |
 
-Returns results for files containing matches on the left _and_ right side of the `and` (set intersection). The number of results reports the number of files containing both strings.
+Returns results for files containing matches on the left _and_ right side of the `and` (set intersection).
 
 | Operator | Example |
 | --- | --- |

--- a/internal/cmd/search-integration-tester/search.go
+++ b/internal/cmd/search-integration-tester/search.go
@@ -12,7 +12,7 @@ const gqlSearch = `query Search($query: String!) {
 	search(query: $query) {
 		results {
 			limitHit
-                        matchCount
+			matchCount
 			results {
 				__typename
 				... on Repository {

--- a/internal/cmd/search-integration-tester/search.go
+++ b/internal/cmd/search-integration-tester/search.go
@@ -12,6 +12,7 @@ const gqlSearch = `query Search($query: String!) {
 	search(query: $query) {
 		results {
 			limitHit
+                        matchCount
 			results {
 				__typename
 				... on Repository {

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -215,7 +215,6 @@ var tests = []test{
 		Name:  `Union file matches per file and accurate counts`,
 		Query: `repo:^github\.com/rvantonderp/DirectXMan12-k8s-prometheus-adapter$@4b5788e file:^cmd/adapter/adapter\.go func or main`,
 	},
-	// FIXME: intersect needs the same update
 	{
 		Name:  `Intersect file matches per file and accurate counts`,
 		Query: `repo:^github\.com/rvantonderp/DirectXMan12-k8s-prometheus-adapter$@4b5788e file:^cmd/adapter/adapter\.go func and main`,

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -205,7 +205,7 @@ var tests = []test{
 	},
 	{
 		Name:  `Concat converted to .* for regexp search`,
-		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go ca Pool or x509 Pool stable:yes type:file`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go ca Pool or x509 Pool patterntype:regexp stable:yes type:file`,
 	},
 	{
 		Name:  `Structural search uses literal search parser`,

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -211,6 +211,15 @@ var tests = []test{
 		Name:  `Structural search uses literal search parser`,
 		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ file:^client\.go :[[v]] := x509 and AppendCertsFromPEM(:[_]) patterntype:structural`,
 	},
+	{
+		Name:  `Union file matches per file and accurate counts`,
+		Query: `repo:^github\.com/rvantonderp/DirectXMan12-k8s-prometheus-adapter$@4b5788e file:^cmd/adapter/adapter\.go func or main`,
+	},
+	// FIXME: intersect needs the same update
+	{
+		Name:  `Intersect file matches per file and accurate counts`,
+		Query: `repo:^github\.com/rvantonderp/DirectXMan12-k8s-prometheus-adapter$@4b5788e file:^cmd/adapter/adapter\.go func and main`,
+	},
 }
 
 func sanitizeFilename(s string) string {


### PR DESCRIPTION
This PR merges line matches in the same file for union operations. If this isn't done, the results may contain distinct line match results for the same file, which means we show the file multiple times in the webapp for the separate results, rather than highlight the union of results in the same file.

Behavior covered by integration test.