### PR TITLE
build: fix version embeds

### DIFF
--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -18,7 +18,7 @@ export CGO_ENABLED=0
 
 echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/cmd/frontend"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 echo "--- docker build $IMAGE"
 docker build -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assets"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 // Note: All frontend code should be added to shared.Main, not here. See that
@@ -14,6 +15,8 @@ func main() {
 	// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
+
+	println(version.Version())
 
 	shared.Main(func() enterprise.Services {
 		return enterprise.DefaultServices()

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assets"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
-	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 // Note: All frontend code should be added to shared.Main, not here. See that
@@ -15,8 +14,6 @@ func main() {
 	// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
-
-	println(version.Version())
 
 	shared.Main(func() enterprise.Services {
 		return enterprise.DefaultServices()

--- a/cmd/github-proxy/build.sh
+++ b/cmd/github-proxy/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg="github.com/sourcegraph/sourcegraph/cmd/github-proxy"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f cmd/github-proxy/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg="github.com/sourcegraph/sourcegraph/cmd/gitserver"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/loadtest/build.sh
+++ b/cmd/loadtest/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg="github.com/sourcegraph/sourcegraph/cmd/loadtest"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f cmd/loadtest/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/query-runner/build.sh
+++ b/cmd/query-runner/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg="github.com/sourcegraph/sourcegraph/cmd/query-runner"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f cmd/query-runner/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/replacer/build.sh
+++ b/cmd/replacer/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg="github.com/sourcegraph/sourcegraph/cmd/replacer"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f cmd/replacer/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -18,7 +18,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 for pkg in $path_to_package; do
-  go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename "$pkg")" "$pkg"
+  go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename "$pkg")" "$pkg"
 done
 
 docker build -f cmd/repo-updater/Dockerfile -t "$IMAGE" "$OUTPUT" \

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg="github.com/sourcegraph/sourcegraph/cmd/searcher"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f cmd/searcher/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/symbols/go-build.sh
+++ b/cmd/symbols/go-build.sh
@@ -18,4 +18,4 @@ export GOOS=linux
 
 echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/cmd/symbols"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"

--- a/enterprise/cmd/frontend/build.sh
+++ b/enterprise/cmd/frontend/build.sh
@@ -17,7 +17,7 @@ export GOOS=linux
 export CGO_ENABLED=0
 
 pkg=github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
 docker build -f enterprise/cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/enterprise/cmd/precise-code-intel-bundle-manager/go-build.sh
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/go-build.sh
@@ -18,4 +18,4 @@ export GOOS=linux
 
 echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-bundle-manager"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"

--- a/enterprise/cmd/precise-code-intel-worker/go-build.sh
+++ b/enterprise/cmd/precise-code-intel-worker/go-build.sh
@@ -18,4 +18,4 @@ export GOOS=linux
 
 echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/11471

```sh
$> IMAGE=sourcegraph/server:rob VERSION=1.2.3 cmd/frontend/build.sh
$> docker run sourcegraph/frontend:rob  # with print version.Version()
1.2.3
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
