### PR TITLE
Add --except/--only to ./dev/start.sh

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -145,25 +145,27 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-if [ ! -z ${only} ] || [ ! -z ${except} ]; then
+if [ -n "${only}" ] || [ -n "${except}" ]; then
   services=${only:-$except}
-  services_pattern=$(echo ${services} | sed 's/,/|/g')
 
-  if [ ! -z ${except} ]; then
+  # "frontend,grafana,gitserver" -> "^(frontend|grafana|gitserver):"
+  services_pattern="^(${services//,/|}):"
+
+  if [ -n "${except}" ]; then
     grep_args="-vE"
   else
     grep_args="-E"
   fi;
 
   tmp_procfile=$(mktemp -t procfile_XXXXXXX)
-  cat ${PROCFILE} | grep ${grep_args} "^(${services_pattern}):" > ${tmp_procfile}
+  grep ${grep_args} "${services_pattern}" "${PROCFILE}" > "${tmp_procfile}"
   export PROCFILE=${tmp_procfile}
 fi
 
-if [ ! -z ${only} ]; then
-  printf >&2 "\nStarting binaries ${only}...\n\n"
-elif [ ! -z ${except} ]; then
-  printf >&2 "\nStarting all binaries, except ${except}...\n\n"
+if [ -n "${only}" ]; then
+  printf >&2 "\nStarting binaries %s...\n\n" "${only}"
+elif [ -n "${except}" ]; then
+  printf >&2 "\nStarting all binaries, except %s...\n\n" "${except}"
 else
   printf >&2 "\nStarting all binaries...\n\n"
 fi

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -137,12 +137,21 @@ export PROCFILE=${PROCFILE:-dev/Procfile}
 only=""
 except=""
 while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        -e|--except) except="$2"; shift ;;
-        -o|--only) only="$2"; shift ;;
-        *) echo "Unknown parameter passed: $1"; exit 1 ;;
-    esac
-    shift
+  case $1 in
+    -e | --except)
+      except="$2"
+      shift
+      ;;
+    -o | --only)
+      only="$2"
+      shift
+      ;;
+    *)
+      echo "Unknown parameter passed: $1"
+      exit 1
+      ;;
+  esac
+  shift
 done
 
 if [ -n "${only}" ] || [ -n "${except}" ]; then
@@ -155,10 +164,10 @@ if [ -n "${only}" ] || [ -n "${except}" ]; then
     grep_args="-vE"
   else
     grep_args="-E"
-  fi;
+  fi
 
   tmp_procfile=$(mktemp -t procfile_XXXXXXX)
-  grep ${grep_args} "${services_pattern}" "${PROCFILE}" > "${tmp_procfile}"
+  grep ${grep_args} "${services_pattern}" "${PROCFILE}" >"${tmp_procfile}"
   export PROCFILE=${tmp_procfile}
 fi
 

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -43,4 +43,4 @@ export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code
 export ENTERPRISE_COMMANDS="frontend repo-updater ${ENTERPRISE_ONLY_COMMANDS}"
 export ENTERPRISE=1
 export PROCFILE=enterprise/dev/Procfile
-../dev/start.sh
+../dev/start.sh "$@"


### PR DESCRIPTION
This allows us to start only a subset of the services in `Procfile`:

 Start only 3 services:

    ./dev/start.sh --only frontend,gitserver,repo-updater

Start every service in Procfile, _except_ these two:

    ./dev/start.sh --except grafana,prometheus

