### PR TITLE
ratelimit: Normalize url in ratelimit package

### DIFF
--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -73,12 +72,11 @@ func NewClient(apiURL *url.URL, httpClient httpcli.Doer) *Client {
 		return category
 	})
 
-	normalisedURL := extsvc.NormalizeBaseURL(apiURL)
 	// Normally our registry will return a default infinite limiter when nothing has been
 	// synced from config. However, we always want to ensure there is at least some form of rate
 	// limiting for Bitbucket.
 	defaultLimiter := rate.NewLimiter(rateLimitRequestsPerSecond, RateLimitMaxBurstRequests)
-	l := ratelimit.DefaultRegistry.GetOrSet(normalisedURL.String(), defaultLimiter)
+	l := ratelimit.DefaultRegistry.GetOrSet(apiURL.String(), defaultLimiter)
 
 	return &Client{
 		httpClient: httpClient,

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/pkg/errors"
 	"github.com/segmentio/fasthash/fnv1"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -95,7 +94,6 @@ func NewClient(c *schema.BitbucketServerConnection, httpClient httpcli.Doer) (*C
 		httpClient = http.DefaultClient
 	}
 	httpClient = requestCounter.Doer(httpClient, categorize)
-	u = extsvc.NormalizeBaseURL(u)
 
 	// Normally our registry will return a default infinite limiter when nothing has been
 	// synced from config. However, we always want to ensure there is at least some form of rate

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/graphql-go/graphql/language/visitor"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -146,8 +145,7 @@ func NewClient(apiURL *url.URL, token string, cli httpcli.Doer) *Client {
 		return category
 	})
 
-	normalized := extsvc.NormalizeBaseURL(apiURL)
-	rl := ratelimit.DefaultRegistry.GetRateLimiter(normalized.String())
+	rl := ratelimit.DefaultRegistry.GetRateLimiter(apiURL.String())
 
 	return &Client{
 		apiURL:           apiURL,

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -187,7 +186,7 @@ func (p *ClientProvider) newClient(baseURL *url.URL, op getClientOp, httpClient 
 	key := sha256.Sum256([]byte(op.personalAccessToken + ":" + op.oauthToken + ":" + baseURL.String()))
 	projCache := rcache.NewWithTTL("gl_proj:"+base64.URLEncoding.EncodeToString(key[:]), int(cacheTTL/time.Second))
 
-	rl := ratelimit.DefaultRegistry.GetRateLimiter(extsvc.NormalizeBaseURL(baseURL).String())
+	rl := ratelimit.DefaultRegistry.GetRateLimiter(baseURL.String())
 
 	return &Client{
 		baseURL:             baseURL,


### PR DESCRIPTION
This removes the dependency on the extsvc package in a few places and
also doesn't couple extsvc.NormalizeBaseURL to the ratelimit
implementation.

