### PR TITLE
Skip TestReaderCacheConcurrentRequests due to race condition

### DIFF
--- a/enterprise/internal/codeintel/bundles/persistence/cache/reader_cache_test.go
+++ b/enterprise/internal/codeintel/bundles/persistence/cache/reader_cache_test.go
@@ -84,6 +84,8 @@ func TestReaderCacheInitError(t *testing.T) {
 }
 
 func TestReaderCacheConcurrentRequests(t *testing.T) {
+	t.Skip("Skipping because there seems to be race condition where the reported number of calls is wrong")
+
 	calls := 0
 	wait := make(chan struct{}) // blocks opener
 


### PR DESCRIPTION
As discussed on Slack, when I run this locally as part of the whole test
suite (`go test ./...`) I get the following failure:

    --- FAIL: TestReaderCacheConcurrentRequests (0.00s)
        reader_cache_test.go:142: unexpected number of calls. want=1 have=2
    FAIL
    FAIL    github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/bundles/persistence/cache      0.128s

