### PR TITLE
Remove distinction between manual and automatic campaigns

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -49,9 +49,9 @@ type Mutation {
     ): PatchSet!
     # Updates a campaign. Updating is not allowed when any of the following are true:
     #
-    # - The campaign has already been closed.
-    # - A plan is added to a manual campaign.
-    # - A non-manual campaign has a changeset that is not published (or is being published).
+    # - The campaign has been closed.
+    # - A campaign has one or more patches that are being published.
+    # - The new patch set contains no patches.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Retry publishing all changesets in the campaign that could not be
     # successfully created on the code host. Retrying will clear the errors
@@ -471,11 +471,12 @@ input CreateCampaignInput {
     # attribute is specified.
     branch: String
 
-    # An optional reference to a patchset that was created before this mutation. If null, existing
-    # changesets can be added manually. If set, no changesets can be added manually; they will be
-    # created. based on the patches belonging to the patchset. An error will be returned if the
-    # patchset has expired. Using a patchset to create or update a campaign will retain it for the
-    # lifetime of the campaign and prevent it from expiring.
+    # An optional reference to a patchset that was created before this
+    # mutation. If null, existing changesets can be added manually. If set,
+    # they will be created based on the patches belonging to the patchset. An
+    # error will be returned if the patchset has expired. Using a patchset to
+    # create or update a campaign will retain it for the lifetime of the
+    # campaign and prevent it from expiring.
     patchSet: ID
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -51,9 +51,9 @@ type Mutation {
     ): PatchSet!
     # Updates a campaign. Updating is not allowed when any of the following are true:
     #
-    # - The campaign has already been closed.
-    # - A plan is added to a manual campaign.
-    # - A non-manual campaign has a changeset that is not published (or is being published).
+    # - The campaign has been closed.
+    # - A campaign has one or more patches that are being published.
+    # - The new patch set contains no patches.
     updateCampaign(input: UpdateCampaignInput!): Campaign!
     # Retry publishing all changesets in the campaign that could not be
     # successfully created on the code host. Retrying will clear the errors
@@ -478,11 +478,12 @@ input CreateCampaignInput {
     # attribute is specified.
     branch: String
 
-    # An optional reference to a patchset that was created before this mutation. If null, existing
-    # changesets can be added manually. If set, no changesets can be added manually; they will be
-    # created. based on the patches belonging to the patchset. An error will be returned if the
-    # patchset has expired. Using a patchset to create or update a campaign will retain it for the
-    # lifetime of the campaign and prevent it from expiring.
+    # An optional reference to a patchset that was created before this
+    # mutation. If null, existing changesets can be added manually. If set,
+    # they will be created based on the patches belonging to the patchset. An
+    # error will be returned if the patchset has expired. Using a patchset to
+    # create or update a campaign will retain it for the lifetime of the
+    # campaign and prevent it from expiring.
     patchSet: ID
 }
 

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -523,8 +523,6 @@ func TestRepositoryPermissions(t *testing.T) {
 		AuthorID:        userID,
 		NamespaceUserID: userID,
 		// We attach the two changesets to the campaign
-		// Note: we are mixing a "manual" and "non-manual" campaign here, but
-		// that shouldn't matter for the purposes of this test.
 		ChangesetIDs: changesetIDs,
 	}
 	if err := store.CreateCampaign(ctx, campaign); err != nil {


### PR DESCRIPTION
I'm pretty sure that's _it_, basically. Our update process already doesn't interfere with manually added changesets, since they don't have `ChangesetJobs`/`Patches` etc. And the other checks I simply removed.

Once we have the frontend in place, we should go through the flow and see if we can find something that the tests don't cover.