### PR TITLE
rate_limit: Rename GetRateLimiter to Get

### DIFF
--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -1011,7 +1011,7 @@ func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context) error {
 	}
 
 	for u, rl := range byURL {
-		l := r.registry.GetRateLimiter(u)
+		l := r.registry.Get(u)
 		l.SetLimit(rl.Limit)
 	}
 

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -680,7 +680,7 @@ func TestSyncRateLimiters(t *testing.T) {
 			}
 
 			// We should have the lower limit
-			l := reg.GetRateLimiter(baseURL)
+			l := reg.Get(baseURL)
 			if l == nil {
 				t.Fatalf("expected a limiter")
 			}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -392,7 +392,7 @@ func (s *PermsSyncer) waitForRateLimit(ctx context.Context, serviceID string, n 
 		return nil
 	}
 
-	rl := s.rateLimiterRegistry.GetRateLimiter(serviceID)
+	rl := s.rateLimiterRegistry.Get(serviceID)
 	if err := rl.WaitN(ctx, n); err != nil {
 		return err
 	}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -416,7 +416,7 @@ func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 
 	t.Run("not enough quota available", func(t *testing.T) {
 		rateLimiterRegistry := ratelimit.NewRegistry()
-		l := rateLimiterRegistry.GetRateLimiter("https://github.com/")
+		l := rateLimiterRegistry.Get("https://github.com/")
 		l.SetLimit(1)
 		s := NewPermsSyncer(nil, nil, nil, rateLimiterRegistry)
 

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -145,7 +145,7 @@ func NewClient(apiURL *url.URL, token string, cli httpcli.Doer) *Client {
 		return category
 	})
 
-	rl := ratelimit.DefaultRegistry.GetRateLimiter(apiURL.String())
+	rl := ratelimit.DefaultRegistry.Get(apiURL.String())
 
 	return &Client{
 		apiURL:           apiURL,

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -186,7 +186,7 @@ func (p *ClientProvider) newClient(baseURL *url.URL, op getClientOp, httpClient 
 	key := sha256.Sum256([]byte(op.personalAccessToken + ":" + op.oauthToken + ":" + baseURL.String()))
 	projCache := rcache.NewWithTTL("gl_proj:"+base64.URLEncoding.EncodeToString(key[:]), int(cacheTTL/time.Second))
 
-	rl := ratelimit.DefaultRegistry.GetRateLimiter(baseURL.String())
+	rl := ratelimit.DefaultRegistry.Get(baseURL.String())
 
 	return &Client{
 		baseURL:             baseURL,

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -184,9 +184,9 @@ func normaliseURL(rawURL string) string {
 	return parsed.String()
 }
 
-// GetRateLimiter fetches the rate limiter associated with the given code host. If none has been
+// Get fetches the rate limiter associated with the given code host. If none has been
 // configured an infinite limiter is returned.
-func (r *Registry) GetRateLimiter(baseURL string) *rate.Limiter {
+func (r *Registry) Get(baseURL string) *rate.Limiter {
 	return r.GetOrSet(baseURL, nil)
 }
 


### PR DESCRIPTION
It is in the ratelimit package so doesn't need to be repeated. It's also
more consistent with the GetOrSet method on the same type.
