### PR TITLE
server docker image: alpine image packages

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -36,7 +36,7 @@ RUN apk update && apk add --no-cache \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/postgresql.md#version-requirements
     'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
-    'redis=5.0.9-r0' bind-tools ca-certificates git@edge \
+    'redis=5.0.5-r0' bind-tools ca-certificates 'git=2.22.4-r0' \
     mailcap nginx openssh-client pcre su-exec tini nodejs-current=12.4.0-r0 curl
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm


### PR DESCRIPTION
not sure why this changed but

https://buildkite.com/sourcegraph/e2e/builds/9941#a244d360-96ad-4668-a383-8d9895300b57

double checked with

```
 docker run -it --entrypoint=sh alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a -c /bin/sh
```

and running the apk commands by hand and verifying with https://pkgs.alpinelinux.org/packages?name=git&branch=v3.10