### PR TITLE
CHANGELOG: tell people to configure critical not warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
   ```
   "observability.alerts": {
     "id": "my-alert",
-    "level": "warning",
+    "level": "critical",
     "notifier": { "type": "slack", /* ... */ }
   }
   ```


### PR DESCRIPTION
Warning alerts are very noisy, most will just want to configure critical alerts to start with. I need to find a better way to communicate the difference.
