### PR TITLE
codeintel: Enforce a max reset count on uploads and index records

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -373,6 +373,7 @@ Indexes:
  finished_at     | timestamp with time zone | 
  repository_id   | integer                  | not null
  process_after   | timestamp with time zone | 
+ num_resets      | integer                  | not null default 0
 Indexes:
     "lsif_indexes_pkey" PRIMARY KEY, btree (id)
 Check constraints:
@@ -433,6 +434,7 @@ Foreign-key constraints:
  num_parts       | integer                  | not null
  uploaded_parts  | integer[]                | not null
  process_after   | timestamp with time zone | 
+ num_resets      | integer                  | not null default 0
 Indexes:
     "lsif_uploads_pkey" PRIMARY KEY, btree (id)
     "lsif_uploads_repository_id_commit_root_indexer" UNIQUE, btree (repository_id, commit, root, indexer) WHERE state = 'completed'::lsif_upload_state

--- a/enterprise/cmd/precise-code-intel-indexer/internal/resetter/metrics.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/resetter/metrics.go
@@ -3,16 +3,23 @@ package resetter
 import "github.com/prometheus/client_golang/prometheus"
 
 type ResetterMetrics struct {
-	Count  prometheus.Counter
-	Errors prometheus.Counter
+	IndexResets        prometheus.Counter
+	IndexResetFailures prometheus.Counter
+	Errors             prometheus.Counter
 }
 
 func NewResetterMetrics(r prometheus.Registerer) ResetterMetrics {
-	count := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "src_index_queue_resets_total",
+	indexResets := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_index_queue_reset_total",
 		Help: "Total number of indexes put back into queued state",
 	})
-	r.MustRegister(count)
+	r.MustRegister(indexResets)
+
+	indexResetFailures := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_index_queue_max_resets_total",
+		Help: "Total number of indexes that exceed the max number of resets",
+	})
+	r.MustRegister(indexResetFailures)
 
 	errors := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_index_queue_reset_errors_total",
@@ -21,7 +28,8 @@ func NewResetterMetrics(r prometheus.Registerer) ResetterMetrics {
 	r.MustRegister(errors)
 
 	return ResetterMetrics{
-		Count:  count,
-		Errors: errors,
+		IndexResets:        indexResets,
+		IndexResetFailures: indexResetFailures,
+		Errors:             errors,
 	}
 }

--- a/enterprise/cmd/precise-code-intel-indexer/internal/resetter/resetter.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/resetter/resetter.go
@@ -28,7 +28,6 @@ func (ur *IndexResetter) Run() {
 		for _, id := range resetIDs {
 			log15.Debug("Reset stalled index", "indexID", id)
 		}
-
 		for _, id := range erroredIDs {
 			log15.Debug("Failed stalled index", "indexID", id)
 		}

--- a/enterprise/cmd/precise-code-intel-worker/internal/resetter/metrics.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/resetter/metrics.go
@@ -3,16 +3,23 @@ package resetter
 import "github.com/prometheus/client_golang/prometheus"
 
 type ResetterMetrics struct {
-	Count  prometheus.Counter
-	Errors prometheus.Counter
+	UploadResets        prometheus.Counter
+	UploadResetFailures prometheus.Counter
+	Errors              prometheus.Counter
 }
 
 func NewResetterMetrics(r prometheus.Registerer) ResetterMetrics {
-	count := prometheus.NewCounter(prometheus.CounterOpts{
+	uploadResets := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_upload_queue_resets_total",
 		Help: "Total number of uploads put back into queued state",
 	})
-	r.MustRegister(count)
+	r.MustRegister(uploadResets)
+
+	uploadResetFailures := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_upload_queue_max_resets_total",
+		Help: "Total number of uploads that exceed the max number of resets",
+	})
+	r.MustRegister(uploadResetFailures)
 
 	errors := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_upload_queue_reset_errors_total",
@@ -21,7 +28,8 @@ func NewResetterMetrics(r prometheus.Registerer) ResetterMetrics {
 	r.MustRegister(errors)
 
 	return ResetterMetrics{
-		Count:  count,
-		Errors: errors,
+		UploadResets:        uploadResets,
+		UploadResetFailures: uploadResetFailures,
+		Errors:              errors,
 	}
 }

--- a/enterprise/internal/codeintel/store/dumps.go
+++ b/enterprise/internal/codeintel/store/dumps.go
@@ -21,6 +21,7 @@ type Dump struct {
 	StartedAt      *time.Time `json:"startedAt"`
 	FinishedAt     *time.Time `json:"finishedAt"`
 	ProcessAfter   *time.Time `json:"processAfter"`
+	NumResets      int        `json:"numResets"`
 	RepositoryID   int        `json:"repositoryId"`
 	Indexer        string     `json:"indexer"`
 }
@@ -46,6 +47,7 @@ func scanDumps(rows *sql.Rows, queryErr error) (_ []Dump, err error) {
 			&dump.StartedAt,
 			&dump.FinishedAt,
 			&dump.ProcessAfter,
+			&dump.NumResets,
 			&dump.RepositoryID,
 			&dump.Indexer,
 		); err != nil {
@@ -86,6 +88,7 @@ func (s *store) GetDumpByID(ctx context.Context, id int) (Dump, bool, error) {
 			d.started_at,
 			d.finished_at,
 			d.process_after,
+			d.num_resets,
 			d.repository_id,
 			d.indexer
 		FROM lsif_dumps d WHERE id = %s
@@ -134,6 +137,7 @@ func (s *store) FindClosestDumps(ctx context.Context, repositoryID int, commit, 
 				d.started_at,
 				d.finished_at,
 				d.process_after,
+				d.num_resets,
 				d.repository_id,
 				d.indexer
 			FROM lsif_dumps d WHERE %s

--- a/enterprise/internal/codeintel/store/dumps_test.go
+++ b/enterprise/internal/codeintel/store/dumps_test.go
@@ -86,6 +86,7 @@ func TestGetDumpByID(t *testing.T) {
 		StartedAt:      expected.StartedAt,
 		FinishedAt:     expected.FinishedAt,
 		ProcessAfter:   expected.ProcessAfter,
+		NumResets:      expected.NumResets,
 		RepositoryID:   expected.RepositoryID,
 		Indexer:        expected.Indexer,
 	})

--- a/enterprise/internal/codeintel/store/helpers_test.go
+++ b/enterprise/internal/codeintel/store/helpers_test.go
@@ -66,11 +66,12 @@ func insertUploads(t *testing.T, db *sql.DB, uploads ...Upload) {
 				started_at,
 				finished_at,
 				process_after,
+				num_resets,
 				repository_id,
 				indexer,
 				num_parts,
 				uploaded_parts
-			) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 		`,
 			upload.ID,
 			upload.Commit,
@@ -82,6 +83,7 @@ func insertUploads(t *testing.T, db *sql.DB, uploads ...Upload) {
 			upload.StartedAt,
 			upload.FinishedAt,
 			upload.ProcessAfter,
+			upload.NumResets,
 			upload.RepositoryID,
 			upload.Indexer,
 			upload.NumParts,
@@ -117,8 +119,9 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 				started_at,
 				finished_at,
 				process_after,
+				num_resets,
 				repository_id
-			) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+			) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 		`,
 			index.ID,
 			index.Commit,
@@ -128,6 +131,7 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 			index.StartedAt,
 			index.FinishedAt,
 			index.ProcessAfter,
+			index.NumResets,
 			index.RepositoryID,
 		)
 

--- a/enterprise/internal/codeintel/store/observability.go
+++ b/enterprise/internal/codeintel/store/observability.go
@@ -474,9 +474,9 @@ func (s *ObservedStore) DeleteUploadByID(ctx context.Context, id int, getTipComm
 }
 
 // ResetStalled calls into the inner store and registers the observed results.
-func (s *ObservedStore) ResetStalled(ctx context.Context, now time.Time) (ids []int, err error) {
+func (s *ObservedStore) ResetStalled(ctx context.Context, now time.Time) (resetIDs, erroredIDs []int, err error) {
 	ctx, endObservation := s.resetStalledOperation.With(ctx, &err, observation.Args{})
-	defer func() { endObservation(float64(len(ids)), observation.Args{}) }()
+	defer func() { endObservation(float64(len(resetIDs)+len(erroredIDs)), observation.Args{}) }()
 	return s.store.ResetStalled(ctx, now)
 }
 
@@ -656,9 +656,9 @@ func (s *ObservedStore) DeleteIndexByID(ctx context.Context, id int) (_ bool, er
 }
 
 // ResetStalledIndexes calls into the inner store and registers the observed results.
-func (s *ObservedStore) ResetStalledIndexes(ctx context.Context, now time.Time) (ids []int, err error) {
+func (s *ObservedStore) ResetStalledIndexes(ctx context.Context, now time.Time) (resetIDs, erroredIDs []int, err error) {
 	ctx, endObservation := s.resetStalledIndexesOperation.With(ctx, &err, observation.Args{})
-	defer func() { endObservation(float64(len(ids)), observation.Args{}) }()
+	defer func() { endObservation(float64(len(resetIDs)+len(erroredIDs)), observation.Args{}) }()
 	return s.store.ResetStalledIndexes(ctx, now)
 }
 

--- a/enterprise/internal/codeintel/store/packages.go
+++ b/enterprise/internal/codeintel/store/packages.go
@@ -21,6 +21,7 @@ func (s *store) GetPackage(ctx context.Context, scheme, name, version string) (D
 			d.started_at,
 			d.finished_at,
 			d.process_after,
+			d.num_resets,
 			d.repository_id,
 			d.indexer
 		FROM lsif_packages p

--- a/enterprise/internal/codeintel/store/packages_test.go
+++ b/enterprise/internal/codeintel/store/packages_test.go
@@ -53,6 +53,7 @@ func TestGetPackage(t *testing.T) {
 		StartedAt:      expected.StartedAt,
 		FinishedAt:     expected.FinishedAt,
 		ProcessAfter:   expected.ProcessAfter,
+		NumResets:      expected.NumResets,
 		RepositoryID:   expected.RepositoryID,
 		Indexer:        expected.Indexer,
 	})

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -76,8 +76,10 @@ type Store interface {
 	DeleteUploadByID(ctx context.Context, id int, getTipCommit GetTipCommitFn) (bool, error)
 
 	// ResetStalled moves all unlocked uploads processing for more than `StalledUploadMaxAge` back to the queued state.
-	// This method returns a list of updated upload identifiers.
-	ResetStalled(ctx context.Context, now time.Time) ([]int, error)
+	// In order to prevent input that continually crashes worker instances, uploads that have been reset more than
+	// UploadMaxNumResets times will be marked as errored. This method returns a list of updated and errored upload
+	// identifiers.
+	ResetStalled(ctx context.Context, now time.Time) ([]int, []int, error)
 
 	// GetDumpIDs returns all dump ids in chronological order.
 	GetDumpIDs(ctx context.Context) ([]int, error)
@@ -164,9 +166,11 @@ type Store interface {
 	// DeleteIndexByID deletes an index by its identifier.
 	DeleteIndexByID(ctx context.Context, id int) (bool, error)
 
-	// ResetStalledIndexes moves all unlocked indexes processing for more than `StalledIndexMaxAge` back to the
-	// queued state. This method returns a list of updated index identifiers.
-	ResetStalledIndexes(ctx context.Context, now time.Time) ([]int, error)
+	// ResetStalledIndexes moves all unlocked index processing for more than `StalledIndexMaxAge` back to the
+	// queued state. In order to prevent input that continually crashes indexer instances, indexes that have
+	// been reset more than IndexMaxNumResets times will be marked as errored. This method returns a list of
+	// updated and errored index identifiers.
+	ResetStalledIndexes(ctx context.Context, now time.Time) ([]int, []int, error)
 
 	// RepoUsageStatistics reads recent event log records and returns the number of search-based and precise
 	// code intelligence activity within the last week grouped by repository. The resulting slice is ordered

--- a/migrations/1528395684_lsif_num_resets.down.sql
+++ b/migrations/1528395684_lsif_num_resets.down.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+DROP VIEW lsif_dumps;
+
+ALTER TABLE lsif_uploads DROP COLUMN num_resets;
+ALTER TABLE lsif_indexes DROP COLUMN num_resets;
+
+-- Recreate view with original columns
+CREATE VIEW lsif_dumps AS SELECT u.*, u.finished_at as processed_at FROM lsif_uploads u WHERE state = 'completed';
+
+COMMIT;

--- a/migrations/1528395684_lsif_num_resets.up.sql
+++ b/migrations/1528395684_lsif_num_resets.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+DROP VIEW lsif_dumps;
+
+ALTER TABLE lsif_uploads ADD COLUMN num_resets integer NOT NULL DEFAULT 0;
+ALTER TABLE lsif_indexes ADD COLUMN num_resets integer NOT NULL DEFAULT 0;
+
+-- Recreate view with new columns
+CREATE VIEW lsif_dumps AS SELECT u.*, u.finished_at as processed_at FROM lsif_uploads u WHERE state = 'completed';
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -68,6 +68,8 @@
 // 1528395682_lsif_remove_failure_stacktrace.up.sql (454B)
 // 1528395683_empty.down.sql (37B)
 // 1528395683_empty.up.sql (159B)
+// 1528395684_lsif_num_resets.down.sql (293B)
+// 1528395684_lsif_num_resets.up.sql (340B)
 
 package migrations
 
@@ -1496,6 +1498,46 @@ func _1528395683_emptyUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395684_lsif_num_resetsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x74\x8f\xc1\x4e\xc3\x30\x18\x83\xef\x79\x0a\xdf\x26\x21\xb6\x17\xa8\x38\x74\xe5\x07\x26\xb5\x2b\xca\x02\x3b\x56\x51\xf3\x8f\x45\x4a\x93\xaa\x7f\xc2\x78\x7c\x04\x3b\x01\xe2\x68\xd9\x9f\x6c\x6f\xe9\x71\xb7\xaf\x94\xba\xd7\xfd\x33\x5e\x77\x74\x44\x10\x7f\x1a\x5c\x99\x66\xa9\x94\xaa\x5b\x43\x1a\xa6\xde\xb6\x74\x35\xca\x1c\x92\x75\x82\xef\x7c\xd3\xb7\x2f\xdd\x1e\xb1\x4c\xc3\xc2\xc2\x59\xaa\xbf\x80\x8f\x8e\x3f\xf8\x7f\x40\xad\xd7\xd0\x3c\x2e\x6c\x33\xe3\xdd\xf3\x05\x17\x9f\xcf\x48\x8b\x7f\xf3\xd1\x06\x8c\x29\x94\x29\x8a\x6a\x34\xd5\x86\x7e\x4f\x44\x7d\xc0\x81\x5a\x6a\x0c\xca\xe6\xe6\x16\x65\x73\xf2\xd1\xcb\x99\xdd\x60\x33\xac\x60\x5e\xd2\xc8\x22\x57\xfd\xa0\xfb\xee\xe7\x8d\x82\xe3\x13\x69\x82\xe4\xaf\xfa\x3b\xac\xc6\x34\xcd\x81\x33\xbb\x55\xa5\x54\xd3\x77\xdd\xce\x54\xea\x33\x00\x00\xff\xff\xa9\x9e\x35\x0a\x25\x01\x00\x00")
+
+func _1528395684_lsif_num_resetsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395684_lsif_num_resetsDownSql,
+		"1528395684_lsif_num_resets.down.sql",
+	)
+}
+
+func _1528395684_lsif_num_resetsDownSql() (*asset, error) {
+	bytes, err := _1528395684_lsif_num_resetsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395684_lsif_num_resets.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd6, 0xec, 0xea, 0x88, 0x2e, 0xac, 0x60, 0x71, 0x6b, 0x62, 0xc8, 0x97, 0xc6, 0x4d, 0xe4, 0x6d, 0x39, 0xec, 0x51, 0x72, 0xe7, 0xff, 0xb4, 0x4d, 0xbf, 0x97, 0xd8, 0x69, 0x98, 0x82, 0x53, 0xb2}}
+	return a, nil
+}
+
+var __1528395684_lsif_num_resetsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x8f\x31\x6b\xf3\x30\x14\x45\x77\xfd\x8a\xbb\x05\x3e\xbe\x84\xee\xa6\x83\x62\xbf\xb4\x01\xd9\x2e\x8a\xd2\x8c\xc6\xd8\x2f\x8d\xc0\x96\x8d\x9f\x54\xf7\xe7\x97\x92\xa9\xed\xd6\xf1\x72\xe1\x1c\xce\x9e\x9e\x8e\x55\xa6\x54\x61\xeb\x17\xbc\x1e\xe9\x82\x41\xfc\xb5\xe9\xd3\x38\x4b\xa6\x94\x36\x8e\x2c\x9c\xde\x1b\xba\x1f\x69\x1e\xa6\xb6\x17\xe8\xa2\x40\x5e\x9b\x73\x59\x21\xa4\xb1\x59\x58\x38\x0a\x7c\x88\xfc\xc6\x0b\xaa\xda\xa1\x3a\x1b\x83\x82\x0e\xfa\x6c\x1c\x1e\xb2\xdf\x28\x1f\x7a\xfe\xe0\xbf\xa0\xd4\x76\x0b\xcb\xdd\xc2\x6d\x64\xbc\x7b\x5e\xb1\xfa\x78\x43\xe0\x15\xdd\x34\xa4\x31\x88\xca\x2d\x69\x47\x3f\x8b\xa0\x4f\x38\x91\xa1\xdc\x21\xed\xfe\xfd\x47\xda\x5d\x7d\xf0\x72\xe3\xbe\x69\x23\x5a\xc1\xbc\x4c\x1d\x8b\xdc\xf7\xc1\xd6\xe5\xf7\xea\x84\xcb\x33\x59\x82\xc4\x2f\xf3\x23\x36\xdd\x34\xce\x03\x47\xee\x37\x99\x52\x79\x5d\x96\x47\x97\xa9\xcf\x00\x00\x00\xff\xff\x35\x4e\x70\x00\x54\x01\x00\x00")
+
+func _1528395684_lsif_num_resetsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395684_lsif_num_resetsUpSql,
+		"1528395684_lsif_num_resets.up.sql",
+	)
+}
+
+func _1528395684_lsif_num_resetsUpSql() (*asset, error) {
+	bytes, err := _1528395684_lsif_num_resetsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395684_lsif_num_resets.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9d, 0xf1, 0xc3, 0x8, 0xc6, 0x51, 0x22, 0xde, 0x5a, 0x48, 0x53, 0x23, 0x28, 0xd8, 0x17, 0x7d, 0x58, 0x93, 0xeb, 0x4e, 0xd, 0x7, 0x13, 0x7e, 0x62, 0xe4, 0x4b, 0xd7, 0xe3, 0x40, 0x76, 0x7c}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1655,6 +1697,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395682_lsif_remove_failure_stacktrace.up.sql":                        _1528395682_lsif_remove_failure_stacktraceUpSql,
 	"1528395683_empty.down.sql":                                               _1528395683_emptyDownSql,
 	"1528395683_empty.up.sql":                                                 _1528395683_emptyUpSql,
+	"1528395684_lsif_num_resets.down.sql":                                     _1528395684_lsif_num_resetsDownSql,
+	"1528395684_lsif_num_resets.up.sql":                                       _1528395684_lsif_num_resetsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -1769,6 +1813,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395682_lsif_remove_failure_stacktrace.up.sql":                        {_1528395682_lsif_remove_failure_stacktraceUpSql, map[string]*bintree{}},
 	"1528395683_empty.down.sql":                                               {_1528395683_emptyDownSql, map[string]*bintree{}},
 	"1528395683_empty.up.sql":                                                 {_1528395683_emptyUpSql, map[string]*bintree{}},
+	"1528395684_lsif_num_resets.down.sql":                                     {_1528395684_lsif_num_resetsDownSql, map[string]*bintree{}},
+	"1528395684_lsif_num_resets.up.sql":                                       {_1528395684_lsif_num_resetsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/monitoring/precise_code_intel_indexer.go
+++ b/monitoring/precise_code_intel_indexer.go
@@ -90,6 +90,41 @@ func PreciseCodeIntelIndexer() *Container {
 				},
 			},
 			{
+				Title:  "Index resetter - re-queues indexes that did not complete processing",
+				Hidden: true,
+				Rows: []Row{
+					{
+						{
+							Name:              "processing_indexes_reset",
+							Description:       "indexes reset to queued state every 5m",
+							Query:             `sum(increase(src_index_queue_resets_total[5m]))`,
+							DataMayNotExist:   true,
+							Warning:           Alert{GreaterOrEqual: 20},
+							PanelOptions:      PanelOptions().LegendFormat("indexes"),
+							PossibleSolutions: "none",
+						},
+						{
+							Name:              "processing_indexes_reset_failures",
+							Description:       "indexes errored after repeated resets every 5m",
+							Query:             `sum(increase(src_index_queue_max_resets_total[5m]))`,
+							DataMayNotExist:   true,
+							Warning:           Alert{GreaterOrEqual: 20},
+							PanelOptions:      PanelOptions().LegendFormat("indexes"),
+							PossibleSolutions: "none",
+						},
+						{
+							Name:              "index_resetter_errors",
+							Description:       "index resetter errors every 5m",
+							Query:             `sum(increase(src_index_queue_reset_errors_total[5m]))`,
+							DataMayNotExist:   true,
+							Warning:           Alert{GreaterOrEqual: 20},
+							PanelOptions:      PanelOptions().LegendFormat("errors"),
+							PossibleSolutions: "none",
+						},
+					},
+				},
+			},
+			{
 				Title:  "Internal service requests",
 				Hidden: true,
 				Rows: []Row{

--- a/monitoring/precise_code_intel_worker.go
+++ b/monitoring/precise_code_intel_worker.go
@@ -78,6 +78,15 @@ func PreciseCodeIntelWorker() *Container {
 							PossibleSolutions: "none",
 						},
 						{
+							Name:              "processing_uploads_reset_failures",
+							Description:       "uploads errored after repeated resets every 5m",
+							Query:             `sum(increase(src_upload_queue_max_resets_total[5m]))`,
+							DataMayNotExist:   true,
+							Warning:           Alert{GreaterOrEqual: 20},
+							PanelOptions:      PanelOptions().LegendFormat("uploads"),
+							PossibleSolutions: "none",
+						},
+						{
 							Name:              "upload_resetter_errors",
 							Description:       "upload resetter errors every 5m",
 							Query:             `sum(increase(src_upload_queue_reset_errors_total[5m]))`,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/10755.

Ensure that each reset (due to a worker or indexer crash) is marked in the record that will be re-tried after the worker/indexer restarts (or another instance takes it). This is to stop scenarios where an index that is too large for the current worker's resources causes an OOM crash from being retried indefinitely at the head of the queue.