### PR TITLE
git: refactor diff out of the GraphQL resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -41,7 +41,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		return []*git.LogCommitSearchResult{
 			{
 				Commit: git.Commit{ID: "c1", Author: gitSignatureWithDate},
-				Diff:   &git.Diff{Raw: "x"},
+				Diff:   &git.RawDiff{Raw: "x"},
 			},
 		}, true, nil
 	}

--- a/internal/vcs/git/diff.go
+++ b/internal/vcs/git/diff.go
@@ -1,0 +1,75 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+)
+
+type DiffOptions struct {
+	Repo gitserver.Repo
+
+	// These fields must be valid <commit> inputs as defined by gitrevisions(7).
+	Base string
+	Head string
+}
+
+// Diff returns an iterator that can be used to access the diff between two
+// commits on a per-file basis. The iterator must be closed with Close when no
+// longer required.
+func Diff(ctx context.Context, opts DiffOptions) (*DiffFileIterator, error) {
+	rangeType := "..."
+	// Rare case: the base is the empty tree, in which case we must use ..
+	// instead of ... as the latter only works for commits.
+	if opts.Base == DevNullSHA {
+		rangeType = ".."
+	}
+	rangeSpec := opts.Base + rangeType + opts.Head
+	if strings.HasPrefix(rangeSpec, "-") || strings.HasPrefix(rangeSpec, ".") {
+		// We don't want to allow user input to add `git diff` command line
+		// flags or refer to a file.
+		return nil, fmt.Errorf("invalid diff range argument: %q", rangeSpec)
+	}
+
+	rdr, err := ExecReader(ctx, opts.Repo, []string{
+		"diff",
+		"--find-renames",
+		// TODO(eseliger): Enable once we have support for copy detection in go-diff
+		// and actually expose a `isCopy` field in the api, otherwise this
+		// information is thrown away anyways.
+		// "--find-copies",
+		"--full-index",
+		"--inter-hunk-context=3",
+		"--no-prefix",
+		rangeSpec,
+		"--",
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "executing git diff")
+	}
+
+	return &DiffFileIterator{
+		rdr:  rdr,
+		mfdr: diff.NewMultiFileDiffReader(rdr),
+	}, nil
+}
+
+type DiffFileIterator struct {
+	rdr  io.ReadCloser
+	mfdr *diff.MultiFileDiffReader
+}
+
+func (i *DiffFileIterator) Close() error {
+	return i.rdr.Close()
+}
+
+// Next returns the next file diff. If no more diffs are available, the diff
+// will be nil and the error will be io.EOF.
+func (i *DiffFileIterator) Next() (*diff.FileDiff, error) {
+	return i.mfdr.ReadFile()
+}

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -79,7 +79,7 @@ type RawLogDiffSearchOptions struct {
 // LogCommitSearchResult describes a matching diff from (Repository).RawLogDiffSearch.
 type LogCommitSearchResult struct {
 	Commit         Commit      // the commit whose diff was matched
-	Diff           *Diff       // the diff, with non-matching/irrelevant portions deleted (respecting diff syntax)
+	Diff           *RawDiff    // the diff, with non-matching/irrelevant portions deleted (respecting diff syntax)
 	DiffHighlights []Highlight // highlighted query matches in the diff
 
 	// Refs is the list of ref names of this commit (from `git log --decorate`).
@@ -95,8 +95,8 @@ type LogCommitSearchResult struct {
 	Incomplete bool
 }
 
-// A Diff represents changes between two commits.
-type Diff struct {
+// A RawDiff represents changes between two commits.
+type RawDiff struct {
 	Raw string // the raw diff output
 }
 
@@ -417,7 +417,7 @@ func RawLogDiffSearch(ctx context.Context, repo gitserver.Repo, opt RawLogDiffSe
 			if rawDiff == nil {
 				hasMatch = false // patch was empty (after applying filters), don't add to results
 			} else {
-				result.Diff = &Diff{Raw: string(rawDiff)}
+				result.Diff = &RawDiff{Raw: string(rawDiff)}
 			}
 		}
 

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -49,7 +49,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			},
 			Refs:       []string{"refs/heads/branch1"},
 			SourceRefs: []string{"refs/heads/branch2"},
-			Diff:       &Diff{Raw: "diff --git a/f b/f\nindex d8649da..1193ff4 100644\n--- a/f\n+++ b/f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
+			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nindex d8649da..1193ff4 100644\n--- a/f\n+++ b/f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
 		}, {
 			Commit: Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
@@ -59,7 +59,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
 			SourceRefs: []string{"refs/heads/branch2"},
-			Diff:       &Diff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
+			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
 		}},
 	}, {
 		name: "empty-query",

--- a/internal/vcs/git/diff_test.go
+++ b/internal/vcs/git/diff_test.go
@@ -9,71 +9,6 @@ import (
 	"testing"
 )
 
-const testDiffFiles = 3
-const testDiff = `diff --git INSTALL.md INSTALL.md
-index e5af166..d44c3fc 100644
---- INSTALL.md
-+++ INSTALL.md
-@@ -3,10 +3,10 @@
- Line 1
- Line 2
- Line 3
--Line 4
-+This is cool: Line 4
- Line 5
- Line 6
--Line 7
--Line 8
-+Another Line 7
-+Foobar Line 8
- Line 9
- Line 10
-diff --git JOKES.md JOKES.md
-index ea80abf..1b86505 100644
---- JOKES.md
-+++ JOKES.md
-@@ -4,10 +4,10 @@ Joke #1
- Joke #2
- Joke #3
- Joke #4
--Joke #5
-+This is not funny: Joke #5
- Joke #6
--Joke #7
-+This one is good: Joke #7
- Joke #8
--Joke #9
-+Waffle: Joke #9
- Joke #10
- Joke #11
-diff --git README.md README.md
-index 9bd8209..d2acfa9 100644
---- README.md
-+++ README.md
-@@ -1,12 +1,13 @@
- # README
-
--Line 1
-+Foobar Line 1
- Line 2
- Line 3
- Line 4
- Line 5
--Line 6
-+Barfoo Line 6
- Line 7
- Line 8
- Line 9
- Line 10
-+Another line
-`
-
-var testDiffFileNames = []string{
-	"INSTALL.md",
-	"JOKES.md",
-	"README.md",
-}
-
 func TestDiff(t *testing.T) {
 	ctx := context.Background()
 
@@ -131,6 +66,71 @@ func TestDiff(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
+		const testDiffFiles = 3
+		const testDiff = `diff --git INSTALL.md INSTALL.md
+index e5af166..d44c3fc 100644
+--- INSTALL.md
++++ INSTALL.md
+@@ -3,10 +3,10 @@
+ Line 1
+ Line 2
+ Line 3
+-Line 4
++This is cool: Line 4
+ Line 5
+ Line 6
+-Line 7
+-Line 8
++Another Line 7
++Foobar Line 8
+ Line 9
+ Line 10
+diff --git JOKES.md JOKES.md
+index ea80abf..1b86505 100644
+--- JOKES.md
++++ JOKES.md
+@@ -4,10 +4,10 @@ Joke #1
+ Joke #2
+ Joke #3
+ Joke #4
+-Joke #5
++This is not funny: Joke #5
+ Joke #6
+-Joke #7
++This one is good: Joke #7
+ Joke #8
+-Joke #9
++Waffle: Joke #9
+ Joke #10
+ Joke #11
+diff --git README.md README.md
+index 9bd8209..d2acfa9 100644
+--- README.md
++++ README.md
+@@ -1,12 +1,13 @@
+ # README
+
+-Line 1
++Foobar Line 1
+ Line 2
+ Line 3
+ Line 4
+ Line 5
+-Line 6
++Barfoo Line 6
+ Line 7
+ Line 8
+ Line 9
+ Line 10
++Another line
+`
+
+		var testDiffFileNames = []string{
+			"INSTALL.md",
+			"JOKES.md",
+			"README.md",
+		}
+
 		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
 			return ioutil.NopCloser(strings.NewReader(testDiff)), nil
 		}

--- a/internal/vcs/git/diff_test.go
+++ b/internal/vcs/git/diff_test.go
@@ -1,0 +1,188 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+const testDiffFiles = 3
+const testDiff = `diff --git INSTALL.md INSTALL.md
+index e5af166..d44c3fc 100644
+--- INSTALL.md
++++ INSTALL.md
+@@ -3,10 +3,10 @@
+ Line 1
+ Line 2
+ Line 3
+-Line 4
++This is cool: Line 4
+ Line 5
+ Line 6
+-Line 7
+-Line 8
++Another Line 7
++Foobar Line 8
+ Line 9
+ Line 10
+diff --git JOKES.md JOKES.md
+index ea80abf..1b86505 100644
+--- JOKES.md
++++ JOKES.md
+@@ -4,10 +4,10 @@ Joke #1
+ Joke #2
+ Joke #3
+ Joke #4
+-Joke #5
++This is not funny: Joke #5
+ Joke #6
+-Joke #7
++This one is good: Joke #7
+ Joke #8
+-Joke #9
++Waffle: Joke #9
+ Joke #10
+ Joke #11
+diff --git README.md README.md
+index 9bd8209..d2acfa9 100644
+--- README.md
++++ README.md
+@@ -1,12 +1,13 @@
+ # README
+
+-Line 1
++Foobar Line 1
+ Line 2
+ Line 3
+ Line 4
+ Line 5
+-Line 6
++Barfoo Line 6
+ Line 7
+ Line 8
+ Line 9
+ Line 10
++Another line
+`
+
+var testDiffFileNames = []string{
+	"INSTALL.md",
+	"JOKES.md",
+	"README.md",
+}
+
+func TestDiff(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid bases", func(t *testing.T) {
+		for _, input := range []string{
+			"",
+			"-foo",
+			".foo",
+		} {
+			t.Run("invalid base: "+input, func(t *testing.T) {
+				i, err := Diff(ctx, DiffOptions{Base: input})
+				if i != nil {
+					t.Errorf("unexpected non-nil iterator: %+v", i)
+				}
+				if err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("rangeSpec calculation", func(t *testing.T) {
+		for _, tc := range []struct {
+			opts DiffOptions
+			want string
+		}{
+			{opts: DiffOptions{Base: "foo", Head: "bar"}, want: "foo...bar"},
+		} {
+			t.Run("rangeSpec: "+tc.want, func(t *testing.T) {
+				Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+					// The range spec is the sixth argument.
+					if args[5] != tc.want {
+						t.Errorf("unexpected rangeSpec: have: %s; want: %s", args[5], tc.want)
+					}
+					return nil, nil
+				}
+				_, _ = Diff(ctx, tc.opts)
+			})
+		}
+	})
+
+	t.Run("ExecReader error", func(t *testing.T) {
+		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+			return nil, errors.New("ExecReader error")
+		}
+		defer ResetMocks()
+
+		i, err := Diff(ctx, DiffOptions{Base: "foo", Head: "bar"})
+		if i != nil {
+			t.Errorf("unexpected non-nil iterator: %+v", i)
+		}
+		if err == nil {
+			t.Error("unexpected nil error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+			return ioutil.NopCloser(strings.NewReader(testDiff)), nil
+		}
+		defer ResetMocks()
+
+		i, err := Diff(ctx, DiffOptions{Base: "foo", Head: "bar"})
+		if i == nil {
+			t.Error("unexpected nil iterator")
+		}
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %+v", err)
+		}
+		defer i.Close()
+
+		count := 0
+		for {
+			diff, err := i.Next()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				t.Errorf("unexpected iteration error: %+v", err)
+			}
+
+			if diff.OrigName != testDiffFileNames[count] {
+				t.Errorf("unexpected diff file name: have: %s; want: %s", diff.OrigName, testDiffFileNames[count])
+			}
+			count++
+		}
+		if count != testDiffFiles {
+			t.Errorf("unexpected diff count: have %d; want %d", count, testDiffFiles)
+		}
+	})
+}
+
+func TestDiffFileIterator(t *testing.T) {
+	t.Run("Close", func(t *testing.T) {
+		c := new(closer)
+		i := &DiffFileIterator{rdr: c}
+		i.Close()
+		if *c != true {
+			t.Errorf("iterator did not close the underlying reader: have: %v; want: %v", *c, true)
+		}
+	})
+}
+
+type closer bool
+
+func (c *closer) Read(p []byte) (int, error) {
+	return 0, errors.New("testing only; this should never be invoked")
+}
+
+func (c *closer) Close() error {
+	*c = true
+	return nil
+}

--- a/internal/vcs/git/object.go
+++ b/internal/vcs/git/object.go
@@ -16,6 +16,10 @@ type OID [20]byte
 
 func (oid OID) String() string { return hex.EncodeToString(oid[:]) }
 
+// 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is `git hash-object -t tree /dev/null`, which is used as the base
+// when computing the `git diff` of the root commit.
+const DevNullSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
 // ObjectType is a valid Git object type (commit, tag, tree, and blob).
 type ObjectType string
 


### PR DESCRIPTION
This moves the details of getting a diff out of `graphqlbackend` and into `internal/vcs/git` where it can be reused. (Such as in #11279.)