### PR TITLE
dev: mirror grafana script in prometheus script

### DIFF
--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -55,7 +55,7 @@ mkdir -p "${GRAFANA_LOGS}"
 # display it in the normal case.
 GRAFANA_LOG_FILE="${GRAFANA_LOGS}/grafana.log"
 
-dump_log() {
+function finish() {
   GRAFANA_EXIT_CODE=$?
 
   # Exit code 2 indicates a normal Ctrl-C termination via goreman, so we'll
@@ -70,12 +70,10 @@ dump_log() {
   return $GRAFANA_EXIT_CODE
 }
 
-docker run --rm \
-  --name=grafana \
+docker run --rm ${DOCKER_NET} ${DOCKER_USER} \
+  --name=${CONTAINER} \
   --cpus=1 \
   --memory=1g \
-  "$DOCKER_USER" \
-  "$DOCKER_NET" \
   -p 0.0.0.0:3370:3370 \
   -v "${GRAFANA_DISK}":/var/lib/grafana \
   -v "$(pwd)"/dev/grafana/${CONFIG_SUB_DIR}:/sg_config_grafana/provisioning/datasources \
@@ -83,7 +81,7 @@ docker run --rm \
   -v "$(pwd)"/docker-images/grafana/jsonnet:/sg_grafana_additional_dashboards/legacy \
   -e SRC_FRONTEND_INTERNAL="${SRC_FRONTEND_INTERNAL}" \
   -e DISABLE_SOURCEGRAPH_CONFIG="${DISABLE_SOURCEGRAPH_CONFIG:-'false'}" \
-  ${IMAGE} >"${GRAFANA_LOG_FILE}" 2>&1 || dump_log
+  ${IMAGE} >"${GRAFANA_LOG_FILE}" 2>&1 || finish
 
 # Add the following lines above if you wish to use an auth proxy with Grafana:
 #

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -1,59 +1,56 @@
 #!/usr/bin/env bash
 
 # Description: Prometheus collects metrics and aggregates them into graphs.
-#
+# Most of this script is very similar to /dev/grafana.sh - refer to inline documentation there.
 
 set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
-CONFIG_DIR="$(pwd)/docker-images/prometheus/config"
-
 PROMETHEUS_DISK="${HOME}/.sourcegraph-dev/data/prometheus"
-
 IMAGE=sourcegraph/prometheus:61407_2020-04-18_9aa5791@sha256:9b31cc8832defb66cd29e5a298422983179495193745324902660073b3fdc835
 CONTAINER=prometheus
 
-CID_FILE="${PROMETHEUS_DISK}/prometheus.cid"
-
-mkdir -p "${PROMETHEUS_DISK}"/logs
-rm -f "${CID_FILE}"
-
-function finish() {
-  if test -f "${CID_FILE}"; then
-    echo 'trapped CTRL-C: stopping docker prometheus container'
-    docker stop "$(cat "${CID_FILE}")"
-    rm -f "${CID_FILE}"
-  fi
-  rm -f "${CONFIG_DIR}"/prometheus_targets.yml
-  docker rm -f $CONTAINER
-}
-trap finish EXIT
-
-NET_ARG=""
+CONFIG_DIR="$(pwd)/docker-images/prometheus/config"
+DOCKER_NET=""
+DOCKER_USER=""
 PROM_TARGETS="dev/prometheus/all/prometheus_targets.yml"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  NET_ARG="--net=host"
+  DOCKER_USER="--user=$UID"
+  DOCKER_NET="--net=host"
   PROM_TARGETS="dev/prometheus/linux/prometheus_targets.yml"
 fi
 
-cp ${PROM_TARGETS} "${CONFIG_DIR}"/prometheus_targets.yml
-
 docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
 
-# Generate Grafana dashboards
+cp ${PROM_TARGETS} "${CONFIG_DIR}"/prometheus_targets.yml
+
 pushd monitoring
 DEV=true RELOAD=false go generate
 popd
 
-docker run --rm ${NET_ARG} --cidfile "${CID_FILE}" \
-  --name=prometheus \
+PROMETHEUS_LOGS="${HOME}/.sourcegraph-dev/logs/prometheus"
+mkdir -p "${PROMETHEUS_LOGS}"
+PROMETHEUS_LOG_FILE="${PROMETHEUS_LOGS}/prometheus.log"
+
+function finish() {
+  PROMETHEUS_EXIT_CODE=$?
+
+  if [ $PROMETHEUS_EXIT_CODE -ne 0 ] && [ $PROMETHEUS_EXIT_CODE -ne 2 ]; then
+    echo "Prometheus exited with unexpected code ${PROMETHEUS_EXIT_CODE}; dumping log:"
+    cat "${PROMETHEUS_LOG_FILE}"
+  fi
+
+  rm -f "${CONFIG_DIR}"/prometheus_targets.yml
+  return $PROMETHEUS_EXIT_CODE
+}
+
+docker run --rm ${DOCKER_NET} ${DOCKER_USER} \
+  --name=${CONTAINER} \
   --cpus=1 \
   --memory=4g \
-  --user=$UID \
   -p 0.0.0.0:9090:9090 \
   -v "${PROMETHEUS_DISK}":/prometheus \
   -v "${CONFIG_DIR}":/sg_prometheus_add_ons \
   -e PROMETHEUS_ADDITIONAL_FLAGS=--web.enable-lifecycle \
-  ${IMAGE} >>"${PROMETHEUS_DISK}"/logs/prometheus.log 2>&1 &
-wait $!
+  ${IMAGE} >"${PROMETHEUS_DISK}"/logs/prometheus.log 2>&1 || finish


### PR DESCRIPTION
follow-up to #11533 

* align Prometheus script with Grafana script
    * remove prometheus custom container shutdown (this also removes the "prometheus not found" message when stopping `./dev/start` I've been seeing)
    * reorders related steps so that they're roughly in the same order as the Grafana script
    * moves prometheus logs to a similar directory
* fix grafana script on mac - it seems like docker was being confused by the empty lines? fiddled around with it until it worked

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
