### PR TITLE
search: prevent issuing more than 200+ unindexed searches for a single query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## 3.17.0
+
+### Added
+
 - The search results page now shows a small UI notification if either repository forks or archives are excluded, when `fork` or `archived` options are not explicitly set. [#10624](https://github.com/sourcegraph/sourcegraph/pull/10624)
 - Prometheus metric `src_gitserver_repos_removed_disk_pressure` which is incremented everytime we remove a repository due to disk pressure. [#10900](https://github.com/sourcegraph/sourcegraph/pull/10900)
 - `gitolite.exclude` setting in [Gitolite external service config](https://docs.sourcegraph.com/admin/external_service/gitolite#configuration) now supports a regular expression via the `pattern` field. This is consistent with how we exclude in other external services. Additionally this is a replacement for the deprecated `blacklist` configuration. [#11403](https://github.com/sourcegraph/sourcegraph/pull/11403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The Site-admin > Pings page no longer incorrectly indicates that pings are disabled when they aren't. [#11229](https://github.com/sourcegraph/sourcegraph/pull/11229)
 - Match counts are now accurately reported for indexed search. [#11242](https://github.com/sourcegraph/sourcegraph/pull/11242)
 - When background permissions syncing is enabled, it is now possible to only enforce permissions for repositories from selected code hosts (instead of enforcing permissions for repositories from all code hosts). [#11336](https://github.com/sourcegraph/sourcegraph/pull/11336)
+- When more than 200+ repository revisions in a search are unindexed (very rare), the remaining repositories are reported as missing instead of Sourcegraph issuing e.g. several thousand unindexed search requests which causes system slowness and ultimately times out - ensuring searches are still fast even if there are indexing issues on a deployment of Sourcegraph. This does not apply if `index:no` is present in the query.
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -814,7 +814,6 @@ func limitSearcherRepos(unindexed []*search.RepositoryRevisions, limit int) (sea
 		if totalRepoRevs > limit {
 			limitedSearcherRepos = append(limitedSearcherRepos, repoRevs.Repo)
 			limitedRepos++
-			continue
 		}
 	}
 	searcherRepos = unindexed[:len(unindexed)-limitedRepos]

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -36,6 +36,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
+const maxUnindexedRepoRevSearchesPerQuery = 200
+
 var (
 	// A global limiter on number of concurrent searcher searches.
 	textSearchLimiter = mutablelimiter.New(32)
@@ -794,8 +796,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	flattened := flattenFileMatches(unflattened, int(args.PatternInfo.FileMatchLimit))
 	return flattened, common, nil
 }
-
-const maxUnindexedRepoRevSearchesPerQuery = 200
 
 // limitSearcherRepos imposes a limit on the number of repo@revs that would go
 // to the unindexed searcher codepath, because sending this many requests to

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -289,6 +289,13 @@ func TestLimitSearcherRepos(t *testing.T) {
 			want:        repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1"),
 			wantLimited: repos("f", "g"),
 		},
+		{
+			name:        "rev_limited_duplication",
+			limit:       6,
+			input:       repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1", "f@1", "f@2", "g@1"),
+			want:        repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1"),
+			wantLimited: repos("f", "g"),
+		},
 	}
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,4 +225,80 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 		r[i] = &search.RepositoryRevisions{Repo: &types.Repo{Name: api.RepoName(repoName)}, Revs: revs}
 	}
 	return r
+}
+
+func TestLimitSearcherRepos(t *testing.T) {
+	repos := func(names ...string) []*types.Repo {
+		var repos []*types.Repo
+		for _, name := range names {
+			repos = append(repos, &types.Repo{Name: api.RepoName(name)})
+		}
+		return repos
+	}
+
+	repoRevs := func(repoRevs ...string) []*search.RepositoryRevisions {
+		var result []*search.RepositoryRevisions
+		for _, repoRev := range repoRevs {
+			split := strings.Split(repoRev, "@")
+			repo, rev := split[0], split[1]
+
+			found := false
+			for _, existing := range result {
+				if string(existing.Repo.Name) == repo {
+					existing.Revs = append(existing.Revs, search.RevisionSpecifier{RevSpec: rev})
+					found = true
+					break
+				}
+			}
+			if found {
+				continue
+			}
+			result = append(result, &search.RepositoryRevisions{
+				Repo: &types.Repo{Name: api.RepoName(repo)},
+				Revs: []search.RevisionSpecifier{{RevSpec: rev}},
+			})
+		}
+		return result
+	}
+
+	tests := []struct {
+		name        string
+		limit       int
+		input       []*search.RepositoryRevisions
+		want        []*search.RepositoryRevisions
+		wantLimited []*types.Repo
+	}{
+		{
+			name:        "non_limited",
+			limit:       5,
+			input:       repoRevs("a@1", "a@2", "b@1", "c@1"),
+			want:        repoRevs("a@1", "a@2", "b@1", "c@1"),
+			wantLimited: nil,
+		},
+		{
+			name:        "limited",
+			limit:       5,
+			input:       repoRevs("a@1", "b@1", "c@1", "d@1", "e@1", "f@1", "g@1"),
+			want:        repoRevs("a@1", "b@1", "c@1", "d@1", "e@1"),
+			wantLimited: repos("f", "g"),
+		},
+		{
+			name:        "rev_limited",
+			limit:       6,
+			input:       repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1", "f@1", "g@1"),
+			want:        repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1"),
+			wantLimited: repos("f", "g"),
+		},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got, gotLimited := limitSearcherRepos(tst.input, tst.limit)
+			if !reflect.DeepEqual(got, tst.want) {
+				t.Errorf("got %+v want %+v", got, tst.limit)
+			}
+			if !reflect.DeepEqual(gotLimited, tst.wantLimited) {
+				t.Errorf("got limited %+v want %+v", gotLimited, tst.wantLimited)
+			}
+		})
+	}
 }

--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -9,8 +9,6 @@ GRAFANA_DISK="${HOME}/.sourcegraph-dev/data/grafana"
 IMAGE=sourcegraph/grafana:dev
 CONTAINER=grafana
 
-mkdir -p "${GRAFANA_DISK}"/logs
-
 # quickly build image - should do this because the image has a Sourcegraph wrapper program
 # see /docker-images/grafana/cmd/grafana-wrapper for more details
 IMAGE=${IMAGE} CACHE=true ./docker-images/grafana/build.sh >/dev/null 2>&1
@@ -18,10 +16,24 @@ IMAGE=${IMAGE} CACHE=true ./docker-images/grafana/build.sh >/dev/null 2>&1
 # docker containers must access things via docker host on non-linux platforms
 CONFIG_SUB_DIR="all"
 SRC_FRONTEND_INTERNAL="host.docker.internal:3090"
+DOCKER_USER=""
+DOCKER_NET=""
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  SRC_FRONTEND_INTERNAL="localhost:3090"
   CONFIG_SUB_DIR="linux"
+
+  # Docker users on Linux will generally be using direct user mapping, which
+  # means that they'll want the data in the volume mount to be owned by the
+  # same user as is running this script. Fortunately, the Grafana container
+  # doesn't really care what user it runs as, so long as it can write to
+  # /var/lib/grafana.
+  DOCKER_USER="--user=$UID"
+
+  # Frontend generally runs outside of Docker, so to access it we need to be
+  # able to access ports on the host. --net=host is a very dirty way of
+  # enabling this.
+  DOCKER_NET="--net=host"
+  SRC_FRONTEND_INTERNAL="localhost:3090"
 fi
 
 docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
@@ -31,10 +43,39 @@ pushd monitoring
 DEV=true RELOAD=false go generate
 popd
 
+# Log file location: since we log outside of the Docker container, we should
+# log somewhere that's _not_ ~/.sourcegraph-dev/data/grafana, since that gets
+# volume mounted into the container and therefore has its own ownership
+# semantics.
+GRAFANA_LOGS="${HOME}/.sourcegraph-dev/logs/grafana"
+mkdir -p "${GRAFANA_LOGS}"
+
+# Now for the actual logging. Grafana's output gets sent to stdout and stderr.
+# We want to capture that output, but because it's fairly noisy, don't want to
+# display it in the normal case.
+GRAFANA_LOG_FILE="${GRAFANA_LOGS}/grafana.log"
+
+dump_log() {
+  GRAFANA_EXIT_CODE=$?
+
+  # Exit code 2 indicates a normal Ctrl-C termination via goreman, so we'll
+  # only dump the log if it's not 0 _or_ 2.
+  if [ $GRAFANA_EXIT_CODE -ne 0 ] && [ $GRAFANA_EXIT_CODE -ne 2 ]; then
+    echo "Grafana exited with unexpected code ${GRAFANA_EXIT_CODE}; dumping log:"
+    cat "${GRAFANA_LOG_FILE}"
+  fi
+
+  # Ensure that we still return the same code so that goreman can do sensible
+  # things once this script exits.
+  return $GRAFANA_EXIT_CODE
+}
+
 docker run --rm \
   --name=grafana \
   --cpus=1 \
   --memory=1g \
+  "$DOCKER_USER" \
+  "$DOCKER_NET" \
   -p 0.0.0.0:3370:3370 \
   -v "${GRAFANA_DISK}":/var/lib/grafana \
   -v "$(pwd)"/dev/grafana/${CONFIG_SUB_DIR}:/sg_config_grafana/provisioning/datasources \
@@ -42,8 +83,7 @@ docker run --rm \
   -v "$(pwd)"/docker-images/grafana/jsonnet:/sg_grafana_additional_dashboards/legacy \
   -e SRC_FRONTEND_INTERNAL="${SRC_FRONTEND_INTERNAL}" \
   -e DISABLE_SOURCEGRAPH_CONFIG="${DISABLE_SOURCEGRAPH_CONFIG:-'false'}" \
-  ${IMAGE} >>"${GRAFANA_DISK}"/logs/grafana.log 2>&1 &
-wait $!
+  ${IMAGE} >"${GRAFANA_LOG_FILE}" 2>&1 || dump_log
 
 # Add the following lines above if you wish to use an auth proxy with Grafana:
 #


### PR DESCRIPTION
Today, if a search query is issued and no repositories are indexed all repositories will be searched using `git grep` via a request to `searcher`.

Historically, this has been desirable for a few reasons:

1. `sourcegraph/server` used to not perform any indexed search, and as such it was *entirely* based on live searching.
2. We advised customers running Kubernetes clusters to deploy a large worker pool of `searcher`s capable of handling a large amount of requests (partially because we in the early days did not have _any_ indexing at all).

Over time, we drifted away from the two above cases: `sourcegraph/server` got indexing and everyone turned it on by default; and customers (and us) began to realize unindexed searching was uncommon and dedicating a ton of resources to it was not wise.

Nowadays, most Sourcegraph deployments only have a few unindexed searchers - primarily for handling the case in which someone wants to search on unindexed non-`HEAD` branches.

The fact that we can still fire off several thousand unindexed search requests to `searcher` is bad and silly for multiple reasons:

- In early 2019 ([link](https://github.com/sourcegraph/sourcegraph/issues/4101)), this caused network outages on the host machines running the searcher containers because we would literally flood the network with requests to `searcher`. At the time, we solved this by limiting the number of requests and this was sufficient to solve the _network DOS we were causing ourselves_.
- Large amounts of unindexed symbol searches have been a major cause for other resource contention in the past (primarily in `sourcegraph/server` deployments).
- When we introduced the new tab-based search UX, it directed users to run e.g. `type:diff` searches globally that would result in thousands of unindexed diff searches, which [caused major instability issues and a poor UX for many users](https://github.com/sourcegraph/sourcegraph/issues/5519#issuecomment-538321132) until we restricted it to search only 50 repositories at a time.
- ("the issue") Today, on a very large $CUSTOMER replica with 400k+ repositories we find a similar issue: 380k repositories are indexed, but due to other issues 20k are not. This causes an otherwise very fast indexed search that only takes a few seconds to spend a _very long time_ trying to complete 20k unindexed search requests to `searcher` - often just resulting in the search request timing out entirely.

The fact that we allow this at all is silly:

- No user wants to wait a long time just to get a timeout
- No admin wants their users to be able to run searches that can take down / harm Sourcegraph.

We almost solely had this behavior for historical reasons, and have been slowly walking it back.

This PR adds one final strict guarantee to fix "the issue" above: A single search query cannot result in more than 200 repo@revs being searched by our unindexed search codepath:

If your search query would result in more than 200+ unindexed repo@revs being searched, we search the first 200 and report the remaining repositories as `missing` in the web UI. In this case, you can hover over the list to see which were omitted. This is the same way we report repositories as unsearchable in a few other scenarios (e.g. if you run an `index:only` search and they are not in the index, or if there is an issue with the repository).

This merely mitigates the underlying issue with a good-enough (albeit not perfect) UX, until us or a site admin can fix the real underlying issue: the repositories aren't indexed.

Helps https://sourcegraph.slack.com/archives/CTQ5LTF8D / https://app.hubspot.com/contacts/2762526/company/557692805/