### PR TITLE
allow unauthenticated viewers to view campaigns

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -80,7 +80,7 @@ interface Props extends ThemeProps, ExtensionsControllerProps, PlatformContextPr
      * If not given, will display a creation form.
      */
     campaignID?: GQL.ID
-    authenticatedUser: Pick<GQL.IUser, 'id' | 'username' | 'avatarURL'>
+    authenticatedUser: Pick<GQL.IUser, 'id' | 'username' | 'avatarURL'> | null
     history: H.History
     location: H.Location
 
@@ -224,6 +224,10 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
             event.preventDefault()
             setMode('saving')
             try {
+                if (!authenticatedUser) {
+                    throw new Error('must sign in')
+                }
+
                 if (campaignID) {
                     const newCampaign = await updateCampaign({
                         id: campaignID,
@@ -259,7 +263,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
             }
         },
         [
-            authenticatedUser.id,
+            authenticatedUser,
             branch,
             campaignID,
             campaignUpdates,
@@ -368,8 +372,6 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
             return <HeroPage icon={AlertCircleIcon} title="Cannot update a closed campaign" />
         }
     }
-
-    const author = campaign ? campaign.author : authenticatedUser
 
     const totalChangesetCount = campaign?.changesets.totalCount ?? 0
 
@@ -518,7 +520,8 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
                             <div className="card mt-2">
                                 <div className="card-header">
                                     <strong>
-                                        <UserAvatar user={author} className="icon-inline" /> {author.username}
+                                        <UserAvatar user={campaign.author} className="icon-inline" />{' '}
+                                        {campaign.author.username}
                                     </strong>{' '}
                                     started <Timestamp date={campaign.createdAt} />
                                 </div>

--- a/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
+++ b/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
@@ -3,7 +3,6 @@ import { RouteComponentProps, Switch, Route } from 'react-router'
 import { GlobalCampaignListPage } from './list/GlobalCampaignListPage'
 import { CampaignDetails } from '../detail/CampaignDetails'
 import { IUser } from '../../../../../shared/src/graphql/schema'
-import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { CreateCampaign } from './create/CreateCampaign'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
@@ -22,19 +21,22 @@ interface Props
         ExtensionsControllerProps,
         TelemetryProps,
         PlatformContextProps {
-    authenticatedUser: IUser
+    authenticatedUser: IUser | null
     isSourcegraphDotCom: boolean
 }
 
 /**
  * The global campaigns area.
  */
-export const GlobalCampaignsArea = withAuthenticatedUser<Props>(({ match, ...outerProps }) => {
+export const GlobalCampaignsArea: React.FunctionComponent<Props> = ({ match, ...outerProps }) => {
     let content: React.ReactFragment
     if (outerProps.isSourcegraphDotCom) {
         content = <CampaignsDotComPage {...outerProps} />
     } else if (window.context.experimentalFeatures?.automation === 'enabled') {
-        if (!outerProps.authenticatedUser.siteAdmin && window.context.site['campaigns.readAccess.enabled'] !== true) {
+        if (
+            (!outerProps.authenticatedUser || !outerProps.authenticatedUser.siteAdmin) &&
+            window.context.site['campaigns.readAccess.enabled'] !== true
+        ) {
             content = <CampaignsUserMarketingPage {...outerProps} enableReadAccess={true} />
         } else {
             content = (
@@ -90,10 +92,10 @@ export const GlobalCampaignsArea = withAuthenticatedUser<Props>(({ match, ...out
                 </>
             )
         }
-    } else if (outerProps.authenticatedUser.siteAdmin) {
+    } else if (outerProps.authenticatedUser?.siteAdmin) {
         content = <CampaignsSiteAdminMarketingPage {...outerProps} />
     } else {
         content = <CampaignsUserMarketingPage {...outerProps} enableReadAccess={false} />
     }
     return <div className="container mt-4">{content}</div>
-})
+}

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -10,7 +10,7 @@ import { useObservable } from '../../../../../../shared/src/util/useObservable'
 import { Observable } from 'rxjs'
 
 interface Props extends Pick<RouteComponentProps, 'history' | 'location'> {
-    authenticatedUser: IUser
+    authenticatedUser: IUser | null
     queryCampaignsCount?: () => Observable<number>
 }
 
@@ -55,7 +55,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
                         <a href="https://docs.sourcegraph.com/user/campaigns">Learn how.</a>
                     </p>
                 </div>
-                {props.authenticatedUser.siteAdmin && (
+                {props.authenticatedUser?.siteAdmin && (
                     <Link to="/campaigns/create" className="btn btn-primary ml-3">
                         <AddIcon className="icon-inline" /> New campaign
                     </Link>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/11501.

Unlike #11528, this lets unauthenticated viewers actually view the campaigns list and detail pages as well. Currently there are no instances where this would occur (because the only instance with unauthenticated viewers is Sourcegraph.com, and that is already special-cased), but I am hacking on such an instance now (https://sourcegraph.slack.com/archives/C0W2E592M/p1592357208354100?thread_ts=1592279188.347200&cid=C0W2E592M) and would appreciate this slight extra flexibility!


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->