### PR TITLE
remove deleted (and now broken) symlink

### DIFF
--- a/doc/admin/config/critical.schema.json
+++ b/doc/admin/config/critical.schema.json
@@ -1,1 +1,0 @@
-../../../schema/critical/critical.schema.json


### PR DESCRIPTION
In another commit I removed the file this symlink refers to. I forgot to remove this symlink.

Upstream docsite fix to fix this in other cases of broken symlinks is at https://github.com/sourcegraph/docsite/pull/47