### PR TITLE
E2e tests: verify that hover contents are visible

### DIFF
--- a/web/src/end-to-end/end-to-end.test.ts
+++ b/web/src/end-to-end/end-to-end.test.ts
@@ -450,18 +450,18 @@ describe('e2e test suite', () => {
             await driver.page.click(selector)
         }
 
-        // expectedCount defaults to one because of we haven't specified, we just want to ensure it exists at all
-        const getHoverContents = async (expectedCount = 1): Promise<string[]> => {
-            const selector =
-                expectedCount > 1 ? `.e2e-tooltip-content:nth-child(${expectedCount})` : '.e2e-tooltip-content'
-            await driver.page.waitForSelector(selector)
+        const getHoverContents = async (): Promise<string[]> => {
+            // Search for any child of e2e-tooltip-content: as e2e-tooltip-content has display: contents,
+            // it will never be detected as visible by waitForSelector(), but its children will.
+            const selector = '.e2e-tooltip-content *'
+            await driver.page.waitForSelector(selector, { visible: true })
             return driver.page.evaluate(() =>
                 // You can't reference hoverContentSelector in puppeteer's driver.page.evaluate
                 [...document.querySelectorAll('.e2e-tooltip-content')].map(content => content.textContent || '')
             )
         }
-        const assertHoverContentContains = async (value: string, count?: number): Promise<void> => {
-            expect(await getHoverContents(count)).toEqual(expect.arrayContaining([expect.stringContaining(value)]))
+        const assertHoverContentContains = async (value: string): Promise<void> => {
+            expect(await getHoverContents()).toEqual(expect.arrayContaining([expect.stringContaining(value)]))
         }
 
         const clickHoverJ2D = async (): Promise<void> => {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/11545/commits/7d986349a29e6423094a4db0208b8671afb0ec8d removed the `{ visible: true }` check for hover contents, but it's impotant to keep.

That check was broken by making `.e2e-tooltip-content` `display: contents`: the element doesn't have a visible bounding rect anymore, so Puppeteer never finds the selector with `{ visible: true }`.

Fixed by looking for any visible child of `.e2e-tooltip-content`. Also removed the `expectedCount` logic from `getHoverContents()`, as it was never used.