### PR TITLE
search: defensive nil-check for and-results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -813,9 +813,6 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 			if new != nil {
 				exhausted = exhausted && !new.limitHit
 				result = intersect(result, new)
-				if result == nil {
-					return nil, nil
-				}
 			}
 		}
 		if exhausted {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -801,6 +801,9 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 		if err != nil {
 			return nil, err
 		}
+		if result == nil {
+			return nil, nil
+		}
 		exhausted = !result.limitHit
 		for _, term := range operands[1:] {
 			new, err = r.evaluatePatternExpression(ctx, scopeParameters, term)
@@ -810,6 +813,9 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 			if new != nil {
 				exhausted = exhausted && !new.limitHit
 				result = intersect(result, new)
+				if result == nil {
+					return nil, nil
+				}
 			}
 		}
 		if exhausted {


### PR DESCRIPTION
This is a defensive change to check whether `result` is nil before it is potentially accessed like `result.limitHit` in this function. I believe it is hard, but not impossible, to induce the value of `nil` for `result` here, but haven't been able to trigger it (the value depends on `evaluateLeaf`, our base search logic, and not something dependent on operators). The ideal solution would be to ensure that result is non-nil (pagination ensures this, for example), but that change would be too involved right now.

This change is checked against search integration tests, and again, it's a defensive change so shouldn't have any meaningful impact to logic.