### PR TITLE
authz: use GitHub database ID as bind ID

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/github/github.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -469,7 +470,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository) 
 		}
 
 		for _, u := range users {
-			userIDs = append(userIDs, extsvc.AccountID(u.ID))
+			userIDs = append(userIDs, extsvc.AccountID(strconv.FormatInt(u.DatabaseID, 10)))
 		}
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/github/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/github/github_test.go
@@ -446,12 +446,12 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 			switch page {
 			case 1:
 				return []*github.Collaborator{
-					{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="},
-					{ID: "MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY="},
+					{DatabaseID: 57463526},
+					{DatabaseID: 67471},
 				}, true, nil
 			case 2:
 				return []*github.Collaborator{
-					{ID: "MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA="},
+					{DatabaseID: 187831},
 				}, false, nil
 			}
 
@@ -474,9 +474,9 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 	}
 
 	wantAccountIDs := []extsvc.AccountID{
-		"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
-		"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
-		"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
+		"57463526",
+		"67471",
+		"187831",
 	}
 	if diff := cmp.Diff(wantAccountIDs, accountIDs); diff != "" {
 		t.Fatalf("AccountIDs mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
We store database ID as `account_id` for GitHub OAuth users, not GraphQL node ID. It was an oversight and this bug has slipped through few iterations already.

Tested end-to-end manually. Covered and caught by our regression test suite.

Fixes #11561