### PR TITLE
Providers: example of removing indirection between UI code and worker thread

### DIFF
--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -112,6 +112,7 @@ import { NotificationType } from 'sourcegraph'
 import { isHTTPAuthError } from '../../../../../shared/src/backend/fetch'
 import { asError } from '../../../../../shared/src/util/errors'
 import { resolveRepoNamesForDiffOrFileInfo, defaultRevisionToCommitID } from './util/fileInfo'
+import { wrapRemoteObservable } from '../../../../../shared/src/api/client/api/common'
 
 registerHighlightContributions()
 
@@ -384,8 +385,10 @@ function initCodeIntelligence({
         ),
         getHover: ({ line, character, part, ...rest }) =>
             combineLatest([
-                extensionsController.services.textDocumentHover.getHover(
-                    toTextDocumentPositionParameters({ ...rest, position: { line, character } })
+                wrapRemoteObservable(
+                    extensionsController.getHover(
+                        toTextDocumentPositionParameters({ ...rest, position: { line, character } })
+                    )
                 ),
                 getActiveHoverAlerts(hoverAlerts),
             ]).pipe(

--- a/shared/src/api/contract.ts
+++ b/shared/src/api/contract.ts
@@ -4,6 +4,9 @@ import * as clientType from '@sourcegraph/extension-api-types'
 import { Remote, ProxyMarked } from 'comlink'
 import { Unsubscribable } from 'sourcegraph'
 import { ProxySubscribable } from './extension/api/common'
+import { TextDocumentPositionParams } from './protocol'
+import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
+import { HoverMerged } from './client/types/hover'
 
 /**
  * This is exposed from the extension host thread to the main thread
@@ -21,6 +24,11 @@ export interface FlatExtHostAPI {
 
     // Search
     transformSearchQuery: (query: string) => ProxySubscribable<string>
+
+    // Languages
+    getHover(parameters: TextDocumentPositionParams): ProxySubscribable<MaybeLoadingResult<HoverMerged | null>>
+    getDefinitions(parameters: TextDocumentPositionParams): ProxySubscribable<Location[]>
+    getReferences(parameters: TextDocumentPositionParams): ProxySubscribable<Location[]>
 }
 
 /**

--- a/shared/src/extensions/controller.ts
+++ b/shared/src/extensions/controller.ts
@@ -12,8 +12,10 @@ import { Notification } from '../notifications/notification'
 import { PlatformContext } from '../platform/context'
 import { asError, ErrorLike, isErrorLike } from '../util/errors'
 import { isDefined } from '../util/types'
+import { FlatExtHostAPI } from '../api/contract'
+import { Remote } from 'comlink'
 
-export interface Controller extends Unsubscribable {
+export interface Controller extends Unsubscribable, Remote<FlatExtHostAPI> {
     /**
      * Global notification messages that should be displayed to the user, from the following sources:
      *
@@ -21,8 +23,6 @@ export interface Controller extends Unsubscribable {
      * - Errors thrown or returned in command invocation
      */
     readonly notifications: Observable<Notification>
-
-    services: Services
 
     /**
      * Executes the command (registered in the CommandRegistry) specified in params. If an error is thrown, the

--- a/web/src/backend/features.ts
+++ b/web/src/backend/features.ts
@@ -3,6 +3,7 @@ import { HoverMerged } from '../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { FileSpec, UIPositionSpec, RepoSpec, ResolvedRevisionSpec } from '../../../shared/src/util/url'
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
+import { wrapRemoteObservable } from '../../../shared/src/api/client/api/common'
 
 /**
  * Fetches hover information for the given location.
@@ -14,11 +15,13 @@ export function getHover(
     context: RepoSpec & ResolvedRevisionSpec & FileSpec & UIPositionSpec,
     { extensionsController }: ExtensionsControllerProps
 ): Observable<MaybeLoadingResult<HoverMerged | null>> {
-    return extensionsController.services.textDocumentHover.getHover({
-        textDocument: { uri: `git://${context.repoName}?${context.commitID}#${context.filePath}` },
-        position: {
-            character: context.position.character - 1,
-            line: context.position.line - 1,
-        },
-    })
+    return wrapRemoteObservable(
+        extensionsController.getHover({
+            textDocument: { uri: `git://${context.repoName}?${context.commitID}#${context.filePath}` },
+            position: {
+                character: context.position.character - 1,
+                line: context.position.line - 1,
+            },
+        })
+    )
 }


### PR DESCRIPTION
This is an example of removing indirection between the UI code and the worker thread, and directly calling into proxied `getHover()`, `getReferences()`, `getDefinition()` from the UI thread, rather than calling into `services.textDocumentDefinition.getLocations()`, `services.textDocumentHover.getHover()`, etc.

As we migrate providers to flatten the extension API implementation according to RFC155, it's probably the right timing to remove `services`. This will:
- Greatly simplify the implementation
- Guarantee that providers can only be invoked when the extension host worker has been created, because, to instantiate `Controller`, you will need to have instantiated the extension host 

I didn't really attempt to make this compile / work, it's just for clarification / discussion purposes.