### PR TITLE
docker-images(grafana): grafana v7

### DIFF
--- a/dev/grafana/all/datasources.yaml
+++ b/dev/grafana/all/datasources.yaml
@@ -8,3 +8,7 @@ datasources:
     url: http://host.docker.internal:9090
     isDefault: true
     editable: false
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://host.docker.internal:16686/-/debug/jaeger

--- a/dev/grafana/linux/datasources.yaml
+++ b/dev/grafana/linux/datasources.yaml
@@ -10,3 +10,7 @@ datasources:
     url: http://127.0.0.1:9090
     isDefault: true
     editable: false
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://127.0.0.1:16686/-/debug/jaeger

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /generated/grafana
 RUN DOC_SOLUTIONS_FILE='' PROMETHEUS_DIR='' GRAFANA_DIR=/generated/grafana /go/bin/monitoring-generator
 
 # when upgrading the Grafana version, please refer to https://about.sourcegraph.com/handbook/engineering/distribution/observability/monitoring#upgrading-grafana
-FROM grafana/grafana:6.7.4@sha256:1ff3999e0fc08a3909e9a3ecdf6e74b4789db9b67c8297c44fdee1e167b9375f as production
-LABEL com.sourcegraph.grafana.version=6.7.4
+FROM grafana/grafana:7.0.3@sha256:d72946c8e5d57a9a121bcc3ae8e4a8ccab96960d81031d18a4c31ad1f7aea03e as production
+LABEL com.sourcegraph.grafana.version=7.0.3
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -631,7 +631,7 @@ type GitoliteConnection struct {
 	Prefix string `json:"prefix"`
 }
 
-// GrafanaNotifierPagerduty description: Pagerduty notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#pagerduty
+// GrafanaNotifierPagerduty description: Pagerduty notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty
 type GrafanaNotifierPagerduty struct {
 	// AutoResolve description: Resolve incidents in PagerDuty once the alert goes back to ok
 	AutoResolve bool `json:"autoResolve,omitempty"`
@@ -640,7 +640,7 @@ type GrafanaNotifierPagerduty struct {
 	Type           string `json:"type"`
 }
 
-// GrafanaNotifierSlack description: Slack notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#slack
+// GrafanaNotifierSlack description: Slack notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#slack
 type GrafanaNotifierSlack struct {
 	// Icon_emoji description: Provide an emoji to use as the icon for the bot’s message. Ex :smile:
 	Icon_emoji string `json:"icon_emoji,omitempty"`
@@ -663,7 +663,7 @@ type GrafanaNotifierSlack struct {
 	Username string `json:"username,omitempty"`
 }
 
-// GrafanaNotifierWebhook description: Webhook notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#webhook
+// GrafanaNotifierWebhook description: Webhook notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#webhook
 type GrafanaNotifierWebhook struct {
 	Password string `json:"password,omitempty"`
 	Type     string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -994,7 +994,7 @@
       }
     },
     "GrafanaNotifierSlack": {
-      "description": "Slack notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#slack",
+      "description": "Slack notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#slack",
       "type": "object",
       "required": ["type"],
       "properties": {
@@ -1041,7 +1041,7 @@
       }
     },
     "GrafanaNotifierPagerduty": {
-      "description": "Pagerduty notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#pagerduty",
+      "description": "Pagerduty notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty",
       "type": "object",
       "required": ["type", "integrationKey"],
       "properties": {
@@ -1060,7 +1060,7 @@
       }
     },
     "GrafanaNotifierWebhook": {
-      "description": "Webhook notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#webhook",
+      "description": "Webhook notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#webhook",
       "type": "object",
       "required": ["type", "url"],
       "properties": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -999,7 +999,7 @@ const SiteSchemaJSON = `{
       }
     },
     "GrafanaNotifierSlack": {
-      "description": "Slack notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#slack",
+      "description": "Slack notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#slack",
       "type": "object",
       "required": ["type"],
       "properties": {
@@ -1046,7 +1046,7 @@ const SiteSchemaJSON = `{
       }
     },
     "GrafanaNotifierPagerduty": {
-      "description": "Pagerduty notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#pagerduty",
+      "description": "Pagerduty notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty",
       "type": "object",
       "required": ["type", "integrationKey"],
       "properties": {
@@ -1065,7 +1065,7 @@ const SiteSchemaJSON = `{
       }
     },
     "GrafanaNotifierWebhook": {
-      "description": "Webhook notifier - see https://grafana.com/docs/grafana/v6.7/alerting/notifications/#webhook",
+      "description": "Webhook notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#webhook",
       "type": "object",
       "required": ["type", "url"],
       "properties": {


### PR DESCRIPTION
Poked around and noticed that Grafana 7 doesn't have any major changes in any file formats :) https://grafana.com/docs/grafana/latest/installation/upgrading/#upgrading-to-v7-0

The UI is much improved and seems a lot nicer overall. It also comes with Jaeger support out of the box, which I've enabled for dev:

<img width="1723" alt="image" src="https://user-images.githubusercontent.com/23356519/85012498-b13c8b80-b195-11ea-8de2-825f369a6b15.png">

It seems like all the dashboards etc are working as expected

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
