### PR TITLE
e2e: add tests for external service `repositoryPathPattern`

### DIFF
--- a/dev/e2e/external_service_test.go
+++ b/dev/e2e/external_service_test.go
@@ -1,0 +1,66 @@
+// +build e2e
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+)
+
+func TestExternalService(t *testing.T) {
+	if len(*githubToken) == 0 {
+		t.Fatal("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	t.Run("repositoryPathPattern", func(t *testing.T) {
+		const repo = "sourcegraph/go-blame" // Tiny repo, fast to clone
+		const slug = "github.com/" + repo
+		// Set up external service
+		esID, err := client.AddExternalService(e2eutil.AddExternalServiceInput{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "e2e-test-github-repoPathPattern",
+			Config: mustMarshalJSONString(struct {
+				URL                   string   `json:"url"`
+				Token                 string   `json:"token"`
+				Repos                 []string `json:"repos"`
+				RepositoryPathPattern string   `json:"repositoryPathPattern"`
+			}{
+				URL:                   "http://github.com",
+				Token:                 *githubToken,
+				Repos:                 []string{repo},
+				RepositoryPathPattern: "foobar/{host}/{nameWithOwner}",
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := client.DeleteExternalService(esID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		err = client.WaitForReposToBeCloned("foobar/" + slug)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The request URL should be redirected to the new path
+		origURL := *baseURL + "/" + slug
+		resp, err := client.Get(origURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		wantURL := *baseURL + "/foobar/" + slug // <baseURL>/foobar/github.com/sourcegraph/go-blame
+		if diff := cmp.Diff(wantURL, resp.Request.URL.String()); diff != "" {
+			t.Fatalf("URL mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/dev/e2e/search_test.go
+++ b/dev/e2e/search_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 func TestSearch(t *testing.T) {
@@ -15,7 +16,7 @@ func TestSearch(t *testing.T) {
 
 	// Set up external service
 	esID, err := client.AddExternalService(e2eutil.AddExternalServiceInput{
-		Kind:        "GITHUB",
+		Kind:        extsvc.KindGitHub,
 		DisplayName: "e2e-test-github",
 		Config: mustMarshalJSONString(struct {
 			URL   string   `json:"url"`

--- a/internal/e2eutil/client.go
+++ b/internal/e2eutil/client.go
@@ -288,3 +288,16 @@ func (c *Client) GraphQL(token, query string, variables map[string]interface{}, 
 
 	return jsoniter.Unmarshal(body, &target)
 }
+
+// Get performs a GET request to the URL with authenticated user.
+func (c *Client) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.AddCookie(c.csrfCookie)
+	req.AddCookie(c.sessionCookie)
+
+	return http.DefaultClient.Do(req)
+}


### PR DESCRIPTION
Adds e2e tests for external service `repositoryPathPattern`, which covers ([source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0211f6583717cf09e7b6e186e98d84cc9824d0d9/-/blob/web/src/e2e/e2e.test.ts#L247:1)):

- Redirect user from `{BaseURL}/github.com/sourcegraph/go-blame` to `{BaseURL}/foobar/github.com/sourcegraph/go-blame`.

Part of #10068