### PR TITLE
perf: Do not unnecessarily load patches.diff from DB

### DIFF
--- a/enterprise/internal/campaigns/resolvers/patch_sets.go
+++ b/enterprise/internal/campaigns/resolvers/patch_sets.go
@@ -78,7 +78,9 @@ func (r *patchSetResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffSt
 }
 
 func patchSetDiffStat(ctx context.Context, store *ee.Store, opts ee.ListPatchesOpts) (*graphqlbackend.DiffStat, error) {
-	patches, _, err := store.ListPatches(ctx, opts)
+	noDiffOpts := opts
+	noDiffOpts.NoDiff = true
+	patches, _, err := store.ListPatches(ctx, noDiffOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -513,6 +513,7 @@ func (s *Service) RetryPublishCampaign(ctx context.Context, id int64) (campaign 
 	patches, _, err := s.store.ListPatches(ctx, ListPatchesOpts{
 		PatchSetID: campaign.PatchSetID,
 		Limit:      -1,
+		NoDiff:     true,
 	})
 	if err != nil {
 		return nil, err
@@ -585,6 +586,7 @@ func (s *Service) EnqueueChangesetJobs(ctx context.Context, campaignID int64) (_
 		Limit:                   -1,
 		OnlyWithDiff:            true,
 		OnlyWithoutChangesetJob: campaign.ID,
+		NoDiff:                  true,
 	})
 	if err != nil {
 		return nil, err
@@ -1007,6 +1009,7 @@ func resetAccessibleChangesetJobs(ctx context.Context, tx *Store, campaign *camp
 		PatchSetID:   campaign.PatchSetID,
 		Limit:        -1,
 		OnlyWithDiff: true,
+		NoDiff:       true,
 	})
 	if err != nil {
 		return errors.Wrap(err, "listing patches")

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -1873,6 +1873,25 @@ func testStorePatches(t *testing.T, ctx context.Context, s *Store, reposStore re
 				}
 			}
 		})
+
+		t.Run("NoDiff", func(t *testing.T) {
+			ps, _, err := s.ListPatches(ctx, ListPatchesOpts{NoDiff: true})
+			if err != nil {
+				fmt.Printf("err=%T", err)
+				t.Fatal(err)
+			}
+
+			have, want := ps, patches
+			if len(have) != len(want) {
+				t.Fatalf("listed %d patches, want: %d", len(have), len(want))
+			}
+
+			for _, p := range ps {
+				if p.Diff != "" {
+					t.Fatalf("patch has non-blank diff: %+v", p)
+				}
+			}
+		})
 	})
 
 	t.Run("Listing OnlyWithoutChangesetJob", func(t *testing.T) {


### PR DESCRIPTION
Most of the time when we load patches from the database we don't need to
load the `diff` column, since we're mainly interested in foreign keys or
the diff stat columns.

Since the `diff`s can get pretty big, it makes sense to only load them
when necessary.

By not loading them, we should get a speed bump and use less memory for
requests in which we're really only interested in the other columns
(e.g. when we calculate the diff stat).

This should fix #11126.

---

@sourcegraph/campaigns on a scale from "meh, I can live with it" to "if you merge this, I'm going to throw up": how bad do you think the `strings.Replace` is?