### PR TITLE
e2e: add search tests

### DIFF
--- a/dev/e2e/external_service_test.go
+++ b/dev/e2e/external_service_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestExternalService(t *testing.T) {
 	if len(*githubToken) == 0 {
-		t.Fatal("Environment variable GITHUB_TOKEN is not set")
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
 	t.Run("repositoryPathPattern", func(t *testing.T) {

--- a/dev/e2e/organization_test.go
+++ b/dev/e2e/organization_test.go
@@ -84,7 +84,7 @@ func TestOrganization(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff([]schema.QuickLink{}, got.QuickLinks); diff != "" {
+			if diff := cmp.Diff([]schema.QuickLink(nil), got.QuickLinks); diff != "" {
 				t.Fatalf("QuickLinks mismatch (-want +got):\n%s", diff)
 			}
 		}

--- a/dev/e2e/search_test.go
+++ b/dev/e2e/search_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSearch(t *testing.T) {
 	if len(*githubToken) == 0 {
-		t.Fatal("Environment variable GITHUB_TOKEN is not set")
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
 	// Set up external service

--- a/dev/e2e/search_test.go
+++ b/dev/e2e/search_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -94,6 +95,20 @@ func TestSearch(t *testing.T) {
 					t.Fatalf("Missing mismatch (-want +got):\n%s", diff)
 				}
 			})
+		}
+	})
+
+	t.Run("execute search with search operators", func(t *testing.T) {
+		results, err := client.SearchFiles("repo:^github.com/sourcegraph/go-diff$ type:file file:.go -file:.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Make sure only got .go files and no .md files
+		for _, r := range results {
+			if !strings.HasSuffix(r.Name, ".go") {
+				t.Fatalf("Found file name does not end with .go: %s", r.Name)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Adds e2e tests for search, which covers:

- Search visibility:private|public
- Can execute search with search operators

Easier to review by commit.

Part of #10068