### PR TITLE
Increase version context name limit

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -166,7 +166,7 @@
                 "description": "Name of the version context, it must be unique.",
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 14
+                "maxLength": 50
               },
               "revisions": {
                 "description": "List of repositories of the version context",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -171,7 +171,7 @@ const SiteSchemaJSON = `{
                 "description": "Name of the version context, it must be unique.",
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 14
+                "maxLength": 50
               },
               "revisions": {
                 "description": "List of repositories of the version context",


### PR DESCRIPTION
This PR increases the size limit of version context names from 14 to 50.

It looks like this now:

<img width="810" alt="Screenshot 2020-06-19 at 10 32 00" src="https://user-images.githubusercontent.com/2102036/85103781-63b53280-b218-11ea-9132-53bdcf11d7bd.png">
<img width="470" alt="Screenshot 2020-06-19 at 10 32 15" src="https://user-images.githubusercontent.com/2102036/85103790-66b02300-b218-11ea-9a7d-20e388db7239.png">

Fixes #11591