### PR TITLE
schema: add support OpsGenie notifier

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -631,19 +631,6 @@ type GitoliteConnection struct {
 	Prefix string `json:"prefix"`
 }
 
-// GrafanaNotifierDingDing description: DingDing or DingTalk notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#dingding-dingtalk
-type GrafanaNotifierDingDing struct {
-	Type string `json:"type"`
-	Url  string `json:"url"`
-}
-
-// GrafanaNotifierKafka description: Kafka notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#kafka
-type GrafanaNotifierKafka struct {
-	KafkaRestProxy string `json:"kafkaRestProxy"`
-	KafkaTopic     string `json:"kafkaTopic"`
-	Type           string `json:"type"`
-}
-
 // GrafanaNotifierOpsGenie description: OpsGenie notifier - see https://docs.opsgenie.com/docs/grafana-integration
 type GrafanaNotifierOpsGenie struct {
 	ApiKey    string `json:"apiKey"`
@@ -659,14 +646,6 @@ type GrafanaNotifierPagerduty struct {
 	// IntegrationKey description: Integration key for PagerDuty.
 	IntegrationKey string `json:"integrationKey"`
 	Type           string `json:"type"`
-}
-
-// GrafanaNotifierPrometheus description: Prometheus alertmanager notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#prometheus-alertmanager
-type GrafanaNotifierPrometheus struct {
-	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
-	BasicAuthUser     string `json:"basicAuthUser,omitempty"`
-	Type              string `json:"type"`
-	Url               string `json:"url"`
 }
 
 // GrafanaNotifierSlack description: Slack notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#slack
@@ -690,12 +669,6 @@ type GrafanaNotifierSlack struct {
 	Url string `json:"url,omitempty"`
 	// Username description: Set the username for the bot’s message.
 	Username string `json:"username,omitempty"`
-}
-
-// GrafanaNotifierTeams description: Microsoft Teams notifier
-type GrafanaNotifierTeams struct {
-	Type string `json:"type"`
-	Url  string `json:"url"`
 }
 
 // GrafanaNotifierWebhook description: Webhook notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#webhook
@@ -766,13 +739,10 @@ type Notice struct {
 	Message string `json:"message"`
 }
 type Notifier struct {
-	Slack                  *GrafanaNotifierSlack
-	Pagerduty              *GrafanaNotifierPagerduty
-	Webhook                *GrafanaNotifierWebhook
-	Kafka                  *GrafanaNotifierKafka
-	PrometheusAlertmanager *GrafanaNotifierPrometheus
-	Dingding               *GrafanaNotifierDingDing
-	Opsgenie               *GrafanaNotifierOpsGenie
+	Slack     *GrafanaNotifierSlack
+	Pagerduty *GrafanaNotifierPagerduty
+	Webhook   *GrafanaNotifierWebhook
+	Opsgenie  *GrafanaNotifierOpsGenie
 }
 
 func (v Notifier) MarshalJSON() ([]byte, error) {
@@ -784,15 +754,6 @@ func (v Notifier) MarshalJSON() ([]byte, error) {
 	}
 	if v.Webhook != nil {
 		return json.Marshal(v.Webhook)
-	}
-	if v.Kafka != nil {
-		return json.Marshal(v.Kafka)
-	}
-	if v.PrometheusAlertmanager != nil {
-		return json.Marshal(v.PrometheusAlertmanager)
-	}
-	if v.Dingding != nil {
-		return json.Marshal(v.Dingding)
 	}
 	if v.Opsgenie != nil {
 		return json.Marshal(v.Opsgenie)
@@ -807,22 +768,16 @@ func (v *Notifier) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	switch d.DiscriminantProperty {
-	case "dingding":
-		return json.Unmarshal(data, &v.Dingding)
-	case "kafka":
-		return json.Unmarshal(data, &v.Kafka)
 	case "opsgenie":
 		return json.Unmarshal(data, &v.Opsgenie)
 	case "pagerduty":
 		return json.Unmarshal(data, &v.Pagerduty)
-	case "prometheus-alertmanager":
-		return json.Unmarshal(data, &v.PrometheusAlertmanager)
 	case "slack":
 		return json.Unmarshal(data, &v.Slack)
 	case "webhook":
 		return json.Unmarshal(data, &v.Webhook)
 	}
-	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"slack", "pagerduty", "webhook", "kafka", "prometheus-alertmanager", "dingding", "opsgenie"})
+	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"slack", "pagerduty", "webhook", "opsgenie"})
 }
 
 type OAuthIdentity struct {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -631,9 +631,6 @@
               { "$ref": "#/definitions/GrafanaNotifierSlack" },
               { "$ref": "#/definitions/GrafanaNotifierPagerduty" },
               { "$ref": "#/definitions/GrafanaNotifierWebhook" },
-              { "$ref": "#/definitions/GrafanaNotifierKafka" },
-              { "$ref": "#/definitions/GrafanaNotifierPrometheus" },
-              { "$ref": "#/definitions/GrafanaNotifierDingDing" },
               { "$ref": "#/definitions/GrafanaNotifierOpsGenie" }
             ],
             "!go": {
@@ -1075,45 +1072,6 @@
         "url": { "type": "string" },
         "username": { "type": "string" },
         "password": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierKafka": {
-      "description": "Kafka notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#kafka",
-      "type": "object",
-      "required": ["type", "kafkaRestProxy", "kafkaTopic"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "kafka"
-        },
-        "kafkaRestProxy": { "type": "string" },
-        "kafkaTopic": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierPrometheus": {
-      "description": "Prometheus alertmanager notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#prometheus-alertmanager",
-      "type": "object",
-      "required": ["type", "url"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "prometheus-alertmanager"
-        },
-        "url": { "type": "string" },
-        "basicAuthUser": { "type": "string" },
-        "basicAuthPassword": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierDingDing": {
-      "description": "DingDing or DingTalk notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#dingding-dingtalk",
-      "type": "object",
-      "required": ["type", "url"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "dingding"
-        },
-        "url": { "type": "string" }
       }
     },
     "GrafanaNotifierOpsGenie": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -630,7 +630,11 @@
             "oneOf": [
               { "$ref": "#/definitions/GrafanaNotifierSlack" },
               { "$ref": "#/definitions/GrafanaNotifierPagerduty" },
-              { "$ref": "#/definitions/GrafanaNotifierWebhook" }
+              { "$ref": "#/definitions/GrafanaNotifierWebhook" },
+              { "$ref": "#/definitions/GrafanaNotifierKafka" },
+              { "$ref": "#/definitions/GrafanaNotifierPrometheus" },
+              { "$ref": "#/definitions/GrafanaNotifierDingDing" },
+              { "$ref": "#/definitions/GrafanaNotifierOpsGenie" }
             ],
             "!go": {
               "taggedUnionType": true
@@ -1071,6 +1075,59 @@
         "url": { "type": "string" },
         "username": { "type": "string" },
         "password": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierKafka": {
+      "description": "Kafka notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#kafka",
+      "type": "object",
+      "required": ["type", "kafkaRestProxy", "kafkaTopic"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "kafka"
+        },
+        "kafkaRestProxy": { "type": "string" },
+        "kafkaTopic": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierPrometheus": {
+      "description": "Prometheus alertmanager notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#prometheus-alertmanager",
+      "type": "object",
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "prometheus-alertmanager"
+        },
+        "url": { "type": "string" },
+        "basicAuthUser": { "type": "string" },
+        "basicAuthPassword": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierDingDing": {
+      "description": "DingDing or DingTalk notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#dingding-dingtalk",
+      "type": "object",
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "dingding"
+        },
+        "url": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierOpsGenie": {
+      "description": "OpsGenie notifier - see https://docs.opsgenie.com/docs/grafana-integration",
+      "type": "object",
+      "required": ["type", "apiKey", "apiUrl"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "opsgenie"
+        },
+        "apiKey": { "type": "string" },
+        "apiUrl": { "type": "string" },
+        "autoClose": { "type": "boolean" }
       }
     }
   }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -636,9 +636,6 @@ const SiteSchemaJSON = `{
               { "$ref": "#/definitions/GrafanaNotifierSlack" },
               { "$ref": "#/definitions/GrafanaNotifierPagerduty" },
               { "$ref": "#/definitions/GrafanaNotifierWebhook" },
-              { "$ref": "#/definitions/GrafanaNotifierKafka" },
-              { "$ref": "#/definitions/GrafanaNotifierPrometheus" },
-              { "$ref": "#/definitions/GrafanaNotifierDingDing" },
               { "$ref": "#/definitions/GrafanaNotifierOpsGenie" }
             ],
             "!go": {
@@ -1080,57 +1077,6 @@ const SiteSchemaJSON = `{
         "url": { "type": "string" },
         "username": { "type": "string" },
         "password": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierKafka": {
-      "description": "Kafka notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#kafka",
-      "type": "object",
-      "required": ["type", "kafkaRestProxy", "kafkaTopic"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "kafka"
-        },
-        "kafkaRestProxy": { "type": "string" },
-        "kafkaTopic": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierPrometheus": {
-      "description": "Prometheus alertmanager notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#prometheus-alertmanager",
-      "type": "object",
-      "required": ["type", "url"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "prometheus-alertmanager"
-        },
-        "url": { "type": "string" },
-        "basicAuthUser": { "type": "string" },
-        "basicAuthPassword": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierDingDing": {
-      "description": "DingDing or DingTalk notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#dingding-dingtalk",
-      "type": "object",
-      "required": ["type", "url"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "dingding"
-        },
-        "url": { "type": "string" }
-      }
-    },
-    "GrafanaNotifierTeams": {
-      "description": "Microsoft Teams notifier",
-      "type": "object",
-      "required": ["type", "url"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "teams"
-        },
-        "url": { "type": "string" }
       }
     },
     "GrafanaNotifierOpsGenie": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -635,7 +635,11 @@ const SiteSchemaJSON = `{
             "oneOf": [
               { "$ref": "#/definitions/GrafanaNotifierSlack" },
               { "$ref": "#/definitions/GrafanaNotifierPagerduty" },
-              { "$ref": "#/definitions/GrafanaNotifierWebhook" }
+              { "$ref": "#/definitions/GrafanaNotifierWebhook" },
+              { "$ref": "#/definitions/GrafanaNotifierKafka" },
+              { "$ref": "#/definitions/GrafanaNotifierPrometheus" },
+              { "$ref": "#/definitions/GrafanaNotifierDingDing" },
+              { "$ref": "#/definitions/GrafanaNotifierOpsGenie" }
             ],
             "!go": {
               "taggedUnionType": true
@@ -1076,6 +1080,71 @@ const SiteSchemaJSON = `{
         "url": { "type": "string" },
         "username": { "type": "string" },
         "password": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierKafka": {
+      "description": "Kafka notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#kafka",
+      "type": "object",
+      "required": ["type", "kafkaRestProxy", "kafkaTopic"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "kafka"
+        },
+        "kafkaRestProxy": { "type": "string" },
+        "kafkaTopic": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierPrometheus": {
+      "description": "Prometheus alertmanager notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#prometheus-alertmanager",
+      "type": "object",
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "prometheus-alertmanager"
+        },
+        "url": { "type": "string" },
+        "basicAuthUser": { "type": "string" },
+        "basicAuthPassword": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierDingDing": {
+      "description": "DingDing or DingTalk notifier - see https://grafana.com/docs/grafana/latest/alerting/notifications/#dingding-dingtalk",
+      "type": "object",
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "dingding"
+        },
+        "url": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierTeams": {
+      "description": "Microsoft Teams notifier",
+      "type": "object",
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "teams"
+        },
+        "url": { "type": "string" }
+      }
+    },
+    "GrafanaNotifierOpsGenie": {
+      "description": "OpsGenie notifier - see https://docs.opsgenie.com/docs/grafana-integration",
+      "type": "object",
+      "required": ["type", "apiKey", "apiUrl"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "opsgenie"
+        },
+        "apiKey": { "type": "string" },
+        "apiUrl": { "type": "string" },
+        "autoClose": { "type": "boolean" }
       }
     }
   }


### PR DESCRIPTION
~This adds support for notifiers that:~

~(have schema in https://grafana.com/docs/grafana/latest/administration/provisioning/#alert-notification-channels) 
AND
( (have docs in https://grafana.com/docs/grafana/latest/alerting/notifications/#list-of-supported-notifiers)
OR (have docs on service website, e.g. OpsGenie) )~

~There are surprisingly few documented notifiers - not sure if I should go ahead and add the rest anyway (I personally lean towards a need-to-have basis), since some are rather obscure~

**update** - PR now only adds OpsGenie

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
