### PR TITLE
Only create GitCommitResolver when doing symbol search

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -209,11 +209,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 		lines := make([]*lineMatch, 0, len(file.LineMatches))
 		symbols := []*searchSymbolResult{}
 		var matchCount int
-		commit := &GitCommitResolver{
-			repoResolver: repoResolvers[repoRev.Repo.Name],
-			oid:          GitObjectID(file.Version),
-			inputRev:     &inputRev,
-		}
+		var commit *GitCommitResolver
 		for _, l := range file.LineMatches {
 			if !l.FileName {
 				if len(l.LineFragments) > maxLineFragmentMatches {
@@ -225,6 +221,13 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 					length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 					offsets[k] = [2]int32{int32(offset), int32(length)}
 					if isSymbol && m.SymbolInfo != nil {
+						if commit == nil {
+							commit = &GitCommitResolver{
+								repoResolver: repoResolvers[repoRev.Repo.Name],
+								oid:          GitObjectID(file.Version),
+								inputRev:     &inputRev,
+							}
+						}
 						symbols = append(symbols, &searchSymbolResult{
 							symbol: protocol.Symbol{
 								Name:       m.SymbolInfo.Sym,


### PR DESCRIPTION
Answer to https://github.com/sourcegraph/sourcegraph/pull/11558#issuecomment-647476049.

Previously, it would have been created independently of the search type.

Now, it still shares the commit resolver, but doesn't actually create the commit resolver when we don't need one.