### PR TITLE
repo-updater: periodically bump priority of uncloned repositories

### DIFF
--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -257,7 +257,7 @@ func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 	schedKnownRepos.Set(float64(known))
 }
 
-// SetCloned will ensure only repos in named are treated as cloned. All other
+// SetCloned will ensure only repos in names are treated as cloned. All other
 // repositories in the scheduler will be marked as uncloned.
 //
 // This method should be called periodically with the list of all repositories

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"container/heap"
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -254,6 +255,19 @@ func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 	}
 
 	schedKnownRepos.Set(float64(known))
+}
+
+// SetCloned will ensure only repos in named are treated as cloned. All other
+// repositories in the scheduler will be marked as uncloned.
+//
+// This method should be called periodically with the list of all repositories
+// cloned on gitserver. This ensures the scheduler treats uncloned
+// repositories with a higher priority.
+func (s *updateScheduler) SetCloned(names []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.schedule.setCloned(names)
 }
 
 func (s *updateScheduler) upsert(r *Repo, enqueue bool) {
@@ -604,6 +618,41 @@ func (s *schedule) upsert(repo configuredRepo2) (updated bool) {
 	s.rescheduleTimer()
 
 	return false
+}
+
+func (s *schedule) setCloned(names []string) {
+	// Set of names created outside of lock for fast checking.
+	cloned := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		cloned[strings.ToLower(n)] = struct{}{}
+	}
+
+	// All non-cloned repos will be due for cloning as if they are newly added
+	// repos.
+	notClonedDue := timeNow().Add(minDelay)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Iterate over all repos in the scheduler. If it isn't in cloned bump it
+	// up the queue. Note: we iterate over index because we will be mutating
+	// heap.
+	rescheduleTimer := false
+	for _, repoUpdate := range s.index {
+		if _, ok := cloned[strings.ToLower(string(repoUpdate.Repo.Name))]; ok {
+			continue
+		}
+		if repoUpdate.Due.After(notClonedDue) {
+			repoUpdate.Due = notClonedDue
+			heap.Fix(s, repoUpdate.Index)
+			rescheduleTimer = true
+		}
+	}
+
+	// We updated the queue, inform the scheduler loop.
+	if rescheduleTimer {
+		s.rescheduleTimer()
+	}
 }
 
 // updateInterval updates the update interval of a repo in the schedule.

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -259,9 +259,6 @@ func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 // cloned on gitserver. This ensures the scheduler treats uncloned
 // repositories with a higher priority.
 func (s *updateScheduler) SetCloned(names []string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.schedule.setCloned(names)
 }
 


### PR DESCRIPTION
The git fetch/clone scheduler is unaware of which repositories are
cloned or uncloned. It is only aware of repositories from the code host
syncer. A repository can not be cloned even if the scheduler is aware of
it for a few reasons:

- The repository failed to cloned.
- The repository was removed due to disk pressure.

This commit adds a periodic sync between the list of repositories
gitserver has cloned and the state of the scheduler. We walk the list of
all repositories in the scheduler and if it is not cloned, we update its
"due" date to be as if the repository was new (default 45s until we
clone it).

Note: all repositories returned from the repo store are in the scheduler
via the code host syncer.

### Comparison to repo-updater: make syncer & scheduler aware of uncloned gitserver repositories 
 #11602

The effect of #11602 is to immediately enqueue all uncloned repos into the queue. It achieves this by making the code host syncer aware of cloned state. I prefer this approach since it keeps the syncer only responsible for state from a code host, rather than some internal gitserver state. Additionally we want to make the scheduler aware of cloned state, which is a different component. This more directly achieves that and keeps the concerns independent.

Note: in the other PR uncloned repos are put straight onto the queue. Here we instead update the priority (due date) in the scheduler. This means there is a delay of 45s before we notice a repo that isn't cloned. However, because it is independent it can run much more regularly than a potentially slow code host sync. So in effect it is faster.