### PR TITLE
repo-updater: optimize computeNotClonedCount

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -589,9 +589,7 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 
 	for _, c := range cloned {
 		lower := strings.ToLower(c)
-		if _, ok := notCloned[lower]; ok {
-			delete(notCloned, lower)
-		}
+		delete(notCloned, lower)
 	}
 
 	s.notClonedCount = uint64(len(notCloned))

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -576,10 +576,10 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 
-	clonedRepos := make(map[string]bool, len(names))
+	notCloned := make(map[string]struct{}, len(names))
 	for _, n := range names {
 		lower := strings.ToLower(string(n))
-		clonedRepos[lower] = false
+		notCloned[lower] = struct{}{}
 	}
 
 	cloned, err := s.GitserverClient.ListCloned(ctx)
@@ -589,22 +589,15 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 
 	for _, c := range cloned {
 		lower := strings.ToLower(c)
-		if _, ok := clonedRepos[lower]; ok {
-			clonedRepos[lower] = true
+		if _, ok := notCloned[lower]; ok {
+			delete(notCloned, lower)
 		}
 	}
 
-	var notCloned uint64
-	for _, cloned := range clonedRepos {
-		if !cloned {
-			notCloned++
-		}
-	}
-
-	s.notClonedCount = notCloned
+	s.notClonedCount = uint64(len(notCloned))
 	s.notClonedCountUpdatedAt = time.Now()
 
-	return notCloned, nil
+	return s.notClonedCount, nil
 }
 
 func (s *Server) handleEnqueueChangesetSync(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is a cherry-pick of an unrelated commit in https://github.com/sourcegraph/sourcegraph/pull/11602

I haven't actually validated this is faster. I would suspect that delete does extra work compared to updating a value in a hashtable. So not sure if it is faster in the common case where nearly everything in the list is cloned (and therefore deleted). However, in the interest of discussion I have opened this PR with @slimsag's commit :)

I made one small change from the original commit. I just always call delete and avoid the extra lookup. Delete is a noop if the key is no present.