### PR TITLE
repo-updater: dynamically update syncer update interval

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -51,7 +51,7 @@ type Syncer struct {
 }
 
 // Run runs the Sync at the specified interval.
-func (s *Syncer) Run(pctx context.Context, interval time.Duration) error {
+func (s *Syncer) Run(pctx context.Context, interval func() time.Duration) error {
 	for pctx.Err() == nil {
 		ctx, cancel := contextWithSignalCancel(pctx, s.syncSignal.Watch())
 
@@ -59,7 +59,7 @@ func (s *Syncer) Run(pctx context.Context, interval time.Duration) error {
 			s.Logger.Error("Syncer", "error", err)
 		}
 
-		sleep(ctx, interval)
+		sleep(ctx, interval())
 
 		cancel()
 	}

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -182,7 +182,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		syncer.Synced = make(chan repos.Diff)
 		syncer.SubsetSynced = make(chan repos.Diff)
 		go watchSyncer(ctx, syncer, scheduler, gps)
-		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval())) }()
+		go func() { log.Fatal(syncer.Run(ctx, repos.GetUpdateInterval)) }()
 	}
 	server.Syncer = syncer
 


### PR DESCRIPTION
I noticed this small change while working on something else. If someone
updates the configuration for the update interval it won't take effect
until the repo-updater process restarts. With this commit we will check
the interval before we do the sleep, so will not require a process
restart.
