### PR TITLE
repo-updater: remove updateScheduler mutex

### DIFF
--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -94,8 +94,6 @@ const (
 // A worker continuously dequeues repos and sends updates to gitserver, but its concurrency
 // is limited by the gitMaxConcurrentClones site configuration.
 type updateScheduler struct {
-	mu sync.Mutex
-
 	updateQueue *updateQueue
 	schedule    *schedule
 }
@@ -228,9 +226,6 @@ var configuredLimiter = func() *mutablelimiter.Limiter {
 
 // UpdateFromDiff updates the scheduled and queued repos from the given sync diff.
 func (s *updateScheduler) UpdateFromDiff(diff Diff) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	for _, r := range diff.Deleted {
 		s.remove(r)
 	}


### PR DESCRIPTION
As far as I can tell this mutex serves no purpose. The only possible
purpose is to serialize calls to UpdateFromDiff. However, the individual
upsert and remove calls on the scheduler and queue have there own
mutexes.

Possibly if we had two concurrent `UpdateFromDiff` we could have an
inconsistent state, but it would converge at the next UpdateFromDiff
call. Additionally we only have one call site for UpdateFromDiff, and
that never runs concurrently.