### PR TITLE
cmd(server): fix build version embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- The single-container `sourcegraph/server` image now correctly reports its version.
+
 ### Removed
 
 - Backwards compatibility for "critical configuration" (a type of configuration that was deprecated in December 2019) was removed. All critical configuration now belongs in site configuration.

--- a/cmd/server/go-build.sh
+++ b/cmd/server/go-build.sh
@@ -12,8 +12,7 @@ if [[ "$BASENAME" != "server" ]] && [[ -f "$RELATIVE_PACKAGE/go-build.sh" ]]; th
 else
   go build \
     -trimpath \
-    -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" \
-    -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" \
+    -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" \
     -buildmode exe \
     -installsuffix netgo \
     -tags "dist netgo" \


### PR DESCRIPTION
Missed one in #11484 😞 The ldflags were changed in https://github.com/sourcegraph/sourcegraph/pull/10843

The current `3.17.0` single-container image has `0.0.0+dev` as the version, but I think other deployment methods should be fine still

https://sourcegraph.com/search?q=repo:%5Egithub.com/sourcegraph/sourcegraph%24%40c667073852cfa57635ec8f45c8380edf8655cd76+-ldflags+%22-X+github.com/sourcegraph/sourcegraph/internal/version.version+AND+-ldflags+%22-X+github.com/sourcegraph/sourcegraph/internal/version.timestamp&patternType=literal

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->


Sanity check:

```
VERSION=bob IMAGE=sourcegraph/server:bob cmd/server/build.sh
docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm sourcegraph/server:bob
```

<img width="861" alt="image" src="https://user-images.githubusercontent.com/23356519/85307616-b45fb080-b4e2-11ea-8599-ea4382a38287.png">
