### PR TITLE
codeintel: Add janitor pass for abandoned uploads

### DIFF
--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
@@ -12,9 +12,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
-// removeProcessedUploadsWithoutBundleFile removes all processed upload records
-// that do not have a corresponding bundle file on disk.
-func (j *Janitor) removeProcessedUploadsWithoutBundleFile() error {
+// removeProcessedRecordsWithoutBundleFile removes all upload records in the
+// processed state that do not have a corresponding bundle file on disk.
+func (j *Janitor) removeProcessedRecordsWithoutBundleFile() error {
 	ctx := context.Background()
 
 	// TODO(efritz) - request in batches
@@ -46,9 +46,9 @@ func (j *Janitor) removeProcessedUploadsWithoutBundleFile() error {
 	return nil
 }
 
-// removeOldUploadingUploads removes all uploads in the uploading state that are
-// older than the max upload part age.
-func (j *Janitor) removeOldUploadingUploads() error {
+// removeOldUploadingRecords removes all upload records in the uploading state that
+// are older than the max upload part age.
+func (j *Janitor) removeOldUploadingRecords() error {
 	ctx := context.Background()
 	t := time.Now().UTC().Add(-j.maxUploadPartAge)
 

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
@@ -12,21 +12,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
+// GetUploadsBatchSize is the maximum number of uploads to request from the database at once.
+const GetUploadsBatchSize = 100
+
 // removeProcessedRecordsWithoutBundleFile removes all upload records in the
 // processed state that do not have a corresponding bundle file on disk.
 func (j *Janitor) removeProcessedRecordsWithoutBundleFile() error {
 	ctx := context.Background()
 
-	// TODO(efritz) - request in batches
-	uploads, _, err := j.store.GetUploads(ctx, store.GetUploadsOptions{
+	ids, err := j.getUploadIDs(ctx, store.GetUploadsOptions{
 		State: "processed",
 	})
 	if err != nil {
-		return errors.Wrap(err, "store.GetUploads")
+		return err
 	}
 
-	for _, upload := range uploads {
-		exists, err := paths.PathExists(paths.DBDir(j.bundleDir, int64(upload.ID)))
+	for _, id := range ids {
+		exists, err := paths.PathExists(paths.DBDir(j.bundleDir, int64(id)))
 		if err != nil {
 			return errors.Wrap(err, "paths.PathExists")
 		}
@@ -34,13 +36,13 @@ func (j *Janitor) removeProcessedRecordsWithoutBundleFile() error {
 			continue
 		}
 
-		deleted, err := j.store.DeleteUploadByID(ctx, upload.ID, j.getTipCommit)
+		deleted, err := j.store.DeleteUploadByID(ctx, id, j.getTipCommit)
 		if err != nil {
 			return errors.Wrap(err, "store.DeleteUploadByID")
 		}
 
 		if deleted {
-			log15.Debug("Removed upload record with no bundle file", "id", upload.ID)
+			log15.Debug("Removed upload record with no bundle file", "id", id)
 			j.metrics.UploadRecordsRemoved.Inc()
 		}
 	}
@@ -54,29 +56,52 @@ func (j *Janitor) removeOldUploadingRecords() error {
 	ctx := context.Background()
 	t := time.Now().UTC().Add(-j.maxUploadPartAge)
 
-	// TODO(efritz) - request in batches
-	uploads, _, err := j.store.GetUploads(ctx, store.GetUploadsOptions{
+	ids, err := j.getUploadIDs(ctx, store.GetUploadsOptions{
 		State:          "uploading",
 		UploadedBefore: &t,
 	})
 	if err != nil {
-		return errors.Wrap(err, "store.GetUploads")
+		return err
 	}
 
-	for _, upload := range uploads {
-		deleted, err := j.store.DeleteUploadByID(ctx, upload.ID, j.getTipCommit)
+	for _, id := range ids {
+		deleted, err := j.store.DeleteUploadByID(ctx, id, j.getTipCommit)
 		if err != nil {
 			return errors.Wrap(err, "store.DeleteUploadByID")
 		}
 
 		if deleted {
-			log15.Debug("Removed upload record stuck uploading", "id", upload.ID)
+			log15.Debug("Removed upload record stuck uploading", "id", id)
 			j.metrics.UploadRecordsRemoved.Inc()
 		}
 	}
 
 	return nil
+}
 
+// getUploadIDs returns the identifiers of all uploads matching the given options.
+func (j *Janitor) getUploadIDs(ctx context.Context, opts store.GetUploadsOptions) ([]int, error) {
+	var ids []int
+
+	for {
+		opts.Limit = GetUploadsBatchSize
+		opts.Offset = len(ids)
+
+		uploads, totalCount, err := j.store.GetUploads(ctx, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "store.GetUploads")
+		}
+
+		for i := range uploads {
+			ids = append(ids, uploads[i].ID)
+		}
+
+		if len(ids) >= totalCount {
+			break
+		}
+	}
+
+	return ids, nil
 }
 
 // getTipCommit returns the head of the default branch for the given repository. This

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
@@ -2,11 +2,13 @@ package janitor
 
 import (
 	"context"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-bundle-manager/internal/paths"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
@@ -42,6 +44,37 @@ func (j *Janitor) removeProcessedUploadsWithoutBundleFile() error {
 	}
 
 	return nil
+}
+
+// removeOldUploadingUploads removes all uploads in the uploading state that are
+// older than the max upload part age.
+func (j *Janitor) removeOldUploadingUploads() error {
+	ctx := context.Background()
+	t := time.Now().UTC().Add(-j.maxUploadPartAge)
+
+	// TODO(efritz) - request in batches
+	uploads, _, err := j.store.GetUploads(ctx, store.GetUploadsOptions{
+		State:          "uploading",
+		UploadedBefore: &t,
+	})
+	if err != nil {
+		return errors.Wrap(err, "store.GetUploads")
+	}
+
+	for _, upload := range uploads {
+		deleted, err := j.store.DeleteUploadByID(ctx, upload.ID, j.getTipCommit)
+		if err != nil {
+			return errors.Wrap(err, "store.DeleteUploadByID")
+		}
+
+		if deleted {
+			log15.Debug("Removed upload record stuck uploading", "id", upload.ID)
+			j.metrics.UploadRecordsRemoved.Inc()
+		}
+	}
+
+	return nil
+
 }
 
 // getTipCommit returns the head of the default branch for the given repository. This

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
 	storemocks "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store/mocks"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
@@ -46,6 +47,46 @@ func TestRemoveProcessedUploadsWithoutBundleFile(t *testing.T) {
 		sort.Ints(ids)
 
 		if diff := cmp.Diff([]int{2, 4}, ids); diff != "" {
+			t.Errorf("unexpected dump ids (-want +got):\n%s", diff)
+		}
+	}
+}
+
+func TestRemoveOldUploadingUploads(t *testing.T) {
+	bundleDir := testRoot(t)
+
+	mockStore := storemocks.NewMockStore()
+	mockStore.GetUploadsFunc.SetDefaultReturn([]store.Upload{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+		{ID: 4},
+		{ID: 5},
+	}, 0, nil)
+
+	j := &Janitor{
+		store:     mockStore,
+		bundleDir: bundleDir,
+		metrics:   NewJanitorMetrics(metrics.TestRegisterer),
+	}
+
+	if err := j.removeOldUploadingUploads(); err != nil {
+		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
+	}
+
+	if len(mockStore.DeleteUploadByIDFunc.History()) != 5 {
+		t.Errorf("unexpected number of DeleteUploadByID calls. want=%d have=%d", 5, len(mockStore.DeleteUploadByIDFunc.History()))
+	} else {
+		ids := []int{
+			mockStore.DeleteUploadByIDFunc.History()[0].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[1].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[2].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[3].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[4].Arg1,
+		}
+		sort.Ints(ids)
+
+		if diff := cmp.Diff([]int{1, 2, 3, 4, 5}, ids); diff != "" {
 			t.Errorf("unexpected dump ids (-want +got):\n%s", diff)
 		}
 	}

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
@@ -16,7 +16,7 @@ import (
 func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 	bundleDir := testRoot(t)
 
-	for _, id := range []int{1, 3, 5} {
+	for _, id := range []int{1, 3, 5, 7, 9} {
 		path := filepath.Join(bundleDir, "dbs", fmt.Sprintf("%d", id), "sqlite.db")
 		if err := makeFile(path, time.Now().Local()); err != nil {
 			t.Fatalf("unexpected error creating file %s: %s", path, err)
@@ -24,13 +24,8 @@ func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 	}
 
 	mockStore := storemocks.NewMockStore()
-	mockStore.GetUploadsFunc.SetDefaultReturn([]store.Upload{
-		{ID: 1},
-		{ID: 2},
-		{ID: 3},
-		{ID: 4},
-		{ID: 5},
-	}, 0, nil)
+	mockStore.GetUploadsFunc.PushReturn([]store.Upload{{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}, {ID: 5}}, 10, nil)
+	mockStore.GetUploadsFunc.PushReturn([]store.Upload{{ID: 6}, {ID: 7}, {ID: 8}, {ID: 9}, {ID: 10}}, 10, nil)
 
 	j := &Janitor{
 		store:     mockStore,
@@ -39,43 +34,6 @@ func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 	}
 
 	if err := j.removeProcessedRecordsWithoutBundleFile(); err != nil {
-		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
-	}
-
-	if len(mockStore.DeleteUploadByIDFunc.History()) != 2 {
-		t.Errorf("unexpected number of DeleteUploadByID calls. want=%d have=%d", 2, len(mockStore.DeleteUploadByIDFunc.History()))
-	} else {
-		ids := []int{
-			mockStore.DeleteUploadByIDFunc.History()[0].Arg1,
-			mockStore.DeleteUploadByIDFunc.History()[1].Arg1,
-		}
-		sort.Ints(ids)
-
-		if diff := cmp.Diff([]int{2, 4}, ids); diff != "" {
-			t.Errorf("unexpected dump ids (-want +got):\n%s", diff)
-		}
-	}
-}
-
-func TestRemoveOldUploadingRecords(t *testing.T) {
-	bundleDir := testRoot(t)
-
-	mockStore := storemocks.NewMockStore()
-	mockStore.GetUploadsFunc.SetDefaultReturn([]store.Upload{
-		{ID: 1},
-		{ID: 2},
-		{ID: 3},
-		{ID: 4},
-		{ID: 5},
-	}, 0, nil)
-
-	j := &Janitor{
-		store:     mockStore,
-		bundleDir: bundleDir,
-		metrics:   NewJanitorMetrics(metrics.TestRegisterer),
-	}
-
-	if err := j.removeOldUploadingRecords(); err != nil {
 		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
 	}
 
@@ -91,7 +49,47 @@ func TestRemoveOldUploadingRecords(t *testing.T) {
 		}
 		sort.Ints(ids)
 
-		if diff := cmp.Diff([]int{1, 2, 3, 4, 5}, ids); diff != "" {
+		if diff := cmp.Diff([]int{2, 4, 6, 8, 10}, ids); diff != "" {
+			t.Errorf("unexpected dump ids (-want +got):\n%s", diff)
+		}
+	}
+}
+
+func TestRemoveOldUploadingRecords(t *testing.T) {
+	bundleDir := testRoot(t)
+
+	mockStore := storemocks.NewMockStore()
+	mockStore.GetUploadsFunc.PushReturn([]store.Upload{{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}, {ID: 5}}, 10, nil)
+	mockStore.GetUploadsFunc.PushReturn([]store.Upload{{ID: 6}, {ID: 7}, {ID: 8}, {ID: 9}, {ID: 10}}, 10, nil)
+
+	j := &Janitor{
+		store:     mockStore,
+		bundleDir: bundleDir,
+		metrics:   NewJanitorMetrics(metrics.TestRegisterer),
+	}
+
+	if err := j.removeOldUploadingRecords(); err != nil {
+		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
+	}
+
+	if len(mockStore.DeleteUploadByIDFunc.History()) != 10 {
+		t.Errorf("unexpected number of DeleteUploadByID calls. want=%d have=%d", 10, len(mockStore.DeleteUploadByIDFunc.History()))
+	} else {
+		ids := []int{
+			mockStore.DeleteUploadByIDFunc.History()[0].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[1].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[2].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[3].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[4].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[5].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[6].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[7].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[8].Arg1,
+			mockStore.DeleteUploadByIDFunc.History()[9].Arg1,
+		}
+		sort.Ints(ids)
+
+		if diff := cmp.Diff([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, ids); diff != "" {
 			t.Errorf("unexpected dump ids (-want +got):\n%s", diff)
 		}
 	}

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func TestRemoveProcessedUploadsWithoutBundleFile(t *testing.T) {
+func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 	bundleDir := testRoot(t)
 	ids := []int{1, 2, 3, 4, 5}
 
@@ -33,7 +33,7 @@ func TestRemoveProcessedUploadsWithoutBundleFile(t *testing.T) {
 		metrics:   NewJanitorMetrics(metrics.TestRegisterer),
 	}
 
-	if err := j.removeProcessedUploadsWithoutBundleFile(); err != nil {
+	if err := j.removeProcessedRecordsWithoutBundleFile(); err != nil {
 		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRemoveProcessedUploadsWithoutBundleFile(t *testing.T) {
 	}
 }
 
-func TestRemoveOldUploadingUploads(t *testing.T) {
+func TestRemoveOldUploadingRecords(t *testing.T) {
 	bundleDir := testRoot(t)
 
 	mockStore := storemocks.NewMockStore()
@@ -70,7 +70,7 @@ func TestRemoveOldUploadingUploads(t *testing.T) {
 		metrics:   NewJanitorMetrics(metrics.TestRegisterer),
 	}
 
-	if err := j.removeOldUploadingUploads(); err != nil {
+	if err := j.removeOldUploadingRecords(); err != nil {
 		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
 	}
 

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 	bundleDir := testRoot(t)
-	ids := []int{1, 2, 3, 4, 5}
 
 	for _, id := range []int{1, 3, 5} {
 		path := filepath.Join(bundleDir, "dbs", fmt.Sprintf("%d", id), "sqlite.db")
@@ -25,7 +24,13 @@ func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 	}
 
 	mockStore := storemocks.NewMockStore()
-	mockStore.GetDumpIDsFunc.SetDefaultReturn(ids, nil)
+	mockStore.GetUploadsFunc.SetDefaultReturn([]store.Upload{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+		{ID: 4},
+		{ID: 5},
+	}, 0, nil)
 
 	j := &Janitor{
 		store:     mockStore,

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
@@ -95,12 +95,12 @@ func (j *Janitor) run() error {
 		return errors.Wrap(err, "janitor.freeSpace")
 	}
 
-	if err := j.removeProcessedUploadsWithoutBundleFile(); err != nil {
-		return errors.Wrap(err, "janitor.removeProcessedUploadsWithoutBundle")
+	if err := j.removeProcessedRecordsWithoutBundleFile(); err != nil {
+		return errors.Wrap(err, "janitor.removeProcessedRecordsWithoutBundleFile")
 	}
 
-	if err := j.removeOldUploadingUploads(); err != nil {
-		return errors.Wrap(err, "janitor.removeOldUploadingUploads")
+	if err := j.removeOldUploadingRecords(); err != nil {
+		return errors.Wrap(err, "janitor.removeOldUploadingRecords")
 	}
 
 	return nil

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
@@ -99,6 +99,10 @@ func (j *Janitor) run() error {
 		return errors.Wrap(err, "janitor.removeProcessedUploadsWithoutBundle")
 	}
 
+	if err := j.removeOldUploadingUploads(); err != nil {
+		return errors.Wrap(err, "janitor.removeOldUploadingUploads")
+	}
+
 	return nil
 }
 

--- a/enterprise/internal/codeintel/store/dumps.go
+++ b/enterprise/internal/codeintel/store/dumps.go
@@ -69,11 +69,6 @@ func scanFirstDump(rows *sql.Rows, err error) (Dump, bool, error) {
 	return dumps[0], true, nil
 }
 
-// GetDumpIDs returns all dump ids in chronological order.
-func (s *store) GetDumpIDs(ctx context.Context) ([]int, error) {
-	return scanInts(s.query(ctx, sqlf.Sprintf(`SELECT d.id FROM lsif_dumps d ORDER BY uploaded_at`)))
-}
-
 // GetDumpByID returns a dump by its identifier and boolean flag indicating its existence.
 func (s *store) GetDumpByID(ctx context.Context, id int) (Dump, bool, error) {
 	return scanFirstDump(s.query(ctx, sqlf.Sprintf(`

--- a/enterprise/internal/codeintel/store/dumps_test.go
+++ b/enterprise/internal/codeintel/store/dumps_test.go
@@ -11,39 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
-func TestGetDumpIDs(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	dbtesting.SetupGlobalTestDB(t)
-	store := testStore()
-
-	t1 := time.Unix(1587396557, 0).UTC()
-	t2 := t1.Add(1 * time.Minute)
-	t3 := t1.Add(2 * time.Minute)
-	t4 := t1.Add(3 * time.Minute)
-	t5 := t1.Add(4 * time.Minute)
-	t6 := t1.Add(5 * time.Minute)
-
-	insertUploads(t, dbconn.Global,
-		Upload{ID: 1, Commit: makeCommit(1), State: "completed", UploadedAt: t2},
-		Upload{ID: 2, Commit: makeCommit(2), State: "completed", UploadedAt: t6},
-		Upload{ID: 3, Commit: makeCommit(3), State: "completed", UploadedAt: t3},
-		Upload{ID: 4, Commit: makeCommit(4), State: "completed", UploadedAt: t4},
-		Upload{ID: 5, Commit: makeCommit(5), State: "completed", UploadedAt: t5},
-		Upload{ID: 6, Commit: makeCommit(6), State: "errored", UploadedAt: t2},
-	)
-
-	ids, err := store.GetDumpIDs(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error getting dump ids: %s", err)
-	}
-
-	if diff := cmp.Diff([]int{1, 3, 4, 5, 2}, ids); diff != "" {
-		t.Errorf("unexpected ids (-want +got):\n%s", diff)
-	}
-}
-
 func TestGetDumpByID(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/enterprise/internal/codeintel/store/helpers_test.go
+++ b/enterprise/internal/codeintel/store/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -18,6 +19,15 @@ func (r printableRank) String() string {
 		return "nil"
 	}
 	return fmt.Sprintf("%d", *r.value)
+}
+
+type printableTime struct{ value *time.Time }
+
+func (r printableTime) String() string {
+	if r.value == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%v", *r.value)
 }
 
 // makeCommit formats an integer as a 40-character git commit hash.

--- a/enterprise/internal/codeintel/store/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/store/mocks/mock_store.go
@@ -45,9 +45,6 @@ type MockStore struct {
 	// GetDumpByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetDumpByID.
 	GetDumpByIDFunc *StoreGetDumpByIDFunc
-	// GetDumpIDsFunc is an instance of a mock function object controlling
-	// the behavior of the method GetDumpIDs.
-	GetDumpIDsFunc *StoreGetDumpIDsFunc
 	// GetIndexByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexByID.
 	GetIndexByIDFunc *StoreGetIndexByIDFunc
@@ -206,11 +203,6 @@ func NewMockStore() *MockStore {
 		GetDumpByIDFunc: &StoreGetDumpByIDFunc{
 			defaultHook: func(context.Context, int) (store.Dump, bool, error) {
 				return store.Dump{}, false, nil
-			},
-		},
-		GetDumpIDsFunc: &StoreGetDumpIDsFunc{
-			defaultHook: func(context.Context) ([]int, error) {
-				return nil, nil
 			},
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
@@ -419,9 +411,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetDumpByIDFunc: &StoreGetDumpByIDFunc{
 			defaultHook: i.GetDumpByID,
-		},
-		GetDumpIDsFunc: &StoreGetDumpIDsFunc{
-			defaultHook: i.GetDumpIDs,
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
 			defaultHook: i.GetIndexByID,
@@ -1633,111 +1622,6 @@ func (c StoreGetDumpByIDFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetDumpByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreGetDumpIDsFunc describes the behavior when the GetDumpIDs method of
-// the parent MockStore instance is invoked.
-type StoreGetDumpIDsFunc struct {
-	defaultHook func(context.Context) ([]int, error)
-	hooks       []func(context.Context) ([]int, error)
-	history     []StoreGetDumpIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpIDs delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetDumpIDs(v0 context.Context) ([]int, error) {
-	r0, r1 := m.GetDumpIDsFunc.nextHook()(v0)
-	m.GetDumpIDsFunc.appendCall(StoreGetDumpIDsFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetDumpIDs method of
-// the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpIDsFunc) SetDefaultHook(hook func(context.Context) ([]int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpIDs method of the parent MockStore instance inovkes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetDumpIDsFunc) PushHook(hook func(context.Context) ([]int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *StoreGetDumpIDsFunc) SetDefaultReturn(r0 []int, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *StoreGetDumpIDsFunc) PushReturn(r0 []int, r1 error) {
-	f.PushHook(func(context.Context) ([]int, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpIDsFunc) nextHook() func(context.Context) ([]int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpIDsFunc) appendCall(r0 StoreGetDumpIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetDumpIDsFuncCall objects describing
-// the invocations of this function.
-func (f *StoreGetDumpIDsFunc) History() []StoreGetDumpIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpIDsFuncCall is an object that describes an invocation of
-// method GetDumpIDs on an instance of MockStore.
-type StoreGetDumpIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetIndexByIDFunc describes the behavior when the GetIndexByID method

--- a/enterprise/internal/codeintel/store/observability.go
+++ b/enterprise/internal/codeintel/store/observability.go
@@ -28,7 +28,6 @@ type ObservedStore struct {
 	getStatesOperation                 *observation.Operation
 	deleteUploadByIDOperation          *observation.Operation
 	resetStalledOperation              *observation.Operation
-	getDumpIDsOperation                *observation.Operation
 	getDumpByIDOperation               *observation.Operation
 	findClosestDumpsOperation          *observation.Operation
 	deleteOldestDumpOperation          *observation.Operation
@@ -149,11 +148,6 @@ func NewObserved(store Store, observationContext *observation.Context) Store {
 		resetStalledOperation: observationContext.Operation(observation.Op{
 			Name:         "store.ResetStalled",
 			MetricLabels: []string{"reset_stalled"},
-			Metrics:      metrics,
-		}),
-		getDumpIDsOperation: observationContext.Operation(observation.Op{
-			Name:         "store.GetDumpIDs",
-			MetricLabels: []string{"get_dump_ids"},
 			Metrics:      metrics,
 		}),
 		getDumpByIDOperation: observationContext.Operation(observation.Op{
@@ -318,7 +312,6 @@ func (s *ObservedStore) wrap(other Store) Store {
 		getStatesOperation:                 s.getStatesOperation,
 		deleteUploadByIDOperation:          s.deleteUploadByIDOperation,
 		resetStalledOperation:              s.resetStalledOperation,
-		getDumpIDsOperation:                s.getDumpIDsOperation,
 		getDumpByIDOperation:               s.getDumpByIDOperation,
 		findClosestDumpsOperation:          s.findClosestDumpsOperation,
 		deleteOldestDumpOperation:          s.deleteOldestDumpOperation,
@@ -478,13 +471,6 @@ func (s *ObservedStore) ResetStalled(ctx context.Context, now time.Time) (resetI
 	ctx, endObservation := s.resetStalledOperation.With(ctx, &err, observation.Args{})
 	defer func() { endObservation(float64(len(resetIDs)+len(erroredIDs)), observation.Args{}) }()
 	return s.store.ResetStalled(ctx, now)
-}
-
-// GetDumpIDs calls into the inner store and registers the observed results.
-func (s *ObservedStore) GetDumpIDs(ctx context.Context) (ids []int, err error) {
-	ctx, endObservation := s.getDumpIDsOperation.With(ctx, &err, observation.Args{})
-	defer func() { endObservation(float64(len(ids)), observation.Args{}) }()
-	return s.store.GetDumpIDs(ctx)
 }
 
 // GetDumpByID calls into the inner store and registers the observed results.

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -81,9 +81,6 @@ type Store interface {
 	// identifiers.
 	ResetStalled(ctx context.Context, now time.Time) ([]int, []int, error)
 
-	// GetDumpIDs returns all dump ids in chronological order.
-	GetDumpIDs(ctx context.Context) ([]int, error)
-
 	// GetDumpByID returns a dump by its identifier and boolean flag indicating its existence.
 	GetDumpByID(ctx context.Context, id int) (Dump, bool, error)
 

--- a/enterprise/internal/codeintel/store/uploads.go
+++ b/enterprise/internal/codeintel/store/uploads.go
@@ -163,12 +163,13 @@ func (s *store) GetUploadByID(ctx context.Context, id int) (Upload, bool, error)
 }
 
 type GetUploadsOptions struct {
-	RepositoryID int
-	State        string
-	Term         string
-	VisibleAtTip bool
-	Limit        int
-	Offset       int
+	RepositoryID   int
+	State          string
+	Term           string
+	VisibleAtTip   bool
+	UploadedBefore *time.Time
+	Limit          int
+	Offset         int
 }
 
 // GetUploads returns a list of uploads and the total count of records matching the given conditions.
@@ -194,6 +195,9 @@ func (s *store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 	}
 	if opts.VisibleAtTip {
 		conds = append(conds, sqlf.Sprintf("u.visible_at_tip = true"))
+	}
+	if opts.UploadedBefore != nil {
+		conds = append(conds, sqlf.Sprintf("u.uploaded_at < %s", *opts.UploadedBefore))
 	}
 
 	if len(conds) == 0 {


### PR DESCRIPTION
Add step to clean up abandoned LSIF uploads in "uploading" state. Closes https://github.com/sourcegraph/sourcegraph/issues/11622.