### PR TITLE
codeintel: Find closest dumps that intersect path

### DIFF
--- a/enterprise/internal/codeintel/api/exists.go
+++ b/enterprise/internal/codeintel/api/exists.go
@@ -22,7 +22,11 @@ func (api *codeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int,
 		return nil, err
 	}
 
-	candidates, err := api.store.FindClosestDumps(ctx, repositoryID, commit, path, indexer)
+	// The parameters exactPath and rootMustEnclosePath align here: if we're looking for dumps
+	// that can answer queries for a directory (e.g. diagnostics), we want any dump that happens
+	// to intersect the target directory. If we're looking for dumps that can answer queries for
+	// a single file, then we need a dump with a root that properly encloses that file.
+	candidates, err := api.store.FindClosestDumps(ctx, repositoryID, commit, path, exactPath, indexer)
 	if err != nil {
 		return nil, errors.Wrap(err, "store.FindClosestDumps")
 	}

--- a/enterprise/internal/codeintel/api/exists_test.go
+++ b/enterprise/internal/codeintel/api/exists_test.go
@@ -22,7 +22,7 @@ func TestFindClosestDumps(t *testing.T) {
 	mockBundleClient4 := bundlemocks.NewMockBundleClient()
 	mockGitserverClient := gitservermocks.NewMockClient()
 
-	setMockStoreFindClosestDumps(t, mockStore, 42, testCommit, "s1/main.go", "idx", []store.Dump{
+	setMockStoreFindClosestDumps(t, mockStore, 42, testCommit, "s1/main.go", true, "idx", []store.Dump{
 		{ID: 50, Root: "s1/"},
 		{ID: 51, Root: "s1/"},
 		{ID: 52, Root: "s1/"},
@@ -97,7 +97,7 @@ func TestFindClosestSkipsGitserverIfCommitIsKnown(t *testing.T) {
 	mockGitserverClient := gitservermocks.NewMockClient()
 
 	setMockStoreHasCommit(t, mockStore, 42, testCommit, true)
-	setMockStoreFindClosestDumps(t, mockStore, 42, testCommit, "main.go", "idx", []store.Dump{
+	setMockStoreFindClosestDumps(t, mockStore, 42, testCommit, "main.go", true, "idx", []store.Dump{
 		{ID: 50, Root: ""},
 	})
 	setMockBundleManagerClientBundleClient(t, mockBundleManagerClient, map[int]bundles.BundleClient{

--- a/enterprise/internal/codeintel/api/helpers_test.go
+++ b/enterprise/internal/codeintel/api/helpers_test.go
@@ -76,8 +76,8 @@ func setMockStoreGetPackage(t *testing.T, mockStore *storemocks.MockStore, expec
 	})
 }
 
-func setMockStoreFindClosestDumps(t *testing.T, mockStore *storemocks.MockStore, expectedRepositoryID int, expectedCommit, expectedFile, expectedIndexer string, dumps []store.Dump) {
-	mockStore.FindClosestDumpsFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit, file, indexer string) ([]store.Dump, error) {
+func setMockStoreFindClosestDumps(t *testing.T, mockStore *storemocks.MockStore, expectedRepositoryID int, expectedCommit, expectedFile string, expectedrootMustEnclosePath bool, expectedIndexer string, dumps []store.Dump) {
+	mockStore.FindClosestDumpsFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit, file string, rootMustEnclosePath bool, indexer string) ([]store.Dump, error) {
 		if repositoryID != expectedRepositoryID {
 			t.Errorf("unexpected repository id for FindClosestDumps. want=%d have=%d", expectedRepositoryID, repositoryID)
 		}
@@ -86,6 +86,9 @@ func setMockStoreFindClosestDumps(t *testing.T, mockStore *storemocks.MockStore,
 		}
 		if file != expectedFile {
 			t.Errorf("unexpected file for FindClosestDumps. want=%s have=%s", expectedFile, file)
+		}
+		if rootMustEnclosePath != expectedrootMustEnclosePath {
+			t.Errorf("unexpected rootMustEnclosePath for FindClosestDumps. want=%v have=%v", expectedrootMustEnclosePath, rootMustEnclosePath)
 		}
 		if indexer != expectedIndexer {
 			t.Errorf("unexpected indexer for FindClosestDumps. want=%s have=%s", expectedIndexer, indexer)

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -28,11 +28,10 @@ type AdjustedDiagnostic struct {
 	AdjustedRange  bundles.Range
 }
 
-// QueryResolver is the main interface to bundle-related operations exposed to the GraphQL API.
-// This resolver consolidates the logic for bundle operations and is not itself concerned with
-// GraphQL/API specifics (auth, validation, marshaling, etc.). This resolver is wrapped by a
-// symmetrics resolver in this package's graphql subpackage, which is exposed directly by the
-// API.
+// QueryResolver is the main interface to bundle-related operations exposed to the GraphQL API. This
+// resolver consolidates the logic for bundle operations and is not itself concerned with GraphQL/API
+// specifics (auth, validation, marshaling, etc.). This resolver is wrapped by a symmetrics resolver
+// in this package's graphql subpackage, which is exposed directly by the API.
 type QueryResolver interface {
 	Definitions(ctx context.Context, line, character int) ([]AdjustedLocation, error)
 	References(ctx context.Context, line, character, limit int, rawCursor string) ([]AdjustedLocation, string, error)

--- a/enterprise/internal/codeintel/store/dumps_test.go
+++ b/enterprise/internal/codeintel/store/dumps_test.go
@@ -133,14 +133,14 @@ func TestFindClosestDumps(t *testing.T) {
 	)
 
 	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
-		{commit: makeCommit(1), file: "file.ts", anyOfIDs: []int{1}},
-		{commit: makeCommit(2), file: "file.ts", anyOfIDs: []int{1}},
-		{commit: makeCommit(3), file: "file.ts", anyOfIDs: []int{2}},
-		{commit: makeCommit(4), file: "file.ts", anyOfIDs: []int{2}},
-		{commit: makeCommit(6), file: "file.ts", anyOfIDs: []int{3}},
-		{commit: makeCommit(7), file: "file.ts", anyOfIDs: []int{3}},
-		{commit: makeCommit(5), file: "file.ts", anyOfIDs: []int{1, 2, 3}},
-		{commit: makeCommit(8), file: "file.ts", anyOfIDs: []int{1, 2}},
+		{commit: makeCommit(1), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{1}},
+		{commit: makeCommit(2), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{1}},
+		{commit: makeCommit(3), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{2}},
+		{commit: makeCommit(4), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{2}},
+		{commit: makeCommit(6), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{3}},
+		{commit: makeCommit(7), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{3}},
+		{commit: makeCommit(5), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{1, 2, 3}},
+		{commit: makeCommit(8), file: "file.ts", rootMustEnclosePath: true, anyOfIDs: []int{1, 2}},
 	})
 }
 
@@ -212,11 +212,11 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 	)
 
 	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
-		{commit: makeCommit(1), file: "blah"},
-		{commit: makeCommit(2), file: "root1/file.ts", allOfIDs: []int{1}},
-		{commit: makeCommit(1), file: "root2/file.ts", allOfIDs: []int{2}},
-		{commit: makeCommit(2), file: "root2/file.ts", allOfIDs: []int{2}},
-		{commit: makeCommit(1), file: "root3/file.ts"},
+		{commit: makeCommit(1), file: "blah", rootMustEnclosePath: true},
+		{commit: makeCommit(2), file: "root1/file.ts", rootMustEnclosePath: true, allOfIDs: []int{1}},
+		{commit: makeCommit(1), file: "root2/file.ts", rootMustEnclosePath: true, allOfIDs: []int{2}},
+		{commit: makeCommit(2), file: "root2/file.ts", rootMustEnclosePath: true, allOfIDs: []int{2}},
+		{commit: makeCommit(1), file: "root3/file.ts", rootMustEnclosePath: true},
 	})
 }
 
@@ -271,11 +271,11 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 	)
 
 	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
-		{commit: makeCommit(4), file: "root1/file.ts", allOfIDs: []int{7, 3}},
-		{commit: makeCommit(5), file: "root2/file.ts", allOfIDs: []int{8, 7}},
-		{commit: makeCommit(3), file: "root3/file.ts", allOfIDs: []int{5, 1}},
-		{commit: makeCommit(1), file: "root4/file.ts", allOfIDs: []int{2}},
-		{commit: makeCommit(2), file: "root4/file.ts", allOfIDs: []int{5}},
+		{commit: makeCommit(4), file: "root1/file.ts", rootMustEnclosePath: true, allOfIDs: []int{7, 3}},
+		{commit: makeCommit(5), file: "root2/file.ts", rootMustEnclosePath: true, allOfIDs: []int{8, 7}},
+		{commit: makeCommit(3), file: "root3/file.ts", rootMustEnclosePath: true, allOfIDs: []int{5, 1}},
+		{commit: makeCommit(1), file: "root4/file.ts", rootMustEnclosePath: true, allOfIDs: []int{2}},
+		{commit: makeCommit(2), file: "root4/file.ts", rootMustEnclosePath: true, allOfIDs: []int{5}},
 	})
 }
 
@@ -317,10 +317,10 @@ func TestFindClosestDumpsMaxTraversalLimit(t *testing.T) {
 	insertUploads(t, dbconn.Global, Upload{ID: 1, Commit: makeCommit(0)})
 
 	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
-		{commit: makeCommit(0), file: "file.ts", allOfIDs: []int{1}},
-		{commit: makeCommit(1), file: "file.ts", allOfIDs: []int{1}},
-		{commit: makeCommit(MaxTraversalLimit/2 - 1), file: "file.ts", allOfIDs: []int{1}},
-		{commit: makeCommit(MaxTraversalLimit / 2), file: "file.ts"},
+		{commit: makeCommit(0), file: "file.ts", rootMustEnclosePath: true, allOfIDs: []int{1}},
+		{commit: makeCommit(1), file: "file.ts", rootMustEnclosePath: true, allOfIDs: []int{1}},
+		{commit: makeCommit(MaxTraversalLimit/2 - 1), file: "file.ts", rootMustEnclosePath: true, allOfIDs: []int{1}},
+		{commit: makeCommit(MaxTraversalLimit / 2), file: "file.ts", rootMustEnclosePath: true},
 	})
 }
 
@@ -365,6 +365,30 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 		{commit: makeCommit(5), file: "root2/file.ts", indexer: "idx2", allOfIDs: []int{6}},
 		{commit: makeCommit(5), file: "root3/file.ts", indexer: "idx2", allOfIDs: []int{7}},
 		{commit: makeCommit(5), file: "root4/file.ts", indexer: "idx2", allOfIDs: []int{8}},
+	})
+}
+
+func TestFindClosestDumpsIntersectingPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	if err := store.UpdateCommits(context.Background(), 50, map[string][]string{
+		makeCommit(1): {},
+	}); err != nil {
+		t.Fatalf("unexpected error updating commits: %s", err)
+	}
+
+	insertUploads(t, dbconn.Global,
+		Upload{ID: 1, Commit: makeCommit(1), Root: "web/src/", Indexer: "lsif-eslint"},
+	)
+
+	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+		{commit: makeCommit(1), file: "", rootMustEnclosePath: false, allOfIDs: []int{1}},
+		{commit: makeCommit(1), file: "web/", rootMustEnclosePath: false, allOfIDs: []int{1}},
+		{commit: makeCommit(1), file: "web/src/file.ts", rootMustEnclosePath: false, allOfIDs: []int{1}},
 	})
 }
 
@@ -414,19 +438,26 @@ func TestDeleteOldestDump(t *testing.T) {
 }
 
 type FindClosestDumpsTestCase struct {
-	commit   string
-	file     string
-	indexer  string
-	anyOfIDs []int
-	allOfIDs []int
+	commit              string
+	file                string
+	rootMustEnclosePath bool
+	indexer             string
+	anyOfIDs            []int
+	allOfIDs            []int
 }
 
 func testFindClosestDumps(t *testing.T, store Store, testCases []FindClosestDumpsTestCase) {
 	for _, testCase := range testCases {
-		name := fmt.Sprintf("commit=%s file=%s", testCase.commit, testCase.file)
+		name := fmt.Sprintf(
+			"commit=%s file=%s rootMustEnclosePath=%v indexer=%s",
+			testCase.commit,
+			testCase.file,
+			testCase.rootMustEnclosePath,
+			testCase.indexer,
+		)
 
 		t.Run(name, func(t *testing.T) {
-			dumps, err := store.FindClosestDumps(context.Background(), 50, testCase.commit, testCase.file, testCase.indexer)
+			dumps, err := store.FindClosestDumps(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer)
 			if err != nil {
 				t.Fatalf("unexpected error finding closest dumps: %s", err)
 			}

--- a/enterprise/internal/codeintel/store/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/store/mocks/mock_store.go
@@ -199,7 +199,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, string) ([]store.Dump, error) {
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]store.Dump, error) {
 				return nil, nil
 			},
 		},
@@ -1409,24 +1409,24 @@ func (c StoreDoneFuncCall) Results() []interface{} {
 // StoreFindClosestDumpsFunc describes the behavior when the
 // FindClosestDumps method of the parent MockStore instance is invoked.
 type StoreFindClosestDumpsFunc struct {
-	defaultHook func(context.Context, int, string, string, string) ([]store.Dump, error)
-	hooks       []func(context.Context, int, string, string, string) ([]store.Dump, error)
+	defaultHook func(context.Context, int, string, string, bool, string) ([]store.Dump, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]store.Dump, error)
 	history     []StoreFindClosestDumpsFuncCall
 	mutex       sync.Mutex
 }
 
 // FindClosestDumps delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 string) ([]store.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.FindClosestDumpsFunc.appendCall(StoreFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, r0, r1})
+func (m *MockStore) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]store.Dump, error) {
+	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestDumpsFunc.appendCall(StoreFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the FindClosestDumps
 // method of the parent MockStore instance is invoked and the hook queue is
 // empty.
-func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) ([]store.Dump, error)) {
+func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]store.Dump, error)) {
 	f.defaultHook = hook
 }
 
@@ -1434,7 +1434,7 @@ func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, in
 // FindClosestDumps method of the parent MockStore instance inovkes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, string) ([]store.Dump, error)) {
+func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]store.Dump, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1443,7 +1443,7 @@ func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, str
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *StoreFindClosestDumpsFunc) SetDefaultReturn(r0 []store.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, string) ([]store.Dump, error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]store.Dump, error) {
 		return r0, r1
 	})
 }
@@ -1451,12 +1451,12 @@ func (f *StoreFindClosestDumpsFunc) SetDefaultReturn(r0 []store.Dump, r1 error) 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *StoreFindClosestDumpsFunc) PushReturn(r0 []store.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, string) ([]store.Dump, error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]store.Dump, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, string) ([]store.Dump, error) {
+func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]store.Dump, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1503,7 +1503,10 @@ type StoreFindClosestDumpsFuncCall struct {
 	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 string
+	Arg4 bool
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []store.Dump
@@ -1515,7 +1518,7 @@ type StoreFindClosestDumpsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestDumpsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/codeintel/store/observability.go
+++ b/enterprise/internal/codeintel/store/observability.go
@@ -495,10 +495,10 @@ func (s *ObservedStore) GetDumpByID(ctx context.Context, id int) (_ Dump, _ bool
 }
 
 // FindClosestDumps calls into the inner store and registers the observed results.
-func (s *ObservedStore) FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) (dumps []Dump, err error) {
+func (s *ObservedStore) FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (dumps []Dump, err error) {
 	ctx, endObservation := s.findClosestDumpsOperation.With(ctx, &err, observation.Args{})
 	defer func() { endObservation(float64(len(dumps)), observation.Args{}) }()
-	return s.store.FindClosestDumps(ctx, repositoryID, commit, file, indexer)
+	return s.store.FindClosestDumps(ctx, repositoryID, commit, path, rootMustEnclosePath, indexer)
 }
 
 // DeleteOldestDump calls into the inner store and registers the observed results.

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -87,8 +87,10 @@ type Store interface {
 	// GetDumpByID returns a dump by its identifier and boolean flag indicating its existence.
 	GetDumpByID(ctx context.Context, id int) (Dump, bool, error)
 
-	// FindClosestDumps returns the set of dumps that can most accurately answer queries for the given repository, commit, file, and optional indexer.
-	FindClosestDumps(ctx context.Context, repositoryID int, commit, file, indexer string) ([]Dump, error)
+	// FindClosestDumps returns the set of dumps that can most accurately answer queries for the given repository, commit, path, and
+	// optional indexer. If rootMustEnclosePath is true, then only dumps with a root which is a prefix of path are returned. Otherwise,
+	// any dump with a root intersecting the given path is returned.
+	FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) ([]Dump, error)
 
 	// DeleteOldestDump deletes the oldest dump that is not currently visible at the tip of its repository's default branch.
 	// This method returns the deleted dump's identifier and a flag indicating its (previous) existence.


### PR DESCRIPTION
Allow intersection OR enclosing of target paths in FindClosestDumps. Closes https://github.com/sourcegraph/sourcegraph/issues/11490.
