### PR TITLE
codeintel: Add local parameter to reference queries

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -81,10 +81,10 @@ func (r *schemaResolver) DeleteLSIFIndex(ctx context.Context, args *struct{ ID g
 }
 
 type LSIFUploadsQueryArgs struct {
-	graphqlutil.ConnectionArgs
 	Query           *string
 	State           *string
 	IsLatestForRepo *bool
+	First           *int32
 	After           *string
 }
 
@@ -115,9 +115,9 @@ type LSIFUploadConnectionResolver interface {
 }
 
 type LSIFIndexesQueryArgs struct {
-	graphqlutil.ConnectionArgs
 	Query *string
 	State *string
+	First *int32
 	After *string
 }
 
@@ -153,9 +153,9 @@ type GitBlobLSIFDataResolver interface {
 	ToGitTreeLSIFData() (GitTreeLSIFDataResolver, bool)
 	ToGitBlobLSIFData() (GitBlobLSIFDataResolver, bool)
 
-	Definitions(ctx context.Context, args *LSIFQueryPositionArgs) (LocationConnectionResolver, error)
-	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
-	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)
+	Definitions(ctx context.Context, args *LSIFDefinitionsArgs) (LocationConnectionResolver, error)
+	References(ctx context.Context, args *LSIFReferencesArgs) (LocationConnectionResolver, error)
+	Hover(ctx context.Context, args *LSIFHoverArgs) (HoverResolver, error)
 }
 
 type GitBlobLSIFDataArgs struct {
@@ -166,19 +166,26 @@ type GitBlobLSIFDataArgs struct {
 	ToolName  string
 }
 
-type LSIFQueryPositionArgs struct {
+type LSIFDefinitionsArgs struct {
 	Line      int32
 	Character int32
 }
 
-type LSIFPagedQueryPositionArgs struct {
-	LSIFQueryPositionArgs
-	graphqlutil.ConnectionArgs
-	After *string
+type LSIFReferencesArgs struct {
+	Line      int32
+	Character int32
+	Local     *bool
+	First     *int32
+	After     *string
+}
+
+type LSIFHoverArgs struct {
+	Line      int32
+	Character int32
 }
 
 type LSIFDiagnosticsArgs struct {
-	graphqlutil.ConnectionArgs
+	First *int32
 }
 
 type LocationConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2975,7 +2975,7 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
         character: Int!
 
         # If true, only return references that exist within the same document.
-        local: Bool
+        local: Boolean
 
         # When specified, indicates that this request should be paginated and
         # to fetch results starting at this cursor.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2974,6 +2974,9 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
         # The character (not byte) of the start line on which the symbol occurs (zero-based, inclusive).
         character: Int!
 
+        # If true, only return references that exist within the same document.
+        local: Bool
+
         # When specified, indicates that this request should be paginated and
         # to fetch results starting at this cursor.
         #

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2981,6 +2981,9 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
         # The character (not byte) of the start line on which the symbol occurs (zero-based, inclusive).
         character: Int!
 
+        # If true, only return references that exist within the same document.
+        local: Boolean
+
         # When specified, indicates that this request should be paginated and
         # to fetch results starting at this cursor.
         #

--- a/enterprise/internal/codeintel/api/api.go
+++ b/enterprise/internal/codeintel/api/api.go
@@ -23,8 +23,9 @@ type CodeIntelAPI interface {
 	Definitions(ctx context.Context, file string, line, character, uploadID int) ([]ResolvedLocation, error)
 
 	// References returns the list of source locations that reference the symbol at the given position.
-	// This may include references from other dumps and repositories.
-	References(ctx context.Context, repositoryID int, commit string, limit int, cursor Cursor) ([]ResolvedLocation, Cursor, bool, error)
+	// This may include references from other dumps and repositories. If local is true, then the result
+	// set will include references only in the source file.
+	References(ctx context.Context, repositoryID int, commit string, local bool, limit int, cursor Cursor) ([]ResolvedLocation, Cursor, bool, error)
 
 	// Hover returns the hover text and range for the symbol at the given position.
 	Hover(ctx context.Context, file string, line, character, uploadID int) (string, bundles.Range, bool, error)

--- a/enterprise/internal/codeintel/api/locations.go
+++ b/enterprise/internal/codeintel/api/locations.go
@@ -21,15 +21,26 @@ func sliceLocations(locations []bundles.Location, lo, hi int) []bundles.Location
 	return locations[lo:hi]
 }
 
+func filterLocationsWithPath(path string, locations []bundles.Location) []bundles.Location {
+	filtered := make([]bundles.Location, 0, len(locations))
+	for _, l := range locations {
+		if l.Path == path {
+			filtered = append(filtered, l)
+		}
+	}
+
+	return filtered
+}
+
 func resolveLocationsWithDump(dump store.Dump, locations []bundles.Location) []ResolvedLocation {
-	var resolvedLocations []ResolvedLocation
+	resolved := make([]ResolvedLocation, 0, len(locations))
 	for _, location := range locations {
-		resolvedLocations = append(resolvedLocations, ResolvedLocation{
+		resolved = append(resolved, ResolvedLocation{
 			Dump:  dump,
 			Path:  dump.Root + location.Path,
 			Range: location.Range,
 		})
 	}
 
-	return resolvedLocations
+	return resolved
 }

--- a/enterprise/internal/codeintel/api/locations.go
+++ b/enterprise/internal/codeintel/api/locations.go
@@ -23,9 +23,9 @@ func sliceLocations(locations []bundles.Location, lo, hi int) []bundles.Location
 
 func filterLocationsWithPath(path string, locations []bundles.Location) []bundles.Location {
 	filtered := make([]bundles.Location, 0, len(locations))
-	for _, l := range locations {
-		if l.Path == path {
-			filtered = append(filtered, l)
+	for _, location := range locations {
+		if location.Path == path {
+			filtered = append(filtered, location)
 		}
 	}
 

--- a/enterprise/internal/codeintel/api/mocks/mock_api.go
+++ b/enterprise/internal/codeintel/api/mocks/mock_api.go
@@ -57,7 +57,7 @@ func NewMockCodeIntelAPI() *MockCodeIntelAPI {
 			},
 		},
 		ReferencesFunc: &CodeIntelAPIReferencesFunc{
-			defaultHook: func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
+			defaultHook: func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
 				return nil, api.Cursor{}, false, nil
 			},
 		},
@@ -574,24 +574,24 @@ func (c CodeIntelAPIHoverFuncCall) Results() []interface{} {
 // CodeIntelAPIReferencesFunc describes the behavior when the References
 // method of the parent MockCodeIntelAPI instance is invoked.
 type CodeIntelAPIReferencesFunc struct {
-	defaultHook func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)
-	hooks       []func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)
+	defaultHook func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)
+	hooks       []func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)
 	history     []CodeIntelAPIReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // References delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockCodeIntelAPI) References(v0 context.Context, v1 int, v2 string, v3 int, v4 api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
-	r0, r1, r2, r3 := m.ReferencesFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.ReferencesFunc.appendCall(CodeIntelAPIReferencesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2, r3})
+func (m *MockCodeIntelAPI) References(v0 context.Context, v1 int, v2 string, v3 bool, v4 int, v5 api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
+	r0, r1, r2, r3 := m.ReferencesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.ReferencesFunc.appendCall(CodeIntelAPIReferencesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2, r3})
 	return r0, r1, r2, r3
 }
 
 // SetDefaultHook sets function that is called when the References method of
 // the parent MockCodeIntelAPI instance is invoked and the hook queue is
 // empty.
-func (f *CodeIntelAPIReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)) {
+func (f *CodeIntelAPIReferencesFunc) SetDefaultHook(hook func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -599,7 +599,7 @@ func (f *CodeIntelAPIReferencesFunc) SetDefaultHook(hook func(context.Context, i
 // References method of the parent MockCodeIntelAPI instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *CodeIntelAPIReferencesFunc) PushHook(hook func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)) {
+func (f *CodeIntelAPIReferencesFunc) PushHook(hook func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -608,7 +608,7 @@ func (f *CodeIntelAPIReferencesFunc) PushHook(hook func(context.Context, int, st
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CodeIntelAPIReferencesFunc) SetDefaultReturn(r0 []api.ResolvedLocation, r1 api.Cursor, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
+	f.SetDefaultHook(func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
 		return r0, r1, r2, r3
 	})
 }
@@ -616,12 +616,12 @@ func (f *CodeIntelAPIReferencesFunc) SetDefaultReturn(r0 []api.ResolvedLocation,
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CodeIntelAPIReferencesFunc) PushReturn(r0 []api.ResolvedLocation, r1 api.Cursor, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
+	f.PushHook(func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
 		return r0, r1, r2, r3
 	})
 }
 
-func (f *CodeIntelAPIReferencesFunc) nextHook() func(context.Context, int, string, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
+func (f *CodeIntelAPIReferencesFunc) nextHook() func(context.Context, int, string, bool, int, api.Cursor) ([]api.ResolvedLocation, api.Cursor, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -665,10 +665,13 @@ type CodeIntelAPIReferencesFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 int
+	Arg3 bool
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 api.Cursor
+	Arg4 int
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 api.Cursor
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []api.ResolvedLocation
@@ -686,7 +689,7 @@ type CodeIntelAPIReferencesFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c CodeIntelAPIReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/codeintel/api/observability.go
+++ b/enterprise/internal/codeintel/api/observability.go
@@ -75,10 +75,10 @@ func (api *ObservedCodeIntelAPI) Definitions(ctx context.Context, file string, l
 }
 
 // References calls into the inner CodeIntelAPI and registers the observed results.
-func (api *ObservedCodeIntelAPI) References(ctx context.Context, repositoryID int, commit string, limit int, cursor Cursor) (references []ResolvedLocation, _ Cursor, _ bool, err error) {
+func (api *ObservedCodeIntelAPI) References(ctx context.Context, repositoryID int, commit string, local bool, limit int, cursor Cursor) (references []ResolvedLocation, _ Cursor, _ bool, err error) {
 	ctx, endObservation := api.referencesOperation.With(ctx, &err, observation.Args{})
 	defer func() { endObservation(float64(len(references)), observation.Args{}) }()
-	return api.codeIntelAPI.References(ctx, repositoryID, commit, limit, cursor)
+	return api.codeIntelAPI.References(ctx, repositoryID, commit, local, limit, cursor)
 }
 
 // Hover calls into the inner CodeIntelAPI and registers the observed results.

--- a/enterprise/internal/codeintel/api/references.go
+++ b/enterprise/internal/codeintel/api/references.go
@@ -113,7 +113,7 @@ func (s *ReferencePageResolver) handleSameDumpCursor(ctx context.Context, cursor
 
 	filteredLocations := sliceLocations(locations, cursor.SkipResults, cursor.SkipResults+s.limit)
 	if s.local {
-		// Remove references outside of the cursor path. Ensure we assign this ot a
+		// Remove references outside of the cursor path. Ensure we assign this to a
 		// variable that does not influence pagination offsets.
 		filteredLocations = filterLocationsWithPath(cursor.Path, filteredLocations)
 	}
@@ -202,7 +202,7 @@ func (s *ReferencePageResolver) handleSameDumpMonikersCursor(ctx context.Context
 
 	filteredLocations := locations
 	if s.local {
-		// Remove references outside of the cursor path. Ensure we assign this ot a
+		// Remove references outside of the cursor path. Ensure we assign this to a
 		// variable that does not influence pagination offsets.
 		filteredLocations = filterLocationsWithPath(cursor.Path, filteredLocations)
 	}

--- a/enterprise/internal/codeintel/api/references_test.go
+++ b/enterprise/internal/codeintel/api/references_test.go
@@ -555,11 +555,6 @@ func TestHandleSameRepoCursorMultipleDumpBatches(t *testing.T) {
 	}
 }
 
-//
-//
-//
-//
-
 func TestHandleRemoteRepoCursor(t *testing.T) {
 	mockStore := storemocks.NewMockStore()
 	mockBundleManagerClient := bundlemocks.NewMockBundleManagerClient()
@@ -808,4 +803,123 @@ func TestApplyBloomFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLocalReferences(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockBundleManagerClient := bundlemocks.NewMockBundleManagerClient()
+	mockBundleClient := bundlemocks.NewMockBundleClient()
+
+	setMockStoreGetDumpByID(t, mockStore, map[int]store.Dump{42: testDump1})
+	setMockBundleManagerClientBundleClient(t, mockBundleManagerClient, map[int]bundles.BundleClient{42: mockBundleClient})
+	setMockBundleClientReferences(t, mockBundleClient, "foo.go", 23, 34, []bundles.Location{
+		{DumpID: 42, Path: "foo.go", Range: testRange1},
+		{DumpID: 42, Path: "bar.go", Range: testRange1},
+		{DumpID: 42, Path: "foo.go", Range: testRange2},
+		{DumpID: 42, Path: "bar.go", Range: testRange2},
+		{DumpID: 42, Path: "foo.go", Range: testRange3},
+		{DumpID: 42, Path: "bar.go", Range: testRange3},
+		{DumpID: 42, Path: "foo.go", Range: testRange4},
+		{DumpID: 42, Path: "bar.go", Range: testRange4},
+		{DumpID: 42, Path: "foo.go", Range: testRange5},
+	})
+
+	t.Run("partial results", func(t *testing.T) {
+		rpr := &ReferencePageResolver{
+			store:               mockStore,
+			bundleManagerClient: mockBundleManagerClient,
+			repositoryID:        100,
+			commit:              testCommit,
+			local:               true,
+			limit:               5,
+		}
+
+		references, newCursor, hasNewCursor, err := rpr.dispatchCursorHandler(context.Background(), Cursor{
+			Phase:       "same-dump",
+			DumpID:      42,
+			Path:        "foo.go",
+			Line:        23,
+			Character:   34,
+			Monikers:    []bundles.MonikerData{{Kind: "export", Scheme: "gomod", Identifier: "pad"}},
+			SkipResults: 0,
+		})
+		if err != nil {
+			t.Fatalf("expected error getting references: %s", err)
+		}
+
+		expectedReferences := []ResolvedLocation{
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange1},
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange2},
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange3},
+		}
+		if diff := cmp.Diff(expectedReferences, references); diff != "" {
+			t.Errorf("unexpected references (-want +got):\n%s", diff)
+		}
+
+		expectedNewCursor := Cursor{
+			Phase:       "same-dump",
+			DumpID:      42,
+			Path:        "foo.go",
+			Line:        23,
+			Character:   34,
+			Monikers:    []bundles.MonikerData{{Kind: "export", Scheme: "gomod", Identifier: "pad"}},
+			SkipResults: 5,
+		}
+		if !hasNewCursor {
+			t.Errorf("expected new cursor")
+		} else if diff := cmp.Diff(expectedNewCursor, newCursor); diff != "" {
+			t.Errorf("unexpected new cursor (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("end of result set", func(t *testing.T) {
+		rpr := &ReferencePageResolver{
+			store:               mockStore,
+			bundleManagerClient: mockBundleManagerClient,
+			repositoryID:        100,
+			commit:              testCommit,
+			local:               true,
+			limit:               10,
+		}
+
+		references, newCursor, hasNewCursor, err := rpr.dispatchCursorHandler(context.Background(), Cursor{
+			Phase:       "same-dump",
+			DumpID:      42,
+			Path:        "foo.go",
+			Line:        23,
+			Character:   34,
+			Monikers:    []bundles.MonikerData{{Kind: "export", Scheme: "gomod", Identifier: "pad"}},
+			SkipResults: 0,
+		})
+		if err != nil {
+			t.Fatalf("expected error getting references: %s", err)
+		}
+
+		expectedReferences := []ResolvedLocation{
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange1},
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange2},
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange3},
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange4},
+			{Dump: testDump1, Path: "sub1/foo.go", Range: testRange5},
+		}
+		if diff := cmp.Diff(expectedReferences, references); diff != "" {
+			t.Errorf("unexpected references (-want +got):\n%s", diff)
+		}
+
+		expectedNewCursor := Cursor{
+			Phase:       "same-dump-monikers",
+			DumpID:      42,
+			Path:        "foo.go",
+			Line:        23,
+			Character:   34,
+			Monikers:    []bundles.MonikerData{{Kind: "export", Scheme: "gomod", Identifier: "pad"}},
+			SkipResults: 0,
+		}
+		if !hasNewCursor {
+			t.Errorf("expected new cursor")
+		} else if diff := cmp.Diff(expectedNewCursor, newCursor); diff != "" {
+			t.Errorf("unexpected new cursor (-want +got):\n%s", diff)
+		}
+	})
+
 }

--- a/enterprise/internal/codeintel/resolvers/graphql/query.go
+++ b/enterprise/internal/codeintel/resolvers/graphql/query.go
@@ -39,7 +39,7 @@ func NewQueryResolver(resolver resolvers.QueryResolver, locationResolver *Cached
 func (r *QueryResolver) ToGitTreeLSIFData() (gql.GitTreeLSIFDataResolver, bool) { return r, true }
 func (r *QueryResolver) ToGitBlobLSIFData() (gql.GitBlobLSIFDataResolver, bool) { return r, true }
 
-func (r *QueryResolver) Definitions(ctx context.Context, args *gql.LSIFQueryPositionArgs) (gql.LocationConnectionResolver, error) {
+func (r *QueryResolver) Definitions(ctx context.Context, args *gql.LSIFDefinitionsArgs) (gql.LocationConnectionResolver, error) {
 	locations, err := r.resolver.Definitions(ctx, int(args.Line), int(args.Character))
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (r *QueryResolver) Definitions(ctx context.Context, args *gql.LSIFQueryPosi
 	return NewLocationConnectionResolver(locations, nil, r.locationResolver), nil
 }
 
-func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFPagedQueryPositionArgs) (gql.LocationConnectionResolver, error) {
+func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFReferencesArgs) (gql.LocationConnectionResolver, error) {
 	limit := derefInt32(args.First, DefaultReferencesPageSize)
 	if limit <= 0 {
 		return nil, ErrIllegalLimit
@@ -58,7 +58,7 @@ func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFPagedQuery
 		return nil, err
 	}
 
-	locations, cursor, err := r.resolver.References(ctx, int(args.Line), int(args.Character), limit, cursor)
+	locations, cursor, err := r.resolver.References(ctx, int(args.Line), int(args.Character), derefBool(args.Local, false), limit, cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFPagedQuery
 	return NewLocationConnectionResolver(locations, strPtr(cursor), r.locationResolver), nil
 }
 
-func (r *QueryResolver) Hover(ctx context.Context, args *gql.LSIFQueryPositionArgs) (gql.HoverResolver, error) {
+func (r *QueryResolver) Hover(ctx context.Context, args *gql.LSIFHoverArgs) (gql.HoverResolver, error) {
 	text, rx, exists, err := r.resolver.Hover(ctx, int(args.Line), int(args.Character))
 	if err != nil || !exists {
 		return nil, err

--- a/enterprise/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/resolvers/mocks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
@@ -94,12 +93,10 @@ func TestMakeGetUploadsOptions(t *testing.T) {
 
 	opts, err := makeGetUploadsOptions(context.Background(), &gql.LSIFRepositoryUploadsQueryArgs{
 		LSIFUploadsQueryArgs: &gql.LSIFUploadsQueryArgs{
-			ConnectionArgs: graphqlutil.ConnectionArgs{
-				First: intPtr(5),
-			},
 			Query:           strPtr("q"),
 			State:           strPtr("s"),
 			IsLatestForRepo: boolPtr(true),
+			First:           intPtr(5),
 			After:           encodeIntCursor(intPtr(25)).EndCursor(),
 		},
 		RepositoryID: graphql.ID(base64.StdEncoding.EncodeToString([]byte("Repo:50"))),
@@ -155,11 +152,9 @@ func TestMakeGetIndexesOptions(t *testing.T) {
 
 	opts, err := makeGetIndexesOptions(context.Background(), &gql.LSIFRepositoryIndexesQueryArgs{
 		LSIFIndexesQueryArgs: &gql.LSIFIndexesQueryArgs{
-			ConnectionArgs: graphqlutil.ConnectionArgs{
-				First: intPtr(5),
-			},
 			Query: strPtr("q"),
 			State: strPtr("s"),
+			First: intPtr(5),
 			After: encodeIntCursor(intPtr(25)).EndCursor(),
 		},
 		RepositoryID: graphql.ID(base64.StdEncoding.EncodeToString([]byte("Repo:50"))),

--- a/enterprise/internal/codeintel/resolvers/mocks/mock_query.go
+++ b/enterprise/internal/codeintel/resolvers/mocks/mock_query.go
@@ -48,7 +48,7 @@ func NewMockQueryResolver() *MockQueryResolver {
 			},
 		},
 		ReferencesFunc: &QueryResolverReferencesFunc{
-			defaultHook: func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error) {
+			defaultHook: func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error) {
 				return nil, "", nil
 			},
 		},
@@ -419,24 +419,24 @@ func (c QueryResolverHoverFuncCall) Results() []interface{} {
 // QueryResolverReferencesFunc describes the behavior when the References
 // method of the parent MockQueryResolver instance is invoked.
 type QueryResolverReferencesFunc struct {
-	defaultHook func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error)
-	hooks       []func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error)
+	defaultHook func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error)
+	hooks       []func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error)
 	history     []QueryResolverReferencesFuncCall
 	mutex       sync.Mutex
 }
 
 // References delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockQueryResolver) References(v0 context.Context, v1 int, v2 int, v3 int, v4 string) ([]resolvers.AdjustedLocation, string, error) {
-	r0, r1, r2 := m.ReferencesFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.ReferencesFunc.appendCall(QueryResolverReferencesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
+func (m *MockQueryResolver) References(v0 context.Context, v1 int, v2 int, v3 bool, v4 int, v5 string) ([]resolvers.AdjustedLocation, string, error) {
+	r0, r1, r2 := m.ReferencesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.ReferencesFunc.appendCall(QueryResolverReferencesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the References method of
 // the parent MockQueryResolver instance is invoked and the hook queue is
 // empty.
-func (f *QueryResolverReferencesFunc) SetDefaultHook(hook func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error)) {
+func (f *QueryResolverReferencesFunc) SetDefaultHook(hook func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error)) {
 	f.defaultHook = hook
 }
 
@@ -444,7 +444,7 @@ func (f *QueryResolverReferencesFunc) SetDefaultHook(hook func(context.Context, 
 // References method of the parent MockQueryResolver instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *QueryResolverReferencesFunc) PushHook(hook func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error)) {
+func (f *QueryResolverReferencesFunc) PushHook(hook func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -453,7 +453,7 @@ func (f *QueryResolverReferencesFunc) PushHook(hook func(context.Context, int, i
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *QueryResolverReferencesFunc) SetDefaultReturn(r0 []resolvers.AdjustedLocation, r1 string, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error) {
+	f.SetDefaultHook(func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error) {
 		return r0, r1, r2
 	})
 }
@@ -461,12 +461,12 @@ func (f *QueryResolverReferencesFunc) SetDefaultReturn(r0 []resolvers.AdjustedLo
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *QueryResolverReferencesFunc) PushReturn(r0 []resolvers.AdjustedLocation, r1 string, r2 error) {
-	f.PushHook(func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error) {
+	f.PushHook(func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *QueryResolverReferencesFunc) nextHook() func(context.Context, int, int, int, string) ([]resolvers.AdjustedLocation, string, error) {
+func (f *QueryResolverReferencesFunc) nextHook() func(context.Context, int, int, bool, int, string) ([]resolvers.AdjustedLocation, string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -510,10 +510,13 @@ type QueryResolverReferencesFuncCall struct {
 	Arg2 int
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 int
+	Arg3 bool
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 string
+	Arg4 int
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []resolvers.AdjustedLocation
@@ -528,7 +531,7 @@ type QueryResolverReferencesFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c QueryResolverReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/codeintel/resolvers/query_test.go
+++ b/enterprise/internal/codeintel/resolvers/query_test.go
@@ -273,22 +273,22 @@ func TestReferences(t *testing.T) {
 	if val := len(mockCodeIntelAPI.ReferencesFunc.History()); val != 3 {
 		t.Errorf("unexpected call count. want=%d have=%d", 3, val)
 	}
-	if val := mockCodeIntelAPI.ReferencesFunc.History()[0].Arg3; val != 3 {
+	if val := mockCodeIntelAPI.ReferencesFunc.History()[0].Arg4; val != 3 {
 		t.Errorf("unexpected limit. want=%d have=%d", 3, val)
 	}
-	if diff := cmp.Diff(cursorIn1, mockCodeIntelAPI.ReferencesFunc.History()[0].Arg4); diff != "" {
+	if diff := cmp.Diff(cursorIn1, mockCodeIntelAPI.ReferencesFunc.History()[0].Arg5); diff != "" {
 		t.Errorf("unexpected cursor (-want +got):\n%s", diff)
 	}
-	if val := mockCodeIntelAPI.ReferencesFunc.History()[1].Arg3; val != 3 {
+	if val := mockCodeIntelAPI.ReferencesFunc.History()[1].Arg4; val != 3 {
 		t.Errorf("unexpected limit. want=%d have=%d", 3, val)
 	}
-	if diff := cmp.Diff(cursorIn2, mockCodeIntelAPI.ReferencesFunc.History()[1].Arg4); diff != "" {
+	if diff := cmp.Diff(cursorIn2, mockCodeIntelAPI.ReferencesFunc.History()[1].Arg5); diff != "" {
 		t.Errorf("unexpected cursor (-want +got):\n%s", diff)
 	}
-	if val := mockCodeIntelAPI.ReferencesFunc.History()[2].Arg3; val != 3 {
+	if val := mockCodeIntelAPI.ReferencesFunc.History()[2].Arg4; val != 3 {
 		t.Errorf("unexpected limit. want=%d have=%d", 3, val)
 	}
-	if diff := cmp.Diff(cursorIn3, mockCodeIntelAPI.ReferencesFunc.History()[2].Arg4); diff != "" {
+	if diff := cmp.Diff(cursorIn3, mockCodeIntelAPI.ReferencesFunc.History()[2].Arg5); diff != "" {
 		t.Errorf("unexpected cursor (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/internal/codeintel/resolvers/query_test.go
+++ b/enterprise/internal/codeintel/resolvers/query_test.go
@@ -220,7 +220,7 @@ func TestReferences(t *testing.T) {
 		t.Fatalf("unexpected error creating cursor: %s", err)
 	}
 
-	references, nextCursor, err := queryResolver.References(context.Background(), 10, 15, 3, cursor)
+	references, nextCursor, err := queryResolver.References(context.Background(), 10, 15, false, 3, cursor)
 	if err != nil {
 		t.Fatalf("unexpected error resolving references: %s", err)
 	}


### PR DESCRIPTION
Add a local parameter to reference queries so that it returns results only within the same file. This will aid in https://github.com/sourcegraph/sourcegraph/issues/10868, which highlights local references to the symbol being hovered.

This changes the resolution of references over pages by marking a paginating resolver as "local" or not (non local has previous behavior). Local resolvers will stop after the second phase and will not open any additional dump files. Additionally, each location is post-filtered to ensure the path matches the input path.