### PR TITLE
zoekt: treat repo names case sensitively

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -117,7 +116,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if !searchIndexEnabled {
 				return true // do not need index
 			}
-			_, ok := indexed[strings.ToLower(string(repo))]
+			_, ok := indexed[string(repo)]
 			return ok
 		}
 		if searchIndexEnabled && (!r.indexed || !r.notIndexed) {

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -120,10 +120,10 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	}
 
 	repoSet := &zoektquery.RepoSet{Set: make(map[string]bool, len(repos))}
-	repoMap := make(map[api.RepoName]*search.RepositoryRevisions, len(repos))
+	repoMap := make(map[string]*search.RepositoryRevisions, len(repos))
 	for _, repoRev := range repos {
 		repoSet.Set[string(repoRev.Repo.Name)] = true
-		repoMap[api.RepoName(strings.ToLower(string(repoRev.Repo.Name)))] = repoRev
+		repoMap[string(repoRev.Repo.Name)] = repoRev
 	}
 
 	k := zoektResultCountFactor(len(repos), args.PatternInfo)
@@ -233,7 +233,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 			fileLimitHit = true
 			limitHit = true
 		}
-		repoRev := repoMap[api.RepoName(strings.ToLower(string(file.Repository)))]
+		repoRev := repoMap[file.Repository]
 		if repoResolvers[repoRev.Repo.Name] == nil {
 			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{repo: repoRev.Repo}
 		}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -67,7 +67,7 @@ func indexedSymbolsBranch(repository, commit string) string {
 		return ""
 	}
 
-	repo, ok := set[strings.ToLower(repository)]
+	repo, ok := set[repository]
 	if !ok || !repo.HasSymbols {
 		return ""
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -86,10 +86,10 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 
 	// Tell zoekt which repos to search
 	repoSet := &zoektquery.RepoSet{Set: make(map[string]bool, len(repos))}
-	repoMap := make(map[api.RepoName]*search.RepositoryRevisions, len(repos))
+	repoMap := make(map[string]*search.RepositoryRevisions, len(repos))
 	for _, repoRev := range repos {
 		repoSet.Set[string(repoRev.Repo.Name)] = true
-		repoMap[api.RepoName(strings.ToLower(string(repoRev.Repo.Name)))] = repoRev
+		repoMap[string(repoRev.Repo.Name)] = repoRev
 	}
 
 	queryExceptRepos, err := queryToZoektQuery(args.PatternInfo, isSymbol)
@@ -200,7 +200,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 			fileLimitHit = true
 			limitHit = true
 		}
-		repoRev := repoMap[api.RepoName(strings.ToLower(string(file.Repository)))]
+		repoRev := repoMap[file.Repository]
 		if repoResolvers[repoRev.Repo.Name] == nil {
 			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{repo: repoRev.Repo}
 		}
@@ -475,7 +475,7 @@ func zoektSingleIndexedRepo(ctx context.Context, z *searchbackend.Zoekt, rev *se
 		return nil, nil, err
 	}
 
-	repo, ok := set[strings.ToLower(string(rev.Repo.Name))]
+	repo, ok := set[string(rev.Repo.Name)]
 	if !ok || (filter != nil && !filter(repo)) {
 		return indexed, append(unindexed, rev), nil
 	}
@@ -541,7 +541,7 @@ func zoektIndexedRepos(ctx context.Context, z *searchbackend.Zoekt, revs []*sear
 			continue
 		}
 
-		repo, ok := set[strings.ToLower(string(rev.Repo.Name))]
+		repo, ok := set[string(rev.Repo.Name)]
 		if !ok || (filter != nil && !filter(repo)) {
 			unindexed = append(unindexed, rev)
 			continue

--- a/internal/search/backend/text.go
+++ b/internal/search/backend/text.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strings"
 	"sync"
 	"time"
 
@@ -88,7 +87,7 @@ func (c *Zoekt) list(ctx context.Context) (map[string]*zoekt.Repository, error) 
 
 	set := make(map[string]*zoekt.Repository, len(resp.Repos))
 	for _, r := range resp.Repos {
-		set[strings.ToLower(r.Repository.Name)] = &r.Repository
+		set[r.Repository.Name] = &r.Repository
 	}
 
 	return set, nil


### PR DESCRIPTION
Previously we treated zoekt repositories as if the case would not match
what is returned from the repo database. However, Zoekt requires the
correct caseing of the repo name to do the search. Additionally Zoekt
uses the correct casing of the repo name when indexing.

So the uses of ToLower when checking if a repo was indexed was
unnecessary. Additionally in the case a repository name changed case we
would incorrectly believe we have indexed the repo, but the actual zoekt
search would fail due to the index being case sensitive.

Additionally avoiding the calls to ToLower should improve
performance. However, I didn't validate this (but naively it should).