### PR TITLE
search: always enable searchMultipleRevisionsPerRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- To search across multiple revisions of the same repository, list multiple branch names (or other revspecs) separated by `:` in your query, as in `repo:myrepo@branch1:branch2:branch2`. To search all branches, use `repo:myrepo@*refs/heads/`. Previously this was only supported for diff and commit searches and only available via the experimental site setting `searchMultipleRevisionsPerRepository`.
+
 ### Changed
 
 - Some monitoring alerts now have more useful descriptions. [#11542](https://github.com/sourcegraph/sourcegraph/pull/11542)
@@ -24,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - Backwards compatibility for "critical configuration" (a type of configuration that was deprecated in December 2019) was removed. All critical configuration now belongs in site configuration.
+- Experimental feature setting `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }` will be removed in 3.19. It is now always on. Please remove references to it.
 
 ## 3.17.0
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 
@@ -627,10 +626,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			revSpecs, err := repoAllRevs.ExpandedRevSpecs(ctx)
 			if err != nil {
 				return err
-			}
-
-			if len(revSpecs) >= 2 && !conf.SearchMultipleRevisionsPerRepository() {
-				return errMultipleRevsNotSupported
 			}
 
 			for _, rev := range revSpecs {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -328,11 +328,6 @@ func AndOrQueryEnabled() bool {
 	return e.AndOrQuery == "enabled"
 }
 
-func SearchMultipleRevisionsPerRepository() bool {
-	x := ExperimentalFeatures()
-	return x.SearchMultipleRevisionsPerRepository != nil && *x.SearchMultipleRevisionsPerRepository
-}
-
 func ExperimentalFeatures() schema.ExperimentalFeatures {
 	val := Get().ExperimentalFeatures
 	if val == nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -399,7 +399,7 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
-	// SearchMultipleRevisionsPerRepository description: Enables searching multiple revisions of the same repository (using `repo:myrepo@branch1:branch2`).
+	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.
 	StructuralSearch string `json:"structuralSearch,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -92,7 +92,7 @@
           "default": "disabled"
         },
         "searchMultipleRevisionsPerRepository": {
-          "description": "Enables searching multiple revisions of the same repository (using `repo:myrepo@branch1:branch2`).",
+          "description": "DEPRECATED. Always on. Will be removed in 3.19.",
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -97,7 +97,7 @@ const SiteSchemaJSON = `{
           "default": "disabled"
         },
         "searchMultipleRevisionsPerRepository": {
-          "description": "Enables searching multiple revisions of the same repository (using ` + "`" + `repo:myrepo@branch1:branch2` + "`" + `).",
+          "description": "DEPRECATED. Always on. Will be removed in 3.19.",
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }


### PR DESCRIPTION
This feature is ready for use. It is also required for Version Contexts
to function with a repository being specified more than once.

The CHANGELOG entry is copied from the original addition of the
experimental feature.

Fixes https://github.com/sourcegraph/sourcegraph/issues/11668