### PR TITLE
grafana: avoid copying go files in tree

### DIFF
--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -3,15 +3,14 @@
 set -ex
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
-BINDIR=".bin"
 
-# We copy just the monitoring directory and the root go.mod/go.sum so that we
-# do not need to send the entire repository as build context to Docker. Additionally,
-# we do not use a separate go.mod/go.sum in the monitoring/ directory because
-# editor tooling would occassionally include and not include it in the root
-# go.mod/go.sum.
-cp -R ../../monitoring .
-cp ../../go.* ./monitoring
+# We build out of tree to prevent triggering dev watch scripts when we copy go
+# files.
+BUILDDIR=$(mktemp -d -t sgdockerbuild_XXXXXXX)
+cleanup() {
+  rm -rf "$BUILDDIR"
+}
+trap cleanup EXIT
 
 # The grafana-wrapper has a dependency on internal/conf which makes its dependency
 # tree quite complicated. Cross-compile it separately before building the image.
@@ -23,7 +22,18 @@ go build \
   -trimpath \
   -installsuffix netgo \
   -tags "dist netgo" \
-  -o $BINDIR/grafana-wrapper ./cmd/grafana-wrapper
+  -o "$BUILDDIR"/.bin/grafana-wrapper ./cmd/grafana-wrapper
+
+# We copy just the monitoring directory and the root go.mod/go.sum so that we
+# do not need to send the entire repository as build context to Docker. Additionally,
+# we do not use a separate go.mod/go.sum in the monitoring/ directory because
+# editor tooling would occassionally include and not include it in the root
+# go.mod/go.sum.
+cp -R . "$BUILDDIR"
+cp -R ../../monitoring "$BUILDDIR"/
+cp ../../go.* "$BUILDDIR"/monitoring
+
+cd "$BUILDDIR"
 
 # Enable image build caching via CACHE=true (the jsonnet builds can take a long time)
 BUILD_CACHE="--no-cache"
@@ -38,5 +48,5 @@ docker build ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/grafana}" . \
   --build-arg DATE \
   --build-arg VERSION
 
-# clean up for convenience
-rm -rf monitoring .bin
+# cd out of $BUILDDIR for cleanup
+cd -


### PR DESCRIPTION
The grafana build script temporarily copies ./monitoring to
./docker-images/grafana/monitoring. ./monitoring contains go
files. However, whenever go files change our dev script would want to
rebuild the things that have changed. So we would get into this state
where the grafana build script would keep adding and removing go files,
and our dev script would keep deciding we need to rebuild grafana.

This commit does the build out of tree instead, to avoid the watch
script seeing the go files come and go. An alternative implementation
would be adding an ignore to the temporary directory, but that requires
touching more places. Instead we adjust the hack used by
grafana/build.sh.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
