### PR TITLE
dev: watchman ignores hidden files

### DIFF
--- a/dev/changewatch.sh
+++ b/dev/changewatch.sh
@@ -52,6 +52,7 @@ execWatchman() {
   exec dev/watchmanwrapper/watchmanwrapper dev/handle-change.sh <<-EOT
 ["subscribe", ".", "gochangewatch", {
   "expression": ["allof",
+    ["not", ["match", ".*"]],
     ["anyof",
       ["suffix", "go"],
       ["dirname", "cmd/symbols"],

--- a/dev/changewatch.sh
+++ b/dev/changewatch.sh
@@ -51,14 +51,14 @@ execWatchman() {
   popd
   exec dev/watchmanwrapper/watchmanwrapper dev/handle-change.sh <<-EOT
 ["subscribe", ".", "gochangewatch", {
-  "expression": ["anyof",
-    ["suffix", "go"],
-    ["dirname", "cmd/symbols"],
-    ["dirname", "schema"],
-    ["dirname", "docker-images/grafana/jsonnet"],
-    ["dirname", "monitoring"],
-    ["name", "cmd/frontend/graphqlbackend/schema.graphql", "wholename"]
-  ],
+  "expression": ["allof",
+    ["anyof",
+      ["suffix", "go"],
+      ["dirname", "cmd/symbols"],
+      ["dirname", "schema"],
+      ["dirname", "docker-images/grafana/jsonnet"],
+      ["dirname", "monitoring"],
+      ["name", "cmd/frontend/graphqlbackend/schema.graphql", "wholename"]]],
   "fields": ["name"]
 }]
 EOT


### PR DESCRIPTION
I noticed editors and other tools will often write to temporarily hidden
files. This excludes them from triggering a rebuild. Note: we will still
watch hidden directories, just not hidden files.