### PR TITLE
Replace redacted Docker image in prometheus/Dockerfile

### DIFF
--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -15,7 +15,7 @@ RUN DOC_SOLUTIONS_FILE='' PROMETHEUS_DIR=/generated/prometheus GRAFANA_DIR='' /g
 FROM prom/prometheus:v2.16.0@sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4 AS upstream
 
 # hadolint ignore=DL3007
-FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:0c38f63cbe19e40123668a48c36466ef72b195e723cbfcbe01e9657a5f14cec6
+FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:248b7ec76e03e6b4fbb796fc3cdd2f91dad45546a6d7dee61c322475e0e8a08f
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
Builds on `master` are failing because they can't build the Docker
images. This should fix it.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
