### PR TITLE
Add support for parenthesized parameters in frontend query parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The single-container `sourcegraph/server` image now correctly reports its version.
 - An issue where repositories would not clone and index in some edge cases where the clones were deleted or not successful on gitserver. [#11602](https://github.com/sourcegraph/sourcegraph/pull/11602)
 - An issue where the sourcegraph/server Jaeger config was invalid. [#11661](https://github.com/sourcegraph/sourcegraph/pull/11661)
+- An issue where valid search queries were improperly hinted as being invalid in the search field. [#11688](https://github.com/sourcegraph/sourcegraph/pull/11688)
 
 ### Removed
 

--- a/shared/src/search/parser/diagnostics.test.ts
+++ b/shared/src/search/parser/diagnostics.test.ts
@@ -81,6 +81,15 @@ describe('getDiagnostics()', () => {
         ).toStrictEqual([])
     })
 
+    test('search query containing parenthesized parameterss', () => {
+        expect(
+            getDiagnostics(
+                (parseSearchQuery('repo:a (file:b and c)') as ParseSuccess<Sequence>).token,
+                SearchPatternType.regexp
+            )
+        ).toStrictEqual([])
+    })
+
     test('search query containing quoted token, literal pattern type', () => {
         expect(
             getDiagnostics(

--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -505,4 +505,321 @@ describe('parseSearchQuery()', () => {
             },
             type: 'success',
         }))
+
+    test('parenthesized parameters', () => {
+        expect(parseSearchQuery('repo:a (file:b and c)')).toMatchObject({
+            range: {
+                end: 21,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 6,
+                            start: 0,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 4,
+                                    start: 0,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'repo',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 6,
+                                    start: 5,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'a',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 7,
+                            start: 6,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 8,
+                            start: 7,
+                        },
+                        token: {
+                            type: 'openingParen',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 14,
+                            start: 8,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    end: 12,
+                                    start: 8,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'file',
+                                },
+                                type: 'success',
+                            },
+                            filterValue: {
+                                range: {
+                                    end: 14,
+                                    start: 13,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'b',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 15,
+                            start: 14,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 18,
+                            start: 15,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'AND',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 19,
+                            start: 18,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 20,
+                            start: 19,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'c',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 21,
+                            start: 20,
+                        },
+                        token: {
+                            type: 'closingParen',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
+
+    test('nested parenthesized parameters', () => {
+        expect(parseSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot({
+            range: {
+                end: 22,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            end: 1,
+                            start: 0,
+                        },
+                        token: {
+                            type: 'openingParen',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 2,
+                            start: 1,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'a',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 3,
+                            start: 2,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 6,
+                            start: 3,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'and',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 7,
+                            start: 6,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 8,
+                            start: 7,
+                        },
+                        token: {
+                            type: 'openingParen',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 9,
+                            start: 8,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'b',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 10,
+                            start: 9,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 12,
+                            start: 10,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'or',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 13,
+                            start: 12,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 14,
+                            start: 13,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'c',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 15,
+                            start: 14,
+                        },
+                        token: {
+                            type: 'closingParen',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 16,
+                            start: 15,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 19,
+                            start: 16,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'and',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 20,
+                            start: 19,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 21,
+                            start: 20,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'd',
+                        },
+                    },
+                    {
+                        range: {
+                            end: 22,
+                            start: 21,
+                        },
+                        token: {
+                            type: 'closingParen',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
 })

--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -610,7 +610,7 @@ describe('parseSearchQuery()', () => {
                         },
                         token: {
                             type: 'literal',
-                            value: 'AND',
+                            value: 'and',
                         },
                     },
                     {
@@ -649,7 +649,7 @@ describe('parseSearchQuery()', () => {
     })
 
     test('nested parenthesized parameters', () => {
-        expect(parseSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot({
+        expect(parseSearchQuery('(a and (b or c) and d)')).toMatchObject({
             range: {
                 end: 22,
                 start: 0,

--- a/shared/src/search/parser/tokens.test.ts
+++ b/shared/src/search/parser/tokens.test.ts
@@ -39,4 +39,53 @@ describe('getMonacoTokens()', () => {
             },
         ])
     })
+
+    test('search query containing parenthesized parameters', () => {
+        expect(getMonacoTokens((parseSearchQuery('r:a (f:b and c)') as ParseSuccess<Sequence>).token)).toStrictEqual([
+            {
+                scopes: 'keyword',
+                startIndex: 0,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 2,
+            },
+            {
+                scopes: 'whitespace',
+                startIndex: 3,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 4,
+            },
+            {
+                scopes: 'keyword',
+                startIndex: 5,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 7,
+            },
+            {
+                scopes: 'whitespace',
+                startIndex: 8,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 9,
+            },
+            {
+                scopes: 'whitespace',
+                startIndex: 12,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 13,
+            },
+            {
+                scopes: 'identifier',
+                startIndex: 14,
+            },
+        ])
+    })
 })

--- a/shared/src/search/parser/tokens.ts
+++ b/shared/src/search/parser/tokens.ts
@@ -7,27 +7,33 @@ import { Sequence } from './parser'
 export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.languages.IToken[] {
     const tokens: Monaco.languages.IToken[] = []
     for (const { token, range } of parsedQuery.members) {
-        if (token.type === 'whitespace') {
-            tokens.push({
-                startIndex: range.start,
-                scopes: 'whitespace',
-            })
-        } else if (token.type === 'quoted' || token.type === 'literal') {
-            tokens.push({
-                startIndex: range.start,
-                scopes: 'identifier',
-            })
-        } else if (token.type === 'filter') {
-            tokens.push({
-                startIndex: token.filterType.range.start,
-                scopes: 'keyword',
-            })
-            if (token.filterValue) {
+        switch (token.type) {
+            case 'whitespace':
                 tokens.push({
-                    startIndex: token.filterValue.range.start,
+                    startIndex: range.start,
+                    scopes: 'whitespace',
+                })
+                break
+            case 'filter':
+                {
+                    tokens.push({
+                        startIndex: token.filterType.range.start,
+                        scopes: 'keyword',
+                    })
+                    if (token.filterValue) {
+                        tokens.push({
+                            startIndex: token.filterValue.range.start,
+                            scopes: 'identifier',
+                        })
+                    }
+                }
+                break
+            default:
+                tokens.push({
+                    startIndex: range.start,
                     scopes: 'identifier',
                 })
-            }
+                break
         }
     }
     return tokens


### PR DESCRIPTION
Fixes #11655

Adds naive parsing of opening & closing parentheses (no grouping / paren matching), to avoid showing squiggles on queries like `r:a (f:b and c)`, where we previously  interpreted `(f:b` as a single literal and suggested quoting it because it contained a colon.

cc @rvantonder 

![image](https://user-images.githubusercontent.com/1741180/85523083-cd618200-b606-11ea-95df-08bb5a8b5d41.png)

