### PR TITLE
repo-updater: remove streaming syncer feature flag

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -21,10 +21,6 @@ type Syncer struct {
 	Store   Store
 	Sourcer Sourcer
 
-	// DisableStreaming if true will prevent the syncer from streaming in new
-	// sourced repositories into the store.
-	DisableStreaming bool
-
 	// FailFullSync prevents Sync from running. This should only be true for
 	// Sourcegraph.com
 	FailFullSync bool
@@ -110,7 +106,7 @@ func (s *Syncer) Sync(ctx context.Context) (err error) {
 	}
 
 	var streamingInserter func(*Repo)
-	if s.DisableStreaming {
+	if s.SubsetSynced == nil {
 		streamingInserter = func(*Repo) {} //noop
 	} else {
 		streamingInserter, err = s.makeNewRepoInserter(ctx)

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -55,7 +55,7 @@ func TestSyncer_Sync(t *testing.T) {
 			name:    "store list error aborts sync",
 			sourcer: repos.NewFakeSourcer(nil, repos.NewFakeSource(&github, nil)),
 			store:   &repos.FakeStore{ListReposError: errors.New("boom")},
-			err:     "syncer.sync.streaming: syncer.storedExternalIDs: boom",
+			err:     "syncer.sync.store.list-repos: boom",
 		},
 		{
 			name:    "store upsert error aborts sync",

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -653,7 +653,7 @@ func TestServer_StatusMessages(t *testing.T) {
 				Messages: []protocol.StatusMessage{
 					{
 						SyncError: &protocol.SyncError{
-							Message: "syncer.sync.streaming: syncer.storedExternalIDs: could not connect to database",
+							Message: "syncer.sync.store.list-repos: could not connect to database",
 						},
 					},
 				},

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -37,8 +36,6 @@ const port = "3182"
 type EnterpriseInit func(db *sql.DB, store repos.Store, cf *httpcli.Factory, server *repoupdater.Server) []debugserver.Dumper
 
 func Main(enterpriseInit EnterpriseInit) {
-	streamingSyncer, _ := strconv.ParseBool(env.Get("SRC_STREAMING_SYNCER_ENABLED", "true", "Use the new, streaming repo metadata syncer."))
-
 	ctx := context.Background()
 	env.Lock()
 	env.HandleHelpFlag()
@@ -169,11 +166,10 @@ func Main(enterpriseInit EnterpriseInit) {
 	gps := repos.NewGitolitePhabricatorMetadataSyncer(store)
 
 	syncer := &repos.Syncer{
-		Store:            store,
-		Sourcer:          src,
-		DisableStreaming: !streamingSyncer,
-		Logger:           log15.Root(),
-		Now:              clock,
+		Store:   store,
+		Sourcer: src,
+		Logger:  log15.Root(),
+		Now:     clock,
 	}
 
 	if envvar.SourcegraphDotComMode() {


### PR DESCRIPTION
It has defaulted to on for many releases.

Additionally I noticed a bug. If SyncedSubset is nil we should not do
streaming inserts. The reason is Synced will never have the Diff.Added
field populated since it will always be via subset synced. So this would
lead to the repo not being noticed in the git update scheduler. However,
we always have SubsetSynced set (except in tests). So this was a benign
bug.