### PR TITLE
repo-updater: populate git fetch scheduler on startup

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -147,7 +147,10 @@ func (s *Syncer) Sync(ctx context.Context) (err error) {
 	}
 
 	if s.Synced != nil {
-		s.Synced <- diff
+		select {
+		case s.Synced <- diff:
+		case <-ctx.Done():
+		}
 	}
 
 	return nil
@@ -219,7 +222,10 @@ func (s *Syncer) syncSubset(ctx context.Context, insertOnly bool, sourcedSubset 
 	}
 
 	if s.SubsetSynced != nil {
-		s.SubsetSynced <- diff
+		select {
+		case s.SubsetSynced <- diff:
+		case <-ctx.Done():
+		}
 	}
 
 	return diff, nil

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gitchander/permutation"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -978,4 +979,72 @@ func TestDiff(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSync_Run(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// some ceremony to setup metadata on our test repos
+	svc := &repos.ExternalService{ID: 1, Kind: extsvc.KindGitHub}
+	mk := func(name string) *repos.Repo {
+		return &repos.Repo{
+			Name:     name,
+			Metadata: &github.Repository{},
+			ExternalRepo: api.ExternalRepoSpec{
+				ID:          name,
+				ServiceID:   "https://github.com",
+				ServiceType: svc.Kind,
+			},
+		}
+	}
+
+	// Our test will have 1 initial repo, and discover a new repo on sourcing.
+	stored := repos.Repos{mk("initial")}.With(repos.Opt.RepoSources(svc.URN()))
+	sourced := repos.Repos{mk("initial"), mk("new")}
+
+	syncer := &repos.Syncer{
+		Store:        &repos.FakeStore{},
+		Sourcer:      repos.NewFakeSourcer(nil, repos.NewFakeSource(svc, nil, sourced...)),
+		Synced:       make(chan repos.Diff),
+		SubsetSynced: make(chan repos.Diff),
+		Now:          time.Now,
+	}
+
+	// Initial repos in store
+	syncer.Store.UpsertRepos(ctx, stored...)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		syncer.Run(ctx, func() time.Duration { return 0 })
+	}()
+
+	// Ignore fields store adds
+	ignore := cmpopts.IgnoreFields(repos.Repo{}, "ID", "CreatedAt", "UpdatedAt", "Sources")
+
+	// First thing it should find the new repo and send it down SubsetSynced
+	diff := <-syncer.SubsetSynced
+	if d := cmp.Diff(repos.Diff{Added: repos.Repos{mk("new")}}, diff, ignore); d != "" {
+		t.Fatalf("SubsetSynced mismatch (-want +got):\n%s", d)
+	}
+
+	// Finally we get the final diff, which will have everything listed as
+	// Unmodified since we added when we did SubsetSynced.
+	diff = <-syncer.Synced
+	if d := cmp.Diff(repos.Diff{Unmodified: sourced}, diff, ignore); d != "" {
+		t.Fatalf("final Synced mismatch (-want +got):\n%s", d)
+	}
+
+	// We check synced again to test us going around the Run loop 2 times in
+	// total.
+	diff = <-syncer.Synced
+	if d := cmp.Diff(repos.Diff{Unmodified: sourced}, diff, ignore); d != "" {
+		t.Fatalf("second final Synced mismatch (-want +got):\n%s", d)
+	}
+
+	// Cancel context and the run loop should stop
+	cancel()
+	<-done
 }

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -1024,8 +1024,14 @@ func TestSync_Run(t *testing.T) {
 	// Ignore fields store adds
 	ignore := cmpopts.IgnoreFields(repos.Repo{}, "ID", "CreatedAt", "UpdatedAt", "Sources")
 
-	// First thing it should find the new repo and send it down SubsetSynced
-	diff := <-syncer.SubsetSynced
+	// The first thing sent down Synced is the list of repos in store.
+	diff := <-syncer.Synced
+	if d := cmp.Diff(repos.Diff{Unmodified: stored}, diff, ignore); d != "" {
+		t.Fatalf("initial Synced mismatch (-want +got):\n%s", d)
+	}
+
+	// Next up it should find the new repo and send it down SubsetSynced
+	diff = <-syncer.SubsetSynced
 	if d := cmp.Diff(repos.Diff{Added: repos.Repos{mk("new")}}, diff, ignore); d != "" {
 		t.Fatalf("SubsetSynced mismatch (-want +got):\n%s", d)
 	}


### PR DESCRIPTION
The git fetch scheduler discovers what repos to fetch/clone by reading
the Synced and SubsetSynced channels from the Syncer. On repo-updater
startup it will only start running once the first Sync is complete (this
is when it first discovers repos). On large installations a sync can
take a while. This change allows the scheduler to start syncing the
pre-existing repos (common case) on startup.

Part of https://github.com/sourcegraph/sourcegraph/issues/11684