### PR TITLE
 codeintel: Search uploads and indexes by repo name

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1305,7 +1305,8 @@ type Query {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifUploads(
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # commit, root, and indexer properties.
         query: String
 
         # The state of returned uploads.
@@ -1332,8 +1333,8 @@ type Query {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifIndexes(
-        # TODO(efritz) - update
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # and commit properties.
         query: String
 
         # The state of returned uploads.
@@ -1878,7 +1879,8 @@ type Repository implements Node & GenericSearchResultInterface {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifUploads(
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # commit, root, and indexer properties.
         query: String
 
         # The state of returned uploads.
@@ -1905,8 +1907,8 @@ type Repository implements Node & GenericSearchResultInterface {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifIndexes(
-        # TODO(efritz) - update
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # and commit properties.
         query: String
 
         # The state of returned uploads.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1312,7 +1312,8 @@ type Query {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifUploads(
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # commit, root, and indexer properties.
         query: String
 
         # The state of returned uploads.
@@ -1339,8 +1340,8 @@ type Query {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifIndexes(
-        # TODO(efritz) - update
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # and commit properties.
         query: String
 
         # The state of returned uploads.
@@ -1885,7 +1886,8 @@ type Repository implements Node & GenericSearchResultInterface {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifUploads(
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # commit, root, and indexer properties.
         query: String
 
         # The state of returned uploads.
@@ -1912,8 +1914,8 @@ type Repository implements Node & GenericSearchResultInterface {
     # CHANGELOG during this time.
     # The repository's LSIF uploads.
     lsifIndexes(
-        # TODO(efritz) - update
-        # An (optional) search query that searches over the commit and root properties.
+        # An (optional) search query that searches over the state, repository name,
+        # and commit properties.
         query: String
 
         # The state of returned uploads.

--- a/enterprise/internal/codeintel/store/ctes.go
+++ b/enterprise/internal/codeintel/store/ctes.go
@@ -25,7 +25,7 @@ var visibleIDsCTE = `
 	-- Correlate commits to dumps and filter out commits without LSIF data
 	lineage_with_dumps AS (
 		SELECT a.*, d.root, d.indexer, d.id as dump_id FROM limited_lineage a
-		JOIN lsif_dumps d ON d.repository_id = a.repository_id AND d."commit" = a."commit"
+		JOIN lsif_dumps_with_repository_name d ON d.repository_id = a.repository_id AND d."commit" = a."commit"
 	),
 	visible_ids AS (
 		-- Remove dumps where there exists another visible dump of smaller depth with an
@@ -50,7 +50,7 @@ func withAncestorLineage(query string, repositoryID int, commit string, args ...
 		RECURSIVE lineage(id, "commit", parent, repository_id) AS (
 			SELECT c.* FROM lsif_commits c WHERE c.repository_id = %s AND c."commit" = %s
 			UNION
-			SELECT c.* FROM lineage a JOIN lsif_commits c ON a.repository_id = c.repository_id AND a.parent = c."commit"
+			SELECT c.* FROM lineage a JOIN lsif_commits c ON c.repository_id = a.repository_id AND a.parent = c."commit"
 		), ` + visibleIDsCTE + " " + query
 
 	return sqlf.Sprintf(queryWithCTEs, append([]interface{}{repositoryID, commit}, args...)...)
@@ -77,10 +77,10 @@ func withBidirectionalLineage(query string, repositoryID int, commit string, arg
 			SELECT * FROM (
 				WITH l_inner AS (SELECT * FROM lineage)
 				-- get next ancestors (multiple parents for merge commits)
-				SELECT c.*, 'A' FROM l_inner l JOIN lsif_commits c ON l.direction = 'A' AND c.repository_id = l.repository_id AND c."commit" = l.parent_commit
+				SELECT c.*, 'A' FROM l_inner l JOIN lsif_commits c ON c.repository_id = l.repository_id AND c."commit" = l.parent_commit AND l.direction = 'A'
 				UNION
 				-- get next descendants
-				SELECT c.*, 'D' FROM l_inner l JOIN lsif_commits c ON l.direction = 'D' and c.repository_id = l.repository_id AND c.parent_commit = l."commit"
+				SELECT c.*, 'D' FROM l_inner l JOIN lsif_commits c ON c.repository_id = l.repository_id AND c.parent_commit = l."commit" AND l.direction = 'D'
 			) subquery
 		), ` + visibleIDsCTE + " " + query
 

--- a/enterprise/internal/codeintel/store/dequeue.go
+++ b/enterprise/internal/codeintel/store/dequeue.go
@@ -15,15 +15,10 @@ type dequeueScanner func(rows *sql.Rows, err error) (interface{}, bool, error)
 // This transaction must be closed by the caller. If there is no such unlocked record, a nil record and a nil store
 // will be returned along with a false-valued flag. This method must not be called from within a transaction.
 //
-// Assumptions: The table name describes a record with an `id`, `state`, `started_at`, and `process_after` column,
-// where state can be one of (at least) 'queued' or 'processing'.
-func (s *store) dequeueRecord(
-	ctx context.Context,
-	tableName string,
-	columnExpressions []*sqlf.Query,
-	sortExpression *sqlf.Query,
-	scan dequeueScanner,
-) (interface{}, Store, bool, error) {
+// Assumptions: The table name describes a record with an `id`, `state`, `started_at`, `process_after`, and
+// `repository_id` column, where state can be one of (at least) 'queued' or 'processing' and repository_id refers
+// to the PK of the repo table..
+func (s *store) dequeueRecord(ctx context.Context, viewName, tableName string, columnExpressions []*sqlf.Query, sortExpression *sqlf.Query, scan dequeueScanner) (interface{}, Store, bool, error) {
 	for {
 		// First, we try to select an eligible record outside of a transaction. This will skip
 		// any rows that are currently locked inside of a transaction of another dequeue process.
@@ -38,7 +33,7 @@ func (s *store) dequeueRecord(
 			return nil, nil, false, err
 		}
 
-		record, tx, ok, err := s.dequeueByID(ctx, tableName, columnExpressions, scan, id)
+		record, tx, ok, err := s.dequeueByID(ctx, viewName, columnExpressions, scan, id)
 		if err != nil {
 			// This will occur if we selected an ID that raced with another dequeue process. If both
 			// dequeue processes select the same ID and the other process begins its transaction first,
@@ -78,7 +73,7 @@ func (s *store) dequeueByID(
 	// on race conditions with other dequeue attempts.
 	record, exists, err := scan(tx.query(
 		ctx,
-		sqlf.Sprintf(`SELECT %s FROM `+tableName+` WHERE id = %s FOR UPDATE SKIP LOCKED LIMIT 1`, sqlf.Join(columnExpressions, ","), id),
+		sqlf.Sprintf(`SELECT %s FROM `+tableName+` u WHERE u.id = %s FOR UPDATE SKIP LOCKED LIMIT 1`, sqlf.Join(columnExpressions, ","), id),
 	))
 	if err != nil {
 		return nil, nil, false, tx.Done(err)

--- a/enterprise/internal/codeintel/store/dequeue_test.go
+++ b/enterprise/internal/codeintel/store/dequeue_test.go
@@ -18,12 +18,12 @@ func TestDequeueRecordConcurrency(t *testing.T) {
 	// Add dequeueable upload
 	insertUploads(t, dbconn.Global, Upload{ID: 1, State: "queued"})
 
-	_, tx1, ok1, err1 := store.dequeueByID(context.Background(), "lsif_uploads", uploadColumnsWithNullRank, scanFirstUploadInterface, 1)
+	_, tx1, ok1, err1 := store.dequeueByID(context.Background(), "lsif_uploads_with_repository_name", uploadColumnsWithNullRank, scanFirstUploadInterface, 1)
 	if ok1 {
 		defer func() { _ = tx1.Done(nil) }()
 	}
 
-	_, tx2, ok2, err2 := store.dequeueByID(context.Background(), "lsif_uploads", uploadColumnsWithNullRank, scanFirstUploadInterface, 1)
+	_, tx2, ok2, err2 := store.dequeueByID(context.Background(), "lsif_uploads_with_repository_name", uploadColumnsWithNullRank, scanFirstUploadInterface, 1)
 	if ok2 {
 		defer func() { _ = tx2.Done(nil) }()
 	}

--- a/enterprise/internal/codeintel/store/dumps.go
+++ b/enterprise/internal/codeintel/store/dumps.go
@@ -8,8 +8,8 @@ import (
 	"github.com/keegancsmith/sqlf"
 )
 
-// Dump is a subset of the lsif_uploads table (queried via the lsif_dumps view) and stores
-// only processed records.
+// Dump is a subset of the lsif_uploads table (queried via the lsif_dumps_with_repository_name view)
+// and stores only processed records.
 type Dump struct {
 	ID             int        `json:"id"`
 	Commit         string     `json:"commit"`
@@ -23,6 +23,7 @@ type Dump struct {
 	ProcessAfter   *time.Time `json:"processAfter"`
 	NumResets      int        `json:"numResets"`
 	RepositoryID   int        `json:"repositoryId"`
+	RepositoryName string     `json:"repositoryName"`
 	Indexer        string     `json:"indexer"`
 }
 
@@ -49,6 +50,7 @@ func scanDumps(rows *sql.Rows, queryErr error) (_ []Dump, err error) {
 			&dump.ProcessAfter,
 			&dump.NumResets,
 			&dump.RepositoryID,
+			&dump.RepositoryName,
 			&dump.Indexer,
 		); err != nil {
 			return nil, err
@@ -85,8 +87,9 @@ func (s *store) GetDumpByID(ctx context.Context, id int) (Dump, bool, error) {
 			d.process_after,
 			d.num_resets,
 			d.repository_id,
+			d.repository_name,
 			d.indexer
-		FROM lsif_dumps d WHERE id = %s
+		FROM lsif_dumps_with_repository_name d WHERE d.id = %s
 	`, id)))
 }
 
@@ -124,7 +127,7 @@ func (s *store) FindClosestDumps(ctx context.Context, repositoryID int, commit, 
 	}
 
 	var conds []*sqlf.Query
-	conds = append(conds, sqlf.Sprintf("id IN (%s)", sqlf.Join(intsToQueries(ids), ", ")))
+	conds = append(conds, sqlf.Sprintf("d.id IN (%s)", sqlf.Join(intsToQueries(ids), ", ")))
 	if indexer != "" {
 		conds = append(conds, sqlf.Sprintf("indexer = %s", indexer))
 	}
@@ -145,8 +148,9 @@ func (s *store) FindClosestDumps(ctx context.Context, repositoryID int, commit, 
 				d.process_after,
 				d.num_resets,
 				d.repository_id,
+				d.repository_name,
 				d.indexer
-			FROM lsif_dumps d WHERE %s
+			FROM lsif_dumps_with_repository_name d WHERE %s
 		`, sqlf.Join(conds, " AND ")),
 	))
 	if err != nil {
@@ -178,7 +182,7 @@ func (s *store) DeleteOldestDump(ctx context.Context) (int, bool, error) {
 	return scanFirstInt(s.query(ctx, sqlf.Sprintf(`
 		DELETE FROM lsif_uploads
 		WHERE id IN (
-			SELECT id FROM lsif_dumps
+			SELECT id FROM lsif_dumps_with_repository_name
 			WHERE visible_at_tip = false
 			ORDER BY uploaded_at
 			LIMIT 1
@@ -189,7 +193,7 @@ func (s *store) DeleteOldestDump(ctx context.Context) (int, bool, error) {
 // UpdateDumpsVisibleFromTip recalculates the visible_at_tip flag of all dumps of the given repository.
 func (s *store) UpdateDumpsVisibleFromTip(ctx context.Context, repositoryID int, tipCommit string) (err error) {
 	return s.queryForEffect(ctx, withAncestorLineage(`
-		UPDATE lsif_dumps d
+		UPDATE lsif_uploads d
 		SET visible_at_tip = id IN (SELECT * from visible_ids)
 		WHERE d.repository_id = %s AND (d.id IN (SELECT * from visible_ids) OR d.visible_at_tip)
 	`, repositoryID, tipCommit, repositoryID))

--- a/enterprise/internal/codeintel/store/dumps_test.go
+++ b/enterprise/internal/codeintel/store/dumps_test.go
@@ -39,6 +39,7 @@ func TestGetDumpByID(t *testing.T) {
 		StartedAt:      &startedAt,
 		FinishedAt:     &finishedAt,
 		RepositoryID:   50,
+		RepositoryName: "n-50",
 		Indexer:        "lsif-go",
 	}
 
@@ -55,6 +56,7 @@ func TestGetDumpByID(t *testing.T) {
 		ProcessAfter:   expected.ProcessAfter,
 		NumResets:      expected.NumResets,
 		RepositoryID:   expected.RepositoryID,
+		RepositoryName: expected.RepositoryName,
 		Indexer:        expected.Indexer,
 	})
 

--- a/enterprise/internal/codeintel/store/helpers_test.go
+++ b/enterprise/internal/codeintel/store/helpers_test.go
@@ -37,7 +37,7 @@ func makeCommit(i int) string {
 
 // getDumpVisibilities returns a map from dump identifiers to its visibility. Fails the test on error.
 func getDumpVisibilities(t *testing.T, db *sql.DB) map[int]bool {
-	visibilities, err := scanVisibilities(db.Query("SELECT id, visible_at_tip FROM lsif_dumps"))
+	visibilities, err := scanVisibilities(db.Query("SELECT id, visible_at_tip FROM lsif_dumps_with_repository_name"))
 	if err != nil {
 		t.Fatalf("unexpected error while scanning dump visibility: %s", err)
 	}
@@ -63,6 +63,9 @@ func insertUploads(t *testing.T, db *sql.DB, uploads ...Upload) {
 		if upload.UploadedParts == nil {
 			upload.UploadedParts = []int{}
 		}
+
+		// Ensure we have a repo for the inner join in select queries
+		insertRepo(t, db, upload.RepositoryID, upload.RepositoryName)
 
 		query := sqlf.Sprintf(`
 			INSERT INTO lsif_uploads (
@@ -119,6 +122,9 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 			index.RepositoryID = 50
 		}
 
+		// Ensure we have a repo for the inner join in select queries
+		insertRepo(t, db, index.RepositoryID, index.RepositoryName)
+
 		query := sqlf.Sprintf(`
 			INSERT INTO lsif_indexes (
 				id,
@@ -148,6 +154,23 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 		if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 			t.Fatalf("unexpected error while inserting index: %s", err)
 		}
+	}
+}
+
+// insertRepo creates a repository record with the given id and name. If there is already a repository
+// with the given identifier, nothing happens
+func insertRepo(t *testing.T, db *sql.DB, id int, name string) {
+	if name == "" {
+		name = fmt.Sprintf("n-%d", id)
+	}
+
+	query := sqlf.Sprintf(
+		`INSERT INTO repo (id, name) VALUES (%s, %s) ON CONFLICT (id) DO NOTHING`,
+		id,
+		name,
+	)
+	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		t.Fatalf("unexpected error while upserting repository: %s", err)
 	}
 }
 

--- a/enterprise/internal/codeintel/store/indexes_test.go
+++ b/enterprise/internal/codeintel/store/indexes_test.go
@@ -37,6 +37,7 @@ func TestGetIndexByID(t *testing.T) {
 		StartedAt:      &startedAt,
 		FinishedAt:     nil,
 		RepositoryID:   123,
+		RepositoryName: "n-123",
 		Rank:           nil,
 	}
 
@@ -126,9 +127,9 @@ func TestGetIndexes(t *testing.T) {
 		Index{ID: 1, Commit: makeCommit(3331), QueuedAt: t1, State: "queued"},
 		Index{ID: 2, QueuedAt: t2, State: "errored", FailureMessage: &failureMessage},
 		Index{ID: 3, Commit: makeCommit(3333), QueuedAt: t3, State: "queued"},
-		Index{ID: 4, QueuedAt: t4, State: "queued", RepositoryID: 51},
+		Index{ID: 4, QueuedAt: t4, State: "queued", RepositoryID: 51, RepositoryName: "foo bar x"},
 		Index{ID: 5, Commit: makeCommit(3333), QueuedAt: t5, State: "processing"},
-		Index{ID: 6, QueuedAt: t6, State: "processing"},
+		Index{ID: 6, QueuedAt: t6, State: "processing", RepositoryID: 52, RepositoryName: "foo bar y"},
 		Index{ID: 7, QueuedAt: t7},
 		Index{ID: 8, QueuedAt: t8},
 		Index{ID: 9, QueuedAt: t9, State: "queued"},
@@ -136,28 +137,38 @@ func TestGetIndexes(t *testing.T) {
 	)
 
 	testCases := []struct {
-		state       string
-		term        string
-		expectedIDs []int
+		repositoryID int
+		state        string
+		term         string
+		expectedIDs  []int
 	}{
-		{expectedIDs: []int{1, 2, 3, 5, 6, 7, 8, 9, 10}},
+		{expectedIDs: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{repositoryID: 50, expectedIDs: []int{1, 2, 3, 5, 7, 8, 9, 10}},
 		{state: "completed", expectedIDs: []int{7, 8, 10}},
-		{term: "003", expectedIDs: []int{1, 3, 5}},    // searches commits
-		{term: "333", expectedIDs: []int{1, 2, 3, 5}}, // searches commits and failure message
+		{term: "003", expectedIDs: []int{1, 3, 5}},       // searches commits
+		{term: "333", expectedIDs: []int{1, 2, 3, 5}},    // searches commits and failure message
+		{term: "QuEuEd", expectedIDs: []int{1, 3, 4, 9}}, // searches text status
+		{term: "bAr", expectedIDs: []int{4, 6}},          // search repo names
 	}
 
 	for _, testCase := range testCases {
-		name := fmt.Sprintf("state=%s term=%s", testCase.state, testCase.term)
+		for lo := 0; lo < len(testCase.expectedIDs); lo++ {
+			hi := lo + 3
+			if hi > len(testCase.expectedIDs) {
+				hi = len(testCase.expectedIDs)
+			}
 
-		t.Run(name, func(t *testing.T) {
-			for lo := 0; lo < len(testCase.expectedIDs); lo++ {
-				hi := lo + 3
-				if hi > len(testCase.expectedIDs) {
-					hi = len(testCase.expectedIDs)
-				}
+			name := fmt.Sprintf(
+				"repositoryID=%d state=%s term=%s offset=%d",
+				testCase.repositoryID,
+				testCase.state,
+				testCase.term,
+				lo,
+			)
 
+			t.Run(name, func(t *testing.T) {
 				indexes, totalCount, err := store.GetIndexes(context.Background(), GetIndexesOptions{
-					RepositoryID: 50,
+					RepositoryID: testCase.repositoryID,
 					State:        testCase.state,
 					Term:         testCase.term,
 					Limit:        3,
@@ -178,8 +189,8 @@ func TestGetIndexes(t *testing.T) {
 				if diff := cmp.Diff(testCase.expectedIDs[lo:hi], ids); diff != "" {
 					t.Errorf("unexpected index ids at offset %d (-want +got):\n%s", lo, diff)
 				}
-			}
-		})
+			})
+		}
 	}
 }
 
@@ -257,6 +268,8 @@ func TestInsertIndex(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	store := rawTestStore()
 
+	insertRepo(t, dbconn.Global, 50, "")
+
 	id, err := store.InsertIndex(context.Background(), Index{
 		Commit:       makeCommit(1),
 		State:        "queued",
@@ -276,6 +289,7 @@ func TestInsertIndex(t *testing.T) {
 		StartedAt:      nil,
 		FinishedAt:     nil,
 		RepositoryID:   50,
+		RepositoryName: "n-50",
 		Rank:           &rank,
 	}
 

--- a/enterprise/internal/codeintel/store/packages.go
+++ b/enterprise/internal/codeintel/store/packages.go
@@ -23,9 +23,10 @@ func (s *store) GetPackage(ctx context.Context, scheme, name, version string) (D
 			d.process_after,
 			d.num_resets,
 			d.repository_id,
+			d.repository_name,
 			d.indexer
 		FROM lsif_packages p
-		JOIN lsif_dumps d ON p.dump_id = d.id
+		JOIN lsif_dumps_with_repository_name d ON d.id = p.dump_id
 		WHERE p.scheme = %s AND p.name = %s AND p.version = %s
 		ORDER BY d.uploaded_at DESC
 		LIMIT 1

--- a/enterprise/internal/codeintel/store/packages_test.go
+++ b/enterprise/internal/codeintel/store/packages_test.go
@@ -39,6 +39,7 @@ func TestGetPackage(t *testing.T) {
 		StartedAt:      &startedAt,
 		FinishedAt:     &finishedAt,
 		RepositoryID:   50,
+		RepositoryName: "n-50",
 		Indexer:        "lsif-go",
 	}
 
@@ -55,6 +56,7 @@ func TestGetPackage(t *testing.T) {
 		ProcessAfter:   expected.ProcessAfter,
 		NumResets:      expected.NumResets,
 		RepositoryID:   expected.RepositoryID,
+		RepositoryName: expected.RepositoryName,
 		Indexer:        expected.Indexer,
 	})
 

--- a/enterprise/internal/codeintel/store/references.go
+++ b/enterprise/internal/codeintel/store/references.go
@@ -78,7 +78,7 @@ func (s *store) SameRepoPager(ctx context.Context, repositoryID int, commit, sch
 			ctx,
 			sqlf.Sprintf(`
 				SELECT d.id, r.scheme, r.name, r.version, r.filter FROM lsif_references r
-				LEFT JOIN lsif_dumps d on r.dump_id = d.id
+				LEFT JOIN lsif_dumps_with_repository_name d ON d.id = r.dump_id
 				WHERE %s ORDER BY d.root LIMIT %d OFFSET %d
 			`, sqlf.Join(conds, " AND "), limit, offset),
 		))
@@ -113,7 +113,7 @@ func (s *store) PackageReferencePager(ctx context.Context, scheme, name, version
 		ctx,
 		sqlf.Sprintf(`
 			SELECT COUNT(*) FROM lsif_references r
-			LEFT JOIN lsif_dumps d ON r.dump_id = d.id
+			LEFT JOIN lsif_dumps_with_repository_name d ON d.id = r.dump_id
 			WHERE %s
 		`, sqlf.Join(conds, " AND ")),
 	))
@@ -124,7 +124,7 @@ func (s *store) PackageReferencePager(ctx context.Context, scheme, name, version
 	pageFromOffset := func(ctx context.Context, offset int) ([]types.PackageReference, error) {
 		return scanPackageReferences(tx.query(ctx, sqlf.Sprintf(`
 			SELECT d.id, r.scheme, r.name, r.version, r.filter FROM lsif_references r
-			LEFT JOIN lsif_dumps d ON r.dump_id = d.id
+			LEFT JOIN lsif_dumps_with_repository_name d ON d.id = r.dump_id
 			WHERE %s ORDER BY d.repository_id, d.root LIMIT %d OFFSET %d
 		`, sqlf.Join(conds, " AND "), limit, offset)))
 	}

--- a/enterprise/internal/codeintel/store/uploads.go
+++ b/enterprise/internal/codeintel/store/uploads.go
@@ -25,6 +25,7 @@ type Upload struct {
 	ProcessAfter   *time.Time `json:"processAfter"`
 	NumResets      int        `json:"numResets"`
 	RepositoryID   int        `json:"repositoryId"`
+	RepositoryName string     `json:"repositoryName"`
 	Indexer        string     `json:"indexer"`
 	NumParts       int        `json:"numParts"`
 	UploadedParts  []int      `json:"uploadedParts"`
@@ -55,6 +56,7 @@ func scanUploads(rows *sql.Rows, queryErr error) (_ []Upload, err error) {
 			&upload.ProcessAfter,
 			&upload.NumResets,
 			&upload.RepositoryID,
+			&upload.RepositoryName,
 			&upload.Indexer,
 			&upload.NumParts,
 			pq.Array(&rawUploadedParts),
@@ -147,14 +149,15 @@ func (s *store) GetUploadByID(ctx context.Context, id int) (Upload, bool, error)
 			u.process_after,
 			u.num_resets,
 			u.repository_id,
+			u.repository_name,
 			u.indexer,
 			u.num_parts,
 			u.uploaded_parts,
 			s.rank
-		FROM lsif_uploads u
+		FROM lsif_uploads_with_repository_name u
 		LEFT JOIN (
 			SELECT r.id, RANK() OVER (ORDER BY COALESCE(r.process_after, r.uploaded_at)) as rank
-			FROM lsif_uploads r
+			FROM lsif_uploads_with_repository_name r
 			WHERE r.state = 'queued'
 		) s
 		ON u.id = s.id
@@ -206,7 +209,7 @@ func (s *store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 
 	count, _, err := scanFirstInt(tx.query(
 		ctx,
-		sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_uploads u WHERE %s`, sqlf.Join(conds, " AND ")),
+		sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_uploads_with_repository_name u WHERE %s`, sqlf.Join(conds, " AND ")),
 	))
 	if err != nil {
 		return nil, 0, err
@@ -228,14 +231,15 @@ func (s *store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 				u.process_after,
 				u.num_resets,
 				u.repository_id,
+				u.repository_name,
 				u.indexer,
 				u.num_parts,
 				u.uploaded_parts,
 				s.rank
-			FROM lsif_uploads u
+			FROM lsif_uploads_with_repository_name u
 			LEFT JOIN (
 				SELECT r.id, RANK() OVER (ORDER BY COALESCE(r.process_after, r.uploaded_at)) as rank
-				FROM lsif_uploads r
+				FROM lsif_uploads_with_repository_name r
 				WHERE r.state = 'queued'
 			) s
 			ON u.id = s.id
@@ -252,15 +256,17 @@ func (s *store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 // makeSearchCondition returns a disjunction of LIKE clauses against all searchable columns of an upload.
 func makeSearchCondition(term string) *sqlf.Query {
 	searchableColumns := []string{
-		"commit",
-		"root",
-		"indexer",
-		"failure_message",
+		"(u.state)::text",
+		`u.repository_name`,
+		"u.commit",
+		"u.root",
+		"u.indexer",
+		"u.failure_message",
 	}
 
 	var termConds []*sqlf.Query
 	for _, column := range searchableColumns {
-		termConds = append(termConds, sqlf.Sprintf("u."+column+" LIKE %s", "%"+term+"%"))
+		termConds = append(termConds, sqlf.Sprintf(column+" ILIKE %s", "%"+term+"%"))
 	}
 
 	return sqlf.Sprintf("(%s)", sqlf.Join(termConds, " OR "))
@@ -268,7 +274,7 @@ func makeSearchCondition(term string) *sqlf.Query {
 
 // QueueSize returns the number of uploads in the queued state.
 func (s *store) QueueSize(ctx context.Context) (int, error) {
-	count, _, err := scanFirstInt(s.query(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_uploads WHERE state = 'queued'`)))
+	count, _, err := scanFirstInt(s.query(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM lsif_uploads_with_repository_name WHERE state = 'queued'`)))
 	return count, err
 }
 
@@ -339,21 +345,22 @@ func (s *store) MarkErrored(ctx context.Context, id int, failureMessage string) 
 }
 
 var uploadColumnsWithNullRank = []*sqlf.Query{
-	sqlf.Sprintf("id"),
-	sqlf.Sprintf("commit"),
-	sqlf.Sprintf("root"),
-	sqlf.Sprintf("visible_at_tip"),
-	sqlf.Sprintf("uploaded_at"),
-	sqlf.Sprintf("state"),
-	sqlf.Sprintf("failure_message"),
-	sqlf.Sprintf("started_at"),
-	sqlf.Sprintf("finished_at"),
-	sqlf.Sprintf("process_after"),
-	sqlf.Sprintf("num_resets"),
-	sqlf.Sprintf("repository_id"),
-	sqlf.Sprintf("indexer"),
-	sqlf.Sprintf("num_parts"),
-	sqlf.Sprintf("uploaded_parts"),
+	sqlf.Sprintf("u.id"),
+	sqlf.Sprintf("u.commit"),
+	sqlf.Sprintf("u.root"),
+	sqlf.Sprintf("u.visible_at_tip"),
+	sqlf.Sprintf("u.uploaded_at"),
+	sqlf.Sprintf("u.state"),
+	sqlf.Sprintf("u.failure_message"),
+	sqlf.Sprintf("u.started_at"),
+	sqlf.Sprintf("u.finished_at"),
+	sqlf.Sprintf("u.process_after"),
+	sqlf.Sprintf("u.num_resets"),
+	sqlf.Sprintf("u.repository_id"),
+	sqlf.Sprintf(`u.repository_name`),
+	sqlf.Sprintf("u.indexer"),
+	sqlf.Sprintf("u.num_parts"),
+	sqlf.Sprintf("u.uploaded_parts"),
 	sqlf.Sprintf("NULL"),
 }
 
@@ -362,7 +369,14 @@ var uploadColumnsWithNullRank = []*sqlf.Query{
 // If there is no such unlocked upload, a zero-value upload and nil store will be returned along with a false
 // valued flag. This method must not be called from within a transaction.
 func (s *store) Dequeue(ctx context.Context) (Upload, Store, bool, error) {
-	upload, tx, ok, err := s.dequeueRecord(ctx, "lsif_uploads", uploadColumnsWithNullRank, sqlf.Sprintf("uploaded_at"), scanFirstUploadInterface)
+	upload, tx, ok, err := s.dequeueRecord(
+		ctx,
+		"lsif_uploads_with_repository_name",
+		"lsif_uploads",
+		uploadColumnsWithNullRank,
+		sqlf.Sprintf("uploaded_at"),
+		scanFirstUploadInterface,
+	)
 	if err != nil || !ok {
 		return Upload{}, tx, ok, err
 	}
@@ -378,7 +392,7 @@ func (s *store) Requeue(ctx context.Context, id int, after time.Time) error {
 // GetStates returns the states for the uploads with the given identifiers.
 func (s *store) GetStates(ctx context.Context, ids []int) (map[int]string, error) {
 	return scanStates(s.query(ctx, sqlf.Sprintf(`
-		SELECT id, state FROM lsif_uploads
+		SELECT id, state FROM lsif_uploads_with_repository_name
 		WHERE id IN (%s)
 	`, sqlf.Join(intsToQueries(ids), ", "))))
 }
@@ -447,7 +461,7 @@ func (s *store) ResetStalled(ctx context.Context, now time.Time) ([]int, []int, 
 			UPDATE lsif_uploads u
 			SET state = 'queued', started_at = null, num_resets = num_resets + 1
 			WHERE id = ANY(
-				SELECT id FROM lsif_uploads
+				SELECT id FROM lsif_uploads_with_repository_name
 				WHERE
 					state = 'processing' AND
 					%s - started_at > (%s * interval '1 second') AND
@@ -467,7 +481,7 @@ func (s *store) ResetStalled(ctx context.Context, now time.Time) ([]int, []int, 
 			UPDATE lsif_uploads u
 			SET state = 'errored', finished_at = clock_timestamp(), failure_message = 'failed to process'
 			WHERE id = ANY(
-				SELECT id FROM lsif_uploads
+				SELECT id FROM lsif_uploads_with_repository_name
 				WHERE
 					state = 'processing' AND
 					%s - started_at > (%s * interval '1 second') AND

--- a/enterprise/internal/codeintel/store/uploads_test.go
+++ b/enterprise/internal/codeintel/store/uploads_test.go
@@ -40,6 +40,7 @@ func TestGetUploadByID(t *testing.T) {
 		StartedAt:      &startedAt,
 		FinishedAt:     nil,
 		RepositoryID:   123,
+		RepositoryName: "n-123",
 		Indexer:        "lsif-go",
 		NumParts:       1,
 		UploadedParts:  []int{},
@@ -132,9 +133,9 @@ func TestGetUploads(t *testing.T) {
 		Upload{ID: 1, Commit: makeCommit(3331), UploadedAt: t1, Root: "sub1/", State: "queued"},
 		Upload{ID: 2, UploadedAt: t2, VisibleAtTip: true, State: "errored", FailureMessage: &failureMessage, Indexer: "lsif-tsc"},
 		Upload{ID: 3, Commit: makeCommit(3333), UploadedAt: t3, Root: "sub2/", State: "queued"},
-		Upload{ID: 4, UploadedAt: t4, State: "queued", RepositoryID: 51},
+		Upload{ID: 4, UploadedAt: t4, State: "queued", RepositoryID: 51, RepositoryName: "foo bar x"},
 		Upload{ID: 5, Commit: makeCommit(3333), UploadedAt: t5, Root: "sub1/", VisibleAtTip: true, State: "processing", Indexer: "lsif-tsc"},
-		Upload{ID: 6, UploadedAt: t6, Root: "sub2/", State: "processing"},
+		Upload{ID: 6, UploadedAt: t6, Root: "sub2/", State: "processing", RepositoryID: 52, RepositoryName: "foo bar y"},
 		Upload{ID: 7, UploadedAt: t7, Root: "sub1/", VisibleAtTip: true, Indexer: "lsif-tsc"},
 		Upload{ID: 8, UploadedAt: t8, VisibleAtTip: true, Indexer: "lsif-tsc"},
 		Upload{ID: 9, UploadedAt: t9, State: "queued"},
@@ -142,40 +143,45 @@ func TestGetUploads(t *testing.T) {
 	)
 
 	testCases := []struct {
+		repositoryID   int
 		state          string
 		term           string
 		visibleAtTip   bool
 		uploadedBefore *time.Time
 		expectedIDs    []int
 	}{
-		{expectedIDs: []int{1, 2, 3, 5, 6, 7, 8, 9, 10}},
+		{expectedIDs: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{repositoryID: 50, expectedIDs: []int{1, 2, 3, 5, 7, 8, 9, 10}},
 		{state: "completed", expectedIDs: []int{7, 8, 10}},
 		{term: "sub", expectedIDs: []int{1, 3, 5, 6, 7, 10}}, // searches root
 		{term: "003", expectedIDs: []int{1, 3, 5}},           // searches commits
 		{term: "333", expectedIDs: []int{1, 2, 3, 5}},        // searches commits and failure message
 		{term: "tsc", expectedIDs: []int{2, 5, 7, 8, 10}},    // searches indexer
+		{term: "QuEuEd", expectedIDs: []int{1, 3, 4, 9}},     // searches text status
+		{term: "bAr", expectedIDs: []int{4, 6}},              // search repo names
 		{visibleAtTip: true, expectedIDs: []int{2, 5, 7, 8}},
 		{uploadedBefore: &t5, expectedIDs: []int{6, 7, 8, 9, 10}},
 	}
 
 	for _, testCase := range testCases {
-		name := fmt.Sprintf(
-			"state=%s term=%s visibleAtTip=%v uploadedBefore=%v",
-			testCase.state,
-			testCase.term,
-			testCase.visibleAtTip,
-			printableTime{testCase.uploadedBefore},
-		)
+		for lo := 0; lo < len(testCase.expectedIDs); lo++ {
+			hi := lo + 3
+			if hi > len(testCase.expectedIDs) {
+				hi = len(testCase.expectedIDs)
+			}
 
-		t.Run(name, func(t *testing.T) {
-			for lo := 0; lo < len(testCase.expectedIDs); lo++ {
-				hi := lo + 3
-				if hi > len(testCase.expectedIDs) {
-					hi = len(testCase.expectedIDs)
-				}
+			name := fmt.Sprintf(
+				"repositoryID=%d state=%s term=%s visibleAtTip=%v offset=%d",
+				testCase.repositoryID,
+				testCase.state,
+				testCase.term,
+				testCase.visibleAtTip,
+				lo,
+			)
 
+			t.Run(name, func(t *testing.T) {
 				uploads, totalCount, err := store.GetUploads(context.Background(), GetUploadsOptions{
-					RepositoryID:   50,
+					RepositoryID:   testCase.repositoryID,
 					State:          testCase.state,
 					Term:           testCase.term,
 					VisibleAtTip:   testCase.visibleAtTip,
@@ -198,8 +204,8 @@ func TestGetUploads(t *testing.T) {
 				if diff := cmp.Diff(testCase.expectedIDs[lo:hi], ids); diff != "" {
 					t.Errorf("unexpected upload ids at offset %d (-want +got):\n%s", lo, diff)
 				}
-			}
-		})
+			})
+		}
 	}
 }
 
@@ -239,6 +245,8 @@ func TestInsertUploadUploading(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	store := testStore()
 
+	insertRepo(t, dbconn.Global, 50, "")
+
 	id, err := store.InsertUpload(context.Background(), Upload{
 		Commit:       makeCommit(1),
 		Root:         "sub/",
@@ -262,6 +270,7 @@ func TestInsertUploadUploading(t *testing.T) {
 		StartedAt:      nil,
 		FinishedAt:     nil,
 		RepositoryID:   50,
+		RepositoryName: "n-50",
 		Indexer:        "lsif-go",
 		NumParts:       3,
 		UploadedParts:  []int{},
@@ -288,6 +297,8 @@ func TestInsertUploadQueued(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	store := rawTestStore()
 
+	insertRepo(t, dbconn.Global, 50, "")
+
 	id, err := store.InsertUpload(context.Background(), Upload{
 		Commit:        makeCommit(1),
 		Root:          "sub/",
@@ -313,6 +324,7 @@ func TestInsertUploadQueued(t *testing.T) {
 		StartedAt:      nil,
 		FinishedAt:     nil,
 		RepositoryID:   50,
+		RepositoryName: "n-50",
 		Indexer:        "lsif-go",
 		NumParts:       1,
 		UploadedParts:  []int{0},


### PR DESCRIPTION
This is a re-attempt at https://github.com/sourcegraph/sourcegraph/pull/11664.

Changes:

- Add view over uploads, indexes, and dumps that add the repository name to the resulting fields and only returns those with resolvable repositories (non-deleted).
- Add state and repository name fields to searchable fields of upload/index
- Make term matching case insensitive

Closes https://github.com/sourcegraph/sourcegraph/issues/11638 and opens https://github.com/sourcegraph/sourcegraph/issues/11696.