### PR TITLE
[src-expose] Add flag for not recursively serving repos

### DIFF
--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -198,7 +198,7 @@ src-expose will default to serving ~/.sourcegraph/src-expose-repos`,
 				return &usageError{"requires zero or one arguments"}
 			}
 
-			return serveRepos(newLogger("serve: "), *globalAddr, repoDir, globalRecurse)
+			return serveRepos(newLogger("serve: "), *globalAddr, repoDir, *globalRecurse)
 		},
 	}
 
@@ -246,7 +246,7 @@ See https://github.com/sourcegraph/sourcegraph/tree/master/dev/src-expose/exampl
 
 			go func() {
 				logger := newLogger("serve: ")
-				if err := serveRepos(logger, *globalAddr, s.Destination, globalRecurse); err != nil {
+				if err := serveRepos(logger, *globalAddr, s.Destination, *globalRecurse); err != nil {
 					log.Fatal(err)
 				}
 			}()

--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -110,6 +110,7 @@ func main() {
 		globalReposDir = globalFlags.String("repos-dir", "", "src-expose's git directories. src-expose creates a git repo per directory synced. The git repo is then served to Sourcegraph. The repositories are stored and served relative to this directory. Default: ~/.sourcegraph/src-expose-repos")
 		globalConfig   = globalFlags.String("config", "", "If set will be used instead of command line arguments to specify configuration.")
 		globalAddr     = globalFlags.String("addr", ":3434", "address on which to serve (end with : for unused port)")
+		globalRecurse  = globalFlags.Bool("recurse", true, "If true, src-expose serve will recursively search for git repositories to serve. Ignored by src-expose sync.")
 	)
 
 	newLogger := func(prefix string) *log.Logger {
@@ -197,7 +198,7 @@ src-expose will default to serving ~/.sourcegraph/src-expose-repos`,
 				return &usageError{"requires zero or one arguments"}
 			}
 
-			return serveRepos(newLogger("serve: "), *globalAddr, repoDir)
+			return serveRepos(newLogger("serve: "), *globalAddr, repoDir, globalRecurse)
 		},
 	}
 
@@ -245,7 +246,7 @@ See https://github.com/sourcegraph/sourcegraph/tree/master/dev/src-expose/exampl
 
 			go func() {
 				logger := newLogger("serve: ")
-				if err := serveRepos(logger, *globalAddr, s.Destination); err != nil {
+				if err := serveRepos(logger, *globalAddr, s.Destination, globalRecurse); err != nil {
 					log.Fatal(err)
 				}
 			}()

--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -36,7 +36,7 @@ func TestReposHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			root := gitInitRepos(t, tc.repos...)
 
-			h, err := reposHandler(testLogger(t), testAddress, root)
+			h, err := reposHandler(testLogger(t), testAddress, root, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -62,7 +62,7 @@ func TestReposHandler(t *testing.T) {
 			// This is the difference to above, we point our root at the git repo
 			root = filepath.Join(root, "project-root")
 
-			h, err := reposHandler(testLogger(t), testAddress, root)
+			h, err := reposHandler(testLogger(t), testAddress, root, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,7 +169,7 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repos := configureRepos(testLogger(t), root)
+	repos := configureRepos(testLogger(t), root, true)
 	if len(repos) != 0 {
 		t.Fatalf("expected no repos, got %v", repos)
 	}


### PR DESCRIPTION
Requested by https://app.hubspot.com/contacts/2762526/company/768958891

See discussion starting at https://sourcegraph.slack.com/archives/CTJCMDCCS/p1593043754316900?thread_ts=1593010018.312200&cid=CTJCMDCCS for context

Short story: they have a lot of large monorepos, which are causing [our dockerized src-expose](https://hub.docker.com/r/sourcegraph/src-expose/tags?page=1) to fail K8s health checks in their deployment.

As far as I can tell this fix doesn't actually work 🤦  but I've never built Go CLIs before... I just get the error:

```
flag provided but not defined: -recurse
```

Can either of you help take this on? Or let me know if you believe something else is the issue here.