### PR TITLE
search: alert for possible structural search pattern

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -494,6 +494,18 @@ func alertForStructuralSearch(multiErr *multierror.Error) (newMultiErr *multierr
 	return newMultiErr, alert
 }
 
+func alertForStructuralSearchNotSet(queryString string) *searchAlert {
+	return &searchAlert{
+		title:       "No results",
+		description: "It looks like you may have meant to run a structural search, but it is not toggled.",
+		proposedQueries: []*searchQueryDescription{{
+			description: "Activate structural search",
+			query:       queryString,
+			patternType: query.SearchTypeStructural,
+		}},
+	}
+}
+
 func alertForMissingRepoRevs(patternType query.SearchType, missingRepoRevs []*search.RepositoryRevisions) *searchAlert {
 	var description string
 	if len(missingRepoRevs) == 1 {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1772,6 +1772,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		alert = newAlert // takes higher precedence
 	}
 
+	if len(results) == 0 && r.patternType != query.SearchTypeStructural {
+		log15.Info("ok", "", args.PatternInfo.Pattern)
+		if matchHoleRegexp.MatchString(r.originalQuery) {
+			log15.Info("set")
+			alert = alertForStructuralSearchNotSet(r.originalQuery)
+		}
+	}
+
 	if len(missingRepoRevs) > 0 {
 		alert = alertForMissingRepoRevs(r.patternType, missingRepoRevs)
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1773,9 +1773,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	}
 
 	if len(results) == 0 && r.patternType != query.SearchTypeStructural {
-		log15.Info("ok", "", args.PatternInfo.Pattern)
 		if matchHoleRegexp.MatchString(r.originalQuery) {
-			log15.Info("set")
 			alert = alertForStructuralSearchNotSet(r.originalQuery)
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1772,10 +1772,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		alert = newAlert // takes higher precedence
 	}
 
-	if len(results) == 0 && r.patternType != query.SearchTypeStructural {
-		if matchHoleRegexp.MatchString(r.originalQuery) {
-			alert = alertForStructuralSearchNotSet(r.originalQuery)
-		}
+	if len(results) == 0 && r.patternType != query.SearchTypeStructural && matchHoleRegexp.MatchString(r.originalQuery) {
+		alert = alertForStructuralSearchNotSet(r.originalQuery)
 	}
 
 	if len(missingRepoRevs) > 0 {

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -59,7 +59,7 @@ var tests = []test{
 	// Global simple text search.
 	{
 		Name:  `Global search, zero results`,
-		Query: `asdfalksd+jflaksjdfklas patterntype:literal`,
+		Query: `asdfalksd+jflaksjdfklas patterntype:literal -repo:sourcegraph`,
 	},
 	{
 		Name:  `Global search, double-quoted pattern, nonzero result`,
@@ -108,6 +108,10 @@ var tests = []test{
 	{
 		Name:  `Structural search quotes are interpreted literally`,
 		Query: `repo:^github\.com/rvantonderp/auth0-go-jwt-middleware$ file:^README\.md "This :[_] authenticated :[_]" patterntype:structural`,
+	},
+	{
+		Name:  `Alert to activate structural search mode`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ patterntype:literal i can't :[believe] it's not butter`,
 	},
 	// Repo search (part 2).
 	{


### PR DESCRIPTION
Resolves #11593. The alert is raised if:

- There are no results AND
- The current search mode is not structural search AND
- The query contains some hole syntax like `:[...]`

It looks like this:

<img width="922" alt="Screen Shot 2020-06-24 at 11 31 59 PM" src="https://user-images.githubusercontent.com/888624/85669368-9c1f9b00-b674-11ea-9081-0b2f3e4fc2c5.png">

Tested with integration test.
