### PR TITLE
Add CampaignSpecs & ChangesetSpecs tables, type definitions and campaigns.Store support

### DIFF
--- a/cmd/frontend/db/schema.md
+++ b/cmd/frontend/db/schema.md
@@ -21,6 +21,32 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.campaign_specs"
+```
+      Column       |           Type           |                          Modifiers                          
+-------------------+--------------------------+-------------------------------------------------------------
+ id                | bigint                   | not null default nextval('campaign_specs_id_seq'::regclass)
+ rand_id           | text                     | not null
+ raw_spec          | text                     | not null
+ spec              | jsonb                    | not null default '{}'::jsonb
+ namespace_user_id | integer                  | 
+ namespace_org_id  | integer                  | 
+ user_id           | integer                  | not null
+ created_at        | timestamp with time zone | not null default now()
+ updated_at        | timestamp with time zone | not null default now()
+Indexes:
+    "campaign_specs_pkey" PRIMARY KEY, btree (id)
+    "campaign_specs_rand_id" btree (rand_id)
+Check constraints:
+    "campaign_specs_has_1_namespace" CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))
+Foreign-key constraints:
+    "campaign_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
+Referenced by:
+    TABLE "campaigns" CONSTRAINT "campaigns_campaign_spec_id_fkey" FOREIGN KEY (campaign_spec_id) REFERENCES campaign_specs(id) DEFERRABLE
+    TABLE "changeset_specs" CONSTRAINT "changeset_specs_campaign_spec_id_fkey" FOREIGN KEY (campaign_spec_id) REFERENCES campaign_specs(id) DEFERRABLE
+
+```
+
 # Table "public.campaigns"
 ```
       Column       |           Type           |                       Modifiers                        
@@ -37,6 +63,7 @@ Foreign-key constraints:
  patch_set_id      | integer                  | 
  closed_at         | timestamp with time zone | 
  branch            | text                     | 
+ campaign_spec_id  | bigint                   | 
 Indexes:
     "campaigns_pkey" PRIMARY KEY, btree (id)
     "campaigns_changeset_ids_gin_idx" gin (changeset_ids)
@@ -49,6 +76,7 @@ Check constraints:
 Foreign-key constraints:
     "campaigns_author_id_fkey" FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     "campaigns_campaign_plan_id_fkey" FOREIGN KEY (patch_set_id) REFERENCES patch_sets(id) DEFERRABLE
+    "campaigns_campaign_spec_id_fkey" FOREIGN KEY (campaign_spec_id) REFERENCES campaign_specs(id) DEFERRABLE
     "campaigns_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     "campaigns_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 Referenced by:
@@ -106,6 +134,29 @@ Foreign-key constraints:
     "changeset_jobs_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE DEFERRABLE
     "changeset_jobs_campaign_job_id_fkey" FOREIGN KEY (patch_id) REFERENCES patches(id) ON DELETE CASCADE DEFERRABLE
     "changeset_jobs_changeset_id_fkey" FOREIGN KEY (changeset_id) REFERENCES changesets(id) ON DELETE CASCADE DEFERRABLE
+
+```
+
+# Table "public.changeset_specs"
+```
+      Column      |           Type           |                          Modifiers                           
+------------------+--------------------------+--------------------------------------------------------------
+ id               | bigint                   | not null default nextval('changeset_specs_id_seq'::regclass)
+ rand_id          | text                     | not null
+ raw_spec         | text                     | not null
+ spec             | jsonb                    | not null default '{}'::jsonb
+ campaign_spec_id | bigint                   | 
+ repo_id          | integer                  | not null
+ user_id          | integer                  | not null
+ created_at       | timestamp with time zone | not null default now()
+ updated_at       | timestamp with time zone | not null default now()
+Indexes:
+    "changeset_specs_pkey" PRIMARY KEY, btree (id)
+    "changeset_specs_rand_id" btree (rand_id)
+Foreign-key constraints:
+    "changeset_specs_campaign_spec_id_fkey" FOREIGN KEY (campaign_spec_id) REFERENCES campaign_specs(id) DEFERRABLE
+    "changeset_specs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
+    "changeset_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
 
 ```
 
@@ -753,6 +804,7 @@ Check constraints:
     "repo_sources_check" CHECK (jsonb_typeof(sources) = 'object'::text)
 Referenced by:
     TABLE "patches" CONSTRAINT "campaign_jobs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "changeset_specs" CONSTRAINT "changeset_specs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
     TABLE "changesets" CONSTRAINT "changesets_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "default_repos" CONSTRAINT "default_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "discussion_threads_target_repo" CONSTRAINT "discussion_threads_target_repo_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
@@ -991,8 +1043,10 @@ Referenced by:
     TABLE "access_tokens" CONSTRAINT "access_tokens_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     TABLE "access_tokens" CONSTRAINT "access_tokens_subject_user_id_fkey" FOREIGN KEY (subject_user_id) REFERENCES users(id)
     TABLE "patch_sets" CONSTRAINT "campaign_plans_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
+    TABLE "campaign_specs" CONSTRAINT "campaign_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
     TABLE "campaigns" CONSTRAINT "campaigns_author_id_fkey" FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "campaigns" CONSTRAINT "campaigns_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "changeset_specs" CONSTRAINT "changeset_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
     TABLE "discussion_comments" CONSTRAINT "discussion_comments_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_mail_reply_tokens" CONSTRAINT "discussion_mail_reply_tokens_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_threads" CONSTRAINT "discussion_threads_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT

--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -31,6 +31,8 @@ func TestIntegration(t *testing.T) {
 		t.Run("PatchSets_DeleteExpired", storeTest(db, testStorePatchSetsDeleteExpired))
 		t.Run("Patches", storeTest(db, testStorePatches))
 		t.Run("ChangesetJobs", storeTest(db, testStoreChangesetJobs))
+		t.Run("CampaignSpecs", storeTest(db, testStoreCampaignSpecs))
+		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
 	})
 
 	t.Run("GitHubWebhook", testGitHubWebhook(db, userID))

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -21,6 +22,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
+
+// seededRand is used to populate the RandID fields on CampaignSpec and
+// ChangesetSpec when creating them.
+var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // Store exposes methods to read and write campaigns domain models
 // from persistent storage.
@@ -384,7 +389,7 @@ func batchChangesetsQuery(fmtstr string, cs []*campaigns.Changeset) (*sqlf.Query
 	records := make([]record, 0, len(cs))
 
 	for _, c := range cs {
-		metadata, err := metadataColumn(c.Metadata)
+		metadata, err := jsonbColumn(c.Metadata)
 		if err != nil {
 			return nil, err
 		}
@@ -1120,7 +1125,7 @@ func batchChangesetEventsQuery(fmtstr string, es []*campaigns.ChangesetEvent) (*
 	records := make([]record, 0, len(es))
 
 	for _, e := range es {
-		metadata, err := metadataColumn(e.Metadata)
+		metadata, err := jsonbColumn(e.Metadata)
 		if err != nil {
 			return nil, err
 		}
@@ -2969,7 +2974,7 @@ func scanBackgroundProcessStatus(b *campaigns.BackgroundProcessStatus, s scanner
 	)
 }
 
-func metadataColumn(metadata interface{}) (msg json.RawMessage, err error) {
+func jsonbColumn(metadata interface{}) (msg json.RawMessage, err error) {
 	switch m := metadata.(type) {
 	case nil:
 		msg = json.RawMessage("{}")

--- a/enterprise/internal/campaigns/store_campaign_specs.go
+++ b/enterprise/internal/campaigns/store_campaign_specs.go
@@ -1,0 +1,288 @@
+package campaigns
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/dineshappavoo/basex"
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
+)
+
+const campaignSpecInsertCols = `
+  rand_id,
+  raw_spec,
+  spec,
+  namespace_user_id,
+  namespace_org_id,
+  user_id,
+  created_at,
+  updated_at
+`
+const campaignSpecCols = `
+  id,` + campaignSpecInsertCols
+
+// CreateCampaignSpec creates the given CampaignSpec.
+func (s *Store) CreateCampaignSpec(ctx context.Context, c *campaigns.CampaignSpec) error {
+	q, err := s.createCampaignSpecQuery(c)
+	if err != nil {
+		return err
+	}
+	err = s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
+		err = scanCampaignSpec(c, sc)
+		return c.ID, 1, err
+	})
+
+	if err, ok := err.(*pq.Error); ok {
+		fmt.Printf("q: %s,\nargs: %s\n,pq error: %#v\n", q.Query(sqlf.PostgresBindVar), q.Args(), err)
+	}
+
+	return err
+}
+
+var createCampaignSpecQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_campaign_specs.go:CreateCampaignSpec
+INSERT INTO campaign_specs (` + campaignSpecInsertCols + `)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+RETURNING` + campaignSpecCols + `;`
+
+func (s *Store) createCampaignSpecQuery(c *campaigns.CampaignSpec) (*sqlf.Query, error) {
+	spec, err := jsonbColumn(c.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = s.now()
+	}
+
+	if c.UpdatedAt.IsZero() {
+		c.UpdatedAt = c.CreatedAt
+	}
+
+	if c.RandID == "" {
+		if c.RandID, err = basex.Encode(strconv.Itoa(seededRand.Int())); err != nil {
+			return nil, errors.Wrap(err, "creating RandID failed")
+		}
+	}
+
+	return sqlf.Sprintf(
+		createCampaignSpecQueryFmtstr,
+		c.RandID,
+		c.RawSpec,
+		spec,
+		nullInt32Column(c.NamespaceUserID),
+		nullInt32Column(c.NamespaceOrgID),
+		c.UserID,
+		c.CreatedAt,
+		c.UpdatedAt,
+	), nil
+}
+
+// UpdateCampaignSpec updates the given CampaignSpec.
+func (s *Store) UpdateCampaignSpec(ctx context.Context, c *campaigns.CampaignSpec) error {
+	q, err := s.updateCampaignSpecQuery(c)
+	if err != nil {
+		return err
+	}
+
+	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
+		err = scanCampaignSpec(c, sc)
+		return c.ID, 1, err
+	})
+}
+
+var updateCampaignSpecQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_campaign_specs.go:UpdateCampaignSpec
+UPDATE campaign_specs
+SET (` + campaignSpecInsertCols + `) = (%s, %s, %s, %s, %s, %s, %s, %s)
+WHERE id = %s
+RETURNING ` + campaignSpecCols
+
+func (s *Store) updateCampaignSpecQuery(c *campaigns.CampaignSpec) (*sqlf.Query, error) {
+	spec, err := jsonbColumn(c.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	c.UpdatedAt = s.now()
+
+	return sqlf.Sprintf(
+		updateCampaignSpecQueryFmtstr,
+		c.RandID,
+		c.RawSpec,
+		spec,
+		nullInt32Column(c.NamespaceUserID),
+		nullInt32Column(c.NamespaceOrgID),
+		c.UserID,
+		c.CreatedAt,
+		c.UpdatedAt,
+		c.ID,
+	), nil
+}
+
+// DeleteCampaignSpec deletes the CampaignSpec with the given ID.
+func (s *Store) DeleteCampaignSpec(ctx context.Context, id int64) error {
+	q := sqlf.Sprintf(deleteCampaignSpecQueryFmtstr, id)
+
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return err
+	}
+	return rows.Close()
+}
+
+var deleteCampaignSpecQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_campaign_specs.go:DeleteCampaignSpec
+DELETE FROM campaign_specs WHERE id = %s
+`
+
+// CountCampaignSpecs returns the number of code mods in the database.
+func (s *Store) CountCampaignSpecs(ctx context.Context) (count int64, _ error) {
+	q := sqlf.Sprintf(countCampaignSpecsQueryFmtstr)
+	return count, s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
+		err = sc.Scan(&count)
+		return 0, count, err
+	})
+}
+
+var countCampaignSpecsQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_campaign_specs.go:CountCampaignSpecs
+SELECT COUNT(id)
+FROM campaign_specs
+`
+
+// GetCampaignSpecOpts captures the query options needed for getting a CampaignSpec
+type GetCampaignSpecOpts struct {
+	ID     int64
+	RandID string
+}
+
+// GetCampaignSpec gets a code mod matching the given options.
+func (s *Store) GetCampaignSpec(ctx context.Context, opts GetCampaignSpecOpts) (*campaigns.CampaignSpec, error) {
+	q := getCampaignSpecQuery(&opts)
+
+	var c campaigns.CampaignSpec
+	err := s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
+		return 0, 0, scanCampaignSpec(&c, sc)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if c.ID == 0 {
+		return nil, ErrNoResults
+	}
+
+	return &c, nil
+}
+
+var getCampaignSpecsQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_campaign_specs.go:GetCampaignSpec
+SELECT ` + campaignSpecCols + `
+FROM campaign_specs
+WHERE %s
+LIMIT 1
+`
+
+func getCampaignSpecQuery(opts *GetCampaignSpecOpts) *sqlf.Query {
+	var preds []*sqlf.Query
+	if opts.ID != 0 {
+		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+	}
+
+	if opts.RandID != "" {
+		preds = append(preds, sqlf.Sprintf("rand_id = %s", opts.RandID))
+	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
+	return sqlf.Sprintf(getCampaignSpecsQueryFmtstr, sqlf.Join(preds, "\n AND "))
+}
+
+// ListCampaignSpecsOpts captures the query options needed for
+// listing code mods.
+type ListCampaignSpecsOpts struct {
+	Cursor int64
+	Limit  int
+}
+
+// ListCampaignSpecs lists CampaignSpecs with the given filters.
+func (s *Store) ListCampaignSpecs(ctx context.Context, opts ListCampaignSpecsOpts) (cs []*campaigns.CampaignSpec, next int64, err error) {
+	q := listCampaignSpecsQuery(&opts)
+
+	cs = make([]*campaigns.CampaignSpec, 0, opts.Limit)
+	_, _, err = s.query(ctx, q, func(sc scanner) (last, count int64, err error) {
+		var c campaigns.CampaignSpec
+		if err = scanCampaignSpec(&c, sc); err != nil {
+			return 0, 0, err
+		}
+		cs = append(cs, &c)
+		return c.ID, 1, err
+	})
+
+	if opts.Limit != 0 && len(cs) == opts.Limit {
+		next = cs[len(cs)-1].ID
+		cs = cs[:len(cs)-1]
+	}
+
+	return cs, next, err
+}
+
+var listCampaignSpecsQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_campaign_specs.go:ListCampaignSpecs
+SELECT ` + campaignSpecCols + ` FROM campaign_specs
+WHERE %s
+ORDER BY id ASC
+LIMIT %s
+`
+
+func listCampaignSpecsQuery(opts *ListCampaignSpecsOpts) *sqlf.Query {
+	if opts.Limit == 0 {
+		opts.Limit = defaultListLimit
+	}
+	opts.Limit++
+
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("id >= %s", opts.Cursor),
+	}
+
+	return sqlf.Sprintf(
+		listCampaignSpecsQueryFmtstr,
+		sqlf.Join(preds, "\n AND "),
+		opts.Limit,
+	)
+}
+
+func scanCampaignSpec(c *campaigns.CampaignSpec, s scanner) error {
+	var spec json.RawMessage
+
+	err := s.Scan(
+		&c.ID,
+		&c.RandID,
+		&c.RawSpec,
+		&spec,
+		&dbutil.NullInt32{N: &c.NamespaceUserID},
+		&dbutil.NullInt32{N: &c.NamespaceOrgID},
+		&c.UserID,
+		&c.CreatedAt,
+		&c.UpdatedAt,
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "scanning campaign spec")
+	}
+
+	if err = json.Unmarshal(spec, &c.Spec); err != nil {
+		return errors.Wrap(err, "scanCampaignSpec: failed to unmarshal spec")
+	}
+
+	return nil
+}

--- a/enterprise/internal/campaigns/store_campaign_specs.go
+++ b/enterprise/internal/campaigns/store_campaign_specs.go
@@ -24,6 +24,8 @@ const campaignSpecInsertCols = `
   created_at,
   updated_at
 `
+const campaignSpecInsertColsFmt = `(%s, %s, %s, %s, %s, %s, %s, %s)`
+
 const campaignSpecCols = `
   id,` + campaignSpecInsertCols
 
@@ -48,7 +50,7 @@ func (s *Store) CreateCampaignSpec(ctx context.Context, c *campaigns.CampaignSpe
 var createCampaignSpecQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store_campaign_specs.go:CreateCampaignSpec
 INSERT INTO campaign_specs (` + campaignSpecInsertCols + `)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+VALUES ` + campaignSpecInsertColsFmt + `
 RETURNING` + campaignSpecCols + `;`
 
 func (s *Store) createCampaignSpecQuery(c *campaigns.CampaignSpec) (*sqlf.Query, error) {
@@ -100,7 +102,7 @@ func (s *Store) UpdateCampaignSpec(ctx context.Context, c *campaigns.CampaignSpe
 var updateCampaignSpecQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store_campaign_specs.go:UpdateCampaignSpec
 UPDATE campaign_specs
-SET (` + campaignSpecInsertCols + `) = (%s, %s, %s, %s, %s, %s, %s, %s)
+SET (` + campaignSpecInsertCols + `) = ` + campaignSpecInsertColsFmt + `
 WHERE id = %s
 RETURNING ` + campaignSpecCols
 

--- a/enterprise/internal/campaigns/store_campaign_specs_test.go
+++ b/enterprise/internal/campaigns/store_campaign_specs_test.go
@@ -1,0 +1,229 @@
+package campaigns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock clock) {
+	campaignSpecs := make([]*cmpgn.CampaignSpec, 0, 3)
+
+	t.Run("Create", func(t *testing.T) {
+		for i := 0; i < cap(campaignSpecs); i++ {
+			c := &cmpgn.CampaignSpec{
+				RawSpec: `{"name": "Foobar", "description": "My description"}`,
+				Spec: cmpgn.CampaignSpecFields{
+					Name:        "Foobar",
+					Description: "My description",
+					ChangesetTemplate: cmpgn.ChangesetTemplate{
+						Title:     "Hello there",
+						Body:      "This is the body",
+						Branch:    "my-branch",
+						Commit:    "d34db33f",
+						Published: false,
+					},
+				},
+				UserID: int32(i + 1234),
+			}
+
+			if i%2 == 0 {
+				c.NamespaceOrgID = 23
+			} else {
+				c.NamespaceUserID = c.UserID
+			}
+
+			want := c.Clone()
+			have := c
+
+			err := s.CreateCampaignSpec(ctx, have)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have.ID == 0 {
+				t.Fatal("ID should not be zero")
+			}
+
+			if have.RandID == "" {
+				t.Fatal("RandID should not be empty")
+			}
+
+			want.ID = have.ID
+			want.RandID = have.RandID
+			want.CreatedAt = clock.now()
+			want.UpdatedAt = clock.now()
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+
+			campaignSpecs = append(campaignSpecs, c)
+		}
+	})
+
+	if len(campaignSpecs) != cap(campaignSpecs) {
+		t.Fatalf("campaignSpecs is empty. creation failed")
+	}
+
+	t.Run("Count", func(t *testing.T) {
+		count, err := s.CountCampaignSpecs(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have, want := count, int64(len(campaignSpecs)); have != want {
+			t.Fatalf("have count: %d, want: %d", have, want)
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Run("NoLimit", func(t *testing.T) {
+			opts := ListCampaignSpecsOpts{}
+
+			ts, next, err := s.ListCampaignSpecs(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := next, int64(0); have != want {
+				t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+			}
+
+			have, want := ts, campaignSpecs
+			if len(have) != len(want) {
+				t.Fatalf("listed %d campaignSpecs, want: %d", len(have), len(want))
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatalf("opts: %+v, diff: %s", opts, diff)
+			}
+
+		})
+
+		t.Run("WithLimit", func(t *testing.T) {
+			for i := 1; i <= len(campaignSpecs); i++ {
+				cs, next, err := s.ListCampaignSpecs(ctx, ListCampaignSpecsOpts{Limit: i})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				{
+					have, want := next, int64(0)
+					if i < len(campaignSpecs) {
+						want = campaignSpecs[i].ID
+					}
+
+					if have != want {
+						t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+					}
+				}
+
+				{
+					have, want := cs, campaignSpecs[:i]
+					if len(have) != len(want) {
+						t.Fatalf("listed %d campaignSpecs, want: %d", len(have), len(want))
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				}
+			}
+
+		})
+
+		t.Run("WithLimitAndCursor", func(t *testing.T) {
+			var cursor int64
+			for i := 1; i <= len(campaignSpecs); i++ {
+				opts := ListCampaignSpecsOpts{Cursor: cursor, Limit: 1}
+				have, next, err := s.ListCampaignSpecs(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				want := campaignSpecs[i-1 : i]
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
+				}
+
+				cursor = next
+			}
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		for _, c := range campaignSpecs {
+			c.UserID += 1234
+
+			clock.add(1 * time.Second)
+
+			want := c
+			want.UpdatedAt = clock.now()
+
+			have := c.Clone()
+			if err := s.UpdateCampaignSpec(ctx, have); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		want := campaignSpecs[1]
+		tests := map[string]GetCampaignSpecOpts{
+			"ByID":          {ID: want.ID},
+			"ByRandID":      {RandID: want.RandID},
+			"ByIDAndRandID": {ID: want.ID, RandID: want.RandID},
+		}
+
+		for name, opts := range tests {
+			t.Run(name, func(t *testing.T) {
+				have, err := s.GetCampaignSpec(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatal(diff)
+				}
+			})
+		}
+
+		t.Run("NoResults", func(t *testing.T) {
+			opts := GetCampaignSpecOpts{ID: 0xdeadbeef}
+
+			_, have := s.GetCampaignSpec(ctx, opts)
+			want := ErrNoResults
+
+			if have != want {
+				t.Fatalf("have err %v, want %v", have, want)
+			}
+		})
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		for i := range campaignSpecs {
+			err := s.DeleteCampaignSpec(ctx, campaignSpecs[i].ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			count, err := s.CountCampaignSpecs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := count, int64(len(campaignSpecs)-(i+1)); have != want {
+				t.Fatalf("have count: %d, want: %d", have, want)
+			}
+		}
+	})
+}

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -1,0 +1,294 @@
+package campaigns
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/dineshappavoo/basex"
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
+)
+
+const changesetSpecInsertCols = `
+  rand_id,
+  raw_spec,
+  spec,
+  campaign_spec_id,
+  repo_id,
+  user_id,
+  created_at,
+  updated_at
+`
+const changesetSpecCols = `
+  id,` + changesetSpecInsertCols
+
+// CreateChangesetSpec creates the given ChangesetSpec.
+func (s *Store) CreateChangesetSpec(ctx context.Context, c *campaigns.ChangesetSpec) error {
+	q, err := s.createChangesetSpecQuery(c)
+	if err != nil {
+		return err
+	}
+	err = s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
+		err = scanChangesetSpec(c, sc)
+		return c.ID, 1, err
+	})
+
+	if err, ok := err.(*pq.Error); ok {
+		fmt.Printf("q: %s,\nargs: %s\n,pq error: %#v\n", q.Query(sqlf.PostgresBindVar), q.Args(), err)
+	}
+
+	return err
+}
+
+var createChangesetSpecQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_changeset_specs.go:CreateChangesetSpec
+INSERT INTO changeset_specs (` + changesetSpecInsertCols + `)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+RETURNING` + changesetSpecCols + `;`
+
+func (s *Store) createChangesetSpecQuery(c *campaigns.ChangesetSpec) (*sqlf.Query, error) {
+	spec, err := jsonbColumn(c.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = s.now()
+	}
+
+	if c.UpdatedAt.IsZero() {
+		c.UpdatedAt = c.CreatedAt
+	}
+
+	if c.RandID == "" {
+		if c.RandID, err = basex.Encode(strconv.Itoa(seededRand.Int())); err != nil {
+			return nil, errors.Wrap(err, "creating RandID failed")
+		}
+	}
+
+	return sqlf.Sprintf(
+		createChangesetSpecQueryFmtstr,
+		c.RandID,
+		c.RawSpec,
+		spec,
+		nullInt64Column(c.CampaignSpecID),
+		c.RepoID,
+		c.UserID,
+		c.CreatedAt,
+		c.UpdatedAt,
+	), nil
+}
+
+// UpdateChangesetSpec updates the given ChangesetSpec.
+func (s *Store) UpdateChangesetSpec(ctx context.Context, c *campaigns.ChangesetSpec) error {
+	q, err := s.updateChangesetSpecQuery(c)
+	if err != nil {
+		return err
+	}
+
+	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
+		err = scanChangesetSpec(c, sc)
+		return c.ID, 1, err
+	})
+}
+
+var updateChangesetSpecQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_changeset_specs.go:UpdateChangesetSpec
+UPDATE changeset_specs
+SET (` + changesetSpecInsertCols + `) = (%s, %s, %s, %s, %s, %s, %s, %s)
+WHERE id = %s
+RETURNING ` + changesetSpecCols
+
+func (s *Store) updateChangesetSpecQuery(c *campaigns.ChangesetSpec) (*sqlf.Query, error) {
+	spec, err := jsonbColumn(c.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	c.UpdatedAt = s.now()
+
+	return sqlf.Sprintf(
+		updateChangesetSpecQueryFmtstr,
+		c.RandID,
+		c.RawSpec,
+		spec,
+		nullInt64Column(c.CampaignSpecID),
+		c.RepoID,
+		c.UserID,
+		c.CreatedAt,
+		c.UpdatedAt,
+		c.ID,
+	), nil
+}
+
+// DeleteChangesetSpec deletes the ChangesetSpec with the given ID.
+func (s *Store) DeleteChangesetSpec(ctx context.Context, id int64) error {
+	q := sqlf.Sprintf(deleteChangesetSpecQueryFmtstr, id)
+
+	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return err
+	}
+	return rows.Close()
+}
+
+var deleteChangesetSpecQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_changeset_specs.go:DeleteChangesetSpec
+DELETE FROM changeset_specs WHERE id = %s
+`
+
+// CountChangesetSpecs returns the number of code mods in the database.
+func (s *Store) CountChangesetSpecs(ctx context.Context) (count int64, _ error) {
+	q := sqlf.Sprintf(countChangesetSpecsQueryFmtstr)
+	return count, s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
+		err = sc.Scan(&count)
+		return 0, count, err
+	})
+}
+
+var countChangesetSpecsQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_changeset_specs.go:CountChangesetSpecs
+SELECT COUNT(id)
+FROM changeset_specs
+`
+
+// GetChangesetSpecOpts captures the query options needed for getting a ChangesetSpec
+type GetChangesetSpecOpts struct {
+	ID     int64
+	RandID string
+}
+
+// GetChangesetSpec gets a code mod matching the given options.
+func (s *Store) GetChangesetSpec(ctx context.Context, opts GetChangesetSpecOpts) (*campaigns.ChangesetSpec, error) {
+	q := getChangesetSpecQuery(&opts)
+
+	var c campaigns.ChangesetSpec
+	err := s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
+		return 0, 0, scanChangesetSpec(&c, sc)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if c.ID == 0 {
+		return nil, ErrNoResults
+	}
+
+	return &c, nil
+}
+
+var getChangesetSpecsQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_changeset_specs.go:GetChangesetSpec
+SELECT ` + changesetSpecCols + `
+FROM changeset_specs
+WHERE %s
+LIMIT 1
+`
+
+func getChangesetSpecQuery(opts *GetChangesetSpecOpts) *sqlf.Query {
+	var preds []*sqlf.Query
+	if opts.ID != 0 {
+		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+	}
+
+	if opts.RandID != "" {
+		preds = append(preds, sqlf.Sprintf("rand_id = %s", opts.RandID))
+	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
+	return sqlf.Sprintf(getChangesetSpecsQueryFmtstr, sqlf.Join(preds, "\n AND "))
+}
+
+// ListChangesetSpecsOpts captures the query options needed for
+// listing code mods.
+type ListChangesetSpecsOpts struct {
+	Cursor int64
+	Limit  int
+
+	CampaignSpecID int64
+}
+
+// ListChangesetSpecs lists ChangesetSpecs with the given filters.
+func (s *Store) ListChangesetSpecs(ctx context.Context, opts ListChangesetSpecsOpts) (cs []*campaigns.ChangesetSpec, next int64, err error) {
+	q := listChangesetSpecsQuery(&opts)
+
+	cs = make([]*campaigns.ChangesetSpec, 0, opts.Limit)
+	_, _, err = s.query(ctx, q, func(sc scanner) (last, count int64, err error) {
+		var c campaigns.ChangesetSpec
+		if err = scanChangesetSpec(&c, sc); err != nil {
+			return 0, 0, err
+		}
+		cs = append(cs, &c)
+		return c.ID, 1, err
+	})
+
+	if opts.Limit != 0 && len(cs) == opts.Limit {
+		next = cs[len(cs)-1].ID
+		cs = cs[:len(cs)-1]
+	}
+
+	return cs, next, err
+}
+
+var listChangesetSpecsQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_changeset_specs.go:ListChangesetSpecs
+SELECT ` + changesetSpecCols + ` FROM changeset_specs
+WHERE %s
+ORDER BY id ASC
+LIMIT %s
+`
+
+func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
+	if opts.Limit == 0 {
+		opts.Limit = defaultListLimit
+	}
+	opts.Limit++
+
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("id >= %s", opts.Cursor),
+	}
+
+	if opts.CampaignSpecID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaign_spec_id = %d", opts.CampaignSpecID))
+	}
+
+	return sqlf.Sprintf(
+		listChangesetSpecsQueryFmtstr,
+		sqlf.Join(preds, "\n AND "),
+		opts.Limit,
+	)
+}
+
+func scanChangesetSpec(c *campaigns.ChangesetSpec, s scanner) error {
+	var spec json.RawMessage
+
+	err := s.Scan(
+		&c.ID,
+		&c.RandID,
+		&c.RawSpec,
+		&spec,
+		&dbutil.NullInt64{N: &c.CampaignSpecID},
+		&c.RepoID,
+		&c.UserID,
+		&c.CreatedAt,
+		&c.UpdatedAt,
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "scanning campaign spec")
+	}
+
+	if err = json.Unmarshal(spec, &c.Spec); err != nil {
+		return errors.Wrap(err, "scanChangesetSpec: failed to unmarshal spec")
+	}
+
+	return nil
+}

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -3,12 +3,10 @@ package campaigns
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/dineshappavoo/basex"
 	"github.com/keegancsmith/sqlf"
-	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
@@ -33,16 +31,11 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, c *campaigns.ChangesetS
 	if err != nil {
 		return err
 	}
-	err = s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
+
+	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
 		err = scanChangesetSpec(c, sc)
 		return c.ID, 1, err
 	})
-
-	if err, ok := err.(*pq.Error); ok {
-		fmt.Printf("q: %s,\nargs: %s\n,pq error: %#v\n", q.Query(sqlf.PostgresBindVar), q.Args(), err)
-	}
-
-	return err
 }
 
 var createChangesetSpecQueryFmtstr = `

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -1,0 +1,239 @@
+package campaigns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock clock) {
+	changesetSpecs := make([]*cmpgn.ChangesetSpec, 0, 3)
+
+	t.Run("Create", func(t *testing.T) {
+		for i := 0; i < cap(changesetSpecs); i++ {
+			c := &cmpgn.ChangesetSpec{
+				RawSpec: `{"repo_id": "abc", "rev": "d34db33f"}`,
+				Spec:    cmpgn.ChangesetSpecFields{},
+
+				UserID:         int32(i + 1234),
+				RepoID:         api.RepoID(i + 5678),
+				CampaignSpecID: int64(i + 910),
+			}
+
+			if i == cap(changesetSpecs)-1 {
+				c.CampaignSpecID = 0
+			}
+
+			want := c.Clone()
+			have := c
+
+			err := s.CreateChangesetSpec(ctx, have)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have.ID == 0 {
+				t.Fatal("ID should not be zero")
+			}
+
+			if have.RandID == "" {
+				t.Fatal("RandID should not be empty")
+			}
+
+			want.ID = have.ID
+			want.RandID = have.RandID
+			want.CreatedAt = clock.now()
+			want.UpdatedAt = clock.now()
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+
+			changesetSpecs = append(changesetSpecs, c)
+		}
+	})
+
+	if len(changesetSpecs) != cap(changesetSpecs) {
+		t.Fatalf("changesetSpecs is empty. creation failed")
+	}
+
+	t.Run("Count", func(t *testing.T) {
+		count, err := s.CountChangesetSpecs(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have, want := count, int64(len(changesetSpecs)); have != want {
+			t.Fatalf("have count: %d, want: %d", have, want)
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Run("NoLimit", func(t *testing.T) {
+			opts := ListChangesetSpecsOpts{}
+
+			ts, next, err := s.ListChangesetSpecs(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := next, int64(0); have != want {
+				t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+			}
+
+			have, want := ts, changesetSpecs
+			if len(have) != len(want) {
+				t.Fatalf("listed %d changesetSpecs, want: %d", len(have), len(want))
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatalf("opts: %+v, diff: %s", opts, diff)
+			}
+
+		})
+
+		t.Run("WithLimit", func(t *testing.T) {
+			for i := 1; i <= len(changesetSpecs); i++ {
+				cs, next, err := s.ListChangesetSpecs(ctx, ListChangesetSpecsOpts{Limit: i})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				{
+					have, want := next, int64(0)
+					if i < len(changesetSpecs) {
+						want = changesetSpecs[i].ID
+					}
+
+					if have != want {
+						t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+					}
+				}
+
+				{
+					have, want := cs, changesetSpecs[:i]
+					if len(have) != len(want) {
+						t.Fatalf("listed %d changesetSpecs, want: %d", len(have), len(want))
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				}
+			}
+
+		})
+
+		t.Run("WithLimitAndCursor", func(t *testing.T) {
+			var cursor int64
+			for i := 1; i <= len(changesetSpecs); i++ {
+				opts := ListChangesetSpecsOpts{Cursor: cursor, Limit: 1}
+				have, next, err := s.ListChangesetSpecs(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				want := changesetSpecs[i-1 : i]
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
+				}
+
+				cursor = next
+			}
+		})
+
+		t.Run("WithCampaignSpecID", func(t *testing.T) {
+			for _, c := range changesetSpecs {
+				if c.CampaignSpecID == 0 {
+					continue
+				}
+				opts := ListChangesetSpecsOpts{CampaignSpecID: c.CampaignSpecID}
+				have, _, err := s.ListChangesetSpecs(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				want := []*cmpgn.ChangesetSpec{c}
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
+				}
+			}
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		for _, c := range changesetSpecs {
+			c.UserID += 1234
+
+			clock.add(1 * time.Second)
+
+			want := c
+			want.UpdatedAt = clock.now()
+
+			have := c.Clone()
+			if err := s.UpdateChangesetSpec(ctx, have); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		want := changesetSpecs[1]
+		tests := map[string]GetChangesetSpecOpts{
+			"ByID":          {ID: want.ID},
+			"ByRandID":      {RandID: want.RandID},
+			"ByIDAndRandID": {ID: want.ID, RandID: want.RandID},
+		}
+
+		for name, opts := range tests {
+			t.Run(name, func(t *testing.T) {
+				have, err := s.GetChangesetSpec(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatal(diff)
+				}
+			})
+		}
+
+		t.Run("NoResults", func(t *testing.T) {
+			opts := GetChangesetSpecOpts{ID: 0xdeadbeef}
+
+			_, have := s.GetChangesetSpec(ctx, opts)
+			want := ErrNoResults
+
+			if have != want {
+				t.Fatalf("have err %v, want %v", have, want)
+			}
+		})
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		for i := range changesetSpecs {
+			err := s.DeleteChangesetSpec(ctx, changesetSpecs[i].ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			count, err := s.CountChangesetSpecs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := count, int64(len(changesetSpecs)-(i+1)); have != want {
+				t.Fatalf("have count: %d, want: %d", have, want)
+			}
+		}
+	})
+}

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -17,9 +17,8 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 	t.Run("Create", func(t *testing.T) {
 		for i := 0; i < cap(changesetSpecs); i++ {
 			c := &cmpgn.ChangesetSpec{
-				RawSpec: `{"repo_id": "abc", "rev": "d34db33f"}`,
-				Spec:    cmpgn.ChangesetSpecFields{},
-
+				RawSpec:        `{"repoID": "abc", "rev": "d34db33f"}`,
+				Spec:           cmpgn.ChangesetSpecFields{},
 				UserID:         int32(i + 1234),
 				RepoID:         api.RepoID(i + 5678),
 				CampaignSpecID: int64(i + 910),

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/dghubble/gologin v2.2.0+incompatible
 	github.com/dgraph-io/ristretto v0.0.2
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
+	github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/efritz/glock v0.0.0-20181228234553-f184d69dff2c
 	github.com/efritz/go-genlib v0.0.0-20200616012750-c21aae2e13ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUn
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.2 h1:nZSDcnkpbotzT/nEHNsO+JCKY8i1Qoki1AYOpeLRb6M=
 github.com/dhui/dktest v0.3.2/go.mod h1:l1/ib23a/CmxAe7yixtrYPc8Iy90Zy2udyaHINM5p58=
+github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663 h1:fctNkSsavbXpt8geFWZb8n+noCqS8MrOXRJ/YfdZ2dQ=
+github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663/go.mod h1:Kad2hux31v/IyD4Rf4wAwIyK48995rs3qAl9IUAhc2k=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v2.7.0+incompatible h1:neUDAlf3wX6Ml4HdqTrbcOHXtfRN0TFIwt6YFL7N9RU=

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1437,3 +1437,75 @@ func UnmarshalCampaignID(id graphql.ID) (campaignID int64, err error) {
 func unixMilliToTime(ms int64) time.Time {
 	return time.Unix(0, ms*int64(time.Millisecond))
 }
+
+// ****************************
+// TODO: NEW CAMPAIGNS WORKFLOW BELOW
+// ****************************
+
+type CampaignSpec struct {
+	ID     int64
+	RandID string
+
+	RawSpec string
+	Spec    CampaignSpecFields
+
+	NamespaceUserID int32
+	NamespaceOrgID  int32
+
+	UserID int32
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Clone returns a clone of a CampaignSpec.
+func (cs *CampaignSpec) Clone() *CampaignSpec {
+	cc := *cs
+	return &cc
+}
+
+type CampaignSpecFields struct {
+	Name              string            `json:"name"`
+	Description       string            `json:"description"`
+	ChangesetTemplate ChangesetTemplate `json:"changeset_template"`
+}
+
+type ChangesetTemplate struct {
+	Title     string `json:"title"`
+	Body      string `json:"body"`
+	Branch    string `json:"branch"`
+	Commit    string `json:"commit"`
+	Published bool   `json:"published"`
+}
+
+type CommitTemplate struct {
+	Message string `json:"message"`
+}
+
+type ChangesetSpec struct {
+	ID     int64
+	RandID string
+
+	RawSpec string
+	Spec    ChangesetSpecFields
+
+	CampaignSpecID int64
+	RepoID         api.RepoID
+	UserID         int32
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Clone returns a clone of a ChangesetSpec.
+func (cs *ChangesetSpec) Clone() *ChangesetSpec {
+	cc := *cs
+	return &cc
+}
+
+type ChangesetSpecFields struct {
+	RepoID  api.RepoID   `json:"repo_id"`
+	Rev     api.CommitID `json:"rev"`
+	BaseRef string       `json:"base_ref"`
+	Diff    string       `json:"diff"`
+}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1467,7 +1467,7 @@ func (cs *CampaignSpec) Clone() *CampaignSpec {
 type CampaignSpecFields struct {
 	Name              string            `json:"name"`
 	Description       string            `json:"description"`
-	ChangesetTemplate ChangesetTemplate `json:"changeset_template"`
+	ChangesetTemplate ChangesetTemplate `json:"changesetTemplate"`
 }
 
 type ChangesetTemplate struct {
@@ -1504,8 +1504,8 @@ func (cs *ChangesetSpec) Clone() *ChangesetSpec {
 }
 
 type ChangesetSpecFields struct {
-	RepoID  api.RepoID   `json:"repo_id"`
+	RepoID  api.RepoID   `json:"repoID"`
 	Rev     api.CommitID `json:"rev"`
-	BaseRef string       `json:"base_ref"`
+	BaseRef string       `json:"baseRef"`
 	Diff    string       `json:"diff"`
 }

--- a/migrations/1528395685_add_campaign_specs_and_changeset_specs.down.sql
+++ b/migrations/1528395685_add_campaign_specs_and_changeset_specs.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS campaigns DROP COLUMN IF EXISTS campaign_spec_id;
+
+DROP TABLE IF EXISTS changeset_specs;
+DROP TABLE IF EXISTS campaign_specs;
+
+COMMIT;

--- a/migrations/1528395685_add_campaign_specs_and_changeset_specs.up.sql
+++ b/migrations/1528395685_add_campaign_specs_and_changeset_specs.up.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+CREATE TABLE campaign_specs (
+    id bigserial NOT NULL PRIMARY KEY,
+    rand_id text NOT NULL,
+
+    raw_spec text NOT NULL,
+    spec jsonb DEFAULT '{}'::jsonb NOT NULL,
+
+    namespace_user_id integer,
+    namespace_org_id integer,
+
+    user_id integer NOT NULL,
+
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+
+    CONSTRAINT campaign_specs_has_1_namespace CHECK (((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))),
+
+    FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE
+);
+
+CREATE INDEX IF NOT EXISTS campaign_specs_rand_id ON campaign_specs(rand_id);
+
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS campaign_spec_id bigint REFERENCES campaign_specs(id) DEFERRABLE;
+
+CREATE TABLE changeset_specs (
+  id bigserial NOT NULL PRIMARY KEY,
+  rand_id text NOT NULL,
+
+  raw_spec text NOT NULL,
+  spec jsonb DEFAULT '{}'::jsonb NOT NULL,
+
+  campaign_spec_id bigint,
+  repo_id integer NOT NULL,
+
+  user_id integer NOT NULL,
+
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL,
+
+  FOREIGN KEY (campaign_spec_id) REFERENCES campaign_specs(id) DEFERRABLE,
+  FOREIGN KEY (repo_id)          REFERENCES repo(id)           DEFERRABLE,
+  FOREIGN KEY (user_id)          REFERENCES users(id)          DEFERRABLE
+);
+
+CREATE INDEX IF NOT EXISTS changeset_specs_rand_id ON changeset_specs(rand_id);
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -70,6 +70,8 @@
 // 1528395683_empty.up.sql (159B)
 // 1528395684_lsif_num_resets.down.sql (293B)
 // 1528395684_lsif_num_resets.up.sql (340B)
+// 1528395685_add_campaign_specs_and_changeset_specs.down.sql (165B)
+// 1528395685_add_campaign_specs_and_changeset_specs.up.sql (1.465kB)
 
 package migrations
 
@@ -1538,6 +1540,46 @@ func _1528395684_lsif_num_resetsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395685_add_campaign_specs_and_changeset_specsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x2b\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\xc3\x22\x1f\x5f\x5c\x90\x9a\x1c\x9f\x99\x62\xcd\xc5\x05\x56\x88\x61\x4e\x46\x62\x5e\x7a\x6a\x71\x6a\x09\x58\x61\xb1\x35\x0e\x55\xc8\xa6\x15\x5b\x73\x71\x39\xfb\xfb\xfa\x7a\x86\x58\x73\x01\x02\x00\x00\xff\xff\xb6\xb7\x40\x4c\xa5\x00\x00\x00")
+
+func _1528395685_add_campaign_specs_and_changeset_specsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395685_add_campaign_specs_and_changeset_specsDownSql,
+		"1528395685_add_campaign_specs_and_changeset_specs.down.sql",
+	)
+}
+
+func _1528395685_add_campaign_specs_and_changeset_specsDownSql() (*asset, error) {
+	bytes, err := _1528395685_add_campaign_specs_and_changeset_specsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395685_add_campaign_specs_and_changeset_specs.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc3, 0x47, 0x6d, 0x4b, 0x9e, 0x76, 0x8f, 0xf4, 0xbe, 0x88, 0xd1, 0xdf, 0xb0, 0x9f, 0xdf, 0xed, 0x23, 0x6b, 0x81, 0x5, 0x28, 0x6c, 0xfc, 0xbb, 0x7c, 0xe5, 0xdf, 0x38, 0xc2, 0x50, 0xa3, 0xea}}
+	return a, nil
+}
+
+var __1528395685_add_campaign_specs_and_changeset_specsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xa4\x93\x51\x6f\xdb\x20\x10\xc7\xdf\xfd\x29\xee\xad\x58\xca\xcb\x5e\xdb\x69\x92\x6b\x93\x0e\xd5\xc1\x13\x26\x52\xfb\x84\x68\x8c\x1c\xa6\x05\x5b\x86\x2a\xd3\xa6\x7d\xf7\x09\xea\xba\x31\x69\xb2\xae\xf5\x9b\xef\x0f\xff\xe3\xee\x7e\x77\x8d\x6f\x08\xbd\x4a\x92\x9c\xe1\x8c\x63\xe0\xd9\x75\x89\x61\x23\x77\xbd\xd4\xad\x11\xb6\x57\x1b\x0b\x28\x01\x00\xd0\x0d\x3c\xe8\xd6\xaa\x41\xcb\x1f\x40\x2b\x0e\x74\x5d\x96\xf0\x8d\x91\x55\xc6\xee\xe1\x16\xdf\x2f\xc2\xb1\x41\x9a\x46\xe8\x06\x9c\xfa\xe9\xa6\x63\x8b\x64\xd4\xf6\xc1\x32\x16\xbd\x16\xe2\xdf\x6d\x67\x1e\xa0\xc0\xcb\x6c\x5d\x72\xb8\xf8\xfd\xe7\xe2\xf2\xf2\x29\x16\x39\x19\xb9\x53\xb6\x97\x1b\x25\x1e\xad\x1a\x7c\x3e\x6d\x9c\x6a\xd5\xb0\x88\xe4\x6e\x68\x67\x6a\x90\xa3\x3b\xb1\xf9\x66\x50\xd2\xa9\x46\x48\x07\x4e\xef\x94\x75\x72\xd7\xc3\x5e\xbb\x6d\xf8\x85\x5f\x9d\x51\xd3\x1b\x4d\xb7\x47\x69\x54\xca\x63\xdf\xbc\xfb\x7e\x30\xc8\x2b\x5a\x73\x96\x11\xca\xa3\x51\x88\xad\xb4\xe2\x93\x98\xca\x83\xfc\x2b\xce\x6f\x01\x21\x74\xdc\x10\x52\x07\xcb\x14\x3e\x7f\x01\x74\xd4\x90\x67\x35\x4d\xc7\x9c\xcb\x8a\x61\x72\x43\xfd\x20\x01\x8d\x1e\x29\x30\xbc\xc4\x0c\xd3\x1c\xd7\xa1\x69\x16\xf9\x60\xe1\x83\xcc\x93\x92\xa4\x2f\xe8\x10\x5a\xe0\x3b\x20\xcb\x50\x0c\xbe\x23\x35\xaf\xe3\xd7\x3f\xb3\x51\xd1\x48\x41\xa3\xe2\xed\xb2\x92\x63\x16\x81\x68\x13\x80\xac\x28\x20\xaf\xca\xf5\x8a\x9e\x4b\x22\x9e\x30\xd5\xc6\x1d\xbe\x3d\xca\x36\x2f\xe2\x88\xfe\xad\x34\xad\xb2\xca\x1d\xe0\xff\x26\xf8\x4f\xa3\x7f\x1a\xfc\xff\xc1\xfe\x44\xa1\x21\xb5\xea\xbb\x93\x44\x9f\xc5\xfd\x63\xb0\x7f\x10\xf5\x19\x74\x71\x79\xe9\x9b\x27\xb8\x88\xad\xc6\x76\xa4\x30\x7d\x07\x56\x5e\x44\x33\xf1\x9c\xd5\xb4\x0a\xaf\x59\xbd\xec\xc4\x2b\x56\xff\x5c\x8e\x39\x67\xb3\xed\x98\x4b\x87\xeb\x91\x57\xab\x15\xe1\x57\xc9\xdf\x00\x00\x00\xff\xff\xb8\xfb\xfc\x64\xb9\x05\x00\x00")
+
+func _1528395685_add_campaign_specs_and_changeset_specsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395685_add_campaign_specs_and_changeset_specsUpSql,
+		"1528395685_add_campaign_specs_and_changeset_specs.up.sql",
+	)
+}
+
+func _1528395685_add_campaign_specs_and_changeset_specsUpSql() (*asset, error) {
+	bytes, err := _1528395685_add_campaign_specs_and_changeset_specsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395685_add_campaign_specs_and_changeset_specs.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf1, 0xe6, 0x7, 0xfa, 0x28, 0x9e, 0xb8, 0x2, 0x19, 0x4c, 0x84, 0xc, 0xb0, 0x65, 0x80, 0x8b, 0xb2, 0x4a, 0xba, 0x5a, 0x68, 0x18, 0x26, 0xd6, 0x1a, 0x31, 0x1a, 0xd6, 0x8a, 0x91, 0xdf, 0x12}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1699,6 +1741,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395683_empty.up.sql":                                                 _1528395683_emptyUpSql,
 	"1528395684_lsif_num_resets.down.sql":                                     _1528395684_lsif_num_resetsDownSql,
 	"1528395684_lsif_num_resets.up.sql":                                       _1528395684_lsif_num_resetsUpSql,
+	"1528395685_add_campaign_specs_and_changeset_specs.down.sql":              _1528395685_add_campaign_specs_and_changeset_specsDownSql,
+	"1528395685_add_campaign_specs_and_changeset_specs.up.sql":                _1528395685_add_campaign_specs_and_changeset_specsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -1815,6 +1859,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395683_empty.up.sql":                                                 {_1528395683_emptyUpSql, map[string]*bintree{}},
 	"1528395684_lsif_num_resets.down.sql":                                     {_1528395684_lsif_num_resetsDownSql, map[string]*bintree{}},
 	"1528395684_lsif_num_resets.up.sql":                                       {_1528395684_lsif_num_resetsUpSql, map[string]*bintree{}},
+	"1528395685_add_campaign_specs_and_changeset_specs.down.sql":              {_1528395685_add_campaign_specs_and_changeset_specsDownSql, map[string]*bintree{}},
+	"1528395685_add_campaign_specs_and_changeset_specs.up.sql":                {_1528395685_add_campaign_specs_and_changeset_specsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
Merge target of this PR is https://github.com/sourcegraph/sourcegraph/pull/11675, which will contain the new campaigns workflow and allows us to merge without breaking master.

This is the next step to build up the necessary CRUD pieces and adds:
- a `campaign_specs` table, a `CampaignSpec` type definition and methods in `campaigns.Store`
- same goes for `ChangesetSpec`

The schema is:

- a `campaign` can have one `campaign_spec`
- a `campaign_spec` can have many `changeset_spec`

Most notable is that `changeset_specs.campaign_spec_id` is nullable so that users can create `ChangesetSpecs` individually and then attach them to `CampaignSpecs`.

And both tables have a new `rand_id` column that contains a short, unguessable text ID that we can use as an external GraphQL node ID for both.

---

Other than that: this is just the usual boilerplate that we used before. Major difference is that I made the tests a bit cleaner and created separate files (!) which I think we should do for the other tables too. It's far easier to work with.