### PR TITLE
search: factor out symbol search code

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -215,9 +215,6 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 		if !isSymbol {
 			lines, matchCount = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
 		} else {
-			// Symbol search returns a resolver so we need to pass in some
-			// extra stuff. This is a sign that we can probably restructure
-			// resolvers to avoid this.
 			symbols = zoektFileMatchToSymbolResults(repoResolvers[repoRev.Repo.Name], inputRev, &file)
 		}
 
@@ -266,12 +263,16 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 }
 
 func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*searchSymbolResult {
+	// Symbol search returns a resolver so we need to pass in some
+	// extra stuff. This is a sign that we can probably restructure
+	// resolvers to avoid this.
 	baseURI := &gituri.URI{URL: url.URL{Scheme: "git://", Host: repo.Name(), RawQuery: "?" + url.QueryEscape(inputRev)}}
 	commit := &GitCommitResolver{
 		repoResolver: repo,
 		oid:          GitObjectID(file.Version),
 		inputRev:     &inputRev,
 	}
+	lang := strings.ToLower(file.Language)
 
 	symbols := make([]*searchSymbolResult, 0, len(file.LineMatches))
 	for _, l := range file.LineMatches {
@@ -293,7 +294,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 					Path:       file.FileName,
 					Line:       l.LineNumber,
 				},
-				lang:    strings.ToLower(file.Language),
+				lang:    lang,
 				baseURI: baseURI,
 				commit:  commit,
 			})

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -266,7 +266,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
-	baseURI := &gituri.URI{URL: url.URL{Scheme: "git://", Host: repo.Name(), RawQuery: "?" + url.QueryEscape(inputRev)}}
+	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
 	commit := &GitCommitResolver{
 		repoResolver: repo,
 		oid:          GitObjectID(file.Version),


### PR DESCRIPTION
I was trying to change this function and it was quite hard to
understand. This was mostly due to the symbol search code that was
added. This commit extracts the logic of how we create symbol resolvers
from a zoekt.FileMatch. This also makes it clearer that baseURI and the
commit resolver are only used by symbol search. We now avoid allocating
those values in the more common text search.