### PR TITLE
search: annotate leaf node ranges

### DIFF
--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -15,69 +15,81 @@ func TestParseParameterList(t *testing.T) {
 		Input      string
 		Want       string
 		WantLabels labels
+		WantRange  string
 	}{
 		{
 			Name:       "Normal field:value",
 			Input:      `file:README.md`,
 			Want:       `{"field":"file","value":"README.md","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "First char is colon",
 			Input:      `:foo`,
 			Want:       `{"value":":foo","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":4}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "Last char is colon",
 			Input:      `foo:`,
 			Want:       `{"value":"foo:","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":4}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "Match first colon",
 			Input:      `file:bar:baz`,
 			Want:       `{"field":"file","value":"bar:baz","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":12}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "No field, start with minus",
 			Input:      `-:foo`,
 			Want:       `{"value":"-:foo","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":5}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "Minus prefix on field",
 			Input:      `-file:README.md`,
 			Want:       `{"field":"file","value":"README.md","negated":true}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":15}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "Double minus prefix on field",
 			Input:      `--foo:bar`,
 			Want:       `{"value":"--foo:bar","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":9}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "Minus in the middle is not a valid field",
 			Input:      `fie-ld:bar`,
 			Want:       `{"value":"fie-ld:bar","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":10}}`,
 			WantLabels: None,
 		},
 		{
 			Name:       "Interpret escaped whitespace",
 			Input:      `a\ pattern`,
 			Want:       `{"value":"a pattern","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":10}}`,
 			WantLabels: None,
 		},
 		{
 			Input:      `"quoted"`,
 			Want:       `{"value":"quoted","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":8}}`,
 			WantLabels: Literal | Quoted,
 		},
 		{
 			Input:      `'\''`,
 			Want:       `{"value":"'","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":4}}`,
 			WantLabels: Literal | Quoted,
 		},
 	}
@@ -90,9 +102,24 @@ func TestParseParameterList(t *testing.T) {
 			}
 			resultNode := result[0]
 			got, _ := json.Marshal(resultNode)
+			// Check parsed values.
 			if diff := cmp.Diff(tt.Want, string(got)); diff != "" {
 				t.Error(diff)
 			}
+			// Check ranges.
+			switch n := resultNode.(type) {
+			case Pattern:
+				rangeStr := n.Annotation.Range.String()
+				if diff := cmp.Diff(tt.WantRange, rangeStr); diff != "" {
+					t.Error(diff)
+				}
+			case Parameter:
+				rangeStr := n.Annotation.Range.String()
+				if diff := cmp.Diff(tt.WantRange, rangeStr); diff != "" {
+					t.Error(diff)
+				}
+			}
+			// Check labels.
 			if patternNode, ok := resultNode.(Pattern); ok {
 				if diff := cmp.Diff(tt.WantLabels, patternNode.Annotation.Labels); diff != "" {
 					t.Error(diff)

--- a/internal/search/query/range.go
+++ b/internal/search/query/range.go
@@ -1,0 +1,27 @@
+package query
+
+import "encoding/json"
+
+type position struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Range struct {
+	Start position `json:"start"`
+	End   position `json:"end"`
+}
+
+// Returns a new range that assumes the string happens on one line.
+// Column positions are in the interval [start, end].
+func newRange(start int, end int) Range {
+	return Range{
+		Start: position{Line: 0, Column: start},
+		End:   position{Line: 0, Column: end},
+	}
+}
+
+func (rrange Range) String() string {
+	result, _ := json.Marshal(rrange)
+	return string(result)
+}


### PR DESCRIPTION
Adds range annotations to leaf nodes (patterns, parameters). I'll add these for expressions later (need to do a refactor for that). The goal is to expose the parse tree via GQL and ranges is a useful value to attach to the data.