### PR TITLE
Add GraphQL resolvers for CampaignSpec/ChangesetSpec

### DIFF
--- a/cmd/frontend/db/orgs.go
+++ b/cmd/frontend/db/orgs.go
@@ -23,6 +23,10 @@ func (e *OrgNotFoundError) Error() string {
 	return fmt.Sprintf("org not found: %s", e.Message)
 }
 
+func (e *OrgNotFoundError) NotFound() bool {
+	return true
+}
+
 var errOrgNameAlreadyExists = errors.New("organization name is already taken (by a user or another organization)")
 
 type orgs struct{}

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -80,6 +80,7 @@ type CampaignsResolver interface {
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
 
 	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
+	ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error)
 }
 
 type CampaignSpecResolver interface {
@@ -99,7 +100,7 @@ type CampaignSpecResolver interface {
 }
 
 type ChangesetSpecResolver interface {
-	ID() (graphql.ID, error)
+	ID() graphql.ID
 
 	// TODO: More fields, see PR
 	ExpiresAt() *DateTime
@@ -294,5 +295,9 @@ func (defaultCampaignsResolver) ChangesetByID(ctx context.Context, id graphql.ID
 }
 
 func (defaultCampaignsResolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -78,18 +78,20 @@ type CampaignsResolver interface {
 	Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error)
 	CampaignByID(ctx context.Context, id graphql.ID) (CampaignResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
+
+	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
 }
 
 type CampaignSpecResolver interface {
-	ID() (graphql.ID, error)
+	ID() graphql.ID
 
 	OriginalInput() (string, error)
 	ParsedInput() (JSONValue, error)
 	ChangesetSpecs() ([]ChangesetSpecResolver, error)
 
-	Creator() (*UserResolver, error)
+	Creator(context.Context) (*UserResolver, error)
 	CreatedAt() *DateTime
-	Namespace() (*NamespaceResolver, error)
+	Namespace(context.Context) (*NamespaceResolver, error)
 
 	ExpiresAt() *DateTime
 
@@ -288,5 +290,9 @@ func (defaultCampaignsResolver) Campaigns(ctx context.Context, args *ListCampaig
 }
 
 func (defaultCampaignsResolver) ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -407,13 +407,13 @@ func (r *NodeResolver) ToChangesetEvent() (ChangesetEventResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToChangesetSpec() (ChangesetSpecResolver, bool) {
-	n, ok := r.Node.(ChangesetSpecResolver)
+func (r *NodeResolver) ToCampaignSpec() (CampaignSpecResolver, bool) {
+	n, ok := r.Node.(CampaignSpecResolver)
 	return n, ok
 }
 
-func (r *NodeResolver) ToCampaignSpec() (CampaignSpecResolver, bool) {
-	n, ok := r.Node.(CampaignSpecResolver)
+func (r *NodeResolver) ToChangesetSpec() (ChangesetSpecResolver, bool) {
+	n, ok := r.Node.(ChangesetSpecResolver)
 	return n, ok
 }
 
@@ -547,6 +547,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return r.CampaignByID(ctx, id)
 	case "CampaignSpec":
 		return r.CampaignSpecByID(ctx, id)
+	case "ChangesetSpec":
+		return r.ChangesetSpecByID(ctx, id)
 	case "ExternalChangeset":
 		return r.ChangesetByID(ctx, id)
 	case "HiddenExternalChangeset":

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -545,6 +545,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return accessTokenByID(ctx, id)
 	case "Campaign":
 		return r.CampaignByID(ctx, id)
+	case "CampaignSpec":
+		return r.CampaignSpecByID(ctx, id)
 	case "ExternalChangeset":
 		return r.ChangesetByID(ctx, id)
 	case "HiddenExternalChangeset":

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -215,3 +215,10 @@ type CampaignSpec struct {
 	CreatedAt *graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 }
+
+type ChangesetSpec struct {
+	Typename string `json:"__typename"`
+	ID       string
+
+	ExpiresAt *graphqlbackend.DateTime
+}

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -185,3 +185,33 @@ type ChangesetCounts struct {
 	OpenChangesRequested int32
 	OpenPending          int32
 }
+
+type ChangesetTemplate struct {
+	Title     string
+	Body      string
+	Branch    string
+	Commit    string
+	Published bool
+}
+
+type CampaignSpecParsedInput struct {
+	Name              string
+	Description       string
+	ChangesetTemplate ChangesetTemplate
+}
+
+type CampaignSpec struct {
+	Typename string `json:"__typename"`
+	ID       string
+
+	OriginalInput string
+	ParsedInput   CampaignSpecParsedInput
+
+	PreviewURL string
+
+	Namespace UserOrg
+	Creator   User
+
+	CreatedAt *graphqlbackend.DateTime
+	ExpiresAt *graphqlbackend.DateTime
+}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -1,0 +1,116 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestCampaignSpecResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	userID := insertTestUser(t, dbconn.Global, "campaign-spec-by-id", false)
+
+	spec := &campaigns.CampaignSpec{
+		RawSpec: `{"name": "Foobar", "description": "My description"}`,
+		Spec: campaigns.CampaignSpecFields{
+			Name:        "Foobar",
+			Description: "My description",
+			ChangesetTemplate: campaigns.ChangesetTemplate{
+				Title:     "Hello there",
+				Body:      "This is the body",
+				Branch:    "my-branch",
+				Commit:    "d34db33f",
+				Published: false,
+			},
+		},
+		UserID:          userID,
+		NamespaceUserID: userID,
+	}
+
+	store := ee.NewStore(dbconn.Global)
+	if err := store.CreateCampaignSpec(ctx, spec); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+
+	}
+
+	apiID := string(marshalCampaignSpecRandID(spec.RandID))
+	userApiID := string(graphqlbackend.MarshalUserID(userID))
+
+	want := apitest.CampaignSpec{
+		Typename:      "CampaignSpec",
+		ID:            apiID,
+		OriginalInput: spec.RawSpec,
+		ParsedInput: apitest.CampaignSpecParsedInput{
+			Name:        spec.Spec.Name,
+			Description: spec.Spec.Description,
+			ChangesetTemplate: apitest.ChangesetTemplate{
+				Title:     spec.Spec.ChangesetTemplate.Title,
+				Body:      spec.Spec.ChangesetTemplate.Body,
+				Branch:    spec.Spec.ChangesetTemplate.Branch,
+				Commit:    spec.Spec.ChangesetTemplate.Commit,
+				Published: spec.Spec.ChangesetTemplate.Published,
+			},
+		},
+		PreviewURL: "/campaigns/new?spec=" + apiID,
+		Namespace:  apitest.UserOrg{ID: userApiID, DatabaseID: userID},
+		Creator:    apitest.User{ID: userApiID, DatabaseID: userID},
+		CreatedAt:  &graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
+		ExpiresAt:  &graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second).Add(2 * time.Hour)},
+	}
+
+	input := map[string]interface{}{"campaignSpec": apiID}
+	var response struct{ Node apitest.CampaignSpec }
+	apitest.MustExec(ctx, t, s, input, &response, queryCampaignSpecNode)
+
+	if diff := cmp.Diff(want, response.Node); diff != "" {
+		t.Fatalf("unexpected response (-want +got):\n%s", diff)
+	}
+}
+
+const queryCampaignSpecNode = `
+fragment u on User { id, databaseID, siteAdmin }
+fragment o on Org  { id, name }
+
+query($campaignSpec: ID!) {
+  node(id: $campaignSpec) {
+    __typename
+
+    ... on CampaignSpec {
+      id
+      originalInput
+      parsedInput
+
+      creator  { ...u }
+      namespace {
+        ... on User { ...u }
+        ... on Org  { ...o }
+      }
+
+      previewURL
+
+      createdAt
+      expiresAt
+    }
+  }
+}
+`

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -4,19 +4,39 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/pkg/errors"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
+
+func marshalChangesetSpecRandID(id string) graphql.ID {
+	return relay.MarshalID("ChangesetSpec", id)
+}
+
+func unmarshalChangesetSpecID(id graphql.ID) (changesetSpecRandID string, err error) {
+	err = relay.UnmarshalSpec(id, &changesetSpecRandID)
+	return
+}
 
 var _ graphqlbackend.ChangesetSpecResolver = &changesetSpecResolver{}
 
 type changesetSpecResolver struct {
+	store       *ee.Store
+	httpFactory *httpcli.Factory
+
+	changesetSpec *campaigns.ChangesetSpec
 }
 
-func (r *changesetSpecResolver) ID() (graphql.ID, error) {
-	return "", errors.New("TODO: not implemented")
+func (r *changesetSpecResolver) ID() graphql.ID {
+	// 🚨 SECURITY: This needs to be the RandID! We can't expose the
+	// sequential, guessable ID.
+	return marshalChangesetSpecRandID(r.changesetSpec.RandID)
 }
 
 func (r *changesetSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: time.Now()}
+	// TODO: This is a bogus value and needs to be implemented properly
+	expiresAt := r.changesetSpec.CreatedAt.Add(2 * time.Hour)
+	return &graphqlbackend.DateTime{Time: expiresAt}
 }

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -1,0 +1,91 @@
+package resolvers
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestChangesetSpecResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	userID := insertTestUser(t, dbconn.Global, "campaign-spec-by-id", false)
+
+	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+	repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)
+	if err := reposStore.UpsertRepos(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+
+	spec := &campaigns.ChangesetSpec{
+		ID:      0,
+		RawSpec: `{"name": "Foobar", "description": "My description"}`,
+		Spec: campaigns.ChangesetSpecFields{
+			RepoID:  graphqlbackend.MarshalRepositoryID(repo.ID),
+			Rev:     "d34db33f",
+			BaseRef: "refs/heads/master",
+			Diff:    "+-",
+		},
+		RepoID: repo.ID,
+		UserID: userID,
+	}
+
+	store := ee.NewStore(dbconn.Global)
+	if err := store.CreateChangesetSpec(ctx, spec); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+
+	}
+
+	apiID := string(marshalChangesetSpecRandID(spec.RandID))
+
+	want := apitest.ChangesetSpec{
+		Typename: "ChangesetSpec",
+		ID:       apiID,
+		ExpiresAt: &graphqlbackend.DateTime{
+			Time: spec.CreatedAt.Truncate(time.Second).Add(2 * time.Hour),
+		},
+	}
+
+	input := map[string]interface{}{"changesetSpec": apiID}
+	var response struct{ Node apitest.ChangesetSpec }
+	apitest.MustExec(ctx, t, s, input, &response, queryChangesetSpecNode)
+
+	if diff := cmp.Diff(want, response.Node); diff != "" {
+		t.Fatalf("unexpected response (-want +got):\n%s", diff)
+	}
+}
+
+const queryChangesetSpecNode = `
+query($changesetSpec: ID!) {
+  node(id: $changesetSpec) {
+    __typename
+
+    ... on ChangesetSpec {
+      id
+
+      expiresAt
+    }
+  }
+}
+`

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -119,6 +119,33 @@ func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlback
 	return &campaignResolver{store: r.store, httpFactory: r.httpFactory, Campaign: campaign}, nil
 }
 
+func (r *Resolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignSpecResolver, error) {
+	// 🚨 SECURITY: Only site admins or users when read-access is enabled may access campaign.
+	if err := allowReadAccess(ctx); err != nil {
+		return nil, err
+	}
+
+	campaignSpecRandID, err := unmarshalCampaignSpecID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if campaignSpecRandID == "" {
+		return nil, nil
+	}
+
+	opts := ee.GetCampaignSpecOpts{RandID: campaignSpecRandID}
+	campaignSpec, err := r.store.GetCampaignSpec(ctx, opts)
+	if err != nil {
+		if err == ee.ErrNoResults {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &campaignSpecResolver{store: r.store, httpFactory: r.httpFactory, campaignSpec: campaignSpec}, nil
+}
+
 func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.CreateCampaignArgs) (graphqlbackend.CampaignResolver, error) {
 	var err error
 	tr, ctx := trace.New(ctx, "Resolver.CreateCampaign", fmt.Sprintf("Namespace %s, CampaignSpec %s", args.Namespace, args.CampaignSpec))

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -792,6 +792,7 @@ func TestNullIDResilience(t *testing.T) {
 	ids := []graphql.ID{
 		campaigns.MarshalCampaignID(0),
 		marshalExternalChangesetID(0),
+		marshalCampaignSpecRandID(""),
 	}
 
 	for _, id := range ids {

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1553,7 +1553,8 @@ func (cs *ChangesetSpec) Clone() *ChangesetSpec {
 }
 
 type ChangesetSpecFields struct {
-	RepoID  api.RepoID   `json:"repoID"`
+	// TODO: Is this a api.RepoID or a graphql.ID?
+	RepoID  graphql.ID   `json:"repoID"`
 	Rev     api.CommitID `json:"rev"`
 	BaseRef string       `json:"baseRef"`
 	Diff    string       `json:"diff"`


### PR DESCRIPTION
This is the next PR to be merged into https://github.com/sourcegraph/sourcegraph/pull/11675 and adds basic resolvers for `ChangesetSpec`/`CampaignSpec`.

I'm going to add the `createChangesetSpec` and `createCampaignSpec` mutations next.