### PR TITLE
src-expose: debug log on serve if verbose

### DIFF
--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -197,7 +197,12 @@ src-expose will default to serving ~/.sourcegraph/src-expose-repos`,
 				return &usageError{"requires zero or one arguments"}
 			}
 
-			return serveRepos(newLogger("serve: "), *globalAddr, repoDir)
+			s := &Serve{
+				Addr: *globalAddr,
+				Root: repoDir,
+				Info: newLogger("serve: "),
+			}
+			return s.Start()
 		},
 	}
 
@@ -244,8 +249,12 @@ See https://github.com/sourcegraph/sourcegraph/tree/master/dev/src-expose/exampl
 			}
 
 			go func() {
-				logger := newLogger("serve: ")
-				if err := serveRepos(logger, *globalAddr, s.Destination); err != nil {
+				s := &Serve{
+					Addr: *globalAddr,
+					Root: s.Destination,
+					Info: newLogger("serve: "),
+				}
+				if err := s.Start(); err != nil {
 					log.Fatal(err)
 				}
 			}()

--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -114,7 +114,14 @@ func main() {
 
 	newLogger := func(prefix string) *log.Logger {
 		if *globalQuiet {
-			return log.New(ioutil.Discard, prefix, log.LstdFlags)
+			return log.New(ioutil.Discard, "", log.LstdFlags)
+		}
+		return log.New(os.Stderr, prefix, log.LstdFlags)
+	}
+
+	newVerbose := func(prefix string) *log.Logger {
+		if !*globalVerbose {
+			return log.New(ioutil.Discard, "", log.LstdFlags)
 		}
 		return log.New(os.Stderr, prefix, log.LstdFlags)
 	}
@@ -198,9 +205,10 @@ src-expose will default to serving ~/.sourcegraph/src-expose-repos`,
 			}
 
 			s := &Serve{
-				Addr: *globalAddr,
-				Root: repoDir,
-				Info: newLogger("serve: "),
+				Addr:  *globalAddr,
+				Root:  repoDir,
+				Info:  newLogger("serve: "),
+				Debug: newVerbose("DBUG serve: "),
 			}
 			return s.Start()
 		},
@@ -250,9 +258,10 @@ See https://github.com/sourcegraph/sourcegraph/tree/master/dev/src-expose/exampl
 
 			go func() {
 				s := &Serve{
-					Addr: *globalAddr,
-					Root: s.Destination,
-					Info: newLogger("serve: "),
+					Addr:  *globalAddr,
+					Root:  s.Destination,
+					Info:  newLogger("serve: "),
+					Debug: newVerbose("DBUG serve: "),
 				}
 				if err := s.Start(); err != nil {
 					log.Fatal(err)

--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -17,9 +17,10 @@ import (
 )
 
 type Serve struct {
-	Addr string
-	Root string
-	Info *log.Logger
+	Addr  string
+	Root  string
+	Info  *log.Logger
+	Debug *log.Logger
 }
 
 func (s *Serve) Start() error {
@@ -183,6 +184,7 @@ func (s *Serve) configureRepos() []string {
 		// will contain nil error. If it does, proceed to configure.
 		gitdir := filepath.Join(path, ".git")
 		if fi, err := os.Stat(gitdir); err != nil || !fi.IsDir() {
+			s.Debug.Print("not a repository root", path)
 			return nil
 		}
 

--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -36,7 +36,11 @@ func TestReposHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			root := gitInitRepos(t, tc.repos...)
 
-			h, err := reposHandler(testLogger(t), testAddress, root)
+			h, err := (&Serve{
+				Info: testLogger(t),
+				Addr: testAddress,
+				Root: root,
+			}).handler()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -62,7 +66,11 @@ func TestReposHandler(t *testing.T) {
 			// This is the difference to above, we point our root at the git repo
 			root = filepath.Join(root, "project-root")
 
-			h, err := reposHandler(testLogger(t), testAddress, root)
+			h, err := (&Serve{
+				Info: testLogger(t),
+				Addr: testAddress,
+				Root: root,
+			}).handler()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,7 +177,10 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repos := configureRepos(testLogger(t), root)
+	repos := (&Serve{
+		Info: testLogger(t),
+		Root: root,
+	}).configureRepos()
 	if len(repos) != 0 {
 		t.Fatalf("expected no repos, got %v", repos)
 	}

--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -19,6 +19,8 @@ import (
 
 const testAddress = "test.local:3939"
 
+var discardLogger = log.New(ioutil.Discard, "", log.LstdFlags)
+
 func TestReposHandler(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -37,9 +39,10 @@ func TestReposHandler(t *testing.T) {
 			root := gitInitRepos(t, tc.repos...)
 
 			h, err := (&Serve{
-				Info: testLogger(t),
-				Addr: testAddress,
-				Root: root,
+				Info:  testLogger(t),
+				Debug: discardLogger,
+				Addr:  testAddress,
+				Root:  root,
 			}).handler()
 			if err != nil {
 				t.Fatal(err)
@@ -67,9 +70,10 @@ func TestReposHandler(t *testing.T) {
 			root = filepath.Join(root, "project-root")
 
 			h, err := (&Serve{
-				Info: testLogger(t),
-				Addr: testAddress,
-				Root: root,
+				Info:  testLogger(t),
+				Debug: discardLogger,
+				Addr:  testAddress,
+				Root:  root,
 			}).handler()
 			if err != nil {
 				t.Fatal(err)
@@ -178,8 +182,9 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 	}
 
 	repos := (&Serve{
-		Info: testLogger(t),
-		Root: root,
+		Info:  testLogger(t),
+		Debug: discardLogger,
+		Root:  root,
 	}).configureRepos()
 	if len(repos) != 0 {
 		t.Fatalf("expected no repos, got %v", repos)


### PR DESCRIPTION
Debug logs for now contain which directories we search which are not
repository roots. This will help debug performance issues where a
customer may unintentionally be crawling a very large tree.

Done to help debug https://github.com/sourcegraph/sourcegraph/pull/11701