### PR TITLE
schema: clearer gitMaxConcurrentClones documentation

### DIFF
--- a/doc/admin/repo/update_frequency.md
+++ b/doc/admin/repo/update_frequency.md
@@ -13,7 +13,7 @@ After Sourcegraph has updated a repository's Git data, the global search index w
 If you wish to control how frequently repositories are discovered or how frequently Sourcegraph polls your code host for updates, tuning parameters are available in the site configuration:
 
 - [repoListUpdateInterval](../config/site_config.md#repoListUpdateInterval) controls how frequently we check the code host _for new repositories_ in minutes.
-- [gitMaxConcurrentClones](../config/site_config.md#gitMaxConcurrentClones) controls the maximum number of _concurrent_ cloning / pulling operations that Sourcegraph will perform.
+- [gitMaxConcurrentClones](../config/site_config.md#gitMaxConcurrentClones) controls the maximum number of _concurrent_ cloning / pulling operations per gitserver that Sourcegraph will perform.
 
 You may also choose to disable automatic Git updates entirely and instead [configure repository webhooks](webhooks.md).
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1086,7 +1086,7 @@ type SiteConfiguration struct {
 	ExternalURL string `json:"externalURL,omitempty"`
 	// GitCloneURLToRepositoryName description: JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
 	GitCloneURLToRepositoryName []*CloneURLToRepositoryName `json:"git.cloneURLToRepositoryName,omitempty"`
-	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently to update repositories.
+	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
 	// GithubClientID description: Client ID for GitHub. (DEPRECATED)
 	GithubClientID string `json:"githubClientID,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -309,7 +309,7 @@
       "hide": true
     },
     "gitMaxConcurrentClones": {
-      "description": "Maximum number of git clone processes that will be run concurrently to update repositories.",
+      "description": "Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.",
       "type": "integer",
       "default": 5,
       "group": "External services"

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -314,7 +314,7 @@ const SiteSchemaJSON = `{
       "hide": true
     },
     "gitMaxConcurrentClones": {
-      "description": "Maximum number of git clone processes that will be run concurrently to update repositories.",
+      "description": "Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.",
       "type": "integer",
       "default": 5,
       "group": "External services"


### PR DESCRIPTION
This commit makes it clearer that it is possible for len(gitservers) *
gitMaxConcurrentClones fetches to be running.

Fixes https://github.com/sourcegraph/sourcegraph/issues/11727