### PR TITLE
docs: Fix Caddy on Windows header

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -534,7 +534,7 @@ We use Caddy 2 to setup HTTPS for local development. It creates self-signed cert
 
 1. If you have completed the previous step and your browser still complains about the certificate, try restarting your browser or your local machine.
 
-### Adding Caddy certificates to Windows
+##### Adding Caddy certificates to Windows
 
 When running Caddy on WSL, you need to manually add the Caddy root certificate to the Windows certificate store using [certutil.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/certutil).
 


### PR DESCRIPTION
The header was created as a h3 when it whould be a h5
to be a section on `Caddy 2 certificate problems`.