### PR TITLE
codeintel: Add envvar to disable janitor process

### DIFF
--- a/enterprise/cmd/precise-code-intel-bundle-manager/env.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/env.go
@@ -16,6 +16,7 @@ var (
 	rawMaxUploadAge        = env.Get("PRECISE_CODE_INTEL_MAX_UPLOAD_AGE", "24h", "The maximum time an upload can sit on disk.")
 	rawMaxUploadPartAge    = env.Get("PRECISE_CODE_INTEL_MAX_UPLOAD_PART_AGE", "2h", "The maximum time an upload part file can sit on disk.")
 	rawMaxDatabasePartAge  = env.Get("PRECISE_CODE_INTEL_MAX_DATABASE_PART_AGE", "2h", "The maximum time a database part file can sit on disk.")
+	rawDisableJanitor      = env.Get("PRECISE_CODE_INTEL_DISABLE_JANITOR", "false", "Set to true to disable the janitor process during system migrations.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.
@@ -56,4 +57,14 @@ func mustParseInterval(rawValue, name string) time.Duration {
 	}
 
 	return d
+}
+
+// mustParseBool returns the boolean version of the given raw value fatally logs on failure.
+func mustParseBool(rawValue, name string) bool {
+	v, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		log.Fatalf("invalid bool %q for %s: %s", rawValue, name, err)
+	}
+
+	return v
 }


### PR DESCRIPTION
As we migrate the Cloud instance off of the current legacy PVC, we'll need to disable some reconiciliation that the precise-code-intel-bundle-manager does between Postgres and disk. This introduces a flag that can be set to disable this process for a short time.

See https://docs.google.com/document/d/1ATRCW9xUW6aEldpnm2QPCuJqRgdGxEgKU13c3KQv2mQ for notes. Disabling this process should not affect anything, but may increase disk pressure and increase the number of "unreachable" Postgres records while it's disabled. This should only really matter if it's disabled for a matter of days.