### PR TITLE
codeintel: Add context parameter to getChildren function in existence checker

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/correlate.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/correlate.go
@@ -16,7 +16,7 @@ import (
 
 // Correlate reads LSIF data from the given reader and returns a correlation state object with
 // the same data canonicalized and pruned for storage.
-func Correlate(r io.Reader, dumpID int, root string, getChildren existence.GetChildrenFunc) (*GroupedBundleData, error) {
+func Correlate(ctx context.Context, r io.Reader, dumpID int, root string, getChildren existence.GetChildrenFunc) (*GroupedBundleData, error) {
 	// Read raw upload stream and return a correlation state
 	state, err := correlateFromReader(r, root)
 	if err != nil {
@@ -27,7 +27,7 @@ func Correlate(r io.Reader, dumpID int, root string, getChildren existence.GetCh
 	canonicalize(state)
 
 	// Remove elements we don't need to store
-	if err := prune(state, root, getChildren); err != nil {
+	if err := prune(ctx, state, root, getChildren); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/prune.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/prune.go
@@ -1,6 +1,8 @@
 package correlation
 
 import (
+	"context"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/existence"
 )
@@ -9,13 +11,13 @@ import (
 // the git clone at the target commit. This is a necessary step as documents not in git will
 // not be the source of any queries (and take up unnecessary space in the converted index),
 // and may be the target of a definition or reference (and references a file we do not have).
-func prune(state *State, root string, getChildren existence.GetChildrenFunc) error {
+func prune(ctx context.Context, state *State, root string, getChildren existence.GetChildrenFunc) error {
 	paths := make([]string, 0, len(state.DocumentData))
 	for _, doc := range state.DocumentData {
 		paths = append(paths, doc.URI)
 	}
 
-	checker, err := existence.NewExistenceChecker(root, paths, getChildren)
+	checker, err := existence.NewExistenceChecker(ctx, root, paths, getChildren)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/prune_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/prune_test.go
@@ -1,6 +1,7 @@
 package correlation
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,7 +15,7 @@ func TestPrune(t *testing.T) {
 		"root/sub": {"root/sub/baz.go"},
 	}
 
-	getChildren := func(dirnames []string) (map[string][]string, error) {
+	getChildren := func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		out := map[string][]string{}
 		for _, dirname := range dirnames {
 			out[dirname] = gitContentsOracle[dirname]
@@ -41,7 +42,7 @@ func TestPrune(t *testing.T) {
 		},
 	}
 
-	if err := prune(state, "root", getChildren); err != nil {
+	if err := prune(context.Background(), state, "root", getChildren); err != nil {
 		t.Fatalf("unexpected error pruning state: %s", err)
 	}
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/existence/directory_contents.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/existence/directory_contents.go
@@ -1,6 +1,7 @@
 package existence
 
 import (
+	"context"
 	"path/filepath"
 	"sort"
 )
@@ -8,18 +9,18 @@ import (
 type StringSet map[string]struct{}
 
 // GetChildrenFunc returns a map of directory contents for a set of directory names.
-type GetChildrenFunc func(dirnames []string) (map[string][]string, error)
+type GetChildrenFunc func(ctx context.Context, dirnames []string) (map[string][]string, error)
 
 // directoryContents takes in a list of files present in an LSIF index and constructs a mapping from
 // directory  names to sets containing that directory's contents. This function calls the given
 // GetChildrenFunc a minimal number of times (and with minimal argument lengths) by pruning missing
 // subtrees from subsequent request batches. This can save a lot of work for large uncommitted subtrees
 // (e.g. node_modules).
-func directoryContents(root string, paths []string, getChildren GetChildrenFunc) (map[string]StringSet, error) {
+func directoryContents(ctx context.Context, root string, paths []string, getChildren GetChildrenFunc) (map[string]StringSet, error) {
 	contents := map[string]StringSet{}
 
 	for batch := makeInitialRequestBatch(root, paths); len(batch) > 0; batch = batch.next(contents) {
-		batchResults, err := getChildren(batch.dirnames())
+		batchResults, err := getChildren(ctx, batch.dirnames())
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/precise-code-intel-worker/internal/existence/directory_contents_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/existence/directory_contents_test.go
@@ -1,6 +1,7 @@
 package existence
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestDirectoryContents(t *testing.T) {
 	}
 
 	var requests [][]string
-	mockGetChildrenFunc := func(dirnames []string) (map[string][]string, error) {
+	mockGetChildrenFunc := func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		out := map[string][]string{}
 		for _, dirname := range dirnames {
 			out[dirname] = gitContentsOracle[dirname]
@@ -39,7 +40,7 @@ func TestDirectoryContents(t *testing.T) {
 		paths = append(paths, fmt.Sprintf("web/node_modules/%d/deeply/nested/lib/file.ts", i))
 	}
 
-	values, err := directoryContents("", paths, mockGetChildrenFunc)
+	values, err := directoryContents(context.Background(), "", paths, mockGetChildrenFunc)
 	if err != nil {
 		t.Fatalf("unexpected error getting directory contents: %s", err)
 	}
@@ -87,7 +88,7 @@ func TestDirectoryContentsWithRoot(t *testing.T) {
 	}
 
 	var requests [][]string
-	mockGetChildrenFunc := func(dirnames []string) (map[string][]string, error) {
+	mockGetChildrenFunc := func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		out := map[string][]string{}
 		for _, dirname := range dirnames {
 			out[dirname] = gitContentsOracle[dirname]
@@ -106,7 +107,7 @@ func TestDirectoryContentsWithRoot(t *testing.T) {
 		"web/shared/quux.generated.ts",
 	}
 
-	values, err := directoryContents("root", paths, mockGetChildrenFunc)
+	values, err := directoryContents(context.Background(), "root", paths, mockGetChildrenFunc)
 	if err != nil {
 		t.Fatalf("unexpected error getting directory contents: %s", err)
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/existence/existence_checker.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/existence/existence_checker.go
@@ -1,6 +1,7 @@
 package existence
 
 import (
+	"context"
 	"path/filepath"
 )
 
@@ -12,8 +13,8 @@ type ExistenceChecker struct {
 // NewExistenceChecker constructs a map of directory contents from the given set of paths and the given
 // getChildren function pointer that determines which of the given paths exist in the git clone at the
 // target commit.
-func NewExistenceChecker(root string, paths []string, getChildren GetChildrenFunc) (*ExistenceChecker, error) {
-	directoryContents, err := directoryContents(root, paths, getChildren)
+func NewExistenceChecker(ctx context.Context, root string, paths []string, getChildren GetChildrenFunc) (*ExistenceChecker, error) {
+	directoryContents, err := directoryContents(ctx, root, paths, getChildren)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/processor.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/processor.go
@@ -84,7 +84,7 @@ func (p *processor) Process(ctx context.Context, store store.Store, upload store
 		tempDir,
 		upload.ID,
 		upload.Root,
-		func(dirnames []string) (map[string][]string, error) {
+		func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 			directoryChildren, err := p.gitserverClient.DirectoryChildren(ctx, store, upload.RepositoryID, upload.Commit, dirnames)
 			if err != nil {
 				return nil, errors.Wrap(err, "gitserverClient.DirectoryChildren")
@@ -209,7 +209,7 @@ func isRepoCurrentlyCloning(ctx context.Context, repoID int, commit string) (boo
 
 // convert correlates the raw input data and commits the correlated data to disk.
 func convert(ctx context.Context, r io.Reader, tempDir string, dumpID int, root string, getChildren existence.GetChildrenFunc) ([]types.Package, []types.PackageReference, error) {
-	groupedBundleData, err := correlation.Correlate(r, dumpID, root, getChildren)
+	groupedBundleData, err := correlation.Correlate(ctx, r, dumpID, root, getChildren)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "correlation.Correlate")
 	}


### PR DESCRIPTION
We need to thread the context to gitserver requests otherwise traces will be all messed up once we add additional tracing context to the worker.