### PR TITLE
codeintel: Use correct enum value in janitor

### DIFF
--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records.go
@@ -15,13 +15,13 @@ import (
 // GetUploadsBatchSize is the maximum number of uploads to request from the database at once.
 const GetUploadsBatchSize = 100
 
-// removeProcessedRecordsWithoutBundleFile removes all upload records in the
-// processed state that do not have a corresponding bundle file on disk.
-func (j *Janitor) removeProcessedRecordsWithoutBundleFile() error {
+// removeCompletedRecordsWithoutBundleFile removes all upload records in the
+// completed state that do not have a corresponding bundle file on disk.
+func (j *Janitor) removeCompletedRecordsWithoutBundleFile() error {
 	ctx := context.Background()
 
 	ids, err := j.getUploadIDs(ctx, store.GetUploadsOptions{
-		State: "processed",
+		State: "completed",
 	})
 	if err != nil {
 		return err

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/db_records_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
+func TestRemoveCompletedRecordsWithoutBundleFile(t *testing.T) {
 	bundleDir := testRoot(t)
 
 	for _, id := range []int{1, 3, 5, 7, 9} {
@@ -33,8 +33,8 @@ func TestRemoveProcessedRecordsWithoutBundleFile(t *testing.T) {
 		metrics:   NewJanitorMetrics(metrics.TestRegisterer),
 	}
 
-	if err := j.removeProcessedRecordsWithoutBundleFile(); err != nil {
-		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
+	if err := j.removeCompletedRecordsWithoutBundleFile(); err != nil {
+		t.Fatalf("unexpected error removing completed uploads without bundle files: %s", err)
 	}
 
 	if len(mockStore.DeleteUploadByIDFunc.History()) != 5 {
@@ -69,7 +69,7 @@ func TestRemoveOldUploadingRecords(t *testing.T) {
 	}
 
 	if err := j.removeOldUploadingRecords(); err != nil {
-		t.Fatalf("unexpected error removing processed uploads without bundle files: %s", err)
+		t.Fatalf("unexpected error removing old records that have not finished uploading: %s", err)
 	}
 
 	if len(mockStore.DeleteUploadByIDFunc.History()) != 10 {

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/janitor/janitor.go
@@ -95,8 +95,8 @@ func (j *Janitor) run() error {
 		return errors.Wrap(err, "janitor.freeSpace")
 	}
 
-	if err := j.removeProcessedRecordsWithoutBundleFile(); err != nil {
-		return errors.Wrap(err, "janitor.removeProcessedRecordsWithoutBundleFile")
+	if err := j.removeCompletedRecordsWithoutBundleFile(); err != nil {
+		return errors.Wrap(err, "janitor.removeCompletedRecordsWithoutBundleFile")
 	}
 
 	if err := j.removeOldUploadingRecords(); err != nil {


### PR DESCRIPTION
Rename "processed" to "completed". Rename function where its used for consistency.