### PR TITLE
gitignore new assets in ui/assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,10 @@ yarn-error.log
 /ui/assets/vs
 /ui/assets/*.html
 /ui/assets/*.map
+/ui/assets/*.txt
 /ui/assets/extension
 /ui/.tmp
+/ui/assets/scripts/
 *.json.actual
 
 eb-bundle.zip


### PR DESCRIPTION
Since we created this gitignore file, the webpack build emits new asset filenames, and these weren't being ignored as intended.