### PR TITLE
gqltest: stop using e2e for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,6 @@ cmd/src/debug
 cmd/gitserver/debug
 cmd/indexer/debug
 
-/dev/e2e/log.html
 /.gtm/
 
 # Web

--- a/dev/gqltest/access_token_test.go
+++ b/dev/gqltest/access_token_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build gqltest
 
 package main
 

--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build gqltest
 
 package main
 
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 
 func TestExternalService(t *testing.T) {
@@ -20,7 +20,7 @@ func TestExternalService(t *testing.T) {
 		const repo = "sourcegraph/go-blame" // Tiny repo, fast to clone
 		const slug = "github.com/" + repo
 		// Set up external service
-		esID, err := client.AddExternalService(e2eutil.AddExternalServiceInput{
+		esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "e2e-test-github-repoPathPattern",
 			Config: mustMarshalJSONString(struct {

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build gqltest
 
 package main
 
@@ -12,7 +12,7 @@ import (
 	"github.com/inconshreveable/log15"
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 
 /*
@@ -20,7 +20,7 @@ import (
 			docker run --publish 7080:7080 --rm sourcegraph/server:insiders
 */
 
-var client *e2eutil.Client
+var client *gqltestutil.Client
 
 var (
 	baseURL  = flag.String("base-url", "http://127.0.0.1:7080", "The base URL of the Sourcegraph instance")
@@ -36,19 +36,19 @@ func TestMain(m *testing.M) {
 
 	*baseURL = strings.TrimSuffix(*baseURL, "/")
 
-	needsSiteInit, err := e2eutil.NeedsSiteInit(*baseURL)
+	needsSiteInit, err := gqltestutil.NeedsSiteInit(*baseURL)
 	if err != nil {
 		log.Fatal("Failed to check if site needs init: ", err)
 	}
 
 	if needsSiteInit {
-		client, err = e2eutil.SiteAdminInit(*baseURL, *email, *username, *password)
+		client, err = gqltestutil.SiteAdminInit(*baseURL, *email, *username, *password)
 		if err != nil {
 			log.Fatal("Failed to create site admin: ", err)
 		}
 		log.Println("Site admin has been created:", *username)
 	} else {
-		client, err = e2eutil.SignIn(*baseURL, *email, *password)
+		client, err = gqltestutil.SignIn(*baseURL, *email, *password)
 		if err != nil {
 			log.Fatal("Failed to sign in:", err)
 		}

--- a/dev/gqltest/organization_test.go
+++ b/dev/gqltest/organization_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build gqltest
 
 package main
 
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -138,7 +138,7 @@ func TestOrganization(t *testing.T) {
 
 		var lastOrgs []string
 		// Retry because the configuration update endpoint is eventually consistent
-		err = e2eutil.Retry(5*time.Second, func() error {
+		err = gqltestutil.Retry(5*time.Second, func() error {
 			// Create another test user (test-org-user-2) and the user should be added to
 			// the organization (e2e-test-org) automatically.
 			const testUsername2 = "test-org-user-2"
@@ -161,7 +161,7 @@ func TestOrganization(t *testing.T) {
 
 			wantOrgs := []string{testOrgName}
 			if cmp.Diff(wantOrgs, orgs) != "" {
-				return e2eutil.ErrContinueRetry
+				return gqltestutil.ErrContinueRetry
 			}
 			return nil
 		})

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build gqltest
 
 package main
 
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/internal/e2eutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 
 func TestSearch(t *testing.T) {
@@ -18,7 +18,7 @@ func TestSearch(t *testing.T) {
 	}
 
 	// Set up external service
-	esID, err := client.AddExternalService(e2eutil.AddExternalServiceInput{
+	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "e2e-test-github",
 		Config: mustMarshalJSONString(struct {
@@ -98,7 +98,7 @@ func TestSearch(t *testing.T) {
 		}
 	})
 
-	t.Run("execute search with search operators", func(t *testing.T) {
+	t.Run("execute search with search parameters", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:^github.com/sourcegraph/go-diff$ type:file file:.go -file:.md")
 		if err != nil {
 			t.Fatal(err)

--- a/internal/gqltestutil/access_token.go
+++ b/internal/gqltestutil/access_token.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"github.com/pkg/errors"

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"bytes"

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"github.com/pkg/errors"

--- a/internal/gqltestutil/helper.go
+++ b/internal/gqltestutil/helper.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"context"

--- a/internal/gqltestutil/organization.go
+++ b/internal/gqltestutil/organization.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"github.com/pkg/errors"

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"time"

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"github.com/pkg/errors"

--- a/internal/gqltestutil/settings.go
+++ b/internal/gqltestutil/settings.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	jsoniter "github.com/json-iterator/go"

--- a/internal/gqltestutil/user.go
+++ b/internal/gqltestutil/user.go
@@ -1,4 +1,4 @@
-package e2eutil
+package gqltestutil
 
 import (
 	"github.com/pkg/errors"


### PR DESCRIPTION
GraphQL-based tests are integration tests according to our handbook: https://about.sourcegraph.com/handbook/engineering/testing#integration-tests.