### PR TITLE
fix old version mentioned in docker compose docs

### DIFF
--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -61,7 +61,7 @@ Cloud specific Sourcegraph installation guides for AWS, Google Cloud and Digital
 
 ## Insiders build
 
-To test new development builds of Sourcegraph (triggered by commits to master), change the all semver tags in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) from `3.14.2` to `insiders`.
+To test new development builds of Sourcegraph (triggered by commits to master), change all `index.docker.io/sourcegraph/*` Docker image semver tags in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) to `insiders` (e.g., `index.docker.io/sourcegraph/frontend:1.2.3` to `index.docker.io/sourcegraph/frontend:1.2.3`).
 
 > WARNING: `insiders` builds may be unstable, so back up Sourcegraph's data and config beforehand.
 

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -61,7 +61,7 @@ Cloud specific Sourcegraph installation guides for AWS, Google Cloud and Digital
 
 ## Insiders build
 
-To test new development builds of Sourcegraph (triggered by commits to master), change all `index.docker.io/sourcegraph/*` Docker image semver tags in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) to `insiders` (e.g., `index.docker.io/sourcegraph/frontend:1.2.3` to `index.docker.io/sourcegraph/frontend:1.2.3`).
+To test new development builds of Sourcegraph (triggered by commits to master), change all `index.docker.io/sourcegraph/*` Docker image semver tags in [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) to `insiders` (e.g., `index.docker.io/sourcegraph/frontend:1.2.3` to `index.docker.io/sourcegraph/frontend:insiders`).
 
 > WARNING: `insiders` builds may be unstable, so back up Sourcegraph's data and config beforehand.
 


### PR DESCRIPTION
Clarifies how to use insiders builds in Docker Compose deployments.