### PR TITLE
gomod: use upstream grafana-tools/sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/gorilla/sessions v1.2.0
 	github.com/gosimple/slug v1.9.0 // indirect
 	github.com/goware/urlx v0.3.1
-	github.com/grafana-tools/sdk v0.0.0-20200610203821-a982d46f0598
+	github.com/grafana-tools/sdk v0.0.0-20200627094057-622ba1f937bb
 	github.com/graph-gophers/graphql-go v0.0.0-20200622220639-c1d9693c95a6
 	github.com/graphql-go/graphql v0.7.9
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
@@ -192,9 +192,6 @@ replace (
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0
 )
-
-// https://github.com/grafana-tools/sdk/pull/80
-replace github.com/grafana-tools/sdk => github.com/slimsag/sdk v0.0.0-20200402190125-fc52c0aed0b7
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,9 @@ github.com/gostaticanalysis/analysisutil v0.0.3 h1:iwp+5/UAyzQSFgQ4uR2sni99sJ8Eo
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/goware/urlx v0.3.1 h1:BbvKl8oiXtJAzOzMqAQ0GfIhf96fKeNEZfm9ocNSUBI=
 github.com/goware/urlx v0.3.1/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
+github.com/grafana-tools/sdk v0.0.0-20200610203821-a982d46f0598/go.mod h1:aqBqJVTJmj0MTX9cP8wuReJPte6HyttMDzSS2u8nJwo=
+github.com/grafana-tools/sdk v0.0.0-20200627094057-622ba1f937bb h1:Xu4WladfCJ4Bpg7oFeQanfKkzlyE7pHQ+2/YPBGo8ww=
+github.com/grafana-tools/sdk v0.0.0-20200627094057-622ba1f937bb/go.mod h1:aqBqJVTJmj0MTX9cP8wuReJPte6HyttMDzSS2u8nJwo=
 github.com/graphql-go/graphql v0.7.9 h1:5Va/Rt4l5g3YjwDnid3vFfn43faaQBq7rMcIZ0VnV34=
 github.com/graphql-go/graphql v0.7.9/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
 github.com/gregjones/httpcache v0.0.0-20170920190843-316c5e0ff04e/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -413,9 +413,9 @@ func (c *Container) dashboard() *sdk.Board {
 			Thresholds:  &[]string{"0.99999", "1"},
 			Type:        "string",
 			MappingType: 1,
-			ValueMaps: []sdk.ColumnStyleValueMap{
-				{Text: "false", Value: "0"},
-				{Text: "true", Value: "1"},
+			ValueMaps: []sdk.ValueMap{
+				{TextType: "false", Value: "0"},
+				{TextType: "true", Value: "1"},
 			},
 		},
 	}


### PR DESCRIPTION
We used a fork which added some fields to the SDK which were missing.
Upstream now has those fields, so we can switch back.

See https://github.com/grafana-tools/sdk/pull/93