### PR TITLE
authz: fix broken `ReposIDsWithOldestPerms` when repo is hard-deleted

### DIFF
--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1505,9 +1505,9 @@ func (s *PermsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int) (ma
 	q := sqlf.Sprintf(`
 -- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.ReposIDsWithOldestPerms
 SELECT perms.repo_id, perms.synced_at FROM repo_permissions AS perms
-WHERE perms.repo_id NOT IN
+WHERE perms.repo_id IN
 	(SELECT repo.id FROM repo
-	 WHERE repo.deleted_at IS NOT NULL)
+	 WHERE repo.deleted_at IS NULL)
 ORDER BY perms.synced_at ASC NULLS FIRST
 LIMIT %s
 `, limit)


### PR DESCRIPTION
Instead of checking if _repository is not in the list of soft-deleted_, we now check _the repository is not deleted_. 

This prevents scheduler trying to sync permissions for hard-deleted repositories. Such scenario is not usual (DB is manually modified) but noticed this is causing problems on my dev instance.

Fixes #11769