### PR TITLE
gqltest: rename e2e string literals

### DIFF
--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -22,7 +22,7 @@ func TestExternalService(t *testing.T) {
 		// Set up external service
 		esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 			Kind:        extsvc.KindGitHub,
-			DisplayName: "e2e-test-github-repoPathPattern",
+			DisplayName: "gqltest-github-repoPathPattern",
 			Config: mustMarshalJSONString(struct {
 				URL                   string   `json:"url"`
 				Token                 string   `json:"token"`

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -24,11 +24,11 @@ var client *gqltestutil.Client
 
 var (
 	baseURL  = flag.String("base-url", "http://127.0.0.1:7080", "The base URL of the Sourcegraph instance")
-	email    = flag.String("email", "e2e@sourcegraph.com", "The email of the admin user")
-	username = flag.String("username", "e2e-admin", "The username of the admin user")
+	email    = flag.String("email", "gqltest@sourcegraph.com", "The email of the admin user")
+	username = flag.String("username", "gqltest-admin", "The username of the admin user")
 	password = flag.String("password", "supersecurepassword", "The password of the admin user")
 
-	githubToken = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
+	githubToken               = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
 )
 
 func TestMain(m *testing.M) {

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -28,7 +28,7 @@ var (
 	username = flag.String("username", "gqltest-admin", "The username of the admin user")
 	password = flag.String("password", "supersecurepassword", "The password of the admin user")
 
-	githubToken               = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
+	githubToken = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
 )
 
 func TestMain(m *testing.M) {

--- a/dev/gqltest/organization_test.go
+++ b/dev/gqltest/organization_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestOrganization(t *testing.T) {
-	const testOrgName = "e2e-test-org"
+	const testOrgName = "gqltest-org"
 	orgID, err := client.CreateOrganization(testOrgName, testOrgName)
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestOrganization(t *testing.T) {
 			}
 		}
 
-		// Remove authenticate user (e2e-admin) from organization (e2e-test-org) should
+		// Remove authenticate user (gqltest-admin) from organization (gqltest-org) should
 		// no longer get cascaded settings from this organization.
 		err = client.RemoveUserFromOrganization(client.AuthenticatedUserID(), orgID)
 		if err != nil {
@@ -92,9 +92,9 @@ func TestOrganization(t *testing.T) {
 
 	// Docs: https://docs.sourcegraph.com/user/organizations
 	t.Run("auth.userOrgMap", func(t *testing.T) {
-		// Create a test user (test-org-user-1) without settings "auth.userOrgMap",
-		// the user should not be added to the organization (e2e-test-org) automatically.
-		const testUsername1 = "test-org-user-1"
+		// Create a test user (gqltest-org-user-1) without settings "auth.userOrgMap",
+		// the user should not be added to the organization (gqltest-org) automatically.
+		const testUsername1 = "gqltest-org-user-1"
 		testUserID1, err := client.CreateUser(testUsername1, testUsername1+"@sourcegraph.com")
 		if err != nil {
 			t.Fatal(err)
@@ -116,7 +116,7 @@ func TestOrganization(t *testing.T) {
 		}
 
 		// Update site configuration to set "auth.userOrgMap" which makes the new user join
-		// the organization (e2e-test-org) automatically.
+		// the organization (gqltest-org) automatically.
 		siteConfig, err := client.SiteConfiguration()
 		if err != nil {
 			t.Fatal(err)
@@ -139,9 +139,9 @@ func TestOrganization(t *testing.T) {
 		var lastOrgs []string
 		// Retry because the configuration update endpoint is eventually consistent
 		err = gqltestutil.Retry(5*time.Second, func() error {
-			// Create another test user (test-org-user-2) and the user should be added to
-			// the organization (e2e-test-org) automatically.
-			const testUsername2 = "test-org-user-2"
+			// Create another test user (gqltest-org-user-2) and the user should be added to
+			// the organization (gqltest-org) automatically.
+			const testUsername2 = "gqltest-org-user-2"
 			testUserID2, err := client.CreateUser(testUsername2, testUsername2+"@sourcegraph.com")
 			if err != nil {
 				t.Fatal(err)

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -20,7 +20,7 @@ func TestSearch(t *testing.T) {
 	// Set up external service
 	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 		Kind:        extsvc.KindGitHub,
-		DisplayName: "e2e-test-github",
+		DisplayName: "gqltest-github-search",
 		Config: mustMarshalJSONString(struct {
 			URL   string   `json:"url"`
 			Token string   `json:"token"`


### PR DESCRIPTION
Follow up of #11761, renamed string literals that contains "e2e" in test code.