### PR TITLE
search: propagate annotations for mapped parameters [1/3]

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -800,11 +800,11 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 
 	var exhausted bool
 	for {
-		scopeParameters = query.MapParameter(scopeParameters, func(field, value string, negated bool) query.Node {
+		scopeParameters = query.MapParameter(scopeParameters, func(field, value string, negated bool, annotation query.Annotation) query.Node {
 			if field == "count" {
 				value = strconv.FormatInt(int64(tryCount), 10)
 			}
-			return query.Parameter{Field: field, Value: value, Negated: negated}
+			return query.Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
 		})
 
 		result, err = r.evaluatePatternExpression(ctx, scopeParameters, operands[0])

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -20,22 +20,22 @@ func SubstituteAliases(nodes []Node) []Node {
 		"m":        FieldMessage,
 		"msg":      FieldMessage,
 	}
-	return MapParameter(nodes, func(field, value string, negated bool) Node {
+	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 		if field == "content" {
 			// The Quoted label is unset if content is specified.
-			return Pattern{Value: value, Negated: negated}
+			return Pattern{Value: value, Negated: negated, Annotation: annotation}
 		}
 		if canonical, ok := aliases[field]; ok {
 			field = canonical
 		}
-		return Parameter{Field: field, Value: value, Negated: negated}
+		return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
 	})
 }
 
 // LowercaseFieldNames performs strings.ToLower on every field name.
 func LowercaseFieldNames(nodes []Node) []Node {
-	return MapParameter(nodes, func(field, value string, negated bool) Node {
-		return Parameter{Field: strings.ToLower(field), Value: value, Negated: negated}
+	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
+		return Parameter{Field: strings.ToLower(field), Value: value, Negated: negated, Annotation: annotation}
 	})
 }
 


### PR DESCRIPTION
We do query mapping/transformation for a number of reasons. This change preserves annotations across transformations. Before this change, mapped parameters did not preserve Annotations (like ranges). This is part 1 of 3 in stack for exposing query info via GQL.