### PR TITLE
search: expose parse tree via GQL [3/3]

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -1,0 +1,101 @@
+package graphqlbackend
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+)
+
+func toJSON(node query.Node) interface{} {
+	switch n := node.(type) {
+	case query.Operator:
+		var jsons []interface{}
+		for _, o := range n.Operands {
+			jsons = append(jsons, toJSON(o))
+		}
+
+		switch n.Kind {
+		case query.And:
+			return struct {
+				And []interface{} `json:"and"`
+			}{
+				And: jsons,
+			}
+		case query.Or:
+			return struct {
+				Or []interface{} `json:"or"`
+			}{
+				Or: jsons,
+			}
+		case query.Concat:
+			// Concat should already be processed at this point, or
+			// the original query expresses something that is not
+			// supported. We just return the parse tree anyway.
+			return struct {
+				Concat []interface{} `json:"concat"`
+			}{
+				Concat: jsons,
+			}
+		}
+	case query.Parameter:
+		return struct {
+			Field   string      `json:"field"`
+			Value   string      `json:"value"`
+			Negated bool        `json:"negated"`
+			Labels  []string    `json:"labels"`
+			Range   query.Range `json:"range"`
+		}{
+			Field:   n.Field,
+			Value:   n.Value,
+			Negated: n.Negated,
+			Labels:  query.Strings(n.Annotation.Labels),
+			Range:   n.Annotation.Range,
+		}
+	case query.Pattern:
+		return struct {
+			Value   string      `json:"value"`
+			Negated bool        `json:"negated"`
+			Labels  []string    `json:"labels"`
+			Range   query.Range `json:"range"`
+		}{
+			Value:   n.Value,
+			Negated: n.Negated,
+			Labels:  query.Strings(n.Annotation.Labels),
+			Range:   n.Annotation.Range,
+		}
+	}
+	// unreachable.
+	return struct{}{}
+}
+
+func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
+	Query       string
+	PatternType string
+}) (*JSONValue, error) {
+	var searchType query.SearchType
+	switch args.PatternType {
+	case "literal":
+		searchType = query.SearchTypeLiteral
+	case "structural":
+		searchType = query.SearchTypeStructural
+	case "regexp", "regex":
+		searchType = query.SearchTypeRegex
+	default:
+		searchType = query.SearchTypeLiteral
+	}
+	q, err := query.ProcessAndOr(args.Query, searchType)
+	if err != nil {
+		return nil, err
+	}
+
+	var jsons []interface{}
+	for _, node := range q.(*query.AndOrQuery).Query {
+		jsons = append(jsons, toJSON(node))
+	}
+	json, err := json.Marshal(jsons)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONValue{Value: string(json)}, nil
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1263,6 +1263,13 @@ type Query {
     repoGroups: [RepoGroup!]!
     # (experimental) All version contexts.
     versionContexts: [VersionContext!]!
+    # (experimental) Return the parse tree of a search query.
+    parseSearchQuery(
+        # The search query (such as "repo:myrepo foo").
+        query: String = ""
+        # The parser to use for this query.
+        patternType: SearchPatternType = literal
+    ): JSONValue
     # The current site.
     site: Site!
     # Retrieve responses to surveys.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1270,6 +1270,13 @@ type Query {
     repoGroups: [RepoGroup!]!
     # (experimental) All version contexts.
     versionContexts: [VersionContext!]!
+    # (experimental) Return the parse tree of a search query.
+    parseSearchQuery(
+        # The search query (such as "repo:myrepo foo").
+        query: String = ""
+        # The parser to use for this query.
+        patternType: SearchPatternType = literal
+    ): JSONValue
     # The current site.
     site: Site!
     # Retrieve responses to surveys.


### PR DESCRIPTION
Stacked on #11773.

This PR introduces the endpoint that exposes the query parse tree via GQL for web/query input applications. It's not ready yet the way I want it, but nevertheless returns the current parse tree data of a processed query. No tests: this is an experimental endpoint and the spec isn't fixed yet.

CC @lguychard @attfarhan: let me know if the choice of capitalization in the JSON output works for you (all fields lowercase, I debated making operator names capitalized, like `AND` or `OR`, but decided against it for consistency's sake).

<details>
  <summary><b>expand for current example JSON format</b></summary>
<pre>
query {
  parseSearchQuery(
    query: "repo:foo file:bar b.*z or qux", 
    patternType: regexp
  )
}
</pre>
<pre>
[
  {
    "and": [
      {
        "field": "repo",
        "value": "foo",
        "negated": false,
        "range": {
          "start": {
            "line": 0,
            "column": 0
          },
          "end": {
            "line": 0,
            "column": 8
          }
        }
      },
      {
        "field": "file",
        "value": "bar",
        "negated": false,
        "range": {
          "start": {
            "line": 0,
            "column": 9
          },
          "end": {
            "line": 0,
            "column": 17
          }
        }
      },
      {
        "or": [
          {
            "value": "b.*z",
            "negated": false,
            "labels": [
              "HeuristicHoisted"
            ],
            "range": {
              "start": {
                "line": 0,
                "column": 18
              },
              "end": {
                "line": 0,
                "column": 23
              }
            }
          },
          {
            "value": "qux",
            "negated": false,
            "labels": [
              "HeuristicHoisted",
              "HeuristicParensAsPatterns",
              "Literal"
            ],
            "range": {
              "start": {
                "line": 0,
                "column": 26
              },
              "end": {
                "line": 0,
                "column": 29
              }
            }
          }
        ]
      }
    ]
  }
]
</pre>
</details>

---

TODOs before it's 'ready for use', I need to update the following in the internals in separate PRs:

- I remove the top-level list that encloses the query. This requires a deeper refactoring so that nodes are always rooted with an operator. The current convention allows a possibly flat list of parameters (i.e., multiple roots) for flat queries, and I'd like to change that convention.

- I need to still describe a spec of the JSON for including (1) the parse tree of the processed/transformed query (which we might produce when simplifying the query) (2) the parse tree of the raw query, and the possibly (3) alternative suggestions for the query in ambiguous cases. The endpoint currently exposes only (1).

- Improving labels for (regex operators, better labels).