### PR TITLE
repo-updater: Do not block in repoLookup for known repos

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -450,11 +450,15 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		return result, nil
 	}
 
-	var repo *repos.Repo
+	return s.remoteRepoSync(ctx, codehost, string(args.Repo))
+}
 
+func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, remoteName string) (result *protocol.RepoLookupResult, err error) {
+	result = &protocol.RepoLookupResult{}
+	var repo *repos.Repo
 	switch codehost {
 	case extsvc.GitHubDotCom:
-		nameWithOwner := strings.TrimPrefix(string(args.Repo), "github.com/")
+		nameWithOwner := strings.TrimPrefix(remoteName, "github.com/")
 		repo, err = s.GithubDotComSource.GetRepo(ctx, nameWithOwner)
 		if err != nil {
 			if github.IsNotFound(err) {
@@ -473,7 +477,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		}
 
 	case extsvc.GitLabDotCom:
-		projectWithNamespace := strings.TrimPrefix(string(args.Repo), "gitlab.com/")
+		projectWithNamespace := strings.TrimPrefix(remoteName, "gitlab.com/")
 		repo, err = s.GitLabDotComSource.GetRepo(ctx, projectWithNamespace)
 		if err != nil {
 			if gitlab.IsNotFound(err) {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -407,6 +407,12 @@ func externalServiceValidate(ctx context.Context, req *protocol.ExternalServiceS
 var mockRepoLookup func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
 
 func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (result *protocol.RepoLookupResult, err error) {
+	// Sourcegraph.com: this is on the user path, do not block for ever if codehost is being
+	// bad. Ideally block before cloudflare 504s the request (1min).
+	// Other: we only speak to our database, so response should be in a few ms.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	tr, ctx := trace.New(ctx, "repoLookup", args.String())
 	defer func() {
 		log15.Debug("repoLookup", "result", result, "error", err)

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -961,7 +961,6 @@ func TestRepoLookup(t *testing.T) {
 					Commit: "github.com/foo/bar/commit/{commit}",
 				},
 			}},
-			assert: repos.Assert.ReposEqual(githubRepository),
 		},
 		{
 			name: "not found - GitHub.com on Sourcegraph.com",
@@ -1051,7 +1050,6 @@ func TestRepoLookup(t *testing.T) {
 				},
 				ExternalRepo: gitlabRepository.ExternalRepo,
 			}},
-			assert: repos.Assert.ReposEqual(gitlabRepository),
 		},
 		{
 			name: "GithubDotcomSource on Sourcegraph.com ignores non-Github.com repos",
@@ -1078,6 +1076,7 @@ func TestRepoLookup(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			clock := clock
 			syncer := &repos.Syncer{
 				Store: store,
 				Now:   clock.Now,


### PR DESCRIPTION
If we have the entry in the DB already, we do not need to block the
repoLookup request. For example GitHub has degraded services today, and
requests for loading repositories timed out on sourcegraph.com due to
this code path. However, if we already have repo metadata we can just
return that in repoLookup. We still do what we did before, but in a
background goroutine. We still need to do it so we can detect metadata
changes (eg renames).

Best reviewed commit by commit.