### PR TITLE
Clarify add/update repository actions

### DIFF
--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -704,7 +704,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         if (!filter) {
             filter = this.state.activeFilter
         }
-        const searchParameters = new URLSearchParams()
+        const searchParameters = new URLSearchParams(this.props.location.search)
         if (query) {
             searchParameters.set(QUERY_KEY, query)
         }

--- a/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminAddExternalServicePage.tsx
@@ -1,11 +1,11 @@
 import * as H from 'history'
-import React from 'react'
-import { Observable, Subject, Subscription } from 'rxjs'
-import { catchError, map, switchMap, tap } from 'rxjs/operators'
+import React, { useEffect, useCallback, useState } from 'react'
+import { Observable, concat } from 'rxjs'
+import { catchError, map, switchMap } from 'rxjs/operators'
 import { Markdown } from '../../../shared/src/components/Markdown'
 import { gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { createAggregateError } from '../../../shared/src/util/errors'
+import { createAggregateError, ErrorLike, asError, isErrorLike } from '../../../shared/src/util/errors'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import { mutateGraphQL } from '../backend/graphql'
 import { PageTitle } from '../components/PageTitle'
@@ -14,6 +14,7 @@ import { ThemeProps } from '../../../shared/src/theme'
 import { ExternalServiceCard } from '../components/ExternalServiceCard'
 import { SiteAdminExternalServiceForm } from './SiteAdminExternalServiceForm'
 import { AddExternalServiceOptions } from './externalServices'
+import { useEventObservable } from '../../../shared/src/util/useObservable'
 
 interface Props extends ThemeProps {
     history: H.History
@@ -24,146 +25,120 @@ interface Props extends ThemeProps {
     }
 }
 
-interface State {
-    displayName: string
-    config: string
-
-    /**
-     * Holds any error returned by the remote GraphQL endpoint on failed requests.
-     */
-    error?: Error
-
-    /**
-     * True if the form is currently being submitted
-     */
-    loading: boolean
-
-    /**
-     * Holds the externalService if creation was successful but produced a warning
-     */
-    externalService?: GQL.IExternalService
-}
+const LOADING = 'loading' as const
 
 /**
  * Page for adding a single external service
  */
-export class SiteAdminAddExternalServicePage extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props)
-        this.state = {
-            loading: false,
-            displayName: props.externalService.defaultDisplayName,
-            config: props.externalService.defaultConfig,
-        }
-    }
+export const SiteAdminAddExternalServicePage: React.FunctionComponent<Props> = props => {
+    const [config, setConfig] = useState(props.externalService.defaultConfig)
+    const [displayName, setDisplayName] = useState(props.externalService.defaultDisplayName)
 
-    private submits = new Subject<GQL.IAddExternalServiceInput>()
-    private subscriptions = new Subscription()
+    useEffect(() => {
+        props.eventLogger.logViewEvent('AddExternalService')
+    }, [props.eventLogger])
 
-    public componentDidMount(): void {
-        this.props.eventLogger.logViewEvent('AddExternalService')
-        this.subscriptions.add(
-            this.submits
-                .pipe(
-                    tap(() => this.setState({ loading: true })),
+    const [nextSubmit, createdServiceOrError] = useEventObservable(
+        useCallback(
+            (
+                submits: Observable<GQL.IAddExternalServiceInput>
+            ): Observable<typeof LOADING | ErrorLike | GQL.IExternalService> =>
+                submits.pipe(
                     switchMap(input =>
-                        addExternalService(input, this.props.eventLogger).pipe(
-                            catchError(error => {
-                                console.error(error)
-                                this.setState({ error, loading: false })
-                                return []
-                            })
+                        concat(
+                            [LOADING],
+                            addExternalService(input, props.eventLogger).pipe(catchError(error => [asError(error)]))
                         )
                     )
-                )
-                .subscribe(externalService => {
-                    if (externalService.warning) {
-                        this.setState({ externalService, error: undefined, loading: false })
-                    } else {
-                        // Refresh site flags so that global site alerts
-                        // reflect the latest configuration.
-                        // eslint-disable-next-line rxjs/no-nested-subscribe, rxjs/no-ignored-subscription
-                        refreshSiteFlags().subscribe({ error: error => console.error(error) })
-                        this.setState({ loading: false })
-                        this.props.history.push('/site-admin/external-services/' + externalService.id)
-                    }
-                })
+                ),
+            [props.eventLogger]
         )
-    }
+    )
 
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
+    useEffect(() => {
+        if (createdServiceOrError && createdServiceOrError !== LOADING && !isErrorLike(createdServiceOrError)) {
+            // Refresh site flags so that global site alerts
+            // reflect the latest configuration.
+            // eslint-disable-next-line rxjs/no-nested-subscribe, rxjs/no-ignored-subscription
+            refreshSiteFlags().subscribe({ error: error => console.error(error) })
+            props.history.push('/site-admin/repositories?repositoriesUpdated')
+        }
+    }, [createdServiceOrError, props.history])
 
-    public render(): JSX.Element | null {
-        const createdExternalService = this.state.externalService
-        return (
-            <div className="add-external-service-page mt-3">
-                <PageTitle title="Add repositories" />
-                <h2>Add repositories</h2>
-                {createdExternalService?.warning ? (
-                    <div>
-                        <div className="mb-3">
-                            <ExternalServiceCard
-                                {...this.props.externalService}
-                                title={createdExternalService.displayName}
-                                shortDescription="Update this external service configuration to manage repository mirroring."
-                                to={`/site-admin/external-services/${createdExternalService.id}`}
-                            />
-                        </div>
-                        <div className="alert alert-warning">
-                            <h4>Warning</h4>
-                            <Markdown
-                                dangerousInnerHTML={renderMarkdown(createdExternalService.warning)}
-                                history={this.props.history}
-                            />
-                        </div>
-                    </div>
-                ) : (
-                    <div>
-                        <div className="mb-3">
-                            <ExternalServiceCard {...this.props.externalService} />
-                        </div>
-                        <h3>Instructions:</h3>
-                        <div className="mb-4">{this.props.externalService.instructions}</div>
-                        <SiteAdminExternalServiceForm
-                            {...this.props}
-                            error={this.state.error}
-                            input={this.getExternalServiceInput()}
-                            editorActions={this.props.externalService.editorActions}
-                            jsonSchema={this.props.externalService.jsonSchema}
-                            mode="create"
-                            onSubmit={this.onSubmit}
-                            onChange={this.onChange}
-                            loading={this.state.loading}
+    const getExternalServiceInput = useCallback(
+        (): GQL.IAddExternalServiceInput => ({
+            displayName,
+            config,
+            kind: props.externalService.kind,
+        }),
+        [displayName, config, props.externalService.kind]
+    )
+
+    const onChange = useCallback(
+        (input: GQL.IAddExternalServiceInput): void => {
+            setDisplayName(input.displayName)
+            setConfig(input.config)
+        },
+        [setDisplayName, setConfig]
+    )
+
+    const onSubmit = useCallback(
+        (event?: React.FormEvent<HTMLFormElement>): void => {
+            if (event) {
+                event.preventDefault()
+            }
+            nextSubmit(getExternalServiceInput())
+        },
+        [nextSubmit, getExternalServiceInput]
+    )
+
+    return (
+        <div className="add-external-service-page mt-3">
+            <PageTitle title="Add repositories" />
+            <h2>Add repositories</h2>
+            {createdServiceOrError &&
+            createdServiceOrError !== LOADING &&
+            !isErrorLike(createdServiceOrError) &&
+            createdServiceOrError.warning ? (
+                <div>
+                    <div className="mb-3">
+                        <ExternalServiceCard
+                            {...props.externalService}
+                            title={createdServiceOrError.displayName}
+                            shortDescription="Update this external service configuration to manage repository mirroring."
+                            to={`/site-admin/external-services/${createdServiceOrError.id}`}
                         />
                     </div>
-                )}
-            </div>
-        )
-    }
-
-    private getExternalServiceInput(): GQL.IAddExternalServiceInput {
-        return {
-            displayName: this.state.displayName,
-            config: this.state.config,
-            kind: this.props.externalService.kind,
-        }
-    }
-
-    private onChange = (input: GQL.IAddExternalServiceInput): void => {
-        this.setState({
-            displayName: input.displayName,
-            config: input.config,
-        })
-    }
-
-    private onSubmit = (event?: React.FormEvent<HTMLFormElement>): void => {
-        if (event) {
-            event.preventDefault()
-        }
-        this.submits.next(this.getExternalServiceInput())
-    }
+                    <div className="alert alert-warning">
+                        <h4>Warning</h4>
+                        <Markdown
+                            dangerousInnerHTML={renderMarkdown(createdServiceOrError.warning)}
+                            history={props.history}
+                        />
+                    </div>
+                </div>
+            ) : (
+                <div>
+                    <div className="mb-3">
+                        <ExternalServiceCard {...props.externalService} />
+                    </div>
+                    <h3>Instructions:</h3>
+                    <div className="mb-4">{props.externalService.instructions}</div>
+                    <SiteAdminExternalServiceForm
+                        {...props}
+                        error={isErrorLike(createdServiceOrError) ? createdServiceOrError : undefined}
+                        input={getExternalServiceInput()}
+                        editorActions={props.externalService.editorActions}
+                        jsonSchema={props.externalService.jsonSchema}
+                        mode="create"
+                        onSubmit={onSubmit}
+                        onChange={onChange}
+                        loading={createdServiceOrError === LOADING}
+                    />
+                </div>
+            )}
+        </div>
+    )
 }
 
 export function addExternalService(

--- a/web/src/site-admin/SiteAdminExternalServiceForm.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.tsx
@@ -13,7 +13,7 @@ interface Props extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorAc
     input: GQL.IAddExternalServiceInput
     isLightTheme: boolean
     error?: ErrorLike
-    warning?: string
+    warning?: string | null
     mode: 'edit' | 'create'
     loading: boolean
     hideDisplayNameField?: boolean

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -1,9 +1,9 @@
 import { parse as parseJSONC } from '@sqs/jsonc-parser'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as React from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { RouteComponentProps } from 'react-router'
-import { concat, Observable, of, Subject, Subscription } from 'rxjs'
-import { catchError, delay, distinctUntilChanged, map, mergeMap, startWith, switchMap } from 'rxjs/operators'
+import { concat, Observable } from 'rxjs'
+import { catchError, map, startWith, switchMap } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
@@ -17,6 +17,7 @@ import { defaultExternalServices, codeHostExternalServices } from './externalSer
 import { hasProperty } from '../../../shared/src/util/types'
 import * as H from 'history'
 import { CopyableText } from '../components/CopyableText'
+import { useEventObservable } from '../../../shared/src/util/useObservable'
 
 type ExternalService = Pick<GQL.IExternalService, 'id' | 'kind' | 'displayName' | 'config' | 'warning' | 'webhookURL'>
 
@@ -27,246 +28,201 @@ interface Props extends RouteComponentProps<{ id: GQL.ID }> {
 
 const LOADING = 'loading' as const
 
-interface State {
-    externalServiceOrError: typeof LOADING | ExternalService | ErrorLike
-
-    /**
-     * The result of updating the external service: null when complete or not started yet,
-     * loading, or an error.
-     */
-    updatedOrError: null | true | typeof LOADING | ErrorLike
-
-    warning?: string
-}
-
-export class SiteAdminExternalServicePage extends React.Component<Props, State> {
-    public state: State = {
-        externalServiceOrError: LOADING,
-        updatedOrError: null,
-    }
-
-    private componentUpdates = new Subject<Props>()
-    private submits = new Subject<GQL.IUpdateExternalServiceInput>()
-    private subscriptions = new Subscription()
-
-    public componentDidMount(): void {
+export const SiteAdminExternalServicePage: React.FunctionComponent<Props> = props => {
+    useEffect(() => {
         eventLogger.logViewEvent('SiteAdminExternalService')
+    })
 
-        this.subscriptions.add(
-            this.componentUpdates
-                .pipe(
-                    map(props => props.match.params.id),
-                    distinctUntilChanged(),
-                    switchMap(id =>
-                        fetchExternalService(id).pipe(
-                            startWith(LOADING),
-                            catchError(error => [asError(error)])
-                        )
-                    ),
-                    map(result => ({ externalServiceOrError: result }))
-                )
-                .subscribe(stateUpdate => this.setState(stateUpdate))
-        )
+    const [externalServiceOrError, setExternalServiceOrError] = useState<typeof LOADING | ExternalService | ErrorLike>(
+        LOADING
+    )
 
-        this.subscriptions.add(
-            this.submits
-                .pipe(
+    useEffect(() => {
+        const subscription = fetchExternalService(props.match.params.id)
+            .pipe(
+                startWith(LOADING),
+                catchError(error => [asError(error)])
+            )
+            .subscribe(result => {
+                setExternalServiceOrError(result)
+            })
+        return () => subscription.unsubscribe()
+    }, [props.match.params.id])
+
+    const onChange = useCallback(
+        (input: GQL.IAddExternalServiceInput) => {
+            if (isExternalService(externalServiceOrError)) {
+                setExternalServiceOrError({ ...externalServiceOrError, ...input })
+            }
+        },
+        [externalServiceOrError, setExternalServiceOrError]
+    )
+
+    const [nextSubmit, updatedServiceOrError] = useEventObservable(
+        useCallback(
+            (submits: Observable<GQL.IExternalService>): Observable<typeof LOADING | ErrorLike | ExternalService> =>
+                submits.pipe(
                     switchMap(input =>
                         concat(
-                            [{ updatedOrError: LOADING, warning: null }],
-                            updateExternalService(input).pipe(
-                                mergeMap(service =>
-                                    service.warning
-                                        ? of({
-                                              warning: service.warning,
-                                              externalServiceOrError: service,
-                                              updatedOrError: null,
-                                          })
-                                        : concat(
-                                              // Flash "updated" text
-                                              of({ updatedOrError: true, externalServiceOrError: service }),
-                                              // Hide "updated" text again after 1s
-                                              of({ updatedOrError: null }).pipe(delay(1000))
-                                          )
-                                ),
-                                catchError((error: Error) => [{ updatedOrError: asError(error) }])
-                            )
+                            [LOADING],
+                            updateExternalService(input).pipe(catchError((error: Error) => [asError(error)]))
                         )
                     )
-                )
-                .subscribe(stateUpdate => this.setState(stateUpdate as State))
+                ),
+            []
         )
+    )
 
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public componentDidUpdate(): void {
-        this.componentUpdates.next(this.props)
-    }
-
-    public render(): JSX.Element | null {
-        let error: ErrorLike | undefined
-        if (isErrorLike(this.state.updatedOrError)) {
-            error = this.state.updatedOrError
-        }
-
-        const externalService =
-            (!isErrorLike(this.state.externalServiceOrError) &&
-                this.state.externalServiceOrError !== LOADING &&
-                this.state.externalServiceOrError) ||
-            undefined
-
-        let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
-        if (
-            externalService &&
-            [GQL.ExternalServiceKind.GITHUB, GQL.ExternalServiceKind.GITLAB].includes(externalService.kind)
-        ) {
-            const parsedConfig: unknown = parseJSONC(externalService.config)
-            const url =
-                typeof parsedConfig === 'object' &&
-                parsedConfig !== null &&
-                hasProperty('url')(parsedConfig) &&
-                typeof parsedConfig.url === 'string'
-                    ? new URL(parsedConfig.url)
-                    : undefined
-            // We have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the URL.
-            if (externalService.kind === GQL.ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
-                externalServiceCategory = codeHostExternalServices.ghe
-            }
-            // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
-            if (externalService.kind === GQL.ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
-                externalServiceCategory = codeHostExternalServices.gitlab
+    // If the update was successful, and did not surface a warning, redirect to the
+    // repositories page, adding `?repositoriesUpdated` to the query string so that we display
+    // a banner at the top of the page.
+    useEffect(() => {
+        if (updatedServiceOrError && updatedServiceOrError !== LOADING && !isErrorLike(updatedServiceOrError)) {
+            if (updatedServiceOrError.warning) {
+                setExternalServiceOrError(updatedServiceOrError)
+            } else {
+                props.history.push('/site-admin/repositories?repositoriesUpdated')
             }
         }
+    }, [updatedServiceOrError, props.history])
 
-        return (
-            <div className="site-admin-configuration-page">
-                {externalService ? (
-                    <PageTitle title={`External service - ${externalService.displayName}`} />
-                ) : (
-                    <PageTitle title="External service" />
-                )}
-                <h2>Update synced repositories</h2>
-                {this.state.externalServiceOrError === LOADING && <LoadingSpinner className="icon-inline" />}
-                {isErrorLike(this.state.externalServiceOrError) && (
-                    <ErrorAlert
-                        className="mb-3"
-                        error={this.state.externalServiceOrError}
-                        history={this.props.history}
-                    />
-                )}
-                {externalServiceCategory && (
-                    <div className="mb-3">
-                        <ExternalServiceCard {...externalServiceCategory} />
-                    </div>
-                )}
-                {externalService && externalServiceCategory && (
-                    <SiteAdminExternalServiceForm
-                        input={externalService}
-                        editorActions={externalServiceCategory.editorActions}
-                        jsonSchema={externalServiceCategory.jsonSchema}
-                        error={error}
-                        warning={this.state.warning}
-                        mode="edit"
-                        loading={this.state.updatedOrError === LOADING}
-                        onSubmit={this.onSubmit}
-                        onChange={this.onChange}
-                        history={this.props.history}
-                        isLightTheme={this.props.isLightTheme}
-                    />
-                )}
-                {this.state.updatedOrError === true && (
-                    <p className="alert alert-success user-settings-profile-page__alert">Updated!</p>
-                )}
-                {externalService?.webhookURL && (
-                    <div className="alert alert-info">
-                        <h3>Campaign webhooks</h3>
-                        {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
-                            <p>
-                                <a
-                                    href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#webhooks"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    Webhooks
-                                </a>{' '}
-                                will be created automatically on the configured Bitbucket Server instance. In case you
-                                don't provide an admin token,{' '}
-                                <a
-                                    href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#manual-configuration"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    follow the docs on how to set up webhooks manually
-                                </a>
-                                .
-                                <br />
-                                To set up another webhook manually, use the following URL:
-                            </p>
-                        ) : (
-                            <p>
-                                Point{' '}
-                                <a
-                                    href="https://docs.sourcegraph.com/admin/external_service/github#webhooks"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    webhooks
-                                </a>{' '}
-                                for this code host connection at the following URL:
-                            </p>
-                        )}
-                        <CopyableText
-                            className="mb-2"
-                            text={externalService.webhookURL}
-                            size={externalService.webhookURL.length}
-                        />
-                        <p className="mb-0">
-                            Note that only{' '}
+    const onSubmit = useCallback(
+        (event?: React.FormEvent<HTMLFormElement>): void => {
+            if (event) {
+                event.preventDefault()
+            }
+            if (isExternalService(externalServiceOrError)) {
+                nextSubmit(externalServiceOrError)
+            }
+        },
+        [externalServiceOrError, nextSubmit]
+    )
+    let error: ErrorLike | undefined
+    if (isErrorLike(updatedServiceOrError)) {
+        error = updatedServiceOrError
+    }
+
+    const externalService =
+        (!isErrorLike(externalServiceOrError) && externalServiceOrError !== LOADING && externalServiceOrError) ||
+        undefined
+
+    let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
+    if (
+        externalService &&
+        [GQL.ExternalServiceKind.GITHUB, GQL.ExternalServiceKind.GITLAB].includes(externalService.kind)
+    ) {
+        const parsedConfig: unknown = parseJSONC(externalService.config)
+        const url =
+            typeof parsedConfig === 'object' &&
+            parsedConfig !== null &&
+            hasProperty('url')(parsedConfig) &&
+            typeof parsedConfig.url === 'string'
+                ? new URL(parsedConfig.url)
+                : undefined
+        // We have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the URL.
+        if (externalService.kind === GQL.ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
+            externalServiceCategory = codeHostExternalServices.ghe
+        }
+        // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
+        if (externalService.kind === GQL.ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
+            externalServiceCategory = codeHostExternalServices.gitlab
+        }
+    }
+
+    return (
+        <div className="site-admin-configuration-page">
+            {externalService ? (
+                <PageTitle title={`External service - ${externalService.displayName}`} />
+            ) : (
+                <PageTitle title="External service" />
+            )}
+            <h2>Update synced repositories</h2>
+            {externalServiceOrError === LOADING && <LoadingSpinner className="icon-inline" />}
+            {isErrorLike(externalServiceOrError) && (
+                <ErrorAlert className="mb-3" error={externalServiceOrError} history={props.history} />
+            )}
+            {externalServiceCategory && (
+                <div className="mb-3">
+                    <ExternalServiceCard {...externalServiceCategory} />
+                </div>
+            )}
+            {externalService && externalServiceCategory && (
+                <SiteAdminExternalServiceForm
+                    input={externalService}
+                    editorActions={externalServiceCategory.editorActions}
+                    jsonSchema={externalServiceCategory.jsonSchema}
+                    error={error}
+                    warning={externalService.warning}
+                    mode="edit"
+                    loading={updatedServiceOrError === LOADING}
+                    onSubmit={onSubmit}
+                    onChange={onChange}
+                    history={props.history}
+                    isLightTheme={props.isLightTheme}
+                />
+            )}
+            {externalService?.webhookURL && (
+                <div className="alert alert-info">
+                    <h3>Campaign webhooks</h3>
+                    {externalService.kind === GQL.ExternalServiceKind.BITBUCKETSERVER ? (
+                        <p>
                             <a
-                                href="https://docs.sourcegraph.com/user/campaigns"
+                                href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#webhooks"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
-                                Campaigns
+                                Webhooks
                             </a>{' '}
-                            make use of this webhook. To enable webhooks to trigger repository updates on Sourcegraph,{' '}
+                            will be created automatically on the configured Bitbucket Server instance. In case you don't
+                            provide an admin token,{' '}
                             <a
-                                href="https://docs.sourcegraph.com/admin/repo/webhooks"
+                                href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#manual-configuration"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
-                                see the docs on how to use them
+                                follow the docs on how to set up webhooks manually
                             </a>
                             .
+                            <br />
+                            To set up another webhook manually, use the following URL:
                         </p>
-                    </div>
-                )}
-            </div>
-        )
-    }
-
-    private onChange = (input: GQL.IAddExternalServiceInput): void => {
-        this.setState(state => {
-            if (isExternalService(state.externalServiceOrError)) {
-                return { ...state, externalServiceOrError: { ...state.externalServiceOrError, ...input } }
-            }
-            return state
-        })
-    }
-
-    private onSubmit = (event?: React.FormEvent<HTMLFormElement>): void => {
-        if (event) {
-            event.preventDefault()
-        }
-        if (isExternalService(this.state.externalServiceOrError)) {
-            this.submits.next(this.state.externalServiceOrError)
-        }
-    }
+                    ) : (
+                        <p>
+                            Point{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/admin/external_service/github#webhooks"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                webhooks
+                            </a>{' '}
+                            for this code host connection at the following URL:
+                        </p>
+                    )}
+                    <CopyableText
+                        className="mb-2"
+                        text={externalService.webhookURL}
+                        size={externalService.webhookURL.length}
+                    />
+                    <p className="mb-0">
+                        Note that only{' '}
+                        <a href="https://docs.sourcegraph.com/user/campaigns" target="_blank" rel="noopener noreferrer">
+                            Campaigns
+                        </a>{' '}
+                        make use of this webhook. To enable webhooks to trigger repository updates on Sourcegraph,{' '}
+                        <a
+                            href="https://docs.sourcegraph.com/admin/repo/webhooks"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            see the docs on how to use them
+                        </a>
+                        .
+                    </p>
+                </div>
+            )}
+        </div>
+    )
 }
 
 function isExternalService(

--- a/web/src/site-admin/SiteAdminExternalServicesPage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicesPage.tsx
@@ -55,9 +55,15 @@ const ExternalServiceNode: React.FunctionComponent<ExternalServiceNodeProps> = (
                         )
                     ),
                     tap(onDidUpdate),
-                    tap(() => refreshSiteFlags().subscribe())
+                    tap(deletedOrError => {
+                        // eslint-disable-next-line rxjs/no-ignored-subscription
+                        refreshSiteFlags().subscribe()
+                        if (deletedOrError === true) {
+                            history.push('/site-admin/repositories?repositoriesUpdated')
+                        }
+                    })
                 ),
-            [node.displayName, node.id, onDidUpdate]
+            [history, node.displayName, node.id, onDidUpdate]
         )
     )
 

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -141,7 +141,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<Props> = props =
             <PageTitle title="Repositories - Admin" />
             {showRepositoriesAddedBanner && (
                 <p className="alert alert-success">
-                    Adding repositories. It may take a few moments to clone and index each repository. Repository
+                    Updating repositories. It may take a few moments to clone and index each repository. Repository
                     statuses are displayed below.
                 </p>
             )}

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -142,7 +142,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<Props> = props =
             {showRepositoriesAddedBanner && (
                 <p className="alert alert-success">
                     Adding repositories. It may take a few moments to clone and index each repository. Repository
-                    statuses are displayed below
+                    statuses are displayed below.
                 </p>
             )}
             <h2>Repositories</h2>

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -2,7 +2,7 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import CloudDownloadIcon from 'mdi-react/CloudDownloadIcon'
 import CloudOutlineIcon from 'mdi-react/CloudOutlineIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
-import * as React from 'react'
+import React, { useEffect, useCallback } from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
 import { Subject, Observable } from 'rxjs'
@@ -18,7 +18,6 @@ import { PageTitle } from '../components/PageTitle'
 import { refreshSiteFlags } from '../site/backend'
 import { eventLogger } from '../tracking/eventLogger'
 import { fetchAllRepositoriesAndPollIfEmptyOrAnyCloning } from './backend'
-import { ErrorAlert } from '../components/alerts'
 import * as H from 'history'
 
 interface RepositoryNodeProps extends ActivationProps {
@@ -27,152 +26,142 @@ interface RepositoryNodeProps extends ActivationProps {
     history: H.History
 }
 
-interface RepositoryNodeState {
-    errorDescription?: string
-}
-
-class RepositoryNode extends React.PureComponent<RepositoryNodeProps, RepositoryNodeState> {
-    public state: RepositoryNodeState = {}
-
-    public render(): JSX.Element | null {
-        return (
-            <li
-                className="repository-node list-group-item py-2"
-                data-e2e-repository={this.props.node.name}
-                data-e2e-cloned={this.props.node.mirrorInfo.cloned}
-            >
-                <div className="d-flex align-items-center justify-content-between">
-                    <div>
-                        <RepoLink repoName={this.props.node.name} to={this.props.node.url} />
-                        {this.props.node.mirrorInfo.cloneInProgress && (
-                            <small className="ml-2 text-success">
-                                <LoadingSpinner className="icon-inline" /> Cloning
-                            </small>
-                        )}
-                        {!this.props.node.mirrorInfo.cloneInProgress && !this.props.node.mirrorInfo.cloned && (
-                            <small
-                                className="ml-2 text-muted"
-                                data-tooltip="Visit the repository to clone it. See its mirroring settings for diagnostics."
-                            >
-                                <CloudOutlineIcon className="icon-inline" /> Not yet cloned
-                            </small>
-                        )}
-                    </div>
-                    <div className="repository-node__actions">
-                        {!this.props.node.mirrorInfo.cloneInProgress && !this.props.node.mirrorInfo.cloned && (
-                            <Link className="btn btn-sm btn-secondary" to={this.props.node.url}>
-                                <CloudDownloadIcon className="icon-inline" /> Clone now
-                            </Link>
-                        )}{' '}
-                        {
-                            <Link
-                                className="btn btn-secondary btn-sm"
-                                to={`/${this.props.node.name}/-/settings`}
-                                data-tooltip="Repository settings"
-                            >
-                                <SettingsIcon className="icon-inline" /> Settings
-                            </Link>
-                        }{' '}
-                    </div>
-                </div>
-                {this.state.errorDescription && (
-                    <ErrorAlert className="mt-2" error={this.state.errorDescription} history={this.props.history} />
+const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = props => (
+    <li
+        className="repository-node list-group-item py-2"
+        data-e2e-repository={props.node.name}
+        data-e2e-cloned={props.node.mirrorInfo.cloned}
+    >
+        <div className="d-flex align-items-center justify-content-between">
+            <div>
+                <RepoLink repoName={props.node.name} to={props.node.url} />
+                {props.node.mirrorInfo.cloneInProgress && (
+                    <small className="ml-2 text-success">
+                        <LoadingSpinner className="icon-inline" /> Cloning
+                    </small>
                 )}
-            </li>
-        )
-    }
-}
+                {!props.node.mirrorInfo.cloneInProgress && !props.node.mirrorInfo.cloned && (
+                    <small
+                        className="ml-2 text-muted"
+                        data-tooltip="Visit the repository to clone it. See its mirroring settings for diagnostics."
+                    >
+                        <CloudOutlineIcon className="icon-inline" /> Not yet cloned
+                    </small>
+                )}
+            </div>
+            <div className="repository-node__actions">
+                {!props.node.mirrorInfo.cloneInProgress && !props.node.mirrorInfo.cloned && (
+                    <Link className="btn btn-sm btn-secondary" to={props.node.url}>
+                        <CloudDownloadIcon className="icon-inline" /> Clone now
+                    </Link>
+                )}{' '}
+                {
+                    <Link
+                        className="btn btn-secondary btn-sm"
+                        to={`/${props.node.name}/-/settings`}
+                        data-tooltip="Repository settings"
+                    >
+                        <SettingsIcon className="icon-inline" /> Settings
+                    </Link>
+                }{' '}
+            </div>
+        </div>
+    </li>
+)
 
 interface Props extends RouteComponentProps<{}>, ActivationProps {}
+
+const FILTERS: FilteredConnectionFilter[] = [
+    {
+        label: 'All',
+        id: 'all',
+        tooltip: 'Show all repositories',
+        args: {},
+    },
+    {
+        label: 'Cloned',
+        id: 'cloned',
+        tooltip: 'Show cloned repositories only',
+        args: { cloned: true, cloneInProgress: false, notCloned: false },
+    },
+    {
+        label: 'Cloning',
+        id: 'cloning',
+        tooltip: 'Show only repositories that are currently being cloned',
+        args: { cloned: false, cloneInProgress: true, notCloned: false },
+    },
+    {
+        label: 'Not cloned',
+        id: 'not-cloned',
+        tooltip: 'Show only repositories that have not been cloned yet',
+        args: { cloned: false, cloneInProgress: false, notCloned: true },
+    },
+    {
+        label: 'Needs index',
+        id: 'needs-index',
+        tooltip: 'Show only repositories that need to be indexed',
+        args: { indexed: false },
+    },
+]
 
 /**
  * A page displaying the repositories on this site.
  */
-export class SiteAdminRepositoriesPage extends React.PureComponent<Props> {
-    private static FILTERS: FilteredConnectionFilter[] = [
-        {
-            label: 'All',
-            id: 'all',
-            tooltip: 'Show all repositories',
-            args: {},
-        },
-        {
-            label: 'Cloned',
-            id: 'cloned',
-            tooltip: 'Show cloned repositories only',
-            args: { cloned: true, cloneInProgress: false, notCloned: false },
-        },
-        {
-            label: 'Cloning',
-            id: 'cloning',
-            tooltip: 'Show only repositories that are currently being cloned',
-            args: { cloned: false, cloneInProgress: true, notCloned: false },
-        },
-        {
-            label: 'Not cloned',
-            id: 'not-cloned',
-            tooltip: 'Show only repositories that have not been cloned yet',
-            args: { cloned: false, cloneInProgress: false, notCloned: true },
-        },
-        {
-            label: 'Needs index',
-            id: 'needs-index',
-            tooltip: 'Show only repositories that need to be indexed',
-            args: { indexed: false },
-        },
-    ]
-
-    private repositoryUpdates = new Subject<void>()
-
-    public componentDidMount(): void {
+export const SiteAdminRepositoriesPage: React.FunctionComponent<Props> = props => {
+    useEffect(() => {
         eventLogger.logViewEvent('SiteAdminRepos')
+    })
 
-        // Refresh global alert about enabling repositories when the user visits here.
+    // Refresh global alert about enabling repositories when the user visits & navigates away from this page.
+    useEffect(() => {
         refreshSiteFlags()
             .toPromise()
             .then(null, error => console.error(error))
-    }
-
-    public componentWillUnmount(): void {
-        // Remove global alert about enabling repositories when the user navigates away from here.
-        refreshSiteFlags()
-            .toPromise()
-            .then(null, error => console.error(error))
-    }
-
-    public render(): JSX.Element | null {
-        const nodeProps: Omit<RepositoryNodeProps, 'node'> = {
-            onDidUpdate: this.onDidUpdateRepository,
-            activation: this.props.activation,
-            history: this.props.history,
+        return () => {
+            refreshSiteFlags()
+                .toPromise()
+                .then(null, error => console.error(error))
         }
-
-        return (
-            <div className="site-admin-repositories-page">
-                <PageTitle title="Repositories - Admin" />
-                <h2>Repositories</h2>
-                <p>
-                    Repositories are synced from connected{' '}
-                    <Link to="/site-admin/external-services">code host connections</Link>.
-                </p>
-                <FilteredConnection<GQL.IRepository, Omit<RepositoryNodeProps, 'node'>>
-                    className="list-group list-group-flush mt-3"
-                    noun="repository"
-                    pluralNoun="repositories"
-                    queryConnection={this.queryRepositories}
-                    nodeComponent={RepositoryNode}
-                    nodeComponentProps={nodeProps}
-                    updates={this.repositoryUpdates}
-                    filters={SiteAdminRepositoriesPage.FILTERS}
-                    history={this.props.history}
-                    location={this.props.location}
-                />
-            </div>
-        )
+    })
+    const repositoryUpdates = new Subject<void>()
+    const nodeProps: Omit<RepositoryNodeProps, 'node'> = {
+        onDidUpdate: repositoryUpdates.next.bind(repositoryUpdates),
+        activation: props.activation,
+        history: props.history,
     }
+    const queryRepositories = useCallback(
+        (args: FilteredConnectionQueryArgs): Observable<GQL.IRepositoryConnection> =>
+            fetchAllRepositoriesAndPollIfEmptyOrAnyCloning({ ...args }),
+        []
+    )
+    const showRepositoriesAddedBanner = new URLSearchParams(props.location.search).has('repositoriesUpdated')
 
-    private queryRepositories = (args: FilteredConnectionQueryArgs): Observable<GQL.IRepositoryConnection> =>
-        fetchAllRepositoriesAndPollIfEmptyOrAnyCloning({ ...args })
-
-    private onDidUpdateRepository = (): void => this.repositoryUpdates.next()
+    return (
+        <div className="site-admin-repositories-page">
+            <PageTitle title="Repositories - Admin" />
+            {showRepositoriesAddedBanner && (
+                <p className="alert alert-success">
+                    Adding repositories. It may take a few moments to clone and index each repository. Repository
+                    statuses are displayed below
+                </p>
+            )}
+            <h2>Repositories</h2>
+            <p>
+                Repositories are synced from connected{' '}
+                <Link to="/site-admin/external-services">code host connections</Link>.
+            </p>
+            <FilteredConnection<GQL.IRepository, Omit<RepositoryNodeProps, 'node'>>
+                className="list-group list-group-flush mt-3"
+                noun="repository"
+                pluralNoun="repositories"
+                queryConnection={queryRepositories}
+                nodeComponent={RepositoryNode}
+                nodeComponentProps={nodeProps}
+                updates={repositoryUpdates}
+                filters={FILTERS}
+                history={props.history}
+                location={props.location}
+            />
+        </div>
+    )
 }


### PR DESCRIPTION
Rel #10899

Upon adding or updating repositories:
- Redirect to `/site-admin/repositories`
- Display a green success banner at the top of the repository status page (as per [figma design](https://www.figma.com/file/V67mcLX9OyR0Ru1KTssP3y/Add-Repositories?node-id=3%3A19&viewport=-1598%2C928%2C0.5)) with the text:

> Adding repositories. It may take a few moments to clone and index each repository. Repository statuses are displayed below.

The banner will not be removed until the next page is loaded.

![image](https://user-images.githubusercontent.com/1741180/86001509-43068d00-ba0f-11ea-9642-617cb8075045.png)

Implementation notes:
- Converted relevant components to function components
- Used a URL query param, `repositoriesUpdated`, to trigger showing the success banner on `/site-admin/repositories`
- Modified `FilteredConnection` to avoid overwriting existing query parameters, otherwise on initial page load of `/site-admin/repositories` `repositoriesUpdated` would get erased.

A couple of questions for @rrhyne:
- Sometimes, updating an external service will not result in _added_ repositories, but in _removed_ repositories (eg. when narrowing a repository query). The banner wording does not account for this. Should the banner read "Updating repositories..." instead of "Adding repositories..." to account for all cases?
- Similarly, when deleting an external service, the user remains on `/site-admin/external-services`, and no banner / confirmation is shown. For consistency, should we also redirect to `/site-admin/repositories` when deleting an external service?
