### PR TITLE
Link to add external service from activation steps

### DIFF
--- a/web/src/tracking/withActivation.tsx
+++ b/web/src/tracking/withActivation.tsx
@@ -119,6 +119,10 @@ const getActivationSteps = (authenticatedUser: GQL.IUser): ActivationStep[] => {
             id: 'ConnectedCodeHost',
             title: 'Add repositories',
             detail: 'Configure Sourcegraph to talk to your code host and fetch a list of your repositories.',
+            onClick: (event: React.MouseEvent<HTMLElement>, history: H.History) => {
+                event.preventDefault()
+                history.push('/site-admin/external-services/new')
+            },
             siteAdminOnly: true,
         },
         {


### PR DESCRIPTION
Rel #10899

Links to `/site-admin/external-services/new` from the "Almost there" accordion under "Add repositories" and the corresponding item under the Getting started dropdown.