### PR TITLE
WIP: Make `SetupGlobalTestDB` faster by only truncating subset of tables

### DIFF
--- a/enterprise/internal/campaigns/resolvers/patch_sets_test.go
+++ b/enterprise/internal/campaigns/resolvers/patch_sets_test.go
@@ -32,7 +32,7 @@ func TestPatchSetResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	dbtesting.SetupGlobalTestDB(t, "patch_sets", "patches")
 	rcache.SetupForTest(t)
 
 	// For testing purposes they all share the same rev, across repos

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -41,7 +41,7 @@ func TestCampaigns(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	dbtesting.SetupGlobalTestDB(t, "repo", "access_tokens", "users", "campaigns", "changesets", "changeset_events", "changeset_jobs")
 	rcache.SetupForTest(t)
 
 	cf, save := httptestutil.NewGitHubRecorderFactory(t, *update, "test-campaigns")


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
