### PR TITLE
search: test fork:true is an alias for fork:yes

### DIFF
--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -24,6 +24,10 @@ var tests = []test{
 		Name:  `Global search, repo search by name, case yes, nonzero result`,
 		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ String case:yes count:1 stable:yes`,
 	},
+	{
+		Name:  `True is an alias for yes is when fork is set`,
+		Query: `fork:true repo:github\.com/rvantonderp/(beego-mux|sgtest-mux)`,
+	},
 	// Text search, focused to repo.
 	{
 		Name:  `Repo search, non-master branch, nonzero result`,

--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -25,7 +25,7 @@ var tests = []test{
 		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ String case:yes count:1 stable:yes`,
 	},
 	{
-		Name:  `True is an alias for yes is when fork is set`,
+		Name:  `True is an alias for yes when fork is set`,
 		Query: `fork:true repo:github\.com/rvantonderp/(beego-mux|sgtest-mux)`,
 	},
 	// Text search, focused to repo.


### PR DESCRIPTION
This test is strong enough to detect the behavior change introduced in #11740. Tester [setup](https://github.com/sourcegraph/sourcegraph/tree/master/internal/cmd/search-integration-tester#setup) describes how to generate the golden output.