### PR TITLE
doc/admin: clarify that upgrades require 10m of downtime by default

### DIFF
--- a/doc/admin/install/kubernetes/update.md
+++ b/doc/admin/install/kubernetes/update.md
@@ -63,15 +63,17 @@ selectors](scale.md#node-selector) for Sourcegraph on Kubernetes.
 
 ## High-availability updates
 
-Sourcegraph is designed to be a high-availability (HA) service. Updates require zero downtime and
-employ health checks to test the health of newly updated components before switching live traffic
-over to them. HA-enabling features include the following:
+Sourcegraph is designed to be a high-availability (HA) service, but upgrades by default require a 10m downtime
+window. If you need zero-downtime upgrades, please contact us. Services employ health checks to test the health
+of newly updated components before switching live traffic over to them by default. HA-enabling features include
+the following:
 
 - Replication: nearly all of the critical services within Sourcegraph are replicated. If a single instance of a
   service fails, that instance is restarted and removed from operation until it comes online again.
 - Updates are applied in a rolling fashion to each service such that a subset of instances are updated first while
   traffic continues to flow to the old instances. Once the health check determines the set of new instances is
-  healthy, traffic is directed to the new set and the old set is terminated.
+  healthy, traffic is directed to the new set and the old set is terminated. By default, some database operations
+  may fail during this time as migrations occur so a scheduled 10m downtime window is required.
 - Each service includes a health check that detects whether the service is in a healthy state. This check is specific to
   the service. These are used to check the health of new instances after an update and during regular operation to
   determine if an instance goes down.

--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -9,7 +9,7 @@ To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.
 You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
 
 - As a precaution, before updating, we recommend backing up the contents of the Docker volumes used by Sourcegraph.
-- If you need zero-downtime updates, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
+- If you need a HA deployment, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
 - There is currently no automated way to downgrade to an older version after you have updated. [Contact support](https://about.sourcegraph.com/contact) for help.
 
 ## For Kubernetes cluster deployments


### PR DESCRIPTION
Prior to this commit we advertised that HA cluster deployment upgrades were zero-downtime. In practice, this is not true as database migrations may mean that e.g. some frontend replicas during a rolling updates will be unable to write (and sometimes read) from the database. In practice this is most likely a service-degradation situation, not complete downtime, but it is good to be explicit about planning a 10m downtime window.

For Sourcegraph.com, we will have zero-downtime upgrades with the explicit tradeoff of more rapid deployments. I am not documenting that here and am merely documenting the current state of the world. @efritz owns this.

This change was discussed and approved live with @efritz @tsenart @pecigonzalo @beyang
