### PR TITLE
enterprise: correctly handle nil pointer when "dotcom" is not in site config

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_expiration.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_expiration.go
@@ -27,7 +27,11 @@ func StartCheckForUpcomingLicenseExpirations() {
 		panic("StartCheckForUpcomingLicenseExpirations called more than once")
 	}
 
-	client := slack.New(conf.Get().Dotcom.SlackLicenseExpirationWebhook)
+	dotcom := conf.Get().Dotcom
+	if dotcom == nil {
+		return
+	}
+	client := slack.New(dotcom.SlackLicenseExpirationWebhook)
 
 	t := time.NewTicker(1 * time.Hour)
 	for range t.C {


### PR DESCRIPTION
This fixes an issue where if "dotcom" is not in the site config (e.g. if testing `SOURCEGRAPHDOTCOM_MODE=t` in dev mode), a nil pointer would cause a panic.
