### PR TITLE
gitserver: set GIT_DIR in exec handler

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -609,7 +609,7 @@ func checkMaybeCorruptRepo(repo api.RepoName, dir GitDir, stderr string) {
 
 func gitConfigGet(dir GitDir, key string) (string, error) {
 	cmd := exec.Command("git", "config", "--get", key)
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		// Exit code 1 means the key is not set.
@@ -623,7 +623,7 @@ func gitConfigGet(dir GitDir, key string) (string, error) {
 
 func gitConfigSet(dir GitDir, key, value string) error {
 	cmd := exec.Command("git", "config", key, value)
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	err := cmd.Run()
 	if err != nil {
 		return errors.Wrapf(wrapCmdError(cmd, err), "failed to set git config %s", key)
@@ -633,7 +633,7 @@ func gitConfigSet(dir GitDir, key, value string) error {
 
 func gitConfigUnset(dir GitDir, key string) error {
 	cmd := exec.Command("git", "config", "--unset-all", key)
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	err := cmd.Run()
 	if err != nil {
 		// Exit code 5 means the key is not set.

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -693,6 +693,11 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	cmdStart = time.Now()
 	cmd := exec.CommandContext(ctx, "git", req.Args...)
 	cmd.Dir = string(dir)
+	// dir (something like "foo/bar/.git") is a GIT_DIR. By setting that here
+	// we avoid git doing discovery of GIT_DIR. This has the benefit of when
+	// the disk gets in a weird state we don't have weird errors were git has
+	// crawled all the way up to root looking for GIT_DIR.
+	cmd.Env = append(os.Environ(), "GIT_DIR="+string(dir))
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -692,12 +692,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	cmdStart = time.Now()
 	cmd := exec.CommandContext(ctx, "git", req.Args...)
-	cmd.Dir = string(dir)
-	// dir (something like "foo/bar/.git") is a GIT_DIR. By setting that here
-	// we avoid git doing discovery of GIT_DIR. This has the benefit of when
-	// the disk gets in a weird state we don't have weird errors were git has
-	// crawled all the way up to root looking for GIT_DIR.
-	cmd.Env = append(os.Environ(), "GIT_DIR="+string(dir))
+	dir.Set(cmd)
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW
 
@@ -1139,12 +1134,12 @@ func removeBadRefs(ctx context.Context, dir GitDir) {
 
 	args := append([]string{"branch", "-D"}, badRefs...)
 	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	_ = cmd.Run()
 
 	args = append([]string{"tag", "-d"}, badRefs...)
 	cmd = exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	_ = cmd.Run()
 }
 
@@ -1211,7 +1206,7 @@ func setLastChanged(dir GitDir) error {
 func computeLatestCommitTimestamp(dir GitDir) (time.Time, error) {
 	now := time.Now() // return current time if we don't find a more accurate time
 	cmd := exec.Command("git", "rev-list", "--all", "--timestamp", "-n", "1")
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	output, err := cmd.Output()
 	// If we don't have a more specific stamp, we'll return the current time,
 	// and possibly an error.
@@ -1244,7 +1239,7 @@ func computeRefHash(dir GitDir) ([]byte, error) {
 	// Do not use CommandContext since this is a fast operation we do not want
 	// to interrupt.
 	cmd := exec.Command("git", "show-ref")
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 	output, err := cmd.Output()
 	if err != nil {
 		// Ignore the failure for an empty repository: show-ref fails with
@@ -1309,7 +1304,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 			cmd = exec.Command("git", "remote", "set-url", "origin", "--", url)
 		}
 		if cmd != nil {
-			cmd.Dir = string(dir)
+			dir.Set(cmd)
 			if _, err := runCommand(ctx, cmd); err != nil {
 				log15.Error("Failed to update repository's Git remote URL.", "repo", repo, "error", err)
 			}
@@ -1336,7 +1331,7 @@ func (s *Server) doRepoUpdate2(repo api.RepoName, url string) error {
 			// Possibly deprecated refs for sourcegraph zap experiment?
 			"+refs/sourcegraph/*:refs/sourcegraph/*")
 	}
-	cmd.Dir = string(dir)
+	dir.Set(cmd)
 
 	// drop temporary pack files after a fetch. this function won't
 	// return until this fetch has completed or definitely-failed,


### PR DESCRIPTION
If a git disk gets in a bad state "dir" may no longer look like a git
dir. This then leads to git trying to discover GIT_DIR and crawling all
the way up the filesystem. This can lead to strange errors. This has
been observed sometimes when we restore from backup.

Part of https://github.com/sourcegraph/sourcegraph/issues/8415#issuecomment-589179274