### PR TITLE
frontend: Allow opt out of EnsureRevision when making a comparison query

### DIFF
--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -197,7 +197,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		}
 		return grepo.URL, nil
 	}
-	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID, git.ResolveRevisionOptions{})
+	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID, nil)
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -197,7 +197,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		}
 		return grepo.URL, nil
 	}
-	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID)
+	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID, git.ResolveRevisionOptions{})
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -77,7 +77,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) {
 		}
 
 		var commit *git.Commit
-		commit, r.err = git.GetCommit(ctx, *cachedRepo, nil, api.CommitID(r.oid))
+		commit, r.err = git.GetCommit(ctx, *cachedRepo, nil, api.CommitID(r.oid), git.ResolveRevisionOptions{})
 		if r.err != nil {
 			return
 		}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -77,7 +77,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) {
 		}
 
 		var commit *git.Commit
-		commit, r.err = git.GetCommit(ctx, *cachedRepo, nil, api.CommitID(r.oid), git.ResolveRevisionOptions{})
+		commit, r.err = git.GetCommit(ctx, *cachedRepo, nil, api.CommitID(r.oid), nil)
 		if r.err != nil {
 			return
 		}

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -51,7 +51,7 @@ func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID)
+	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -51,7 +51,7 @@ func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID, git.ResolveRevisionOptions{})
+	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -27,8 +27,9 @@ type RepositoryComparisonConnectionResolver interface {
 }
 
 type RepositoryComparisonInput struct {
-	Base *string
-	Head *string
+	Base         *string
+	Head         *string
+	FetchMissing bool
 }
 
 type FileDiffConnection interface {
@@ -68,20 +69,23 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 			return nil, nil
 		}
 
+		opt := git.ResolveRevisionOptions{
+			NoEnsureRevision: !args.FetchMissing,
+		}
 		// Optimistically fetch using revspec
-		commit, err := git.GetCommit(ctx, repo, nil, api.CommitID(revspec))
+		commit, err := git.GetCommit(ctx, repo, nil, api.CommitID(revspec), opt)
 		if err == nil {
 			return toGitCommitResolver(r, commit), nil
 		}
 
 		// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't
 		// exist).
-		commitID, err := git.ResolveRevision(ctx, repo, nil, revspec, nil)
+		commitID, err := git.ResolveRevision(ctx, repo, nil, revspec, &opt)
 		if err != nil {
 			return nil, err
 		}
 
-		commit, err = git.GetCommit(ctx, repo, nil, commitID)
+		commit, err = git.GetCommit(ctx, repo, nil, commitID, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -69,7 +69,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 			return nil, nil
 		}
 
-		opt := git.ResolveRevisionOptions{
+		opt := &git.ResolveRevisionOptions{
 			NoEnsureRevision: !args.FetchMissing,
 		}
 		// Optimistically fetch using revspec
@@ -80,7 +80,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 
 		// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't
 		// exist).
-		commitID, err := git.ResolveRevision(ctx, repo, nil, revspec, &opt)
+		commitID, err := git.ResolveRevision(ctx, repo, nil, revspec, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -164,7 +164,7 @@ func hydrateBranchCommits(ctx context.Context, repo gitserver.Repo, interactive 
 	}
 
 	for _, branch := range branches {
-		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head)
+		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head, git.ResolveRevisionOptions{})
 		if err != nil {
 			if parentCtx.Err() == nil && ctx.Err() != nil {
 				// reached interactive timeout

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -164,7 +164,7 @@ func hydrateBranchCommits(ctx context.Context, repo gitserver.Repo, interactive 
 	}
 
 	for _, branch := range branches {
-		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head, git.ResolveRevisionOptions{})
+		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head, nil)
 		if err != nil {
 			if parentCtx.Err() == nil && ctx.Err() != nil {
 				// reached interactive timeout

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1851,6 +1851,8 @@ type Repository implements Node & GenericSearchResultInterface {
         base: String
         # The head of the diff ("new" or "right-hand side"), or "HEAD" if not specified.
         head: String
+        # Attempt to fetch missing revisions from remote if they are not found
+        fetchMissing: Boolean = true
     ): RepositoryComparison!
     # The repository's contributors.
     contributors(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1858,6 +1858,8 @@ type Repository implements Node & GenericSearchResultInterface {
         base: String
         # The head of the diff ("new" or "right-hand side"), or "HEAD" if not specified.
         head: String
+        # Attempt to fetch missing revisions from remote if they are not found
+        fetchMissing: Boolean = true
     ): RepositoryComparison!
     # The repository's contributors.
     contributors(

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -401,8 +401,9 @@ func (r *changesetResolver) Diff(ctx context.Context) (*graphqlbackend.Repositor
 	}
 
 	return graphqlbackend.NewRepositoryComparison(ctx, repo, &graphqlbackend.RepositoryComparisonInput{
-		Base: &base,
-		Head: &head,
+		Base:         &base,
+		Head:         &head,
+		FetchMissing: true,
 	})
 }
 

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -104,7 +104,7 @@ func Commits(ctx context.Context, repo gitserver.Repo, opt CommitsOptions) ([]*C
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
-	if err := checkSpecArgSafety(string(opt.Range)); err != nil {
+	if err := checkSpecArgSafety(opt.Range); err != nil {
 		return nil, err
 	}
 
@@ -176,8 +176,8 @@ func runCommitLog(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) (
 	data, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		data = bytes.TrimSpace(data)
-		if isBadObjectErr(string(stderr), string(opt.Range)) {
-			return nil, &gitserver.RevisionNotFoundError{Repo: cmd.Repo.Name, Spec: string(opt.Range)}
+		if isBadObjectErr(string(stderr), opt.Range) {
+			return nil, &gitserver.RevisionNotFoundError{Repo: cmd.Repo.Name, Spec: opt.Range}
 		}
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args, data))
 	}
@@ -198,7 +198,7 @@ func runCommitLog(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) (
 }
 
 func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err error) {
-	if err := checkSpecArgSafety(string(opt.Range)); err != nil {
+	if err := checkSpecArgSafety(opt.Range); err != nil {
 		return nil, err
 	}
 

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -172,7 +172,8 @@ func commitLog(ctx context.Context, repo gitserver.Repo, opt CommitsOptions) (co
 
 // runCommitLog sends the git command to gitserver. It interprets missing
 // revision responses and converts them into RevisionNotFoundError.
-func runCommitLog(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*Commit, error) {
+// It is declared as a variable so that we can swap it out in tests
+var runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*Commit, error) {
 	data, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		data = bytes.TrimSpace(data)

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -49,6 +49,9 @@ type CommitsOptions struct {
 	// gitserver doesn't already contain a clone of the repository or if the
 	// commit must be fetched from the remote.
 	RemoteURLFunc func() (string, error)
+
+	// When true we opt out of attempting to fetch missing revisions
+	NoEnsureRevision bool
 }
 
 // logEntryPattern is the regexp pattern that matches entries in the output of the `git shortlog
@@ -56,7 +59,7 @@ type CommitsOptions struct {
 var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
 
 // getCommit returns the commit with the given id.
-func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID) (*Commit, error) {
+func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID, opt ResolveRevisionOptions) (*Commit, error) {
 	if Mocks.GetCommit != nil {
 		return Mocks.GetCommit(id)
 	}
@@ -65,7 +68,7 @@ func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (s
 		return nil, err
 	}
 
-	commits, err := commitLog(ctx, repo, CommitsOptions{Range: string(id), N: 1, RemoteURLFunc: remoteURLFunc})
+	commits, err := commitLog(ctx, repo, CommitsOptions{Range: string(id), N: 1, RemoteURLFunc: remoteURLFunc, NoEnsureRevision: opt.NoEnsureRevision})
 	if err != nil {
 		return nil, err
 	}
@@ -83,12 +86,12 @@ func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (s
 // The remoteURLFunc is called to get the Git remote URL if it's not set in repo and if it is
 // needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 // the repository or if the commit must be fetched from the remote.
-func GetCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID) (*Commit, error) {
+func GetCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID, opt ResolveRevisionOptions) (*Commit, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetCommit")
 	span.SetTag("Commit", id)
 	defer span.Finish()
 
-	return getCommit(ctx, repo, remoteURLFunc, id)
+	return getCommit(ctx, repo, remoteURLFunc, id, opt)
 }
 
 // Commits returns all commits matching the options.
@@ -152,7 +155,9 @@ func commitLog(ctx context.Context, repo gitserver.Repo, opt CommitsOptions) (co
 
 	cmd := gitserver.DefaultClient.Command("git", args...)
 	cmd.Repo = repo
-	cmd.EnsureRevision = opt.Range
+	if !opt.NoEnsureRevision {
+		cmd.EnsureRevision = opt.Range
+	}
 	retryer := &commandRetryer{
 		cmd:           cmd,
 		remoteURLFunc: opt.RemoteURLFunc,

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -28,19 +28,19 @@ func TestRepository_GetCommit(t *testing.T) {
 		repo             gitserver.Repo
 		id               api.CommitID
 		wantCommit       *Commit
-		NoEnsureRevision bool
+		noEnsureRevision bool
 	}{
 		"git cmd with NoEnsureRevision false": {
 			repo:             MakeGitRepository(t, gitCommands...),
 			id:               "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommit:       wantGitCommit,
-			NoEnsureRevision: false,
+			noEnsureRevision: false,
 		},
 		"git cmd with NoEnsureRevision true": {
 			repo:             MakeGitRepository(t, gitCommands...),
 			id:               "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommit:       wantGitCommit,
-			NoEnsureRevision: true,
+			noEnsureRevision: true,
 		},
 	}
 
@@ -57,7 +57,7 @@ func TestRepository_GetCommit(t *testing.T) {
 			return oldRunCommitLog(ctx, cmd, opt)
 		}
 
-		commit, err := GetCommit(ctx, test.repo, nil, test.id, ResolveRevisionOptions{NoEnsureRevision: test.NoEnsureRevision})
+		commit, err := GetCommit(ctx, test.repo, nil, test.id, ResolveRevisionOptions{NoEnsureRevision: test.noEnsureRevision})
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -68,12 +68,12 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, ResolveRevisionOptions{NoEnsureRevision: test.NoEnsureRevision}); !gitserver.IsRevisionNotFound(err) {
+		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, ResolveRevisionOptions{NoEnsureRevision: test.noEnsureRevision}); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 
-		if noEnsureRevision != test.NoEnsureRevision {
-			t.Fatalf("Expected %t, got %t", test.NoEnsureRevision, noEnsureRevision)
+		if noEnsureRevision != test.noEnsureRevision {
+			t.Fatalf("Expected %t, got %t", test.noEnsureRevision, noEnsureRevision)
 		}
 	}
 }

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -57,7 +57,10 @@ func TestRepository_GetCommit(t *testing.T) {
 			return oldRunCommitLog(ctx, cmd, opt)
 		}
 
-		commit, err := GetCommit(ctx, test.repo, nil, test.id, ResolveRevisionOptions{NoEnsureRevision: test.noEnsureRevision})
+		resolveRevisionOptions := &ResolveRevisionOptions{
+			NoEnsureRevision: test.noEnsureRevision,
+		}
+		commit, err := GetCommit(ctx, test.repo, nil, test.id, resolveRevisionOptions)
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -68,7 +71,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, ResolveRevisionOptions{NoEnsureRevision: test.noEnsureRevision}); !gitserver.IsRevisionNotFound(err) {
+		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, resolveRevisionOptions); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -39,7 +39,7 @@ func TestRepository_GetCommit(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commit, err := GetCommit(ctx, test.repo, nil, test.id)
+		commit, err := GetCommit(ctx, test.repo, nil, test.id, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -50,7 +50,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID); !gitserver.IsRevisionNotFound(err) {
+		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, ResolveRevisionOptions{}); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 	}

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -13,8 +13,6 @@ import (
 var ctx = context.Background()
 
 func TestRepository_GetCommit(t *testing.T) {
-	t.Parallel()
-
 	gitCommands := []string{
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
@@ -27,19 +25,39 @@ func TestRepository_GetCommit(t *testing.T) {
 		Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 	}
 	tests := map[string]struct {
-		repo       gitserver.Repo
-		id         api.CommitID
-		wantCommit *Commit
+		repo             gitserver.Repo
+		id               api.CommitID
+		wantCommit       *Commit
+		NoEnsureRevision bool
 	}{
-		"git cmd": {
-			repo:       MakeGitRepository(t, gitCommands...),
-			id:         "b266c7e3ca00b1a17ad0b1449825d0854225c007",
-			wantCommit: wantGitCommit,
+		"git cmd with NoEnsureRevision false": {
+			repo:             MakeGitRepository(t, gitCommands...),
+			id:               "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+			wantCommit:       wantGitCommit,
+			NoEnsureRevision: false,
+		},
+		"git cmd with NoEnsureRevision true": {
+			repo:             MakeGitRepository(t, gitCommands...),
+			id:               "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+			wantCommit:       wantGitCommit,
+			NoEnsureRevision: true,
 		},
 	}
 
+	oldRunCommitLog := runCommitLog
+
 	for label, test := range tests {
-		commit, err := GetCommit(ctx, test.repo, nil, test.id, ResolveRevisionOptions{})
+		var noEnsureRevision bool
+		t.Cleanup(func() {
+			runCommitLog = oldRunCommitLog
+		})
+		runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*Commit, error) {
+			// Track the value of NoEnsureRevision we pass to gitserver
+			noEnsureRevision = opt.NoEnsureRevision
+			return oldRunCommitLog(ctx, cmd, opt)
+		}
+
+		commit, err := GetCommit(ctx, test.repo, nil, test.id, ResolveRevisionOptions{NoEnsureRevision: test.NoEnsureRevision})
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -50,8 +68,12 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, ResolveRevisionOptions{}); !gitserver.IsRevisionNotFound(err) {
+		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, ResolveRevisionOptions{NoEnsureRevision: test.NoEnsureRevision}); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
+		}
+
+		if noEnsureRevision != test.NoEnsureRevision {
+			t.Fatalf("Expected %t, got %t", test.NoEnsureRevision, noEnsureRevision)
 		}
 	}
 }

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -180,7 +180,7 @@ func ListBranches(ctx context.Context, repo gitserver.Repo, opt BranchesOptions)
 
 		branch := &Branch{Name: name, Head: ref.CommitID}
 		if opt.IncludeCommit {
-			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID)
+			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID, ResolveRevisionOptions{})
 			if err != nil {
 				return nil, err
 			}

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -180,7 +180,7 @@ func ListBranches(ctx context.Context, repo gitserver.Repo, opt BranchesOptions)
 
 		branch := &Branch{Name: name, Head: ref.CommitID}
 		if opt.IncludeCommit {
-			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID, ResolveRevisionOptions{})
+			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID, nil)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Add an optional `FetchMissing` field to the `comparison` query. The
default is true which respects the previous default behaviour.

If set to false then we will not attempt to fetch revisions that are
missing.

Part of: https://github.com/sourcegraph/sourcegraph/issues/11654