### PR TITLE
Add createCampaignSpec/createChangesetSpec mutations

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -88,7 +88,7 @@ type CampaignSpecResolver interface {
 
 	OriginalInput() (string, error)
 	ParsedInput() (JSONValue, error)
-	ChangesetSpecs() ([]ChangesetSpecResolver, error)
+	ChangesetSpecs(context.Context) ([]ChangesetSpecResolver, error)
 
 	Creator(context.Context) (*UserResolver, error)
 	CreatedAt() *DateTime
@@ -104,6 +104,11 @@ type ChangesetSpecResolver interface {
 
 	// TODO: More fields, see PR
 	ExpiresAt() *DateTime
+
+	// TODO: This is a hack so that a CampaignSpecResolver cannot be cast into
+	// this interface in `(NodeResolver).ToChangesetSpec`
+	// This should be removed as soon as this resolver gets more methods.
+	OnlyChangesetSpec() bool
 }
 
 type CampaignDeltaResolver interface {

--- a/enterprise/internal/campaigns/resolvers/apitest/exec.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/exec.go
@@ -41,7 +41,18 @@ func Exec(
 
 	query = strings.Replace(query, "\t", "  ", -1)
 
-	r := s.Exec(ctx, query, "", in)
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("failed to marshal input: %s", err)
+	}
+
+	var anonInput map[string]interface{}
+	err = json.Unmarshal(b, &anonInput)
+	if err != nil {
+		t.Fatalf("failed to unmarshal input back: %s", err)
+	}
+
+	r := s.Exec(ctx, query, "", anonInput)
 	if len(r.Errors) != 0 {
 		return r.Errors
 	}

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -186,11 +186,15 @@ type ChangesetCounts struct {
 	OpenPending          int32
 }
 
+type CommitTemplate struct {
+	Message string
+}
+
 type ChangesetTemplate struct {
 	Title     string
 	Body      string
 	Branch    string
-	Commit    string
+	Commit    CommitTemplate
 	Published bool
 }
 
@@ -211,6 +215,8 @@ type CampaignSpec struct {
 
 	Namespace UserOrg
 	Creator   User
+
+	ChangesetSpecs []ChangesetSpec
 
 	CreatedAt *graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
@@ -26,15 +27,17 @@ func TestCampaignSpecResolver(t *testing.T) {
 	userID := insertTestUser(t, dbconn.Global, "campaign-spec-by-id", false)
 
 	spec := &campaigns.CampaignSpec{
-		RawSpec: `{"name": "Foobar", "description": "My description"}`,
+		RawSpec: ct.TestRawCampaignSpec,
 		Spec: campaigns.CampaignSpecFields{
 			Name:        "Foobar",
 			Description: "My description",
 			ChangesetTemplate: campaigns.ChangesetTemplate{
-				Title:     "Hello there",
-				Body:      "This is the body",
-				Branch:    "my-branch",
-				Commit:    "d34db33f",
+				Title:  "Hello there",
+				Body:   "This is the body",
+				Branch: "my-branch",
+				Commit: campaigns.CommitTemplate{
+					Message: "Add hello world",
+				},
 				Published: false,
 			},
 		},
@@ -64,10 +67,12 @@ func TestCampaignSpecResolver(t *testing.T) {
 			Name:        spec.Spec.Name,
 			Description: spec.Spec.Description,
 			ChangesetTemplate: apitest.ChangesetTemplate{
-				Title:     spec.Spec.ChangesetTemplate.Title,
-				Body:      spec.Spec.ChangesetTemplate.Body,
-				Branch:    spec.Spec.ChangesetTemplate.Branch,
-				Commit:    spec.Spec.ChangesetTemplate.Commit,
+				Title:  spec.Spec.ChangesetTemplate.Title,
+				Body:   spec.Spec.ChangesetTemplate.Body,
+				Branch: spec.Spec.ChangesetTemplate.Branch,
+				Commit: apitest.CommitTemplate{
+					Message: spec.Spec.ChangesetTemplate.Commit.Message,
+				},
 				Published: spec.Spec.ChangesetTemplate.Published,
 			},
 		},

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -29,6 +29,9 @@ type changesetSpecResolver struct {
 	changesetSpec *campaigns.ChangesetSpec
 }
 
+// TODO: This is a hack, see docstring in graphqlbackend.ChangesetSpecResolver
+func (r *changesetSpecResolver) OnlyChangesetSpec() bool { return true }
+
 func (r *changesetSpecResolver) ID() graphql.ID {
 	// 🚨 SECURITY: This needs to be the RandID! We can't expose the
 	// sequential, guessable ID.

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
@@ -33,9 +34,11 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	repoID := graphqlbackend.MarshalRepositoryID(repo.ID)
 	spec := &campaigns.ChangesetSpec{
+		RawSpec: ct.NewRawChangesetSpec(repoID),
 		Spec: campaigns.ChangesetSpecFields{
-			RepoID: graphqlbackend.MarshalRepositoryID(repo.ID),
+			RepoID: repoID,
 		},
 		RepoID: repo.ID,
 		UserID: userID,

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -25,7 +25,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
 
-	userID := insertTestUser(t, dbconn.Global, "campaign-spec-by-id", false)
+	userID := insertTestUser(t, dbconn.Global, "changeset-spec-by-id", false)
 
 	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)
@@ -34,13 +34,8 @@ func TestChangesetSpecResolver(t *testing.T) {
 	}
 
 	spec := &campaigns.ChangesetSpec{
-		ID:      0,
-		RawSpec: `{"name": "Foobar", "description": "My description"}`,
 		Spec: campaigns.ChangesetSpecFields{
-			RepoID:  graphqlbackend.MarshalRepositoryID(repo.ID),
-			Rev:     "d34db33f",
-			BaseRef: "refs/heads/master",
-			Diff:    "+-",
+			RepoID: graphqlbackend.MarshalRepositoryID(repo.ID),
 		},
 		RepoID: repo.ID,
 		UserID: userID,

--- a/enterprise/internal/campaigns/store_campaign_specs.go
+++ b/enterprise/internal/campaigns/store_campaign_specs.go
@@ -243,7 +243,6 @@ var listCampaignSpecsQueryFmtstr = `
 SELECT ` + campaignSpecCols + ` FROM campaign_specs
 WHERE %s
 ORDER BY id ASC
-LIMIT %s
 `
 
 func listCampaignSpecsQuery(opts *ListCampaignSpecsOpts) *sqlf.Query {
@@ -252,14 +251,18 @@ func listCampaignSpecsQuery(opts *ListCampaignSpecsOpts) *sqlf.Query {
 	}
 	opts.Limit++
 
+	var limitClause string
+	if opts.Limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+	}
+
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
 	}
 
 	return sqlf.Sprintf(
-		listCampaignSpecsQueryFmtstr,
+		listCampaignSpecsQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
-		opts.Limit,
 	)
 }
 

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -207,6 +207,7 @@ type ListChangesetSpecsOpts struct {
 	Limit  int
 
 	CampaignSpecID int64
+	RandIDs        []string
 }
 
 // ListChangesetSpecs lists ChangesetSpecs with the given filters.
@@ -251,6 +252,16 @@ func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
 
 	if opts.CampaignSpecID != 0 {
 		preds = append(preds, sqlf.Sprintf("campaign_spec_id = %d", opts.CampaignSpecID))
+	}
+
+	if len(opts.RandIDs) != 0 {
+		ids := make([]*sqlf.Query, 0, len(opts.RandIDs))
+		for _, id := range opts.RandIDs {
+			if id != "" {
+				ids = append(ids, sqlf.Sprintf("%s", id))
+			}
+		}
+		preds = append(preds, sqlf.Sprintf("rand_id IN (%s)", sqlf.Join(ids, ",")))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -3,6 +3,7 @@ package campaigns
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/dineshappavoo/basex"
@@ -237,7 +238,6 @@ var listChangesetSpecsQueryFmtstr = `
 SELECT ` + changesetSpecCols + ` FROM changeset_specs
 WHERE %s
 ORDER BY id ASC
-LIMIT %s
 `
 
 func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
@@ -245,6 +245,11 @@ func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
 		opts.Limit = defaultListLimit
 	}
 	opts.Limit++
+
+	var limitClause string
+	if opts.Limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+	}
 
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
@@ -265,9 +270,8 @@ func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listChangesetSpecsQueryFmtstr,
+		listChangesetSpecsQueryFmtstr+limitClause,
 		sqlf.Join(preds, "\n AND "),
-		opts.Limit,
 	)
 }
 

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -74,26 +74,30 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 
 	t.Run("List", func(t *testing.T) {
 		t.Run("NoLimit", func(t *testing.T) {
-			opts := ListChangesetSpecsOpts{}
-
-			ts, next, err := s.ListChangesetSpecs(ctx, opts)
-			if err != nil {
-				t.Fatal(err)
+			opts := []ListChangesetSpecsOpts{
+				{},          // Empty limit should return default limit
+				{Limit: -1}, // -1 should return all entries
 			}
 
-			if have, want := next, int64(0); have != want {
-				t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
-			}
+			for _, o := range opts {
+				ts, next, err := s.ListChangesetSpecs(ctx, o)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			have, want := ts, changesetSpecs
-			if len(have) != len(want) {
-				t.Fatalf("listed %d changesetSpecs, want: %d", len(have), len(want))
-			}
+				if have, want := next, int64(0); have != want {
+					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+				}
 
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatalf("opts: %+v, diff: %s", opts, diff)
-			}
+				have, want := ts, changesetSpecs
+				if len(have) != len(want) {
+					t.Fatalf("listed %d changesetSpecs, want: %d", len(have), len(want))
+				}
 
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
+				}
+			}
 		})
 
 		t.Run("WithLimit", func(t *testing.T) {
@@ -125,7 +129,6 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 					}
 				}
 			}
-
 		})
 
 		t.Run("WithLimitAndCursor", func(t *testing.T) {

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -163,6 +163,35 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 				}
 			}
 		})
+
+		t.Run("WithRandIDs", func(t *testing.T) {
+			for _, c := range changesetSpecs {
+				opts := ListChangesetSpecsOpts{RandIDs: []string{c.RandID}}
+				have, _, err := s.ListChangesetSpecs(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				want := []*cmpgn.ChangesetSpec{c}
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
+				}
+			}
+
+			opts := ListChangesetSpecsOpts{}
+			for _, c := range changesetSpecs {
+				opts.RandIDs = append(opts.RandIDs, c.RandID)
+			}
+
+			have, _, err := s.ListChangesetSpecs(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, changesetSpecs); diff != "" {
+				t.Fatalf("opts: %+v, diff: %s", opts, diff)
+			}
+		})
 	})
 
 	t.Run("Update", func(t *testing.T) {

--- a/enterprise/internal/campaigns/testing/specs.go
+++ b/enterprise/internal/campaigns/testing/specs.go
@@ -1,5 +1,11 @@
 package testing
 
+import (
+	"fmt"
+
+	"github.com/graph-gophers/graphql-go"
+)
+
 const TestRawCampaignSpec = `{
   "name": "The name",
   "description": "My description",
@@ -13,3 +19,14 @@ const TestRawCampaignSpec = `{
     "published": false
   }
 }`
+
+func NewRawChangesetSpec(repo graphql.ID) string {
+	tmpl := `{
+		"repoID": %q,
+		"rev":"d34db33f",
+		"baseRef":"refs/heads/master",
+		"diff":"+-"
+	}`
+
+	return fmt.Sprintf(tmpl, repo)
+}

--- a/enterprise/internal/campaigns/testing/specs.go
+++ b/enterprise/internal/campaigns/testing/specs.go
@@ -1,0 +1,15 @@
+package testing
+
+const TestRawCampaignSpec = `{
+  "name": "The name",
+  "description": "My description",
+  "changesetTemplate": {
+    "title": "Hello World",
+    "body": "My first campaign!",
+    "branch": "hello-world",
+    "commit": {
+      "message": "Append Hello World to all README.md files"
+    },
+    "published": false
+  }
+}`

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1520,11 +1520,11 @@ type CampaignSpecFields struct {
 }
 
 type ChangesetTemplate struct {
-	Title     string `json:"title"`
-	Body      string `json:"body"`
-	Branch    string `json:"branch"`
-	Commit    string `json:"commit"`
-	Published bool   `json:"published"`
+	Title     string         `json:"title"`
+	Body      string         `json:"body"`
+	Branch    string         `json:"branch"`
+	Commit    CommitTemplate `json:"commit"`
+	Published bool           `json:"published"`
 }
 
 type CommitTemplate struct {

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1544,8 +1544,6 @@ type ChangesetSpec struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
-
-	ReconciledAt time.Time
 }
 
 // Clone returns a clone of a ChangesetSpec.

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1544,6 +1544,8 @@ type ChangesetSpec struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+
+	ReconciledAt time.Time
 }
 
 // Clone returns a clone of a ChangesetSpec.
@@ -1553,7 +1555,6 @@ func (cs *ChangesetSpec) Clone() *ChangesetSpec {
 }
 
 type ChangesetSpecFields struct {
-	// TODO: Is this a api.RepoID or a graphql.ID?
 	RepoID  graphql.ID   `json:"repoID"`
 	Rev     api.CommitID `json:"rev"`
 	BaseRef string       `json:"baseRef"`


### PR DESCRIPTION
The next PR to be merged into https://github.com/sourcegraph/sourcegraph/pull/11675.

This adds more data-layer infrastructure: the `createCampaignSpec` and `createChangesetSpec` mutations. There are still TODOs, the big ones revolving around validation of the specs, but since we haven't settled on a schema yet, I just left them in there.

The two mutations also check for repository permissions. 
