### PR TITLE
doc: admin config ssh gitserver link to k8s configure

### DIFF
--- a/doc/admin/repo/custom_git_or_ssh_config.md
+++ b/doc/admin/repo/custom_git_or_ssh_config.md
@@ -5,7 +5,7 @@ Sourcegraph supports customising [git-config](https://git-scm.com/docs/git-confi
 ## Setting configuration
 
 For cluster environments, we have guides for configuring SSH cloning. These can be adapted to additionally set `/etc/gitconfig`:
-- Kubernetes guide to [configure repository cloning via SSH](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/configure.md#configure-repository-cloning-via-ssh).
+- Kubernetes guide to [configure repository cloning via SSH](../install/kubernetes/configure.md#configure-repository-cloning-via-ssh).
 - Docker guide to [configure SSH cloning](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/README.md#configuring-ssh-cloning)
 
 Upon the Sourcegraph Docker image container start, it copies all files from `/etc/sourcegraph/{ssh,gitconfig,netrc}` into its own `$HOME` directory. Alternatively you can create a new Docker image which inherits from Sourcegraph and then mutates the environment:


### PR DESCRIPTION
pointing to doc instead of detour