### PR TITLE
dev: write to the correct Prometheus log

### DIFF
--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -53,4 +53,4 @@ docker run --rm ${DOCKER_NET} ${DOCKER_USER} \
   -v "${PROMETHEUS_DISK}":/prometheus \
   -v "${CONFIG_DIR}":/sg_prometheus_add_ons \
   -e PROMETHEUS_ADDITIONAL_FLAGS=--web.enable-lifecycle \
-  ${IMAGE} >"${PROMETHEUS_DISK}"/logs/prometheus.log 2>&1 || finish
+  ${IMAGE} >"${PROMETHEUS_LOG_FILE}" 2>&1 || finish


### PR DESCRIPTION
Users with pre-existing developer setups wouldn't have had this issue, but the log file was being written to a directory that wouldn't be created for new users.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
