### PR TITLE
search: do not limit default repos search

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -686,6 +686,11 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 		if err != nil {
 			return nil, nil, false, nil, errors.Wrap(err, "getting list of default repos")
 		}
+
+		// Search all default repos since indexed search is fast.
+		if len(defaultRepos) > maxRepoListSize {
+			maxRepoListSize = len(defaultRepos)
+		}
 	}
 
 	var repos []*types.Repo


### PR DESCRIPTION
Even though we index all default repos on sourcegraph.com, we would
still limit the number of repos searched. This is unintentional. This
commit now allows us to search all indexed repos on sourcegraph.com in
the default case.