### PR TITLE
usagestats: treat ID as anonymous if not all digits

### DIFF
--- a/cmd/frontend/internal/pkg/usagestatsdeprecated/usage_stats.go
+++ b/cmd/frontend/internal/pkg/usagestatsdeprecated/usage_stats.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -204,10 +205,11 @@ func uniques(dayStart time.Time, period *UsageDuration) (*ActiveUsers, error) {
 			bid := id.([]byte)
 			sid := string(bid)
 			allUniqueUserIDs[sid] = true
-			if len(bid) != 36 { // id is a numerical Sourcegraph user id, not an anonymous user's UUID
-				registeredUserIDs[sid] = true
-			} else {
+			if strings.Contains(sid, "-") {
+				// Looks like an anonymous user's UUID not a numerical Sourcegraph user ID.
 				anonymousUserIDs[sid] = true
+			} else {
+				registeredUserIDs[sid] = true
 			}
 		}
 

--- a/cmd/frontend/internal/pkg/usagestatsdeprecated/usage_stats.go
+++ b/cmd/frontend/internal/pkg/usagestatsdeprecated/usage_stats.go
@@ -11,12 +11,12 @@ import (
 	"context"
 	"math/rand"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
@@ -201,16 +201,19 @@ func uniques(dayStart time.Time, period *UsageDuration) (*ActiveUsers, error) {
 		if err != nil && err != redis.ErrNil {
 			return nil, err
 		}
+	nextValue:
 		for _, id := range values {
-			bid := id.([]byte)
-			sid := string(bid)
+			sid := string(id.([]byte))
 			allUniqueUserIDs[sid] = true
-			if strings.Contains(sid, "-") {
-				// Looks like an anonymous user's UUID not a numerical Sourcegraph user ID.
-				anonymousUserIDs[sid] = true
-			} else {
-				registeredUserIDs[sid] = true
+
+			// If any character is not a digit, then treat it as an anonymous user ID.
+			for _, s := range sid {
+				if s < '0' || s > '9' {
+					anonymousUserIDs[sid] = true
+					continue nextValue
+				}
 			}
+			registeredUserIDs[sid] = true
 		}
 
 		d = d.AddDate(0, 0, -1)


### PR DESCRIPTION
Quoting problem statement from https://github.com/sourcegraph/sourcegraph/issues/11801#issuecomment-652300018:

> The root cause is that we check length to determine if the ID looks like a UUID, but for some reason we stored double quotes along with the UUID, the length check no longer works.
> 
> https://github.com/sourcegraph/sourcegraph/blob/ce4381d9f01edd0201bf8e41c8d437e82828e494/cmd/frontend/internal/pkg/usagestatsdeprecated/usage_stats.go#L207

Checking digits is more robust. No tests added specifically for this given it's in deprecated codebase.

Fixes #11801