### PR TITLE
doc: Remove use of -endpoint flag from src-cli

### DIFF
--- a/doc/user/code_intelligence/languages/go.md
+++ b/doc/user/code_intelligence/languages/go.md
@@ -22,7 +22,7 @@ This guide is meant to provide specific instructions to get you producing index 
 1. Upload the data to a Sourcegraph instance with
    ```
    # for private instances
-   src -endpoint=<your sourcegraph endpoint> lsif upload
+   SRC_ENDPOINT=<your sourcegraph endpoint> src lsif upload
    # for public instances
    src lsif upload -github-token=<your github token>
    ```

--- a/doc/user/code_intelligence/languages/typescript_and_javascript.md
+++ b/doc/user/code_intelligence/languages/typescript_and_javascript.md
@@ -26,7 +26,7 @@ This guide is meant to provide specific instructions to get you producing index 
 1. Upload the data to a Sourcegraph instance with
    ```
    # for private instances
-   src -endpoint=<your sourcegraph endpoint> lsif upload
+   SRC_ENDPOINT=<your sourcegraph endpoint> src lsif upload
    # for public instances
    src lsif upload -github-token=<your github token>
    ```

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -36,7 +36,7 @@ For all languages, the upload step is the same. Make sure the current working di
 
 ```console
 # for private instances
-$ src -endpoint=<your sourcegraph endpoint> lsif upload -file=<LSIF file (e.g. dump.lsif)>
+$ SRC_ENDPOINT=<your sourcegraph endpoint> src lsif upload -file=<LSIF file (e.g. dump.lsif)>
 # to upload to Sourcegraph.com
 $ src lsif upload -github-token=<your github token> -file=<LSIF file (e.g. dump.lsif)>
 ```
@@ -60,7 +60,7 @@ View processing status at <link to your Sourcegraph instance LSIF status>.
 Possible upload errors include:
 
 - Clone in progress: the instance doesn't have the necessary data to process your upload yet, retry in a few minutes
-- Unknown repository (404): check your `-endpoint` and make sure you can view the repository on your Sourcegraph instance
+- Unknown repository (404): check your `SRC_ENDPOINT` and make sure you can view the repository on your Sourcegraph instance
 - Invalid commit (404): try visiting the repository at that commit on your Sourcegraph instance to trigger an update
 - Invalid auth when using Sourcegraph.com or when [`lsifEnforceAuth`](https://docs.sourcegraph.com/admin/config/site_config#lsifEnforceAuth) is `true` (401 for an invalid token or 404 if the repository cannot be found on GitHub.com): make sure your GitHub token is valid and that the repository is correct
 - Unexpected errors (500s): [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new)

--- a/internal/cmd/precise-code-intel-tester/main.go
+++ b/internal/cmd/precise-code-intel-tester/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	endpoint = env.Get("ENDPOINT", "http://127.0.0.1:3080", "Sourcegraph frontend endpoint")
+	endpoint = env.Get("SRC_ENDPOINT", "http://127.0.0.1:3080", "Sourcegraph frontend endpoint")
 	token    = env.Get("ACCESS_TOKEN", "", "Access token")
 
 	// Flags

--- a/internal/cmd/precise-code-intel-tester/upload.go
+++ b/internal/cmd/precise-code-intel-tester/upload.go
@@ -270,7 +270,6 @@ func upload(ctx context.Context, name, rev string, limiter *util.Limiter) (strin
 	defer limiter.Release()
 
 	args := []string{
-		fmt.Sprintf("-endpoint=%s", endpoint),
 		"lsif",
 		"upload",
 		"-root=/",


### PR DESCRIPTION
The flag is being deprecated in favour of environment variables.