### PR TITLE
search: use type:repo for repohasfile queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -95,6 +95,27 @@ func HandleFilePathPatterns(query *search.TextPatternInfo) (zoektquery.Q, error)
 		and = append(and, &zoektquery.Not{Child: q})
 	}
 
+	// For conditionals that happen on a repo we can use type:repo queries. eg
+	// (type:repo file:foo) (type:repo file:bar) will match all repos which
+	// contain a filename matching "foo" and a filename matchinb "bar".
+	//
+	// Note: (type:repo file:foo file:bar) will only find repos with a
+	// filename containing both "foo" and "bar".
+	for _, p := range query.FilePatternsReposMustInclude {
+		q, err := fileRe(p, query.IsCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, &zoektquery.Type{Type: zoektquery.TypeRepo, Child: q})
+	}
+	for _, p := range query.FilePatternsReposMustExclude {
+		q, err := fileRe(p, query.IsCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, &zoektquery.Not{Child: &zoektquery.Type{Type: zoektquery.TypeRepo, Child: q}})
+	}
+
 	return zoektquery.NewAnd(and...), nil
 }
 
@@ -157,14 +178,8 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		return nil, false, nil, err
 	}
 
-	// Handle `repohasfile` or `-repohasfile`
-	newRepoSet, err := createNewRepoSetWithRepoHasFileInputs(ctx, args.PatternInfo, args.Zoekt.Client, repoSet)
-	if err != nil {
-		return nil, false, nil, err
-	}
-
 	t0 := time.Now()
-	q, err := buildQuery(args, newRepoSet, filePathPatterns, true)
+	q, err := buildQuery(args, repoSet, filePathPatterns, true)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -181,7 +196,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	// If the previous indexed search did not return a substantial number of matching file candidates or count was
 	// manually specified, run a more complete and expensive search.
 	if resp.FileCount < 10 || args.PatternInfo.FileMatchLimit != defaultMaxSearchResults {
-		q, err = buildQuery(args, newRepoSet, filePathPatterns, false)
+		q, err = buildQuery(args, repoSet, filePathPatterns, false)
 		resp, err = args.Zoekt.Client.Search(ctx, q, &searchOpts)
 		if err != nil {
 			return nil, false, nil, err

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -373,208 +372,6 @@ func Benchmark_zoektIndexedRepos(b *testing.B) {
 	}
 }
 
-// repoURLsFakeSearcher fakes a searcher for use in
-// createNewRepoSetWithRepoHasFileInputs. It only supports setting the
-// RepoURLs field in search results, and will only evaluate search queries
-// containing RepoSets and file path filters.
-//
-// It is a map from repo name to list of files.
-type repoURLsFakeSearcher map[string][]string
-
-func (repoPaths repoURLsFakeSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	matchedRepoURLs := map[string]string{}
-	for repo, files := range repoPaths {
-		// We only expect a subset of query atoms. So we can evaluate them
-		// against our repo and files and tell if this repo should be in the
-		// result set.
-		errS := ""
-		eval := zoektquery.Map(q, func(q zoektquery.Q) zoektquery.Q {
-			switch r := q.(type) {
-			case *zoektquery.RepoSet:
-				return &zoektquery.Const{Value: r.Set[repo]}
-
-			case *zoektquery.Substring:
-				// Return true if any file name matches pattern
-				if r.Content || !r.FileName {
-					errS = "content substr"
-					return q
-				}
-
-				match := func(v string) bool {
-					return strings.Contains(v, r.Pattern)
-				}
-				if !r.CaseSensitive {
-					pat := strings.ToLower(r.Pattern)
-					match = func(v string) bool {
-						return strings.Contains(strings.ToLower(v), pat)
-					}
-				}
-
-				for _, f := range files {
-					if match(f) {
-						return &zoektquery.Const{Value: true}
-					}
-				}
-				return &zoektquery.Const{Value: false}
-
-			case *zoektquery.Regexp:
-				// Return true if any file name matches regexp
-				if r.Content || !r.FileName {
-					errS = "content regexp"
-					return q
-				}
-
-				prefix := ""
-				if !r.CaseSensitive {
-					prefix = "(?i)"
-				}
-				re := regexp.MustCompile(prefix + r.Regexp.String())
-
-				for _, f := range files {
-					if re.FindStringIndex(f) != nil {
-						return &zoektquery.Const{Value: true}
-					}
-				}
-				return &zoektquery.Const{Value: false}
-
-			case *zoektquery.And:
-				return q
-
-			default:
-				errS = "unexpected query atom: " + q.String()
-				return q
-			}
-		})
-		if errS != "" {
-			return nil, errors.Errorf("unsupported query %s: %s", q.String(), errS)
-		}
-		eval = zoektquery.Simplify(eval)
-		if eval.(*zoektquery.Const).Value {
-			matchedRepoURLs[repo] = repo
-		}
-	}
-
-	return &zoekt.SearchResult{RepoURLs: matchedRepoURLs}, nil
-}
-
-func (repoURLsFakeSearcher) List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoList, error) {
-	panic("unimplemented")
-}
-
-func (repoURLsFakeSearcher) String() string {
-	panic("unimplemented")
-}
-
-func (repoURLsFakeSearcher) Close() {
-	panic("unimplemented")
-}
-
-func TestCreateNewRepoSetWithRepoHasFileInputs(t *testing.T) {
-	searcher := repoURLsFakeSearcher{
-		"github.com/test/1": []string{"1.md"},
-		"github.com/test/2": []string{"2.md"},
-	}
-	allRepos := []string{"github.com/test/1", "github.com/test/2"}
-
-	tests := []struct {
-		name        string
-		include     []string
-		exclude     []string
-		repoSet     []string
-		wantRepoSet []string
-	}{
-		{
-			name:        "all",
-			include:     []string{"md"},
-			repoSet:     allRepos,
-			wantRepoSet: allRepos,
-		},
-		{
-			name:    "none",
-			include: []string{"foo"},
-			repoSet: allRepos,
-		},
-		{
-			name:        "one include",
-			include:     []string{"1"},
-			repoSet:     allRepos,
-			wantRepoSet: []string{"github.com/test/1"},
-		},
-		{
-			name:        "two include",
-			include:     []string{"md", "2"},
-			repoSet:     allRepos,
-			wantRepoSet: []string{"github.com/test/2"},
-		},
-		{
-			name:        "include exclude",
-			include:     []string{"md"},
-			exclude:     []string{"1"},
-			repoSet:     allRepos,
-			wantRepoSet: []string{"github.com/test/2"},
-		},
-		{
-			name:        "exclude",
-			exclude:     []string{"1"},
-			repoSet:     allRepos,
-			wantRepoSet: []string{"github.com/test/2"},
-		},
-		{
-			name:    "exclude all",
-			exclude: []string{"md"},
-			repoSet: allRepos,
-		},
-		{
-			name:        "exclude none",
-			exclude:     []string{"foo"},
-			repoSet:     allRepos,
-			wantRepoSet: allRepos,
-		},
-		{
-			name:        "subset of reposet",
-			include:     []string{"md"},
-			repoSet:     []string{"github.com/test/1"},
-			wantRepoSet: []string{"github.com/test/1"},
-		},
-		{
-			name:    "exclude subset of reposet",
-			exclude: []string{"1"},
-			repoSet: []string{"github.com/test/1"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			repoSet := &zoektquery.RepoSet{Set: map[string]bool{}}
-			for _, r := range tt.repoSet {
-				repoSet.Set[r] = true
-			}
-
-			info := &search.TextPatternInfo{
-				FilePatternsReposMustInclude: tt.include,
-				FilePatternsReposMustExclude: tt.exclude,
-				PathPatternsAreRegExps:       true,
-			}
-
-			gotRepoSet, err := createNewRepoSetWithRepoHasFileInputs(context.Background(), info, searcher, repoSet)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var got []string
-			for r := range gotRepoSet.Set {
-				got = append(got, r)
-			}
-
-			sort.Strings(got)
-			sort.Strings(tt.wantRepoSet)
-			if !cmp.Equal(tt.wantRepoSet, got) {
-				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.wantRepoSet, got))
-			}
-		})
-	}
-}
-
 func TestZoektResultCountFactor(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -702,6 +499,17 @@ func TestQueryToZoektQuery(t *testing.T) {
 				PatternMatchesPath:           true,
 			},
 			Query: `f:test`,
+		},
+		{
+			Name: "repos must include",
+			Pattern: &search.TextPatternInfo{
+				IsRegExp:                     true,
+				Pattern:                      "foo",
+				PathPatternsAreRegExps:       true,
+				FilePatternsReposMustInclude: []string{`\.go$`, `\.yaml$`},
+				FilePatternsReposMustExclude: []string{`\.java$`, `\.xml$`},
+			},
+			Query: `foo (type:repo file:\.go$) (type:repo file:\.yaml$) -(type:repo file:\.java$) -(type:repo file:\.xml$)`,
 		},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
Previously we would search zoekt to narrow down the set of repositories
to search for each repohasfile token. However, we can instead directly
create a zoekt query which captures the same meaning. By directly
creating the query we can remove our application level filtering we do.

This change is motivated by multiple branch search. The reposet code is
unaware of branches and makes it difficult to adapt to branches.

Note: I have duplicated the logic for structural search's
HandleFilePathPatterns. Structural search is already duplicating logic,
so I am following the pattern. I will soon investigate how to
potentially remove the duplication in structural search.

Note: type:repo is a Sourcegraph specific extension to Zoekt.