### PR TITLE
authz: fix broken `UserIDsWithOldestPerms` when user is hard-deleted

### DIFF
--- a/enterprise/cmd/frontend/db/perms_store.go
+++ b/enterprise/cmd/frontend/db/perms_store.go
@@ -1489,9 +1489,9 @@ func (s *PermsStore) UserIDsWithOldestPerms(ctx context.Context, limit int) (map
 	q := sqlf.Sprintf(`
 -- source: enterprise/cmd/frontend/db/perms_store.go:PermsStore.UserIDsWithOldestPerms
 SELECT perms.user_id, perms.synced_at FROM user_permissions AS perms
-WHERE perms.user_id NOT IN
+WHERE perms.user_id IN
 	(SELECT users.id FROM users
-	 WHERE users.deleted_at IS NOT NULL)
+	 WHERE users.deleted_at IS NULL)
 ORDER BY perms.synced_at ASC NULLS FIRST
 LIMIT %s
 `, limit)


### PR DESCRIPTION
Instead of checking if _user is not in the list of soft-deleted_, we now check _the user is not deleted_. 

This prevents scheduler trying to sync permissions for hard-deleted users. Such scenario is not usual (DB is manually modified).

Similar fix to #11770