### PR TITLE
Fix hostname regexes

### DIFF
--- a/browser/src/shared/code-hosts/github/codeHost.test.ts
+++ b/browser/src/shared/code-hosts/github/codeHost.test.ts
@@ -2,7 +2,12 @@ import { existsSync, readdirSync } from 'fs'
 import { startCase } from 'lodash'
 import { testCodeHostMountGetters, testToolbarMountGetter } from '../shared/codeHostTestUtils'
 import { CodeView } from '../shared/codeViews'
-import { createFileActionsToolbarMount, createFileLineContainerToolbarMount, githubCodeHost } from './codeHost'
+import {
+    createFileActionsToolbarMount,
+    createFileLineContainerToolbarMount,
+    githubCodeHost,
+    checkIsGitHubDotCom,
+} from './codeHost'
 import { readFile } from 'mz/fs'
 
 const testCodeHost = (fixturePath: string): void => {
@@ -167,6 +172,21 @@ describe('github/codeHost', () => {
                     'https://github.com/sourcegraph/sourcegraph/pull/3257/files#diff-93ceb95cf0be7b7b17815c5638fc4c5cR1335'
                 )
             })
+        })
+    })
+
+    describe('githubCodeHost.checkIsGithubDotCom()', () => {
+        it('returns true with a github.com URL', () => {
+            expect(checkIsGitHubDotCom('https://www.github.com')).toBe(true)
+            expect(checkIsGitHubDotCom('https://github.com')).toBe(true)
+            expect(checkIsGitHubDotCom('http://github.com')).toBe(true)
+            expect(checkIsGitHubDotCom('http://www.github.com')).toBe(true)
+        })
+
+        it('returns false on domains that impersonate github.com', () => {
+            expect(checkIsGitHubDotCom('https://wwwwgithub.com')).toBe(false)
+            expect(checkIsGitHubDotCom('https://www.githubccom')).toBe(false)
+            expect(checkIsGitHubDotCom('http://githubccom')).toBe(false)
         })
     })
 })

--- a/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/browser/src/shared/code-hosts/github/codeHost.ts
@@ -247,7 +247,7 @@ export function checkIsGitHubEnterprise(): boolean {
 /**
  * Returns true if the current page is github.com.
  */
-export const checkIsGitHubDotCom = (): boolean => /^https?:\/\/(www.)?github.com/.test(window.location.href)
+export const checkIsGitHubDotCom = (): boolean => /^https?:\/\/(www\.)?github\.com/.test(window.location.href)
 
 /**
  * Returns true if the current page is either github.com or GitHub Enterprise.

--- a/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/browser/src/shared/code-hosts/github/codeHost.ts
@@ -247,7 +247,7 @@ export function checkIsGitHubEnterprise(): boolean {
 /**
  * Returns true if the current page is github.com.
  */
-export const checkIsGitHubDotCom = (): boolean => /^https?:\/\/(www\.)?github\.com/.test(window.location.href)
+export const checkIsGitHubDotCom = (url = window.location.href): boolean => /^https?:\/\/(www\.)?github\.com/.test(url)
 
 /**
  * Returns true if the current page is either github.com or GitHub Enterprise.

--- a/browser/src/shared/code-hosts/sourcegraph/inject.test.tsx
+++ b/browser/src/shared/code-hosts/sourcegraph/inject.test.tsx
@@ -1,0 +1,16 @@
+import { checkIsSourcegraph } from './inject'
+
+describe('checkIsSourcegraph()', () => {
+    it('returns true when the location matches the provided sourcegraphServerURL', () => {
+        expect(checkIsSourcegraph('https://sourcegraph.test:3443', new URL('https://sourcegraph.test:3443'))).toBe(true)
+        expect(
+            checkIsSourcegraph('https://sourcegraph.test:3443', new URL('https://sourcegraph.test:3443/search?q=test'))
+        ).toBe(true)
+    })
+    it('returns true for sourcegraph.com', () => {
+        expect(checkIsSourcegraph('https://sourcegraph.test:3443', new URL('https://sourcegraph.com'))).toBe(true)
+    })
+    it('returns false when the location attempts to impersonate sourcegraph.com', () => {
+        expect(checkIsSourcegraph('https://sourcegraph.test:3443', new URL('https://wwwwsourcegraph.com'))).toBe(false)
+    })
+})

--- a/browser/src/shared/code-hosts/sourcegraph/inject.tsx
+++ b/browser/src/shared/code-hosts/sourcegraph/inject.tsx
@@ -40,7 +40,10 @@ function dispatchSourcegraphEvents(): void {
     document.dispatchEvent(new CustomEvent<{}>('sourcegraph:browser-extension-registration'))
 }
 
-export const checkIsSourcegraph = (sourcegraphServerUrl: string): boolean =>
-    window.location.origin === sourcegraphServerUrl ||
-    /^https?:\/\/(www\.)?sourcegraph\.com/.test(location.href) ||
+export const checkIsSourcegraph = (
+    sourcegraphServerUrl: string,
+    { origin, href }: Pick<Location, 'origin' | 'href'> = window.location
+): boolean =>
+    origin === sourcegraphServerUrl ||
+    /^https?:\/\/(www\.)?sourcegraph\.com/.test(href) ||
     !!document.querySelector('#sourcegraph-chrome-webstore-item')

--- a/browser/src/shared/code-hosts/sourcegraph/inject.tsx
+++ b/browser/src/shared/code-hosts/sourcegraph/inject.tsx
@@ -42,5 +42,5 @@ function dispatchSourcegraphEvents(): void {
 
 export const checkIsSourcegraph = (sourcegraphServerUrl: string): boolean =>
     window.location.origin === sourcegraphServerUrl ||
-    /^https?:\/\/(www.)?sourcegraph.com/.test(location.href) ||
+    /^https?:\/\/(www\.)?sourcegraph\.com/.test(location.href) ||
     !!document.querySelector('#sourcegraph-chrome-webstore-item')


### PR DESCRIPTION
Fixes two hostname regexes with unescaped `.`, detected by GitHub code scanning.