### PR TITLE
licenses: approve mdi-react, pin license_finder

### DIFF
--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -14,7 +14,7 @@ jobs:
       with: { node-version: '14.4' }
 
     - name: Install license_finder
-      run: gem install license_finder
+      run: gem install license_finder:6.6.1
 
     - name: Check dependencies
       run: LICENSE_CHECK=true ./dev/licenses.sh

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -16,7 +16,7 @@ jobs:
       with: { node-version: '14.4' }
 
     - name: Install license_finder
-      run: gem install license_finder
+      run: gem install license_finder:6.6.1
 
     - name: Generate report
       run: ./dev/licenses.sh

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -309,3 +309,10 @@
     :why:
     :versions: []
     :when: 2020-06-16 02:20:33.870044000 Z
+- - :approve
+  - mdi-react
+  - :who:
+    :why: Seems to be a bug approving this dependency, despite its license already
+      being on the approvelist
+    :versions: []
+    :when: 2020-07-02 01:16:22.339839000 Z


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/11866

`mdi-react`'s license and version did not change, and its license was already on the allowlist, but for whatever reason the check no longer recognizes the license, so I've added an override for it:

```
license_finder approvals add mdi-react
```

I suspect it's a regression in `license_finder`, as there was [an update recently](https://github.com/pivotal/LicenseFinder/releases/tag/v6.6.1). To hopefully prevent this from being an issue again I've pinned the version installed in both github actions

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
