### PR TITLE
ci: enable go-acc on default branch

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -14,5 +14,26 @@ echo "--- comby install"
 echo "--- go mod download"
 go mod download
 
-echo "--- go test"
-go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
+goacc=""
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --goacc)
+      goacc="$2"
+      shift
+      ;;
+    *)
+      echo "Unknown parameter passed: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ "$goacc" == "true" ]; then
+  echo "--- go test with accurate code coverage"
+  go get github.com/ory/go-acc
+  "$(go env GOPATH)/bin/go-acc" ./...
+else
+  echo "--- go test"
+  go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
+fi

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -122,12 +122,15 @@ func (c Config) ensureCommit() error {
 	return nil
 }
 
+func (c Config) isDefaultBranch() bool {
+	return c.branch == "master" || strings.HasPrefix(c.branch, "master-dry-run/")
+}
+
 func (c Config) isPR() bool {
 	return !c.isBextReleaseBranch &&
 		!c.releaseBranch &&
 		!c.taggedRelease &&
-		c.branch != "master" &&
-		!strings.HasPrefix(c.branch, "master-dry-run/") &&
+		!c.isDefaultBranch() &&
 		!strings.HasPrefix(c.branch, "docker-images-patch/")
 }
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -128,11 +128,14 @@ func addPostgresBackcompat(pipeline *bk.Pipeline) {
 		bk.Cmd("./dev/ci/ci-db-backcompat.sh"))
 }
 
-// Adds the Go test step.
-func addGoTests(pipeline *bk.Pipeline) {
-	pipeline.AddStep(":go:",
-		bk.Cmd("./dev/ci/go-test.sh"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go -F unit"))
+// Adds the Go test step. The runAcc parameter indicates whether to generate accurate
+// code coverage for these Go tests.
+func addGoTests(runAcc bool) func(*bk.Pipeline) {
+	return func(pipeline *bk.Pipeline) {
+		pipeline.AddStep(":go:",
+			bk.Cmd(fmt.Sprintf("./dev/ci/go-test.sh --goacc %v", runAcc)),
+			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go -F unit"))
+	}
 }
 
 // Builds the OSS and Enterprise Go commands.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -106,7 +106,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addBrowserExt,
 			addWebApp,
 			addSharedTests,
-			addGoTests,
+			addGoTests(false),
 			addGoBuild,
 			addDockerfileLint,
 		}
@@ -120,15 +120,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
-			addLint,               // ~3.5m
-			addWebApp,             // ~3m
-			addSharedTests,        // ~3m
-			addBrowserExt,         // ~2m
-			addGoTests,            // ~1.5m
-			addCheck,              // ~1m
-			addGoBuild,            // ~0.5m
-			addPostgresBackcompat, // ~0.25m
-			addDockerfileLint,     // ~0.2m
+			addGoTests(c.isDefaultBranch()), // ~2m or ~9m
+			addLint,                         // ~3.5m
+			addWebApp,                       // ~3m
+			addSharedTests,                  // ~3m
+			addBrowserExt,                   // ~2m
+			addCheck,                        // ~1m
+			addGoBuild,                      // ~0.5m
+			addPostgresBackcompat,           // ~0.25m
+			addDockerfileLint,               // ~0.2m
 			addDockerImages(c, false),
 			wait,
 			addDockerImages(c, true),


### PR DESCRIPTION
Uses github.com/ory/go-acc to calculate accurate code coverage that counts for integration tests on default branch. Because it takes 4x times of simple `go test ./...` (>8m vs ~2m), running it on every PR is not worth.

Fixes #11781