### PR TITLE
gqltest: add search integration tests

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1130,5 +1130,3 @@ func handleRepoSearchResult(common *searchResultsCommon, repoRev *search.Reposit
 	}
 	return nil
 }
-
-var errMultipleRevsNotSupported = errors.New("not yet supported: searching multiple revs in the same repo")

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -5,11 +5,14 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestSearch(t *testing.T) {
@@ -106,9 +109,74 @@ func TestSearch(t *testing.T) {
 
 		// Make sure only got .go files and no .md files
 		for _, r := range results {
-			if !strings.HasSuffix(r.Name, ".go") {
-				t.Fatalf("Found file name does not end with .go: %s", r.Name)
+			if !strings.HasSuffix(r.File.Name, ".go") {
+				t.Fatalf("Found file name does not end with .go: %s", r.File.Name)
 			}
+		}
+	})
+
+	t.Run("multiple revisions per repository", func(t *testing.T) {
+		// Update site configuration to set "experimentalFeatures.searchMultipleRevisionsPerRepository".
+		siteConfig, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldSiteConfig := new(schema.SiteConfiguration)
+		*oldSiteConfig = *siteConfig
+		defer func() {
+			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		val := true
+		siteConfig.ExperimentalFeatures = &schema.ExperimentalFeatures{
+			SearchMultipleRevisionsPerRepository: &val,
+		}
+		err = client.UpdateSiteConfiguration(siteConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var lastExprs []string
+		// Retry because the configuration update endpoint is eventually consistent
+		err = gqltestutil.Retry(5*time.Second, func() error {
+			results, err := client.SearchFiles("repo:sourcegraph/go-diff$@master:print-options:*refs/heads/ func NewHunksReader")
+			if err != nil {
+				if strings.Contains(err.Error(), "text search failed: not yet supported: searching multiple revs in the same repo") {
+					return gqltestutil.ErrContinueRetry
+				}
+				t.Fatal(err)
+			}
+
+			wantExprs := map[string]struct{}{
+				"master":        {},
+				"print-options": {},
+
+				// These next 2 branches are included because of the *refs/heads/ in the query.
+				// If they are ever deleted from the actual live repository, replace them with
+				// any other branches that still exist.
+				"test-already-exist-pr": {},
+				"bug-fix-wip":           {},
+			}
+
+			for _, r := range results {
+				delete(wantExprs, r.RevSpec.Expr)
+				lastExprs = append(lastExprs, r.RevSpec.Expr)
+			}
+
+			if len(wantExprs) > 0 {
+				missing := make([]string, 0, len(wantExprs))
+				for expr := range wantExprs {
+					missing = append(missing, expr)
+				}
+				return errors.Errorf("missing exprs: %v", missing)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err, "lastExprs:", lastExprs)
 		}
 	})
 }

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -14,7 +14,7 @@ func (c *Client) WaitForReposToBeCloned(repos ...string) error {
 	return Retry(30*time.Second, func() error {
 		const query = `
 query Repositories($first: Int) {
-	repositories(first: $first, cloned: true) {
+	repositories(first: $first, cloned: true, cloneInProgress: false, notCloned: false) {
 		nodes {
 			name
 		}

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -115,3 +115,42 @@ query Search($query: String!) {
 
 	return resp.Data.Search.Results.Results, nil
 }
+
+type SearchStatsResult struct {
+	Languages []struct {
+		Name       string `json:"name"`
+		TotalLines int    `json:"totalLines"`
+	} `json:"languages"`
+}
+
+// SearchStats returns statistics of given query.
+func (c *Client) SearchStats(query string) (*SearchStatsResult, error) {
+	const gqlQuery = `
+query SearchResultsStats($query: String!) {
+	search(query: $query) {
+		stats {
+			languages {
+				name
+				totalLines
+			}
+		}
+	}
+}
+`
+	variables := map[string]interface{}{
+		"query": query,
+	}
+	var resp struct {
+		Data struct {
+			Search struct {
+				Stats *SearchStatsResult `json:"stats"`
+			} `json:"search"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", gqlQuery, variables, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.Search.Stats, nil
+}

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -64,7 +64,12 @@ query Search($query: String!) {
 }
 
 type SearchFileResult struct {
-	Name string `json:"name"`
+	File struct {
+		Name string `json:"name"`
+	} `json:"file"`
+	RevSpec struct {
+		Expr string `json:"expr"`
+	} `json:"revSpec"`
 }
 
 type SearchFileResults []*SearchFileResult
@@ -80,6 +85,11 @@ query Search($query: String!) {
 					file {
 						name
 					}
+					revSpec {
+						... on GitRevSpecExpr {
+							expr
+						}
+					}
 				}
 			}
 		}
@@ -93,9 +103,7 @@ query Search($query: String!) {
 		Data struct {
 			Search struct {
 				Results struct {
-					Results []struct {
-						*SearchFileResult `json:"file"`
-					} `json:"results"`
+					Results []*SearchFileResult `json:"results"`
 				} `json:"results"`
 			} `json:"search"`
 		} `json:"data"`
@@ -105,9 +113,5 @@ query Search($query: String!) {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
 
-	results := make([]*SearchFileResult, 0, len(resp.Data.Search.Results.Results))
-	for _, r := range resp.Data.Search.Results.Results {
-		results = append(results, r.SearchFileResult)
-	}
-	return results, nil
+	return resp.Data.Search.Results.Results, nil
 }


### PR DESCRIPTION
Adds integrations tests for search, which covers:

- [Multiple revisions per repository](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0211f6583717cf09e7b6e186e98d84cc9824d0d/-/blob/web/src/e2e/e2e.test.ts#L1171)
- [Search statistics](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0211f6583717cf09e7b6e186e98d84cc9824d0d/-/blob/web/src/e2e/e2e.test.ts#L1424:22)

Please review by commit.

Part of #10068