### PR TITLE
siteAdmin: wait for all report data to load before rendering

### DIFF
--- a/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -16,6 +16,7 @@ import { PageTitle } from '../components/PageTitle'
 import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { useObservable } from '../../../shared/src/util/useObservable'
 import { mapValues, values } from 'lodash'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
 /**
  * Minimal shape of a JSON Schema. These values are treated as opaque, so more specific types are
@@ -92,6 +93,7 @@ export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLight
     const monitoringDaysBack = 7
     const monitoringStats = useObservable(useMemo(() => fetchMonitoringStats(monitoringDaysBack), []))
     const allConfig = useObservable(useMemo(fetchAllConfigAndSettings, []))
+    const isLoading = allConfig === undefined || monitoringStats === undefined
     return (
         <div>
             <PageTitle title="Report a bug - Admin" />
@@ -117,23 +119,29 @@ export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLight
                     support@sourcegraph.com.
                 </div>
             </div>
-            <DynamicallyImportedMonacoSettingsEditor
-                value={
-                    allConfig
-                        ? JSON.stringify(
-                              monitoringStats ? { ...allConfig, ...monitoringStats } : { ...allConfig, alerts: null },
-                              undefined,
-                              2
-                          )
-                        : ''
-                }
-                jsonSchema={allConfigSchema}
-                canEdit={false}
-                height={800}
-                isLightTheme={isLightTheme}
-                history={history}
-                readOnly={true}
-            />
+            {isLoading ? (
+                <LoadingSpinner className="icon-inline mt-2" />
+            ) : (
+                <DynamicallyImportedMonacoSettingsEditor
+                    value={
+                        allConfig
+                            ? JSON.stringify(
+                                  monitoringStats
+                                      ? { ...allConfig, ...monitoringStats }
+                                      : { ...allConfig, alerts: null },
+                                  undefined,
+                                  2
+                              )
+                            : ''
+                    }
+                    jsonSchema={allConfigSchema}
+                    canEdit={false}
+                    height={800}
+                    isLightTheme={isLightTheme}
+                    history={history}
+                    readOnly={true}
+                />
+            )}
         </div>
     )
 }

--- a/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -122,17 +122,11 @@ export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLight
                 <LoadingSpinner className="icon-inline mt-2" />
             ) : (
                 <DynamicallyImportedMonacoSettingsEditor
-                    value={
-                        allConfig
-                            ? JSON.stringify(
-                                  monitoringStats
-                                      ? { ...allConfig, ...monitoringStats }
-                                      : { ...allConfig, alerts: null },
-                                  undefined,
-                                  2
-                              )
-                            : ''
-                    }
+                    value={JSON.stringify(
+                        monitoringStats ? { ...allConfig, ...monitoringStats } : { ...allConfig, alerts: null },
+                        undefined,
+                        2
+                    )}
                     jsonSchema={allConfigSchema}
                     canEdit={false}
                     height={800}

--- a/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -93,7 +93,6 @@ export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLight
     const monitoringDaysBack = 7
     const monitoringStats = useObservable(useMemo(() => fetchMonitoringStats(monitoringDaysBack), []))
     const allConfig = useObservable(useMemo(fetchAllConfigAndSettings, []))
-    const isLoading = allConfig === undefined || monitoringStats === undefined
     return (
         <div>
             <PageTitle title="Report a bug - Admin" />
@@ -119,7 +118,7 @@ export const SiteAdminReportBugPage: React.FunctionComponent<Props> = ({ isLight
                     support@sourcegraph.com.
                 </div>
             </div>
-            {isLoading ? (
+            {allConfig === undefined || monitoringStats === undefined ? (
                 <LoadingSpinner className="icon-inline mt-2" />
             ) : (
                 <DynamicallyImportedMonacoSettingsEditor


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/11806

Suspected race condition in `DynamicallyImportedMonacoSettingsEditor` has been causing alerts data to load inconsistently. This PR works around it by rendering a loader until all data is available.

Opened a separate issue re: potentially fixing the root cause: https://github.com/sourcegraph/sourcegraph/issues/11890

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
