### PR TITLE
search: do not process paths as regexp for structural searcher

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -188,11 +188,6 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		}
 	}(time.Now())
 
-	rg, err := compile(&p.PatternInfo)
-	if err != nil {
-		return nil, false, false, badRequestError{err.Error()}
-	}
-
 	if p.FetchTimeout == "" {
 		p.FetchTimeout = "500ms"
 	}
@@ -230,6 +225,10 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	if p.IsStructuralPat {
 		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, p.Repo)
 	} else {
+		rg, err := compile(&p.PatternInfo)
+		if err != nil {
+			return nil, false, false, badRequestError{err.Error()}
+		}
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath)
 	}
 	return matches, limitHit, false, err


### PR DESCRIPTION
Fixes #11831

Before this PR, it was possible that we compile/validate parameters like `file:<value>` for regexp search in searcher before running comby for a structural search. It could happen that we want to search a file containing metacharacters (in this case a file path like `recipes/C++/576559_Fast_prime_generator/recipe-576559.cpp`) that is passed directly without any quoting, resulting in the error in the above issue. It's pretty rare to trigger since not many regex metacharacters are valid for file paths, but `+` is one exception, which is why this wasn't caught till now.

This PR moves the part that is particular to regexp search so that it doesn't affect structural search, and it is safe to treat the file paths literally.