### PR TITLE
monitoring: wrap cadvisor metrics in label_replace

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -150,7 +150,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 1+ container restarts every 5m by instance (not available on server)_
+- _frontend: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -165,7 +165,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 99%+ container memory usage by instance (not available on server)_
+- _frontend: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -176,7 +176,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _frontend: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -187,7 +187,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _frontend: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -200,7 +200,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _frontend: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _frontend: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -213,7 +213,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _frontend: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _frontend: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -224,7 +224,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _frontend: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _frontend: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -317,7 +317,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 1+ container restarts every 5m by instance (not available on server)_
+- _gitserver: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -332,7 +332,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 99%+ container memory usage by instance (not available on server)_
+- _gitserver: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -343,7 +343,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _gitserver: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -354,7 +354,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _gitserver: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -367,7 +367,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _gitserver: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -380,7 +380,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _gitserver: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -391,7 +391,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _gitserver: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _gitserver: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -402,7 +402,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 1+ container restarts every 5m by instance (not available on server)_
+- _github-proxy: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -417,7 +417,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 99%+ container memory usage by instance (not available on server)_
+- _github-proxy: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -428,7 +428,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _github-proxy: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -439,7 +439,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _github-proxy: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -452,7 +452,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _github-proxy: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -465,7 +465,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _github-proxy: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -476,7 +476,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _github-proxy: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _github-proxy: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -516,7 +516,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 1+ container restarts every 5m by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -531,7 +531,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 99%+ container memory usage by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -542,7 +542,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -553,7 +553,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -566,7 +566,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -579,7 +579,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -590,7 +590,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _precise-code-intel-bundle-manager: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -617,7 +617,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 1+ container restarts every 5m by instance (not available on server)_
+- _precise-code-intel-worker: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -632,7 +632,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 99%+ container memory usage by instance (not available on server)_
+- _precise-code-intel-worker: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -643,7 +643,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _precise-code-intel-worker: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -654,7 +654,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _precise-code-intel-worker: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -667,7 +667,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _precise-code-intel-worker: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -680,7 +680,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _precise-code-intel-worker: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -691,7 +691,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _precise-code-intel-worker: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -718,7 +718,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 1+ container restarts every 5m by instance (not available on server)_
+- _precise-code-intel-indexer: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -733,7 +733,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 99%+ container memory usage by instance (not available on server)_
+- _precise-code-intel-indexer: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -744,7 +744,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _precise-code-intel-indexer: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -755,7 +755,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _precise-code-intel-indexer: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -768,7 +768,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _precise-code-intel-indexer: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -781,7 +781,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _precise-code-intel-indexer: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -792,7 +792,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _precise-code-intel-indexer: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -819,7 +819,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 1+ container restarts every 5m by instance (not available on server)_
+- _query-runner: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -834,7 +834,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 99%+ container memory usage by instance (not available on server)_
+- _query-runner: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -845,7 +845,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _query-runner: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -856,7 +856,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _query-runner: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -869,7 +869,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _query-runner: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -882,7 +882,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _query-runner: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -893,7 +893,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _query-runner: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _query-runner: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -920,7 +920,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 1+ container restarts every 5m by instance (not available on server)_
+- _replacer: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -935,7 +935,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 99%+ container memory usage by instance (not available on server)_
+- _replacer: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -946,7 +946,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _replacer: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -957,7 +957,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _replacer: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -970,7 +970,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _replacer: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -983,7 +983,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _replacer: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -994,7 +994,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _replacer: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _replacer: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -1021,7 +1021,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 1+ container restarts every 5m by instance (not available on server)_
+- _repo-updater: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -1036,7 +1036,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 99%+ container memory usage by instance (not available on server)_
+- _repo-updater: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -1047,7 +1047,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _repo-updater: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1058,7 +1058,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _repo-updater: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1071,7 +1071,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _repo-updater: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -1084,7 +1084,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _repo-updater: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1095,7 +1095,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _repo-updater: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _repo-updater: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -1122,7 +1122,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 1+ container restarts every 5m by instance (not available on server)_
+- _searcher: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -1137,7 +1137,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 99%+ container memory usage by instance (not available on server)_
+- _searcher: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -1148,7 +1148,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _searcher: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1159,7 +1159,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _searcher: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1172,7 +1172,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _searcher: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -1185,7 +1185,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _searcher: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1196,7 +1196,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _searcher: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _searcher: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -1223,7 +1223,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 1+ container restarts every 5m by instance (not available on server)_
+- _symbols: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -1238,7 +1238,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 99%+ container memory usage by instance (not available on server)_
+- _symbols: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -1249,7 +1249,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _symbols: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1260,7 +1260,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _symbols: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1273,7 +1273,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _symbols: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -1286,7 +1286,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _symbols: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1297,7 +1297,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _symbols: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _symbols: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -1308,7 +1308,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 1+ container restarts every 5m by instance (not available on server)_
+- _syntect-server: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -1323,7 +1323,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 99%+ container memory usage by instance (not available on server)_
+- _syntect-server: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -1334,7 +1334,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _syntect-server: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1345,7 +1345,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _syntect-server: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1358,7 +1358,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _syntect-server: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -1371,7 +1371,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _syntect-server: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1382,7 +1382,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _syntect-server: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _syntect-server: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -1393,7 +1393,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 1+ container restarts every 5m by instance (not available on server)_
+- _zoekt-indexserver: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -1408,7 +1408,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 99%+ container memory usage by instance (not available on server)_
+- _zoekt-indexserver: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -1419,7 +1419,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _zoekt-indexserver: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1430,7 +1430,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _zoekt-indexserver: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1443,7 +1443,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _zoekt-indexserver: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -1456,7 +1456,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _zoekt-indexserver: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1467,7 +1467,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _zoekt-indexserver: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 
@@ -1478,7 +1478,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 1+ container restarts every 5m by instance (not available on server)_
+- _zoekt-webserver: 1+ container restarts every 5m by instance_
 
 **Possible solutions:**
 
@@ -1493,7 +1493,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 99%+ container memory usage by instance (not available on server)_
+- _zoekt-webserver: 99%+ container memory usage by instance_
 
 **Possible solutions:**
 
@@ -1504,7 +1504,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 99%+ container cpu usage total (1m average) across all cores by instance (not available on server)_
+- _zoekt-webserver: 99%+ container cpu usage total (1m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1515,7 +1515,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance (not available on server)_
+- _zoekt-webserver: 80%+ or less than 30% container cpu usage total (1d average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1528,7 +1528,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 80%+ or less than 30% container memory usage (1d average) by instance (not available on server)_
+- _zoekt-webserver: 80%+ or less than 30% container memory usage (1d average) by instance_
 
 **Possible solutions:**
 
@@ -1541,7 +1541,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 90%+ container cpu usage total (5m average) across all cores by instance (not available on server)_
+- _zoekt-webserver: 90%+ container cpu usage total (5m average) across all cores by instance_
 
 **Possible solutions:**
 
@@ -1552,7 +1552,7 @@ If usage is low, consider decreasing the above values.
 
 **Descriptions:**
 
-- _zoekt-webserver: 90%+ container memory usage (5m average) by instance (not available on server)_
+- _zoekt-webserver: 90%+ container memory usage (5m average) by instance_
 
 **Possible solutions:**
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -191,10 +191,10 @@ for assistance.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the frontend container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the frontend container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # frontend: provisioning_container_memory_usage_1d
 
@@ -204,10 +204,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of frontend container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of frontend container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # frontend: provisioning_container_cpu_usage_5m
 
@@ -358,10 +358,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the gitserver container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the gitserver container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # gitserver: provisioning_container_memory_usage_1d
 
@@ -371,10 +371,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of gitserver container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of gitserver container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # gitserver: provisioning_container_cpu_usage_5m
 
@@ -443,10 +443,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the github-proxy container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the github-proxy container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # github-proxy: provisioning_container_memory_usage_1d
 
@@ -456,10 +456,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of github-proxy container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of github-proxy container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # github-proxy: provisioning_container_cpu_usage_5m
 
@@ -557,10 +557,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the precise-code-intel-bundle-manager container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the precise-code-intel-bundle-manager container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # precise-code-intel-bundle-manager: provisioning_container_memory_usage_1d
 
@@ -570,10 +570,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of precise-code-intel-bundle-manager container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of precise-code-intel-bundle-manager container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # precise-code-intel-bundle-manager: provisioning_container_cpu_usage_5m
 
@@ -658,10 +658,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # precise-code-intel-worker: provisioning_container_memory_usage_1d
 
@@ -671,10 +671,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # precise-code-intel-worker: provisioning_container_cpu_usage_5m
 
@@ -759,10 +759,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the precise-code-intel-indexer container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the precise-code-intel-indexer container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # precise-code-intel-indexer: provisioning_container_memory_usage_1d
 
@@ -772,10 +772,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of precise-code-intel-indexer container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of precise-code-intel-indexer container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # precise-code-intel-indexer: provisioning_container_cpu_usage_5m
 
@@ -860,10 +860,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the query-runner container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the query-runner container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # query-runner: provisioning_container_memory_usage_1d
 
@@ -873,10 +873,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of query-runner container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of query-runner container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # query-runner: provisioning_container_cpu_usage_5m
 
@@ -961,10 +961,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the replacer container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the replacer container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # replacer: provisioning_container_memory_usage_1d
 
@@ -974,10 +974,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of replacer container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of replacer container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # replacer: provisioning_container_cpu_usage_5m
 
@@ -1062,10 +1062,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the repo-updater container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the repo-updater container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # repo-updater: provisioning_container_memory_usage_1d
 
@@ -1075,10 +1075,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of repo-updater container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of repo-updater container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # repo-updater: provisioning_container_cpu_usage_5m
 
@@ -1163,10 +1163,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the searcher container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the searcher container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # searcher: provisioning_container_memory_usage_1d
 
@@ -1176,10 +1176,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of searcher container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of searcher container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # searcher: provisioning_container_cpu_usage_5m
 
@@ -1264,10 +1264,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the symbols container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the symbols container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # symbols: provisioning_container_memory_usage_1d
 
@@ -1277,10 +1277,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of symbols container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of symbols container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # symbols: provisioning_container_cpu_usage_5m
 
@@ -1349,10 +1349,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the syntect-server container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the syntect-server container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # syntect-server: provisioning_container_memory_usage_1d
 
@@ -1362,10 +1362,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of syntect-server container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of syntect-server container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # syntect-server: provisioning_container_cpu_usage_5m
 
@@ -1434,10 +1434,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # zoekt-indexserver: provisioning_container_memory_usage_1d
 
@@ -1447,10 +1447,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of zoekt-indexserver container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of zoekt-indexserver container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # zoekt-indexserver: provisioning_container_cpu_usage_5m
 
@@ -1519,10 +1519,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider descreasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing CPU limits in the the relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider descreasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # zoekt-webserver: provisioning_container_memory_usage_1d
 
@@ -1532,10 +1532,10 @@ If usage is low, consider decreasing the above values.
 
 **Possible solutions:**
 
-If usage is high:
-- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider decreasing `memory:` of zoekt-webserver container in `docker-compose.yml`.
-If usage is low, consider decreasing the above values.
+- If usage is high:
+	- **Kubernetes:** Consider decreasing memory limit in relevant `Deployment.yaml`.
+	- **Docker Compose:** Consider decreasing `memory:` of zoekt-webserver container in `docker-compose.yml`.
+- If usage is low, consider decreasing the above values.
 
 # zoekt-webserver: provisioning_container_cpu_usage_5m
 

--- a/docker-images/prometheus/config/cadvisor_container_restart_count_rules.yml
+++ b/docker-images/prometheus/config/cadvisor_container_restart_count_rules.yml
@@ -8,7 +8,7 @@ groups:
     rules:
       - record: cadvisor_container_restart_count
         expr: |-
-          (
+          label_replace((
           (count by (name)(container_spec_cpu_shares{container_label_restartcount=~"^$"}) * 0)
           or (count by (name)(container_spec_cpu_shares{container_label_restartcount=~".*1$"}) * 1)
           or (count by (name)(container_spec_cpu_shares{container_label_restartcount=~".*2$"}) * 2)
@@ -77,4 +77,4 @@ groups:
           or (count by (name)(container_spec_cpu_shares{container_label_restartcount=~"^7....$"}) * 70000)
           or (count by (name)(container_spec_cpu_shares{container_label_restartcount=~"^8....$"}) * 80000)
           or (count by (name)(container_spec_cpu_shares{container_label_restartcount=~"^9....$"}) * 90000)
-          )
+          ), "container", "$1", "name", "(.*)")

--- a/docker-images/prometheus/config/cadvisor_rules.yml
+++ b/docker-images/prometheus/config/cadvisor_rules.yml
@@ -5,14 +5,14 @@ groups:
     rules:
       # The number of CPUs allocated to the container according to the configured Docker / Kubernetes limits.
       - record: cadvisor_container_cpu_limit
-        expr: avg by (name)(container_spec_cpu_quota) / avg by (name)(container_spec_cpu_period)
+        expr: label_replace(avg by (name)(container_spec_cpu_quota) / avg by (name)(container_spec_cpu_period), "container", "$1", "name", "(.*)")
 
       # Percentage of CPU cores the container consumed on average over a 1m period.
       # For example, if a container has a 4 CPU limit and this metric reports 50%,
       # it means the container consumed 2 cores on average over that 1m period.
       - record: cadvisor_container_cpu_usage_percentage_total
-        expr: (avg by (name)(rate(container_cpu_usage_seconds_total[1m])) / cadvisor_container_cpu_limit) * 100.0
+        expr: label_replace((avg by (name)(rate(container_cpu_usage_seconds_total[1m])) / cadvisor_container_cpu_limit) * 100.0, "container", "$1", "name", "(.*)")
 
       # Percentage of memory usage the container is consuming.
       - record: cadvisor_container_memory_usage_percentage_total
-        expr: max by (name)(container_memory_working_set_bytes / container_spec_memory_limit_bytes) * 100.0
+        expr: label_replace(max by (name)(container_memory_working_set_bytes / container_spec_memory_limit_bytes) * 100.0, "container", "$1", "name", "(.*)")

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -156,10 +156,10 @@ var sharedProvisioningCPUUsage1d sharedObservable = func(containerName string) O
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
 		PossibleSolutions: strings.Replace(`
-			If usage is high:
-			- **Kubernetes:** Consider decreasing CPU limits in the the relevant 'Deployment.yaml'.
-			- **Docker Compose:** Consider descreasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-			If usage is low, consider decreasing the above values.
+			- If usage is high:
+				- **Kubernetes:** Consider decreasing CPU limits in the the relevant 'Deployment.yaml'.
+				- **Docker Compose:** Consider descreasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
+			- If usage is low, consider decreasing the above values.
 		`, "{{CONTAINER_NAME}}", containerName, -1),
 	}
 }
@@ -173,10 +173,10 @@ var sharedProvisioningMemoryUsage1d sharedObservable = func(containerName string
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
 		PossibleSolutions: strings.Replace(`
-			If usage is high:
-			- **Kubernetes:** Consider decreasing memory limit in relevant 'Deployment.yaml'.
-			- **Docker Compose:** Consider decreasing 'memory:' of {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-			If usage is low, consider decreasing the above values.
+			- If usage is high:
+				- **Kubernetes:** Consider decreasing memory limit in relevant 'Deployment.yaml'.
+				- **Docker Compose:** Consider decreasing 'memory:' of {{CONTAINER_NAME}} container in 'docker-compose.yml'.
+			- If usage is low, consider decreasing the above values.
 		`, "{{CONTAINER_NAME}}", containerName, -1),
 	}
 }

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -55,14 +55,20 @@ func promCadvisorContainerMatchers(containerName string) string {
 	return fmt.Sprintf(`name=~".*%s.*",name!~".*(_POD_|_jaeger-agent_).*"`, containerName)
 }
 
+// promCopyNameAsContainer copies the `name` label (which seems to have special meaning in Prometheus) to a `container` label,
+// since cAdvisor export it as `name`.
+func promCopyNameAsContainer(metric string) string {
+	return fmt.Sprintf(`label_replace(%s, "container", "$1", "name", "(.*)")`, metric)
+}
+
 // Container monitoring overviews - alert on all container failures, but only alert on extreme resource usage.
 // More granular resource usage warnings are provided by the provisioning observables.
 
 var sharedContainerRestarts sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "container_restarts",
-		Description:     "container restarts every 5m by instance (not available on server)",
-		Query:           fmt.Sprintf(`increase(cadvisor_container_restart_count{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container restarts every 5m by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`increase(cadvisor_container_restart_count{%s}[5m])`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 1},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}"),
@@ -80,8 +86,8 @@ var sharedContainerRestarts sharedObservable = func(containerName string) Observ
 var sharedContainerMemoryUsage sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "container_memory_usage",
-		Description:     "container memory usage by instance (not available on server)",
-		Query:           fmt.Sprintf(`cadvisor_container_memory_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container memory usage by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`cadvisor_container_memory_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 99},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -95,8 +101,8 @@ var sharedContainerMemoryUsage sharedObservable = func(containerName string) Obs
 var sharedContainerCPUUsage sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "container_cpu_usage",
-		Description:     "container cpu usage total (1m average) across all cores by instance (not available on server)",
-		Query:           fmt.Sprintf(`cadvisor_container_cpu_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container cpu usage total (1m average) across all cores by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`cadvisor_container_cpu_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 99},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -112,8 +118,8 @@ var sharedContainerCPUUsage sharedObservable = func(containerName string) Observ
 var sharedProvisioningCPUUsage5m sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_cpu_usage_5m",
-		Description:     "container cpu usage total (5m average) across all cores by instance (not available on server)",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container cpu usage total (5m average) across all cores by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -127,8 +133,8 @@ var sharedProvisioningCPUUsage5m sharedObservable = func(containerName string) O
 var sharedProvisioningMemoryUsage5m sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_memory_usage_5m",
-		Description:     "container memory usage (5m average) by instance (not available on server)",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container memory usage (5m average) by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -144,8 +150,8 @@ var sharedProvisioningMemoryUsage5m sharedObservable = func(containerName string
 var sharedProvisioningCPUUsage1d sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_cpu_usage_1d",
-		Description:     "container cpu usage total (1d average) across all cores by instance (not available on server)",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container cpu usage total (1d average) across all cores by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -161,8 +167,8 @@ var sharedProvisioningCPUUsage1d sharedObservable = func(containerName string) O
 var sharedProvisioningMemoryUsage1d sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_memory_usage_1d",
-		Description:     "container memory usage (1d average) by instance (not available on server)",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container memory usage (1d average) by instance",
+		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName))),
 		DataMayNotExist: true,
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -55,12 +55,6 @@ func promCadvisorContainerMatchers(containerName string) string {
 	return fmt.Sprintf(`name=~".*%s.*",name!~".*(_POD_|_jaeger-agent_).*"`, containerName)
 }
 
-// promCopyNameAsContainer copies the `name` label (which seems to have special meaning in Prometheus) to a `container` label,
-// since cAdvisor export it as `name`.
-func promCopyNameAsContainer(metric string) string {
-	return fmt.Sprintf(`label_replace(%s, "container", "$1", "name", "(.*)")`, metric)
-}
-
 // Container monitoring overviews - alert on all container failures, but only alert on extreme resource usage.
 // More granular resource usage warnings are provided by the provisioning observables.
 
@@ -68,7 +62,7 @@ var sharedContainerRestarts sharedObservable = func(containerName string) Observ
 	return Observable{
 		Name:            "container_restarts",
 		Description:     "container restarts every 5m by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`increase(cadvisor_container_restart_count{%s}[5m])`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`increase(cadvisor_container_restart_count{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 1},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}"),
@@ -87,7 +81,7 @@ var sharedContainerMemoryUsage sharedObservable = func(containerName string) Obs
 	return Observable{
 		Name:            "container_memory_usage",
 		Description:     "container memory usage by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`cadvisor_container_memory_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`cadvisor_container_memory_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 99},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -102,7 +96,7 @@ var sharedContainerCPUUsage sharedObservable = func(containerName string) Observ
 	return Observable{
 		Name:            "container_cpu_usage",
 		Description:     "container cpu usage total (1m average) across all cores by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`cadvisor_container_cpu_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`cadvisor_container_cpu_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 99},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -119,7 +113,7 @@ var sharedProvisioningCPUUsage5m sharedObservable = func(containerName string) O
 	return Observable{
 		Name:            "provisioning_container_cpu_usage_5m",
 		Description:     "container cpu usage total (5m average) across all cores by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -134,7 +128,7 @@ var sharedProvisioningMemoryUsage5m sharedObservable = func(containerName string
 	return Observable{
 		Name:            "provisioning_container_memory_usage_5m",
 		Description:     "container memory usage (5m average) by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -151,7 +145,7 @@ var sharedProvisioningCPUUsage1d sharedObservable = func(containerName string) O
 	return Observable{
 		Name:            "provisioning_container_cpu_usage_1d",
 		Description:     "container cpu usage total (1d average) across all cores by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -168,7 +162,7 @@ var sharedProvisioningMemoryUsage1d sharedObservable = func(containerName string
 	return Observable{
 		Name:            "provisioning_container_memory_usage_1d",
 		Description:     "container memory usage (1d average) by instance",
-		Query:           promCopyNameAsContainer(fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName))),
+		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/11571

It seems the `name` label has some special undocumented purpose, which was causing the [provisioning `alert_rules` to fail to create](https://github.com/sourcegraph/sourcegraph/issues/11571#issuecomment-645921031).

This PR wraps each of the cAdvisor dashboards with a `label_replace` to add a `container` label that is just the value of the `name` label. I manually updated Prometheus on k8s.sgdev.org and it seems to do the trick for alert_counts that were previously failing:

<img width="1763" alt="Screen Shot 2020-07-02 at 5 25 37 PM" src="https://user-images.githubusercontent.com/23356519/86342069-aef42a00-bc89-11ea-9c49-9055b2a3911f.png">

This PR also includes two misc. improvements:

* remove `(not available on server)` from individual metrics - this text already shows up on dashboard section titles
* fix formatting for possible solutions

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
