### PR TITLE
cmd/tracking-issue: Skip tracking issues with no labels

### DIFF
--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -708,7 +708,7 @@ func loadTrackingIssues(ctx context.Context, cli *graphql.Client, org string, is
 		for query, s := range data {
 			q := queries[query]
 
-			if s.PageInfo.HasNextPage {
+			if s.PageInfo.HasNextPage && len(s.Nodes) > 0 {
 				hasNextPage = true
 				q.cursor = s.PageInfo.EndCursor
 			} else {
@@ -750,7 +750,9 @@ func listTrackingIssues(ctx context.Context, cli *graphql.Client, issuesQuery st
 		issues, _ := unmarshalSearchNodes(data.Tracking.Nodes)
 
 		for _, issue := range issues {
-			all = append(all, NewTrackingIssue(issue))
+			if len(issue.Labels) > 1 { // Skip tracking issues that have only the "tracking" label
+				all = append(all, NewTrackingIssue(issue))
+			}
 		}
 
 		if data.Tracking.PageInfo.HasNextPage {


### PR DESCRIPTION
This commit makes it so the tracking issue tool:

1. Skips tracking issues that only have the tracking label.
2. Stops paginating when no nodes are returned and the GitHub API lies
about having more results.

The tracking issue tool was failing because it couldn't handle listing issues without specific label filter (the data set was too big): https://github.com/sourcegraph/sourcegraph/issues/11532