### PR TITLE
git: Pass ResolveRevisionOptions as value

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -123,7 +123,7 @@ func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) (
 	if err != nil {
 		return nil, err
 	}
-	commitID, err := git.ResolveRevision(ctx, *gitRepo, nil, "HEAD", nil)
+	commitID, err := git.ResolveRevision(ctx, *gitRepo, nil, "HEAD", git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -45,7 +45,7 @@ func TestCountGoImporters(t *testing.T) {
 			},
 		}, nil
 	}
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		return "c", nil
 	}
 	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error) {

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -164,7 +164,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 		}
 		return grepo.URL, nil
 	}
-	return git.ResolveRevision(ctx, *gitserverRepo, remoteURLFunc, rev, nil)
+	return git.ResolveRevision(ctx, *gitserverRepo, remoteURLFunc, rev, git.ResolveRevisionOptions{})
 }
 
 func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *git.Commit, err error) {
@@ -197,7 +197,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		}
 		return grepo.URL, nil
 	}
-	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID, nil)
+	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID, git.ResolveRevisionOptions{})
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -31,7 +31,7 @@ func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 	var calledVCSRepoResolveRevision bool
-	git.Mocks.ResolveRevision = func(rev string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(rev string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		calledVCSRepoResolveRevision = true
 		return api.CommitID(want), nil
 	}
@@ -71,7 +71,7 @@ func TestRepos_ResolveRev_noCommitIDSpecified_resolvesRev(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 	var calledVCSRepoResolveRevision bool
-	git.Mocks.ResolveRevision = func(rev string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(rev string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		calledVCSRepoResolveRevision = true
 		return api.CommitID(want), nil
 	}
@@ -110,7 +110,7 @@ func TestRepos_ResolveRev_commitIDSpecified_resolvesCommitID(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 	var calledVCSRepoResolveRevision bool
-	git.Mocks.ResolveRevision = func(rev string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(rev string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		calledVCSRepoResolveRevision = true
 		return api.CommitID(want), nil
 	}
@@ -149,7 +149,7 @@ func TestRepos_ResolveRev_commitIDSpecified_failsToResolve(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 	var calledVCSRepoResolveRevision bool
-	git.Mocks.ResolveRevision = func(rev string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(rev string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		calledVCSRepoResolveRevision = true
 		return "", errors.New("x")
 	}

--- a/cmd/frontend/graphqlbackend/codemod.go
+++ b/cmd/frontend/graphqlbackend/codemod.go
@@ -235,7 +235,7 @@ func callCodemodInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions
 	}()
 
 	// For performance, assume repo is cloned in gitserver and do not trigger a repo-updater lookup (this call fails if repo is not on gitserver).
-	commit, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), nil, repoRevs.Revs[0].RevSpec, &git.ResolveRevisionOptions{NoEnsureRevision: true})
+	commit, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), nil, repoRevs.Revs[0].RevSpec, git.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return nil, errors.Wrap(err, "codemod repo lookup failed: it's possible that the repo is not cloned in gitserver. Try force a repo update another way.")
 	}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -77,7 +77,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) {
 		}
 
 		var commit *git.Commit
-		commit, r.err = git.GetCommit(ctx, *cachedRepo, nil, api.CommitID(r.oid), nil)
+		commit, r.err = git.GetCommit(ctx, *cachedRepo, nil, api.CommitID(r.oid), git.ResolveRevisionOptions{})
 		if r.err != nil {
 			return
 		}

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -21,7 +21,7 @@ func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
 	if err != nil {
 		return nil, err
 	}
-	oid, err := git.ResolveRevision(ctx, *cachedRepo, nil, r.expr, nil)
+	oid, err := git.ResolveRevision(ctx, *cachedRepo, nil, r.expr, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -51,7 +51,7 @@ func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID, nil)
+	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -186,7 +186,7 @@ func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver
 
 		if err == nil && exitCode == 0 {
 			// Check that our repo is not empty
-			_, err = git.ResolveRevision(ctx, *cachedRepo, nil, "HEAD", &git.ResolveRevisionOptions{NoEnsureRevision: true})
+			_, err = git.ResolveRevision(ctx, *cachedRepo, nil, "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
 		}
 
 		// If we fail to get the default branch due to cloning or being empty, we return nothing.
@@ -388,7 +388,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 		if err != nil {
 			return nil, err
 		}
-		_, err = git.ResolveRevision(ctx, *cachedRepo, nil, targetRef, &git.ResolveRevisionOptions{
+		_, err = git.ResolveRevision(ctx, *cachedRepo, nil, targetRef, git.ResolveRevisionOptions{
 			NoEnsureRevision: true,
 		})
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -69,7 +69,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 			return nil, nil
 		}
 
-		opt := &git.ResolveRevisionOptions{
+		opt := git.ResolveRevisionOptions{
 			NoEnsureRevision: !args.FetchMissing,
 		}
 		// Optimistically fetch using revspec

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -164,7 +164,7 @@ func hydrateBranchCommits(ctx context.Context, repo gitserver.Repo, interactive 
 	}
 
 	for _, branch := range branches {
-		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head, nil)
+		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head, git.ResolveRevisionOptions{})
 		if err != nil {
 			if parentCtx.Err() == nil && ctx.Err() != nil {
 				// reached interactive timeout

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -772,7 +772,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 				// searches like "repo:@foobar" (where foobar is an invalid revspec on most repos)
 				// taking a long time because they all ask gitserver to try to fetch from the remote
 				// repo.
-				if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), nil, rev.RevSpec, &git.ResolveRevisionOptions{NoEnsureRevision: true}); gitserver.IsRevisionNotFound(err) || err == context.DeadlineExceeded {
+				if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), nil, rev.RevSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); gitserver.IsRevisionNotFound(err) || err == context.DeadlineExceeded {
 					// The revspec does not exist, so don't include it, and report that it's missing.
 					if rev.RevSpec == "" {
 						// Report as HEAD not "" (empty string) to avoid user confusion.

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -41,7 +41,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		// Mock default branch lookup in (*RepsitoryResolver).DefaultBranch.
 		return []byte(wantDefaultBranchRef), nil, 0, nil
 	}
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		if want := "HEAD"; spec != want {
 			t.Errorf("got spec %q, want %q", spec, want)
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -93,7 +93,7 @@ func TestSearchSuggestions(t *testing.T) {
 		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
 
 		defer func() { db.Mocks = db.MockStores{} }()
-		git.Mocks.ResolveRevision = func(rev string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+		git.Mocks.ResolveRevision = func(rev string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 			return api.CommitID("deadbeef"), nil
 		}
 		defer git.ResetMocks()

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -232,7 +232,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commitID, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), nil, inputRev, nil)
+	commitID, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), nil, inputRev, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		searchQuery                  string
 		searchVersion                string
 		reposListMock                func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error)
-		repoRevsMock                 func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error)
+		repoRevsMock                 func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error)
 		externalServicesListMock     func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error)
 		phabricatorGetRepoByNameMock func(repo api.RepoName) (*types.PhabricatorRepo, error)
 		wantResults                  Results
@@ -44,8 +44,8 @@ func TestSearch(t *testing.T) {
 			reposListMock: func(v0 context.Context, v1 db.ReposListOptions) ([]*types.Repo, error) {
 				return nil, nil
 			},
-			repoRevsMock: func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
-				return api.CommitID(""), nil
+			repoRevsMock: func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+				return "", nil
 			},
 			externalServicesListMock: func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 				return nil, nil
@@ -67,8 +67,8 @@ func TestSearch(t *testing.T) {
 
 					nil
 			},
-			repoRevsMock: func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
-				return api.CommitID(""), nil
+			repoRevsMock: func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+				return "", nil
 			},
 			externalServicesListMock: func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
 				return nil, nil

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -369,7 +369,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commit, err := git.ResolveRevision(ctx, gitserverRepo, nil, rev, &git.ResolveRevisionOptions{NoEnsureRevision: true})
+	commit, err := git.ResolveRevision(ctx, gitserverRepo, nil, rev, git.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return nil, false, err
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -500,7 +500,7 @@ func serveGitResolveRevision(w http.ResponseWriter, r *http.Request) error {
 	spec := vars["Spec"]
 
 	// Do not to trigger a repo-updater lookup since this is a batch job.
-	commitID, err := git.ResolveRevision(r.Context(), gitserver.Repo{Name: name}, nil, spec, nil)
+	commitID, err := git.ResolveRevision(r.Context(), gitserver.Repo{Name: name}, nil, spec, git.ResolveRevisionOptions{})
 	if err != nil {
 		return err
 	}
@@ -518,7 +518,7 @@ func serveGitTar(w http.ResponseWriter, r *http.Request) error {
 
 	// Ensure commit exists. Do not want to trigger a repo-updater lookup since this is a batch job.
 	repo := gitserver.Repo{Name: name}
-	commit, err := git.ResolveRevision(r.Context(), repo, nil, spec, nil)
+	commit, err := git.ResolveRevision(r.Context(), repo, nil, spec, git.ResolveRevisionOptions{})
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -501,7 +501,7 @@ func (r *changesetResolver) commitID(ctx context.Context, repo *graphqlbackend.R
 	}
 	// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't
 	// exist).
-	return git.ResolveRevision(ctx, *grepo, nil, refName, nil)
+	return git.ResolveRevision(ctx, *grepo, nil, refName, git.ResolveRevisionOptions{})
 }
 
 type changesetLabelResolver struct {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -270,7 +270,7 @@ func TestCampaigns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		return "mockcommitid", nil
 	}
 	defer func() { git.Mocks.ResolveRevision = nil }()

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -510,7 +510,7 @@ func computeRev(ctx context.Context, c *cmpgn.Changeset, repo gitserver.Repo, ge
 		return "", err
 	}
 
-	rev, err := git.ResolveRevision(ctx, repo, nil, ref, nil)
+	rev, err := git.ResolveRevision(ctx, repo, nil, ref, git.ResolveRevisionOptions{})
 	return string(rev), err
 }
 

--- a/enterprise/internal/campaigns/testing/mock_github.go
+++ b/enterprise/internal/campaigns/testing/mock_github.go
@@ -15,7 +15,7 @@ import (
 type MockedGitHubChangesetSyncState struct {
 	execReader      func([]string) (io.ReadCloser, error)
 	mockRepoLookup  func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
-	resolveRevision func(string, *git.ResolveRevisionOptions) (api.CommitID, error)
+	resolveRevision func(string, git.ResolveRevisionOptions) (api.CommitID, error)
 }
 
 // MockGitHubChangesetSync sets up mocks such that invoking LoadChangesets() on
@@ -65,8 +65,8 @@ index 884601b..c4886d5 100644
 		return ioutil.NopCloser(strings.NewReader(testGitHubDiff)), nil
 	}
 
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
-		return api.CommitID("mockcommitid"), nil
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+		return "mockcommitid", nil
 	}
 
 	return state

--- a/enterprise/internal/codeintel/gitserver/archive.go
+++ b/enterprise/internal/codeintel/gitserver/archive.go
@@ -17,7 +17,7 @@ func Archive(ctx context.Context, store store.Store, repositoryID int, commit st
 		return nil, err
 	}
 
-	if _, err := git.ResolveRevision(ctx, repo, nil, commit, nil); err != nil {
+	if _, err := git.ResolveRevision(ctx, repo, nil, commit, git.ResolveRevisionOptions{}); err != nil {
 		return nil, errors.Wrap(err, "git.ResolveRevision")
 	}
 

--- a/enterprise/internal/codeintel/gitserver/files.go
+++ b/enterprise/internal/codeintel/gitserver/files.go
@@ -17,7 +17,7 @@ func FileExists(ctx context.Context, store store.Store, repositoryID int, commit
 		return false, err
 	}
 
-	if _, err := git.ResolveRevision(ctx, repo, nil, commit, nil); err != nil {
+	if _, err := git.ResolveRevision(ctx, repo, nil, commit, git.ResolveRevisionOptions{}); err != nil {
 		return false, errors.Wrap(err, "git.ResolveRevision")
 	}
 

--- a/enterprise/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/internal/codeintel/resolvers/graphql/locations.go
@@ -220,7 +220,7 @@ func (r *CachedLocationResolver) resolveCommit(ctx context.Context, repositoryRe
 		return nil, err
 	}
 
-	commitID, err := git.ResolveRevision(ctx, *gitserverRepo, nil, commit, &git.ResolveRevisionOptions{NoEnsureRevision: true})
+	commitID, err := git.ResolveRevision(ctx, *gitserverRepo, nil, commit, git.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			return nil, nil

--- a/enterprise/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/internal/codeintel/resolvers/graphql/locations_test.go
@@ -38,7 +38,7 @@ func TestCachedLocationResolver(t *testing.T) {
 		return &types.Repo{ID: id}, nil
 	}
 
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		return api.CommitID(spec), nil
 	}
 
@@ -192,7 +192,7 @@ func TestCachedLocationResolverUnknownCommit(t *testing.T) {
 		return &types.Repo{ID: id}, nil
 	}
 
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		return "", &gitserver.RevisionNotFoundError{}
 	}
 
@@ -225,7 +225,7 @@ func TestResolveLocations(t *testing.T) {
 		return &types.Repo{ID: id, Name: api.RepoName(fmt.Sprintf("repo%d", id))}, nil
 	}
 
-	git.Mocks.ResolveRevision = func(spec string, opt *git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
 		if spec == "deadbeef3" {
 			return "", &gitserver.RevisionNotFoundError{}
 		}

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -47,7 +47,7 @@ func TestRepository_BlameFile(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		newestCommitID, err := ResolveRevision(ctx, test.repo, nil, string(test.opt.NewestCommit), nil)
+		newestCommitID, err := ResolveRevision(ctx, test.repo, nil, string(test.opt.NewestCommit), ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on base: %s", label, test.opt.NewestCommit, err)
 			continue

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -59,7 +59,7 @@ type CommitsOptions struct {
 var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
 
 // getCommit returns the commit with the given id.
-func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID, opt *ResolveRevisionOptions) (*Commit, error) {
+func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID, opt ResolveRevisionOptions) (*Commit, error) {
 	if Mocks.GetCommit != nil {
 		return Mocks.GetCommit(id)
 	}
@@ -72,10 +72,7 @@ func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (s
 		Range:            string(id),
 		N:                1,
 		RemoteURLFunc:    remoteURLFunc,
-		NoEnsureRevision: false,
-	}
-	if opt != nil {
-		commitOptions.NoEnsureRevision = opt.NoEnsureRevision
+		NoEnsureRevision: opt.NoEnsureRevision,
 	}
 
 	commits, err := commitLog(ctx, repo, commitOptions)
@@ -96,7 +93,7 @@ func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (s
 // The remoteURLFunc is called to get the Git remote URL if it's not set in repo and if it is
 // needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 // the repository or if the commit must be fetched from the remote.
-func GetCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID, opt *ResolveRevisionOptions) (*Commit, error) {
+func GetCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), id api.CommitID, opt ResolveRevisionOptions) (*Commit, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetCommit")
 	span.SetTag("Commit", id)
 	defer span.Finish()
@@ -133,7 +130,7 @@ func HasCommitAfter(ctx context.Context, repo gitserver.Repo, date string, revsp
 		revspec = "HEAD"
 	}
 
-	commitid, err := ResolveRevision(ctx, repo, nil, revspec, &ResolveRevisionOptions{NoEnsureRevision: true})
+	commitid, err := ResolveRevision(ctx, repo, nil, revspec, ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return false, err
 	}

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -57,7 +57,7 @@ func TestRepository_GetCommit(t *testing.T) {
 			return oldRunCommitLog(ctx, cmd, opt)
 		}
 
-		resolveRevisionOptions := &ResolveRevisionOptions{
+		resolveRevisionOptions := ResolveRevisionOptions{
 			NoEnsureRevision: test.noEnsureRevision,
 		}
 		commit, err := GetCommit(ctx, test.repo, nil, test.id, resolveRevisionOptions)

--- a/internal/vcs/git/merge_base_test.go
+++ b/internal/vcs/git/merge_base_test.go
@@ -40,19 +40,19 @@ func TestMerger_MergeBase(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		a, err := ResolveRevision(ctx, test.repo, nil, test.a, nil)
+		a, err := ResolveRevision(ctx, test.repo, nil, test.a, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on a: %s", label, test.a, err)
 			continue
 		}
 
-		b, err := ResolveRevision(ctx, test.repo, nil, test.b, nil)
+		b, err := ResolveRevision(ctx, test.repo, nil, test.b, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on b: %s", label, test.b, err)
 			continue
 		}
 
-		want, err := ResolveRevision(ctx, test.repo, nil, test.wantMergeBase, nil)
+		want, err := ResolveRevision(ctx, test.repo, nil, test.wantMergeBase, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on wantMergeBase: %s", label, test.wantMergeBase, err)
 			continue

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -20,7 +20,7 @@ var Mocks, emptyMocks struct {
 	NewFileReader    func(commit api.CommitID, name string) (io.ReadCloser, error)
 	ReadFile         func(commit api.CommitID, name string) ([]byte, error)
 	ReadDir          func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error)
-	ResolveRevision  func(spec string, opt *ResolveRevisionOptions) (api.CommitID, error)
+	ResolveRevision  func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
 	Stat             func(commit api.CommitID, name string) (os.FileInfo, error)
 	GetObject        func(objectName string) (OID, ObjectType, error)
 	Commits          func(repo gitserver.Repo, opt CommitsOptions) ([]*Commit, error)

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -180,7 +180,7 @@ func ListBranches(ctx context.Context, repo gitserver.Repo, opt BranchesOptions)
 
 		branch := &Branch{Name: name, Head: ref.CommitID}
 		if opt.IncludeCommit {
-			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID, nil)
+			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID, ResolveRevisionOptions{})
 			if err != nil {
 				return nil, err
 			}

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -40,6 +40,8 @@ func ensureAbsoluteCommit(commitID api.CommitID) error {
 	return nil
 }
 
+// ResolveRevisionOptions configure how we resolve revisions.
+// The zero value should contain appropriate default values.
 type ResolveRevisionOptions struct {
 	NoEnsureRevision bool // do not try to fetch from remote if revision doesn't exist locally
 }
@@ -57,7 +59,7 @@ type ResolveRevisionOptions struct {
 // needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 // the repository or if the revision must be fetched from the remote. This only happens when calling
 // ResolveRevision.
-func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), spec string, opt *ResolveRevisionOptions) (api.CommitID, error) {
+func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), spec string, opt ResolveRevisionOptions) (api.CommitID, error) {
 	if Mocks.ResolveRevision != nil {
 		return Mocks.ResolveRevision(spec, opt)
 	}
@@ -96,7 +98,7 @@ func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc fun
 			return err
 		},
 	}
-	if opt != nil && opt.NoEnsureRevision {
+	if opt.NoEnsureRevision {
 		// Make the commandRetryer no-op so that gitserver does not try to
 		// update the repository.
 		cmd.EnsureRevision = ""

--- a/internal/vcs/git/revisions_test.go
+++ b/internal/vcs/git/revisions_test.go
@@ -41,7 +41,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -72,7 +72,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -104,7 +104,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -135,7 +135,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -329,7 +329,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, "master", nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, "master", ResolveRevisionOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -387,7 +387,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, "master", nil)
+		commitID, err := ResolveRevision(ctx, test.repo, nil, "master", ResolveRevisionOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
By passing as a value instead of a pointer we avoid nil references
and keep values on the stack.

