### PR TITLE
cloud: Add CountClonedRepos to repo-updater

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -55,6 +55,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/ListRepos", testStoreListRepos(store)},
 		{"DBStore/ListRepos/Pagination", testStoreListReposPagination(store)},
 		{"DBStore/SetClonedRepos", testStoreSetClonedRepos(store)},
+		{"DBStore/CountClonedRepos", testStoreCountClonedRepos(store)},
 		{"DBStore/Syncer/Sync", testSyncerSync(store)},
 		{"DBStore/Syncer/SyncSubset", testSyncSubset(store)},
 	} {

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -55,7 +55,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/ListRepos", testStoreListRepos(store)},
 		{"DBStore/ListRepos/Pagination", testStoreListReposPagination(store)},
 		{"DBStore/SetClonedRepos", testStoreSetClonedRepos(store)},
-		{"DBStore/CountClonedRepos", testStoreCountClonedRepos(store)},
+		{"DBStore/CountNotClonedRepos", testStoreCountNotClonedRepos(store)},
 		{"DBStore/Syncer/Sync", testSyncerSync(store)},
 		{"DBStore/Syncer/SyncSubset", testSyncSubset(store)},
 	} {

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -127,7 +127,7 @@ type StoreMetrics struct {
 	ListExternalServices   *metrics.OperationMetrics
 	ListAllRepoNames       *metrics.OperationMetrics
 	SetClonedRepos         *metrics.OperationMetrics
-	CountClonedRepos       *metrics.OperationMetrics
+	CountNotClonedRepos    *metrics.OperationMetrics
 }
 
 // MustRegister registers all metrics in StoreMetrics in the given
@@ -265,17 +265,17 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when setting cloned repos",
 			}, []string{}),
 		},
-		CountClonedRepos: &metrics.OperationMetrics{
+		CountNotClonedRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Name: "src_repoupdater_store_count_cloned_repos_duration_seconds",
+				Name: "src_repoupdater_store_count_not_cloned_repos_duration_seconds",
 				Help: "Time spent counting cloned repos",
 			}, []string{}),
 			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: "src_repoupdater_store_count_cloned_repos_total",
+				Name: "src_repoupdater_store_count_not_cloned_repos_total",
 				Help: "Total number of count cloned repos calls",
 			}, []string{}),
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: "src_repoupdater_store_count_cloned_repos_errors_total",
+				Name: "src_repoupdater_store_count_not_cloned_repos_errors_total",
 				Help: "Total number of errors when counting cloned repos",
 			}, []string{}),
 		},
@@ -481,21 +481,21 @@ func (o *ObservedStore) SetClonedRepos(ctx context.Context, repoNames ...string)
 	return o.store.SetClonedRepos(ctx, repoNames...)
 }
 
-// CountClonedRepos calls into the inner Store and registers the observed results.
-func (o *ObservedStore) CountClonedRepos(ctx context.Context) (count uint64, err error) {
-	tr, ctx := o.trace(ctx, "Store.CountClonedRepos")
+// CountNotClonedRepos calls into the inner Store and registers the observed results.
+func (o *ObservedStore) CountNotClonedRepos(ctx context.Context) (count uint64, err error) {
+	tr, ctx := o.trace(ctx, "Store.CountNotClonedRepos")
 
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 
-		o.metrics.CountClonedRepos.Observe(secs, float64(count), &err)
-		logging.Log(o.log, "store.count-cloned-repos", &err, "count", count)
+		o.metrics.CountNotClonedRepos.Observe(secs, float64(count), &err)
+		logging.Log(o.log, "store.count-not-cloned-repos", &err, "count", count)
 
 		tr.SetError(err)
 		tr.Finish()
 	}(time.Now())
 
-	return o.store.CountClonedRepos(ctx)
+	return o.store.CountNotClonedRepos(ctx)
 }
 
 func (o *ObservedStore) trace(ctx context.Context, family string) (*trace.Trace, context.Context) {

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -30,7 +30,6 @@ type Store interface {
 	UpsertRepos(ctx context.Context, repos ...*Repo) error
 	SetClonedRepos(ctx context.Context, repoNames ...string) error
 	CountNotClonedRepos(ctx context.Context) (uint64, error)
-	ListAllRepoNames(context.Context) ([]api.RepoName, error)
 }
 
 // StoreListReposArgs is a query arguments type used by
@@ -402,38 +401,6 @@ func listReposQuery(args StoreListReposArgs) paginatedQuery {
 			limit,
 		)
 	}
-}
-
-// ListAllRepoNames lists the names of all stored repos
-func (s DBStore) ListAllRepoNames(ctx context.Context) (names []api.RepoName, _ error) {
-	return names, s.paginate(ctx, 0, 0, listAllRepoNamesQuery,
-		func(sc scanner) (last, count int64, err error) {
-			var (
-				id   int64
-				name api.RepoName
-			)
-			if err = sc.Scan(&id, &name); err != nil {
-				return 0, 0, err
-			}
-			names = append(names, name)
-			return id, 1, nil
-		},
-	)
-}
-
-const listAllRepoNamesQueryFmtstr = `
--- source: cmd/repo-updater/repos/store.go:DBStore.ListAllRepoNames
-SELECT
-  id,
-  name
-FROM repo
-WHERE id > %s
-AND deleted_at IS NULL
-ORDER BY id ASC LIMIT %s
-`
-
-func listAllRepoNamesQuery(cursor, limit int64) *sqlf.Query {
-	return sqlf.Sprintf(listAllRepoNamesQueryFmtstr, cursor, limit)
 }
 
 // SetClonedRepos updates cloned status for all repositories.

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -468,7 +468,7 @@ WITH c AS (
 
 // CountClonedRepos returns the number of repos whose cloned column is true.
 func (s DBStore) CountClonedRepos(ctx context.Context) (uint64, error) {
-	q := sqlf.Sprintf(setClonedReposQueryFmtstr)
+	q := sqlf.Sprintf(countClonedReposQueryFmtstr)
 
 	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -470,19 +470,10 @@ WITH c AS (
 func (s DBStore) CountClonedRepos(ctx context.Context) (uint64, error) {
 	q := sqlf.Sprintf(countClonedReposQueryFmtstr)
 
-	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	if err != nil {
-		return 0, err
-	}
-	defer rows.Close()
-
-	rows.Next()
-	if rows.Err() != nil {
-		return 0, rows.Err()
-	}
+	row := s.db.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 
 	var count uint64
-	err = rows.Scan(&count)
+	err := row.Scan(&count)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -738,10 +738,6 @@ func isCloned(r *repos.Repo) bool {
 	return r.Cloned
 }
 
-func isNotCloned(r *repos.Repo) bool {
-	return !r.Cloned
-}
-
 func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
 	clock := repos.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
@@ -895,28 +891,26 @@ func testStoreCountNotClonedRepos(store repos.Store) func(*testing.T) {
 		})
 
 		t.Run("multiple cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
-			stored := mkRepos(9, repositories...)
+			stored := mkRepos(10, repositories...)
 
 			if err := tx.UpsertRepos(ctx, stored...); err != nil {
 				t.Fatalf("UpsertRepos error: %s", err)
 			}
 
 			sort.Sort(stored)
-
-			cloned := stored.Filter(isCloned).Names()
-			notCloned := stored.Filter(isNotCloned).Names()
-			sort.Strings(cloned)
-			sort.Strings(notCloned)
+			cloned := stored[:3].Names()
 
 			if err := tx.SetClonedRepos(ctx, cloned...); err != nil {
 				t.Fatalf("SetClonedRepos error: %s", err)
 			}
 
+			sort.Strings(cloned)
+
 			count, err := tx.CountNotClonedRepos(ctx)
 			if err != nil {
 				t.Fatalf("CountNotClonedRepos error: %s", err)
 			}
-			if diff := cmp.Diff(count, uint64(len(notCloned))); diff != "" {
+			if diff := cmp.Diff(count, uint64(7)); diff != "" {
 				t.Fatalf("CountNotClonedRepos:\n%s", diff)
 			}
 		}))

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -931,7 +931,7 @@ func testStoreCountClonedRepos(store repos.Store) func(*testing.T) {
 
 		ctx := context.Background()
 
-		t.Run("no repo name", func(t *testing.T) {
+		t.Run("no clones repos", func(t *testing.T) {
 			count, err := store.CountClonedRepos(ctx)
 			if err != nil {
 				t.Fatalf("CountClonedRepos error: %s", err)
@@ -941,7 +941,7 @@ func testStoreCountClonedRepos(store repos.Store) func(*testing.T) {
 			}
 		})
 
-		t.Run("many repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("multiple cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
 			stored := mkRepos(9, repositories...)
 
 			if err := tx.UpsertRepos(ctx, stored...); err != nil {
@@ -960,7 +960,7 @@ func testStoreCountClonedRepos(store repos.Store) func(*testing.T) {
 			if err != nil {
 				t.Fatalf("CountClonedRepos error: %s", err)
 			}
-			if diff := cmp.Diff(count, uint64(3)); diff != "" {
+			if diff := cmp.Diff(count, uint64(len(names))); diff != "" {
 				t.Fatalf("CountClonedRepos:\n%s", diff)
 			}
 		}))

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -74,6 +74,7 @@ type FakeStore struct {
 	UpsertReposError            error // error to be returned in UpsertRepos
 	ListAllRepoNamesError       error // error to be returned in ListAllRepoNames
 	SetClonedReposError         error // error to be returned in SetClonedRepos
+	CountClonedReposError       error // error to be returned in CountClonedRepos
 	svcIDSeq                    int64
 	repoIDSeq                   api.RepoID
 	svcByID                     map[int64]*ExternalService
@@ -106,6 +107,7 @@ func (s *FakeStore) Transact(ctx context.Context) (TxStore, error) {
 		UpsertReposError:            s.UpsertReposError,
 		ListAllRepoNamesError:       s.ListAllRepoNamesError,
 		SetClonedReposError:         s.SetClonedReposError,
+		CountClonedReposError:       s.CountClonedReposError,
 
 		svcIDSeq:  s.svcIDSeq,
 		svcByID:   svcByID,
@@ -389,6 +391,27 @@ func (s *FakeStore) SetClonedRepos(ctx context.Context, repoNames ...string) err
 	}
 
 	return s.checkConstraints()
+}
+
+// CountClonedRepos counts the number of repos whose cloned field is true.
+func (s *FakeStore) CountClonedRepos(ctx context.Context) (uint64, error) {
+	if s.CountClonedReposError != nil {
+		return 0, s.CountClonedReposError
+	}
+
+	var count uint64
+
+	for _, r := range s.repoByID {
+		if r.IsDeleted() {
+			continue
+		}
+
+		if r.Cloned {
+			count++
+		}
+	}
+
+	return count, nil
 }
 
 // checkConstraints ensures the FakeStore has not violated any constraints we

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -74,7 +74,7 @@ type FakeStore struct {
 	UpsertReposError            error // error to be returned in UpsertRepos
 	ListAllRepoNamesError       error // error to be returned in ListAllRepoNames
 	SetClonedReposError         error // error to be returned in SetClonedRepos
-	CountClonedReposError       error // error to be returned in CountClonedRepos
+	CountNotClonedReposError    error // error to be returned in CountNotClonedRepos
 	svcIDSeq                    int64
 	repoIDSeq                   api.RepoID
 	svcByID                     map[int64]*ExternalService
@@ -107,7 +107,7 @@ func (s *FakeStore) Transact(ctx context.Context) (TxStore, error) {
 		UpsertReposError:            s.UpsertReposError,
 		ListAllRepoNamesError:       s.ListAllRepoNamesError,
 		SetClonedReposError:         s.SetClonedReposError,
-		CountClonedReposError:       s.CountClonedReposError,
+		CountNotClonedReposError:    s.CountNotClonedReposError,
 
 		svcIDSeq:  s.svcIDSeq,
 		svcByID:   svcByID,
@@ -393,10 +393,10 @@ func (s *FakeStore) SetClonedRepos(ctx context.Context, repoNames ...string) err
 	return s.checkConstraints()
 }
 
-// CountClonedRepos counts the number of repos whose cloned field is true.
-func (s *FakeStore) CountClonedRepos(ctx context.Context) (uint64, error) {
-	if s.CountClonedReposError != nil {
-		return 0, s.CountClonedReposError
+// CountNotClonedRepos counts the number of repos whose cloned field is true.
+func (s *FakeStore) CountNotClonedRepos(ctx context.Context) (uint64, error) {
+	if s.CountNotClonedReposError != nil {
+		return 0, s.CountNotClonedReposError
 	}
 
 	var count uint64
@@ -406,7 +406,7 @@ func (s *FakeStore) CountClonedRepos(ctx context.Context) (uint64, error) {
 			continue
 		}
 
-		if r.Cloned {
+		if !r.Cloned {
 			count++
 		}
 	}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -72,7 +72,6 @@ type FakeStore struct {
 	GetRepoByNameError          error // error to be returned in GetRepoByName
 	ListReposError              error // error to be returned in ListRepos
 	UpsertReposError            error // error to be returned in UpsertRepos
-	ListAllRepoNamesError       error // error to be returned in ListAllRepoNames
 	SetClonedReposError         error // error to be returned in SetClonedRepos
 	CountNotClonedReposError    error // error to be returned in CountNotClonedRepos
 	svcIDSeq                    int64
@@ -105,7 +104,6 @@ func (s *FakeStore) Transact(ctx context.Context) (TxStore, error) {
 		GetRepoByNameError:          s.GetRepoByNameError,
 		ListReposError:              s.ListReposError,
 		UpsertReposError:            s.UpsertReposError,
-		ListAllRepoNamesError:       s.ListAllRepoNamesError,
 		SetClonedReposError:         s.SetClonedReposError,
 		CountNotClonedReposError:    s.CountNotClonedReposError,
 
@@ -280,22 +278,6 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 	}
 
 	return repos, nil
-}
-
-// ListAllRepoNames lists names of all repos in the store
-func (s FakeStore) ListAllRepoNames(ctx context.Context) ([]api.RepoName, error) {
-	if s.ListAllRepoNamesError != nil {
-		return nil, s.ListAllRepoNamesError
-	}
-
-	names := make([]api.RepoName, 0, len(s.repoByID))
-	for _, r := range s.repoByID {
-		if !r.IsDeleted() {
-			names = append(names, api.RepoName(r.Name))
-		}
-	}
-
-	return names, nil
 }
 
 func evalOr(bs ...bool) bool {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -614,23 +614,12 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 
-	notCloned := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		lower := strings.ToLower(string(n))
-		notCloned[lower] = struct{}{}
-	}
-
-	cloned, err := s.GitserverClient.ListCloned(ctx)
+	cloned, err := s.Store.CountClonedRepos(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	for _, c := range cloned {
-		lower := strings.ToLower(c)
-		delete(notCloned, lower)
-	}
-
-	s.notClonedCount = uint64(len(notCloned))
+	s.notClonedCount = uint64(len(names)) - cloned
 	s.notClonedCountUpdatedAt = time.Now()
 
 	return s.notClonedCount, nil

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -62,10 +61,6 @@ type Server struct {
 		// ScheduleRepos schedules new permissions syncing requests for given repositories.
 		ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID)
 	}
-
-	notClonedCountMu        sync.Mutex
-	notClonedCount          uint64
-	notClonedCountUpdatedAt time.Time
 }
 
 // Handler returns the http.Handler that should be used to serve requests.
@@ -545,7 +540,7 @@ func (s *Server) handleStatusMessages(w http.ResponseWriter, r *http.Request) {
 		Messages: []protocol.StatusMessage{},
 	}
 
-	notCloned, err := s.computeNotClonedCount(r.Context())
+	notCloned, err := s.Store.CountNotClonedRepos(r.Context())
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return
@@ -598,26 +593,6 @@ func (s *Server) handleStatusMessages(w http.ResponseWriter, r *http.Request) {
 	log15.Debug("TRACE handleStatusMessages", "messages", log15.Lazy{Fn: messagesSummary})
 
 	respond(w, http.StatusOK, resp)
-}
-
-func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
-	// Coarse lock so we single flight the expensive computation.
-	s.notClonedCountMu.Lock()
-	defer s.notClonedCountMu.Unlock()
-
-	if expiresAt := s.notClonedCountUpdatedAt.Add(30 * time.Second); expiresAt.After(time.Now()) {
-		return s.notClonedCount, nil
-	}
-
-	var err error
-
-	s.notClonedCount, err = s.Store.CountNotClonedRepos(ctx)
-	if err != nil {
-		return 0, err
-	}
-	s.notClonedCountUpdatedAt = time.Now()
-
-	return s.notClonedCount, nil
 }
 
 func (s *Server) handleEnqueueChangesetSync(w http.ResponseWriter, r *http.Request) {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -609,17 +609,12 @@ func (s *Server) computeNotClonedCount(ctx context.Context) (uint64, error) {
 		return s.notClonedCount, nil
 	}
 
-	names, err := s.Store.ListAllRepoNames(ctx)
+	var err error
+
+	s.notClonedCount, err = s.Store.CountNotClonedRepos(ctx)
 	if err != nil {
 		return 0, err
 	}
-
-	cloned, err := s.Store.CountClonedRepos(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	s.notClonedCount = uint64(len(names)) - cloned
 	s.notClonedCountUpdatedAt = time.Now()
 
 	return s.notClonedCount, nil

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -561,7 +561,7 @@ func TestServer_StatusMessages(t *testing.T) {
 		{
 			name:            "all cloned",
 			gitserverCloned: []string{"foobar"},
-			stored:          []*repos.Repo{{Name: "foobar"}},
+			stored:          []*repos.Repo{{Name: "foobar", Cloned: true}},
 			res: &protocol.StatusMessagesResponse{
 				Messages: []protocol.StatusMessage{},
 			},
@@ -582,7 +582,7 @@ func TestServer_StatusMessages(t *testing.T) {
 		},
 		{
 			name:            "subset cloned",
-			stored:          []*repos.Repo{{Name: "foobar"}, {Name: "barfoo"}},
+			stored:          []*repos.Repo{{Name: "foobar", Cloned: true}, {Name: "barfoo"}},
 			gitserverCloned: []string{"foobar"},
 			res: &protocol.StatusMessagesResponse{
 				Messages: []protocol.StatusMessage{
@@ -596,7 +596,7 @@ func TestServer_StatusMessages(t *testing.T) {
 		},
 		{
 			name:            "more cloned than stored",
-			stored:          []*repos.Repo{{Name: "foobar"}},
+			stored:          []*repos.Repo{{Name: "foobar", Cloned: true}},
 			gitserverCloned: []string{"foobar", "barfoo"},
 			res: &protocol.StatusMessagesResponse{
 				Messages: []protocol.StatusMessage{},
@@ -619,7 +619,7 @@ func TestServer_StatusMessages(t *testing.T) {
 		{
 			name:            "case insensitivity",
 			gitserverCloned: []string{"foobar"},
-			stored:          []*repos.Repo{{Name: "FOOBar"}},
+			stored:          []*repos.Repo{{Name: "FOOBar", Cloned: true}},
 			res: &protocol.StatusMessagesResponse{
 				Messages: []protocol.StatusMessage{},
 			},
@@ -627,7 +627,7 @@ func TestServer_StatusMessages(t *testing.T) {
 		{
 			name:            "case insensitivity to gitserver names",
 			gitserverCloned: []string{"FOOBar"},
-			stored:          []*repos.Repo{{Name: "FOOBar"}},
+			stored:          []*repos.Repo{{Name: "FOOBar", Cloned: true}},
 			res: &protocol.StatusMessagesResponse{
 				Messages: []protocol.StatusMessage{},
 			},

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -108,6 +108,10 @@ func (s *mockReposStore) SetClonedRepos(ctx context.Context, repoNames ...string
 	return nil
 }
 
+func (s *mockReposStore) CountClonedRepos(ctx context.Context) (uint64, error) {
+	return 0, nil
+}
+
 func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	p := &mockProvider{
 		serviceType: extsvc.TypeGitLab,

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -108,7 +108,7 @@ func (s *mockReposStore) SetClonedRepos(ctx context.Context, repoNames ...string
 	return nil
 }
 
-func (s *mockReposStore) CountClonedRepos(ctx context.Context) (uint64, error) {
+func (s *mockReposStore) CountNotClonedRepos(ctx context.Context) (uint64, error) {
 	return 0, nil
 }
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -100,10 +100,6 @@ func (s *mockReposStore) UpsertRepos(context.Context, ...*repos.Repo) error {
 	return nil
 }
 
-func (s *mockReposStore) ListAllRepoNames(context.Context) ([]api.RepoName, error) {
-	return nil, nil
-}
-
 func (s *mockReposStore) SetClonedRepos(ctx context.Context, repoNames ...string) error {
 	return nil
 }

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -590,6 +590,10 @@ func (m MockRepoStore) SetClonedRepos(ctx context.Context, repoNames ...string) 
 	panic("implement me")
 }
 
+func (m MockRepoStore) CountClonedRepos(ctx context.Context) (uint64, error) {
+	panic("implement me")
+}
+
 func mockListChangesets(ctx context.Context, opts ListChangesetsOpts) (campaigns.Changesets, int64, error) {
 	return nil, 0, nil
 }

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -574,10 +574,6 @@ func (m MockRepoStore) UpsertRepos(ctx context.Context, repos ...*repos.Repo) er
 	panic("implement me")
 }
 
-func (m MockRepoStore) ListAllRepoNames(ctx context.Context) ([]api.RepoName, error) {
-	panic("implement me")
-}
-
 func (m MockRepoStore) ListExternalServices(ctx context.Context, args repos.StoreListExternalServicesArgs) ([]*repos.ExternalService, error) {
 	return m.listExternalServices(ctx, args)
 }

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -590,7 +590,7 @@ func (m MockRepoStore) SetClonedRepos(ctx context.Context, repoNames ...string) 
 	panic("implement me")
 }
 
-func (m MockRepoStore) CountClonedRepos(ctx context.Context) (uint64, error) {
+func (m MockRepoStore) CountNotClonedRepos(ctx context.Context) (uint64, error) {
 	panic("implement me")
 }
 

--- a/internal/db/dbutil/dbutil.go
+++ b/internal/db/dbutil/dbutil.go
@@ -59,6 +59,7 @@ func Transaction(ctx context.Context, db *sql.DB, f func(tx *sql.Tx) error) (err
 type DB interface {
 	QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error)
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
 // A Tx captures the essential methods of a sql.Tx.


### PR DESCRIPTION
This PR changes the way we compute the number of non-cloned repositories by introducing a new method to the repo-updater store that returns the number of cloned repositories.
Related to #11029 