### PR TITLE
search: avoid allocating revspecs slice per indexed filematch

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -321,7 +321,7 @@ func zoektSearchHEAD(ctx context.Context, args *search.TextParameters, repos []*
 		if repoResolvers[repoRev.Repo.Name] == nil {
 			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{repo: repoRev.Repo}
 		}
-		inputRev := repoRev.Revs[0].RevSpec // RevSpec is gaurenteed to be explicit via zoektIndexedRepos
+		inputRev := repoRev.Revs[0].RevSpec // RevSpec is guaranteed to be explicit via zoektIndexedRepos
 
 		// symbols is set in symbols search, lines in text search.
 		var (

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -138,6 +138,16 @@ func (r *RepositoryRevisions) String() string {
 	return string(r.Repo.Name) + "@" + strings.Join(parts, ":")
 }
 
+// OnlyExplicit returns true if all revspecs in Revs are explicit.
+func (r *RepositoryRevisions) OnlyExplicit() bool {
+	for _, rev := range r.Revs {
+		if rev.RefGlob != "" || rev.ExcludeRefGlob != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // RevSpecs returns a list of all explicitly listed Git revspecs. It does not expand ref globs to
 // their matching revspecs.
 func (r *RepositoryRevisions) RevSpecs() []string {


### PR DESCRIPTION
Minor optimization to avoid needless allocations.