### PR TITLE
Permissions issue fix with the build scripts.

### DIFF
--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -6,6 +6,10 @@ set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 GRAFANA_DISK="${HOME}/.sourcegraph-dev/data/grafana"
+if [ ! -e "${GRAFANA_DISK}" ]; then
+    mkdir -p ${GRAFANA_DISK}
+fi
+
 IMAGE=sourcegraph/grafana:dev
 CONTAINER=grafana
 

--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -7,7 +7,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 GRAFANA_DISK="${HOME}/.sourcegraph-dev/data/grafana"
 if [ ! -e "${GRAFANA_DISK}" ]; then
-  mkdir -p ${GRAFANA_DISK}
+  mkdir -p "${GRAFANA_DISK}"
 fi
 
 IMAGE=sourcegraph/grafana:dev

--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -7,7 +7,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 GRAFANA_DISK="${HOME}/.sourcegraph-dev/data/grafana"
 if [ ! -e "${GRAFANA_DISK}" ]; then
-    mkdir -p ${GRAFANA_DISK}
+  mkdir -p ${GRAFANA_DISK}
 fi
 
 IMAGE=sourcegraph/grafana:dev

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -8,7 +8,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 PROMETHEUS_DISK="${HOME}/.sourcegraph-dev/data/prometheus"
 if [ ! -e "${PROMETHEUS_DISK}" ]; then
-  mkdir -p ${PROMETHEUS_DISK}
+  mkdir -p "${PROMETHEUS_DISK}"
 fi
 
 IMAGE=sourcegraph/prometheus:61407_2020-04-18_9aa5791@sha256:9b31cc8832defb66cd29e5a298422983179495193745324902660073b3fdc835

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -8,7 +8,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 PROMETHEUS_DISK="${HOME}/.sourcegraph-dev/data/prometheus"
 if [ ! -e "${PROMETHEUS_DISK}" ]; then
-    mkdir -p ${PROMETHEUS_DISK}
+  mkdir -p ${PROMETHEUS_DISK}
 fi
 
 IMAGE=sourcegraph/prometheus:61407_2020-04-18_9aa5791@sha256:9b31cc8832defb66cd29e5a298422983179495193745324902660073b3fdc835

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -7,6 +7,10 @@ set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 PROMETHEUS_DISK="${HOME}/.sourcegraph-dev/data/prometheus"
+if [ ! -e "${PROMETHEUS_DISK}" ]; then
+    mkdir -p ${PROMETHEUS_DISK}
+fi
+
 IMAGE=sourcegraph/prometheus:61407_2020-04-18_9aa5791@sha256:9b31cc8832defb66cd29e5a298422983179495193745324902660073b3fdc835
 CONTAINER=prometheus
 


### PR DESCRIPTION
Docker references directories within the home directory, but as directories don't exist *prior* to docker run calls, the directories are created and owned by root. As the dockers themselves run as the current UID, that means permission denials exist all over these place, and the docker's cannot start.

Now, we create the directories in advance, prior to the docker call, thereby ensuring permissions to write exist for the logged in user.