### PR TITLE
graphqlbackend: remove errant PathPatternsAreRegExps

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -425,7 +425,6 @@ func TestQueryToZoektQuery(t *testing.T) {
 				Pattern:                      "foo",
 				IncludePatterns:              nil,
 				ExcludePattern:               "",
-				PathPatternsAreRegExps:       true,
 				PathPatternsAreCaseSensitive: false,
 			},
 			Query: "sym:foo case:no",


### PR DESCRIPTION
Merged two PRs into master. The one removed PathPatternsAreRegExps, the
other added this test case. This lead to a broken build.
