### PR TITLE
search: explicitly dissallow multi branch structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -69,6 +69,16 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		}
 	}
 
+	// We do not yet support searching non-HEAD for fileRequest (structural
+	// search).
+	if typ == fileRequest {
+		for _, r := range args.Repos {
+			if !r.OnlyHEAD() {
+				return nil, fmt.Errorf("structural search only supports searching the default branch https://github.com/sourcegraph/sourcegraph/issues/11906: %s", r.String())
+			}
+		}
+	}
+
 	// If Zoekt is disabled just fallback to Unindexed.
 	if !args.Zoekt.Enabled() {
 		if indexParam == Only {

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -138,6 +138,20 @@ func (r *RepositoryRevisions) String() string {
 	return string(r.Repo.Name) + "@" + strings.Join(parts, ":")
 }
 
+// OnlyHEAD returns true iff there is only one ref and it is explicitly the
+// default branch.
+//
+// Note: This doesn't resolve what the default branch is. It relies on the rev
+// being "" (Sourcegraph convention for default) or "HEAD" (git symref for
+// default).
+func (r *RepositoryRevisions) OnlyHEAD() bool {
+	if !r.OnlyExplicit() || len(r.Revs) != 1 {
+		return false
+	}
+	rev := r.Revs[0].RevSpec
+	return rev == "" || rev == "HEAD"
+}
+
 // OnlyExplicit returns true if all revspecs in Revs are explicit.
 func (r *RepositoryRevisions) OnlyExplicit() bool {
 	for _, rev := range r.Revs {


### PR DESCRIPTION
Structural search will only search indexed commits. Previously we did
not need to explicitly exclude multi branch search since indexed search
only supported searching HEAD. However, now indexed search could search
other revs.

We still need to update structural search to support non-HEAD
search. For now we dissallow it to prevent bugs.

Part of https://github.com/sourcegraph/sourcegraph/issues/11906 and #6728 