### PR TITLE
cloud: use the cloned column to filter by clone status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Configuration for `observability.alerts` has changed and notifications are now provided by Prometheus Alertmanager. [#11832](https://github.com/sourcegraph/sourcegraph/pull/11832)
   - Removed: `observability.alerts.id`.
   - Removed: Slack notifiers no longer accept `mentionUsers`, `mentionGroups`, `mentionChannel`, and `token` options.
+-
 
 ### Fixed
 
@@ -41,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue where valid search queries were improperly hinted as being invalid in the search field. [#11688](https://github.com/sourcegraph/sourcegraph/pull/11688)
 - Reduce frontend memory spikes by limiting the number of goroutines launched by our GraphQL resolvers. [#11736](https://github.com/sourcegraph/sourcegraph/pull/11736)
 - Fixed a bug affecting Sourcegraph icon display in our Phabricator native integration [#11825](https://github.com/sourcegraph/sourcegraph/pull/11825).
+- Improve performance of site-admin repositories status page. [#11932](https://github.com/sourcegraph/sourcegraph/pull/11932)
 
 ### Removed
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -154,6 +154,7 @@ var getBySQLColumns = []string{
 	"language",
 	"fork",
 	"archived",
+	"cloned",
 }
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
@@ -222,6 +223,7 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		&r.Language,
 		&r.Fork,
 		&r.Archived,
+		&r.Cloned,
 	)
 }
 
@@ -263,6 +265,12 @@ type ReposListOptions struct {
 
 	// OnlyArchived excludes non-archived repositories from the list.
 	OnlyArchived bool
+
+	// NoCloned excludes cloned repositories from the list.
+	NoCloned bool
+
+	// OnlyCloned excludes non-cloned repositories from the list.
+	OnlyCloned bool
 
 	// NoPrivate excludes private repositories from the list.
 	NoPrivate bool
@@ -457,6 +465,12 @@ func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 	}
 	if opt.OnlyArchived {
 		conds = append(conds, sqlf.Sprintf("archived"))
+	}
+	if opt.NoCloned {
+		conds = append(conds, sqlf.Sprintf("NOT cloned"))
+	}
+	if opt.OnlyCloned {
+		conds = append(conds, sqlf.Sprintf("cloned"))
 	}
 	if opt.NoPrivate {
 		conds = append(conds, sqlf.Sprintf("NOT private"))

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -334,7 +334,7 @@ func TestRepos_List_cloned(t *testing.T) {
 
 	mine := mustCreate(ctx, t, &types.Repo{Name: "a/r", RepoFields: &types.RepoFields{Cloned: false}})
 	yours := mustCreate(ctx, t, &types.Repo{Name: "b/r", RepoFields: &types.RepoFields{Cloned: true}})
-	t.Logf("Yours: %#v", yours[0].RepoFields)
+
 	{
 		repos, err := Repos.List(ctx, ReposListOptions{OnlyCloned: true})
 		if err != nil {

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -335,33 +335,25 @@ func TestRepos_List_cloned(t *testing.T) {
 	mine := mustCreate(ctx, t, &types.Repo{Name: "a/r", RepoFields: &types.RepoFields{Cloned: false}})
 	yours := mustCreate(ctx, t, &types.Repo{Name: "b/r", RepoFields: &types.RepoFields{Cloned: true}})
 
-	{
-		repos, err := Repos.List(ctx, ReposListOptions{OnlyCloned: true})
-		if err != nil {
-			t.Fatal(err)
-		}
-		assertJSONEqual(t, yours, repos)
+	tests := []struct {
+		name string
+		opt  ReposListOptions
+		want []*types.Repo
+	}{
+		{"OnlyCloned", ReposListOptions{OnlyCloned: true}, yours},
+		{"NoCloned", ReposListOptions{NoCloned: true}, mine},
+		{"NoCloned && OnlyCloned", ReposListOptions{NoCloned: true, OnlyCloned: true}, nil},
+		{"Default", ReposListOptions{}, append(append([]*types.Repo(nil), mine...), yours...)},
 	}
-	{
-		repos, err := Repos.List(ctx, ReposListOptions{NoCloned: true})
-		if err != nil {
-			t.Fatal(err)
-		}
-		assertJSONEqual(t, mine, repos)
-	}
-	{
-		repos, err := Repos.List(ctx, ReposListOptions{NoCloned: true, OnlyCloned: true})
-		if err != nil {
-			t.Fatal(err)
-		}
-		assertJSONEqual(t, nil, repos)
-	}
-	{
-		repos, err := Repos.List(ctx, ReposListOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		assertJSONEqual(t, append(append([]*types.Repo(nil), mine...), yours...), repos)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repos, err := Repos.List(ctx, test.opt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertJSONEqual(t, test.want, repos)
+		})
 	}
 }
 

--- a/cmd/frontend/db/repos_db_test.go
+++ b/cmd/frontend/db/repos_db_test.go
@@ -42,6 +42,7 @@ func createRepo(ctx context.Context, t *testing.T, repo *types.Repo) {
 		op.Description = repo.Description
 		op.Fork = repo.Fork
 		op.Cloned = repo.Cloned
+		op.Archived = repo.Archived
 	}
 
 	if err := Repos.Upsert(ctx, op); err != nil {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -115,6 +115,9 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 		if !r.cloned {
 			opt2.NoCloned = true
 		} else if !r.notCloned || !r.cloneInProgress {
+			// notCloned and cloneInProgress are true by default.
+			// this condition is valid only if one of them has been
+			// explicitly set to false by the client.
 			opt2.OnlyCloned = true
 		}
 

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -81,107 +81,78 @@ type repositoryConnectionResolver struct {
 
 func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Repo, error) {
 	r.once.Do(func() {
+		opt2 := r.opt
+
 		if envvar.SourcegraphDotComMode() {
 			// 🚨 SECURITY: Don't allow non-admins to perform huge queries on Sourcegraph.com.
 			if isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil; !isSiteAdmin {
-				if r.opt.LimitOffset == nil {
-					r.opt.LimitOffset = &db.LimitOffset{Limit: 1000}
+				if opt2.LimitOffset == nil {
+					opt2.LimitOffset = &db.LimitOffset{Limit: 1000}
 				}
 			}
 		}
 
-		if !r.indexed || !r.notIndexed {
-			r.repos, r.err = r.computeIndexedRepositories(ctx)
-			return
+		var indexed map[string]*zoekt.Repository
+		searchIndexEnabled := search.Indexed().Enabled()
+		isIndexed := func(repo api.RepoName) bool {
+			if !searchIndexEnabled {
+				return true // do not need index
+			}
+			_, ok := indexed[string(repo)]
+			return ok
+		}
+		if searchIndexEnabled && (!r.indexed || !r.notIndexed) {
+			listCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			var err error
+			indexed, err = search.Indexed().ListAll(listCtx)
+			if err != nil {
+				r.err = err
+				return
+			}
 		}
 
-		r.repos, r.err = r.computeRepositories(ctx)
+		if !r.cloned {
+			opt2.NoCloned = true
+		} else if !r.notCloned || !r.cloneInProgress {
+			opt2.OnlyCloned = true
+		}
+
+		for {
+			repos, err := backend.Repos.List(ctx, opt2)
+			if err != nil {
+				r.err = err
+				return
+			}
+			reposFromDB := len(repos)
+
+			if !r.indexed || !r.notIndexed {
+				keepRepos := repos[:0]
+				for _, repo := range repos {
+					indexed := isIndexed(repo.Name)
+					if (r.indexed && indexed) || (r.notIndexed && !indexed) {
+						keepRepos = append(keepRepos, repo)
+					}
+				}
+				repos = keepRepos
+			}
+
+			r.repos = append(r.repos, repos...)
+
+			if opt2.LimitOffset == nil {
+				break
+			} else {
+				// check if we filtered some repos and if
+				// we need to get more from the DB
+				if len(repos) >= r.opt.Limit || reposFromDB < r.opt.Limit {
+					break
+				}
+				opt2.Offset += opt2.Limit
+			}
+		}
 	})
 
 	return r.repos, r.err
-}
-
-func (r *repositoryConnectionResolver) computeRepositories(ctx context.Context) ([]*types.Repo, error) {
-	opt2 := r.opt
-
-	if !r.cloned {
-		opt2.NoCloned = true
-	} else if !r.notCloned || !r.cloneInProgress {
-		opt2.OnlyCloned = true
-	}
-
-	return backend.Repos.List(ctx, opt2)
-}
-
-func (r *repositoryConnectionResolver) computeIndexedRepositories(ctx context.Context) ([]*types.Repo, error) {
-	var repos []*types.Repo
-	var err error
-
-	opt2 := r.opt
-
-	var indexed map[string]*zoekt.Repository
-	searchIndexEnabled := search.Indexed().Enabled()
-	isIndexed := func(repo api.RepoName) bool {
-		if !searchIndexEnabled {
-			return true // do not need index
-		}
-		_, ok := indexed[string(repo)]
-		return ok
-	}
-	if searchIndexEnabled && (!r.indexed || !r.notIndexed) {
-		listCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-		defer cancel()
-		var err error
-		indexed, err = search.Indexed().ListAll(listCtx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if !r.cloned {
-		opt2.NoCloned = true
-	} else if !r.notCloned || !r.cloneInProgress {
-		opt2.OnlyCloned = true
-	}
-
-	for {
-		repos, err = backend.Repos.List(ctx, opt2)
-		if err != nil {
-			return nil, err
-		}
-		reposFromDB := len(repos)
-
-		if !r.indexed || !r.notIndexed {
-			keepRepos := repos[:0]
-			for _, repo := range repos {
-				indexed := isIndexed(repo.Name)
-				if (r.indexed && indexed) || (r.notIndexed && !indexed) {
-					keepRepos = append(keepRepos, repo)
-				}
-			}
-			repos = keepRepos
-		}
-
-		if opt2.LimitOffset == nil {
-			break
-		} else {
-			if len(repos) > r.opt.Limit {
-				// Cut off the repos we additionally loaded to save
-				// roundtrips to `gitserver` and only return the number
-				// that was requested.
-				// But, when possible, we add one more so we can detect if
-				// there is a "next page" that could be loaded
-				repos = repos[:r.opt.Limit+1]
-				break
-			}
-			if reposFromDB < r.opt.Limit {
-				break
-			}
-			opt2.Offset += opt2.Limit
-		}
-	}
-
-	return repos, nil
 }
 
 func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*RepositoryResolver, error) {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -61,6 +61,34 @@ func TestRepositories(t *testing.T) {
 		},
 		{
 			Schema: mustParseGraphQLSchema(t),
+			// cloned and notCloned are true by default
+			// this test ensures the behavior is the same
+			// when setting them explicitly
+			Query: `
+				{
+					repositories(cloned: true, notCloned: true) {
+						nodes { name }
+						totalCount
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"repositories": {
+						"nodes": [
+							{ "name": "repo1" },
+							{ "name": "repo2" },
+							{ "name": "repo3" }
+						],
+						"totalCount": null,
+						"pageInfo": {"hasNextPage": false}
+					}
+				}
+			`,
+		},
+		{
+			Schema: mustParseGraphQLSchema(t),
 			Query: `
 				{
 					repositories(first: 2) {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -11,13 +11,14 @@ import (
 
 func TestRepositories(t *testing.T) {
 	resetMocks()
-	repos := make([]*types.Repo, 3)
-	repos[0] = &types.Repo{Name: "repo1"}
-	repos[1] = &types.Repo{Name: "repo2"}
-	repos[2] = &types.Repo{
-		Name: "repo3",
-		RepoFields: &types.RepoFields{
-			Cloned: true,
+	repos := []*types.Repo{
+		{Name: "repo1"},
+		{Name: "repo2"},
+		{
+			Name: "repo3",
+			RepoFields: &types.RepoFields{
+				Cloned: true,
+			},
 		},
 	}
 	db.Mocks.Repos.List = func(ctx context.Context, opt db.ReposListOptions) ([]*types.Repo, error) {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -228,6 +228,10 @@ func (r *RepositoryResolver) Language(ctx context.Context) string {
 
 func (r *RepositoryResolver) Enabled() bool { return true }
 
+// No clients that we know of read this field. Additionally on performance profiles
+// the marshalling of timestamps is significant in our postgres client. So we
+// deprecate the fields and return fake data for created_at.
+// https://github.com/sourcegraph/sourcegraph/pull/4668
 func (r *RepositoryResolver) CreatedAt() DateTime {
 	return DateTime{Time: time.Now()}
 }

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -28,6 +28,9 @@ type RepoFields struct {
 
 	// Archived is whether this repository has been archived.
 	Archived bool
+
+	// Cloned is whether this repository is cloned.
+	Cloned bool
 }
 
 // Repo represents a source code repository.

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -251,15 +251,15 @@ func NewStoreMetrics() StoreMetrics {
 		CountNotClonedRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_duration_seconds",
-				Help: "Time spent counting cloned repos",
+				Help: "Time spent counting not-cloned repos",
 			}, []string{}),
 			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_total",
-				Help: "Total number of count cloned repos calls",
+				Help: "Total number of count not-cloned repos calls",
 			}, []string{}),
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_errors_total",
-				Help: "Total number of errors when counting cloned repos",
+				Help: "Total number of errors when counting not-cloned repos",
 			}, []string{}),
 		},
 	}

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -438,17 +438,17 @@ their cloned column is true but they are not in cloned_repos
 or they are in cloned_repos but their cloned column is false
 */
 WITH cloned_repos AS (
-	SELECT jsonb_array_elements_text(%s)
+  SELECT jsonb_array_elements_text(%s)
 ),
 diff AS (
-    SELECT id,
-        cloned
-    FROM repo
-	WHERE
-		NOT cloned
-			AND name IN (SELECT * FROM cloned_repos)
-		OR cloned
-			AND name NOT IN (SELECT * FROM cloned_repos)
+  SELECT id,
+    cloned
+  FROM repo
+  WHERE
+    NOT cloned
+      AND name IN (SELECT * FROM cloned_repos)
+    OR cloned
+      AND name NOT IN (SELECT * FROM cloned_repos)
 )
 UPDATE repo
 SET cloned = NOT diff.cloned

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -431,12 +431,12 @@ const setClonedReposQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.SetClonedRepos
 WITH c AS (
 	UPDATE repo SET cloned = true
-	WHERE NOT cloned AND name in (%s)
+	WHERE name IN (%s)
 	RETURNING id
  )
  UPDATE repo SET cloned = false
  FROM c
- WHERE cloned AND repo.id != c.id;
+ WHERE cloned AND repo.id NOT IN (SELECT id FROM c);
 `
 
 // CountNotClonedRepos returns the number of repos whose cloned column is true.

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -739,79 +739,28 @@ func isCloned(r *repos.Repo) bool {
 }
 
 func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
-	clock := repos.NewFakeClock(time.Now(), 0)
-	now := clock.Now()
-
 	return func(t *testing.T) {
 		t.Helper()
 
-		github := repos.Repo{
-			Name:        "github.com/foo/bar",
-			URI:         "github.com/foo/bar",
-			Description: "The description",
-			Language:    "barlang",
-			CreatedAt:   now,
-			Cloned:      true,
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "AAAAA==",
-				ServiceType: "github",
-				ServiceID:   "http://github.com",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:1": {
-					ID:       "extsvc:1",
-					CloneURL: "git@github.com:foo/bar.git",
+		var repositories repos.Repos
+		for i := 0; i < 3; i++ {
+			repositories = append(repositories, &repos.Repo{
+				Name:   fmt.Sprintf("github.com/%d/%d", i, i),
+				URI:    fmt.Sprintf("github.com/%d/%d", i, i),
+				Cloned: false,
+				ExternalRepo: api.ExternalRepoSpec{
+					ID:          fmt.Sprintf("%d", i),
+					ServiceType: extsvc.TypeGitHub,
+					ServiceID:   "http://github.com",
 				},
-			},
-			Metadata: new(github.Repository),
-		}
-
-		gitlab := repos.Repo{
-			Name:        "gitlab.com/foo/bar",
-			URI:         "gitlab.com/foo/bar",
-			Description: "The description",
-			Language:    "barlang",
-			CreatedAt:   now,
-			Cloned:      false,
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "1234",
-				ServiceType: extsvc.TypeGitLab,
-				ServiceID:   "http://gitlab.com",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:2": {
-					ID:       "extsvc:2",
-					CloneURL: "git@gitlab.com:foo/bar.git",
+				Sources: map[string]*repos.SourceInfo{
+					"extsvc:3": {
+						ID:       "extsvc:3",
+						CloneURL: "git@github.com:foo/bar.git",
+					},
 				},
-			},
-			Metadata: new(gitlab.Project),
-		}
-
-		bitbucketServer := repos.Repo{
-			Name:        "bitbucketserver.mycorp.com/foo/bar",
-			URI:         "bitbucketserver.mycorp.com/foo/bar",
-			Description: "The description",
-			Language:    "barlang",
-			CreatedAt:   now,
-			Cloned:      true,
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "1234",
-				ServiceType: "bitbucketServer",
-				ServiceID:   "http://bitbucketserver.mycorp.com",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:3": {
-					ID:       "extsvc:3",
-					CloneURL: "git@bitbucketserver.mycorp.com:foo/bar.git",
-				},
-			},
-			Metadata: new(bitbucketserver.Repo),
-		}
-
-		repositories := repos.Repos{
-			&github,
-			&gitlab,
-			&bitbucketServer,
+				Metadata: new(github.Repository),
+			})
 		}
 
 		ctx := context.Background()
@@ -948,7 +897,8 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 	}
 
 	github := repos.Repo{
-		Name: "github.com/bar/foo",
+		Name:   "github.com/bar/foo",
+		Cloned: true,
 		Sources: map[string]*repos.SourceInfo{
 			"extsvc:123": {
 				ID:       "extsvc:123",
@@ -1158,6 +1108,17 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		},
 		stored: repositories,
 		repos:  repos.Assert.ReposEqual(&gitlab),
+	})
+
+	testCases = append(testCases, testCase{
+		name: "only include cloned",
+		args: func(repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				ClonedOnly: true,
+			}
+		},
+		stored: repositories,
+		repos:  repos.Assert.ReposEqual(&github),
 	})
 
 	testCases = append(testCases, testCase{

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -263,6 +263,9 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 		if args.PrivateOnly {
 			preds = append(preds, r.Private)
 		}
+		if args.ClonedOnly {
+			preds = append(preds, r.Cloned)
+		}
 
 		if (args.UseOr && evalOr(preds...)) || (!args.UseOr && evalAnd(preds...)) {
 			repos = append(repos, r)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -275,12 +275,6 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 // update the scheduler with the list.
 func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store repos.Store) {
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(repos.GetUpdateInterval() / 2):
-		}
-
 		cloned, err := gitserverClient.ListCloned(ctx)
 		if err != nil {
 			log15.Warn("failed to update git fetch scheduler with list of cloned repositories", "error", err)
@@ -293,6 +287,12 @@ func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver
 		if err != nil {
 			log15.Warn("failed to set cloned repository list", "error", err)
 			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(10 * time.Second):
 		}
 	}
 }


### PR DESCRIPTION
This makes the frontend store know about the new `cloned` column and add filtering capabilities based on its value. It also removes the application level filtering done in by the [repositoryResolver](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@51a804d45ba8ea0e73aef301ac9675a575e844be/-/blob/cmd/frontend/graphqlbackend/repositories.go#L69:6) which used to ask Gitserver for clone status, and uses the database instead.

Related to #11029