### PR TITLE
repo-updater: Move ratelimit syncing our of enterprise

### DIFF
--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -927,16 +927,13 @@ type externalServiceLister interface {
 	ListExternalServices(context.Context, StoreListExternalServicesArgs) ([]*ExternalService, error)
 }
 
-// NewRateLimitSyncer returns a new syncer and attempts to perform an initial sync it. On error, an
-// empty syncer is returned which can still to handle syncs.
-func NewRateLimitSyncer(ctx context.Context, registry *ratelimit.Registry, serviceLister externalServiceLister) (*RateLimitSyncer, error) {
+// NewRateLimitSyncer returns a new syncer
+func NewRateLimitSyncer(registry *ratelimit.Registry, serviceLister externalServiceLister) *RateLimitSyncer {
 	r := &RateLimitSyncer{
 		registry:      registry,
 		serviceLister: serviceLister,
 	}
-
-	// We'll return r either way as we'll try again if a service is added or updated
-	return r, r.SyncRateLimiters(ctx)
+	return r
 }
 
 // RateLimitSyncer syncs rate limits based on external service configuration

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -100,6 +101,13 @@ func Main(enterpriseInit EnterpriseInit) {
 		Store:           store,
 		Scheduler:       scheduler,
 		GitserverClient: gitserver.DefaultClient,
+	}
+
+	rateLimitSyncer, err := repos.NewRateLimitSyncer(ctx, ratelimit.DefaultRegistry, store)
+	if err != nil {
+		log15.Error("Creating rate limit syncer", "err", err)
+	} else {
+		server.RateLimitSyncer = rateLimitSyncer
 	}
 
 	// All dependencies ready

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -45,13 +45,6 @@ func enterpriseInit(
 	ctx := context.Background()
 	campaignsStore := campaigns.NewStore(db)
 
-	rateLimitSyncer, err := repos.NewRateLimitSyncer(ctx, ratelimit.DefaultRegistry, repoStore)
-	if err != nil {
-		log15.Error("Creating rate limit registry", "err", err)
-	} else if server != nil {
-		server.RateLimitSyncer = rateLimitSyncer
-	}
-
 	syncRegistry := campaigns.NewSyncRegistry(ctx, campaignsStore, repoStore, cf)
 	if server != nil {
 		server.ChangesetSyncRegistry = syncRegistry


### PR DESCRIPTION
The rate limit syncer was only being started in the enterprise
version of repo-updater but it is safe to start it in the non enterprise
version too.

Also, we should always add it to the server so that it handles future external 
service changes even if the initial sync failed.