### PR TITLE
Add a basic implementation of the applyCampaign mutation

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -236,12 +236,12 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		return nil, backend.ErrMustBeSiteAdmin
 	}
 
-	var namespaceUserID, namespaceOrgID int32
+	opts := ee.ApplyCampaignOpts{}
 	switch relay.UnmarshalKind(args.Namespace) {
 	case "User":
-		err = relay.UnmarshalSpec(args.Namespace, &namespaceUserID)
+		err = relay.UnmarshalSpec(args.Namespace, &opts.NamespaceUserID)
 	case "Org":
-		err = relay.UnmarshalSpec(args.Namespace, &namespaceOrgID)
+		err = relay.UnmarshalSpec(args.Namespace, &opts.NamespaceOrgID)
 	default:
 		err = errors.Errorf("Invalid namespace %q", args.Namespace)
 	}
@@ -250,21 +250,20 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		return nil, err
 	}
 
-	campaignSpecRandID, err := unmarshalCampaignSpecID(args.CampaignSpec)
+	opts.CampaignSpecRandID, err = unmarshalCampaignSpecID(args.CampaignSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	var ensureCampaignID int64
 	if args.EnsureCampaign != nil {
-		ensureCampaignID, err = campaigns.UnmarshalCampaignID(*args.EnsureCampaign)
+		opts.EnsureCampaignID, err = campaigns.UnmarshalCampaignID(*args.EnsureCampaign)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	svc := ee.NewService(r.store, r.httpFactory)
-	campaign, err := svc.ApplyCampaign(ctx, namespaceUserID, namespaceOrgID, campaignSpecRandID, ensureCampaignID)
+	campaign, err := svc.ApplyCampaign(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -255,8 +255,16 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		return nil, err
 	}
 
+	var ensureCampaignID int64
+	if args.EnsureCampaign != nil {
+		ensureCampaignID, err = campaigns.UnmarshalCampaignID(*args.EnsureCampaign)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	svc := ee.NewService(r.store, r.httpFactory)
-	campaign, err := svc.ApplyCampaign(ctx, namespaceUserID, namespaceOrgID, campaignSpecRandID)
+	campaign, err := svc.ApplyCampaign(ctx, namespaceUserID, namespaceOrgID, campaignSpecRandID, ensureCampaignID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1112,8 +1112,8 @@ func TestApplyCampaign(t *testing.T) {
 			DatabaseID: userID,
 			SiteAdmin:  true,
 		},
-
-		// TODO: Test for CampaignSpec/ChangesetSpecs etc.
+		// TODO: Test for CampaignSpec/ChangesetSpecs once they're defined in
+		// the schema.
 	}
 
 	if diff := cmp.Diff(want, have); diff != "" {

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -226,6 +226,7 @@ func (s *Service) ApplyCampaign(
 	ctx context.Context,
 	namespaceUserID, namespaceOrgID int32,
 	campaignSpecRandID string,
+	ensureCampaignID int64,
 ) (campaign *campaigns.Campaign, err error) {
 	title := fmt.Sprintf(
 		"CampaignSpec %s, NamespaceOrgID %d, NamespaceUserID %d",
@@ -266,6 +267,10 @@ func (s *Service) ApplyCampaign(
 		campaign = &campaigns.Campaign{}
 	}
 
+	if ensureCampaignID != 0 && campaign.ID != ensureCampaignID {
+		return nil, ErrEnsureCampaignFailed
+	}
+
 	if campaign.CampaignSpecID == campaignSpec.ID {
 		return campaign, nil
 	}
@@ -289,6 +294,11 @@ func (s *Service) ApplyCampaign(
 
 	return campaign, s.store.UpdateCampaign(ctx, campaign)
 }
+
+// ErrEnsureCampaignFailed is returned by ApplyCampaign when a ensureCampaignID
+// is provided but a campaign with the name specified the campaignSpec exists
+// in the given namespace but has a different ID.
+var ErrEnsureCampaignFailed = errors.New("a campaign in the given namespace and with the given name exists but does not match the given ID")
 
 // ErrNoPatches is returned by CreateCampaign or UpdateCampaign if a
 // PatchSetID was specified but the PatchSet does not have any

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -731,7 +731,10 @@ func TestService(t *testing.T) {
 
 		t.Run("new campaign", func(t *testing.T) {
 			campaignSpec := createCampaignSpec(t, "campaign-name", user.ID)
-			campaign, err := svc.ApplyCampaign(ctx, user.ID, 0, campaignSpec.RandID, 0)
+			campaign, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+				NamespaceUserID:    user.ID,
+				CampaignSpecRandID: campaignSpec.RandID,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -762,7 +765,10 @@ func TestService(t *testing.T) {
 
 		t.Run("existing campaign", func(t *testing.T) {
 			campaignSpec := createCampaignSpec(t, "campaign-name", user.ID)
-			campaign, err := svc.ApplyCampaign(ctx, user.ID, 0, campaignSpec.RandID, 0)
+			campaign, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+				NamespaceUserID:    user.ID,
+				CampaignSpecRandID: campaignSpec.RandID,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -772,7 +778,10 @@ func TestService(t *testing.T) {
 			}
 
 			t.Run("apply same campaignSpec", func(t *testing.T) {
-				campaign2, err := svc.ApplyCampaign(ctx, user.ID, 0, campaignSpec.RandID, 0)
+				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+					NamespaceUserID:    user.ID,
+					CampaignSpecRandID: campaignSpec.RandID,
+				})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -784,7 +793,10 @@ func TestService(t *testing.T) {
 
 			t.Run("apply campaign spec with same name", func(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user.ID)
-				campaign2, err := svc.ApplyCampaign(ctx, user.ID, 0, campaignSpec2.RandID, 0)
+				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+					NamespaceUserID:    user.ID,
+					CampaignSpecRandID: campaignSpec2.RandID,
+				})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -797,7 +809,11 @@ func TestService(t *testing.T) {
 			t.Run("apply campaign spec with same name but different namespace", func(t *testing.T) {
 				user2 := createTestUser(ctx, t)
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user2.ID)
-				campaign2, err := svc.ApplyCampaign(ctx, user2.ID, 0, campaignSpec2.RandID, 0)
+
+				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+					NamespaceUserID:    user2.ID,
+					CampaignSpecRandID: campaignSpec2.RandID,
+				})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -813,22 +829,28 @@ func TestService(t *testing.T) {
 
 			t.Run("campaign spec with same name and same ensureCampaignID", func(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user.ID)
-				ensureID := campaign.ID
 
-				campaign2, err := svc.ApplyCampaign(ctx, user.ID, 0, campaignSpec2.RandID, ensureID)
+				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+					NamespaceUserID:    user.ID,
+					CampaignSpecRandID: campaignSpec2.RandID,
+					EnsureCampaignID:   campaign.ID,
+				})
 				if err != nil {
 					t.Fatal(err)
 				}
-				if have, want := campaign2.ID, ensureID; have != want {
+				if have, want := campaign2.ID, campaign.ID; have != want {
 					t.Fatalf("campaign has wrong ID. want=%d, have=%d", want, have)
 				}
 			})
 
 			t.Run("campaign spec with same name but different ensureCampaignID", func(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user.ID)
-				ensureID := campaign.ID + 999
 
-				_, err := svc.ApplyCampaign(ctx, user.ID, 0, campaignSpec2.RandID, ensureID)
+				_, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+					NamespaceUserID:    user.ID,
+					CampaignSpecRandID: campaignSpec2.RandID,
+					EnsureCampaignID:   campaign.ID + 999,
+				})
 				if err != ErrEnsureCampaignFailed {
 					t.Fatalf("wrong error: %s", err)
 				}

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -1225,9 +1225,10 @@ INSERT INTO campaigns (
   updated_at,
   changeset_ids,
   patch_set_id,
-  closed_at
+  closed_at,
+  campaign_spec_id
 )
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING
   id,
   name,
@@ -1240,7 +1241,8 @@ RETURNING
   updated_at,
   changeset_ids,
   patch_set_id,
-  closed_at
+  closed_at,
+  campaign_spec_id
 `
 
 func (s *Store) createCampaignQuery(c *campaigns.Campaign) (*sqlf.Query, error) {
@@ -1270,6 +1272,7 @@ func (s *Store) createCampaignQuery(c *campaigns.Campaign) (*sqlf.Query, error) 
 		changesetIDs,
 		nullInt64Column(c.PatchSetID),
 		nullTimeColumn(c.ClosedAt),
+		nullInt64Column(c.CampaignSpecID),
 	), nil
 }
 
@@ -1327,8 +1330,9 @@ SET (
   updated_at,
   changeset_ids,
   patch_set_id,
-  closed_at
-) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+  closed_at,
+  campaign_spec_id
+) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   id,
@@ -1342,7 +1346,8 @@ RETURNING
   updated_at,
   changeset_ids,
   patch_set_id,
-  closed_at
+  closed_at,
+  campaign_spec_id
 `
 
 func (s *Store) updateCampaignQuery(c *campaigns.Campaign) (*sqlf.Query, error) {
@@ -1365,6 +1370,7 @@ func (s *Store) updateCampaignQuery(c *campaigns.Campaign) (*sqlf.Query, error) 
 		changesetIDs,
 		nullInt64Column(c.PatchSetID),
 		nullTimeColumn(c.ClosedAt),
+		nullInt64Column(c.CampaignSpecID),
 		c.ID,
 	), nil
 }
@@ -1447,6 +1453,12 @@ func countCampaignsQuery(opts *CountCampaignsOpts) *sqlf.Query {
 type GetCampaignOpts struct {
 	ID         int64
 	PatchSetID int64
+
+	NamespaceUserID int32
+	NamespaceOrgID  int32
+
+	CampaignSpecID   int64
+	CampaignSpecName string
 }
 
 // GetCampaign gets a campaign matching the given options.
@@ -1468,22 +1480,26 @@ func (s *Store) GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaig
 	return &c, nil
 }
 
-var getCampaignsQueryFmtstr = `
+var getCampaignsQueryFmtstrPre = `
 -- source: enterprise/internal/campaigns/store.go:GetCampaign
 SELECT
-  id,
-  name,
-  description,
-  branch,
-  author_id,
-  namespace_user_id,
-  namespace_org_id,
-  created_at,
-  updated_at,
-  changeset_ids,
-  patch_set_id,
-  closed_at
+  campaigns.id,
+  campaigns.name,
+  campaigns.description,
+  campaigns.branch,
+  campaigns.author_id,
+  campaigns.namespace_user_id,
+  campaigns.namespace_org_id,
+  campaigns.created_at,
+  campaigns.updated_at,
+  campaigns.changeset_ids,
+  campaigns.patch_set_id,
+  campaigns.closed_at,
+  campaigns.campaign_spec_id
 FROM campaigns
+`
+
+var getCampaignsQueryFmtstrPost = `
 WHERE %s
 LIMIT 1
 `
@@ -1491,18 +1507,40 @@ LIMIT 1
 func getCampaignQuery(opts *GetCampaignOpts) *sqlf.Query {
 	var preds []*sqlf.Query
 	if opts.ID != 0 {
-		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+		preds = append(preds, sqlf.Sprintf("campaigns.id = %s", opts.ID))
 	}
 
 	if opts.PatchSetID != 0 {
-		preds = append(preds, sqlf.Sprintf("patch_set_id = %s", opts.PatchSetID))
+		preds = append(preds, sqlf.Sprintf("campaigns.patch_set_id = %s", opts.PatchSetID))
+	}
+
+	if opts.CampaignSpecID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaigns.campaign_spec_id = %s", opts.CampaignSpecID))
+	}
+
+	if opts.NamespaceUserID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaigns.namespace_user_id = %s", opts.NamespaceUserID))
+	}
+
+	if opts.NamespaceOrgID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaigns.namespace_org_id = %s", opts.NamespaceOrgID))
 	}
 
 	if len(preds) == 0 {
 		preds = append(preds, sqlf.Sprintf("TRUE"))
 	}
 
-	return sqlf.Sprintf(getCampaignsQueryFmtstr, sqlf.Join(preds, "\n AND "))
+	var joinClause string
+	if opts.CampaignSpecName != "" {
+		joinClause = "JOIN campaign_specs ON campaigns.campaign_spec_id = campaign_specs.id"
+		cond := fmt.Sprintf(`campaign_specs.spec @> '{"name": %q}'`, opts.CampaignSpecName)
+		preds = append(preds, sqlf.Sprintf(cond))
+
+	}
+	return sqlf.Sprintf(
+		getCampaignsQueryFmtstrPre+joinClause+getCampaignsQueryFmtstrPost,
+		sqlf.Join(preds, "\n AND "),
+	)
 }
 
 // ListCampaignsOpts captures the query options needed for
@@ -1553,7 +1591,8 @@ SELECT
   updated_at,
   changeset_ids,
   patch_set_id,
-  closed_at
+  closed_at,
+  campaign_spec_id
 FROM campaigns
 WHERE %s
 ORDER BY id ASC
@@ -2982,6 +3021,7 @@ func scanCampaign(c *campaigns.Campaign, s scanner) error {
 		&dbutil.JSONInt64Set{Set: &c.ChangesetIDs},
 		&dbutil.NullInt64{N: &c.PatchSetID},
 		&dbutil.NullTime{Time: &c.ClosedAt},
+		&dbutil.NullInt64{N: &c.CampaignSpecID},
 	)
 }
 

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -62,23 +62,25 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 	t.Run("Create", func(t *testing.T) {
 		for i := 0; i < cap(campaigns); i++ {
 			c := &cmpgn.Campaign{
-				Name:         fmt.Sprintf("Upgrade ES-Lint %d", i),
-				Description:  "All the Javascripts are belong to us",
-				Branch:       "upgrade-es-lint",
-				AuthorID:     int32(i) + 50,
-				ChangesetIDs: []int64{int64(i) + 1},
-				PatchSetID:   42 + int64(i),
-				ClosedAt:     clock.now(),
+				Name:           fmt.Sprintf("Upgrade ES-Lint %d", i),
+				Description:    "All the Javascripts are belong to us",
+				Branch:         "upgrade-es-lint",
+				AuthorID:       int32(i) + 50,
+				ChangesetIDs:   []int64{int64(i) + 1},
+				PatchSetID:     42 + int64(i),
+				CampaignSpecID: 1742 + int64(i),
+				ClosedAt:       clock.now(),
 			}
 			if i == 0 {
-				// don't have a patch set for the first one
+				// don't have associations for the first one
 				c.PatchSetID = 0
+				c.CampaignSpecID = 0
 				// Don't close the first one
 				c.ClosedAt = time.Time{}
 			}
 
 			if i%2 == 0 {
-				c.NamespaceOrgID = 23
+				c.NamespaceOrgID = int32(i) + 23
 			} else {
 				c.NamespaceUserID = c.AuthorID
 			}
@@ -398,6 +400,87 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 
 			if diff := cmp.Diff(have, want); diff != "" {
 				t.Fatal(diff)
+			}
+		})
+
+		t.Run("ByCampaignSpecID", func(t *testing.T) {
+			want := campaigns[0]
+			opts := GetCampaignOpts{CampaignSpecID: want.CampaignSpecID}
+
+			have, err := s.GetCampaign(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+
+		t.Run("ByCampaignSpecName", func(t *testing.T) {
+			want := campaigns[0]
+
+			campaignSpec := &cmpgn.CampaignSpec{
+				Spec:           cmpgn.CampaignSpecFields{Name: "the-name"},
+				NamespaceOrgID: want.NamespaceOrgID,
+			}
+			if err := s.CreateCampaignSpec(ctx, campaignSpec); err != nil {
+				t.Fatal(err)
+			}
+
+			want.CampaignSpecID = campaignSpec.ID
+			if err := s.UpdateCampaign(ctx, want); err != nil {
+				t.Fatal(err)
+			}
+
+			opts := GetCampaignOpts{CampaignSpecName: campaignSpec.Spec.Name}
+			have, err := s.GetCampaign(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+
+		t.Run("ByNamespaceUserID", func(t *testing.T) {
+			for _, c := range campaigns {
+				if c.NamespaceUserID == 0 {
+					continue
+				}
+
+				want := c
+				opts := GetCampaignOpts{NamespaceUserID: c.NamespaceUserID}
+
+				have, err := s.GetCampaign(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+
+		t.Run("ByNamespaceOrgID", func(t *testing.T) {
+			for _, c := range campaigns {
+				if c.NamespaceOrgID == 0 {
+					continue
+				}
+
+				want := c
+				opts := GetCampaignOpts{NamespaceOrgID: c.NamespaceOrgID}
+
+				have, err := s.GetCampaign(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatal(diff)
+				}
 			}
 		})
 

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -138,6 +138,7 @@ type Campaign struct {
 	ChangesetIDs    []int64
 	PatchSetID      int64
 	ClosedAt        time.Time
+	CampaignSpecID  int64
 }
 
 // Clone returns a clone of a Campaign.


### PR DESCRIPTION
This is another PR to be merged into https://github.com/sourcegraph/sourcegraph/pull/11675 and adds a basic implementation of the `applyCampaign` mutation.

What the mutation already does:
- Find/create a campaign based on the given namespace and the name of the given `campaignSpec`.
- Transfer fields from the given `campaignSpec` to the `campaign` — I'm not sure whether we want to keep that. I can see some pros in copying the data, but I don't think it's necessary, since to compute the "desired state" we'll need to have the `campaign`, `campaignSpec` and `changesetSpecs` at hand anyway.
- handle the `ensureCampaign` parameter

What I'm not sure about:
- Copying fields, mentioned above.
- why we need a `namespace: ID!` in `applyCampaign`, since the `campaignSpec` has a `namespace` already.
