### PR TITLE
codeintel: Add cache for git diff hunks

### DIFF
--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -166,7 +166,7 @@ func initCampaigns(ctx context.Context, enterpriseServices *enterprise.Services)
 }
 
 var bundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
-var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "10000", "Maximum number of git diff hunks that can be loaded into the cache at once.")
+var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "1000", "Maximum number of git diff hunk objects that can be loaded into the cache at once.")
 
 func initCodeIntel(enterpriseServices *enterprise.Services) {
 	if bundleManagerURL == "" {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -166,7 +166,7 @@ func initCampaigns(ctx context.Context, enterpriseServices *enterprise.Services)
 }
 
 var bundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
-var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "1000", "Maximum number of git diff hunk objects that can be loaded into the cache at once.")
+var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "1000", "Maximum number of git diff hunk objects that can be loaded into the hunk cache at once.")
 
 func initCodeIntel(enterpriseServices *enterprise.Services) {
 	if bundleManagerURL == "" {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -166,7 +166,7 @@ func initCampaigns(ctx context.Context, enterpriseServices *enterprise.Services)
 }
 
 var bundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
-var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "1000", "Maximum capacity of the git diff data cache.")
+var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "10000", "Maximum number of git diff hunks that can be held in memory.")
 
 func initCodeIntel(enterpriseServices *enterprise.Services) {
 	if bundleManagerURL == "" {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -166,7 +166,7 @@ func initCampaigns(ctx context.Context, enterpriseServices *enterprise.Services)
 }
 
 var bundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
-var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "10000", "Maximum number of git diff hunks that can be held in memory.")
+var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "10000", "Maximum number of git diff hunks that can be loaded into the cache at once.")
 
 func initCodeIntel(enterpriseServices *enterprise.Services) {
 	if bundleManagerURL == "" {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -166,10 +166,16 @@ func initCampaigns(ctx context.Context, enterpriseServices *enterprise.Services)
 }
 
 var bundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
+var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "10000", "Maximum capacity of the git diff data cache.")
 
 func initCodeIntel(enterpriseServices *enterprise.Services) {
 	if bundleManagerURL == "" {
 		log.Fatalf("invalid value for PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL: no value supplied")
+	}
+
+	hunkCacheSize, err := strconv.ParseInt(rawHunkCacheSize, 10, 64)
+	if err != nil {
+		log.Fatalf("invalid int %q for PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY: %s", rawHunkCacheSize, err)
 	}
 
 	observationContext := &observation.Context{
@@ -181,11 +187,16 @@ func initCodeIntel(enterpriseServices *enterprise.Services) {
 	store := store.NewObserved(store.NewWithHandle(dbconn.Global), observationContext)
 	bundleManagerClient := bundles.New(bundleManagerURL)
 	api := codeintelapi.NewObserved(codeintelapi.New(store, bundleManagerClient, codeintelgitserver.DefaultClient), observationContext)
+	hunkCache, err := codeintelresolvers.NewHunkCache(int(hunkCacheSize))
+	if err != nil {
+		log.Fatalf("failed to initialize hunk cache: %s", err)
+	}
 
 	enterpriseServices.CodeIntelResolver = codeintelgqlresolvers.NewResolver(codeintelresolvers.NewResolver(
 		store,
 		bundleManagerClient,
 		api,
+		hunkCache,
 	))
 
 	enterpriseServices.NewCodeIntelUploadHandler = func(internal bool) http.Handler {

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -166,7 +166,7 @@ func initCampaigns(ctx context.Context, enterpriseServices *enterprise.Services)
 }
 
 var bundleManagerURL = env.Get("PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL", "", "HTTP address for internal LSIF bundle manager server.")
-var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "10000", "Maximum capacity of the git diff data cache.")
+var rawHunkCacheSize = env.Get("PRECISE_CODE_INTEL_HUNK_CACHE_CAPACITY", "1000", "Maximum capacity of the git diff data cache.")
 
 func initCodeIntel(enterpriseServices *enterprise.Services) {
 	if bundleManagerURL == "" {

--- a/enterprise/cmd/precise-code-intel-bundle-manager/env.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/env.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	rawBundleDir           = env.Get("PRECISE_CODE_INTEL_BUNDLE_DIR", "/lsif-storage", "Root dir containing uploads and converted bundles.")
-	rawReaderDataCacheSize = env.Get("PRECISE_CODE_INTEL_READER_DATA_CACHE_CAPACITY", "10000", "Maximum sum of (compressed and marshalled) source data that can be loaded into the SQLite reader data cache at once.")
+	rawReaderDataCacheSize = env.Get("PRECISE_CODE_INTEL_READER_DATA_CACHE_CAPACITY", "100000", "Maximum sum of (compressed and marshalled) source data that can be loaded into the SQLite reader data cache at once.")
 	rawDesiredPercentFree  = env.Get("PRECISE_CODE_INTEL_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
 	rawJanitorInterval     = env.Get("PRECISE_CODE_INTEL_JANITOR_INTERVAL", "1m", "Interval between cleanup runs.")
 	rawMaxUploadAge        = env.Get("PRECISE_CODE_INTEL_MAX_UPLOAD_AGE", "24h", "The maximum time an upload can sit on disk.")

--- a/enterprise/cmd/precise-code-intel-bundle-manager/env.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/env.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	rawBundleDir           = env.Get("PRECISE_CODE_INTEL_BUNDLE_DIR", "/lsif-storage", "Root dir containing uploads and converted bundles.")
-	rawReaderDataCacheSize = env.Get("PRECISE_CODE_INTEL_READER_DATA_CACHE_CAPACITY", "10000", "Maximum capacity of the sqlite data cache.")
+	rawReaderDataCacheSize = env.Get("PRECISE_CODE_INTEL_READER_DATA_CACHE_CAPACITY", "10000", "Maximum sum of (compressed and marshalled) source data that can be loaded into the SQLite reader data cache at once.")
 	rawDesiredPercentFree  = env.Get("PRECISE_CODE_INTEL_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
 	rawJanitorInterval     = env.Get("PRECISE_CODE_INTEL_JANITOR_INTERVAL", "1m", "Interval between cleanup runs.")
 	rawMaxUploadAge        = env.Get("PRECISE_CODE_INTEL_MAX_UPLOAD_AGE", "24h", "The maximum time an upload can sit on disk.")

--- a/enterprise/cmd/precise-code-intel-bundle-manager/env.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/env.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	rawBundleDir           = env.Get("PRECISE_CODE_INTEL_BUNDLE_DIR", "/lsif-storage", "Root dir containing uploads and converted bundles.")
-	rawReaderDataCacheSize = env.Get("PRECISE_CODE_INTEL_READER_DATA_CACHE_CAPACITY", "100000", "Maximum sum of (compressed and marshalled) source data that can be loaded into the SQLite reader data cache at once.")
+	rawReaderDataCacheSize = env.Get("PRECISE_CODE_INTEL_READER_DATA_CACHE_CAPACITY", "1000000", "Maximum sum of (compressed and marshalled) source data (in bytes) that can be loaded into the SQLite reader data cache at once.")
 	rawDesiredPercentFree  = env.Get("PRECISE_CODE_INTEL_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
 	rawJanitorInterval     = env.Get("PRECISE_CODE_INTEL_JANITOR_INTERVAL", "1m", "Interval between cleanup runs.")
 	rawMaxUploadAge        = env.Get("PRECISE_CODE_INTEL_MAX_UPLOAD_AGE", "24h", "The maximum time an upload can sit on disk.")

--- a/enterprise/internal/codeintel/resolvers/hunk_cache.go
+++ b/enterprise/internal/codeintel/resolvers/hunk_cache.go
@@ -1,0 +1,23 @@
+package resolvers
+
+import "github.com/dgraph-io/ristretto"
+
+// HunkCache is a LRU cache that holds git diff hunks.
+type HunkCache interface {
+	// Get returns the value (if any) and a boolean representing whether the value was
+	// found or not.
+	Get(key interface{}) (interface{}, bool)
+
+	// Set attempts to add the key-value item to the cache with the given cost. If it
+	// returns false, then the value as dropped and the item isn't added to the cache.
+	Set(key, value interface{}, cost int64) bool
+}
+
+// NewHunkCache creates a data cache instance with the given maximum capacity.
+func NewHunkCache(size int) (HunkCache, error) {
+	return ristretto.NewCache(&ristretto.Config{
+		NumCounters: int64(size) * 10,
+		MaxCost:     int64(size),
+		BufferItems: 64,
+	})
+}

--- a/enterprise/internal/codeintel/resolvers/position.go
+++ b/enterprise/internal/codeintel/resolvers/position.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -35,15 +36,17 @@ type PositionAdjuster interface {
 }
 
 type positionAdjuster struct {
-	repo   *types.Repo
-	commit string
+	repo      *types.Repo
+	commit    string
+	hunkCache HunkCache
 }
 
 // NewPositionAdjuster creates a new PositionAdjuster with the given repository and source commit.
-func NewPositionAdjuster(repo *types.Repo, commit string) PositionAdjuster {
+func NewPositionAdjuster(repo *types.Repo, commit string, hunkCache HunkCache) PositionAdjuster {
 	return &positionAdjuster{
-		repo:   repo,
-		commit: commit,
+		repo:      repo,
+		commit:    commit,
+		hunkCache: hunkCache,
 	}
 }
 
@@ -58,7 +61,7 @@ func (p *positionAdjuster) AdjustPath(ctx context.Context, commit, path string, 
 // indicating that the translation was successful. If revese is true, then the source and
 // target commits are swapped.
 func (p *positionAdjuster) AdjustPosition(ctx context.Context, commit, path string, px bundles.Position, reverse bool) (string, bundles.Position, bool, error) {
-	hunks, err := p.readHunks(ctx, p.repo, p.commit, commit, path, reverse)
+	hunks, err := p.readHunksCached(ctx, p.repo, p.commit, commit, path, reverse)
 	if err != nil {
 		return "", bundles.Position{}, false, err
 	}
@@ -72,7 +75,7 @@ func (p *positionAdjuster) AdjustPosition(ctx context.Context, commit, path stri
 // that the translation was successful. If revese is true, then the source and target commits
 // are swapped.
 func (p *positionAdjuster) AdjustRange(ctx context.Context, commit, path string, rx bundles.Range, reverse bool) (string, bundles.Range, bool, error) {
-	hunks, err := p.readHunks(ctx, p.repo, p.commit, commit, path, reverse)
+	hunks, err := p.readHunksCached(ctx, p.repo, p.commit, commit, path, reverse)
 	if err != nil {
 		return "", bundles.Range{}, false, err
 	}
@@ -81,10 +84,12 @@ func (p *positionAdjuster) AdjustRange(ctx context.Context, commit, path string,
 	return path, adjusted, ok, nil
 }
 
-// readHunks returns a position-ordered slice of changes (additions or deletions) of the
-// given path between the given source and target commits. If revese is true, then the
-// source and target commits are swapped.
-func (p *positionAdjuster) readHunks(ctx context.Context, repo *types.Repo, sourceCommit, targetCommit, path string, reverse bool) ([]*diff.Hunk, error) {
+// readHunksCached returns a position-ordered slice of changes (additions or deletions) of
+// the given path between the given source and target commits. If revese is true, then the
+// source and target commits are swapped. If the position adjuster has a hunk cache, it
+// will read from it before attempting to contact a remote server, and populate the cache
+// with new results
+func (p *positionAdjuster) readHunksCached(ctx context.Context, repo *types.Repo, sourceCommit, targetCommit, path string, reverse bool) ([]*diff.Hunk, error) {
 	if sourceCommit == targetCommit {
 		return nil, nil
 	}
@@ -92,6 +97,32 @@ func (p *positionAdjuster) readHunks(ctx context.Context, repo *types.Repo, sour
 		sourceCommit, targetCommit = targetCommit, sourceCommit
 	}
 
+	if p.hunkCache == nil {
+		return p.readHunks(ctx, repo, sourceCommit, targetCommit, path)
+	}
+
+	key := makeKey(fmt.Sprintf("%d", repo.ID), sourceCommit, targetCommit, path)
+	if hunks, ok := p.hunkCache.Get(key); ok {
+		if hunks == nil {
+			return nil, nil
+		}
+
+		return hunks.([]*diff.Hunk), nil
+	}
+
+	hunks, err := p.readHunks(ctx, repo, sourceCommit, targetCommit, path)
+	if err != nil {
+		return nil, err
+	}
+
+	p.hunkCache.Set(key, hunks, int64(len(hunks)))
+
+	return hunks, nil
+}
+
+// readHunks returns a position-ordered slice of changes (additions or deletions) of
+// the given path between the given source and target commits.
+func (p *positionAdjuster) readHunks(ctx context.Context, repo *types.Repo, sourceCommit, targetCommit, path string) ([]*diff.Hunk, error) {
 	cachedRepo, err := backend.CachedGitRepo(ctx, repo)
 	if err != nil {
 		return nil, err
@@ -219,4 +250,8 @@ func adjustRange(hunks []*diff.Hunk, r bundles.Range) (bundles.Range, bool) {
 	}
 
 	return bundles.Range{Start: start, End: end}, true
+}
+
+func makeKey(parts ...string) string {
+	return strings.Join(parts, ":")
 }

--- a/enterprise/internal/codeintel/resolvers/position_test.go
+++ b/enterprise/internal/codeintel/resolvers/position_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAdjustPath(t *testing.T) {
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, ok, err := adjuster.AdjustPath(context.Background(), "deadbeef2", "/foo/bar.go", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -45,7 +45,7 @@ func TestAdjustPosition(t *testing.T) {
 
 	posIn := bundles.Position{Line: 302, Character: 15}
 
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, posOut, ok, err := adjuster.AdjustPosition(context.Background(), "deadbeef2", "/foo/bar.go", posIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -74,7 +74,7 @@ func TestAdjustPositionEmptyDiff(t *testing.T) {
 
 	posIn := bundles.Position{Line: 10, Character: 15}
 
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, posOut, ok, err := adjuster.AdjustPosition(context.Background(), "deadbeef2", "/foo/bar.go", posIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -106,7 +106,7 @@ func TestAdjustPositionReverse(t *testing.T) {
 
 	posIn := bundles.Position{Line: 302, Character: 15}
 
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, posOut, ok, err := adjuster.AdjustPosition(context.Background(), "deadbeef2", "/foo/bar.go", posIn, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -143,7 +143,7 @@ func TestAdjustRange(t *testing.T) {
 		End:   bundles.Position{Line: 305, Character: 20},
 	}
 
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, rOut, ok, err := adjuster.AdjustRange(context.Background(), "deadbeef2", "/foo/bar.go", rIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -178,7 +178,7 @@ func TestAdjustRangeEmptyDiff(t *testing.T) {
 		End:   bundles.Position{Line: 305, Character: 20},
 	}
 
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, rOut, ok, err := adjuster.AdjustRange(context.Background(), "deadbeef2", "/foo/bar.go", rIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -213,7 +213,7 @@ func TestAdjustRangeReverse(t *testing.T) {
 		End:   bundles.Position{Line: 305, Character: 20},
 	}
 
-	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1")
+	adjuster := NewPositionAdjuster(&types.Repo{ID: 50}, "deadbeef1", nil)
 	path, rOut, ok, err := adjuster.AdjustRange(context.Background(), "deadbeef2", "/foo/bar.go", rIn, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/enterprise/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/internal/codeintel/resolvers/resolver.go
@@ -30,14 +30,16 @@ type resolver struct {
 	store               store.Store
 	bundleManagerClient bundles.BundleManagerClient
 	codeIntelAPI        codeintelapi.CodeIntelAPI
+	hunkCache           HunkCache
 }
 
 // NewResolver creates a new resolver with the given services.
-func NewResolver(store store.Store, bundleManagerClient bundles.BundleManagerClient, codeIntelAPI codeintelapi.CodeIntelAPI) Resolver {
+func NewResolver(store store.Store, bundleManagerClient bundles.BundleManagerClient, codeIntelAPI codeintelapi.CodeIntelAPI, hunkCache HunkCache) Resolver {
 	return &resolver{
 		store:               store,
 		bundleManagerClient: bundleManagerClient,
 		codeIntelAPI:        codeIntelAPI,
+		hunkCache:           hunkCache,
 	}
 }
 
@@ -87,7 +89,7 @@ func (r *resolver) QueryResolver(ctx context.Context, args *gql.GitBlobLSIFDataA
 		r.store,
 		r.bundleManagerClient,
 		r.codeIntelAPI,
-		NewPositionAdjuster(args.Repo, string(args.Commit)),
+		NewPositionAdjuster(args.Repo, string(args.Commit), r.hunkCache),
 		int(args.Repo.ID),
 		string(args.Commit),
 		args.Path,

--- a/enterprise/internal/codeintel/resolvers/resolver_test.go
+++ b/enterprise/internal/codeintel/resolvers/resolver_test.go
@@ -17,7 +17,7 @@ func TestQueryResolver(t *testing.T) {
 	mockBundleManagerClient := bundlemocks.NewMockBundleManagerClient()
 	mockCodeIntelAPI := apimocks.NewMockCodeIntelAPI() // returns no dumps
 
-	resolver := NewResolver(mockStore, mockBundleManagerClient, mockCodeIntelAPI)
+	resolver := NewResolver(mockStore, mockBundleManagerClient, mockCodeIntelAPI, nil)
 	queryResolver, err := resolver.QueryResolver(context.Background(), &gql.GitBlobLSIFDataArgs{
 		Repo:      &types.Repo{ID: 50},
 		Commit:    api.CommitID("deadbeef"),


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/11815 is introducing batch requests, which can really hammer gitserver for the same git diff information for each sub resolver. This is happening regardless, but this new feature really made it obvious.

This PR adds a cache for git diff hunks keyed by the repository, path, and target/source commits that the codeintel resolvers can use to reduce the number of requests necessary to return large location responses for a nearest commit.