### PR TITLE
Bump sourcegraph-extension-api to 24.6.0 (document highlight providers)

### DIFF
--- a/packages/sourcegraph-extension-api/package.json
+++ b/packages/sourcegraph-extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "24.5.0",
+  "version": "24.6.0",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",
   "bugs": {


### PR DESCRIPTION
Bump Sourcegraph extension API.