### PR TITLE
monitoring: add observability.alerts support for sourcegraph/server

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -24,7 +24,7 @@ var grafanaURLFromEnv = env.Get("GRAFANA_SERVER_URL", "", "URL at which Grafana 
 var jaegerURLFromEnv = env.Get("JAEGER_SERVER_URL", "", "URL at which Jaeger UI can be reached")
 
 func init() {
-	conf.ContributeWarning(newPrometheusValidator(prometheusutil.PrometheusURL, conf.DeployType()))
+	conf.ContributeWarning(newPrometheusValidator(prometheusutil.PrometheusURL))
 }
 
 func addNoK8sClientHandler(r *mux.Router) {
@@ -145,15 +145,9 @@ func adminOnly(next http.Handler) http.Handler {
 
 // newPrometheusValidator renders problems with the Prometheus deployment and configuration
 // as reported by `prom-wrapper` inside the `sourcegraph/prometheus` container if Prometheus is enabled.
-func newPrometheusValidator(prometheusURL, deployType string) conf.Validator {
+func newPrometheusValidator(prometheusURL string) conf.Validator {
 	return func(c conf.Unified) (problems conf.Problems) {
 		if len(prometheusURL) == 0 || len(c.ObservabilityAlerts) == 0 {
-			return
-		}
-
-		// see https://github.com/sourcegraph/sourcegraph/issues/11473
-		if conf.IsDeployTypeSingleDockerContainer(deployType) {
-			problems = append(problems, conf.NewSiteProblem("`observability.alerts` is not currently supported in sourcegraph/server deployments. Follow [this issue](https://github.com/sourcegraph/sourcegraph/issues/11473) for updates."))
 			return
 		}
 

--- a/cmd/frontend/internal/app/debug_test.go
+++ b/cmd/frontend/internal/app/debug_test.go
@@ -12,7 +12,6 @@ func Test_prometheusValidator(t *testing.T) {
 	// test some simple problem cases
 	type args struct {
 		prometheusURL string
-		deployType    string
 		config        conf.Unified
 	}
 	tests := []struct {
@@ -66,7 +65,7 @@ func Test_prometheusValidator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fn := newPrometheusValidator(tt.args.prometheusURL, tt.args.deployType)
+			fn := newPrometheusValidator(tt.args.prometheusURL)
 			problems := fn(tt.args.config)
 			if tt.wantProblemSubstring == "" {
 				if len(problems) > 0 {

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -49,9 +49,17 @@ COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5f
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/prometheus:61407_2020-04-18_9aa5791@sha256:9b31cc8832defb66cd29e5a298422983179495193745324902660073b3fdc835 /bin/prometheus /usr/local/bin
+COPY --from=sourcegraph/prometheus:server /bin/prom-wrapper /bin
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/prometheus:61407_2020-04-18_9aa5791@sha256:9b31cc8832defb66cd29e5a298422983179495193745324902660073b3fdc835 /usr/share/prometheus /usr/share/prometheus
+COPY --from=sourcegraph/prometheus:server /bin/alertmanager /bin
+# hadolint ignore=DL3022
+COPY --from=sourcegraph/prometheus:server /alertmanager.sh /alertmanager.sh
+# hadolint ignore=DL3022
+COPY --from=sourcegraph/prometheus:server /bin/prometheus /bin
+# hadolint ignore=DL3022
+COPY --from=sourcegraph/prometheus:server /prometheus.sh /prometheus.sh
+# hadolint ignore=DL3022
+COPY --from=sourcegraph/prometheus:server /usr/share/prometheus /usr/share/prometheus
 
 # hadolint ignore=DL3018
 RUN set -ex && \

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -88,10 +88,11 @@ else
   pushd monitoring && go generate && popd
 fi
 
-echo "--- prometheus config"
+echo "--- prometheus"
 cp -r docker-images/prometheus/config "$OUTPUT/sg_config_prometheus"
 mkdir "$OUTPUT/sg_prometheus_add_ons"
 cp dev/prometheus/linux/prometheus_targets.yml "$OUTPUT/sg_prometheus_add_ons"
+IMAGE=sourcegraph/prometheus:server CACHE=true docker-images/prometheus/build.sh
 
 echo "--- grafana config"
 cp -r docker-images/grafana/config "$OUTPUT/sg_config_grafana"

--- a/cmd/server/shared/monitoring.go
+++ b/cmd/server/shared/monitoring.go
@@ -6,7 +6,7 @@ import (
 	"github.com/inconshreveable/log15"
 )
 
-const prometheusProcLine = `prometheus: prometheus --config.file=/sg_config_prometheus/prometheus.yml --web.enable-admin-api --storage.tsdb.path=/var/opt/sourcegraph/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles >> /var/opt/sourcegraph/prometheus.log 2>&1`
+const prometheusProcLine = `prometheus: env STORAGE_PATH=/var/opt/sourcegraph/prometheus /bin/prom-wrapper >> /var/opt/sourcegraph/prometheus.log 2>&1`
 
 const grafanaProcLine = `grafana: /usr/share/grafana/bin/grafana-server -config /sg_config_grafana/grafana-single-container.ini -homepath /usr/share/grafana >> /var/opt/sourcegraph/grafana.log 2>&1`
 
@@ -14,7 +14,7 @@ const jaegerProcLine = `jaeger --memory.max-traces=20000 >> /var/opt/sourcegraph
 
 func maybeMonitoring() ([]string, error) {
 	if os.Getenv("DISABLE_OBSERVABILITY") != "" {
-		log15.Info("WARNING: Running with monitoring disabled ")
+		log15.Info("WARNING: Running with monitoring disabled")
 		return []string{""}, nil
 	}
 	return []string{

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -23,11 +23,9 @@ if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then
   rm -rf $DATA
 fi
 
+# docker run pulls image if not found locally
 IMAGE=${IMAGE:-sourcegraph/server:${TAG:-insiders}}
-echo "pulling docker image ${IMAGE}"
-docker pull "$IMAGE"
-
-echo "starting server..."
+echo "starting server ${IMAGE}"
 docker run "$@" \
   --publish 7080:7080 \
   --rm \

--- a/docker-images/prometheus/prometheus.sh
+++ b/docker-images/prometheus/prometheus.sh
@@ -7,5 +7,7 @@ if [ -e /sg_prometheus_add_ons/prometheus.yml ]; then
   CONFIG_FILE=/sg_prometheus_add_ons/prometheus.yml
 fi
 
+STORAGE_PATH="${STORAGE_PATH:-"/prometheus"}"
+
 # shellcheck disable=SC2086
-exec /bin/prometheus --config.file=$CONFIG_FILE --storage.tsdb.path=/prometheus --web.enable-admin-api $PROMETHEUS_ADDITIONAL_FLAGS --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles "$@"
+exec /bin/prometheus --config.file=$CONFIG_FILE --storage.tsdb.path=$STORAGE_PATH --web.enable-admin-api $PROMETHEUS_ADDITIONAL_FLAGS --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles "$@"


### PR DESCRIPTION
Stacked PR on top of https://github.com/sourcegraph/sourcegraph/pull/11832. Adds support for the functionality added in the above PR to `sourcegraph/server`

Closes #11473, closes #11612 

```
VERSION=dev IMAGE=sourcegraph/server:dev cmd/server/build.sh
IMAGE=sourcegraph/server:dev dev/run-server-image.sh
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
