### PR TITLE
codeintel: Improve stitching

### DIFF
--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-bundle-manager/internal/paths"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/bundles/persistence"
 	sqlitereader "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/bundles/persistence/sqlite"
-	"github.com/sourcegraph/sourcegraph/internal/tar"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -120,20 +119,13 @@ func (s *Server) handlePostDatabasePart(w http.ResponseWriter, r *http.Request) 
 // POST /dbs/{id:[0-9]+}/stitch
 func (s *Server) handlePostDatabaseStitch(w http.ResponseWriter, r *http.Request) {
 	id := idFromRequest(r)
-	dirname := paths.DBDir(s.bundleDir, id)
+	filename := paths.SQLiteDBFilename(s.bundleDir, idFromRequest(r))
 	makePartFilename := func(index int) string {
 		return paths.DBPartFilename(s.bundleDir, id, int64(index))
 	}
 
-	stitchedReader, err := codeintelutils.StitchFilesReader(makePartFilename, false)
-	if err != nil {
+	if err := codeintelutils.StitchFiles(filename, makePartFilename, false); err != nil {
 		log15.Error("Failed to stitch multipart database", "err", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err := tar.Extract(dirname, stitchedReader); err != nil {
-		log15.Error("Failed to extract database archive", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -304,11 +296,8 @@ func writeToFile(filename string, r io.Reader) (err error) {
 		}
 	}()
 
-	if _, err := io.Copy(targetFile, r); err != nil {
-		return err
-	}
-
-	return nil
+	_, err = io.Copy(targetFile, r)
+	return err
 }
 
 func (s *Server) deleteUpload(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/server/handler.go
@@ -95,7 +95,7 @@ func (s *Server) handlePostUploadStitch(w http.ResponseWriter, r *http.Request) 
 		return paths.UploadPartFilename(s.bundleDir, id, int64(index))
 	}
 
-	if err := codeintelutils.StitchFiles(filename, makePartFilename, true); err != nil {
+	if err := codeintelutils.StitchFiles(filename, makePartFilename, false, false); err != nil {
 		log15.Error("Failed to stitch multipart upload", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -124,7 +124,7 @@ func (s *Server) handlePostDatabaseStitch(w http.ResponseWriter, r *http.Request
 		return paths.DBPartFilename(s.bundleDir, id, int64(index))
 	}
 
-	if err := codeintelutils.StitchFiles(filename, makePartFilename, false); err != nil {
+	if err := codeintelutils.StitchFiles(filename, makePartFilename, true, false); err != nil {
 		log15.Error("Failed to stitch multipart database", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/enterprise/cmd/precise-code-intel-indexer/internal/indexer/processor.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/indexer/processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/codeintelutils"
@@ -74,6 +75,8 @@ func (p *processor) upload(ctx context.Context, repoDir string, index store.Inde
 		Indexer:             "lsif-go",
 		File:                filepath.Join(repoDir, "dump.lsif"),
 		MaxPayloadSizeBytes: 100 * 1000 * 1000, // 100Mb
+		MaxRetries:          10,
+		RetryInterval:       time.Second * 250,
 	}
 
 	if _, err := codeintelutils.UploadIndex(opts); err != nil {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/processor.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/processor.go
@@ -118,7 +118,7 @@ func (p *processor) Process(ctx context.Context, store store.Store, upload store
 	}
 
 	// Send converted database file to bundle manager
-	if err := p.sendDB(ctx, upload.ID, tempDir); err != nil {
+	if err := p.sendDB(ctx, upload.ID, filepath.Join(tempDir, "sqlite.db")); err != nil {
 		return false, err
 	}
 

--- a/enterprise/internal/codeintel/bundles/client/bundle_manager_client.go
+++ b/enterprise/internal/codeintel/bundles/client/bundle_manager_client.go
@@ -350,11 +350,8 @@ func writeToTempFile(r io.Reader) (_ string, err error) {
 		}
 	}()
 
-	if _, err := io.Copy(file, r); err != nil {
-		return "", err
-	}
-
-	return file.Name(), nil
+	_, err = io.Copy(file, r)
+	return file.Name(), err
 }
 
 // doAndDrop performs an HTTP request to the bundle manager and ignores the body contents.

--- a/enterprise/internal/codeintel/bundles/client/bundle_manager_client.go
+++ b/enterprise/internal/codeintel/bundles/client/bundle_manager_client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/sourcegraph/codeintelutils"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
-	"github.com/sourcegraph/sourcegraph/internal/tar"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -59,7 +58,7 @@ type BundleManagerClient interface {
 	// from the bundle manager.
 	GetUpload(ctx context.Context, bundleID int) (io.ReadCloser, error)
 
-	// SendDB transfers a converted database archive to the bundle manager to be stored on disk.
+	// SendDB transfers a converted database to the bundle manager to be stored on disk.
 	SendDB(ctx context.Context, bundleID int, path string) error
 
 	// Exists determines if a file exists on disk for all the supplied identifiers.
@@ -236,9 +235,9 @@ func (c *bundleManagerClientImpl) getUploadChunk(ctx context.Context, w io.Write
 	return c.ioCopy(w, body)
 }
 
-// SendDB transfers a converted database archive to the bundle manager to be stored on disk.
+// SendDB transfers a converted database to the bundle manager to be stored on disk.
 func (c *bundleManagerClientImpl) SendDB(ctx context.Context, bundleID int, path string) (err error) {
-	files, cleanup, err := codeintelutils.SplitReader(tar.Archive(path), c.maxPayloadSizeBytes)
+	files, cleanup, err := codeintelutils.SplitFile(path, c.maxPayloadSizeBytes)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/sloonz/go-qprintable v0.0.0-20160203160305-775b3a4592d5 // indirect
 	github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d // indirect
-	github.com/sourcegraph/codeintelutils v0.0.0-20200602000243-9543a4b9c9f8
+	github.com/sourcegraph/codeintelutils v0.0.0-20200706134726-59faffa53cc3
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
 	github.com/sourcegraph/go-diff v0.5.3
 	github.com/sourcegraph/go-jsonschema v0.0.0-20200429204646-54904d837db8

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/sloonz/go-qprintable v0.0.0-20160203160305-775b3a4592d5 // indirect
 	github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d // indirect
-	github.com/sourcegraph/codeintelutils v0.0.0-20200706134726-59faffa53cc3
+	github.com/sourcegraph/codeintelutils v0.0.0-20200706141440-54ddac67b5b6
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
 	github.com/sourcegraph/go-diff v0.5.3
 	github.com/sourcegraph/go-jsonschema v0.0.0-20200429204646-54904d837db8

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9Ev6lojP2XaIshpT4ymkqhMeSghO5Ps00E=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
-github.com/sourcegraph/codeintelutils v0.0.0-20200602000243-9543a4b9c9f8 h1:W0oFiF6o3iRzdiJSKcfhxAi93tQDaVYC5hKA6VYOnSA=
-github.com/sourcegraph/codeintelutils v0.0.0-20200602000243-9543a4b9c9f8/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
+github.com/sourcegraph/codeintelutils v0.0.0-20200706134726-59faffa53cc3 h1:XFO7WU0JQD61WzzIhAKLkUdtYNlGgpAw8OlAylTnPqM=
+github.com/sourcegraph/codeintelutils v0.0.0-20200706134726-59faffa53cc3/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWifxmICRqgXK7khThjw03RfdGhyeA2S4EQ=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
 github.com/sourcegraph/go-diff v0.5.1 h1:gO6i5zugwzo1RVTvgvfwCOSVegNuvnNi6bAD1QCmkHs=

--- a/go.sum
+++ b/go.sum
@@ -948,6 +948,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/codeintelutils v0.0.0-20200706134726-59faffa53cc3 h1:XFO7WU0JQD61WzzIhAKLkUdtYNlGgpAw8OlAylTnPqM=
 github.com/sourcegraph/codeintelutils v0.0.0-20200706134726-59faffa53cc3/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
+github.com/sourcegraph/codeintelutils v0.0.0-20200706141440-54ddac67b5b6 h1:91WE5oskxcHBJIiK8GeUDqGQJWaUBiI0LBfvRxAcDX4=
+github.com/sourcegraph/codeintelutils v0.0.0-20200706141440-54ddac67b5b6/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWifxmICRqgXK7khThjw03RfdGhyeA2S4EQ=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
 github.com/sourcegraph/go-diff v0.5.1 h1:gO6i5zugwzo1RVTvgvfwCOSVegNuvnNi6bAD1QCmkHs=


### PR DESCRIPTION
This PR updates the codeintelutils to provide a parameter to control file stitching compression of the resulting file / decompression of each parts. The upload stitch endpoint is a bit slow as it needs to read all part files, decompress them, concatenate them, then recompress them into the target file.

This is unnecessary as the concatenation of a gzip stream is a valid gzip stream. We don't need to de/re-compress the stream and can simply concatenate the files. (This is not true of db files, which are uncompressed on disk so that sqlite can read them).

This PR additionally cuts out the tar archive/extraction for database files, as we're only ever sending one file and wrapping it in a tar archive is unnecessary. This change was made when we were exploring alternate backends that are not restricted to a single file.

This covers the second task in https://github.com/sourcegraph/sourcegraph/issues/11876.