### PR TITLE
search: test indexed multi-branch search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -858,7 +858,7 @@ func TestSearchResultsHydration(t *testing.T) {
 
 	z := &searchbackend.Zoekt{
 		Client: &fakeSearcher{
-			repos:  &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{zoektRepo}},
+			repos:  []*zoekt.RepoListEntry{zoektRepo},
 			result: &zoekt.SearchResult{Files: zoektFileMatches},
 		},
 		DisableCache: true,

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -80,7 +80,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 
 	z := &searchbackend.Zoekt{
 		Client: &fakeSearcher{
-			repos:  &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{zoektRepo}},
+			repos:  []*zoekt.RepoListEntry{zoektRepo},
 			result: &zoekt.SearchResult{Files: zoektFileMatches},
 		},
 		DisableCache: true,

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -317,7 +317,7 @@ func TestDefaultRepositories(t *testing.T) {
 				indexed = append(indexed, &zoekt.RepoListEntry{Repository: zoekt.Repository{Name: name}})
 			}
 			z := &searchbackend.Zoekt{
-				Client:       &fakeSearcher{repos: &zoekt.RepoList{Repos: indexed}},
+				Client:       &fakeSearcher{repos: indexed},
 				DisableCache: true,
 			}
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/zoekt"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -58,7 +57,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	}
 	defer func() { mockSearchFilesInRepo = nil }()
 
-	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{repos: &zoekt.RepoList{}}}
+	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	q, err := query.ParseAndCheck("foo")
 	if err != nil {
@@ -133,7 +132,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	}})
 	defer conf.Mock(nil)
 
-	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{repos: &zoekt.RepoList{}}}
+	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	q, err := query.ParseAndCheck("foo")
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -82,7 +82,7 @@ func TestIndexedSearch(t *testing.T) {
 	zoektRepos := []*zoekt.RepoListEntry{{
 		Repository: zoekt.Repository{
 			Name:     "foo/bar",
-			Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "barHEADSHA"}},
+			Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "barHEADSHA"}, {Name: "dev", Version: "bardevSHA"}},
 		},
 	}, {
 		Repository: zoekt.Repository{
@@ -190,6 +190,35 @@ func TestIndexedSearch(t *testing.T) {
 			wantMatchURLs: []string{
 				"git://foo/bar#baz.go",
 				"git://foo/foobar#baz.go",
+			},
+			wantErr: false,
+		},
+		{
+			name: "results multi-branch",
+			args: args{
+				ctx:             context.Background(),
+				query:           &search.TextPatternInfo{FileMatchLimit: 100},
+				repos:           makeRepositoryRevisions("foo/bar@HEAD:dev"),
+				useFullDeadline: false,
+				results: []zoekt.FileMatch{
+					{
+						Repository: "foo/bar",
+						Branches:   []string{"HEAD"},
+						FileName:   "baz.go",
+					},
+					{
+						Repository: "foo/bar",
+						Branches:   []string{"dev"},
+						FileName:   "baz.go",
+					},
+				},
+				since: func(time.Time) time.Duration { return 0 },
+			},
+			wantLimitHit:      false,
+			wantReposLimitHit: map[string]struct{}{},
+			wantMatchURLs: []string{
+				"git://foo/bar?HEAD#baz.go",
+				"git://foo/bar?dev#baz.go",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Best reviewed commit by commit. See individual commit descriptions.

We adapt the existing test for TestZoektSearchHEAD to instead test the
new indexedSearchRequest abstraction. This will allow us to test the
interaction between zoektIndexedRepos and zoektIndexedSearch.

The test code has had a few changes to it, but is the same
functionality. Additionally we test the returned file URLs (an important
component of what zoektSearch does).

We also remove the test for zoekt returning an error. Allowing this test
makes the test cases harder to read, and doesn't provide that much
value.

Child of https://github.com/sourcegraph/sourcegraph/pull/11952