### PR TITLE
search: add indexedRepoRevs for Sourcegraph Zoekt mapping

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -131,19 +131,17 @@ func buildQuery(args *search.TextParameters, newRepoSet *zoektquery.RepoSet, fil
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos []*search.RepositoryRevisions, isSymbol bool, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
-	if len(repos) == 0 {
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repoMap map[string]*search.RepositoryRevisions, isSymbol bool, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
+	if len(repoMap) == 0 {
 		return nil, false, nil, nil
 	}
 
-	repoSet := &zoektquery.RepoSet{Set: make(map[string]bool, len(repos))}
-	repoMap := make(map[string]*search.RepositoryRevisions, len(repos))
-	for _, repoRev := range repos {
-		repoSet.Set[string(repoRev.Repo.Name)] = true
-		repoMap[string(repoRev.Repo.Name)] = repoRev
+	repoSet := &zoektquery.RepoSet{Set: make(map[string]bool, len(repoMap))}
+	for name := range repoMap {
+		repoSet.Set[name] = true
 	}
 
-	k := zoektResultCountFactor(len(repos), args.PatternInfo)
+	k := zoektResultCountFactor(len(repoMap), args.PatternInfo)
 	searchOpts := zoektSearchOpts(k, args.PatternInfo)
 
 	if args.UseFullDeadline {

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -128,7 +128,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		mu.Lock()
 		defer mu.Unlock()
 		if ctx.Err() == nil {
-			for _, repo := range indexed.Repos {
+			for _, repo := range indexed.Repos() {
 				common.searched = append(common.searched, repo.Repo)
 				common.indexed = append(common.indexed, repo.Repo)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -491,7 +491,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 
 	// if there are no indexed repos and this is a structural search
 	// query, there will be no results. Raise a friendly alert.
-	if args.PatternInfo.IsStructuralPat && len(indexed.Repos) == 0 {
+	if args.PatternInfo.IsStructuralPat && len(indexed.Repos()) == 0 {
 		return nil, nil, errors.New("no indexed repositories for structural search")
 	}
 
@@ -505,7 +505,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return nil, common, nil
 	}
 
-	tr.LazyPrintf("%d indexed repos, %d unindexed repos", len(indexed.Repos), len(indexed.Unindexed))
+	tr.LazyPrintf("%d indexed repos, %d unindexed repos", len(indexed.Repos()), len(indexed.Unindexed))
 
 	var searcherRepos []*search.RepositoryRevisions
 	if indexed.DisableUnindexedSearch {
@@ -675,7 +675,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		mu.Lock()
 		defer mu.Unlock()
 		if ctx.Err() == nil {
-			for _, repo := range indexed.Repos {
+			for _, repo := range indexed.Repos() {
 				common.searched = append(common.searched, repo.Repo)
 				common.indexed = append(common.indexed, repo.Repo)
 			}
@@ -692,7 +692,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		}
 		if err == errNoResultsInTimeout {
 			// Effectively, all repositories have timed out.
-			for _, repo := range indexed.Repos {
+			for _, repo := range indexed.Repos() {
 				common.timedout = append(common.timedout, repo.Repo)
 			}
 		}
@@ -714,7 +714,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			}
 
 			// Filter Zoekt repos that didn't contain matches
-			for _, repo := range indexed.Repos {
+			for _, repo := range indexed.Repos() {
 				for key := range partition {
 					if string(repo.Repo.Name) == key {
 						repos = append(repos, repo)

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -342,8 +342,10 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		}
 
 		repo, inputRev := repos.GetRepoInputRev(&file)
-		if repoResolvers[repo.Name] == nil {
-			repoResolvers[repo.Name] = &RepositoryResolver{repo: repo}
+		repoResolver := repoResolvers[repo.Name]
+		if repoResolver == nil {
+			repoResolver = &RepositoryResolver{repo: repo}
+			repoResolvers[repo.Name] = repoResolver
 		}
 
 		// symbols is set in symbols search, lines in text search.
@@ -355,7 +357,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		if typ != symbolRequest {
 			lines, matchCount = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
 		} else {
-			symbols = zoektFileMatchToSymbolResults(repoResolvers[repo.Name], inputRev, &file)
+			symbols = zoektFileMatchToSymbolResults(repoResolver, inputRev, &file)
 		}
 
 		matches[i] = &FileMatchResolver{
@@ -365,7 +367,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 			MatchCount:   matchCount, // We do not use resp.MatchCount because it counts the number of lines matched, not the number of fragments.
 			uri:          fileMatchURI(repo.Name, inputRev, file.FileName),
 			symbols:      symbols,
-			Repo:         repoResolvers[repo.Name],
+			Repo:         repoResolver,
 			CommitID:     api.CommitID(file.Version),
 		}
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -145,7 +145,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		args: args,
 		typ:  typ,
 
-		Repos:        indexed.indexed,
+		Repos:        indexed.repoRevs,
 		Unindexed:    searcherRepos,
 		repoBranches: indexed.repoBranches,
 
@@ -577,7 +577,7 @@ func zoektIndexedRepos(indexedSet map[string]*zoekt.Repository, revs []*search.R
 	// PERF: If len(revs) is large, we expect to be doing an indexed
 	// search. So set indexed to the max size it can be to avoid growing.
 	indexed = &indexedRepoRevs{
-		indexed:      make([]*search.RepositoryRevisions, 0, len(revs)),
+		repoRevs:     make([]*search.RepositoryRevisions, 0, len(revs)),
 		repoBranches: make(map[string][]string, len(revs)),
 	}
 	unindexed = make([]*search.RepositoryRevisions, 0)
@@ -601,9 +601,10 @@ func zoektIndexedRepos(indexedSet map[string]*zoekt.Repository, revs []*search.R
 // indexedRepoRevs creates both the Sourcegraph and Zoekt representation of a
 // list of repository and refs to search.
 type indexedRepoRevs struct {
-	// indexed is the Sourcegraph representation of a the list of indexed
+	// repoRevs is the Sourcegraph representation of a the list of repoRevs
 	// repository and revisions to search.
-	indexed []*search.RepositoryRevisions
+	repoRevs []*search.RepositoryRevisions
+
 	// repoBranches will be used when we query zoekt. The order of branches
 	// must match that in a reporev such that we can map back results. IE this
 	// invariant is maintained:
@@ -656,7 +657,7 @@ func (rb *indexedRepoRevs) Add(reporev *search.RepositoryRevisions, repo *zoekt.
 		return false
 	}
 
-	rb.indexed = append(rb.indexed, reporev)
+	rb.repoRevs = append(rb.repoRevs, reporev)
 	rb.repoBranches[string(reporev.Repo.Name)] = branches
 	return true
 }

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -343,7 +343,7 @@ func TestZoektIndexedRepos(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			indexed, unindexed := zoektIndexedRepos(zoektRepos, tc.repos, nil)
 
-			if diff := cmp.Diff(tc.indexed, indexed.indexed); diff != "" {
+			if diff := cmp.Diff(tc.indexed, indexed.repoRevs); diff != "" {
 				t.Error("unexpected indexed:", diff)
 			}
 			if diff := cmp.Diff(tc.unindexed, unindexed); diff != "" {
@@ -829,7 +829,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	for _, tt := range cases {
 		indexed, unindexed := zoektIndexedRepos(zoektRepos, []*search.RepositoryRevisions{repoRev(tt.rev)}, nil)
 		got := ret{
-			Indexed:   indexed.indexed,
+			Indexed:   indexed.repoRevs,
 			Unindexed: unindexed,
 		}
 		want := ret{

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -343,7 +343,7 @@ func TestZoektIndexedRepos(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			indexed, unindexed := zoektIndexedRepos(zoektRepos, tc.repos, nil)
 
-			if diff := cmp.Diff(tc.indexed, indexed.repoRevs); diff != "" {
+			if diff := cmp.Diff(repoRevsSliceToMap(tc.indexed), indexed.repoRevs); diff != "" {
 				t.Error("unexpected indexed:", diff)
 			}
 			if diff := cmp.Diff(tc.unindexed, unindexed); diff != "" {
@@ -823,7 +823,8 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	}
 
 	type ret struct {
-		Indexed, Unindexed []*search.RepositoryRevisions
+		Indexed   map[string]*search.RepositoryRevisions
+		Unindexed []*search.RepositoryRevisions
 	}
 
 	for _, tt := range cases {
@@ -833,7 +834,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 			Unindexed: unindexed,
 		}
 		want := ret{
-			Indexed:   tt.wantIndexed,
+			Indexed:   repoRevsSliceToMap(tt.wantIndexed),
 			Unindexed: tt.wantUnindexed,
 		}
 		if !cmp.Equal(want, got) {
@@ -921,4 +922,12 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	if diff := cmp.Diff(want, symbols); diff != "" {
 		t.Fatalf("symbol mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func repoRevsSliceToMap(rs []*search.RepositoryRevisions) map[string]*search.RepositoryRevisions {
+	m := map[string]*search.RepositoryRevisions{}
+	for _, r := range rs {
+		m[string(r.Repo.Name)] = r
+	}
+	return m
 }

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -342,14 +341,12 @@ func TestZoektIndexedRepos(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, indexed, unindexed := zoektIndexedRepos(zoektRepos, tc.repos, nil)
+			indexed, unindexed := zoektIndexedRepos(zoektRepos, tc.repos, nil)
 
-			if !reflect.DeepEqual(tc.indexed, indexed) {
-				diff := cmp.Diff(tc.indexed, indexed)
+			if diff := cmp.Diff(tc.indexed, indexed.indexed); diff != "" {
 				t.Error("unexpected indexed:", diff)
 			}
-			if !reflect.DeepEqual(tc.unindexed, unindexed) {
-				diff := cmp.Diff(tc.unindexed, unindexed)
+			if diff := cmp.Diff(tc.unindexed, unindexed); diff != "" {
 				t.Error("unexpected unindexed:", diff)
 			}
 		})
@@ -379,7 +376,7 @@ func Benchmark_zoektIndexedRepos(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		_, _, _ = zoektIndexedRepos(zoektRepos, repos, nil)
+		_, _ = zoektIndexedRepos(zoektRepos, repos, nil)
 	}
 }
 
@@ -830,9 +827,9 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		_, indexed, unindexed := zoektIndexedRepos(zoektRepos, []*search.RepositoryRevisions{repoRev(tt.rev)}, nil)
+		indexed, unindexed := zoektIndexedRepos(zoektRepos, []*search.RepositoryRevisions{repoRev(tt.rev)}, nil)
 		got := ret{
-			Indexed:   indexed,
+			Indexed:   indexed.indexed,
 			Unindexed: unindexed,
 		}
 		want := ret{


### PR DESCRIPTION
This PR introduces `indexedRepoRevs` which is responsible for creating and maintaining the maps for indexed search. We currently have an invariant that needs to be maintained between the zoekt and sourcegraph representations. This moves the responsibility solely into indexedRepoRevs, rather than spread out across functions.

Can be reviewed commit by commit. No commit adds/changes functionality, they are all refactorings to get to the final state of nicer code :)

Part of #6728 