### PR TITLE
codeintel: Fix comparison to last_index_enqueued_at

### DIFF
--- a/enterprise/internal/codeintel/store/indexable_repos.go
+++ b/enterprise/internal/codeintel/store/indexable_repos.go
@@ -90,7 +90,7 @@ func (s *store) IndexableRepositories(ctx context.Context, opts IndexableReposit
 	}
 	if opts.MinimumTimeSinceLastEnqueue > 0 {
 		conds = append(conds, sqlf.Sprintf(
-			"(last_index_enqueued_at IS NULL OR %s - last_index_enqueued_at < (%s || ' second')::interval)",
+			"(last_index_enqueued_at IS NULL OR %s - last_index_enqueued_at >= (%s || ' second')::interval)",
 			opts.now,
 			opts.MinimumTimeSinceLastEnqueue/time.Second,
 		))

--- a/enterprise/internal/codeintel/store/indexable_repos_test.go
+++ b/enterprise/internal/codeintel/store/indexable_repos_test.go
@@ -96,8 +96,8 @@ func TestIndexableRepositoriesMinimumTimeSinceLastEnqueue(t *testing.T) {
 
 	expectedIndexableRepositories := []IndexableRepository{
 		{RepositoryID: 1},
-		{RepositoryID: 2, LastIndexEnqueuedAt: &t1},
-		{RepositoryID: 3, LastIndexEnqueuedAt: &t2},
+		{RepositoryID: 4, LastIndexEnqueuedAt: &t3},
+		{RepositoryID: 5, LastIndexEnqueuedAt: &t4},
 	}
 	if diff := cmp.Diff(expectedIndexableRepositories, indexableRepositories); diff != "" {
 		t.Errorf("unexpected ids (-want +got):\n%s", diff)


### PR DESCRIPTION
We want to avoid multiple indexes within the same timespan, not filter out everything older than the timespan.

🤦 