### PR TITLE
search: add query parser migration flag

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -90,10 +90,10 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	}
 
 	var queryInfo query.QueryInfo
-	if (conf.AndOrQueryEnabled() && query.ContainsAndOrKeyword(args.Query)) || searchType == query.SearchTypeStructural {
-		// To process the input as an and/or query, the flag must be
-		// enabled (default is on) and must contain either an 'and' or
-		// 'or' expression. Else, fallback to the older existing parser.
+	if conf.MigrateParserEnabled() || (conf.AndOrQueryEnabled() && query.ContainsAndOrKeyword(args.Query)) || searchType == query.SearchTypeStructural {
+		// To process the input with the new parser, the migration flag must be
+		// enabled (default is off), or the query must contain an 'and' or 'or'
+		// keyword, or it must be a structural search query.
 		queryInfo, err = query.ProcessAndOr(args.Query, searchType)
 		if err != nil {
 			return alertForQuery(args.Query, err), nil

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -328,6 +328,14 @@ func AndOrQueryEnabled() bool {
 	return e.AndOrQuery == "enabled"
 }
 
+func MigrateParserEnabled() bool {
+	e := Get().ExperimentalFeatures
+	if e == nil || e.MigrateParser == "" {
+		return false
+	}
+	return e.AndOrQuery == "enabled"
+}
+
 func ExperimentalFeatures() schema.ExperimentalFeatures {
 	val := Get().ExperimentalFeatures
 	if val == nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -399,6 +399,8 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// MigrateParser description: If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.
+	MigrateParser string `json:"migrateParser,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -86,10 +86,10 @@
           "default": "enabled"
         },
         "migrateParser": {
-            "description": "If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
-            "type": "string",
-            "enum": ["enabled", "disabled"],
-            "default": "disabled"
+          "description": "If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
         },
         "bitbucketServerFastPerm": {
           "description": "DEPRECATED: Configure in Bitbucket Server config.",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -85,6 +85,12 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "migrateParser": {
+            "description": "If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+            "type": "string",
+            "enum": ["enabled", "disabled"],
+            "default": "disabled"
+        },
         "bitbucketServerFastPerm": {
           "description": "DEPRECATED: Configure in Bitbucket Server config.",
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -91,10 +91,10 @@ const SiteSchemaJSON = `{
           "default": "enabled"
         },
         "migrateParser": {
-            "description": "If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
-            "type": "string",
-            "enum": ["enabled", "disabled"],
-            "default": "disabled"
+          "description": "If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
         },
         "bitbucketServerFastPerm": {
           "description": "DEPRECATED: Configure in Bitbucket Server config.",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -90,6 +90,12 @@ const SiteSchemaJSON = `{
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "migrateParser": {
+            "description": "If enabled, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+            "type": "string",
+            "enum": ["enabled", "disabled"],
+            "default": "disabled"
+        },
         "bitbucketServerFastPerm": {
           "description": "DEPRECATED: Configure in Bitbucket Server config.",
           "type": "string",


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/10844. This flag allows to use the new parser for all queries. This is to help the transition/migration. Mainly, if there is a show-stopping bug in the new parser, the flag is a fallback to the previous parser until a fix can happen.

I am disabling it by default, because I want to do some differential testing first, and then I'll enable it on Sourcegraph.com. When enabled, it'll solve a lot of existing issues (see https://github.com/sourcegraph/sourcegraph/issues/8780). 

Side question: I actually wanted to make this a user/org/global setting, but I need a handle to `ctx` for that, but can't get a context inside the `NewSearchImplementer` function, so :shrug:.

Example query that works when the flag is enabled: [`repo:^github\.com/sourcegraph/sourcegraph$ query:`](https://sourcegraph.test:3443/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+query:&patternType=literal&case=yes)