### PR TITLE
update GraphQL API to remove unneeded namespace param, add applyCampaign test

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -11,12 +11,10 @@ import (
 )
 
 type CreateCampaignArgs struct {
-	Namespace    graphql.ID
 	CampaignSpec graphql.ID
 }
 
 type ApplyCampaignArgs struct {
-	Namespace      graphql.ID
 	CampaignSpec   graphql.ID
 	EnsureCampaign *graphql.ID
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -369,9 +369,6 @@ type Mutation {
     # the same namespace with the same name already exists, an error is returned. The newly created
     # campaign is returned.
     createCampaign(
-        # The campaign's namespace (either a user or organization).
-        namespace: ID!
-
         # The campaign spec that describes the desired state of the campaign.
         campaignSpec: ID!
     ): Campaign!
@@ -380,9 +377,6 @@ type Mutation {
     # campaign exists in the namespace with the name given in the campaign spec, a campaign will be
     # created. Otherwise, the existing campaign will be updated. The campaign is returned.
     applyCampaign(
-        # The campaign's namespace (either a user or organization).
-        namespace: ID!
-
         # The campaign spec that describes the new desired state of the campaign.
         campaignSpec: ID!
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -376,9 +376,6 @@ type Mutation {
     # the same namespace with the same name already exists, an error is returned. The newly created
     # campaign is returned.
     createCampaign(
-        # The campaign's namespace (either a user or organization).
-        namespace: ID!
-
         # The campaign spec that describes the desired state of the campaign.
         campaignSpec: ID!
     ): Campaign!
@@ -387,9 +384,6 @@ type Mutation {
     # campaign exists in the namespace with the name given in the campaign spec, a campaign will be
     # created. Otherwise, the existing campaign will be updated. The campaign is returned.
     applyCampaign(
-        # The campaign's namespace (either a user or organization).
-        namespace: ID!
-
         # The campaign spec that describes the new desired state of the campaign.
         campaignSpec: ID!
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -180,42 +180,10 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	user, err := db.Users.GetByCurrentAuthUser(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "%v", backend.ErrNotAuthenticated)
-	}
 
-	// 🚨 SECURITY: Only site admins may create a campaign for now.
-	if !user.SiteAdmin {
-		return nil, backend.ErrMustBeSiteAdmin
-	}
-
-	campaign := &campaigns.Campaign{
-		Name:     "TODO: not blank",
-		AuthorID: user.ID,
-	}
-
-	switch relay.UnmarshalKind(args.Namespace) {
-	case "User":
-		err = relay.UnmarshalSpec(args.Namespace, &campaign.NamespaceUserID)
-	case "Org":
-		err = relay.UnmarshalSpec(args.Namespace, &campaign.NamespaceOrgID)
-	default:
-		err = errors.Errorf("Invalid namespace %q", args.Namespace)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	svc := ee.NewService(r.store, r.httpFactory)
-	err = svc.CreateCampaign(ctx, campaign)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: This mutation is not done.
-	return &campaignResolver{store: r.store, httpFactory: r.httpFactory, Campaign: campaign}, nil
+	// TODO(sqs): Implement createCampaign when we've implemented applyCampaign and are happy about
+	// how it works.
+	return nil, errors.New("createCampaign is not yet implemented (use applyCampaign instead)")
 }
 
 func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.ApplyCampaignArgs) (graphqlbackend.CampaignResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -175,7 +175,7 @@ func (r *Resolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (graphq
 
 func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.CreateCampaignArgs) (graphqlbackend.CampaignResolver, error) {
 	var err error
-	tr, ctx := trace.New(ctx, "Resolver.CreateCampaign", fmt.Sprintf("Namespace %s, CampaignSpec %s", args.Namespace, args.CampaignSpec))
+	tr, ctx := trace.New(ctx, "Resolver.CreateCampaign", fmt.Sprintf("CampaignSpec %s", args.CampaignSpec))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -188,7 +188,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 
 func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.ApplyCampaignArgs) (graphqlbackend.CampaignResolver, error) {
 	var err error
-	tr, ctx := trace.New(ctx, "Resolver.ApplyCampaign", fmt.Sprintf("Namespace %s, CampaignSpec %s", args.Namespace, args.CampaignSpec))
+	tr, ctx := trace.New(ctx, "Resolver.ApplyCampaign", fmt.Sprintf("CampaignSpec %s", args.CampaignSpec))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -205,18 +205,6 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 	}
 
 	opts := ee.ApplyCampaignOpts{}
-	switch relay.UnmarshalKind(args.Namespace) {
-	case "User":
-		err = relay.UnmarshalSpec(args.Namespace, &opts.NamespaceUserID)
-	case "Org":
-		err = relay.UnmarshalSpec(args.Namespace, &opts.NamespaceOrgID)
-	default:
-		err = errors.Errorf("Invalid namespace %q", args.Namespace)
-	}
-
-	if err != nil {
-		return nil, err
-	}
 
 	opts.CampaignSpecRandID, err = unmarshalCampaignSpecID(args.CampaignSpec)
 	if err != nil {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -111,10 +111,8 @@ func TestCampaigns(t *testing.T) {
 
 	var campaigns struct{ A, B apitest.Campaign }
 	apitest.MustExec(ctx, t, s, map[string]interface{}{
-		"specA":          campaignSpecs.A.ID,
-		"specANamespace": campaignSpecs.A.Namespace.ID,
-		"specB":          campaignSpecs.B.ID,
-		"specBNamespace": campaignSpecs.B.Namespace.ID,
+		"specA": campaignSpecs.A.ID,
+		"specB": campaignSpecs.B.ID,
 	}, &campaigns, `
 		fragment u on User { id, databaseID, siteAdmin }
 		fragment o on Org  { id, name }
@@ -126,9 +124,9 @@ func TestCampaigns(t *testing.T) {
 				... on Org  { ...o }
 			}
 		}
-		mutation($specA: ID!, $specANamespace: ID!, $specB: ID!, $specBNamespace: ID!) {
-			A: applyCampaign(namespace: $specANamespace, campaignSpec: $specA) { ...c }
-			B: applyCampaign(namespace: $specBNamespace, campaignSpec: $specB) { ...c }
+		mutation($specA: ID!, $specB: ID!) {
+			A: applyCampaign(campaignSpec: $specA) { ...c }
+			B: applyCampaign(campaignSpec: $specB) { ...c }
 		}
 	`)
 
@@ -1102,8 +1100,6 @@ func TestApplyCampaign(t *testing.T) {
 
 	userApiID := string(graphqlbackend.MarshalUserID(userID))
 	input := map[string]interface{}{
-		// TODO: Do we need the namespace in this mutation?
-		"namespace":    userApiID,
 		"campaignSpec": string(marshalCampaignSpecRandID(campaignSpec.RandID)),
 	}
 
@@ -1166,8 +1162,8 @@ const mutationApplyCampaign = `
 fragment u on User { id, databaseID, siteAdmin }
 fragment o on Org  { id, name }
 
-mutation($namespace: ID!, $campaignSpec: ID!, $ensureCampaign: ID){
-  applyCampaign(namespace: $namespace, campaignSpec: $campaignSpec, ensureCampaign: $ensureCampaign) {
+mutation($campaignSpec: ID!, $ensureCampaign: ID){
+  applyCampaign(campaignSpec: $campaignSpec, ensureCampaign: $ensureCampaign) {
 	id, name, description, branch
 	author    { ...u }
 	namespace {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -90,17 +90,32 @@ func TestCampaigns(t *testing.T) {
 		}
 	`)
 
-	var campaigns struct{ Admin, Org apitest.Campaign }
-
-	input := map[string]interface{}{
+	var campaignSpecs struct{ A, B apitest.CampaignSpec }
+	apitest.MustExec(ctx, t, s, map[string]interface{}{
 		"admin": users.Admin.ID,
 		"org":   orgs.ACME.ID,
-		// TODO: Use real campaign specs
-		"spec1": "CampaignSpec:TODO:0",
-		"spec2": "CampaignSpec:TODO:1",
-	}
+		"specA": `{"name":"specA"}`,
+		"specB": `{"name":"specB"}`,
+	}, &campaignSpecs, `
+		fragment s on CampaignSpec {
+			id
+			namespace {
+				id
+			}
+		}
+		mutation($admin: ID!, $org: ID!, $specA: String!, $specB: String!) {
+			A: createCampaignSpec(namespace: $admin, campaignSpec: $specA, changesetSpecs: []) { ...s }
+			B: createCampaignSpec(namespace: $org, campaignSpec: $specB, changesetSpecs: [])   { ...s }
+		}
+	`)
 
-	apitest.MustExec(ctx, t, s, input, &campaigns, `
+	var campaigns struct{ A, B apitest.Campaign }
+	apitest.MustExec(ctx, t, s, map[string]interface{}{
+		"specA":          campaignSpecs.A.ID,
+		"specANamespace": campaignSpecs.A.Namespace.ID,
+		"specB":          campaignSpecs.B.ID,
+		"specBNamespace": campaignSpecs.B.Namespace.ID,
+	}, &campaigns, `
 		fragment u on User { id, databaseID, siteAdmin }
 		fragment o on Org  { id, name }
 		fragment c on Campaign {
@@ -111,17 +126,17 @@ func TestCampaigns(t *testing.T) {
 				... on Org  { ...o }
 			}
 		}
-		mutation($admin: ID!, $org: ID!, $spec1: ID!, $spec2: ID!){
-			admin: createCampaign(namespace: $admin, campaignSpec: $spec1) { ...c }
-			org: createCampaign(namespace: $org, campaignSpec: $spec2)     { ...c }
+		mutation($specA: ID!, $specANamespace: ID!, $specB: ID!, $specBNamespace: ID!) {
+			A: applyCampaign(namespace: $specANamespace, campaignSpec: $specA) { ...c }
+			B: applyCampaign(namespace: $specBNamespace, campaignSpec: $specB) { ...c }
 		}
 	`)
 
-	if have, want := campaigns.Admin.Namespace.ID, users.Admin.ID; have != want {
+	if have, want := campaigns.A.Namespace.ID, users.Admin.ID; have != want {
 		t.Fatalf("have admin's campaign namespace id %q, want %q", have, want)
 	}
 
-	if have, want := campaigns.Org.Namespace.ID, orgs.ACME.ID; have != want {
+	if have, want := campaigns.B.Namespace.ID, orgs.ACME.ID; have != want {
 		t.Fatalf("have orgs's campaign namespace id %q, want %q", have, want)
 	}
 
@@ -149,7 +164,7 @@ func TestCampaigns(t *testing.T) {
 	`)
 
 	have := listed.First.Nodes
-	want := []apitest.Campaign{campaigns.Admin}
+	want := []apitest.Campaign{campaigns.A}
 	if !reflect.DeepEqual(have, want) {
 		t.Errorf("wrong campaigns listed. diff=%s", cmp.Diff(have, want))
 	}
@@ -159,7 +174,7 @@ func TestCampaigns(t *testing.T) {
 	}
 
 	have = listed.All.Nodes
-	want = []apitest.Campaign{campaigns.Admin, campaigns.Org}
+	want = []apitest.Campaign{campaigns.A, campaigns.B}
 	if !reflect.DeepEqual(have, want) {
 		t.Errorf("wrong campaigns listed. diff=%s", cmp.Diff(have, want))
 	}

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -223,19 +223,13 @@ func (e *changesetSpecNotFoundErr) NotFound() bool { return true }
 
 type ApplyCampaignOpts struct {
 	CampaignSpecRandID string
-
-	NamespaceUserID int32
-	NamespaceOrgID  int32
-
-	EnsureCampaignID int64
+	EnsureCampaignID   int64
 }
 
 func (o ApplyCampaignOpts) String() string {
 	return fmt.Sprintf(
-		"CampaignSpec %s, NamespaceOrgID %d, NamespaceUserID %d, EnsureCampaignID %d",
+		"CampaignSpec %s, EnsureCampaignID %d",
 		o.CampaignSpecRandID,
-		o.NamespaceOrgID,
-		o.NamespaceUserID,
 		o.EnsureCampaignID,
 	)
 }
@@ -261,13 +255,10 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 		return nil, err
 	}
 
-	getOpts := GetCampaignOpts{CampaignSpecName: campaignSpec.Spec.Name}
-	if opts.NamespaceUserID != 0 {
-		getOpts.NamespaceUserID = opts.NamespaceUserID
-	} else if opts.NamespaceOrgID != 0 {
-		getOpts.NamespaceOrgID = opts.NamespaceOrgID
-	} else {
-		return nil, errors.New("no namespace specified")
+	getOpts := GetCampaignOpts{
+		CampaignSpecName: campaignSpec.Spec.Name,
+		NamespaceUserID:  campaignSpec.NamespaceUserID,
+		NamespaceOrgID:   campaignSpec.NamespaceOrgID,
 	}
 
 	campaign, err = tx.GetCampaign(ctx, getOpts)
@@ -296,8 +287,8 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 
 	// TODO Do we need these fields on Campaign or is it enough that
 	// we have them on CampaignSpec?
-	campaign.NamespaceOrgID = opts.NamespaceOrgID
-	campaign.NamespaceUserID = opts.NamespaceUserID
+	campaign.NamespaceOrgID = campaignSpec.NamespaceOrgID
+	campaign.NamespaceUserID = campaignSpec.NamespaceUserID
 	campaign.Branch = campaignSpec.Spec.ChangesetTemplate.Branch
 	campaign.Name = campaignSpec.Spec.Name
 	campaign.Description = campaignSpec.Spec.Description

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -732,7 +732,6 @@ func TestService(t *testing.T) {
 		t.Run("new campaign", func(t *testing.T) {
 			campaignSpec := createCampaignSpec(t, "campaign-name", user.ID)
 			campaign, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-				NamespaceUserID:    user.ID,
 				CampaignSpecRandID: campaignSpec.RandID,
 			})
 			if err != nil {
@@ -766,7 +765,6 @@ func TestService(t *testing.T) {
 		t.Run("existing campaign", func(t *testing.T) {
 			campaignSpec := createCampaignSpec(t, "campaign-name", user.ID)
 			campaign, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-				NamespaceUserID:    user.ID,
 				CampaignSpecRandID: campaignSpec.RandID,
 			})
 			if err != nil {
@@ -779,7 +777,6 @@ func TestService(t *testing.T) {
 
 			t.Run("apply same campaignSpec", func(t *testing.T) {
 				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-					NamespaceUserID:    user.ID,
 					CampaignSpecRandID: campaignSpec.RandID,
 				})
 				if err != nil {
@@ -794,7 +791,6 @@ func TestService(t *testing.T) {
 			t.Run("apply campaign spec with same name", func(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user.ID)
 				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-					NamespaceUserID:    user.ID,
 					CampaignSpecRandID: campaignSpec2.RandID,
 				})
 				if err != nil {
@@ -811,7 +807,6 @@ func TestService(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user2.ID)
 
 				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-					NamespaceUserID:    user2.ID,
 					CampaignSpecRandID: campaignSpec2.RandID,
 				})
 				if err != nil {
@@ -831,7 +826,6 @@ func TestService(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user.ID)
 
 				campaign2, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-					NamespaceUserID:    user.ID,
 					CampaignSpecRandID: campaignSpec2.RandID,
 					EnsureCampaignID:   campaign.ID,
 				})
@@ -847,7 +841,6 @@ func TestService(t *testing.T) {
 				campaignSpec2 := createCampaignSpec(t, "campaign-name", user.ID)
 
 				_, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
-					NamespaceUserID:    user.ID,
 					CampaignSpecRandID: campaignSpec2.RandID,
 					EnsureCampaignID:   campaign.ID + 999,
 				})

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -54,17 +54,17 @@ const campaignFragment = gql`
     ${DiffStatFields}
 `
 
-export async function createCampaign(namespace: ID, campaignSpec: ID): Promise<ICampaign> {
+export async function createCampaign(campaignSpec: ID): Promise<ICampaign> {
     const result = await mutateGraphQL(
         gql`
-            mutation CreateCampaign($namespace: ID!, $campaignSpec: ID!) {
-                createCampaign(namespace: $namespace, campaignSpec: $campaignSpec) {
+            mutation CreateCampaign($campaignSpec: ID!) {
+                createCampaign(campaignSpec: $campaignSpec) {
                     id
                     url
                 }
             }
         `,
-        { namespace, campaignSpec }
+        { campaignSpec }
     ).toPromise()
     return dataOrThrowErrors(result).createCampaign
 }


### PR DESCRIPTION
Just a small contribution that addresses an issue (needless namespace param) raised by @mrnugget and adds a new resolver test.