### PR TITLE
Fix file header text wrapping on long paths on Bitbucket

### DIFF
--- a/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
+++ b/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
@@ -36,6 +36,8 @@ export const getToolbarMount = (codeView: HTMLElement): HTMLElement => {
     mount.classList.add('btn-group')
     mount.classList.add('sg-toolbar-mount')
     mount.classList.add('sg-toolbar-mount-bitbucket-server')
+    // Adds AUI (bitbucket) style for buttons in toolbar
+    mount.classList.add('aui-buttons')
 
     fileActions.prepend(mount)
 

--- a/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -52,6 +52,11 @@
     }
 }
 
+// Fix for vertical alignment on bitbucket-server
+.actions-nav-items__action-item.action-item--bitbucket-server {
+    overflow: visible;
+}
+
 .btn-icon--bitbucket-server {
     padding: 0 !important;
     background: transparent !important;

--- a/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -40,31 +40,6 @@
     margin-top: 5px;
 }
 
-// Use flexbox instead of float, so we can handle wrapping action items
-.file-toolbar {
-    display: flex;
-    > .primary {
-        flex: 1 0 auto;
-        order: 1;
-
-        display: flex;
-        align-items: center;
-    }
-    > .secondary {
-        // Overrides
-        float: none;
-        white-space: normal;
-        line-height: initial;
-
-        flex: 1 1 auto;
-        order: 2;
-
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-    }
-}
-
 // Hover overlay buttons
 .hover-action-item--bitbucket-server {
     margin: 0 !important;


### PR DESCRIPTION
Fix #11110 

Summary of attempts to solve this issue:

- Didn't find a way to keep using display flex while making the file path wrap
- No clear solution to wrap both file path and toolbar buttons: because they're on the same line, the desired wrapping behavior isn't obvious
- Simplest apparent solution: remove flex and use `aui-buttons` class which already exists and is used on Bitbucket toolbar buttons.

Limitations of this solution:

- Toolbar buttons don't wrap if there's an excessive number of them. The file path (sharing space with the buttons) will wrap instead.