### PR TITLE
add structural to search help dropdown

### DIFF
--- a/web/src/search/input/SearchHelpDropdownButton.tsx
+++ b/web/src/search/input/SearchHelpDropdownButton.tsx
@@ -31,7 +31,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent = () => {
                     <li>
                         <span className="text-muted small">Structural:</span>{' '}
                         <code>
-                            <strong>try&#123;:[my_match]&#125; </strong>
+                            <strong>if(:[my_match]) </strong>
                         </code>
                     </li>
                     <li>

--- a/web/src/search/input/SearchHelpDropdownButton.tsx
+++ b/web/src/search/input/SearchHelpDropdownButton.tsx
@@ -29,6 +29,12 @@ export const SearchHelpDropdownButton: React.FunctionComponent = () => {
                 <DropdownItem header={true}>Finding matches:</DropdownItem>
                 <ul className="list-unstyled px-2 mb-2">
                     <li>
+                        <span className="text-muted small">Structural:</span>{' '}
+                        <code>
+                            <strong>try&#123;:[my_match]&#125; </strong>
+                        </code>
+                    </li>
+                    <li>
                         <span className="text-muted small">Regexp:</span>{' '}
                         <code>
                             <strong>(read|write)File</strong>


### PR DESCRIPTION
Adds a structural search example to the search reference.

<img width="804" alt="Screen Shot 2020-07-07 at 5 33 14 PM" src="https://user-images.githubusercontent.com/539268/86860675-2820c200-c07a-11ea-9911-7b94af7a6018.png">
