### PR TITLE
search suggestion dropdown: remove quotes from exact

### DIFF
--- a/web/src/search/input/SearchHelpDropdownButton.tsx
+++ b/web/src/search/input/SearchHelpDropdownButton.tsx
@@ -37,7 +37,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent = () => {
                     <li>
                         <span className="text-muted small">Exact:</span>{' '}
                         <code>
-                            "<strong>fs.open(f)</strong>"
+                            <strong>fs.open(f)</strong>
                         </code>
                     </li>
                 </ul>


### PR DESCRIPTION
In default (literal) mode, quotes should not be included for "Exact". But, this suggestion is still relevant for regexp mode. So to be totally accurate we need to change this contextually based on the kind of search.