### PR TITLE
restore the glory of ctrl-k shortcut in search bar

### DIFF
--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -300,7 +300,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
             throw new Error('Cannot unbind default Monaco keybindings')
         }
         for (const action of Object.keys(editor._actions)) {
-            // Keep ctrl+space to show all available completions
+            // Keep ctrl+space to show all available completions. Keep ctrl+k to delete text on right of cursor.
             if (action === 'editor.action.triggerSuggest' || action === 'deleteAllRight') {
                 continue
             }

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -301,7 +301,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
         }
         for (const action of Object.keys(editor._actions)) {
             // Keep ctrl+space to show all available completions
-            if (action === 'editor.action.triggerSuggest') {
+            if (action === 'editor.action.triggerSuggest' || action === 'deleteAllRight') {
                 continue
             }
             // Prefixing action ids with `-` to unbind the default actions.


### PR DESCRIPTION


![ineedit](https://user-images.githubusercontent.com/888624/86877540-f1f43a00-c09b-11ea-9ddc-06d4a5bff40a.gif)

Addresses #10756. I can't go on without it any longer.