### PR TITLE
Revert "monitoring: adjust thresholds for disk_space_remaining (#11988)"

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -235,7 +235,10 @@ for assistance.
 
 **Descriptions:**
 
-- _gitserver: less than 5% disk space remaining by instance_
+- _gitserver: less than 25% disk space remaining by instance_
+
+
+- _gitserver: less than 15% disk space remaining by instance_
 
 **Possible solutions:**
 
@@ -484,10 +487,10 @@ for assistance.
 
 **Descriptions:**
 
+- _precise-code-intel-bundle-manager: less than 25% disk space remaining by instance_
+
+
 - _precise-code-intel-bundle-manager: less than 15% disk space remaining by instance_
-
-
-- _precise-code-intel-bundle-manager: less than 5% disk space remaining by instance_
 
 **Possible solutions:**
 

--- a/monitoring/git_server.go
+++ b/monitoring/git_server.go
@@ -15,7 +15,8 @@ func GitServer() *Container {
 							Description:     "disk space remaining by instance",
 							Query:           `(src_gitserver_disk_space_available / src_gitserver_disk_space_total) * 100`,
 							DataMayNotExist: true,
-							Critical:        Alert{LessOrEqual: 5},
+							Warning:         Alert{LessOrEqual: 25},
+							Critical:        Alert{LessOrEqual: 15},
 							PanelOptions:    PanelOptions().LegendFormat("{{instance}}").Unit(Percentage),
 							PossibleSolutions: `
 								- **Provision more disk space:** Sourcegraph will begin deleting least-used repository clones at 10% disk space remaining which may result in decreased performance, users having to wait for repositories to clone, etc.

--- a/monitoring/precise_code_intel_bundle_manager.go
+++ b/monitoring/precise_code_intel_bundle_manager.go
@@ -59,8 +59,8 @@ func PreciseCodeIntelBundleManager() *Container {
 							Description:     "disk space remaining by instance",
 							Query:           `(src_disk_space_available_bytes{job="precise-code-intel-bundle-manager"} / src_disk_space_total_bytes{job="precise-code-intel-bundle-manager"}) * 100`,
 							DataMayNotExist: true,
-							Warning:         Alert{LessOrEqual: 15},
-							Critical:        Alert{LessOrEqual: 5},
+							Warning:         Alert{LessOrEqual: 25},
+							Critical:        Alert{LessOrEqual: 15},
 							PanelOptions:    PanelOptions().LegendFormat("{{instance}}").Unit(Percentage),
 							PossibleSolutions: `
 								- **Provision more disk space:** Sourcegraph will begin deleting the oldest uploaded bundle files at 10% disk space remaining.


### PR DESCRIPTION
This reverts commit c08ce9a7ef017f9663560ef6e7b55b1ff20e4d8f.

Upon further assessment @ https://github.com/sourcegraph/sourcegraph/issues/12011 , seems like it might be best to keep these thresholds as-is and try and address the underlying issues (eg https://github.com/sourcegraph/sourcegraph/issues/12014 , https://github.com/sourcegraph/sourcegraph/issues/9359) or silence them on dot-com (https://github.com/sourcegraph/sourcegraph/issues/11210)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
