### PR TITLE
search: allow structural search when commit is alias for HEAD

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -593,7 +593,7 @@ type indexedRepoRevs struct {
 
 	// NotHEADOnlySearch is true if we are searching a branch other than HEAD.
 	//
-	// This function can be removed once structural search supports searching
+	// This option can be removed once structural search supports searching
 	// more than HEAD.
 	NotHEADOnlySearch bool
 }

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -138,20 +138,6 @@ func (r *RepositoryRevisions) String() string {
 	return string(r.Repo.Name) + "@" + strings.Join(parts, ":")
 }
 
-// OnlyHEAD returns true iff there is only one ref and it is explicitly the
-// default branch.
-//
-// Note: This doesn't resolve what the default branch is. It relies on the rev
-// being "" (Sourcegraph convention for default) or "HEAD" (git symref for
-// default).
-func (r *RepositoryRevisions) OnlyHEAD() bool {
-	if !r.OnlyExplicit() || len(r.Revs) != 1 {
-		return false
-	}
-	rev := r.Revs[0].RevSpec
-	return rev == "" || rev == "HEAD"
-}
-
 // OnlyExplicit returns true if all revspecs in Revs are explicit.
 func (r *RepositoryRevisions) OnlyExplicit() bool {
 	for _, rev := range r.Revs {


### PR DESCRIPTION
By checking which branches we will search on zoekt, we allow structural
searching a specific commit if it is HEAD.

Tested manually. Automated tests defered for when we add structural search on any indexed branch.

Fixes https://github.com/sourcegraph/sourcegraph/issues/12012