### PR TITLE
monitoring: fix alert grouping

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -37,7 +37,7 @@ func changeReceivers(ctx context.Context, log log15.Logger, change ChangeContext
 	})
 
 	// make sure alerts are routed appropriately
-	groupBy := []string{"level", "service_name", "name"}
+	groupBy := []string{"alertname", "level", "service_name", "name"}
 	change.AMConfig.Route = &amconfig.Route{
 		Receiver:   alertmanagerNoopReceiver,
 		GroupByStr: groupBy,

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -36,8 +36,11 @@ func changeReceivers(ctx context.Context, log log15.Logger, change ChangeContext
 		Name: alertmanagerNoopReceiver,
 	})
 
-	// make sure alerts are routed appropriately
+	// include `alertname` for now to accomodate non-generator alerts - in the long run, we want to remove grouping on `alertname`
+	// because all alerts should have some predefined labels
+	// https://github.com/sourcegraph/sourcegraph/issues/5370
 	groupBy := []string{"alertname", "level", "service_name", "name"}
+	// make sure alerts are routed appropriately
 	change.AMConfig.Route = &amconfig.Route{
 		Receiver:   alertmanagerNoopReceiver,
 		GroupByStr: groupBy,

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/inconshreveable/log15"
 	amconfig "github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/common/model"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -38,20 +37,21 @@ func changeReceivers(ctx context.Context, log log15.Logger, change ChangeContext
 	})
 
 	// make sure alerts are routed appropriately
-	groupBy := []model.LabelName{"level", "service_name", "name"}
+	groupBy := []string{"level", "service_name", "name"}
 	change.AMConfig.Route = &amconfig.Route{
-		Receiver: alertmanagerNoopReceiver,
+		Receiver:   alertmanagerNoopReceiver,
+		GroupByStr: groupBy,
 		Routes: []*amconfig.Route{
 			{
-				Receiver: alertmanagerWarningReceiver,
-				GroupBy:  groupBy,
+				Receiver:   alertmanagerWarningReceiver,
+				GroupByStr: groupBy,
 				Match: map[string]string{
 					"level": "warning",
 				},
 			},
 			{
-				Receiver: alertmanagerCriticalReceiver,
-				GroupBy:  groupBy,
+				Receiver:   alertmanagerCriticalReceiver,
+				GroupByStr: groupBy,
 				Match: map[string]string{
 					"level": "critical",
 				},

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -21,7 +21,8 @@ const (
 )
 
 var (
-	// alertmanager notification template reference: https://prometheus.io/docs/alerting/latest/notifications
+	// Alertmanager notification template reference: https://prometheus.io/docs/alerting/latest/notifications
+	// All labels used in these templates should be included in route.GroupByStr
 	alertSolutionsTemplate    = `https://docs.sourcegraph.com/admin/observability/alert_solutions#{{ .CommonLabels.service_name }}-{{ .CommonLabels.name | reReplaceAll "(_low|_high)$" "" | reReplaceAll "_" "-" }}`
 	notificationTitleTemplate = "[{{ .CommonLabels.level | toUpper }}] {{ .CommonLabels.description }}"
 	notificationBodyTemplate  = fmt.Sprintf(`{{ .CommonLabels.level | title }} alert '{{ .CommonLabels.name }}' is firing for service '{{ .CommonLabels.service_name }}'.


### PR DESCRIPTION
🤦 follow-up to #11832 

I was setting the wrong field for grouping:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/23356519/86887332-f287e180-c12a-11ea-9339-292634693e09.png">

Leading to:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/23356519/86887378-07fd0b80-c12b-11ea-9fa0-3cbcb5375a65.png">

Did not show up in local testing because I only had 1 alert firing at a time. Tested with multiple:

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/23356519/86889279-16005b80-c12e-11ea-9543-2391680dc447.png">

<img width="438" alt="image" src="https://user-images.githubusercontent.com/23356519/86889309-1e589680-c12e-11ea-8810-ae3b41543231.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
