### PR TITLE
Revert "Update comby/comby Docker tag to v0.16.0"

### DIFF
--- a/cmd/replacer/Dockerfile
+++ b/cmd/replacer/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add pcre
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine
 # hadolint ignore=DL3022
-COPY --from=comby/comby:0.16.0@sha256:3807c4d87afe226a120da8fbf745685a5a2cb7ff1d0a0a4a5dfdce7b116f986f /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add pcre
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine
 # hadolint ignore=DL3022
-COPY --from=comby/comby:0.16.0@sha256:3807c4d87afe226a120da8fbf745685a5a2cb7ff1d0a0a4a5dfdce7b116f986f /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -43,7 +43,7 @@ RUN apk update && apk add --no-cache \
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
 # have been appropriately set in cmd/server/shared/shared.go.
 # hadolint ignore=DL3022
-COPY --from=comby/comby:0.16.0@sha256:3807c4d87afe226a120da8fbf745685a5a2cb7ff1d0a0a4a5dfdce7b116f986f /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/


### PR DESCRIPTION
Addresses #12030 by reverting sourcegraph/sourcegraph#12021. Need to update a sqlite3 dependency or figure out how to avoid it.