### PR TITLE
Add storybooks for file diffs and improve ugly states

### DIFF
--- a/web/src/components/diff/FileDiffHunks.story.tsx
+++ b/web/src/components/diff/FileDiffHunks.story.tsx
@@ -1,0 +1,82 @@
+import { storiesOf } from '@storybook/react'
+import { radios, boolean } from '@storybook/addon-knobs'
+import React from 'react'
+import { FileDiffHunks } from './FileDiffHunks'
+import { createMemoryHistory } from 'history'
+import webStyles from '../../SourcegraphWebApp.scss'
+import { DiffHunkLineType, IFileDiffHunk } from '../../../../shared/src/graphql/schema'
+
+export const DEMO_HUNKS: IFileDiffHunk[] = [
+    {
+        __typename: 'FileDiffHunk',
+        oldRange: { __typename: 'FileDiffHunkRange', lines: 7, startLine: 3 },
+        newRange: { __typename: 'FileDiffHunkRange', lines: 7, startLine: 3 },
+        oldNoNewlineAt: false,
+        section: 'func awesomeness(param string) (int, error) {',
+        highlight: {
+            __typename: 'HighlightedDiffHunkBody',
+            aborted: false,
+            lines: [
+                {
+                    kind: DiffHunkLineType.UNCHANGED,
+                    html: '    v, err := makeAwesome()',
+                    __typename: 'HighlightedDiffHunkLine',
+                },
+                {
+                    kind: DiffHunkLineType.UNCHANGED,
+                    html: '    if err != nil {',
+                    __typename: 'HighlightedDiffHunkLine',
+                },
+                {
+                    kind: DiffHunkLineType.UNCHANGED,
+                    html: '        fmt.Printf("wow: %v", err)',
+                    __typename: 'HighlightedDiffHunkLine',
+                },
+                {
+                    kind: DiffHunkLineType.DELETED,
+                    html: '        return err',
+                    __typename: 'HighlightedDiffHunkLine',
+                },
+                {
+                    kind: DiffHunkLineType.ADDED,
+                    html: '        return nil, err',
+                    __typename: 'HighlightedDiffHunkLine',
+                },
+                { kind: DiffHunkLineType.UNCHANGED, html: '    }', __typename: 'HighlightedDiffHunkLine' },
+                {
+                    kind: DiffHunkLineType.UNCHANGED,
+                    html: '    return v.Score, nil',
+                    __typename: 'HighlightedDiffHunkLine',
+                },
+                { kind: DiffHunkLineType.UNCHANGED, html: '}', __typename: 'HighlightedDiffHunkLine' },
+            ],
+        },
+        body: '',
+    },
+]
+
+const { add } = storiesOf('web/FileDiffHunks', module).addDecorator(story => {
+    // TODO find a way to do this globally for all stories and storybook itself.
+    const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')
+    document.body.classList.toggle('theme-light', theme === 'light')
+    document.body.classList.toggle('theme-dark', theme === 'dark')
+    return (
+        <>
+            <style>{webStyles}</style>
+            <div className="p-3 container">{story()}</div>
+        </>
+    )
+})
+
+add('One diff hunk', () => (
+    <FileDiffHunks
+        persistLines={boolean('persistLines', false)}
+        fileDiffAnchor="abc"
+        lineNumbers={boolean('lineNumbers', true)}
+        isLightTheme={true}
+        hunks={DEMO_HUNKS}
+        className="abcdef"
+        location={createMemoryHistory().location}
+        history={createMemoryHistory()}
+    />
+))

--- a/web/src/components/diff/FileDiffNode.story.tsx
+++ b/web/src/components/diff/FileDiffNode.story.tsx
@@ -1,0 +1,213 @@
+import { storiesOf } from '@storybook/react'
+import { radios, boolean } from '@storybook/addon-knobs'
+import React from 'react'
+import { FileDiffNode } from './FileDiffNode'
+import { createMemoryHistory } from 'history'
+import webStyles from '../../SourcegraphWebApp.scss'
+import { DEMO_HUNKS } from './FileDiffHunks.story'
+import { MemoryRouter } from 'react-router'
+import { IVirtualFile, IGitBlob, IFileDiff } from '../../../../shared/src/graphql/schema'
+
+export const FILE_DIFF_NODES: IFileDiff[] = [
+    {
+        __typename: 'FileDiff',
+        hunks: DEMO_HUNKS,
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 1, deleted: 0 },
+        oldFile: null,
+        newFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'new_file.md',
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'new_file.md',
+        } as IVirtualFile,
+        newPath: 'new_file.md',
+        oldPath: null,
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: DEMO_HUNKS,
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 1, deleted: 0 },
+        newFile: null,
+        oldFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'deleted_file.md',
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'deleted_file.md',
+        } as IVirtualFile,
+        newPath: null,
+        oldPath: 'deleted_file.md',
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: [],
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 0, deleted: 0 },
+        oldFile: null,
+        newFile: {
+            __typename: 'VirtualFile',
+            binary: true,
+            name: 'new_file.md',
+            byteSize: 1280,
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: true,
+            name: 'new_file.md',
+            byteSize: 1280,
+        } as IVirtualFile,
+        newPath: 'new_file.md',
+        oldPath: null,
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: [],
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 0, deleted: 0 },
+        newFile: null,
+        oldFile: {
+            __typename: 'VirtualFile',
+            binary: true,
+            name: 'deleted_file.md',
+            byteSize: 1280,
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: true,
+            name: 'deleted_file.md',
+            byteSize: 1280,
+        } as IVirtualFile,
+        newPath: null,
+        oldPath: 'deleted_file.md',
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: DEMO_HUNKS,
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 1, deleted: 0 },
+        oldFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'existing_file.md',
+        } as IVirtualFile,
+        newFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'existing_file.md',
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'existing_file.md',
+        } as IVirtualFile,
+        newPath: 'existing_file.md',
+        oldPath: 'existing_file.md',
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: DEMO_HUNKS,
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 1, deleted: 0 },
+        oldFile: {
+            __typename: 'GitBlob',
+            binary: false,
+            name: 'existing_git_file.md',
+        } as IGitBlob,
+        newFile: {
+            __typename: 'GitBlob',
+            binary: false,
+            name: 'existing_git_file.md',
+        } as IGitBlob,
+        mostRelevantFile: {
+            __typename: 'GitBlob',
+            binary: false,
+            name: 'existing_git_file.md',
+        } as IGitBlob,
+        newPath: 'existing_git_file.md',
+        oldPath: 'existing_git_file.md',
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: DEMO_HUNKS,
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 1, deleted: 0 },
+        oldFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'from.md',
+        } as IVirtualFile,
+        newFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'to.md',
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'to.md',
+        } as IVirtualFile,
+        newPath: 'to.md',
+        oldPath: 'from.md',
+    },
+    {
+        __typename: 'FileDiff',
+        hunks: [],
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 0, deleted: 0 },
+        oldFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'from.md',
+        } as IVirtualFile,
+        newFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'to.md',
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'to.md',
+        } as IVirtualFile,
+        newPath: 'to.md',
+        oldPath: 'from.md',
+    },
+]
+
+const { add } = storiesOf('web/FileDiffNode', module).addDecorator(story => {
+    const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')
+    document.body.classList.toggle('theme-light', theme === 'light')
+    document.body.classList.toggle('theme-dark', theme === 'dark')
+    return (
+        <>
+            <style>{webStyles}</style>
+            <div className="p-3 container">{story()}</div>
+        </>
+    )
+})
+
+add('All file node states overview', () => (
+    <MemoryRouter>
+        {FILE_DIFF_NODES.map((node, index) => (
+            <FileDiffNode
+                key={index}
+                persistLines={boolean('persistLines', false)}
+                lineNumbers={boolean('lineNumbers', true)}
+                isLightTheme={true}
+                node={node}
+                className="abcdef"
+                location={createMemoryHistory().location}
+                history={createMemoryHistory()}
+            />
+        ))}
+    </MemoryRouter>
+))

--- a/web/src/components/diff/FileDiffNode.tsx
+++ b/web/src/components/diff/FileDiffNode.tsx
@@ -38,11 +38,12 @@ export interface FileDiffNodeProps extends ThemeProps {
 
 interface State {
     expanded: boolean
+    renderDeleted: boolean
 }
 
 /** A file diff. */
 export class FileDiffNode extends React.PureComponent<FileDiffNodeProps, State> {
-    public state: State = { expanded: true }
+    public state: State = { expanded: true, renderDeleted: false }
 
     public render(): JSX.Element | null {
         const node = this.props.node
@@ -98,6 +99,9 @@ export class FileDiffNode extends React.PureComponent<FileDiffNodeProps, State> 
                         <div className="file-diff-node__header-path-stat align-items-baseline">
                             {!node.oldPath && <span className="badge badge-success mr-2">Added file</span>}
                             {!node.newPath && <span className="badge badge-danger mr-2">Deleted file</span>}
+                            {node.newPath && node.oldPath && node.newPath !== node.oldPath && (
+                                <span className="badge badge-merged mr-2">Moved file</span>
+                            )}
                             {stat}
                             <Link to={{ ...this.props.location, hash: anchor }} className="file-diff-node__header-path">
                                 {path}
@@ -119,6 +123,13 @@ export class FileDiffNode extends React.PureComponent<FileDiffNodeProps, State> 
                     {this.state.expanded &&
                         (node.oldFile?.binary || node.newFile?.binary ? (
                             <div className="text-muted m-2">Binary files can't be rendered.</div>
+                        ) : !node.newPath && !this.state.renderDeleted ? (
+                            <div className="text-muted m-2">
+                                <p className="mb-0">Deleted files aren't rendered by default.</p>
+                                <button type="button" className="btn btn-link m-0 p-0" onClick={this.setRenderDeleted}>
+                                    Click here to view.
+                                </button>
+                            </div>
                         ) : (
                             <FileDiffHunks
                                 {...this.props}
@@ -147,4 +158,6 @@ export class FileDiffNode extends React.PureComponent<FileDiffNodeProps, State> 
     }
 
     private toggleExpand = (): void => this.setState(previousState => ({ expanded: !previousState.expanded }))
+
+    private setRenderDeleted = (): void => this.setState(() => ({ renderDeleted: true }))
 }


### PR DESCRIPTION
For work on campaigns interfaces, I needed those as a storybook as well.
While working on it, I realized two things:
- We are inconsistent with the badging for moved files, so I added a badge there as well.
- We always show the diff for deleted files by default, but most codehosts hide those by default (for good reasons, I think), so I added that functionality to ours as well.