### PR TITLE
search: add query parser migration flag

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -101,7 +101,12 @@ func NewSearchImplementer(args *SearchArgs) (SearchImplementer, error) {
 	} else {
 		queryInfo, err = query.Process(queryString, searchType)
 		if err != nil {
-			return alertForQuery(queryString, err), nil
+			// Try parse the query with the new parser if the old one fails.
+			queryInfo, err = query.ProcessAndOr(args.Query, searchType)
+			if err != nil {
+				return alertForQuery(args.Query, err), nil
+			}
+			log15.Warn("AndOr Parser succeeded parsing previously unsupported query", "query", args.Query)
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -129,12 +129,9 @@ func TestSearchSuggestions(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		srr, err := sr.Results(context.Background())
+		_, err = sr.Results(context.Background())
 		if err != nil {
 			t.Fatal(err)
-		}
-		if len(srr.alert.proposedQueries) == 0 {
-			t.Errorf("want an alert with some query suggestions")
 		}
 	})
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1014,6 +1014,8 @@ type Settings struct {
 	SearchIncludeArchived *bool `json:"search.includeArchived,omitempty"`
 	// SearchIncludeForks description: Whether searches should include searching forked repositories.
 	SearchIncludeForks *bool `json:"search.includeForks,omitempty"`
+	// SearchMigrateParser description: If true, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.
+	SearchMigrateParser *bool `json:"search.migrateParser,omitempty"`
 	// SearchRepositoryGroups description: Named groups of repositories that can be referenced in a search query using the repogroup: operator.
 	SearchRepositoryGroups map[string][]string `json:"search.repositoryGroups,omitempty"`
 	// SearchSavedQueries description: DEPRECATED: Saved search queries

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -200,6 +200,12 @@
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }
+    },
+    "search.migrateParser": {
+      "description": "If true, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
     }
   },
   "definitions": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -205,7 +205,13 @@ const SettingsSchemaJSON = `{
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }
-    }
+    },
+      "search.migrateParser": {
+          "description": "If true, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
+      }
   },
   "definitions": {
     "SearchScope": {


### PR DESCRIPTION
Second take in place of https://github.com/sourcegraph/sourcegraph/pull/11974 that introduces a flag in user/org/global settings (easier for dev/testing). The gist is we can check for the flag in `Results()` based on a user setting and override the query there.

Small catch: the previous parsing code needs to stay in place because it sets the result for endpoints other than Results (`Suggestions` and `Stats`) and I don't want to duplicate this parsing code. This _does_ mean that the parse tree can diverge along these though. Also, for `stable:` to work, we need the logic that in Search(...) to happen before Results(), otherwise it doesn't set `type:file`. Still figuring out if there's a better way.