### PR TITLE
Delete cloning tab from the site-admin repositories page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Backwards compatibility for "critical configuration" (a type of configuration that was deprecated in December 2019) was removed. All critical configuration now belongs in site configuration.
 - Experimental feature setting `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }` will be removed in 3.19. It is now always on. Please remove references to it.
-- Removed "Cloning" tab in site-admin Repository Status page.
+- Removed "Cloning" tab in site-admin Repository Status page. [#12043](https://github.com/sourcegraph/sourcegraph/pull/12043)
 
 ## 3.17.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Backwards compatibility for "critical configuration" (a type of configuration that was deprecated in December 2019) was removed. All critical configuration now belongs in site configuration.
 - Experimental feature setting `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }` will be removed in 3.19. It is now always on. Please remove references to it.
+- Removed "Cloning" tab in site-admin Repository Status page.
 
 ## 3.17.3
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1157,6 +1157,7 @@ type Query {
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
+        # DEPRECATED: This will be removed.
         cloneInProgress: Boolean = true
         # Include repositories that are not yet cloned and for which cloning is not in progress.
         notCloned: Boolean = true

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1164,6 +1164,7 @@ type Query {
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
+        # DEPRECATED: This will be removed.
         cloneInProgress: Boolean = true
         # Include repositories that are not yet cloned and for which cloning is not in progress.
         notCloned: Boolean = true

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -85,12 +85,6 @@ const FILTERS: FilteredConnectionFilter[] = [
         args: { cloned: true, cloneInProgress: false, notCloned: false },
     },
     {
-        label: 'Cloning',
-        id: 'cloning',
-        tooltip: 'Show only repositories that are currently being cloned',
-        args: { cloned: false, cloneInProgress: true, notCloned: false },
-    },
-    {
         label: 'Not cloned',
         id: 'not-cloned',
         tooltip: 'Show only repositories that have not been cloned yet',


### PR DESCRIPTION
This PR removes the `Cloning` tab from the site-admin repositories list and the `cloneInProgress` API parameter from the `Repositories` API.

<img width="970" alt="Screenshot 2020-07-09 at 12 39 50" src="https://user-images.githubusercontent.com/2102036/87017730-671d5780-c1e1-11ea-8e05-8e87dfed7657.png">

Context: This page being slow, and this information being already provided in the activity progress indicator for site admin, we decided to remove it.

More information on issue #11029, particularly in this [discussion](https://github.com/sourcegraph/sourcegraph/issues/11029#issuecomment-651836231)
