### PR TITLE
monitoring: fix alert banner wording, link to grafana

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -312,7 +312,7 @@ func observabilityActiveAlertsAlert(prometheusURL string) func(AlertFuncArgs) []
 		if criticalAlerts == 0 {
 			return nil
 		}
-		msg := fmt.Sprintf("%s across %s are currently firing - [view alerts](/-/debug/grafana)",
+		msg := fmt.Sprintf("%s across %s currently firing - [view alerts](/-/debug/grafana)",
 			pluralize(criticalAlerts, "critical alert", "critical alerts"),
 			pluralize(servicesCritical, "service", "services"))
 		return []*Alert{{TypeValue: AlertTypeError, MessageValue: msg}}

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -33,6 +33,12 @@ export interface LayoutRouteProps<Params extends { [K in keyof Params]?: string 
     condition?: (props: LayoutRouteComponentProps<Params>) => boolean
 }
 
+// Force a hard reload so that we delegate to the serverside HTTP handler for a route.
+function passThroughToServer(): React.ReactNode {
+    window.location.reload()
+    return null
+}
+
 /**
  * Holds all top-level routes for the app because both the navbar and the main content area need to
  * switch over matched path.
@@ -142,13 +148,11 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: '/help',
-        render: () => {
-            // Force a hard reload so that we delegate to the HTTP handler for /help, which handles
-            // redirecting /help to https://docs.sourcegraph.com. That logic is not duplicated in
-            // the web app because that would add complexity with no user benefit.
-            window.location.reload()
-            return null
-        },
+        render: passThroughToServer,
+    },
+    {
+        path: '/-/debug/*',
+        render: passThroughToServer,
     },
     {
         path: '/snippets',


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/issues/12026

* remove "are" from message so that the message is okay for all pluralities ("1 alert across 1 service currently firing", "12 alerts across 4 services currently firing")
* trigger a `window.location` reload on `/-/debug/*` paths so that the link in the alert to grafana works ([thread](https://sourcegraph.slack.com/archives/CHPC7UX16/p1594216721153200?thread_ts=1594212174.150300&cid=CHPC7UX16))

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
