### PR TITLE
monitoring: improved notification timings, resolved templates

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/alertmanager.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/alertmanager.go
@@ -9,6 +9,7 @@ import (
 
 	amclient "github.com/prometheus/alertmanager/api/v2/client"
 	"github.com/prometheus/alertmanager/api/v2/client/general"
+	"github.com/prometheus/common/model"
 )
 
 // Prefix to serve alertmanager on. If you change this, make sure you update prometheus.yml as well
@@ -64,4 +65,9 @@ func reloadAlertmanager(ctx context.Context) error {
 		return fmt.Errorf("reload failed with status %d: %s", resp.StatusCode, string(data))
 	}
 	return nil
+}
+
+func duration(dur time.Duration) *model.Duration {
+	d := model.Duration(dur)
+	return &d
 }

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	amconfig "github.com/prometheus/alertmanager/config"
@@ -36,25 +37,32 @@ func changeReceivers(ctx context.Context, log log15.Logger, change ChangeContext
 		Name: alertmanagerNoopReceiver,
 	})
 
-	// include `alertname` for now to accomodate non-generator alerts - in the long run, we want to remove grouping on `alertname`
-	// because all alerts should have some predefined labels
-	// https://github.com/sourcegraph/sourcegraph/issues/5370
-	groupBy := []string{"alertname", "level", "service_name", "name"}
 	// make sure alerts are routed appropriately
 	change.AMConfig.Route = &amconfig.Route{
-		Receiver:   alertmanagerNoopReceiver,
-		GroupByStr: groupBy,
+		Receiver: alertmanagerNoopReceiver,
+		// include `alertname` for now to accommodate non-generator alerts - in the long run, we want to remove grouping on `alertname`
+		// because all alerts should have some predefined labels
+		// https://github.com/sourcegraph/sourcegraph/issues/5370
+		GroupByStr: []string{"alertname", "level", "service_name", "name"},
+
+		// How long to initially wait to send a notification for a group - each group matches exactly one alert, so fire immediately
+		GroupWait: duration(1 * time.Second),
+
+		// How long to wait before sending a notification about new alerts that are added to a group of alerts - in this case,
+		// equivalent to how long to wait until notifying about an alert re-firing
+		GroupInterval:  duration(1 * time.Minute),
+		RepeatInterval: duration(48 * time.Hour),
+
+		// Route alerts to notifications
 		Routes: []*amconfig.Route{
 			{
-				Receiver:   alertmanagerWarningReceiver,
-				GroupByStr: groupBy,
+				Receiver: alertmanagerWarningReceiver,
 				Match: map[string]string{
 					"level": "warning",
 				},
 			},
 			{
-				Receiver:   alertmanagerCriticalReceiver,
-				GroupByStr: groupBy,
+				Receiver: alertmanagerCriticalReceiver,
 				Match: map[string]string{
 					"level": "critical",
 				},

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -34,7 +34,7 @@ var (
 	// Body templates
 	firingBodyTemplate = fmt.Sprintf(`{{ .CommonLabels.level | title }} alert '{{ .CommonLabels.name }}' is firing for service '{{ .CommonLabels.service_name }}'.
 
-	For possible solutions, please refer to %s`, alertSolutionsURLTemplate)
+For possible solutions, please refer to %s`, alertSolutionsURLTemplate)
 	resolvedBodyTemplate     = `{{ .CommonLabels.level | title }} alert '{{ .CommonLabels.name }}' for service '{{ .CommonLabels.service_name }}' has resolved.`
 	notificationBodyTemplate = fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, firingBodyTemplate, resolvedBodyTemplate)
 )

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -18,16 +18,25 @@ const (
 const (
 	colorWarning  = "#FFFF00" // yellow
 	colorCritical = "#FF0000" // red
+	colorGood     = "#00FF00" // green
 )
 
 var (
 	// Alertmanager notification template reference: https://prometheus.io/docs/alerting/latest/notifications
 	// All labels used in these templates should be included in route.GroupByStr
-	alertSolutionsTemplate    = `https://docs.sourcegraph.com/admin/observability/alert_solutions#{{ .CommonLabels.service_name }}-{{ .CommonLabels.name | reReplaceAll "(_low|_high)$" "" | reReplaceAll "_" "-" }}`
-	notificationTitleTemplate = "[{{ .CommonLabels.level | toUpper }}] {{ .CommonLabels.description }}"
-	notificationBodyTemplate  = fmt.Sprintf(`{{ .CommonLabels.level | title }} alert '{{ .CommonLabels.name }}' is firing for service '{{ .CommonLabels.service_name }}'.
+	alertSolutionsURLTemplate = `https://docs.sourcegraph.com/admin/observability/alert_solutions#{{ .CommonLabels.service_name }}-{{ .CommonLabels.name | reReplaceAll "(_low|_high)$" "" | reReplaceAll "_" "-" }}`
 
-For possible solutions, please refer to %s`, alertSolutionsTemplate)
+	// Title templates
+	firingTitleTemplate       = "[{{ .CommonLabels.level | toUpper }}] {{ .CommonLabels.description }}"
+	resolvedTitleTemplate     = "[RESOLVED] {{ .CommonLabels.description }}"
+	notificationTitleTemplate = fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, firingTitleTemplate, resolvedTitleTemplate)
+
+	// Body templates
+	firingBodyTemplate = fmt.Sprintf(`{{ .CommonLabels.level | title }} alert '{{ .CommonLabels.name }}' is firing for service '{{ .CommonLabels.service_name }}'.
+
+	For possible solutions, please refer to %s`, alertSolutionsURLTemplate)
+	resolvedBodyTemplate     = `{{ .CommonLabels.level | title }} alert '{{ .CommonLabels.name }}' for service '{{ .CommonLabels.service_name }}' has resolved.`
+	notificationBodyTemplate = fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, firingBodyTemplate, resolvedBodyTemplate)
 )
 
 // newReceivers converts the given alerts from Sourcegraph site configuration into Alertmanager receivers.
@@ -48,6 +57,7 @@ func newReceivers(newAlerts []*schema.ObservabilityAlerts, newProblem func(error
 			receiver = warningReceiver
 			color = colorWarning
 		}
+		colorTemplate := fmt.Sprintf(`{{ if eq .Status "firing" }}%s{{ else }}%s{{ end }}`, color, colorGood)
 
 		notifierConfig := amconfig.NotifierConfig{
 			VSendResolved: !alert.DisableSendResolved,
@@ -74,12 +84,12 @@ func newReceivers(newAlerts []*schema.ObservabilityAlerts, newProblem func(error
 		case notifier.Opsgenie != nil:
 			var apiURL *amconfig.URL
 			if notifier.Opsgenie.ApiUrl != "" {
-				url, err := url.Parse(notifier.Opsgenie.ApiUrl)
+				u, err := url.Parse(notifier.Opsgenie.ApiUrl)
 				if err != nil {
 					newProblem(fmt.Errorf("failed to apply notifier %d: %w", i, err))
 					continue
 				}
-				apiURL = &amconfig.URL{URL: url}
+				apiURL = &amconfig.URL{URL: u}
 			}
 			responders := make([]amconfig.OpsGenieConfigResponder, len(notifier.Opsgenie.Responders))
 			for i, resp := range notifier.Opsgenie.Responders {
@@ -105,12 +115,12 @@ func newReceivers(newAlerts []*schema.ObservabilityAlerts, newProblem func(error
 		case notifier.Pagerduty != nil:
 			var apiURL *amconfig.URL
 			if notifier.Pagerduty.ApiUrl != "" {
-				url, err := url.Parse(notifier.Pagerduty.ApiUrl)
+				u, err := url.Parse(notifier.Pagerduty.ApiUrl)
 				if err != nil {
 					newProblem(fmt.Errorf("failed to apply notifier %d: %w", i, err))
 					continue
 				}
-				apiURL = &amconfig.URL{URL: url}
+				apiURL = &amconfig.URL{URL: u}
 			}
 			receiver.PagerdutyConfigs = append(receiver.PagerdutyConfigs, &amconfig.PagerdutyConfig{
 				RoutingKey: amconfig.Secret(notifier.Pagerduty.IntegrationKey),
@@ -120,7 +130,7 @@ func newReceivers(newAlerts []*schema.ObservabilityAlerts, newProblem func(error
 				Description: notificationTitleTemplate,
 				Links: []amconfig.PagerdutyLink{{
 					Text: "Alert solutions",
-					Href: alertSolutionsTemplate,
+					Href: alertSolutionsURLTemplate,
 				}},
 
 				NotifierConfig: notifierConfig,
@@ -128,7 +138,7 @@ func newReceivers(newAlerts []*schema.ObservabilityAlerts, newProblem func(error
 
 		// https://prometheus.io/docs/alerting/latest/configuration/#slack_config
 		case notifier.Slack != nil:
-			url, err := url.Parse(notifier.Slack.Url)
+			u, err := url.Parse(notifier.Slack.Url)
 			if err != nil {
 				newProblem(fmt.Errorf("failed to apply notifier %d: %w", i, err))
 				continue
@@ -138,29 +148,29 @@ func newReceivers(newAlerts []*schema.ObservabilityAlerts, newProblem func(error
 			}
 
 			receiver.SlackConfigs = append(receiver.SlackConfigs, &amconfig.SlackConfig{
-				APIURL:    &amconfig.SecretURL{URL: url},
+				APIURL:    &amconfig.SecretURL{URL: u},
 				Username:  notifier.Slack.Username,
 				Channel:   notifier.Slack.Recipient,
 				IconEmoji: notifier.Slack.Icon_emoji,
 				IconURL:   notifier.Slack.Icon_url,
 
 				Title:     notificationTitleTemplate,
-				TitleLink: alertSolutionsTemplate,
+				TitleLink: alertSolutionsURLTemplate,
 				Text:      notificationBodyTemplate,
-				Color:     color,
+				Color:     colorTemplate,
 
 				NotifierConfig: notifierConfig,
 			})
 
 		// https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
 		case notifier.Webhook != nil:
-			url, err := url.Parse(notifier.Webhook.Url)
+			u, err := url.Parse(notifier.Webhook.Url)
 			if err != nil {
 				newProblem(fmt.Errorf("failed to apply notifier %d: %w", i, err))
 				continue
 			}
 			receiver.WebhookConfigs = append(receiver.WebhookConfigs, &amconfig.WebhookConfig{
-				URL: &amconfig.URL{URL: url},
+				URL: &amconfig.URL{URL: u},
 				HTTPConfig: &commoncfg.HTTPClientConfig{
 					BasicAuth: &commoncfg.BasicAuth{
 						Username: notifier.Webhook.Username,


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/issues/12026

* timings improvements
    * group == alert, so reduce time to initial notification and increase re-notify time to 2d
* resolved vs firing
    * after a closer look, I believe a lot of the spam in #alerts is actually alerts resolving - turns out the templates don't currently account for this

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

<img width="413" alt="image" src="https://user-images.githubusercontent.com/23356519/87036305-365b1380-c21d-11ea-8645-e13e53bbf377.png">
