### PR TITLE
New campaigns flow: implement moveCampaign mutation

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -54,9 +54,9 @@ type OrgResolver struct {
 
 func NewOrg(org *types.Org) *OrgResolver { return &OrgResolver{org: org} }
 
-func (o *OrgResolver) ID() graphql.ID { return marshalOrgID(o.org.ID) }
+func (o *OrgResolver) ID() graphql.ID { return MarshalOrgID(o.org.ID) }
 
-func marshalOrgID(id int32) graphql.ID { return relay.MarshalID("Org", id) }
+func MarshalOrgID(id int32) graphql.ID { return relay.MarshalID("Org", id) }
 
 func UnmarshalOrgID(id graphql.ID) (orgID int32, err error) {
 	err = relay.UnmarshalSpec(id, &orgID)

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -82,7 +82,7 @@ func (r savedSearchResolver) Query() string { return r.s.Query }
 
 func (r savedSearchResolver) Namespace(ctx context.Context) (*NamespaceResolver, error) {
 	if r.s.OrgID != nil {
-		n, err := NamespaceByID(ctx, marshalOrgID(*r.s.OrgID))
+		n, err := NamespaceByID(ctx, MarshalOrgID(*r.s.OrgID))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This implements the next missing mutation as part of #11675: `moveCampaign`.

It also adds "null ID" tests and fixes one that was failing.