### PR TITLE
 Repo group dark mode

### DIFF
--- a/web/src/repogroups/RepogroupPage.scss
+++ b/web/src/repogroups/RepogroupPage.scss
@@ -7,15 +7,6 @@
     overflow: auto;
     padding-bottom: 4rem;
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        color: $gray-14;
-    }
-
     &__logo {
         width: 3rem;
         height: 3rem;
@@ -50,6 +41,11 @@
         }
     }
 
+    &__content-description {
+        font-size: 16px;
+        line-height: 150%;
+    }
+
     &__repo-card {
         padding: 1rem;
         background: $color-bg-2;
@@ -60,7 +56,7 @@
         padding-right: 2rem;
     }
 
-    &__keyword-text {
+    &__keyword-text .highlight  {
         color: #1c7cd6;
     }
 
@@ -70,7 +66,6 @@
 
     &__repo-list-icon {
         margin-right: 0.5rem;
-        color: #cad2e2;
     }
 
     &__example-bar {
@@ -91,16 +86,79 @@
     }
 
     &__web-link {
-        color: #1c7cd6;
         font-size: 12px;
     }
 }
 
 .theme-light {
     .repogroup-page {
+
         &__repo-card {
             background: #f7fafd;
             border-color: $color-light-border-2;
         }
+
+        h1, h2 {
+            color: #39496A;
+        }
+
+        h3, h4, h6 {
+            color: #566E9F;
+        }
+
+        h5 {
+            color: #32405D;
+        }
+
+        &__web-link {
+            color: #1C7CD6;
+        }
+
+        &__repo-list-icon {
+            color: #6D84B0;
+        }
+
+        &__repo-list-icon {
+            color: #cad2e2;
+        }
+    }
+}
+
+.theme-dark {
+
+    .repogroup-page {
+
+        h1, h2 {
+            color: #889ABF;
+        }
+
+        h3, h4, h6 {
+            color: #95A5C6;
+        }
+
+        span.h3 {
+            color: #889ABF;
+        }
+
+        h5 {
+            color: #D7DDEA;
+        }
+
+        p, i {
+            color: #AFBCD4;
+        }
+
+        &__web-link {
+            color: #329AF0;
+        }
+
+        &__repo-list-icon {
+            color: #475C85;
+        }
+
+        &__keyword-text {
+            color: #A2B0CD;
+        }
+
     }
 }

--- a/web/src/repogroups/RepogroupPage.scss
+++ b/web/src/repogroups/RepogroupPage.scss
@@ -38,12 +38,9 @@
 
         &-description {
             max-width: 60rem;
+            font-size: 16px;
+            line-height: 150%;
         }
-    }
-
-    &__content-description {
-        font-size: 16px;
-        line-height: 150%;
     }
 
     &__repo-card {
@@ -89,17 +86,19 @@
 
 .theme-light {
     .repogroup-page {
-
         &__repo-card {
             background: #f7fafd;
             border-color: $color-light-border-2;
         }
 
-        h1, h2 {
+        h1,
+        h2 {
             color: $gray-17;
         }
 
-        h3, h4, h6 {
+        h3,
+        h4,
+        h6 {
             color: $color-border-hover;
         }
 
@@ -108,32 +107,30 @@
         }
 
         &__web-link {
-            color: #1C7CD6;
+            color: #1c7cd6;
         }
 
-        &__keyword-text  {
+        &__keyword-text {
             color: #1c7cd6;
         }
 
         &__repo-list-icon {
             color: $gray-11;
         }
-
-        &__repo-list-icon {
-            color: $color-light-border;
-        }
     }
 }
 
 .theme-dark {
-
     .repogroup-page {
-
-        h1, h2 {
+        h1,
+        h2 {
             color: $gray-05;
         }
 
-        h3, span.h3,  h4, h6 {
+        h3,
+        span.h3,
+        h4,
+        h6 {
             color: $gray-08;
         }
 
@@ -141,12 +138,13 @@
             color: $gray-03;
         }
 
-        p, i {
+        p,
+        i {
             color: $gray-06;
         }
 
         &__web-link {
-            color: #329AF0;
+            color: #329af0;
         }
 
         &__repo-list-icon {
@@ -154,8 +152,7 @@
         }
 
         &__keyword-text {
-            color: #329AF0;
+            color: #329af0;
         }
-
     }
 }

--- a/web/src/repogroups/RepogroupPage.scss
+++ b/web/src/repogroups/RepogroupPage.scss
@@ -73,6 +73,7 @@
         height: fit-content;
         font-size: 12px;
         background-color: transparent;
+        border-radius: 2px 0 0 2px;
     }
 
     &__repo-item {
@@ -99,27 +100,27 @@
         }
 
         h1, h2 {
-            color: #39496A;
+            color: $gray-17;
         }
 
         h3, h4, h6 {
-            color: #566E9F;
+            color: $color-border-hover;
         }
 
         h5 {
-            color: #32405D;
+            color: $gray-18;
         }
 
         &__web-link {
-            color: #1C7CD6;
+            color: #1C7CD6; /*todo: i can't find the definition for this color*/
         }
 
         &__repo-list-icon {
-            color: #6D84B0;
+            color: $gray-11;
         }
 
         &__repo-list-icon {
-            color: #cad2e2;
+            color: $color-light-border;
         }
     }
 }
@@ -129,23 +130,19 @@
     .repogroup-page {
 
         h1, h2 {
-            color: #889ABF;
+            color: $gray-09;
         }
 
-        h3, h4, h6 {
-            color: #95A5C6;
-        }
-
-        span.h3 {
-            color: #889ABF;
+        h3, span.h3,  h4, h6 {
+            color: $gray-08;
         }
 
         h5 {
-            color: #D7DDEA;
+            color: $gray-03;
         }
 
         p, i {
-            color: #AFBCD4;
+            color: $gray-06;
         }
 
         &__web-link {
@@ -153,11 +150,11 @@
         }
 
         &__repo-list-icon {
-            color: #475C85;
+            color: $gray-15;
         }
 
         &__keyword-text {
-            color: #A2B0CD;
+            color: $color-text-1;
         }
 
     }

--- a/web/src/repogroups/RepogroupPage.scss
+++ b/web/src/repogroups/RepogroupPage.scss
@@ -56,10 +56,6 @@
         padding-right: 2rem;
     }
 
-    &__keyword-text .highlight  {
-        color: #1c7cd6;
-    }
-
     &__subheading {
         margin-top: 1.5rem;
     }
@@ -112,7 +108,11 @@
         }
 
         &__web-link {
-            color: #1C7CD6; /*todo: i can't find the definition for this color*/
+            color: #1C7CD6;
+        }
+
+        &__keyword-text  {
+            color: #1c7cd6;
         }
 
         &__repo-list-icon {
@@ -130,7 +130,7 @@
     .repogroup-page {
 
         h1, h2 {
-            color: $gray-09;
+            color: $gray-05;
         }
 
         h3, span.h3,  h4, h6 {
@@ -154,7 +154,7 @@
         }
 
         &__keyword-text {
-            color: $color-text-1;
+            color: #329AF0;
         }
 
     }

--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -92,8 +92,8 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                 text={props.repogroupMetadata.title}
             />
             <div className="repogroup-page__subheading">
-                <span className="text-monospace">
-                    <span className="repogroup-page__keyword-text">repogroup:</span>
+                <span className="repogroup-page__keyword-text text-monospace">
+                    <span className="highlight">repogroup:</span>
                     {props.repogroupMetadata.name}
                 </span>
             </div>
@@ -110,7 +110,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                             <h3 className="mb-3">{example.title}</h3>
                             <p>{example.description}</p>
                             <div className="d-flex mb-4">
-                                <div className="repogroup-page__example-bar form-control text-monospace">
+                                <div className="repogroup-page__example-bar form-control text-monospace ">
                                     <span className="repogroup-page__keyword-text">repogroup:</span>
                                     {props.repogroupMetadata.name} {example.exampleQuery}
                                 </div>

--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -92,8 +92,8 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                 text={props.repogroupMetadata.title}
             />
             <div className="repogroup-page__subheading">
-                <span className="repogroup-page__keyword-text text-monospace">
-                    <span>repogroup:</span>
+                <span className="text-monospace">
+                    <span className="repogroup-page__keyword-text">repogroup:</span>
                     {props.repogroupMetadata.name}
                 </span>
             </div>

--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -105,8 +105,10 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                     <p className="repogroup-page__content-description h5 font-weight-normal mb-4">
                         {props.repogroupMetadata.description}
                     </p>
+
+                    <h2>Search examples</h2>
                     {props.repogroupMetadata.examples.map(example => (
-                        <>
+                        <div className="mt-3" key={example.title}>
                             <h3 className="mb-3">{example.title}</h3>
                             <p>{example.description}</p>
                             <div className="d-flex mb-4">
@@ -128,7 +130,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                                     </button>
                                 </div>
                             </div>
-                        </>
+                        </div>
                     ))}
                 </div>
                 <div className="repogroup-page__column">

--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -93,7 +93,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
             />
             <div className="repogroup-page__subheading">
                 <span className="repogroup-page__keyword-text text-monospace">
-                    <span className="highlight">repogroup:</span>
+                    <span>repogroup:</span>
                     {props.repogroupMetadata.name}
                 </span>
             </div>

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -15,6 +15,21 @@
     overflow: auto;
     padding-bottom: 4rem;
 
+    &__web-link {
+        color: #1C7CD6;
+    }
+
+    h5 {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+    }
+
+    p {
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+    }
+
     &__logo {
         flex: 0 0 auto;
         display: flex;
@@ -82,25 +97,18 @@
         display: grid;
         grid-template-columns: 2fr 1fr 2fr;
         column-gap: 2rem;
+        color: #475C85;
 
-        &-header {
-            color: $gray-14;
-        }
 
         &-subheading {
-            color: $gray-07;
-            margin-bottom: 0.5rem;
+            margin-bottom: 1rem;
         }
-    }
-
-    &__web-link {
-        color: #1c7cd6;
     }
 
     &__keyword-value-text {
-        color: '#6078A9';
-        font-size: '12px';
-        line-height: '140%';
+        color: #6078A9;
+        font-size: 12px;
+        line-height: 140%;
     }
 
     &__repogroup-listing-title {
@@ -121,6 +129,46 @@
     .search-page {
         &__sign-in {
             color: $color-light-text-4;
+        }
+
+        h1, h2 {
+            color: #2B3750;
+        }
+
+        h3, h4, h6 {
+            color: #566E9F;
+        }
+
+        h5 {
+            color: #32405D;
+        }
+
+        &__web-link {
+            color: #1C7CD6;
+        }
+    }
+}
+
+.theme-dark {
+    .search-page {
+        h1, h2 {
+            color: #889ABF;
+        }
+
+        h3, h4, h6 {
+            color: #95A5C6;
+        }
+
+        h5 {
+            color: #D7DDEA;
+        }
+
+        p, i {
+            color: #AFBCD4;
+        }
+
+        &__web-link {
+            color: #329AF0;
         }
     }
 }

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -97,7 +97,7 @@
         display: grid;
         grid-template-columns: 2fr 1fr 2fr;
         column-gap: 2rem;
-        color: #475C85;
+        color: $gray-13;
 
 
         &-subheading {
@@ -132,15 +132,15 @@
         }
 
         h1, h2 {
-            color: #2B3750;
+            color: $gray-19;
         }
 
         h3, h4, h6 {
-            color: #566E9F;
+            color: $gray-13;
         }
 
         h5 {
-            color: #32405D;
+            color: $gray-18;
         }
 
         &__web-link {
@@ -152,19 +152,19 @@
 .theme-dark {
     .search-page {
         h1, h2 {
-            color: #889ABF;
+            color: $gray-09;
         }
 
         h3, h4, h6 {
-            color: #95A5C6;
+            color: $gray-08;
         }
 
         h5 {
-            color: #D7DDEA;
+            color: $gray-03;
         }
 
         p, i {
-            color: #AFBCD4;
+            color: $gray-06;
         }
 
         &__web-link {

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -97,8 +97,6 @@
         display: grid;
         grid-template-columns: 2fr 1fr 2fr;
         column-gap: 2rem;
-        color: $gray-13;
-
 
         &-subheading {
             margin-bottom: 1rem;
@@ -143,7 +141,25 @@
             color: $gray-18;
         }
 
+        strong {
+            color: $gray-11
+        }
+
+        &__help-content {
+            color: $gray-11;
+        }
+
+        &__example-searches {
+            a {
+                color: $gray-19;
+            }
+        }
+
         &__web-link {
+            color: #1C7CD6;
+        }
+
+        &__keyword-text {
             color: #1C7CD6;
         }
     }
@@ -167,7 +183,21 @@
             color: $gray-06;
         }
 
+        strong {
+            color: $gray-11
+        }
+
+        &__example-searches {
+            a {
+                color: $white;
+            }
+        }
+
         &__web-link {
+            color: #329AF0;
+        }
+
+        &__keyword-text {
             color: #329AF0;
         }
     }

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -16,7 +16,7 @@
     padding-bottom: 4rem;
 
     &__web-link {
-        color: #1C7CD6;
+        color: #1c7cd6;
     }
 
     h5 {
@@ -104,7 +104,7 @@
     }
 
     &__keyword-value-text {
-        color: #6078A9;
+        color: #6078a9;
         font-size: 12px;
         line-height: 140%;
     }
@@ -129,11 +129,14 @@
             color: $color-light-text-4;
         }
 
-        h1, h2 {
+        h1,
+        h2 {
             color: $gray-19;
         }
 
-        h3, h4, h6 {
+        h3,
+        h4,
+        h6 {
             color: $gray-13;
         }
 
@@ -142,7 +145,7 @@
         }
 
         strong {
-            color: $gray-11
+            color: $gray-11;
         }
 
         &__help-content {
@@ -156,22 +159,25 @@
         }
 
         &__web-link {
-            color: #1C7CD6;
+            color: #1c7cd6;
         }
 
         &__keyword-text {
-            color: #1C7CD6;
+            color: #1c7cd6;
         }
     }
 }
 
 .theme-dark {
     .search-page {
-        h1, h2 {
+        h1,
+        h2 {
             color: $gray-09;
         }
 
-        h3, h4, h6 {
+        h3,
+        h4,
+        h6 {
             color: $gray-08;
         }
 
@@ -179,12 +185,13 @@
             color: $gray-03;
         }
 
-        p, i {
+        p,
+        i {
             color: $gray-06;
         }
 
         strong {
-            color: $gray-11
+            color: $gray-11;
         }
 
         &__example-searches {
@@ -194,11 +201,11 @@
         }
 
         &__web-link {
-            color: #329AF0;
+            color: #329af0;
         }
 
         &__keyword-text {
-            color: #329AF0;
+            color: #329af0;
         }
     }
 }

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -133,7 +133,9 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                         <span className="search-page__keyword-text">lang:</span>javascript
                                         alert(:[variable])
                                     </Link>{' '}
-                                    <p className="mt-2">Find usages of the alert() method that displays an alert box.</p>
+                                    <p className="mt-2">
+                                        Find usages of the alert() method that displays an alert box.
+                                    </p>
                                 </li>
                                 <li className="list-group-item px-0 pt-3 pb-2">
                                     <Link
@@ -154,17 +156,12 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                         className="text-monospace mb-2"
                                     >
                                         <span className="search-page__keyword-text">repo:</span>
-                                        ^github\.com/golang/go${' '}
-                                        <span className="search-page__keyword-text">type:</span>diff{' '}
-                                        <span className="search-page__keyword-text">after:</span>"1 week ago"
+                                        ^github\.com/golang/go$ <span className="search-page__keyword-text">type:</span>
+                                        diff <span className="search-page__keyword-text">after:</span>"1 week ago"
                                     </Link>{' '}
-<<<<<<< HEAD
-                                    <p>Browse diffs for recent code changes in the 'golang/go' GitHub repository.</p>
-=======
                                     <p className="mt-2">
                                         Browse diffs for recent code changes in the 'golang/go' GitHub repository.
                                     </p>
->>>>>>> 7f5eae3f9a... syntax help and color on links.
                                 </li>
                                 <li className="list-group-item px-0 pt-3 pb-2">
                                     <Link
@@ -245,7 +242,8 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                     </dt>
                                     <dd>
                                         <p>
-                                            <strong>Regexp:</strong> <span className="text-monospace">(read|write)File</span>
+                                            <strong>Regexp:</strong>{' '}
+                                            <span className="text-monospace">(read|write)File</span>
                                         </p>
                                     </dd>{' '}
                                     <dd>
@@ -255,7 +253,8 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                     </dd>
                                     <dd>
                                         <p>
-                                            <strong>Structural:</strong> <span className="text-monospace">if(:[my_match])</span>
+                                            <strong>Structural:</strong>{' '}
+                                            <span className="text-monospace">if(:[my_match])</span>
                                         </p>
                                     </dd>
                                 </dl>

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -99,7 +99,7 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                     <div className="d-flex align-items-baseline mb-3">
                         <h3 className="search-page__help-content-header mr-2">Search in repository groups</h3>
                         <span className="text-monospace font-weight-normal search-page__lang-ref">
-                            <span className="repogroup-page__keyword-text">repogroup:</span>
+                            <span className="search-page__keyword-text">repogroup:</span>
                             <i>name</i>
                         </span>
                     </div>
@@ -122,54 +122,60 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                         ))}
                     </div>
                     <div className="search-page__help-content mt-5">
-                        <div>
+                        <div className="search-page__example-searches">
                             <h3 className="search-page__help-content-header">Example searches</h3>
                             <ul className="list-group-flush p-0 mt-2">
-                                <li className="list-group-item px-0 pb-3">
+                                <li className="list-group-item px-0 pt-3 pb-2">
                                     <Link
                                         to="/search?q=lang:javascript+alert%28:%5Bvariable%5D%29&patternType=structural"
-                                        className="text-monospace mb-1"
+                                        className="text-monospace mb-2"
                                     >
-                                        <span className="repogroup-page__keyword-text">lang:</span>javascript
+                                        <span className="search-page__keyword-text">lang:</span>javascript
                                         alert(:[variable])
                                     </Link>{' '}
-                                    <p>Find usages of the alert() method that displays an alert box.</p>
+                                    <p className="mt-2">Find usages of the alert() method that displays an alert box.</p>
                                 </li>
-                                <li className="list-group-item px-0 py-3">
+                                <li className="list-group-item px-0 pt-3 pb-2">
                                     <Link
                                         to="/search?q=lang:python+from+%5CB%5C.%5Cw%2B+import+%5Cw%2B&patternType=regexp"
-                                        className="text-monospace mb-1"
+                                        className="text-monospace mb-2"
                                     >
-                                        <span className="repogroup-page__keyword-text">lang:</span>python from \B\.\w+
+                                        <span className="search-page__keyword-text">lang:</span>python from \B\.\w+
                                         import \w+
                                     </Link>{' '}
-                                    <p>
+                                    <p className="mt-2">
                                         Search for explicit imports with one or more leading dots that indicate current
                                         and parent packages involved.
                                     </p>
                                 </li>
-                                <li className="list-group-item px-0 py-3">
+                                <li className="list-group-item px-0 pt-3 pb-2">
                                     <Link
                                         to='/search?q=repo:%5Egithub%5C.com/golang/go%24+type:diff+after:"1+week+ago"&patternType=literal"'
-                                        className="text-monospace mb-1"
+                                        className="text-monospace mb-2"
                                     >
-                                        <span className="repogroup-page__keyword-text">repo:</span>
+                                        <span className="search-page__keyword-text">repo:</span>
                                         ^github\.com/golang/go${' '}
-                                        <span className="repogroup-page__keyword-text">type:</span>diff{' '}
-                                        <span className="repogroup-page__keyword-text">after:</span>"1 week ago"
+                                        <span className="search-page__keyword-text">type:</span>diff{' '}
+                                        <span className="search-page__keyword-text">after:</span>"1 week ago"
                                     </Link>{' '}
+<<<<<<< HEAD
                                     <p>Browse diffs for recent code changes in the 'golang/go' GitHub repository.</p>
+=======
+                                    <p className="mt-2">
+                                        Browse diffs for recent code changes in the 'golang/go' GitHub repository.
+                                    </p>
+>>>>>>> 7f5eae3f9a... syntax help and color on links.
                                 </li>
-                                <li className="list-group-item px-0 py-3">
+                                <li className="list-group-item px-0 pt-3 pb-2">
                                     <Link
                                         to='/search?q=file:pod.yaml+content:"kind:+ReplicationController"&patternType=literal'
-                                        className="text-monospace mb-1"
+                                        className="text-monospace mb-2"
                                     >
-                                        <span className="repogroup-page__keyword-text">file:</span>pod.yaml{' '}
-                                        <span className="repogroup-page__keyword-text">content:</span>"kind:
+                                        <span className="search-page__keyword-text">file:</span>pod.yaml{' '}
+                                        <span className="search-page__keyword-text">content:</span>"kind:
                                         ReplicationController"
                                     </Link>{' '}
-                                    <p>
+                                    <p className="mt-2">
                                         Use a ReplicationController configuration to ensure specified number of pod
                                         replicas are running at any one time.
                                     </p>
@@ -180,8 +186,8 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                             <div className="d-flex align-items-baseline">
                                 <h3 className="search-page__help-content-header mr-2">Search a language</h3>
                                 <span className="text-monospace font-weight-normal search-page__lang-ref">
-                                    <span className="repogroup-page__keyword-text">lang:</span>
-                                    <i className="repogroup-page__keyword-value-text">name</i>
+                                    <span className="search-page__keyword-text">lang:</span>
+                                    <i className="search-page__keyword-value-text">name</i>
                                 </span>
                             </div>
                             <div className="search-page__lang-list mt-2">
@@ -237,18 +243,21 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                     <dt className="search-page__help-content-subheading">
                                         <h5>Finding matches</h5>
                                     </dt>
-                                    <dd className="text-monospace">
-                                        <p>Regexp: (read|write)File</p>
+                                    <dd>
+                                        <p>
+                                            <strong>Regexp:</strong> <span className="text-monospace">(read|write)File</span>
+                                        </p>
                                     </dd>{' '}
-                                    <dd className="text-monospace">
-                                        <p>Exact: “fs.open(f)”</p>
+                                    <dd>
+                                        <p>
+                                            <strong>Exact:</strong> <span className="text-monospace">"fs.open(f)"</span>
+                                        </p>
                                     </dd>
-                                </dl>
-                                <dl>
-                                    <dt className="search-page__help-content-subheading">
-                                        <h5>Structural Searches</h5>
-                                    </dt>
-                                    <dd className="text-monospace">:[arg] matches arguments</dd>
+                                    <dd>
+                                        <p>
+                                            <strong>Structural:</strong> <span className="text-monospace">if(:[my_match])</span>
+                                        </p>
+                                    </dd>
                                 </dl>
                             </div>
                         </div>

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -124,7 +124,7 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                     <div className="search-page__help-content mt-5">
                         <div>
                             <h3 className="search-page__help-content-header">Example searches</h3>
-                            <ul className="list-group-flush p-0">
+                            <ul className="list-group-flush p-0 mt-2">
                                 <li className="list-group-item px-0 pb-3">
                                     <Link
                                         to="/search?q=lang:javascript+alert%28:%5Bvariable%5D%29&patternType=structural"
@@ -133,7 +133,7 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                         <span className="repogroup-page__keyword-text">lang:</span>javascript
                                         alert(:[variable])
                                     </Link>{' '}
-                                    <div>Find usages of the alert() method that displays an alert box.</div>
+                                    <p>Find usages of the alert() method that displays an alert box.</p>
                                 </li>
                                 <li className="list-group-item px-0 py-3">
                                     <Link
@@ -143,10 +143,10 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                         <span className="repogroup-page__keyword-text">lang:</span>python from \B\.\w+
                                         import \w+
                                     </Link>{' '}
-                                    <div>
+                                    <p>
                                         Search for explicit imports with one or more leading dots that indicate current
                                         and parent packages involved.
-                                    </div>
+                                    </p>
                                 </li>
                                 <li className="list-group-item px-0 py-3">
                                     <Link
@@ -158,9 +158,7 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                         <span className="repogroup-page__keyword-text">type:</span>diff{' '}
                                         <span className="repogroup-page__keyword-text">after:</span>"1 week ago"
                                     </Link>{' '}
-                                    <div>
-                                        Browse diffs for recent code changes in the 'golang/go' GitHub repository.
-                                    </div>
+                                    <p>Browse diffs for recent code changes in the 'golang/go' GitHub repository.</p>
                                 </li>
                                 <li className="list-group-item px-0 py-3">
                                     <Link
@@ -171,10 +169,10 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                         <span className="repogroup-page__keyword-text">content:</span>"kind:
                                         ReplicationController"
                                     </Link>{' '}
-                                    <div>
+                                    <p>
                                         Use a ReplicationController configuration to ensure specified number of pod
                                         replicas are running at any one time.
-                                    </div>
+                                    </p>
                                 </li>
                             </ul>
                         </div>
@@ -186,7 +184,7 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                                     <i className="repogroup-page__keyword-value-text">name</i>
                                 </span>
                             </div>
-                            <div className="search-page__lang-list">
+                            <div className="search-page__lang-list mt-2">
                                 {homepageLanguageList.map(language => (
                                     <Link
                                         className="text-monospace search-page__web-link"
@@ -200,30 +198,56 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                         </div>
                         <div>
                             <h3 className="search-page__help-content-header">Search syntax</h3>
-                            <div className="search-page__lang-list">
+                            <div className="search-page__lang-list mt-3">
                                 <dl>
-                                    <dt className="search-page__help-content-subheading">Common search keywords</dt>
-                                    <dd className="text-monospace">repo:my/repo</dd>
-                                    <dd className="text-monospace">repo:github.com/myorg/</dd>
-                                    <dd className="text-monospace">file:my/file</dd>
-                                    <dd className="text-monospace">lang:javascript</dd>
+                                    <dt className="search-page__help-content-subheading">
+                                        <h5>Common search keywords</h5>
+                                    </dt>
+                                    <dd className="text-monospace">
+                                        <p>repo:my/repo</p>
+                                    </dd>
+                                    <dd className="text-monospace">
+                                        <p>repo:github.com/myorg/</p>
+                                    </dd>
+                                    <dd className="text-monospace">
+                                        <p>file:my/file</p>
+                                    </dd>
+                                    <dd className="text-monospace">
+                                        <p>lang:javascript</p>
+                                    </dd>
                                 </dl>
                                 <dl>
                                     <dt className="search-page__help-content-subheading">
-                                        Diff/commit search keywords:
+                                        <h5>Diff/commit search keywords</h5>
                                     </dt>
-                                    <dd className="text-monospace">type:diff or type:commit</dd>
-                                    <dd className="text-monospace">after:"2 weeks ago"</dd>
-                                    <dd className="text-monospace">author:alice@example.com</dd>{' '}
-                                    <dd className="text-monospace">repo:r@*refs/heads/ (all branches)</dd>
+                                    <dd className="text-monospace">
+                                        <p>type:diff or type:commit</p>
+                                    </dd>
+                                    <dd className="text-monospace">
+                                        <p>after:”2 weeks ago”</p>
+                                    </dd>
+                                    <dd className="text-monospace">
+                                        <p>author:alice@example.com</p>
+                                    </dd>{' '}
+                                    <dd className="text-monospace">
+                                        <p>repo:r@*refs/heads/ (all branches)</p>
+                                    </dd>
                                 </dl>
                                 <dl>
-                                    <dt className="search-page__help-content-subheading">Finding matches</dt>
-                                    <dd className="text-monospace">Regexp: (read|write)File</dd>{' '}
-                                    <dd className="text-monospace">Exact: "fs.open(f)"</dd>
+                                    <dt className="search-page__help-content-subheading">
+                                        <h5>Finding matches</h5>
+                                    </dt>
+                                    <dd className="text-monospace">
+                                        <p>Regexp: (read|write)File</p>
+                                    </dd>{' '}
+                                    <dd className="text-monospace">
+                                        <p>Exact: “fs.open(f)”</p>
+                                    </dd>
                                 </dl>
                                 <dl>
-                                    <dt className="search-page__help-content-subheading">Structural Searches</dt>
+                                    <dt className="search-page__help-content-subheading">
+                                        <h5>Structural Searches</h5>
+                                    </dt>
                                     <dd className="text-monospace">:[arg] matches arguments</dd>
                                 </dl>
                             </div>


### PR DESCRIPTION
Fixes #11922

Fixes contrast issues with dark mode, corrects text and link colors, segments light and dark colors from styles and other issues related to the new homepage. 

Home before:

![Screen Shot 2020-07-09 at 8 34 03 PM](https://user-images.githubusercontent.com/539268/87113659-9e145d00-c223-11ea-9a75-9b08e4377709.png)

Home after:

![Screen Shot 2020-07-09 at 8 34 16 PM](https://user-images.githubusercontent.com/539268/87113677-a8365b80-c223-11ea-844a-1590e6809a22.png)


Repository group page before:

![Screen Shot 2020-07-09 at 8 34 09 PM](https://user-images.githubusercontent.com/539268/87113687-b1272d00-c223-11ea-8ee2-bae30fc093d4.png)

Repository group page after:

![Screen Shot 2020-07-09 at 8 34 20 PM](https://user-images.githubusercontent.com/539268/87113704-bb492b80-c223-11ea-992e-414eb180c184.png)

