### PR TITLE
search: remove dead function SearchRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -943,43 +943,6 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 	return suggestions, nil
 }
 
-// SearchRepos searches for the provided query but only the the unique list of
-// repositories belonging to the search results.
-// It's used by campaigns to search.
-func SearchRepos(ctx context.Context, plainQuery string) ([]*RepositoryResolver, error) {
-	queryString := query.ConvertToLiteral(plainQuery)
-
-	var queryInfo query.QueryInfo
-	var err error
-	if conf.AndOrQueryEnabled() {
-		andOrQuery, err := query.ParseAndOr(plainQuery)
-		if err != nil {
-			return nil, err
-		}
-		queryInfo = &query.AndOrQuery{Query: andOrQuery}
-	} else {
-		queryInfo, err = query.ParseAndCheck(queryString)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	sr := &searchResolver{
-		query:         queryInfo,
-		originalQuery: plainQuery,
-		pagination:    nil,
-		patternType:   query.SearchTypeLiteral,
-		zoekt:         search.Indexed(),
-		searcherURLs:  search.SearcherURLs(),
-	}
-
-	results, err := sr.Results(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return results.Repositories(), nil
-}
-
 func unionRegExps(patterns []string) string {
 	if len(patterns) == 0 {
 		return ""


### PR DESCRIPTION
This looks dead as of that other PR that removed a bunch of campaigns stuff. It was introduced as part of https://github.com/sourcegraph/sourcegraph/commit/61c29221e06580e831d6119ab16cfe524928c4f4 and there are no references to `type RepoSearcher` or `SearchRepos` introduced there.

If we can get rid of this it would help me with a refactor :3