### PR TITLE
gqltest: add search integration tests

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -274,4 +274,39 @@ func TestSearch(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("global filename search", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			query          string
+			wantMinResults int
+			wantMaxResults int
+		}{
+			{
+				name:           "search for a non-existent file",
+				query:          "file:asdfasdf.go",
+				wantMaxResults: 0,
+			},
+			{
+				name:           "search for a common file",
+				query:          "file:doc.go",
+				wantMinResults: 5,
+				wantMaxResults: -1,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if test.wantMaxResults != -1 && len(results.Results) > test.wantMaxResults {
+					t.Fatalf("Want results to be less than %d but got %d", test.wantMaxResults, len(results.Results))
+				} else if len(results.Results) < test.wantMinResults {
+					t.Fatalf("Want at least %d results but got %d", test.wantMinResults, len(results.Results))
+				}
+			})
+		}
+	})
 }

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -288,9 +288,44 @@ func TestSearch(t *testing.T) {
 				wantMaxResults: 0,
 			},
 			{
-				name:           "search for a common file",
+				name:           "search for a known file",
 				query:          "file:doc.go",
 				wantMinResults: 5,
+				wantMaxResults: -1,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if test.wantMaxResults != -1 && len(results.Results) > test.wantMaxResults {
+					t.Fatalf("Want results to be less than %d but got %d", test.wantMaxResults, len(results.Results))
+				} else if len(results.Results) < test.wantMinResults {
+					t.Fatalf("Want at least %d results but got %d", test.wantMinResults, len(results.Results))
+				}
+			})
+		}
+	})
+
+	t.Run("global symbol search", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			query          string
+			wantMinResults int
+			wantMaxResults int
+		}{
+			{
+				name:           "search for a non-existent symbol",
+				query:          "type:symbol asdfasdf",
+				wantMaxResults: 0,
+			},
+			{
+				name:           "search for a known symbol",
+				query:          "type:symbol count:100 patterntype:regexp ^newroute",
+				wantMinResults: 1,
 				wantMaxResults: -1,
 			},
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -32,14 +32,15 @@ func TestSearch(t *testing.T) {
 			Token: *githubToken,
 			Repos: []string{
 				"sourcegraph/java-langserver",
-				"gorilla/mux",
-				"gorilla/securecookie",
 				"sourcegraph/jsonrpc2",
 				"sourcegraph/go-diff",
 				"sourcegraph/appdash",
 				"sourcegraph/sourcegraph-typescript",
 				"sourcegraph-testing/automation-e2e-test",
 				"sourcegraph/e2e-test-private-repository",
+				"sgtest/mux", // Fork
+				"gorilla/mux",
+				"gorilla/securecookie",
 			},
 		}),
 	})
@@ -55,14 +56,15 @@ func TestSearch(t *testing.T) {
 
 	err = client.WaitForReposToBeCloned(
 		"github.com/sourcegraph/java-langserver",
-		"github.com/gorilla/mux",
-		"github.com/gorilla/securecookie",
 		"github.com/sourcegraph/jsonrpc2",
 		"github.com/sourcegraph/go-diff",
 		"github.com/sourcegraph/appdash",
 		"github.com/sourcegraph/sourcegraph-typescript",
 		"github.com/sourcegraph-testing/automation-e2e-test",
 		"github.com/sourcegraph/e2e-test-private-repository",
+		"github.com/sgtest/mux", // Fork
+		"github.com/gorilla/mux",
+		"github.com/gorilla/securecookie",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -107,7 +109,7 @@ func TestSearch(t *testing.T) {
 		}
 
 		// Make sure only got .go files and no .md files
-		for _, r := range results {
+		for _, r := range results.Results {
 			if !strings.HasSuffix(r.File.Name, ".go") {
 				t.Fatalf("Found file name does not end with .go: %s", r.File.Name)
 			}
@@ -131,7 +133,7 @@ func TestSearch(t *testing.T) {
 			"bug-fix-wip":           {},
 		}
 
-		for _, r := range results {
+		for _, r := range results.Results {
 			delete(wantExprs, r.RevSpec.Expr)
 		}
 
@@ -163,10 +165,10 @@ func TestSearch(t *testing.T) {
 		}
 
 		// Make sure there are results and all results are from the same repository
-		if len(results) == 0 {
+		if len(results.Results) == 0 {
 			t.Fatal("Unexpected zero result")
 		}
-		for _, r := range results {
+		for _, r := range results.Results {
 			if r.Repository.Name != repoName {
 				t.Fatalf("Repository: want %q but got %q", repoName, r.Repository.Name)
 			}
@@ -207,6 +209,69 @@ func TestSearch(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatal(err, "lastResult:", lastResult)
+		}
+	})
+
+	t.Run("global text search", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			query             string
+			wantMinResults    int
+			wantMaxResults    int
+			wantMinMatchCount int64
+		}{
+			{
+				name:           "error",
+				query:          "error",
+				wantMinResults: 10,
+				wantMaxResults: -1,
+			},
+			{
+				name:           "error count:1000",
+				query:          "error count:1000",
+				wantMinResults: 10,
+				wantMaxResults: -1,
+			},
+			{
+				name:              "something with more than 1000 results and use count:1000",
+				query:             ". count:1000",
+				wantMinResults:    10,
+				wantMaxResults:    -1,
+				wantMinMatchCount: 1001,
+			},
+			{
+				name:           "regular expression without indexed search",
+				query:          "index:no patterntype:regexp ^func.*$",
+				wantMinResults: 10,
+				wantMaxResults: -1,
+			},
+			{
+				name:           "fork:only",
+				query:          "fork:only router",
+				wantMinResults: 10,
+				wantMaxResults: -1,
+			},
+			{
+				name:           "fork:no",
+				query:          "fork:no FORK_SENTINEL",
+				wantMaxResults: 0,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if test.wantMaxResults != -1 && len(results.Results) > test.wantMaxResults {
+					t.Fatalf("Want results to be less than %d but got %d", test.wantMaxResults, len(results.Results))
+				} else if len(results.Results) < test.wantMinResults {
+					t.Fatalf("Want at least %d results but got %d", test.wantMinResults, len(results.Results))
+				} else if results.MatchCount < test.wantMinMatchCount {
+					t.Fatalf("Want at least %d match count but got %d", test.wantMinMatchCount, results.MatchCount)
+				}
+			})
 		}
 	})
 }

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -67,6 +67,9 @@ type SearchFileResult struct {
 	File struct {
 		Name string `json:"name"`
 	} `json:"file"`
+	Repository struct {
+		Name string `json:"name"`
+	} `json:"repository"`
 	RevSpec struct {
 		Expr string `json:"expr"`
 	} `json:"revSpec"`
@@ -83,6 +86,9 @@ query Search($query: String!) {
 			results {
 				... on FileMatch {
 					file {
+						name
+					}
+					repository {
 						name
 					}
 					revSpec {

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -63,26 +63,29 @@ query Search($query: String!) {
 	return resp.Data.Search.Results.Results, nil
 }
 
-type SearchFileResult struct {
-	File struct {
-		Name string `json:"name"`
-	} `json:"file"`
-	Repository struct {
-		Name string `json:"name"`
-	} `json:"repository"`
-	RevSpec struct {
-		Expr string `json:"expr"`
-	} `json:"revSpec"`
+type SearchFileResults struct {
+	MatchCount int64 `json:"matchCount"`
+	Results    []*struct {
+		File struct {
+			Name string `json:"name"`
+		} `json:"file"`
+		Repository struct {
+			Name string `json:"name"`
+		} `json:"repository"`
+		RevSpec struct {
+			Expr string `json:"expr"`
+		} `json:"revSpec"`
+	} `json:"results"`
 }
 
-type SearchFileResults []*SearchFileResult
-
-// SearchFiles search files with given query.
-func (c *Client) SearchFiles(query string) (SearchFileResults, error) {
+// SearchFiles search files with given query. It returns the match count and
+// corresponding file matches.
+func (c *Client) SearchFiles(query string) (*SearchFileResults, error) {
 	const gqlQuery = `
 query Search($query: String!) {
 	search(query: $query) {
 		results {
+			matchCount
 			results {
 				... on FileMatch {
 					file {
@@ -109,7 +112,7 @@ query Search($query: String!) {
 		Data struct {
 			Search struct {
 				Results struct {
-					Results []*SearchFileResult `json:"results"`
+					*SearchFileResults
 				} `json:"results"`
 			} `json:"search"`
 		} `json:"data"`
@@ -119,7 +122,7 @@ query Search($query: String!) {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
 
-	return resp.Data.Search.Results.Results, nil
+	return resp.Data.Search.Results.SearchFileResults, nil
 }
 
 type SearchStatsResult struct {

--- a/internal/gqltestutil/settings.go
+++ b/internal/gqltestutil/settings.go
@@ -10,9 +10,14 @@ import (
 
 // OverwriteSettings overwrites settings for given subject ID with contents.
 func (c *Client) OverwriteSettings(subjectID, contents string) error {
+	lastID, err := c.lastSettingsID(subjectID)
+	if err != nil {
+		return errors.Wrap(err, "get last settings ID")
+	}
+
 	const query = `
-mutation OverwriteSettings($subject: ID!, $contents: String!) {
-	settingsMutation(input: { subject: $subject }) {
+mutation OverwriteSettings($subject: ID!, $lastID: Int, $contents: String!) {
+	settingsMutation(input: { subject: $subject, lastID: $lastID }) {
 		overwriteSettings(contents: $contents) {
 			empty {
 				alwaysNil
@@ -23,13 +28,61 @@ mutation OverwriteSettings($subject: ID!, $contents: String!) {
 `
 	variables := map[string]interface{}{
 		"subject":  subjectID,
+		"lastID":   lastID,
 		"contents": contents,
 	}
-	err := c.GraphQL("", query, variables, nil)
+	err = c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}
 	return nil
+}
+
+// lastSettingsID returns the ID of last settings of given subject.
+// It is required to be used to update corresponding settings.
+func (c *Client) lastSettingsID(subjectID string) (int, error) {
+	const query = `
+query ViewerSettings {
+	viewerSettings {
+		subjects {
+			id
+			latestSettings {
+				id
+			}
+		}
+	}
+}
+`
+	var resp struct {
+		Data struct {
+			ViewerSettings struct {
+				Subjects []struct {
+					ID             string `json:"id"`
+					LatestSettings *struct {
+						ID int
+					} `json:"latestSettings"`
+				} `json:"subjects"`
+			} `json:"viewerSettings"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, nil, &resp)
+	if err != nil {
+		return 0, errors.Wrap(err, "request GraphQL")
+	}
+
+	lastID := 0
+	for _, s := range resp.Data.ViewerSettings.Subjects {
+		if s.ID != subjectID {
+			continue
+		}
+
+		// It is nil in the initial state, which effectively makes lastID as 0.
+		if s.LatestSettings != nil {
+			lastID = s.LatestSettings.ID
+		}
+		break
+	}
+	return lastID, nil
 }
 
 // ViewerSettings returns the latest cascaded settings of authenticated user.


### PR DESCRIPTION
Adds integrations tests for search, which covers:

- [repository group](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@41db04954c28180792defbc5cf0496c24e08ef37/-/blob/web/src/regression/search.test.ts#L471:1)
- global text search: 
	- [(error) with many results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bb1daacb6d09a77a9337040361baba439d661072/-/blob/web/src/regression/search.test.ts#L221:1)
	- [(error count:>1000), expect many results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cab1a64cfdbe0c930cccdc9fd550e60913972b60/-/blob/web/src/regression/search.test.ts#L225:1)
	- [for something with more than 1000 results and use "count:1000"](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cab1a64cfdbe0c930cccdc9fd550e60913972b60/-/blob/web/src/regression/search.test.ts#L239:1)
	- [for a regular expression without indexed search: (index:no ^func.*$), expect many results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cab1a64cfdbe0c930cccdc9fd550e60913972b60/-/blob/web/src/regression/search.test.ts#L252:1)
	- [fork:only, few results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cab1a64cfdbe0c930cccdc9fd550e60913972b60/-/blob/web/src/regression/search.test.ts#L274:1)
	- [fork:no, 0 results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cab1a64cfdbe0c930cccdc9fd550e60913972b60/-/blob/web/src/regression/search.test.ts#L282:1)
- global filename search:
	- [with 0 results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7b5cbd9dfcaa5e279ff8f6294d58e1f0dbecfa4b/-/blob/web/src/regression/search.test.ts#L314:1)
	- [with many results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7b5cbd9dfcaa5e279ff8f6294d58e1f0dbecfa4b/-/blob/web/src/regression/search.test.ts#L322:1)
- global symbol search:
	- [with 0 results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7b5cbd9dfcaa5e279ff8f6294d58e1f0dbecfa4b/-/blob/web/src/regression/search.test.ts#L341:1)
	- [("type:symbol ^newroute count:100") with a few results](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7b5cbd9dfcaa5e279ff8f6294d58e1f0dbecfa4b/-/blob/web/src/regression/search.test.ts#L345:1)

Please review by commit.

Part of #10068