### PR TITLE
search: refactor to expose context and settings before processing args

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -312,7 +312,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			if reposExist(ctx, tryIncludeForks) {
 				proposedQueries = append(proposedQueries, &searchQueryDescription{
 					description: "include forked repositories in your query.",
-					query:       r.originalQuery + " fork:yes",
+					query:       r.args.Query + " fork:yes",
 					patternType: r.patternType,
 				})
 			}
@@ -329,7 +329,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			if reposExist(ctx, tryIncludeArchived) {
 				proposedQueries = append(proposedQueries, &searchQueryDescription{
 					description: "include archived repositories in your query.",
-					query:       r.originalQuery + " archived:yes",
+					query:       r.args.Query + " archived:yes",
 					patternType: r.patternType,
 				})
 			}
@@ -601,18 +601,10 @@ func addRegexpField(p syntax.ParseTree, field, pattern string) string {
 	return modified.String()
 }
 
-func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
-	alert := &searchAlert{
-		prometheusType:  a.prometheusType,
-		title:           a.title,
-		description:     a.description,
-		proposedQueries: a.proposedQueries,
-	}
-	// ElapsedMilliseconds() will calculate a very large value for duration if start takes on the nil-value of year 1. As a workaround, instantiate start with time.now(). TODO(rvantonder): #10801.
-	return &SearchResultsResolver{alert: alert, start: time.Now()}, nil
+// Wrap an alert in a SearchResultsResolver.
+func (a searchAlert) wrap() *SearchResultsResolver {
+	// ElapsedMilliseconds() will calculate a very large value for duration
+	// if start takes on the nil-value of year 1. As a workaround,
+	// instantiate start with time.now(). TODO(rvantonder): #10801.
+	return &SearchResultsResolver{alert: &a, start: time.Now()}
 }
-
-func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
-	return nil, nil
-}
-func (searchAlert) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -866,11 +866,13 @@ func TestSearchResultsHydration(t *testing.T) {
 
 	ctx := context.Background()
 
-	q, err := query.ParseAndCheck(`foobar index:only count:350`)
-	if err != nil {
-		t.Fatal(err)
+	resolver := &searchResolver{
+		args: &SearchArgs{
+			Query:   `foobar index:only count:350`,
+			Version: "V2",
+		},
+		zoekt: z,
 	}
-	resolver := &searchResolver{query: q, zoekt: z}
 	results, err := resolver.Results(ctx)
 	if err != nil {
 		t.Fatal("Results:", err)

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
-	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -88,13 +87,9 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 
 	ctx := context.Background()
 
-	q, err := query.ParseAndCheck(`patterntype:structural index:only foo`)
-	if err != nil {
-		t.Fatal(err)
-	}
+	queryInput := `patterntype:structural index:only foo`
 	resolver := &searchResolver{
-		query:        q,
-		patternType:  query.SearchTypeStructural,
+		args:         &SearchArgs{Query: queryInput, Version: "V2"},
 		zoekt:        z,
 		searcherURLs: endpoint.Static("test"),
 	}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -44,6 +44,14 @@ var (
 )
 
 func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {
+	alert, err := r.setup(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if alert != nil {
+		return nil, nil
+	}
+	// Override user context to ensure that stats for this query are cached
 	args.applyDefaultsAndConstraints()
 
 	if len(r.query.ParseTree()) == 0 {


### PR DESCRIPTION
(Sigh, typing this up again)

Before this PR:

- We did some work parsing queries and processing pagination requests in the `Search` function before calling any of the search resolvers implementing methods:

```
type SearchImplementer interface {                                                                                                                                                                 
        Results(context.Context) (*SearchResultsResolver, error)                                                                                                                                   
        Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error)                                                                                                  
        Stats(context.Context) (*searchResultsStats, error)                                                                                                                                        
} 
```

The problem is that we don't have a handle to `context` in the Search function, meaning that adding any flags to control parsing, or query options, or pagination (or things we might add in future) is ugly and hard to add to user/org/global settings.

After this PR:

The logic we do in `Search` is moved to a common function `setup(ctx)` that is called by each of the three methods above. But now, we have a handle to `ctx` and can case out on settings before parsing (or anything else). This had some follow-on changes (which are generally nice):

- No need to have alerts implement the `searchResolver` interface (which was previously necessary when returning alerts from the `Search` function). Now we can just wrap in in a `SearchResultsResolver` like we elsewhere.

- We can remove references to `originalQuery` and reference search args directly, which is propagated in the resolver now.

- Allows for a user/org/site flag, see #12088 (still WIP)

---

Open question: I'm not sure that `setup` is a great name for this method. Alternatives?

