### PR TITLE
search: add migrate parser flag

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1014,6 +1014,8 @@ type Settings struct {
 	SearchIncludeArchived *bool `json:"search.includeArchived,omitempty"`
 	// SearchIncludeForks description: Whether searches should include searching forked repositories.
 	SearchIncludeForks *bool `json:"search.includeForks,omitempty"`
+	// SearchMigrateParser description: If true, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.
+	SearchMigrateParser *bool `json:"search.migrateParser,omitempty"`
 	// SearchRepositoryGroups description: Named groups of repositories that can be referenced in a search query using the repogroup: operator.
 	SearchRepositoryGroups map[string][]string `json:"search.repositoryGroups,omitempty"`
 	// SearchSavedQueries description: DEPRECATED: Saved search queries

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -200,6 +200,12 @@
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }
+    },
+    "search.migrateParser": {
+      "description": "If true, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
     }
   },
   "definitions": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -205,6 +205,12 @@ const SettingsSchemaJSON = `{
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }
+    },
+    "search.migrateParser": {
+      "description": "If true, uses the new and/or-compatible parser for all search queries. It is a flag to aid transition to the new parser.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
     }
   },
   "definitions": {


### PR DESCRIPTION
Stacked on #12086. Uses user/org/global settings for the parser migration flag. This PR happens in place of #11974, which uses a site-wide flag.

TODO: settings needs to be mocked for tests.