### PR TITLE
search: return branches to index to Zoekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
     - Webhook notifiers: `bearerToken`
   - A new `disableSendResolved` option disables notifications for when alerts resolve themselves.
 - Recently firing critical alerts are now displayed to admins in site alerts.
+- Revisions listed in `experimentalFeatures.versionContext` will be indexed for faster searching. This is the first support towards indexing non-default branches. [#6728](https://github.com/sourcegraph/sourcegraph/issues/6728)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -124,7 +124,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 	}
 	if entry != nil {
 		for _, branch := range entry.Repository.Branches {
-			name := "refs/heads/" + branch.Name
+			name := branch.Name
 			if branch.Name == "HEAD" {
 				name = defaultBranchRef.name
 			}

--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,6 @@ require (
 replace (
 	// protobuf v1.3.5+ causes issues - https://github.com/sourcegraph/sourcegraph/issues/11804
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200622101713-7b13614a083e
 
 	// We need our fork until https://github.com/graph-gophers/graphql-go/pull/400 is merged upstream
 	// Our change limits the number of goroutines spawned by resolvers which was causing memory spikes on our frontend
@@ -197,6 +196,9 @@ replace (
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.3.2-0.20200109173551-5cfddeb48b17
 	github.com/uber/gonduit => github.com/sourcegraph/gonduit v0.4.0
 )
+
+// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200713223616-6c04e2e54f66
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1209,6 +1209,10 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/zoekt v0.0.0-20200622101713-7b13614a083e h1:g7164BqqH/2SXaWaUjHtgUL3808yFfrbnKZ/JiWmiTI=
 github.com/sourcegraph/zoekt v0.0.0-20200622101713-7b13614a083e/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200713222406-e18ef28c5e83 h1:EB6RKE5d+i1zw2+yprhkZz97kQNt5syWw8dO/oucd4s=
+github.com/sourcegraph/zoekt v0.0.0-20200713222406-e18ef28c5e83/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200713223616-6c04e2e54f66 h1:YSsYlwZkAO3Fc+PlXtFbTBNqFCQNVFAxRhFPIabiHI8=
+github.com/sourcegraph/zoekt v0.0.0-20200713223616-6c04e2e54f66/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -219,14 +219,6 @@ func SearchIndexEnabled() bool {
 	return DeployType() != DeploySingleDocker
 }
 
-func SymbolIndexEnabled() bool {
-	enabled := SearchIndexEnabled()
-	if v := Get().SearchIndexSymbolsEnabled; v != nil {
-		enabled = enabled && *v
-	}
-	return enabled
-}
-
 func CampaignsReadAccessEnabled() bool {
 	if v := Get().CampaignsReadAccessEnabled; v != nil {
 		return *v

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -1,0 +1,39 @@
+package backend
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// zoektIndexOptions are options which change what we index for a
+// repository. Everytime a repository is indexed by zoekt this structure is
+// fetched. See getIndexOptions in the zoekt codebase.
+//
+// We only specify a subset of the fields.
+type zoektIndexOptions struct {
+	// LargeFiles is a slice of glob patterns where matching file paths should
+	// be indexed regardless of their size. The pattern syntax can be found
+	// here: https://golang.org/pkg/path/filepath/#Match.
+	LargeFiles []string
+
+	// Symbols if true will make zoekt index the output of ctags.
+	Symbols bool
+}
+
+// GetIndexOptions returns a json blob for consumption by
+// sourcegraph-zoekt-indexserver.
+func GetIndexOptions(c *schema.SiteConfiguration) ([]byte, error) {
+	o := &zoektIndexOptions{
+		LargeFiles: c.SearchLargeFiles,
+		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
+	}
+	return json.Marshal(o)
+}
+
+func getBoolPtr(b *bool, default_ bool) bool {
+	if b == nil {
+		return default_
+	}
+	return *b
+}

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -2,7 +2,9 @@ package backend
 
 import (
 	"encoding/json"
+	"sort"
 
+	"github.com/google/zoekt"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -19,15 +21,61 @@ type zoektIndexOptions struct {
 
 	// Symbols if true will make zoekt index the output of ctags.
 	Symbols bool
+
+	// Branches is a slice of branches to index. If empty it will be
+	// HEAD. These will be resolved, so you can pass in tags/refs/commits.
+	//
+	// Indexing multiple branches is still experimental. As such this should
+	// only be set if an admin has opted into it.
+	Branches []zoekt.RepositoryBranch `json:",omitempty"`
 }
 
 // GetIndexOptions returns a json blob for consumption by
-// sourcegraph-zoekt-indexserver.
-func GetIndexOptions(c *schema.SiteConfiguration) ([]byte, error) {
+// sourcegraph-zoekt-indexserver. It is for repoName based on site settings c.
+//
+// getVersion is used to resolve revisions for repoName. If it fails, the
+// error is returned.
+func GetIndexOptions(c *schema.SiteConfiguration, repoName string, getVersion func(branch string) (string, error)) ([]byte, error) {
 	o := &zoektIndexOptions{
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
 	}
+
+	// Only set Branches if we have VersionContexts set. Using the presence as
+	// a feature flag for multi-branch indexing.
+	if repoName != "" && c.ExperimentalFeatures != nil && len(c.ExperimentalFeatures.VersionContexts) > 0 {
+		// Set of branch names. Always index HEAD
+		branches := map[string]struct{}{"HEAD": {}}
+		for _, vc := range c.ExperimentalFeatures.VersionContexts {
+			for _, rev := range vc.Revisions {
+				if rev.Repo == repoName && rev.Rev != "" {
+					branches[rev.Rev] = struct{}{}
+				}
+			}
+		}
+
+		for branch := range branches {
+			v, err := getVersion(branch)
+			if err != nil {
+				return nil, err
+			}
+
+			o.Branches = append(o.Branches, zoekt.RepositoryBranch{
+				Name:    branch,
+				Version: v,
+			})
+		}
+
+		sort.Slice(o.Branches, func(i, j int) bool {
+			a, b := o.Branches[i].Name, o.Branches[j].Name
+			// Zoekt treats first branch as default branch, so put HEAD first
+			if a == "HEAD" || b == "HEAD" {
+				return a == "HEAD"
+			}
+			return a < b
+		})
+	}
+
 	return json.Marshal(o)
 }
 

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -1,0 +1,160 @@
+package backend
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestGetIndexOptions(t *testing.T) {
+	vc := parseVersionContext
+	vcConf := func(contexts ...*schema.VersionContext) schema.SiteConfiguration {
+		return schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				VersionContexts: contexts,
+			},
+		}
+	}
+
+	cases := []struct {
+		name string
+		conf schema.SiteConfiguration
+		repo string
+		want zoektIndexOptions
+	}{{
+		name: "default",
+		conf: schema.SiteConfiguration{},
+		repo: "",
+		want: zoektIndexOptions{
+			Symbols: true,
+		},
+	}, {
+		name: "nosymbols",
+		conf: schema.SiteConfiguration{
+			SearchIndexSymbolsEnabled: boolPtr(false)},
+		repo: "",
+		want: zoektIndexOptions{},
+	}, {
+		name: "largefiles",
+		conf: schema.SiteConfiguration{
+			SearchLargeFiles: []string{"**/*.jar", "*.bin"},
+		},
+		repo: "",
+		want: zoektIndexOptions{
+			Symbols:    true,
+			LargeFiles: []string{"**/*.jar", "*.bin"},
+		},
+	}, {
+		name: "implicit HEAD",
+		conf: vcConf(vc("foo", "repo@b", "repo@a"), vc("bar", "repo@c", "repo@a", "other@d")),
+		repo: "repo",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+				{Name: "a", Version: "!a"},
+				{Name: "b", Version: "!b"},
+				{Name: "c", Version: "!c"},
+			},
+		},
+	}, {
+		name: "implicit HEAD not in vc",
+		conf: vcConf(vc("foo", "repo@a")),
+		repo: "not_in_version_context",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{{
+				Name:    "HEAD",
+				Version: "!HEAD",
+			}},
+		},
+	}, {
+		name: "explicit HEAD",
+		conf: vcConf(vc("foo", "repo@HEAD", "repo@a")),
+		repo: "repo",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+				{Name: "a", Version: "!a"},
+			},
+		},
+	}, {
+		// a revision can be the empty string, treat as HEAD
+		name: "explicit HEAD empty",
+		conf: vcConf(vc("foo", "repo", "repo@a")),
+		repo: "repo",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+				{Name: "a", Version: "!a"},
+			},
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := GetIndexOptions(&tc.conf, tc.repo, func(branch string) (string, error) {
+				return "!" + branch, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var got zoektIndexOptions
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal("mismatch (-want, +got):\n", diff)
+			}
+		})
+	}
+}
+
+func TestGetIndexOptions_error(t *testing.T) {
+	conf := schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			VersionContexts: []*schema.VersionContext{
+				parseVersionContext("foo", "repo@a"),
+			},
+		},
+	}
+	boom := errors.New("boom")
+	b, err := GetIndexOptions(&conf, "repo", func(branch string) (string, error) {
+		return "", boom
+	})
+	if err != boom {
+		t.Fatalf("expected error, got body %s and error %v", b, err)
+	}
+}
+
+func parseVersionContext(name string, repoRevStrs ...string) *schema.VersionContext {
+	var repoRevs []*schema.VersionContextRevision
+	for _, repo := range repoRevStrs {
+		rev := ""
+		if idx := strings.LastIndex(repo, "@"); idx > 0 {
+			rev = repo[idx+1:]
+			repo = repo[:idx]
+		}
+		repoRevs = append(repoRevs, &schema.VersionContextRevision{
+			Repo: repo,
+			Rev:  rev,
+		})
+	}
+	return &schema.VersionContext{
+		Name:      name,
+		Revisions: repoRevs,
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -29,6 +29,16 @@ func TestGetIndexOptions(t *testing.T) {
 	}{{
 		name: "default",
 		conf: schema.SiteConfiguration{},
+		repo: "repo",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+			},
+		},
+	}, {
+		name: "compat default",
+		conf: schema.SiteConfiguration{},
 		repo: "",
 		want: zoektIndexOptions{
 			Symbols: true,


### PR DESCRIPTION
If we have version contexts enabled we will tell Zoekt to index the
branches in the version context. There is a related Zoekt change to pass
in the repository as well as understand the Branches field being set.

Previously Zoekt was responsible for resolving HEAD. Now that we will do
more than HEAD, it was easier to implement the resolving logic in
Sourcegraph. This will both simplify the responsiblilities of
zoekt-sourcegraph-indexserver as well as allow us to optimize patterns
around resolving version context revisions.

Supersedes https://github.com/sourcegraph/sourcegraph/pull/10851
Part of #6728 