### PR TITLE
search: support globbing for selected keywords

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -84,7 +84,7 @@ func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	default:
 		searchType = query.SearchTypeLiteral
 	}
-	q, err := query.ProcessAndOr(args.Query, searchType, false)
+	q, err := query.ProcessAndOr(args.Query, query.ParserOptions{searchType, false})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -84,7 +84,7 @@ func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	default:
 		searchType = query.SearchTypeLiteral
 	}
-	q, err := query.ProcessAndOr(args.Query, searchType)
+	q, err := query.ProcessAndOr(args.Query, searchType, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -84,7 +84,15 @@ func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	default:
 		searchType = query.SearchTypeLiteral
 	}
-	q, err := query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: false})
+
+	settings, err := decodedViewerFinalSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	globbing := getBoolPtr(settings.SearchGlobbing, false)
+
+	q, err := query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -84,7 +84,7 @@ func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	default:
 		searchType = query.SearchTypeLiteral
 	}
-	q, err := query.ProcessAndOr(args.Query, query.ParserOptions{searchType, false})
+	q, err := query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: false})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -91,25 +91,13 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 	}
 
 	var queryInfo query.QueryInfo
-	if (conf.AndOrQueryEnabled() && query.ContainsAndOrKeyword(args.Query)) || searchType == query.SearchTypeStructural {
-		settings, err := decodedViewerFinalSettings(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		globbing := false
-		if v := settings.SearchGlobbing; v != nil && *v {
-			globbing = true
-		}
+	if (conf.AndOrQueryEnabled() && query.ContainsAndOrKeyword(args.Query)) || useNewParser || searchType == query.SearchTypeStructural {
 		// To process the input as an and/or query, the flag must be
 		// enabled (default is on) and must contain either an 'and' or
-		// 'or' expression. Else, fallback to the older existing parser.
+		// 'or' expression or set in settings. Else, fallback to the
+		// older existing parser.
+		globbing := getBoolPtr(settings.SearchGlobbing, false)
 		queryInfo, err = query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
-		if err != nil {
-			return alertForQuery(args.Query, err), nil
-		}
-	} else if useNewParser {
-		queryInfo, err = query.ProcessAndOr(args.Query, searchType)
 		if err != nil {
 			return alertForQuery(args.Query, err), nil
 		}
@@ -243,6 +231,7 @@ var patternTypeRegex = lazyregexp.New(`(?i)patterntype:([a-zA-Z"']+)`)
 func overrideSearchType(input string, searchType query.SearchType, useNewParser bool) query.SearchType {
 	if useNewParser {
 		q, err := query.ParseAndOrLiteral(input)
+		q = query.LowercaseFieldNames(q)
 		if err != nil {
 			// If parsing fails, return the default search type. Any actual
 			// parse errors will be raised by subsequent parser calls.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -59,6 +59,7 @@ type SearchArgs struct {
 	After          *string
 	First          *int32
 	VersionContext *string
+	Globbing       bool
 }
 
 type SearchImplementer interface {
@@ -95,7 +96,7 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 		// To process the input as an and/or query, the flag must be
 		// enabled (default is on) and must contain either an 'and' or
 		// 'or' expression. Else, fallback to the older existing parser.
-		queryInfo, err = query.ProcessAndOr(args.Query, searchType)
+		queryInfo, err = query.ProcessAndOr(args.Query, searchType, args.Globbing)
 		if err != nil {
 			return alertForQuery(args.Query, err), nil
 		}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1101,7 +1101,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 }
 
 func TestSearchResolver_evaluateWarning(t *testing.T) {
-	q, _ := query.ProcessAndOr("file:foo or file:bar", query.SearchTypeRegex)
+	q, _ := query.ProcessAndOr("file:foo or file:bar", query.ParserOptions{query.SearchTypeRegex, false})
 	wantPrefix := "I'm having trouble understanding that query."
 	andOrQuery, _ := q.(*query.AndOrQuery)
 	got, _ := (&searchResolver{}).evaluate(context.Background(), andOrQuery.Query)
@@ -1111,7 +1111,7 @@ func TestSearchResolver_evaluateWarning(t *testing.T) {
 		}
 	})
 
-	_, err := query.ProcessAndOr("file:foo or or or", query.SearchTypeRegex)
+	_, err := query.ProcessAndOr("file:foo or or or", query.ParserOptions{query.SearchTypeRegex, false})
 	gotAlert := alertForQuery("", err)
 	t.Run("warn for unsupported ambiguous and/or query", func(t *testing.T) {
 		if !strings.HasPrefix(gotAlert.description, wantPrefix) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1101,7 +1101,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 }
 
 func TestSearchResolver_evaluateWarning(t *testing.T) {
-	q, _ := query.ProcessAndOr("file:foo or file:bar", query.ParserOptions{query.SearchTypeRegex, false})
+	q, _ := query.ProcessAndOr("file:foo or file:bar", query.ParserOptions{SearchType: query.SearchTypeRegex, Globbing: false})
 	wantPrefix := "I'm having trouble understanding that query."
 	andOrQuery, _ := q.(*query.AndOrQuery)
 	got, _ := (&searchResolver{}).evaluate(context.Background(), andOrQuery.Query)
@@ -1111,7 +1111,7 @@ func TestSearchResolver_evaluateWarning(t *testing.T) {
 		}
 	})
 
-	_, err := query.ProcessAndOr("file:foo or or or", query.ParserOptions{query.SearchTypeRegex, false})
+	_, err := query.ProcessAndOr("file:foo or or or", query.ParserOptions{SearchType: query.SearchTypeRegex, Globbing: false})
 	gotAlert := alertForQuery("", err)
 	t.Run("warn for unsupported ambiguous and/or query", func(t *testing.T) {
 		if !strings.HasPrefix(gotAlert.description, wantPrefix) {

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -63,7 +63,6 @@ func TestValidateCustom(t *testing.T) {
 				}
 				return
 			}
-
 			if test.wantProblem == "" {
 				if len(problems) > 0 {
 					t.Fatalf("unexpected problems: %v", problems)

--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -351,11 +351,7 @@ func ParseAndOrLiteral(in string) ([]Node, error) {
 			nodes = hoistedNodes
 		}
 	}
-	nodes = Map(nodes, LowercaseFieldNames, SubstituteAliases)
-	err = validate(nodes)
-	if err != nil {
-		return nil, err
-	}
+
 	err = validatePureLiteralPattern(nodes, parser.balanced == 0)
 	if err != nil {
 		return nil, err

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -842,7 +842,7 @@ func ParseAndOr(in string) ([]Node, error) {
 }
 
 // ProcessAndOr query parses and validates an and/or query for a given search type.
-func ProcessAndOr(in string, searchType SearchType) (QueryInfo, error) {
+func ProcessAndOr(in string, searchType SearchType, globbing bool) (QueryInfo, error) {
 	var query []Node
 	var err error
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -871,7 +871,7 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 
 	if options.Globbing {
 		query, err = mapGlobToRegex(query)
-		if err!=nil {
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -860,6 +860,11 @@ func ProcessAndOr(in string, searchType SearchType, globbing bool) (QueryInfo, e
 		}
 		query = EmptyGroupsToLiteral(query)
 	}
+
+	if globbing {
+		query = Map(query, globToRegex)
+	}
+
 	query = Map(query, LowercaseFieldNames, SubstituteAliases)
 	err = validate(query)
 	if err != nil {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -841,12 +841,20 @@ func ParseAndOr(in string) ([]Node, error) {
 	return newOperator(nodes, And), nil
 }
 
+type ParserOptions struct {
+	SearchType SearchType
+
+	// defines whether field values of supported
+	// fields are treated as regex or glob.
+	Globbing bool
+}
+
 // ProcessAndOr query parses and validates an and/or query for a given search type.
-func ProcessAndOr(in string, searchType SearchType, globbing bool) (QueryInfo, error) {
+func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	var query []Node
 	var err error
 
-	switch searchType {
+	switch options.SearchType {
 	case SearchTypeLiteral, SearchTypeStructural:
 		query, err = ParseAndOrLiteral(in)
 		if err != nil {
@@ -861,7 +869,7 @@ func ProcessAndOr(in string, searchType SearchType, globbing bool) (QueryInfo, e
 		query = EmptyGroupsToLiteral(query)
 	}
 
-	if globbing {
+	if options.Globbing {
 		query = Map(query, globToRegex)
 	}
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -844,8 +844,7 @@ func ParseAndOr(in string) ([]Node, error) {
 type ParserOptions struct {
 	SearchType SearchType
 
-	// defines whether field values of supported
-	// fields are treated as regex or glob.
+	// treat repo, file, or repohasfile values as glob syntax if true.
 	Globbing bool
 }
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -870,7 +870,10 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	}
 
 	if options.Globbing {
-		query = Map(query, globToRegex)
+		query, err = mapGlobToRegex(query)
+		if err!=nil {
+			return nil, err
+		}
 	}
 
 	query = Map(query, LowercaseFieldNames, SubstituteAliases)

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -41,7 +41,7 @@ func LowercaseFieldNames(nodes []Node) []Node {
 
 var ErrBadGlobPattern = errors.New("syntax error in glob pattern")
 
-// translateCharacterClass translates character classes like [A-Z] or [!0-9]
+// translateCharacterClass translates character classes like [a-zA-Z].
 func translateCharacterClass(r []rune, startIx int) (int, string, error) {
 	sb := strings.Builder{}
 	i := startIx
@@ -62,7 +62,7 @@ Loop:
 			}
 			sb.WriteRune(r[i])
 			i++
-		default: // range lo-hi
+		default: // translate character range lo-hi.
 
 			// '-' is treated literally at the start and end of
 			// of a character class.
@@ -73,9 +73,9 @@ Loop:
 				}
 
 				if i > startIx && r[i+1] != ']' {
-					// "-" cannot be the lower end of a range
+					// '-' cannot be the lower end of a range
 					// unless it is the first character within
-					// the character class
+					// the character class.
 					return -1, "", ErrBadGlobPattern
 				}
 			}
@@ -129,15 +129,15 @@ var globSpecialSymbols = map[rune]struct{}{
 	'[':  {},
 }
 
-// globToRegex converts a glob to a regex
-// we support: *, ?, character classes [...], ranges [A-F]
+// globToRegex converts a glob string to a regular expression.
+// We support: *, ?, and character classes [...].
 func globToRegex(value string) (string, error) {
 	r := []rune(value)
 	l := len(r)
 	sb := strings.Builder{}
 
 	i := 0
-	// add regex anchor "^" if glob does not start with *
+	// Add regex anchor "^" if glob does not start with *.
 	if r[i] != '*' {
 		sb.WriteRune('^')
 	}
@@ -149,14 +149,14 @@ func globToRegex(value string) (string, error) {
 			} else {
 				sb.WriteString("[^/]*?")
 			}
-			// skip repeated '*'
+			// Skip repeated '*'.
 			for i < l-1 && r[i+1] == '*' {
 				i++
 			}
 		case '?':
 			sb.WriteRune('.')
 		case '\\':
-			// handle escaped special characters
+			// Handle escaped special characters.
 			sb.WriteRune('\\')
 			i++
 			if _, ok := globSpecialSymbols[r[i]]; !ok {
@@ -188,8 +188,8 @@ func globToRegex(value string) (string, error) {
 	return sb.String(), nil
 }
 
-// globError caries the actual error plus the name of field where the
-// error occurred.
+// globError carries the error message and the name of
+// field where the error occurred.
 type globError struct {
 	field string
 	err   error
@@ -199,7 +199,7 @@ func (g globError) Error() string {
 	return g.err.Error()
 }
 
-// mapGlobToRegex translates glob to regexp for fields repo, file, repohasfile
+// mapGlobToRegex translates glob to regexp for fields repo, file, and repohasfile.
 func mapGlobToRegex(nodes []Node) ([]Node, error) {
 	var globErrors []globError
 	var err error
@@ -216,7 +216,6 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 		return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
 	})
 
-	// error formatting
 	if len(globErrors) == 1 {
 		return nil, fmt.Errorf("invalid glob syntax in field %s: ", globErrors[0].field)
 	}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -64,8 +64,8 @@ Loop:
 			i++
 		default: // range lo-hi
 
-		// '-' is treated literally at the start and end of
-		// of a character class.
+			// '-' is treated literally at the start and end of
+			// of a character class.
 			if r[i] == '-' {
 				if i == lenR-1 {
 					// no closing bracket
@@ -105,8 +105,8 @@ Loop:
 				continue
 			}
 
-			hi:=r[i]
-			if lo>hi {
+			hi := r[i]
+			if lo > hi {
 				// range is reversed
 				return -1, "", ErrBadGlobPattern
 			}
@@ -123,10 +123,10 @@ Loop:
 }
 
 var globSpecialSymbols = map[rune]struct{}{
-	'\\': struct{}{},
-	'*':  struct{}{},
-	'?':  struct{}{},
-	'[':  struct{}{},
+	'\\': {},
+	'*':  {},
+	'?':  {},
+	'[':  {},
 }
 
 // globToRegex converts a glob to a regex
@@ -188,7 +188,7 @@ func globToRegex(value string) (string, error) {
 // error occurred.
 type globError struct {
 	field string
-	err error
+	err   error
 }
 
 func (g globError) Error() string {
@@ -216,7 +216,7 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 	}
 
 	if len(globErrors) > 1 {
-		fields :=  globErrors[0].field + ":"
+		fields := globErrors[0].field + ":"
 
 		for _, e := range globErrors[1:] {
 			fields += fmt.Sprintf(", %s:", e.field)

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -131,12 +131,8 @@ func isValidRegexp(value string) bool {
 // * the translated value is not a valid regexp
 func globToRegex(nodes []Node) []Node {
 	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
-		fieldType, ok := conf.FieldTypes[field]
-		if !ok {
-			// this should never happen, but we handle it gracefully just in case
-			return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
-		}
-		if reflect.DeepEqual(fieldType, regexpNegatableFieldType) && !isValidRegexp(value) {
+
+		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {
 			tempValue := translateGlobToRegex(value)
 			if isValidRegexp(tempValue) {
 				value = tempValue

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -183,11 +183,6 @@ func globToRegex(value string) (string, error) {
 	return sb.String(), nil
 }
 
-func isValidRegexp(value string) bool {
-	if _, err := regexp.Compile(value); err != nil {
-		return false
-	}
-	return true
 }
 
 // mapGlobToRegex translates glob with regexp for fields supporting regexp

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -144,7 +144,11 @@ func globToRegex(value string) (string, error) {
 	for i = 0; i < l; i++ {
 		switch r[i] {
 		case '*':
-			sb.WriteString(".*?")
+			if i < l-1 && r[i+1] == '*' {
+				sb.WriteString(".*?")
+			} else {
+				sb.WriteString("[^/]*?")
+			}
 			// skip repeated '*'
 			for i < l-1 && r[i+1] == '*' {
 				i++
@@ -202,7 +206,9 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 
 	nodes = MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {
+			fmt.Println("before: ", value)
 			value, err = globToRegex(value)
+			fmt.Println("after: ", value)
 			if err != nil {
 				globErrors = append(globErrors, globError{field: field, err: err})
 			}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -51,14 +51,14 @@ func translateRange(r []rune, ix int) (int, string) {
 		sb.WriteRune('!')
 	} else {
 		// since character sets cannot be empty,
-		// a [ followed direclty by a ] means ] has to
+		// a [ followed directly by a ] means ] has to
 		// be interpreted literally.
 		sb.WriteRune(r[ix])
 	}
-	ix += 1
+	ix++
 	for ix < len(r) && r[ix] != ']' {
 		sb.WriteRune(r[ix])
-		ix += 1
+		ix++
 	}
 
 	return len(sb.String()), sb.String()
@@ -83,18 +83,18 @@ func translateGlobToRegex(value string) string {
 			sb.WriteString(".*?")
 			// skip repeated '*'
 			for i < l-1 && r[i+1] == '*' {
-				i = i + 1
+				i++
 			}
 		case '?':
 			sb.WriteRune('.')
 		case '\\':
 			// handle escaped special characters
 			sb.WriteRune('\\')
-			i += 1
+			i++
 			sb.WriteRune(r[i])
 		case '[':
 			sb.WriteRune('[')
-			i += 1
+			i++
 
 			advanced, s := translateRange(r, i)
 			i += advanced
@@ -126,7 +126,6 @@ func isValidRegexp(value string) bool {
 // * the translated value is not a valid regexp
 func globToRegex(nodes []Node) []Node {
 	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
-
 		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {
 			tempValue := translateGlobToRegex(value)
 			if isValidRegexp(tempValue) {
@@ -311,7 +310,6 @@ func substituteConcat(nodes []Node, separator string) []Node {
 				new = append(new, newOperator(substituteConcat(v.Operands, separator), v.Kind)...)
 			}
 		}
-
 	}
 	return new
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -182,7 +182,7 @@ func globToRegex(value string) (string, error) {
 	}
 
 	// add regex anchor "$" if glob doesn't end with *
-	if r[len(r)-1] != '*' {
+	if r[l-1] != '*' {
 		sb.WriteRune('$')
 	}
 	return sb.String(), nil

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -48,6 +48,18 @@ func translateGlobToRegex(value string) string {
 	value = regexp.QuoteMeta(value)
 	value = strings.ReplaceAll(value, "\\*", ".*?")
 	value = strings.ReplaceAll(value, "\\?", ".")
+
+	// add anchors ^ and/or $ if necessary
+	l := len(value)
+	for i, r := range value {
+		if i == 0 && r != '.' {
+			value = "^" + value
+		}
+		if i == l-1 && r != '?' {
+			value = value + "$"
+		}
+	}
+
 	return value
 }
 

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -42,18 +42,17 @@ func LowercaseFieldNames(nodes []Node) []Node {
 // translateRange translates character classes and ranges
 func translateRange(r []rune, ix int) (int, string) {
 	sb := strings.Builder{}
-	ix += 1
 
-	// the first character of range or character set is special
-	// because
+	// the first character of a range or character set
+	// is special because
 	//   * ranges or character sets cannot be empty
 	//   * we have to translate negation from ^ to !
 	if r[ix] == '^' {
 		sb.WriteRune('!')
 	} else {
-		// character sets or ranges cannot be empty: this means
-		// a [ followed direclty by a ] means ] has to be interpreted
-		// literally.
+		// since character sets cannot be empty,
+		// a [ followed direclty by a ] means ] has to
+		// be interpreted literally.
 		sb.WriteRune(r[ix])
 	}
 	ix += 1
@@ -62,13 +61,7 @@ func translateRange(r []rune, ix int) (int, string) {
 		ix += 1
 	}
 
-	return len(sb.String()) + 1, sb.String()
-
-	// if ix == len(r) {
-	// unmatched [
-	// return 0, "["
-	// } else {
-	// }
+	return len(sb.String()), sb.String()
 }
 
 // translateGlobToRegex converts a globbing string to a regex
@@ -100,10 +93,12 @@ func translateGlobToRegex(value string) string {
 			i += 1
 			sb.WriteRune(r[i])
 		case '[':
+			sb.WriteRune('[')
+			i += 1
+
 			advanced, s := translateRange(r, i)
 			i += advanced
 
-			sb.WriteRune('[')
 			sb.WriteString(s)
 			sb.WriteRune(']')
 		default:

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -121,9 +121,7 @@ func isValidRegexp(value string) bool {
 }
 
 // globToRegex substitutes glob with regexp for fields supporting regexp
-// the value is left unchanged if
-// * is a valid regexp
-// * the translated value is not a valid regexp
+// the value is left unchanged if the translated value is not a valid regexp
 func globToRegex(nodes []Node) []Node {
 	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -206,9 +206,7 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 
 	nodes = MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {
-			fmt.Println("before: ", value)
 			value, err = globToRegex(value)
-			fmt.Println("after: ", value)
 			if err != nil {
 				globErrors = append(globErrors, globError{field: field, err: err})
 			}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -132,6 +132,10 @@ var globSpecialSymbols = map[rune]struct{}{
 // globToRegex converts a glob string to a regular expression.
 // We support: *, ?, and character classes [...].
 func globToRegex(value string) (string, error) {
+	if value == "" {
+		return value, nil
+	}
+
 	r := []rune(value)
 	l := len(r)
 	sb := strings.Builder{}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -315,7 +315,7 @@ func TestMap(t *testing.T) {
 }
 
 func TestTranslateGlobToRegex(t *testing.T) {
-	tests := []struct {
+	cases := []struct {
 		input string
 		want  string
 	}{
@@ -409,17 +409,17 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "[--0]",
-			want: "^[--0]$",
+			want:  "^[--0]$",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			got, err := globToRegex(tt.input)
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			got, err := globToRegex(c.input)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -427,18 +427,21 @@ func TestTranslateGlobToRegex(t *testing.T) {
 }
 
 func TestTranslateBadGlobPattern(t *testing.T) {
-	tests := []struct {
+	cases := []struct {
 		input string
 	}{
 		{input: "fo[a-b-c]"},
 		{input: "fo\\o"},
 		{input: "fo[o"},
 		{input: "[z-a]"},
+		{input: "[a-z--0]"},
 	}
-	for _, tt := range tests {
-		_, err := globToRegex(tt.input)
-		if diff := cmp.Diff(ErrBadGlobPattern.Error(), err.Error()); diff != "" {
-			t.Fatal(diff)
-		}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			_, err := globToRegex(c.input)
+			if diff := cmp.Diff(ErrBadGlobPattern.Error(), err.Error()); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -326,31 +326,43 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "*repo",
-			want:  ".*?repo",
+			want:  ".*?repo$",
 		},
 		{
 			input: "re*o",
-			want:  "re.*?o",
+			want:  "^re.*?o$",
 		},
 		{
 			input: "repo*",
-			want:  "repo.*?",
+			want:  "^repo.*?",
 		},
 		{
 			input: "?",
-			want:  ".",
+			want:  ".$",
 		},
 		{
 			input: "?repo",
-			want:  ".repo",
+			want:  ".repo$",
 		},
 		{
 			input: "re?o",
-			want:  "re.o",
+			want:  "^re.o$",
 		},
 		{
 			input: "repo?",
-			want:  "repo.",
+			want:  "^repo.$",
+		},
+		{
+			input: "123",
+			want:  "^123$",
+		},
+		{
+			input: ".123",
+			want:  "^\\.123$",
+		},
+		{
+			input: "*.go",
+			want:  ".*?\\.go$",
 		},
 	}
 

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -338,11 +338,11 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "?",
-			want:  ".$",
+			want:  "^.$",
 		},
 		{
 			input: "?repo",
-			want:  ".repo$",
+			want:  "^.repo$",
 		},
 		{
 			input: "re?o",
@@ -363,6 +363,42 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		{
 			input: "*.go",
 			want:  ".*?\\.go$",
+		},
+		{
+			input: "h[a-z]llo",
+			want:  "^h[a-z]llo$",
+		},
+		{
+			input: "h[^a-z]llo",
+			want:  "^h[!a-z]llo$",
+		},
+		{
+			input: "h[^abcde]llo",
+			want:  "^h[!abcde]llo$",
+		},
+		{
+			input: "h[]-]llo",
+			want:  "^h[]-]llo$",
+		},
+		{
+			input: "h\\[llo",
+			want:  "^h\\[llo$",
+		},
+		{
+			input: "h\\*llo",
+			want:  "^h\\*llo$",
+		},
+		{
+			input: "h\\?llo",
+			want:  "^h\\?llo$",
+		},
+		{
+			input: "fo[a-z]baz",
+			want:  "^fo[a-z]baz$",
+		},
+		{
+			input: "foo/**",
+			want:  "^foo/.*?",
 		},
 	}
 

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -411,6 +411,10 @@ func TestTranslateGlobToRegex(t *testing.T) {
 			input: "[--0]",
 			want:  "^[--0]$",
 		},
+		{
+			input: "",
+			want:  "",
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -313,3 +313,51 @@ func TestMap(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateGlobToRegex(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			input: "*",
+			want:  ".*?",
+		},
+		{
+			input: "*repo",
+			want:  ".*?repo",
+		},
+		{
+			input: "re*o",
+			want:  "re.*?o",
+		},
+		{
+			input: "repo*",
+			want:  "repo.*?",
+		},
+		{
+			input: "?",
+			want:  ".",
+		},
+		{
+			input: "?repo",
+			want:  ".repo",
+		},
+		{
+			input: "re?o",
+			want:  "re.o",
+		},
+		{
+			input: "repo?",
+			want:  "repo.",
+		},
+	}
+
+	for _, tt := range tests {
+		got := translateGlobToRegex(tt.input)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -321,19 +321,19 @@ func TestTranslateGlobToRegex(t *testing.T) {
 	}{
 		{
 			input: "*",
-			want:  ".*?",
+			want:  "[^/]*?",
 		},
 		{
 			input: "*repo",
-			want:  ".*?repo$",
+			want:  "[^/]*?repo$",
 		},
 		{
 			input: "re*o",
-			want:  "^re.*?o$",
+			want:  "^re[^/]*?o$",
 		},
 		{
 			input: "repo*",
-			want:  "^repo.*?",
+			want:  "^repo[^/]*?",
 		},
 		{
 			input: "?",
@@ -361,7 +361,7 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "*.go",
-			want:  ".*?\\.go$",
+			want:  "[^/]*?\\.go$",
 		},
 		{
 			input: "h[a-z]llo",

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -56,7 +56,7 @@ func TestAndOrQuery_Validation(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
-			_, err := ProcessAndOr(c.input, SearchTypeRegex)
+			_, err := ProcessAndOr(c.input, SearchTypeRegex, false)
 			if err == nil {
 				t.Fatal("expected test to fail")
 			}
@@ -93,7 +93,7 @@ func TestAndOrQuery_IsCaseSensitive(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			query, err := ProcessAndOr(c.input, SearchTypeRegex)
+			query, err := ProcessAndOr(c.input, SearchTypeRegex, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -123,7 +123,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 		},
 	}
 	t.Run("for regexp field", func(t *testing.T) {
-		query, err := ProcessAndOr(c.query, SearchTypeRegex)
+		query, err := ProcessAndOr(c.query, SearchTypeRegex, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -138,7 +138,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 }
 
 func TestAndOrQuery_CaseInsensitiveFields(t *testing.T) {
-	query, err := ProcessAndOr("repoHasFile:foo", SearchTypeRegex)
+	query, err := ProcessAndOr("repoHasFile:foo", SearchTypeRegex, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -56,7 +56,7 @@ func TestAndOrQuery_Validation(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
-			_, err := ProcessAndOr(c.input, SearchTypeRegex, false)
+			_, err := ProcessAndOr(c.input, ParserOptions{SearchTypeRegex, false})
 			if err == nil {
 				t.Fatal("expected test to fail")
 			}
@@ -93,7 +93,7 @@ func TestAndOrQuery_IsCaseSensitive(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			query, err := ProcessAndOr(c.input, SearchTypeRegex, false)
+			query, err := ProcessAndOr(c.input, ParserOptions{SearchTypeRegex, false})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -123,7 +123,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 		},
 	}
 	t.Run("for regexp field", func(t *testing.T) {
-		query, err := ProcessAndOr(c.query, SearchTypeRegex, false)
+		query, err := ProcessAndOr(c.query, ParserOptions{SearchTypeRegex, false})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -138,7 +138,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 }
 
 func TestAndOrQuery_CaseInsensitiveFields(t *testing.T) {
-	query, err := ProcessAndOr("repoHasFile:foo", SearchTypeRegex, false)
+	query, err := ProcessAndOr("repoHasFile:foo", ParserOptions{SearchTypeRegex, false})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1012,6 +1012,8 @@ type Settings struct {
 	SearchContextLines int `json:"search.contextLines,omitempty"`
 	// SearchDefaultPatternType description: The default pattern type (literal or regexp) that search queries will be intepreted as.
 	SearchDefaultPatternType string `json:"search.defaultPatternType,omitempty"`
+	// SearchGlobbing description: Enables globbing for supported field values
+	SearchGlobbing *bool `json:"search.globbing,omitempty"`
 	// SearchIncludeArchived description: Whether searches should include searching archived repositories.
 	SearchIncludeArchived *bool `json:"search.includeArchived,omitempty"`
 	// SearchIncludeForks description: Whether searches should include searching forked repositories.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -92,6 +92,12 @@
         "required": ["key", "description", "query"]
       }
     },
+    "search.globbing": {
+      "description": "Enables globbing for supported field values",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
+    },
     "search.scopes": {
       "description": "Predefined search scopes",
       "type": "array",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -97,6 +97,12 @@ const SettingsSchemaJSON = `{
         "required": ["key", "description", "query"]
       }
     },
+    "search.globbing": {
+      "description": "Enables globbing for supported field values",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
+    },
     "search.scopes": {
       "description": "Predefined search scopes",
       "type": "array",


### PR DESCRIPTION
Relates to #10094 

This PR adds support for globbing for the keywords `repo`, `file`, and `repohasfile`. Support for globbing is disabled per default. It can be switched on in the org/user settings like this:
```
{
  "search.globbing": true
}
```

The feature is implemented as part of the new parser, which means it is (for now) limited to queries containing `AND` or `OR`. We can backport the feature to the old parser if we want to roll it out before the new parser is ready.

Example of a query that will be supported:
```
repo:*sour*ph file:*.go -file:*_test.go foo and bar
```

If the user submits a query with an invalid glob, we show an error like this

![image](https://user-images.githubusercontent.com/26413131/87527505-81957c00-c68c-11ea-9203-ca05c55c7717.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
