### PR TITLE
repo-updater: Consistent use of MustRegister

### DIFF
--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -39,6 +39,14 @@ type SourceMetrics struct {
 	ListRepos *metrics.OperationMetrics
 }
 
+// MustRegister registers all metrics in SourceMetrics in the given
+// prometheus.Registerer. It panics in case of failure.
+func (sm SourceMetrics) MustRegister(r prometheus.Registerer) {
+	r.MustRegister(sm.ListRepos.Count)
+	r.MustRegister(sm.ListRepos.Duration)
+	r.MustRegister(sm.ListRepos.Errors)
+}
+
 // NewSourceMetrics returns SourceMetrics that need to be registered
 // in a Prometheus registry.
 func NewSourceMetrics() SourceMetrics {

--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -40,6 +40,14 @@ func NewHandlerMetrics() HandlerMetrics {
 	}
 }
 
+// MustRegister registers all metrics in HandlerMetrics in the given
+// prometheus.Registerer. It panics in case of failure.
+func (m HandlerMetrics) MustRegister(r prometheus.Registerer) {
+	r.MustRegister(m.ServeHTTP.Count)
+	r.MustRegister(m.ServeHTTP.Duration)
+	r.MustRegister(m.ServeHTTP.Errors)
+}
+
 // ObservedHandler returns a decorator that wraps an http.Handler
 // with logging, Prometheus metrics and tracing.
 func ObservedHandler(

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -89,9 +89,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	var src repos.Sourcer
 	{
 		m := repos.NewSourceMetrics()
-		prometheus.DefaultRegisterer.MustRegister(m.ListRepos.Count)
-		prometheus.DefaultRegisterer.MustRegister(m.ListRepos.Duration)
-		prometheus.DefaultRegisterer.MustRegister(m.ListRepos.Errors)
+		m.MustRegister(prometheus.DefaultRegisterer)
 
 		src = repos.NewSourcer(cf, repos.ObservedSource(log15.Root(), m))
 	}
@@ -116,19 +114,6 @@ func Main(enterpriseInit EnterpriseInit) {
 	var debugDumpers []debugserver.Dumper
 	if enterpriseInit != nil {
 		debugDumpers = enterpriseInit(db, store, cf, server)
-	}
-
-	var handler http.Handler
-	{
-		m := repoupdater.NewHandlerMetrics()
-		prometheus.DefaultRegisterer.MustRegister(m.ServeHTTP.Count)
-		prometheus.DefaultRegisterer.MustRegister(m.ServeHTTP.Duration)
-		prometheus.DefaultRegisterer.MustRegister(m.ServeHTTP.Errors)
-		handler = repoupdater.ObservedHandler(
-			log15.Root(),
-			m,
-			opentracing.GlobalTracer(),
-		)(server.Handler())
 	}
 
 	if envvar.SourcegraphDotComMode() {
@@ -212,6 +197,19 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	addr := net.JoinHostPort(host, port)
 	log15.Info("repo-updater: listening", "addr", addr)
+
+	var handler http.Handler
+	{
+		m := repoupdater.NewHandlerMetrics()
+		m.MustRegister(prometheus.DefaultRegisterer)
+
+		handler = repoupdater.ObservedHandler(
+			log15.Root(),
+			m,
+			opentracing.GlobalTracer(),
+		)(server.Handler())
+	}
+
 	srv := &http.Server{Addr: addr, Handler: handler}
 	go func() { log.Fatal(srv.ListenAndServe()) }()
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -210,9 +210,6 @@ func Main(enterpriseInit EnterpriseInit) {
 		)(server.Handler())
 	}
 
-	srv := &http.Server{Addr: addr, Handler: handler}
-	go func() { log.Fatal(srv.ListenAndServe()) }()
-
 	go debugserver.Start(debugserver.Endpoint{
 		Name: "Repo Updater State",
 		Path: "/repo-updater-state",
@@ -234,7 +231,8 @@ func Main(enterpriseInit EnterpriseInit) {
 		}),
 	})
 
-	select {}
+	srv := &http.Server{Addr: addr, Handler: handler}
+	log.Fatal(srv.ListenAndServe())
 }
 
 type scheduler interface {


### PR DESCRIPTION
Make it a method of each metric type.

Also moved "handler" closer to where it's used.

Noticed another opportunity to clean up since the server doesn't need to run in a goroutine.