### PR TITLE
codeintel: Additional worker memory improvements

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/correlate_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/correlate_test.go
@@ -24,17 +24,9 @@ func TestCorrelate(t *testing.T) {
 	expectedState := &State{
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///test/root",
-		DocumentData: map[int]lsif.Document{
-			2: {
-				URI:         "foo.go",
-				Contains:    datastructures.IDSetWith(4, 5, 6),
-				Diagnostics: datastructures.IDSetWith(49),
-			},
-			3: {
-				URI:         "bar.go",
-				Contains:    datastructures.IDSetWith(7, 8, 9),
-				Diagnostics: datastructures.NewIDSet(),
-			},
+		DocumentData: map[int]string{
+			2: "foo.go",
+			3: "bar.go",
 		},
 		RangeData: map[int]lsif.Range{
 			4: {
@@ -43,7 +35,6 @@ func TestCorrelate(t *testing.T) {
 				EndLine:            3,
 				EndCharacter:       4,
 				DefinitionResultID: 13,
-				MonikerIDs:         datastructures.NewIDSet(),
 			},
 			5: {
 				StartLine:         2,
@@ -51,7 +42,6 @@ func TestCorrelate(t *testing.T) {
 				EndLine:           4,
 				EndCharacter:      5,
 				ReferenceResultID: 15,
-				MonikerIDs:        datastructures.NewIDSet(),
 			},
 			6: {
 				StartLine:          3,
@@ -60,7 +50,6 @@ func TestCorrelate(t *testing.T) {
 				EndCharacter:       6,
 				DefinitionResultID: 13,
 				HoverResultID:      17,
-				MonikerIDs:         datastructures.NewIDSet(),
 			},
 			7: {
 				StartLine:         4,
@@ -68,7 +57,6 @@ func TestCorrelate(t *testing.T) {
 				EndLine:           6,
 				EndCharacter:      7,
 				ReferenceResultID: 15,
-				MonikerIDs:        datastructures.IDSetWith(18),
 			},
 			8: {
 				StartLine:      5,
@@ -76,34 +64,30 @@ func TestCorrelate(t *testing.T) {
 				EndLine:        7,
 				EndCharacter:   8,
 				HoverResultID:  17,
-				MonikerIDs:     datastructures.NewIDSet(),
 			},
 			9: {
 				StartLine:      6,
 				StartCharacter: 7,
 				EndLine:        8,
 				EndCharacter:   9,
-				MonikerIDs:     datastructures.IDSetWith(19),
 			},
 		},
 		ResultSetData: map[int]lsif.ResultSet{
 			10: {
 				DefinitionResultID: 12,
 				ReferenceResultID:  14,
-				MonikerIDs:         datastructures.IDSetWith(20),
 			},
 			11: {
 				HoverResultID: 16,
-				MonikerIDs:    datastructures.IDSetWith(21),
 			},
 		},
-		DefinitionData: map[int]datastructures.DefaultIDSetMap{
-			12: {3: datastructures.IDSetWith(7)},
-			13: {3: datastructures.IDSetWith(8)},
+		DefinitionData: map[int]*datastructures.DefaultIDSetMap{
+			12: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{3: datastructures.IDSetWith(7)}),
+			13: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{3: datastructures.IDSetWith(8)}),
 		},
-		ReferenceData: map[int]datastructures.DefaultIDSetMap{
-			14: {2: datastructures.IDSetWith(4, 5)},
-			15: {},
+		ReferenceData: map[int]*datastructures.DefaultIDSetMap{
+			14: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{2: datastructures.IDSetWith(4, 5)}),
+			15: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{}),
 		},
 		HoverData: map[int]string{
 			16: "```go\ntext A\n```",
@@ -139,19 +123,17 @@ func TestCorrelate(t *testing.T) {
 			22: {Name: "pkg A", Version: "v0.1.0"},
 			23: {Name: "pkg B", Version: "v1.2.3"},
 		},
-		Diagnostics: map[int]lsif.DiagnosticResult{
+		DiagnosticResults: map[int][]lsif.Diagnostic{
 			49: {
-				Result: []lsif.Diagnostic{
-					{
-						Severity:       1,
-						Code:           "2322",
-						Message:        "Type '10' is not assignable to type 'string'.",
-						Source:         "eslint",
-						StartLine:      1,
-						StartCharacter: 5,
-						EndLine:        1,
-						EndCharacter:   6,
-					},
+				{
+					Severity:       1,
+					Code:           "2322",
+					Message:        "Type '10' is not assignable to type 'string'.",
+					Source:         "eslint",
+					StartLine:      1,
+					StartCharacter: 5,
+					EndLine:        1,
+					EndCharacter:   6,
 				},
 			},
 		},
@@ -159,19 +141,26 @@ func TestCorrelate(t *testing.T) {
 			9:  10,
 			10: 11,
 		},
-		ImportedMonikers: datastructures.IDSetWith(18),
-		ExportedMonikers: datastructures.IDSetWith(19),
-		LinkedMonikers: datastructures.DisjointIDSet{
-			19: datastructures.IDSetWith(21),
-			21: datastructures.IDSetWith(19),
-		},
-		LinkedReferenceResults: datastructures.DisjointIDSet{
-			14: datastructures.IDSetWith(15),
-			15: datastructures.IDSetWith(14),
-		},
+		ImportedMonikers:       datastructures.IDSetWith(18),
+		ExportedMonikers:       datastructures.IDSetWith(19),
+		LinkedMonikers:         datastructures.DisjointIDSetWith(19, 21),
+		LinkedReferenceResults: datastructures.DisjointIDSetWith(14, 15),
+		Contains: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
+			2: datastructures.IDSetWith(4, 5, 6),
+			3: datastructures.IDSetWith(7, 8, 9),
+		}),
+		Monikers: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
+			7:  datastructures.IDSetWith(18),
+			9:  datastructures.IDSetWith(19),
+			10: datastructures.IDSetWith(20),
+			11: datastructures.IDSetWith(21),
+		}),
+		Diagnostics: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
+			2: datastructures.IDSetWith(49),
+		}),
 	}
 
-	if diff := cmp.Diff(expectedState, state, datastructures.IDSetComparer); diff != "" {
+	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {
 		t.Errorf("unexpected state (-want +got):\n%s", diff)
 	}
 }
@@ -190,29 +179,28 @@ func TestCorrelateMetaDataRoot(t *testing.T) {
 	expectedState := &State{
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///test/root/",
-		DocumentData: map[int]lsif.Document{
-			2: {
-				URI:         "foo.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
+		DocumentData: map[int]string{
+			2: "foo.go",
 		},
 		RangeData:              map[int]lsif.Range{},
 		ResultSetData:          map[int]lsif.ResultSet{},
-		DefinitionData:         map[int]datastructures.DefaultIDSetMap{},
-		ReferenceData:          map[int]datastructures.DefaultIDSetMap{},
+		DefinitionData:         map[int]*datastructures.DefaultIDSetMap{},
+		ReferenceData:          map[int]*datastructures.DefaultIDSetMap{},
 		HoverData:              map[int]string{},
 		MonikerData:            map[int]lsif.Moniker{},
 		PackageInformationData: map[int]lsif.PackageInformation{},
-		Diagnostics:            map[int]lsif.DiagnosticResult{},
+		DiagnosticResults:      map[int][]lsif.Diagnostic{},
 		NextData:               map[int]int{},
 		ImportedMonikers:       datastructures.NewIDSet(),
 		ExportedMonikers:       datastructures.NewIDSet(),
-		LinkedMonikers:         datastructures.DisjointIDSet{},
-		LinkedReferenceResults: datastructures.DisjointIDSet{},
+		LinkedMonikers:         datastructures.NewDisjointIDSet(),
+		LinkedReferenceResults: datastructures.NewDisjointIDSet(),
+		Contains:               datastructures.NewDefaultIDSetMap(),
+		Monikers:               datastructures.NewDefaultIDSetMap(),
+		Diagnostics:            datastructures.NewDefaultIDSetMap(),
 	}
 
-	if diff := cmp.Diff(expectedState, state, datastructures.IDSetComparer); diff != "" {
+	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {
 		t.Errorf("unexpected state (-want +got):\n%s", diff)
 	}
 }
@@ -231,29 +219,28 @@ func TestCorrelateMetaDataRootX(t *testing.T) {
 	expectedState := &State{
 		LSIFVersion: "0.4.3",
 		ProjectRoot: "file:///__w/sourcegraph/sourcegraph/shared/",
-		DocumentData: map[int]lsif.Document{
-			2: {
-				URI:         "../node_modules/@types/history/index.d.ts",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
+		DocumentData: map[int]string{
+			2: "../node_modules/@types/history/index.d.ts",
 		},
 		RangeData:              map[int]lsif.Range{},
 		ResultSetData:          map[int]lsif.ResultSet{},
-		DefinitionData:         map[int]datastructures.DefaultIDSetMap{},
-		ReferenceData:          map[int]datastructures.DefaultIDSetMap{},
+		DefinitionData:         map[int]*datastructures.DefaultIDSetMap{},
+		ReferenceData:          map[int]*datastructures.DefaultIDSetMap{},
 		HoverData:              map[int]string{},
 		MonikerData:            map[int]lsif.Moniker{},
 		PackageInformationData: map[int]lsif.PackageInformation{},
-		Diagnostics:            map[int]lsif.DiagnosticResult{},
+		DiagnosticResults:      map[int][]lsif.Diagnostic{},
 		NextData:               map[int]int{},
 		ImportedMonikers:       datastructures.NewIDSet(),
 		ExportedMonikers:       datastructures.NewIDSet(),
-		LinkedMonikers:         datastructures.DisjointIDSet{},
-		LinkedReferenceResults: datastructures.DisjointIDSet{},
+		LinkedMonikers:         datastructures.NewDisjointIDSet(),
+		LinkedReferenceResults: datastructures.NewDisjointIDSet(),
+		Contains:               datastructures.NewDefaultIDSetMap(),
+		Monikers:               datastructures.NewDefaultIDSetMap(),
+		Diagnostics:            datastructures.NewDefaultIDSetMap(),
 	}
 
-	if diff := cmp.Diff(expectedState, state, datastructures.IDSetComparer); diff != "" {
+	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {
 		t.Errorf("unexpected state (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/compare.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/compare.go
@@ -1,0 +1,18 @@
+package datastructures
+
+import "github.com/google/go-cmp/cmp"
+
+var Comparers = []cmp.Option{
+	IDSetComparer,
+	DefaultIDSetMapComparer,
+}
+
+// IDSetComparer is a github.com/google/go-cmp/cmp comparer that can be
+// supplied to the cmp.Diff method to determine if two identifier sets
+// contain the same set of identifiers.
+var IDSetComparer = cmp.Comparer(compareIDSets)
+
+// DefaultIDSetMapComparer is a github.com/google/go-cmp/cmp comparer that can
+// be supplied to the cmp.Diff method to determine if two identifier sets contain
+// the same set of identifiers.
+var DefaultIDSetMapComparer = cmp.Comparer(compareDefaultIDSetMaps)

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/default_idset_map.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/default_idset_map.go
@@ -1,15 +1,204 @@
 package datastructures
 
-// DefaultIDSetMap is a map from identifiers to IDSets.
-type DefaultIDSetMap map[int]*IDSet
+// DefaultIDSetMap is a space-efficient map from integer keys to identifier sets. This
+// map adds convenience operations that will operate on the set at a specific key, and
+// create it if it does not yet exist in the map.
+//
+// The correlation process creates many such maps (e.g. result set and contains relations),
+// the majority of which contain only a single element. This structure optimizes for the
+// case where only a single key is present in the map.
+//
+// For concrete numbers, processing an index for aws-sdk-go produces 1.5 million singleton
+// maps, and only 25k non-singleton maps.
+//
+// Each map starts out empty. Insertion of the first element sets a key and value field
+// directly in the map struct. Insertion of a second element will promote the struct into
+// a non-singleton map and heap-allocate a builtin map to hold additional keys. Maps have
+// large overhead (see https://golang.org/src/runtime/map.go#L115), so we only want to pay
+// this cost when we need to.
+type DefaultIDSetMap struct {
+	key   int            // singleton map key
+	value *IDSet         // singleton map value
+	m     map[int]*IDSet // non-singleton map
+}
+
+// NewDefaultIDSetMap creates a new empty default identifier set map.
+func NewDefaultIDSetMap() *DefaultIDSetMap {
+	return &DefaultIDSetMap{}
+}
+
+// DefaultIDSetMapWith creates a default identifier set map with the given contents.
+func DefaultIDSetMapWith(m map[int]*IDSet) *DefaultIDSetMap {
+	return &DefaultIDSetMap{m: m}
+}
+
+// Get returns the identifier set at the given key or nil if it does not exist.
+func (sm *DefaultIDSetMap) Get(key int) *IDSet {
+	if sm.key == key {
+		return sm.value
+	}
+	if sm.m != nil {
+		return sm.m[key]
+	}
+	return nil
+}
+
+// Delete removes the identifier set at the given key if it exists.
+func (sm *DefaultIDSetMap) Delete(key int) {
+	if sm.key == key {
+		sm.key = 0
+		sm.value = nil
+	}
+	if sm.m != nil {
+		delete(sm.m, key)
+	}
+}
+
+// Each invokes the given function with each key and identifier set in the map.
+func (sm *DefaultIDSetMap) Each(f func(key int, value *IDSet)) {
+	if sm.key != 0 {
+		f(sm.key, sm.value)
+	}
+	if sm.m != nil {
+		for k, v := range sm.m {
+			f(k, v)
+		}
+	}
+}
+
+// SetLen returns the number of identifiers in the identifier set at the given key.
+func (sm *DefaultIDSetMap) SetLen(key int) int {
+	if sm.key == key {
+		return sm.value.Len()
+	}
+	if sm.m != nil {
+		if s, ok := sm.m[key]; ok {
+			return s.Len()
+		}
+	}
+
+	return 0
+}
+
+// SetContains determines if the given identifier belongs to the set at the given key.
+func (sm *DefaultIDSetMap) SetContains(key, id int) bool {
+	if sm.key == key {
+		return sm.value.Contains(id)
+	}
+	if sm.m != nil {
+		if s, ok := sm.m[key]; ok {
+			return s.Contains(id)
+		}
+	}
+
+	return false
+}
+
+// SetEach determines if the given identifier belongs to the set at the given key.
+func (sm *DefaultIDSetMap) SetEach(key int, f func(id int)) {
+	if sm.key == key {
+		sm.value.Each(f)
+		return
+	}
+	if sm.m != nil {
+		if s, ok := sm.m[key]; ok {
+			s.Each(f)
+		}
+	}
+}
+
+// SetAdd inserts an identifier into the set at the given key.
+func (sm *DefaultIDSetMap) SetAdd(key, id int) {
+	sm.getOrCreate(key).Add(id)
+}
+
+// SetUnion inserts all the identifiers of other into the set a the given key.
+func (sm *DefaultIDSetMap) SetUnion(key int, other *IDSet) {
+	if other == nil || other.Len() == 0 {
+		return
+	}
+
+	sm.getOrCreate(key).Union(other)
+}
 
 // GetOrCreate will return the set at the given key, or create an empty set if it does not exist.
-func (sm DefaultIDSetMap) GetOrCreate(key int) *IDSet {
-	if s, ok := sm[key]; ok {
+func (sm *DefaultIDSetMap) getOrCreate(key int) *IDSet {
+	if sm.key == key {
+		return sm.value
+	}
+	if sm.m != nil {
+		if s, ok := sm.m[key]; ok {
+			return s
+		}
+	}
+
+	if sm.m != nil {
+		// Already a map, just add a new key
+		s := NewIDSet()
+		sm.m[key] = s
 		return s
 	}
 
+	if sm.key == 0 {
+		// Populating a singleton set
+		s := NewIDSet()
+		sm.key = key
+		sm.value = s
+		return s
+	}
+
+	// Adding to a singleton set. Create a new map and add the
+	// new value along with the old singleton value to the it
 	s := NewIDSet()
-	sm[key] = s
+	sm.m = make(map[int]*IDSet, 2)
+	sm.m[key] = s
+	sm.m[sm.key] = sm.value
+	sm.key = 0
+	sm.value = nil
 	return s
+}
+
+// compareDefaultIDSetMaps returns true if the given identifier default identifier set maps
+// have equivalent keys and each key contains equivalent elements.
+func compareDefaultIDSetMaps(x, y *DefaultIDSetMap) bool {
+	if x == nil && y == nil {
+		return true
+	}
+
+	if x == nil || y == nil {
+		return false
+	}
+
+	m1 := toMap(x)
+	m2 := toMap(y)
+
+	if len(m1) == len(m2) {
+		for k, v := range m1 {
+			if !compareIDSets(v, m2[k]) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// toMap returns a copy of the map backing the default identifier set map. This is called from
+// compareDefaultIDSetMaps for testing and should not be used in the hot path.
+func toMap(s *DefaultIDSetMap) map[int]*IDSet {
+	if s.key != 0 {
+		return map[int]*IDSet{
+			s.key: s.value,
+		}
+	}
+
+	if s.m != nil {
+		m := map[int]*IDSet{}
+		for k, v := range s.m {
+			m[k] = v
+		}
+		return m
+	}
+
+	return nil
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/default_idset_map_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/default_idset_map_test.go
@@ -1,34 +1,116 @@
 package datastructures
 
 import (
-	"sort"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestDefaultIDSetMap(t *testing.T) {
-	m := DefaultIDSetMap{}
-	m.GetOrCreate(50).Add(51)
-	m.GetOrCreate(50).Add(52)
-	m.GetOrCreate(51).Add(53)
-	m.GetOrCreate(51).Add(54)
+func TestDefaultIDSetMapAdd(t *testing.T) {
+	for _, numUnrelatedKeys := range []int{0, 1, 16} {
+		for _, max := range []int{SmallSetThreshold / 2, SmallSetThreshold, SmallSetThreshold * 16} {
+			name := fmt.Sprintf("numUnrelatedKeys=%d max=%d", numUnrelatedKeys, max)
 
-	keys := []int{}
-	for k := range m {
-		keys = append(keys, k)
+			t.Run(name, func(t *testing.T) {
+				m := NewDefaultIDSetMap()
+				for i := 0; i < numUnrelatedKeys; i++ {
+					m.SetAdd(1000+i, 42)
+				}
+
+				for i := 1; i <= max; i++ {
+					m.SetAdd(50, i)
+				}
+
+				if m.SetLen(50) != max {
+					t.Errorf("unexpected length. want=%d have=%d", max, m.SetLen(50))
+					return
+				}
+
+				for i := 1; i <= max; i++ {
+					if !m.SetContains(50, i) {
+						t.Errorf("unexpected contains. want=%v have=%v", true, m.SetContains(50, i))
+					}
+				}
+			})
+		}
 	}
-	sort.Ints(keys)
+}
 
-	if diff := cmp.Diff([]int{50, 51}, keys); diff != "" {
-		t.Errorf("unexpected keys (-want +got):\n%s", diff)
+func TestDefaultIDSetMapUnion(t *testing.T) {
+	for _, numUnrelatedKeys := range []int{0, 1, 16} {
+		for _, max := range []int{16, 10000} {
+			name := fmt.Sprintf("numUnrelatedKeys=%d max=%d", numUnrelatedKeys, max)
+
+			t.Run(name, func(t *testing.T) {
+				m := NewDefaultIDSetMap()
+				for i := 0; i < numUnrelatedKeys; i++ {
+					m.SetAdd(1000+i, 42)
+				}
+
+				for i := 1; i <= max; i++ {
+					if i%2 == 0 {
+						m.SetAdd(50, i)
+					}
+					if i%3 == 0 {
+						m.SetAdd(51, i)
+					}
+				}
+
+				m.SetUnion(50, m.Get(51))
+
+				if m.SetLen(50) != (max/2)+(max/3)-(max/6) {
+					t.Errorf("unexpected length. want=%d have=%d", (max/2)+(max/3)-(max/6), m.SetLen(50))
+				}
+
+				for i := 1; i <= max/2; i++ {
+					expected := (i%2 == 0) || (i%3 == 0)
+
+					if m.SetContains(50, i) != expected {
+						t.Errorf("unexpected contains. want=%v have=%v", expected, m.SetContains(50, i))
+					}
+				}
+			})
+		}
 	}
+}
 
-	if diff := cmp.Diff([]int{51, 52}, m[50].Identifiers()); diff != "" {
-		t.Errorf("unexpected keys (-want +got):\n%s", diff)
+func TestDefaultIDSetMapDelete(t *testing.T) {
+	for _, unrelatedKey := range []int{0, 1, 16} {
+		m := NewDefaultIDSetMap()
+		for i := 0; i < unrelatedKey; i++ {
+			m.SetAdd(1000+i, 42)
+		}
+
+		m.SetAdd(50, 51)
+		m.Delete(50)
+
+		if v := m.Get(50); v != nil {
+			t.Errorf("unexpected set: %v", v)
+		}
 	}
+}
 
-	if diff := cmp.Diff([]int{53, 54}, m[51].Identifiers()); diff != "" {
-		t.Errorf("unexpected keys (-want +got):\n%s", diff)
+func TestDefaultIDSetMapMultipleValues(t *testing.T) {
+	m := NewDefaultIDSetMap()
+	m.SetAdd(50, 51)
+	m.SetAdd(50, 52)
+	m.SetAdd(51, 53)
+	m.SetAdd(51, 54)
+	m.SetAdd(52, 55)
+
+	for value, expectedSet := range map[int]*IDSet{
+		50: IDSetWith(51, 52),
+		51: IDSetWith(53, 54),
+		52: IDSetWith(55),
+		53: nil,
+	} {
+		name := fmt.Sprintf("value=%d", value)
+
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(expectedSet, m.Get(value), Comparers...); diff != "" {
+				t.Errorf("unexpected set (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/disjoint_idset.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/disjoint_idset.go
@@ -4,16 +4,35 @@ package datastructures
 // linking items together and retrieving the set of all items for a given set.
 type DisjointIDSet = DefaultIDSetMap
 
-// Union links two values into the same set. If one or the other value is already
-// in the set, then the sets of the two values will merge.
-func (sm DisjointIDSet) Union(id1, id2 int) {
-	sm.GetOrCreate(id1).Add(id2)
-	sm.GetOrCreate(id2).Add(id1)
+// NewDisjointIDSet creates a new empty disjoint identifier set.
+func NewDisjointIDSet() *DisjointIDSet {
+	return &DisjointIDSet{}
+}
+
+// DisjointIDSetWith creates a disjoint identifier set with the given linked pairs.
+func DisjointIDSetWith(pairs ...int) *DisjointIDSet {
+	if len(pairs)%2 != 0 {
+		panic("DisjointIDSetWith must be supplied pairs of values")
+	}
+
+	s := NewDisjointIDSet()
+	for i := 0; i < len(pairs); i += 2 {
+		s.Link(pairs[i], pairs[i+1])
+	}
+
+	return s
+}
+
+// Link composes the connected components containing the given identifiers. If one or
+// the other value is already in the set, then the sets of the two values will merge.
+func (sm *DisjointIDSet) Link(id1, id2 int) {
+	sm.SetAdd(id1, id2)
+	sm.SetAdd(id2, id1)
 }
 
 // ExtractSet returns a set of all values reachable from the given source value. The
 // resulting set would be reachable using any of the values as the source.
-func (sm DisjointIDSet) ExtractSet(id int) *IDSet {
+func (sm *DisjointIDSet) ExtractSet(id int) *IDSet {
 	s := NewIDSet()
 	frontier := IDSetWith(id)
 
@@ -21,7 +40,7 @@ func (sm DisjointIDSet) ExtractSet(id int) *IDSet {
 	for frontier.Pop(&v) {
 		if !s.Contains(v) {
 			s.Add(v)
-			frontier.Union(sm[v])
+			frontier.Union(sm.Get(v))
 		}
 	}
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/disjoint_idset_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/disjoint_idset_test.go
@@ -6,25 +6,36 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestDisjointIDSet(t *testing.T) {
-	s := DisjointIDSet{}
-	s.Union(1, 2)
-	s.Union(3, 4)
-	s.Union(1, 3)
-	s.Union(5, 6)
+func TestDisjointIDSetExtract(t *testing.T) {
+	s := NewDisjointIDSet()
+	s.Link(1, 2)
+	s.Link(3, 4)
+	s.Link(1, 3)
+	s.Link(5, 6)
 
 	setA := []int{1, 2, 3, 4}
 	setB := []int{5, 6}
 
 	for _, i := range setA {
-		if diff := cmp.Diff(setA, s.ExtractSet(i).Identifiers()); diff != "" {
-			t.Errorf("unexpected keys (-want +got):\n%s", diff)
+		if diff := cmp.Diff(IDSetWith(setA...), s.ExtractSet(i), Comparers...); diff != "" {
+			t.Errorf("unexpected set (-want +got):\n%s", diff)
 		}
 	}
 
 	for _, i := range setB {
-		if diff := cmp.Diff(setB, s.ExtractSet(i).Identifiers()); diff != "" {
-			t.Errorf("unexpected keys (-want +got):\n%s", diff)
+		if diff := cmp.Diff(IDSetWith(setB...), s.ExtractSet(i), Comparers...); diff != "" {
+			t.Errorf("unexpected set (-want +got):\n%s", diff)
 		}
+	}
+}
+
+func TestDisjointIDSetExtractEmptyReturnsValue(t *testing.T) {
+	s := NewDisjointIDSet()
+	s.Link(1, 2)
+	s.Link(2, 3)
+	s.Link(3, 4)
+
+	if diff := cmp.Diff(IDSetWith(5), s.ExtractSet(5), Comparers...); diff != "" {
+		t.Errorf("unexpected set (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/idset_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures/idset_test.go
@@ -1,50 +1,67 @@
 package datastructures
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestIDSetOperations(t *testing.T) {
+func TestIDSetAdd(t *testing.T) {
+	for _, max := range []int{SmallSetThreshold / 2, SmallSetThreshold, SmallSetThreshold * 16} {
+		name := fmt.Sprintf("max=%d", max)
+
+		t.Run(name, func(t *testing.T) {
+			ids := NewIDSet()
+			for i := 1; i <= max; i++ {
+				ids.Add(i)
+			}
+
+			if ids.Len() != max {
+				t.Errorf("unexpected length. want=%d have=%d", max, ids.Len())
+			}
+
+			for i := 1; i <= max; i++ {
+				if !ids.Contains(i) {
+					t.Errorf("unexpected contains. want=%v have=%v", true, ids.Contains(i))
+				}
+			}
+		})
+	}
+}
+
+func TestIDSetUnion(t *testing.T) {
 	for _, max := range []int{16, 10000} {
-		ids := NewIDSet()
-		for i := 0; i < max; i += 2 {
-			ids.Add(i)
-		}
+		name := fmt.Sprintf("max=%d", max)
 
-		if ids.Len() != max/2 {
-			t.Errorf("unexpected length. want=%d have=%d", max/2, ids.Len())
-		}
-
-		for i := 0; i < max; i++ {
-			expected := i%2 == 0
-
-			if ids.Contains(i) != expected {
-				t.Errorf("unexpected contains. want=%v have=%v", expected, ids.Contains(i))
+		t.Run(name, func(t *testing.T) {
+			ids1 := NewIDSet()
+			ids2 := NewIDSet()
+			for i := 1; i <= max; i++ {
+				if i%2 == 0 {
+					ids1.Add(i)
+				}
+				if i%3 == 0 {
+					ids2.Add(i)
+				}
 			}
-		}
 
-		ids2 := NewIDSet()
-		for i := 0; i < max; i += 3 {
-			ids2.Add(i)
-		}
+			ids1.Union(nil)
+			ids1.Union(ids2)
 
-		ids.Union(nil)
-		ids.Union(ids2)
-
-		if ids.Len() != max/2+max/3-(max/6) {
-			t.Errorf("unexpected length. want=%d have=%d", max/2+max/3-(max/6), ids.Len())
-		}
-
-		for i := 0; i < max/2; i++ {
-			expected := (i%2 == 0) || (i%3 == 0)
-
-			if ids.Contains(i) != expected {
-				t.Errorf("unexpected contains. want=%v have=%v", expected, ids.Contains(i))
+			if ids1.Len() != (max/2)+(max/3)-(max/6) {
+				t.Errorf("unexpected length. want=%d have=%d", (max/2)+(max/3)-(max/6), ids1.Len())
 			}
-		}
+
+			for i := 1; i <= max/2; i++ {
+				expected := (i%2 == 0) || (i%3 == 0)
+
+				if ids1.Contains(i) != expected {
+					t.Errorf("unexpected contains. want=%v have=%v", expected, ids1.Contains(i))
+				}
+			}
+		})
 	}
 }
 
@@ -61,7 +78,7 @@ func TestIDSetMin(t *testing.T) {
 	for _, numUpperValues := range []int{0, 1000} {
 		ids := NewIDSet()
 
-		for i := 0; i < numUpperValues; i++ {
+		for i := 1; i <= numUpperValues; i++ {
 			ids.Add(1000 + i)
 		}
 
@@ -87,7 +104,7 @@ func TestIDSetPop(t *testing.T) {
 	small := []int{1, 2, 3, 4, 5}
 
 	large := make([]int, 0, 10000)
-	for i := 0; i < 10000; i++ {
+	for i := 1; i <= 10000; i++ {
 		large = append(large, i)
 	}
 
@@ -95,7 +112,7 @@ func TestIDSetPop(t *testing.T) {
 		set := IDSetWith(values...)
 
 		popped := []int{}
-		for i := 0; i < len(values); i++ {
+		for i := 1; i <= len(values); i++ {
 			var v int
 			if !set.Pop(&v) {
 				t.Fatalf("failed to pop")

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/group.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/group.go
@@ -63,53 +63,34 @@ func groupBundleData(state *State, dumpID int) (*GroupedBundleData, error) {
 
 func serializeBundleDocuments(state *State) map[string]types.DocumentData {
 	out := make(map[string]types.DocumentData, len(state.DocumentData))
-	for _, doc := range state.DocumentData {
-		if strings.HasPrefix(doc.URI, "..") {
+	for documentID, uri := range state.DocumentData {
+		if strings.HasPrefix(uri, "..") {
 			continue
 		}
 
-		out[doc.URI] = serializeDocument(state, doc)
+		out[uri] = serializeDocument(state, documentID)
 	}
 
 	return out
 }
 
-func serializeDocument(state *State, doc lsif.Document) types.DocumentData {
+func serializeDocument(state *State, documentID int) types.DocumentData {
 	document := types.DocumentData{
-		Ranges:             map[types.ID]types.RangeData{},
+		Ranges:             make(map[types.ID]types.RangeData, state.Contains.SetLen(documentID)),
 		HoverResults:       map[types.ID]string{},
 		Monikers:           map[types.ID]types.MonikerData{},
 		PackageInformation: map[types.ID]types.PackageInformationData{},
-		Diagnostics:        []types.DiagnosticData{},
+		Diagnostics:        make([]types.DiagnosticData, 0, state.Diagnostics.SetLen(documentID)),
 	}
 
-	doc.Contains.Each(func(rangeID int) {
-		k := rangeID
-		v := state.RangeData[rangeID]
+	state.Contains.SetEach(documentID, func(rangeID int) {
+		rangeData := state.RangeData[rangeID]
 
-		monikerIDs := make([]types.ID, 0, v.MonikerIDs.Len())
-		v.MonikerIDs.Each(func(m int) {
-			monikerIDs = append(monikerIDs, toID(m))
-		})
-
-		document.Ranges[toID(k)] = types.RangeData{
-			StartLine:          v.StartLine,
-			StartCharacter:     v.StartCharacter,
-			EndLine:            v.EndLine,
-			EndCharacter:       v.EndCharacter,
-			DefinitionResultID: toID(v.DefinitionResultID),
-			ReferenceResultID:  toID(v.ReferenceResultID),
-			HoverResultID:      toID(v.HoverResultID),
-			MonikerIDs:         monikerIDs,
-		}
-
-		if v.HoverResultID != 0 {
-			hoverData := state.HoverData[v.HoverResultID]
-			document.HoverResults[toID(v.HoverResultID)] = hoverData
-		}
-
-		v.MonikerIDs.Each(func(monikerID int) {
+		monikerIDs := make([]types.ID, 0, state.Monikers.SetLen(rangeID))
+		state.Monikers.SetEach(rangeID, func(monikerID int) {
 			moniker := state.MonikerData[monikerID]
+			monikerIDs = append(monikerIDs, toID(monikerID))
+
 			document.Monikers[toID(monikerID)] = types.MonikerData{
 				Kind:                 moniker.Kind,
 				Scheme:               moniker.Scheme,
@@ -125,10 +106,26 @@ func serializeDocument(state *State, doc lsif.Document) types.DocumentData {
 				}
 			}
 		})
+
+		document.Ranges[toID(rangeID)] = types.RangeData{
+			StartLine:          rangeData.StartLine,
+			StartCharacter:     rangeData.StartCharacter,
+			EndLine:            rangeData.EndLine,
+			EndCharacter:       rangeData.EndCharacter,
+			DefinitionResultID: toID(rangeData.DefinitionResultID),
+			ReferenceResultID:  toID(rangeData.ReferenceResultID),
+			HoverResultID:      toID(rangeData.HoverResultID),
+			MonikerIDs:         monikerIDs,
+		}
+
+		if rangeData.HoverResultID != 0 {
+			hoverData := state.HoverData[rangeData.HoverResultID]
+			document.HoverResults[toID(rangeData.HoverResultID)] = hoverData
+		}
 	})
 
-	doc.Diagnostics.Each(func(diagnosticID int) {
-		for _, diagnostic := range state.Diagnostics[diagnosticID].Result {
+	state.Diagnostics.SetEach(documentID, func(diagnosticID int) {
+		for _, diagnostic := range state.DiagnosticResults[diagnosticID] {
 			document.Diagnostics = append(document.Diagnostics, types.DiagnosticData{
 				Severity:       diagnostic.Severity,
 				Code:           diagnostic.Code,
@@ -146,52 +143,58 @@ func serializeDocument(state *State, doc lsif.Document) types.DocumentData {
 }
 
 func serializeResultChunks(state *State, numResultChunks int) map[int]types.ResultChunkData {
-	resultChunks := make([]types.ResultChunkData, 0, numResultChunks)
-	for i := 0; i < numResultChunks; i++ {
-		resultChunks = append(resultChunks, types.ResultChunkData{
-			DocumentPaths:      map[types.ID]string{},
-			DocumentIDRangeIDs: map[types.ID][]types.DocumentIDRangeID{},
-		})
+	chunkAssignments := make(map[int][]int, numResultChunks)
+	for id := range state.DefinitionData {
+		index := types.HashKey(toID(id), numResultChunks)
+		chunkAssignments[index] = append(chunkAssignments[index], id)
+	}
+	for id := range state.ReferenceData {
+		index := types.HashKey(toID(id), numResultChunks)
+		chunkAssignments[index] = append(chunkAssignments[index], id)
 	}
 
-	addToChunk(state, resultChunks, state.DefinitionData)
-	addToChunk(state, resultChunks, state.ReferenceData)
-
-	out := make(map[int]types.ResultChunkData, len(resultChunks))
-	for id, resultChunk := range resultChunks {
-		if len(resultChunk.DocumentPaths) == 0 && len(resultChunk.DocumentIDRangeIDs) == 0 {
+	resultChunks := map[int]types.ResultChunkData{}
+	for id, resultIDs := range chunkAssignments {
+		if len(resultIDs) == 0 {
 			continue
 		}
 
-		out[id] = resultChunk
-	}
+		documentPaths := map[types.ID]string{}
+		documentIDRangeIDs := map[types.ID][]types.DocumentIDRangeID{}
 
-	return out
-}
+		for _, resultID := range resultIDs {
+			documentRanges, ok := state.DefinitionData[resultID]
+			if !ok {
+				documentRanges = state.ReferenceData[resultID]
+			}
 
-func addToChunk(state *State, resultChunks []types.ResultChunkData, data map[int]datastructures.DefaultIDSetMap) {
-	for id, documentRanges := range data {
-		resultChunk := resultChunks[types.HashKey(toID(id), len(resultChunks))]
+			// Ensure we always make an assignment for every definition and reference result,
+			// even if we've pruned all of the referenced documents and ranges. This prevents
+			// us from throwing an error in the bundle manager because we try to dereference
+			// a missing identifier.
+			documentIDRangeIDs[toID(resultID)] = nil
 
-		if len(documentRanges) == 0 {
-			// We may have pruned all document/ranges from a definition or reference result,
-			// but we add a dummy set here so that we don't hit an unknown key during queries.
-			// TODO(efritz) - remove these as part of the prune pass instead
-			resultChunk.DocumentIDRangeIDs[toID(id)] = nil
-		}
+			documentRanges.Each(func(documentID int, rangeIDs *datastructures.IDSet) {
+				documentPaths[toID(documentID)] = state.DocumentData[documentID]
 
-		for documentID, rangeIDs := range documentRanges {
-			doc := state.DocumentData[documentID]
-			resultChunk.DocumentPaths[toID(documentID)] = doc.URI
-
-			rangeIDs.Each(func(rangeID int) {
-				resultChunk.DocumentIDRangeIDs[toID(id)] = append(resultChunk.DocumentIDRangeIDs[toID(id)], types.DocumentIDRangeID{
-					DocumentID: toID(documentID),
-					RangeID:    toID(rangeID),
+				rangeIDs.Each(func(rangeID int) {
+					documentIDRangeIDs[toID(resultID)] = append(documentIDRangeIDs[toID(resultID)], types.DocumentIDRangeID{
+						DocumentID: toID(documentID),
+						RangeID:    toID(rangeID),
+					})
 				})
 			})
 		}
+
+		resultChunk := types.ResultChunkData{
+			DocumentPaths:      documentPaths,
+			DocumentIDRangeIDs: documentIDRangeIDs,
+		}
+
+		resultChunks[id] = resultChunk
 	}
+
+	return resultChunks
 }
 
 var (
@@ -199,77 +202,68 @@ var (
 	getReferenceResultID  = func(r lsif.Range) int { return r.ReferenceResultID }
 )
 
-func gatherMonikersLocations(state *State, data map[int]datastructures.DefaultIDSetMap, getResultID func(r lsif.Range) int) []types.MonikerLocations {
-	monikers := datastructures.DefaultIDSetMap{}
-	for _, r := range state.RangeData {
-		resultID := getResultID(r)
-
-		if resultID != 0 && r.MonikerIDs.Len() > 0 {
-			monikers.GetOrCreate(resultID).Union(r.MonikerIDs)
+func gatherMonikersLocations(state *State, data map[int]*datastructures.DefaultIDSetMap, getResultID func(r lsif.Range) int) []types.MonikerLocations {
+	monikers := datastructures.NewDefaultIDSetMap()
+	for rangeID, r := range state.RangeData {
+		if resultID := getResultID(r); resultID != 0 {
+			monikers.SetUnion(resultID, state.Monikers.Get(rangeID))
 		}
 	}
 
-	n := 0
+	idsBySchemeByIdentifier := map[string]map[string][]int{}
 	for id := range data {
-		monikerIDs, ok := monikers[id]
-		if !ok {
-			continue
-		}
-
-		n += monikerIDs.Len()
-	}
-
-	uniques := make(map[string]types.MonikerLocations, n)
-	for id, documentRanges := range data {
-		monikerIDs, ok := monikers[id]
-		if !ok {
+		monikerIDs := monikers.Get(id)
+		if monikerIDs == nil {
 			continue
 		}
 
 		monikerIDs.Each(func(monikerID int) {
-			n := 0
-			for _, rangeIDs := range documentRanges {
-				n += rangeIDs.Len()
+			moniker := state.MonikerData[monikerID]
+			idsByIdentifier, ok := idsBySchemeByIdentifier[moniker.Scheme]
+			if !ok {
+				idsByIdentifier = map[string][]int{}
+				idsBySchemeByIdentifier[moniker.Scheme] = idsByIdentifier
 			}
+			idsByIdentifier[moniker.Identifier] = append(idsByIdentifier[moniker.Identifier], id)
+		})
+	}
 
-			locations := make([]types.Location, 0, n)
-			for documentID, rangeIDs := range documentRanges {
-				document := state.DocumentData[documentID]
-				if strings.HasPrefix(document.URI, "..") {
-					continue
-				}
+	var out []types.MonikerLocations
+	for scheme, idsByIdentifier := range idsBySchemeByIdentifier {
+		for identifier, ids := range idsByIdentifier {
+			var locations []types.Location
+			for _, id := range ids {
+				data[id].Each(func(documentID int, rangeIDs *datastructures.IDSet) {
+					uri := state.DocumentData[documentID]
+					if strings.HasPrefix(uri, "..") {
+						return
+					}
 
-				rangeIDs.Each(func(id int) {
-					r := state.RangeData[id]
+					rangeIDs.Each(func(id int) {
+						r := state.RangeData[id]
 
-					locations = append(locations, types.Location{
-						URI:            document.URI,
-						StartLine:      r.StartLine,
-						StartCharacter: r.StartCharacter,
-						EndLine:        r.EndLine,
-						EndCharacter:   r.EndCharacter,
+						locations = append(locations, types.Location{
+							URI:            uri,
+							StartLine:      r.StartLine,
+							StartCharacter: r.StartCharacter,
+							EndLine:        r.EndLine,
+							EndCharacter:   r.EndCharacter,
+						})
 					})
 				})
 			}
 
-			moniker := state.MonikerData[monikerID]
-			key := makeKey(moniker.Scheme, moniker.Identifier)
-			uniques[key] = types.MonikerLocations{
-				Scheme:     moniker.Scheme,
-				Identifier: moniker.Identifier,
-				Locations:  append(uniques[key].Locations, locations...),
+			if len(locations) > 0 {
+				out = append(out, types.MonikerLocations{
+					Scheme:     scheme,
+					Identifier: identifier,
+					Locations:  locations,
+				})
 			}
-		})
-	}
-
-	monikerLocations := make([]types.MonikerLocations, 0, len(uniques))
-	for _, v := range uniques {
-		if len(v.Locations) > 0 {
-			monikerLocations = append(monikerLocations, v)
 		}
 	}
 
-	return monikerLocations
+	return out
 }
 
 func gatherPackages(state *State, dumpID int) []types.Package {

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/group_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/group_test.go
@@ -14,22 +14,10 @@ import (
 
 func TestGroupBundleData(t *testing.T) {
 	state := &State{
-		DocumentData: map[int]lsif.Document{
-			1001: {
-				URI:         "foo.go",
-				Contains:    datastructures.IDSetWith(2001, 2002, 2003),
-				Diagnostics: datastructures.IDSetWith(1001, 1002),
-			},
-			1002: {
-				URI:         "bar.go",
-				Contains:    datastructures.IDSetWith(2004, 2005, 2006),
-				Diagnostics: datastructures.IDSetWith(1003),
-			},
-			1003: {
-				URI:         "baz.go",
-				Contains:    datastructures.IDSetWith(2007, 2008, 2009),
-				Diagnostics: datastructures.NewIDSet(),
-			},
+		DocumentData: map[int]string{
+			1001: "foo.go",
+			1002: "bar.go",
+			1003: "baz.go",
 		},
 		RangeData: map[int]lsif.Range{
 			2001: {
@@ -39,7 +27,6 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       4,
 				DefinitionResultID: 3001,
 				ReferenceResultID:  0,
-				MonikerIDs:         datastructures.IDSetWith(4001, 4002),
 			},
 			2002: {
 				StartLine:          2,
@@ -48,7 +35,7 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       5,
 				DefinitionResultID: 0,
 				ReferenceResultID:  3006,
-				MonikerIDs:         datastructures.IDSetWith(4003, 4004)},
+			},
 			2003: {
 				StartLine:          3,
 				StartCharacter:     4,
@@ -56,7 +43,6 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       6,
 				DefinitionResultID: 3002,
 				ReferenceResultID:  0,
-				MonikerIDs:         datastructures.NewIDSet(),
 			},
 			2004: {
 				StartLine:          4,
@@ -65,7 +51,7 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       7,
 				DefinitionResultID: 0,
 				ReferenceResultID:  3007,
-				MonikerIDs:         datastructures.NewIDSet()},
+			},
 			2005: {
 				StartLine:          5,
 				StartCharacter:     6,
@@ -73,7 +59,6 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       8,
 				DefinitionResultID: 3003,
 				ReferenceResultID:  0,
-				MonikerIDs:         datastructures.NewIDSet(),
 			},
 			2006: {
 				StartLine:          6,
@@ -82,7 +67,7 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       9,
 				DefinitionResultID: 0,
 				HoverResultID:      3008,
-				MonikerIDs:         datastructures.NewIDSet()},
+			},
 			2007: {
 				StartLine:          7,
 				StartCharacter:     8,
@@ -90,7 +75,6 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       0,
 				DefinitionResultID: 3004,
 				ReferenceResultID:  0,
-				MonikerIDs:         datastructures.NewIDSet(),
 			},
 			2008: {
 				StartLine:          8,
@@ -99,7 +83,7 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       1,
 				DefinitionResultID: 0,
 				HoverResultID:      3009,
-				MonikerIDs:         datastructures.NewIDSet()},
+			},
 			2009: {
 				StartLine:          9,
 				StartCharacter:     0,
@@ -107,45 +91,44 @@ func TestGroupBundleData(t *testing.T) {
 				EndCharacter:       2,
 				DefinitionResultID: 3005,
 				ReferenceResultID:  0,
-				MonikerIDs:         datastructures.NewIDSet(),
 			},
 		},
-		DefinitionData: map[int]datastructures.DefaultIDSetMap{
-			3001: {
+		DefinitionData: map[int]*datastructures.DefaultIDSetMap{
+			3001: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2003),
 				1002: datastructures.IDSetWith(2004),
 				1003: datastructures.IDSetWith(2007),
-			},
-			3002: {
+			}),
+			3002: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2002),
 				1002: datastructures.IDSetWith(2005),
 				1003: datastructures.IDSetWith(2008),
-			},
-			3003: {
+			}),
+			3003: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2001),
 				1002: datastructures.IDSetWith(2006),
 				1003: datastructures.IDSetWith(2009),
-			},
-			3004: {
+			}),
+			3004: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2003),
 				1002: datastructures.IDSetWith(2005),
 				1003: datastructures.IDSetWith(2007),
-			},
-			3005: {
+			}),
+			3005: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2002),
 				1002: datastructures.IDSetWith(2006),
 				1003: datastructures.IDSetWith(2008),
-			},
+			}),
 		},
-		ReferenceData: map[int]datastructures.DefaultIDSetMap{
-			3006: {
+		ReferenceData: map[int]*datastructures.DefaultIDSetMap{
+			3006: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2003),
 				1003: datastructures.IDSetWith(2007, 2009),
-			},
-			3007: {
+			}),
+			3007: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.IDSetWith(2002),
 				1003: datastructures.IDSetWith(2007, 2009),
-			},
+			}),
 		},
 		HoverData: map[int]string{
 			3008: "foo",
@@ -187,376 +170,103 @@ func TestGroupBundleData(t *testing.T) {
 				Version: "1.2.3",
 			},
 		},
-		Diagnostics: map[int]lsif.DiagnosticResult{
+		DiagnosticResults: map[int][]lsif.Diagnostic{
 			1001: {
-				Result: []lsif.Diagnostic{
-					{
-						Severity:       1,
-						Code:           "1234",
-						Message:        "m1",
-						Source:         "s1",
-						StartLine:      11,
-						StartCharacter: 12,
-						EndLine:        13,
-						EndCharacter:   14,
-					},
+				{
+					Severity:       1,
+					Code:           "1234",
+					Message:        "m1",
+					Source:         "s1",
+					StartLine:      11,
+					StartCharacter: 12,
+					EndLine:        13,
+					EndCharacter:   14,
 				},
 			},
 			1002: {
-				Result: []lsif.Diagnostic{
-					{
-						Severity:       2,
-						Code:           "2",
-						Message:        "m2",
-						Source:         "s2",
-						StartLine:      21,
-						StartCharacter: 22,
-						EndLine:        23,
-						EndCharacter:   24,
-					},
+				{
+					Severity:       2,
+					Code:           "2",
+					Message:        "m2",
+					Source:         "s2",
+					StartLine:      21,
+					StartCharacter: 22,
+					EndLine:        23,
+					EndCharacter:   24,
 				},
 			},
 			1003: {
-				Result: []lsif.Diagnostic{
-					{
-						Severity:       3,
-						Code:           "3234",
-						Message:        "m3",
-						Source:         "s3",
-						StartLine:      31,
-						StartCharacter: 32,
-						EndLine:        33,
-						EndCharacter:   34,
-					},
-					{
-						Severity:       4,
-						Code:           "4234",
-						Message:        "m4",
-						Source:         "s4",
-						StartLine:      41,
-						StartCharacter: 42,
-						EndLine:        43,
-						EndCharacter:   44,
-					},
+				{
+					Severity:       3,
+					Code:           "3234",
+					Message:        "m3",
+					Source:         "s3",
+					StartLine:      31,
+					StartCharacter: 32,
+					EndLine:        33,
+					EndCharacter:   34,
+				},
+				{
+					Severity:       4,
+					Code:           "4234",
+					Message:        "m4",
+					Source:         "s4",
+					StartLine:      41,
+					StartCharacter: 42,
+					EndLine:        43,
+					EndCharacter:   44,
 				},
 			},
 		},
 		ImportedMonikers: datastructures.IDSetWith(4001),
 		ExportedMonikers: datastructures.IDSetWith(4003),
+		Contains: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
+			1001: datastructures.IDSetWith(2001, 2002, 2003),
+			1002: datastructures.IDSetWith(2004, 2005, 2006),
+			1003: datastructures.IDSetWith(2007, 2008, 2009),
+		}),
+		Monikers: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
+			2001: datastructures.IDSetWith(4001, 4002),
+			2002: datastructures.IDSetWith(4003, 4004),
+		}),
+		Diagnostics: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
+			1001: datastructures.IDSetWith(1001, 1002),
+			1002: datastructures.IDSetWith(1003),
+		}),
 	}
 
 	actualBundleData, err := groupBundleData(state, 42)
 	if err != nil {
 		t.Fatalf("unexpected error converting correlation state to types: %s", err)
 	}
-	// Ensure arrays have deterministic order so we can compare with a canned expected object structure
-	normalizeGroupedBundleData(actualBundleData)
+
+	expectedMetaData := types.MetaData{
+		NumResultChunks: 1,
+	}
+	if diff := cmp.Diff(expectedMetaData, actualBundleData.Meta); diff != "" {
+		t.Errorf("unexpected meta data (-want +got):\n%s", diff)
+	}
+
+	expectedPackages := []types.Package{
+		{DumpID: 42, Scheme: "scheme C", Name: "pkg B", Version: "1.2.3"},
+	}
+	if diff := cmp.Diff(expectedPackages, actualBundleData.Packages); diff != "" {
+		t.Errorf("unexpected packages (-want +got):\n%s", diff)
+	}
 
 	expectedFilter, err := bloomfilter.CreateFilter([]string{"ident A"})
 	if err != nil {
 		t.Fatalf("unexpected error creating bloom filter: %s", err)
 	}
-
-	expectedBundleData := &GroupedBundleData{
-		Meta: types.MetaData{
-			NumResultChunks: 1,
-		},
-		Documents: map[string]types.DocumentData{
-			"foo.go": {
-				Ranges: map[types.ID]types.RangeData{
-					"2001": {
-						StartLine:          1,
-						StartCharacter:     2,
-						EndLine:            3,
-						EndCharacter:       4,
-						DefinitionResultID: "3001",
-						ReferenceResultID:  "",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{"4001", "4002"},
-					},
-					"2002": {
-						StartLine:          2,
-						StartCharacter:     3,
-						EndLine:            4,
-						EndCharacter:       5,
-						DefinitionResultID: "",
-						ReferenceResultID:  "3006",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{"4003", "4004"},
-					},
-					"2003": {
-						StartLine:          3,
-						StartCharacter:     4,
-						EndLine:            5,
-						EndCharacter:       6,
-						DefinitionResultID: "3002",
-						ReferenceResultID:  "",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{},
-					},
-				},
-				HoverResults: map[types.ID]string{},
-				Monikers: map[types.ID]types.MonikerData{
-					"4001": {
-						Kind:                 "import",
-						Scheme:               "scheme A",
-						Identifier:           "ident A",
-						PackageInformationID: "5001",
-					},
-					"4002": {
-						Kind:                 "import",
-						Scheme:               "scheme B",
-						Identifier:           "ident B",
-						PackageInformationID: "",
-					},
-					"4003": {
-						Kind:                 "export",
-						Scheme:               "scheme C",
-						Identifier:           "ident C",
-						PackageInformationID: "5002",
-					},
-					"4004": {
-						Kind:                 "export",
-						Scheme:               "scheme D",
-						Identifier:           "ident D",
-						PackageInformationID: "",
-					},
-				},
-				PackageInformation: map[types.ID]types.PackageInformationData{
-					"5001": {
-						Name:    "pkg A",
-						Version: "0.1.0",
-					},
-					"5002": {
-						Name:    "pkg B",
-						Version: "1.2.3",
-					},
-				},
-				Diagnostics: []types.DiagnosticData{
-					{
-						Severity:       1,
-						Code:           "1234",
-						Message:        "m1",
-						Source:         "s1",
-						StartLine:      11,
-						StartCharacter: 12,
-						EndLine:        13,
-						EndCharacter:   14,
-					},
-					{
-						Severity:       2,
-						Code:           "2",
-						Message:        "m2",
-						Source:         "s2",
-						StartLine:      21,
-						StartCharacter: 22,
-						EndLine:        23,
-						EndCharacter:   24,
-					},
-				},
-			},
-			"bar.go": {
-				Ranges: map[types.ID]types.RangeData{
-					"2004": {
-						StartLine:          4,
-						StartCharacter:     5,
-						EndLine:            6,
-						EndCharacter:       7,
-						DefinitionResultID: "",
-						ReferenceResultID:  "3007",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{},
-					},
-					"2005": {
-						StartLine:          5,
-						StartCharacter:     6,
-						EndLine:            7,
-						EndCharacter:       8,
-						DefinitionResultID: "3003",
-						ReferenceResultID:  "",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{},
-					},
-					"2006": {
-						StartLine:          6,
-						StartCharacter:     7,
-						EndLine:            8,
-						EndCharacter:       9,
-						DefinitionResultID: "",
-						ReferenceResultID:  "",
-						HoverResultID:      "3008",
-						MonikerIDs:         []types.ID{},
-					},
-				},
-				HoverResults:       map[types.ID]string{"3008": "foo"},
-				Monikers:           map[types.ID]types.MonikerData{},
-				PackageInformation: map[types.ID]types.PackageInformationData{},
-				Diagnostics: []types.DiagnosticData{
-					{
-						Severity:       3,
-						Code:           "3234",
-						Message:        "m3",
-						Source:         "s3",
-						StartLine:      31,
-						StartCharacter: 32,
-						EndLine:        33,
-						EndCharacter:   34,
-					},
-					{
-						Severity:       4,
-						Code:           "4234",
-						Message:        "m4",
-						Source:         "s4",
-						StartLine:      41,
-						StartCharacter: 42,
-						EndLine:        43,
-						EndCharacter:   44,
-					},
-				},
-			},
-			"baz.go": {
-				Ranges: map[types.ID]types.RangeData{
-					"2007": {
-						StartLine:          7,
-						StartCharacter:     8,
-						EndLine:            9,
-						EndCharacter:       0,
-						DefinitionResultID: "3004",
-						ReferenceResultID:  "",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{},
-					},
-					"2008": {
-						StartLine:          8,
-						StartCharacter:     9,
-						EndLine:            0,
-						EndCharacter:       1,
-						DefinitionResultID: "",
-						ReferenceResultID:  "",
-						HoverResultID:      "3009",
-						MonikerIDs:         []types.ID{},
-					},
-					"2009": {
-						StartLine:          9,
-						StartCharacter:     0,
-						EndLine:            1,
-						EndCharacter:       2,
-						DefinitionResultID: "3005",
-						ReferenceResultID:  "",
-						HoverResultID:      "",
-						MonikerIDs:         []types.ID{},
-					},
-				},
-				HoverResults:       map[types.ID]string{"3009": "bar"},
-				Monikers:           map[types.ID]types.MonikerData{},
-				PackageInformation: map[types.ID]types.PackageInformationData{},
-				Diagnostics:        []types.DiagnosticData{},
-			},
-		},
-		ResultChunks: map[int]types.ResultChunkData{
-			0: {
-				DocumentPaths: map[types.ID]string{
-					"1001": "foo.go",
-					"1002": "bar.go",
-					"1003": "baz.go",
-				},
-				DocumentIDRangeIDs: map[types.ID][]types.DocumentIDRangeID{
-					"3001": {
-						{DocumentID: "1001", RangeID: "2003"},
-						{DocumentID: "1002", RangeID: "2004"},
-						{DocumentID: "1003", RangeID: "2007"},
-					},
-					"3002": {
-						{DocumentID: "1001", RangeID: "2002"},
-						{DocumentID: "1002", RangeID: "2005"},
-						{DocumentID: "1003", RangeID: "2008"},
-					},
-					"3003": {
-						{DocumentID: "1001", RangeID: "2001"},
-						{DocumentID: "1002", RangeID: "2006"},
-						{DocumentID: "1003", RangeID: "2009"},
-					},
-					"3004": {
-						{DocumentID: "1001", RangeID: "2003"},
-						{DocumentID: "1002", RangeID: "2005"},
-						{DocumentID: "1003", RangeID: "2007"},
-					},
-					"3005": {
-						{DocumentID: "1001", RangeID: "2002"},
-						{DocumentID: "1002", RangeID: "2006"},
-						{DocumentID: "1003", RangeID: "2008"},
-					},
-					"3006": {
-						{DocumentID: "1001", RangeID: "2003"},
-						{DocumentID: "1003", RangeID: "2007"},
-						{DocumentID: "1003", RangeID: "2009"},
-					},
-					"3007": {
-						{DocumentID: "1001", RangeID: "2002"},
-						{DocumentID: "1003", RangeID: "2007"},
-						{DocumentID: "1003", RangeID: "2009"},
-					},
-				},
-			},
-		},
-		Definitions: []types.MonikerLocations{
-			{
-				Scheme:     "scheme A",
-				Identifier: "ident A",
-				Locations: []types.Location{
-					{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
-				},
-			},
-			{
-				Scheme:     "scheme B",
-				Identifier: "ident B",
-				Locations: []types.Location{
-					{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
-				},
-			},
-		},
-		References: []types.MonikerLocations{
-			{
-				Scheme:     "scheme C",
-				Identifier: "ident C",
-				Locations: []types.Location{
-					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-					{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
-				},
-			},
-			{
-				Scheme:     "scheme D",
-				Identifier: "ident D",
-				Locations: []types.Location{
-					{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-					{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-					{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
-				},
-			},
-		},
-		Packages: []types.Package{
-			{DumpID: 42, Scheme: "scheme C", Name: "pkg B", Version: "1.2.3"},
-		},
-		PackageReferences: []types.PackageReference{
-			{DumpID: 42, Scheme: "scheme A", Name: "pkg A", Version: "0.1.0", Filter: expectedFilter},
-		},
+	expectedPackageReferences := []types.PackageReference{
+		{DumpID: 42, Scheme: "scheme A", Name: "pkg A", Version: "0.1.0", Filter: expectedFilter},
+	}
+	if diff := cmp.Diff(expectedPackageReferences, actualBundleData.PackageReferences); diff != "" {
+		t.Errorf("unexpected package references (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(expectedBundleData, actualBundleData, datastructures.IDSetComparer); diff != "" {
-		t.Errorf("unexpected bundle data (-want +got):\n%s", diff)
-	}
-}
-
-//
-//
-
-func normalizeGroupedBundleData(groupedBundleData *GroupedBundleData) {
-	for _, document := range groupedBundleData.Documents {
+	documents := actualBundleData.Documents
+	for _, document := range documents {
 		sortDiagnostics(document.Diagnostics)
 
 		for _, r := range document.Ranges {
@@ -564,15 +274,316 @@ func normalizeGroupedBundleData(groupedBundleData *GroupedBundleData) {
 		}
 	}
 
-	for _, resultChunk := range groupedBundleData.ResultChunks {
+	expectedDocumentData := map[string]types.DocumentData{
+		"foo.go": {
+			Ranges: map[types.ID]types.RangeData{
+				"2001": {
+					StartLine:          1,
+					StartCharacter:     2,
+					EndLine:            3,
+					EndCharacter:       4,
+					DefinitionResultID: "3001",
+					ReferenceResultID:  "",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{"4001", "4002"},
+				},
+				"2002": {
+					StartLine:          2,
+					StartCharacter:     3,
+					EndLine:            4,
+					EndCharacter:       5,
+					DefinitionResultID: "",
+					ReferenceResultID:  "3006",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{"4003", "4004"},
+				},
+				"2003": {
+					StartLine:          3,
+					StartCharacter:     4,
+					EndLine:            5,
+					EndCharacter:       6,
+					DefinitionResultID: "3002",
+					ReferenceResultID:  "",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{},
+				},
+			},
+			HoverResults: map[types.ID]string{},
+			Monikers: map[types.ID]types.MonikerData{
+				"4001": {
+					Kind:                 "import",
+					Scheme:               "scheme A",
+					Identifier:           "ident A",
+					PackageInformationID: "5001",
+				},
+				"4002": {
+					Kind:                 "import",
+					Scheme:               "scheme B",
+					Identifier:           "ident B",
+					PackageInformationID: "",
+				},
+				"4003": {
+					Kind:                 "export",
+					Scheme:               "scheme C",
+					Identifier:           "ident C",
+					PackageInformationID: "5002",
+				},
+				"4004": {
+					Kind:                 "export",
+					Scheme:               "scheme D",
+					Identifier:           "ident D",
+					PackageInformationID: "",
+				},
+			},
+			PackageInformation: map[types.ID]types.PackageInformationData{
+				"5001": {
+					Name:    "pkg A",
+					Version: "0.1.0",
+				},
+				"5002": {
+					Name:    "pkg B",
+					Version: "1.2.3",
+				},
+			},
+			Diagnostics: []types.DiagnosticData{
+				{
+					Severity:       1,
+					Code:           "1234",
+					Message:        "m1",
+					Source:         "s1",
+					StartLine:      11,
+					StartCharacter: 12,
+					EndLine:        13,
+					EndCharacter:   14,
+				},
+				{
+					Severity:       2,
+					Code:           "2",
+					Message:        "m2",
+					Source:         "s2",
+					StartLine:      21,
+					StartCharacter: 22,
+					EndLine:        23,
+					EndCharacter:   24,
+				},
+			},
+		},
+		"bar.go": {
+			Ranges: map[types.ID]types.RangeData{
+				"2004": {
+					StartLine:          4,
+					StartCharacter:     5,
+					EndLine:            6,
+					EndCharacter:       7,
+					DefinitionResultID: "",
+					ReferenceResultID:  "3007",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{},
+				},
+				"2005": {
+					StartLine:          5,
+					StartCharacter:     6,
+					EndLine:            7,
+					EndCharacter:       8,
+					DefinitionResultID: "3003",
+					ReferenceResultID:  "",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{},
+				},
+				"2006": {
+					StartLine:          6,
+					StartCharacter:     7,
+					EndLine:            8,
+					EndCharacter:       9,
+					DefinitionResultID: "",
+					ReferenceResultID:  "",
+					HoverResultID:      "3008",
+					MonikerIDs:         []types.ID{},
+				},
+			},
+			HoverResults:       map[types.ID]string{"3008": "foo"},
+			Monikers:           map[types.ID]types.MonikerData{},
+			PackageInformation: map[types.ID]types.PackageInformationData{},
+			Diagnostics: []types.DiagnosticData{
+				{
+					Severity:       3,
+					Code:           "3234",
+					Message:        "m3",
+					Source:         "s3",
+					StartLine:      31,
+					StartCharacter: 32,
+					EndLine:        33,
+					EndCharacter:   34,
+				},
+				{
+					Severity:       4,
+					Code:           "4234",
+					Message:        "m4",
+					Source:         "s4",
+					StartLine:      41,
+					StartCharacter: 42,
+					EndLine:        43,
+					EndCharacter:   44,
+				},
+			},
+		},
+		"baz.go": {
+			Ranges: map[types.ID]types.RangeData{
+				"2007": {
+					StartLine:          7,
+					StartCharacter:     8,
+					EndLine:            9,
+					EndCharacter:       0,
+					DefinitionResultID: "3004",
+					ReferenceResultID:  "",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{},
+				},
+				"2008": {
+					StartLine:          8,
+					StartCharacter:     9,
+					EndLine:            0,
+					EndCharacter:       1,
+					DefinitionResultID: "",
+					ReferenceResultID:  "",
+					HoverResultID:      "3009",
+					MonikerIDs:         []types.ID{},
+				},
+				"2009": {
+					StartLine:          9,
+					StartCharacter:     0,
+					EndLine:            1,
+					EndCharacter:       2,
+					DefinitionResultID: "3005",
+					ReferenceResultID:  "",
+					HoverResultID:      "",
+					MonikerIDs:         []types.ID{},
+				},
+			},
+			HoverResults:       map[types.ID]string{"3009": "bar"},
+			Monikers:           map[types.ID]types.MonikerData{},
+			PackageInformation: map[types.ID]types.PackageInformationData{},
+			Diagnostics:        []types.DiagnosticData{},
+		},
+	}
+	if diff := cmp.Diff(expectedDocumentData, documents, datastructures.Comparers...); diff != "" {
+		t.Errorf("unexpected document data (-want +got):\n%s", diff)
+	}
+
+	resultChunkData := actualBundleData.ResultChunks
+	for _, resultChunk := range resultChunkData {
 		for _, documentRanges := range resultChunk.DocumentIDRangeIDs {
 			sortDocumentIDRangeIDs(documentRanges)
 		}
 	}
 
-	sortMonikerLocations(groupedBundleData.Definitions)
-	sortMonikerLocations(groupedBundleData.References)
+	expectedResultChunkData := map[int]types.ResultChunkData{
+		0: {
+			DocumentPaths: map[types.ID]string{
+				"1001": "foo.go",
+				"1002": "bar.go",
+				"1003": "baz.go",
+			},
+			DocumentIDRangeIDs: map[types.ID][]types.DocumentIDRangeID{
+				"3001": {
+					{DocumentID: "1001", RangeID: "2003"},
+					{DocumentID: "1002", RangeID: "2004"},
+					{DocumentID: "1003", RangeID: "2007"},
+				},
+				"3002": {
+					{DocumentID: "1001", RangeID: "2002"},
+					{DocumentID: "1002", RangeID: "2005"},
+					{DocumentID: "1003", RangeID: "2008"},
+				},
+				"3003": {
+					{DocumentID: "1001", RangeID: "2001"},
+					{DocumentID: "1002", RangeID: "2006"},
+					{DocumentID: "1003", RangeID: "2009"},
+				},
+				"3004": {
+					{DocumentID: "1001", RangeID: "2003"},
+					{DocumentID: "1002", RangeID: "2005"},
+					{DocumentID: "1003", RangeID: "2007"},
+				},
+				"3005": {
+					{DocumentID: "1001", RangeID: "2002"},
+					{DocumentID: "1002", RangeID: "2006"},
+					{DocumentID: "1003", RangeID: "2008"},
+				},
+				"3006": {
+					{DocumentID: "1001", RangeID: "2003"},
+					{DocumentID: "1003", RangeID: "2007"},
+					{DocumentID: "1003", RangeID: "2009"},
+				},
+				"3007": {
+					{DocumentID: "1001", RangeID: "2002"},
+					{DocumentID: "1003", RangeID: "2007"},
+					{DocumentID: "1003", RangeID: "2009"},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(expectedResultChunkData, resultChunkData); diff != "" {
+		t.Errorf("unexpected result chunk data (-want +got):\n%s", diff)
+	}
+
+	definitions := actualBundleData.Definitions
+	sortMonikerLocations(definitions)
+
+	expectedDefinitions := []types.MonikerLocations{
+		{
+			Scheme:     "scheme A",
+			Identifier: "ident A",
+			Locations: []types.Location{
+				{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+			},
+		},
+		{
+			Scheme:     "scheme B",
+			Identifier: "ident B",
+			Locations: []types.Location{
+				{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+			},
+		},
+	}
+	if diff := cmp.Diff(expectedDefinitions, definitions); diff != "" {
+		t.Errorf("unexpected definitions (-want +got):\n%s", diff)
+	}
+
+	references := actualBundleData.References
+	sortMonikerLocations(references)
+
+	expectedReferences := []types.MonikerLocations{
+		{
+			Scheme:     "scheme C",
+			Identifier: "ident C",
+			Locations: []types.Location{
+				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+			},
+		},
+		{
+			Scheme:     "scheme D",
+			Identifier: "ident D",
+			Locations: []types.Location{
+				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+			},
+		},
+	}
+	if diff := cmp.Diff(expectedReferences, references); diff != "" {
+		t.Errorf("unexpected references (-want +got):\n%s", diff)
+	}
 }
+
+//
+//
 
 func sortMonikerIDs(s []types.ID) {
 	sort.Slice(s, func(i, j int) bool {

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif/types.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif/types.go
@@ -1,7 +1,5 @@
 package lsif
 
-import "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures"
-
 type Element struct {
 	ID      int
 	Type    string
@@ -21,12 +19,6 @@ type MetaData struct {
 	ProjectRoot string
 }
 
-type Document struct {
-	URI         string
-	Contains    *datastructures.IDSet
-	Diagnostics *datastructures.IDSet
-}
-
 type Range struct {
 	StartLine          int
 	StartCharacter     int
@@ -35,7 +27,6 @@ type Range struct {
 	DefinitionResultID int
 	ReferenceResultID  int
 	HoverResultID      int
-	MonikerIDs         *datastructures.IDSet
 }
 
 func (d Range) SetDefinitionResultID(id int) Range {
@@ -47,7 +38,6 @@ func (d Range) SetDefinitionResultID(id int) Range {
 		DefinitionResultID: id,
 		ReferenceResultID:  d.ReferenceResultID,
 		HoverResultID:      d.HoverResultID,
-		MonikerIDs:         d.MonikerIDs,
 	}
 }
 
@@ -60,7 +50,6 @@ func (d Range) SetReferenceResultID(id int) Range {
 		DefinitionResultID: d.DefinitionResultID,
 		ReferenceResultID:  id,
 		HoverResultID:      d.HoverResultID,
-		MonikerIDs:         d.MonikerIDs,
 	}
 }
 
@@ -73,20 +62,6 @@ func (d Range) SetHoverResultID(id int) Range {
 		DefinitionResultID: d.DefinitionResultID,
 		ReferenceResultID:  d.ReferenceResultID,
 		HoverResultID:      id,
-		MonikerIDs:         d.MonikerIDs,
-	}
-}
-
-func (d Range) SetMonikerIDs(ids *datastructures.IDSet) Range {
-	return Range{
-		StartLine:          d.StartLine,
-		StartCharacter:     d.StartCharacter,
-		EndLine:            d.EndLine,
-		EndCharacter:       d.EndCharacter,
-		DefinitionResultID: d.DefinitionResultID,
-		ReferenceResultID:  d.ReferenceResultID,
-		HoverResultID:      d.HoverResultID,
-		MonikerIDs:         ids,
 	}
 }
 
@@ -94,7 +69,6 @@ type ResultSet struct {
 	DefinitionResultID int
 	ReferenceResultID  int
 	HoverResultID      int
-	MonikerIDs         *datastructures.IDSet
 }
 
 func (d ResultSet) SetDefinitionResultID(id int) ResultSet {
@@ -102,7 +76,6 @@ func (d ResultSet) SetDefinitionResultID(id int) ResultSet {
 		DefinitionResultID: id,
 		ReferenceResultID:  d.ReferenceResultID,
 		HoverResultID:      d.HoverResultID,
-		MonikerIDs:         d.MonikerIDs,
 	}
 }
 
@@ -111,7 +84,6 @@ func (d ResultSet) SetReferenceResultID(id int) ResultSet {
 		DefinitionResultID: d.DefinitionResultID,
 		ReferenceResultID:  id,
 		HoverResultID:      d.HoverResultID,
-		MonikerIDs:         d.MonikerIDs,
 	}
 }
 
@@ -120,16 +92,6 @@ func (d ResultSet) SetHoverResultID(id int) ResultSet {
 		DefinitionResultID: d.DefinitionResultID,
 		ReferenceResultID:  d.ReferenceResultID,
 		HoverResultID:      id,
-		MonikerIDs:         d.MonikerIDs,
-	}
-}
-
-func (d ResultSet) SetMonikerIDs(ids *datastructures.IDSet) ResultSet {
-	return ResultSet{
-		DefinitionResultID: d.DefinitionResultID,
-		ReferenceResultID:  d.ReferenceResultID,
-		HoverResultID:      d.HoverResultID,
-		MonikerIDs:         ids,
 	}
 }
 
@@ -152,10 +114,6 @@ func (d Moniker) SetPackageInformationID(id int) Moniker {
 type PackageInformation struct {
 	Name    string
 	Version string
-}
-
-type DiagnosticResult struct {
-	Result []Diagnostic
 }
 
 type Diagnostic struct {

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif/unmarshal.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif/unmarshal.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures"
 )
 
 var unmarshaller = jsoniter.ConfigFastest
@@ -119,11 +118,7 @@ func unmarshalDocument(line []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	return Document{
-		URI:         payload.URI,
-		Contains:    datastructures.NewIDSet(),
-		Diagnostics: datastructures.NewIDSet(),
-	}, nil
+	return payload.URI, nil
 }
 
 func unmarshalRange(line []byte) (interface{}, error) {
@@ -144,7 +139,6 @@ func unmarshalRange(line []byte) (interface{}, error) {
 		StartCharacter: payload.Start.Character,
 		EndLine:        payload.End.Line,
 		EndCharacter:   payload.End.Character,
-		MonikerIDs:     datastructures.NewIDSet(),
 	}, nil
 }
 
@@ -289,7 +283,7 @@ func unmarshalDiagnosticResult(line []byte) (interface{}, error) {
 		})
 	}
 
-	return DiagnosticResult{Result: diagnostics}, nil
+	return diagnostics, nil
 }
 
 type StringOrInt string

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif/unmarshal_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif/unmarshal_test.go
@@ -90,18 +90,13 @@ func TestUnmarshalMetaData(t *testing.T) {
 }
 
 func TestUnmarshalDocument(t *testing.T) {
-	document, err := unmarshalDocument([]byte(`{"id": "02", "type": "vertex", "label": "document", "uri": "file:///test/root/foo.go"}`))
+	uri, err := unmarshalDocument([]byte(`{"id": "02", "type": "vertex", "label": "document", "uri": "file:///test/root/foo.go"}`))
 	if err != nil {
 		t.Fatalf("unexpected error unmarshalling document data: %s", err)
 	}
 
-	expectedDocument := Document{
-		URI:         "file:///test/root/foo.go",
-		Contains:    datastructures.NewIDSet(),
-		Diagnostics: datastructures.NewIDSet(),
-	}
-	if diff := cmp.Diff(expectedDocument, document, datastructures.IDSetComparer); diff != "" {
-		t.Errorf("unexpected document (-want +got):\n%s", diff)
+	if diff := cmp.Diff("file:///test/root/foo.go", uri, datastructures.Comparers...); diff != "" {
+		t.Errorf("unexpected uri (-want +got):\n%s", diff)
 	}
 }
 
@@ -119,9 +114,8 @@ func TestUnmarshalRange(t *testing.T) {
 		DefinitionResultID: 0,
 		ReferenceResultID:  0,
 		HoverResultID:      0,
-		MonikerIDs:         datastructures.NewIDSet(),
 	}
-	if diff := cmp.Diff(expectedRange, r, datastructures.IDSetComparer); diff != "" {
+	if diff := cmp.Diff(expectedRange, r, datastructures.Comparers...); diff != "" {
 		t.Errorf("unexpected range (-want +got):\n%s", diff)
 	}
 }
@@ -202,18 +196,16 @@ func TestUnmarshalDiagnosticResult(t *testing.T) {
 		t.Fatalf("unexpected error unmarshalling diagnostic result data: %s", err)
 	}
 
-	expectedDiagnosticResult := DiagnosticResult{
-		Result: []Diagnostic{
-			{
-				Severity:       1,
-				Code:           "2322",
-				Message:        "Type '10' is not assignable to type 'string'.",
-				Source:         "eslint",
-				StartLine:      1,
-				StartCharacter: 5,
-				EndLine:        1,
-				EndCharacter:   6,
-			},
+	expectedDiagnosticResult := []Diagnostic{
+		{
+			Severity:       1,
+			Code:           "2322",
+			Message:        "Type '10' is not assignable to type 'string'.",
+			Source:         "eslint",
+			StartLine:      1,
+			StartCharacter: 5,
+			EndLine:        1,
+			EndCharacter:   6,
 		},
 	}
 	if diff := cmp.Diff(expectedDiagnosticResult, diagnosticResult); diff != "" {

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/prune_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/prune_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/correlation/datastructures"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/correlation/lsif"
 )
 
 func TestPrune(t *testing.T) {
@@ -25,50 +24,30 @@ func TestPrune(t *testing.T) {
 	}
 
 	state := &State{
-		DocumentData: map[int]lsif.Document{
-			1001: {
-				URI:         "foo.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
-			1002: {
-				URI:         "bar.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
-			1003: {
-				URI:         "sub/baz.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
-			1004: {
-				URI:         "foo.generated.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
-			1005: {
-				URI:         "foo.generated.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
+		DocumentData: map[int]string{
+			1001: "foo.go",
+			1002: "bar.go",
+			1003: "sub/baz.go",
+			1004: "foo.generated.go",
+			1005: "foo.generated.go",
 		},
-		DefinitionData: map[int]datastructures.DefaultIDSetMap{
-			2001: {
+		DefinitionData: map[int]*datastructures.DefaultIDSetMap{
+			2001: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.NewIDSet(),
 				1004: datastructures.NewIDSet(),
-			},
-			2002: {
+			}),
+			2002: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1002: datastructures.NewIDSet(),
-			},
+			}),
 		},
-		ReferenceData: map[int]datastructures.DefaultIDSetMap{
-			2003: {
+		ReferenceData: map[int]*datastructures.DefaultIDSetMap{
+			2003: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1002: datastructures.NewIDSet(),
-			},
-			2004: {
+			}),
+			2004: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1002: datastructures.NewIDSet(),
 				1005: datastructures.NewIDSet(),
-			},
+			}),
 		},
 	}
 
@@ -77,41 +56,29 @@ func TestPrune(t *testing.T) {
 	}
 
 	expectedState := &State{
-		DocumentData: map[int]lsif.Document{
-			1001: {
-				URI:         "foo.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
-			1002: {
-				URI:         "bar.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
-			1003: {
-				URI:         "sub/baz.go",
-				Contains:    datastructures.NewIDSet(),
-				Diagnostics: datastructures.NewIDSet(),
-			},
+		DocumentData: map[int]string{
+			1001: "foo.go",
+			1002: "bar.go",
+			1003: "sub/baz.go",
 		},
-		DefinitionData: map[int]datastructures.DefaultIDSetMap{
-			2001: {
+		DefinitionData: map[int]*datastructures.DefaultIDSetMap{
+			2001: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1001: datastructures.NewIDSet(),
-			},
-			2002: {
+			}),
+			2002: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1002: datastructures.NewIDSet(),
-			},
+			}),
 		},
-		ReferenceData: map[int]datastructures.DefaultIDSetMap{
-			2003: {
+		ReferenceData: map[int]*datastructures.DefaultIDSetMap{
+			2003: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1002: datastructures.NewIDSet(),
-			},
-			2004: {
+			}),
+			2004: datastructures.DefaultIDSetMapWith(map[int]*datastructures.IDSet{
 				1002: datastructures.NewIDSet(),
-			},
+			}),
 		},
 	}
-	if diff := cmp.Diff(expectedState, state, datastructures.IDSetComparer); diff != "" {
+	if diff := cmp.Diff(expectedState, state, datastructures.Comparers...); diff != "" {
 		t.Errorf("unexpected state (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/state.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/state.go
@@ -9,38 +9,44 @@ import (
 type State struct {
 	LSIFVersion            string
 	ProjectRoot            string
-	DocumentData           map[int]lsif.Document
+	DocumentData           map[int]string
 	RangeData              map[int]lsif.Range
 	ResultSetData          map[int]lsif.ResultSet
-	DefinitionData         map[int]datastructures.DefaultIDSetMap
-	ReferenceData          map[int]datastructures.DefaultIDSetMap
+	DefinitionData         map[int]*datastructures.DefaultIDSetMap
+	ReferenceData          map[int]*datastructures.DefaultIDSetMap
 	HoverData              map[int]string
 	MonikerData            map[int]lsif.Moniker
 	PackageInformationData map[int]lsif.PackageInformation
-	Diagnostics            map[int]lsif.DiagnosticResult
-	NextData               map[int]int                  // maps vertices related via next edges
-	ImportedMonikers       *datastructures.IDSet        // moniker ids that have kind "import"
-	ExportedMonikers       *datastructures.IDSet        // moniker ids that have kind "export"
-	LinkedMonikers         datastructures.DisjointIDSet // tracks which moniker ids are related via next edges
-	LinkedReferenceResults datastructures.DisjointIDSet // tracks which reference result ids are related via next edges
+	DiagnosticResults      map[int][]lsif.Diagnostic
+	NextData               map[int]int                     // maps range/result sets related via next edges
+	ImportedMonikers       *datastructures.IDSet           // moniker ids that have kind "import"
+	ExportedMonikers       *datastructures.IDSet           // moniker ids that have kind "export"
+	LinkedMonikers         *datastructures.DisjointIDSet   // tracks which moniker ids are related via next edges
+	LinkedReferenceResults *datastructures.DisjointIDSet   // tracks which reference result ids are related via next edges
+	Monikers               *datastructures.DefaultIDSetMap // maps items to their monikers
+	Contains               *datastructures.DefaultIDSetMap // maps ranges to containing documents
+	Diagnostics            *datastructures.DefaultIDSetMap // maps diagnostics to their documents
 }
 
 // newState create a new State with zero-valued map fields.
 func newState() *State {
 	return &State{
-		DocumentData:           map[int]lsif.Document{},
+		DocumentData:           map[int]string{},
 		RangeData:              map[int]lsif.Range{},
 		ResultSetData:          map[int]lsif.ResultSet{},
-		DefinitionData:         map[int]datastructures.DefaultIDSetMap{},
-		ReferenceData:          map[int]datastructures.DefaultIDSetMap{},
+		DefinitionData:         map[int]*datastructures.DefaultIDSetMap{},
+		ReferenceData:          map[int]*datastructures.DefaultIDSetMap{},
 		HoverData:              map[int]string{},
 		MonikerData:            map[int]lsif.Moniker{},
 		PackageInformationData: map[int]lsif.PackageInformation{},
-		Diagnostics:            map[int]lsif.DiagnosticResult{},
+		DiagnosticResults:      map[int][]lsif.Diagnostic{},
 		NextData:               map[int]int{},
 		ImportedMonikers:       datastructures.NewIDSet(),
 		ExportedMonikers:       datastructures.NewIDSet(),
-		LinkedMonikers:         datastructures.DisjointIDSet{},
-		LinkedReferenceResults: datastructures.DisjointIDSet{},
+		LinkedMonikers:         datastructures.NewDisjointIDSet(),
+		LinkedReferenceResults: datastructures.NewDisjointIDSet(),
+		Monikers:               datastructures.NewDefaultIDSetMap(),
+		Contains:               datastructures.NewDefaultIDSetMap(),
+		Diagnostics:            datastructures.NewDefaultIDSetMap(),
 	}
 }


### PR DESCRIPTION
This PR reorganizes some data structures to be a bit more memory-efficient. Most of these changes are mechanical.

- Collapse document data (which was a struct containing single field) into a string
- Collapse diagnostic result (which was a struct containing single field) into a list of diagnostics
- Move contains, moniker, and diagnostic relations out of documents/ranges and into a global map in the correlation state
- Create a more memory-efficient version of DefaultIDSetMap that optimizes singleton sets (of which there are multiple orders of magnitude more in proportion to other sized maps)
- Change the order in which result chunk are populated (by result chunk, not by random ordering of result identifiers)
- Change the order in which moniker locations are pouplated (remove need for string-hashing for uniqueness)
