### PR TITLE
Don't use goacc on master branch

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -14,26 +14,5 @@ echo "--- comby install"
 echo "--- go mod download"
 go mod download
 
-goacc=""
-while [[ "$#" -gt 0 ]]; do
-  case $1 in
-    --goacc)
-      goacc="$2"
-      shift
-      ;;
-    *)
-      echo "Unknown parameter passed: $1"
-      exit 1
-      ;;
-  esac
-  shift
-done
-
-if [ "$goacc" == "true" ]; then
-  echo "--- go test with accurate code coverage"
-  go get github.com/ory/go-acc
-  "$(go env GOPATH)/bin/go-acc" ./...
-else
-  echo "--- go test"
-  go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
-fi
+echo "--- go test"
+go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -138,12 +138,11 @@ func addPostgresBackcompat(pipeline *bk.Pipeline) {
 
 // Adds the Go test step. The runAcc parameter indicates whether to generate accurate
 // code coverage for these Go tests.
-func addGoTests(runAcc bool) func(*bk.Pipeline) {
-	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(":go:",
-			bk.Cmd(fmt.Sprintf("./dev/ci/go-test.sh --goacc %v", runAcc)),
-			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go -F unit"))
-	}
+func addGoTests(pipeline *bk.Pipeline) {
+	pipeline.AddStep(":go:",
+		bk.Cmd("./dev/ci/go-test.sh"),
+		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go -F unit"),
+	)
 }
 
 // Builds the OSS and Enterprise Go commands.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -120,15 +120,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
-			addGoTests(c.isDefaultBranch()), // ~2m or ~9m
-			addLint,                         // ~3.5m
-			addWebApp,                       // ~3m
-			addSharedTests,                  // ~3m
-			addBrowserExt,                   // ~2m
-			addCheck,                        // ~1m
-			addGoBuild,                      // ~0.5m
-			addPostgresBackcompat,           // ~0.25m
-			addDockerfileLint,               // ~0.2m
+			addGoTests(false),     // ~2m
+			addLint,               // ~3.5m
+			addWebApp,             // ~3m
+			addSharedTests,        // ~3m
+			addBrowserExt,         // ~2m
+			addCheck,              // ~1m
+			addGoBuild,            // ~0.5m
+			addPostgresBackcompat, // ~0.25m
+			addDockerfileLint,     // ~0.2m
 			addDockerImages(c, false),
 			wait,
 			addDockerImages(c, true),

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -106,7 +106,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addBrowserExt,
 			addWebApp,
 			addSharedTests,
-			addGoTests(false),
+			addGoTests,
 			addGoBuild,
 			addDockerfileLint,
 		}
@@ -120,7 +120,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
-			addGoTests(false),     // ~2m
+			addGoTests,            // ~2m
 			addLint,               // ~3.5m
 			addWebApp,             // ~3m
 			addSharedTests,        // ~3m


### PR DESCRIPTION
Currently, all PRs report a decrease in coverage, which creates a lot of noise and breaks the trust in our coverage tracking. The root cause is that we use two different methods to determine the coverage, on `master` we use `go-acc` and on branches just `go test -cover`. Since codecov uses the merge-base on the master branch as a base for the coverage comparison, there will always be the difference that these two algorithms create. Since `go-acc` is around 4 times slower than `go test -cover`, I think we should (for now) just use the less accurate one.

Closes https://github.com/sourcegraph/sourcegraph/issues/12103