### PR TITLE
gqltest: add tests for external services and `allowSignup`

### DIFF
--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -33,6 +33,9 @@ var (
 	awsSecretAccessKey    = flag.String("aws-secret-access-key", os.Getenv("AWS_SECRET_ACCESS_KEY"), "The AWS secret access key")
 	awsCodeCommitUsername = flag.String("aws-code-commit-username", os.Getenv("AWS_CODE_COMMIT_USERNAME"), "The AWS code commit username")
 	awsCodeCommitPassword = flag.String("aws-code-commit-password", os.Getenv("AWS_CODE_COMMIT_PASSWORD"), "The AWS code commit password")
+	bbsURL                = flag.String("bbs-url", os.Getenv("BITBUCKET_SERVER_URL"), "The Bitbucket Server URL")
+	bbsToken              = flag.String("bbs-token", os.Getenv("BITBUCKET_SERVER_TOKEN"), "The Bitbucket Server token")
+	bbsUsername           = flag.String("bbs-username", os.Getenv("BITBUCKET_SERVER_USERNAME"), "The Bitbucket Server username")
 )
 
 func TestMain(m *testing.M) {

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -28,7 +28,11 @@ var (
 	username = flag.String("username", "gqltest-admin", "The username of the admin user")
 	password = flag.String("password", "supersecurepassword", "The password of the admin user")
 
-	githubToken = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
+	githubToken           = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
+	awsAccessKeyID        = flag.String("aws-access-key-id", os.Getenv("AWS_ACCESS_KEY_ID"), "The AWS access key ID")
+	awsSecretAccessKey    = flag.String("aws-secret-access-key", os.Getenv("AWS_SECRET_ACCESS_KEY"), "The AWS secret access key")
+	awsCodeCommitUsername = flag.String("aws-code-commit-username", os.Getenv("AWS_CODE_COMMIT_USERNAME"), "The AWS code commit username")
+	awsCodeCommitPassword = flag.String("aws-code-commit-password", os.Getenv("AWS_CODE_COMMIT_PASSWORD"), "The AWS code commit password")
 )
 
 func TestMain(m *testing.M) {

--- a/dev/gqltest/site_config_test.go
+++ b/dev/gqltest/site_config_test.go
@@ -1,0 +1,80 @@
+// +build gqltest
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestSiteConfig(t *testing.T) {
+	t.Run("builtin auth provider: allowSignup", func(t *testing.T) {
+		// Sign up a new user is allowed by default.
+		const testUsername1 = "gqltest-auth-user-1"
+		testClient1, err := gqltestutil.SignUp(*baseURL, testUsername1+"@sourcegraph.com", testUsername1, "mysecurepassword")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := client.DeleteUser(testClient1.AuthenticatedUserID(), true)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// Update site configuration to not allow sign up for builtin auth provider.
+		siteConfig, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldSiteConfig := new(schema.SiteConfiguration)
+		*oldSiteConfig = *siteConfig
+		defer func() {
+			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		siteConfig.AuthProviders = []schema.AuthProviders{
+			{
+				Builtin: &schema.BuiltinAuthProvider{
+					AllowSignup: false,
+					Type:        "builtin",
+				},
+			},
+		}
+		err = client.UpdateSiteConfiguration(siteConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var lastErr error
+		// Retry because the configuration update endpoint is eventually consistent
+		err = gqltestutil.Retry(5*time.Second, func() error {
+			// Sign up a new user should fail.
+			const testUsername2 = "gqltest-auth-user-2"
+			testClient2, err := gqltestutil.SignUp(*baseURL, testUsername2+"@sourcegraph.com", testUsername2, "mysecurepassword")
+			if err != nil {
+				if strings.Contains(err.Error(), "Signup is not enabled") {
+					return nil
+				}
+				t.Fatal(err)
+			}
+			defer func() {
+				err := client.DeleteUser(testClient2.AuthenticatedUserID(), true)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}()
+			return gqltestutil.ErrContinueRetry
+		})
+		if err != nil {
+			t.Fatal(err, "lastErr:", lastErr)
+		}
+	})
+}

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -28,46 +28,42 @@ func NeedsSiteInit(baseURL string) (bool, error) {
 }
 
 // SiteAdminInit initializes the instance with given admin account.
-// It returns an authenticated client as the admin for doing e2e testing.
+// It returns an authenticated client as the admin for doing testing.
 func SiteAdminInit(baseURL, email, username, password string) (*Client, error) {
-	client, err := newClient(baseURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "new client")
-	}
+	return authenticate(baseURL, "/-/site-init", map[string]string{
+		"email":    email,
+		"username": username,
+		"password": password,
+	})
+}
 
-	var request = struct {
-		Email    string `json:"email"`
-		Username string `json:"username"`
-		Password string `json:"password"`
-	}{
-		Email:    email,
-		Username: username,
-		Password: password,
-	}
-	err = client.authenticate("/-/site-init", request)
-	if err != nil {
-		return nil, errors.Wrap(err, "authenticate")
-	}
-
-	return client, nil
+// SignUp signs up a new user with given credentials.
+// It returns an authenticated client as the user for doing testing.
+func SignUp(baseURL, email, username, password string) (*Client, error) {
+	return authenticate(baseURL, "/-/sign-up", map[string]string{
+		"email":    email,
+		"username": username,
+		"password": password,
+	})
 }
 
 // SignIn performs the sign in with given user credentials.
-// It returns an authenticated client as the user for doing e2e testing.
+// It returns an authenticated client as the user for doing testing.
 func SignIn(baseURL, email, password string) (*Client, error) {
+	return authenticate(baseURL, "/-/sign-in", map[string]string{
+		"email":    email,
+		"password": password,
+	})
+}
+
+// authenticate initializes an authenticated client with given request body.
+func authenticate(baseURL, path string, body interface{}) (*Client, error) {
 	client, err := newClient(baseURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "new client")
 	}
 
-	var request = struct {
-		Email    string `json:"email"`
-		Password string `json:"password"`
-	}{
-		Email:    email,
-		Password: password,
-	}
-	err = client.authenticate("/-/sign-in", request)
+	err = client.authenticate(path, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "authenticate")
 	}

--- a/internal/gqltestutil/git_blob.go
+++ b/internal/gqltestutil/git_blob.go
@@ -1,0 +1,42 @@
+package gqltestutil
+
+import (
+	"github.com/pkg/errors"
+)
+
+// GitBlob returns blob content of the file in given repository at given revision.
+func (c *Client) GitBlob(repoName, revision, filePath string) (string, error) {
+	const gqlQuery = `
+query Blob($repoName: String!, $revision: String!, $filePath: String!) {
+	repository(name: $repoName) {
+		commit(rev: $revision) {
+			file(path: $filePath) {
+				content
+			}
+		}
+	}
+}
+`
+	variables := map[string]interface{}{
+		"repoName": repoName,
+		"revision": revision,
+		"filePath": filePath,
+	}
+	var resp struct {
+		Data struct {
+			Repository struct {
+				Commit struct {
+					File struct {
+						Content string `json:"content"`
+					} `json:"file"`
+				} `json:"commit"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", gqlQuery, variables, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.Repository.Commit.File.Content, nil
+}

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -13,17 +13,14 @@ import (
 func (c *Client) WaitForReposToBeCloned(repos ...string) error {
 	return Retry(30*time.Second, func() error {
 		const query = `
-query Repositories($first: Int) {
-	repositories(first: $first, cloned: true, cloneInProgress: false, notCloned: false) {
+query Repositories {
+	repositories(first: 1000, cloned: true, cloneInProgress: false, notCloned: false) {
 		nodes {
 			name
 		}
 	}
 }
 `
-		variables := map[string]interface{}{
-			"first": len(repos),
-		}
 		var resp struct {
 			Data struct {
 				Repositories struct {
@@ -33,13 +30,9 @@ query Repositories($first: Int) {
 				} `json:"repositories"`
 			} `json:"data"`
 		}
-		err := c.GraphQL("", query, variables, &resp)
+		err := c.GraphQL("", query, nil, &resp)
 		if err != nil {
 			return errors.Wrap(err, "request GraphQL")
-		}
-
-		if len(resp.Data.Repositories.Nodes) != len(repos) {
-			return ErrContinueRetry
 		}
 
 		repoSet := make(map[string]struct{}, len(repos))


### PR DESCRIPTION
Adds integrations tests for search, which covers:

- [AWS CodeCommit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0211f6583717cf09e7b6e186e98d84cc9824d0d9/-/blob/web/src/e2e/e2e.test.ts#L282)
- [Bitbucket Server](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0211f6583717cf09e7b6e186e98d84cc9824d0d9/-/blob/web/src/e2e/e2e.test.ts#L315)
- [Builtin auth provider: allowSignup](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@8f01e217cdd08a5a2fc327bce53ff0c86579ba65/-/blob/web/src/regression/config-settings.test.ts#L69:1)

Please review by commit.

Part of #10068