### PR TITLE
Fix: add missing repogroup query to repogroup page search bar

### DIFF
--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -98,7 +98,12 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                 </span>
             </div>
             <div className="repogroup-page__container">
-                <SearchPageInput {...props} source="repogroupPage" interactiveModeHomepageMode={true} />
+                <SearchPageInput
+                    {...props}
+                    queryPrefix={repogroupQuery}
+                    source="repogroupPage"
+                    interactiveModeHomepageMode={true}
+                />
             </div>
             <div className="repogroup-page__content">
                 <div className="repogroup-page__column">

--- a/web/src/search/input/SearchPageInput.tsx
+++ b/web/src/search/input/SearchPageInput.tsx
@@ -24,7 +24,6 @@ import {
     InteractiveSearchProps,
     SmartSearchFieldProps,
     CopyQueryButtonProps,
-    parseSearchURLQuery,
 } from '..'
 import { EventLoggerProps } from '../../tracking/eventLogger'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
@@ -69,7 +68,7 @@ interface Props
 export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) => {
     /** The query cursor position and value entered by the user in the query input */
     const [userQueryState, setUserQueryState] = useState({
-        query: props.queryPrefix ?? props.queryPrefix,
+        query: props.queryPrefix ? props.queryPrefix : '',
         cursorPosition: props.queryPrefix ? props.queryPrefix.length : 0,
     })
 

--- a/web/src/search/input/SearchPageInput.tsx
+++ b/web/src/search/input/SearchPageInput.tsx
@@ -58,6 +58,8 @@ interface Props
 
     /** Whether to display the interactive mode input centered on the page, as on the search homepage. */
     interactiveModeHomepageMode?: boolean
+    /** A query fragment to appear at the beginning of the input. */
+    queryPrefix?: string
 
     // For NavLinks
     authRequired?: boolean
@@ -65,12 +67,10 @@ interface Props
 }
 
 export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) => {
-    const queryFromUrl = parseSearchURLQuery(props.location.search) || ''
-
     /** The query cursor position and value entered by the user in the query input */
     const [userQueryState, setUserQueryState] = useState({
-        query: queryFromUrl,
-        cursorPosition: queryFromUrl.length,
+        query: props.queryPrefix ?? props.queryPrefix,
+        cursorPosition: props.queryPrefix ? props.queryPrefix.length : 0,
     })
 
     const quickLinks =


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/12083.

This got removed in a late commit in the original PR which refactored the search input component. 
