### PR TITLE
Revert "Delete cloning tab from the site-admin repositories page"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Backwards compatibility for "critical configuration" (a type of configuration that was deprecated in December 2019) was removed. All critical configuration now belongs in site configuration.
 - Experimental feature setting `{ "experimentalFeatures": { "searchMultipleRevisionsPerRepository": true } }` will be removed in 3.19. It is now always on. Please remove references to it.
-- Removed "Cloning" tab in site-admin Repository Status page. [#12043](https://github.com/sourcegraph/sourcegraph/pull/12043)
 
 ## 3.17.3
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1157,7 +1157,6 @@ type Query {
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
-        # DEPRECATED: This will be removed.
         cloneInProgress: Boolean = true
         # Include repositories that are not yet cloned and for which cloning is not in progress.
         notCloned: Boolean = true

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1164,7 +1164,6 @@ type Query {
         # Include cloned repositories.
         cloned: Boolean = true
         # Include repositories that are currently being cloned.
-        # DEPRECATED: This will be removed.
         cloneInProgress: Boolean = true
         # Include repositories that are not yet cloned and for which cloning is not in progress.
         notCloned: Boolean = true

--- a/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -85,6 +85,12 @@ const FILTERS: FilteredConnectionFilter[] = [
         args: { cloned: true, cloneInProgress: false, notCloned: false },
     },
     {
+        label: 'Cloning',
+        id: 'cloning',
+        tooltip: 'Show only repositories that are currently being cloned',
+        args: { cloned: false, cloneInProgress: true, notCloned: false },
+    },
+    {
         label: 'Not cloned',
         id: 'not-cloned',
         tooltip: 'Show only repositories that have not been cloned yet',


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#12043

A bug causing the repository status page to not display the cloned repositories properly has been introduced by #11932. I'm reverting this PR because it relies on the changes of that PR.