### PR TITLE
Revert "cloud: use the cloned column to filter by clone status"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Configuration for `observability.alerts` has changed and notifications are now provided by Prometheus Alertmanager. [#11832](https://github.com/sourcegraph/sourcegraph/pull/11832)
   - Removed: `observability.alerts.id`.
   - Removed: Slack notifiers no longer accept `mentionUsers`, `mentionGroups`, `mentionChannel`, and `token` options.
--
 
 ### Fixed
 
@@ -42,7 +41,6 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue where valid search queries were improperly hinted as being invalid in the search field. [#11688](https://github.com/sourcegraph/sourcegraph/pull/11688)
 - Reduce frontend memory spikes by limiting the number of goroutines launched by our GraphQL resolvers. [#11736](https://github.com/sourcegraph/sourcegraph/pull/11736)
 - Fixed a bug affecting Sourcegraph icon display in our Phabricator native integration [#11825](https://github.com/sourcegraph/sourcegraph/pull/11825).
-- Improve performance of site-admin repositories status page. [#11932](https://github.com/sourcegraph/sourcegraph/pull/11932)
 
 ### Removed
 

--- a/cmd/frontend/db/repos.go
+++ b/cmd/frontend/db/repos.go
@@ -154,7 +154,6 @@ var getBySQLColumns = []string{
 	"language",
 	"fork",
 	"archived",
-	"cloned",
 }
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
@@ -223,7 +222,6 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		&r.Language,
 		&r.Fork,
 		&r.Archived,
-		&r.Cloned,
 	)
 }
 
@@ -265,12 +263,6 @@ type ReposListOptions struct {
 
 	// OnlyArchived excludes non-archived repositories from the list.
 	OnlyArchived bool
-
-	// NoCloned excludes cloned repositories from the list.
-	NoCloned bool
-
-	// OnlyCloned excludes non-cloned repositories from the list.
-	OnlyCloned bool
 
 	// NoPrivate excludes private repositories from the list.
 	NoPrivate bool
@@ -465,12 +457,6 @@ func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 	}
 	if opt.OnlyArchived {
 		conds = append(conds, sqlf.Sprintf("archived"))
-	}
-	if opt.NoCloned {
-		conds = append(conds, sqlf.Sprintf("NOT cloned"))
-	}
-	if opt.OnlyCloned {
-		conds = append(conds, sqlf.Sprintf("cloned"))
 	}
 	if opt.NoPrivate {
 		conds = append(conds, sqlf.Sprintf("NOT private"))

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -6,32 +6,11 @@ import (
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/db"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 )
 
 func TestRepositories(t *testing.T) {
 	resetMocks()
-	repos := []*types.Repo{
-		{Name: "repo1"},
-		{Name: "repo2"},
-		{
-			Name: "repo3",
-			RepoFields: &types.RepoFields{
-				Cloned: true,
-			},
-		},
-	}
-	db.Mocks.Repos.List = func(ctx context.Context, opt db.ReposListOptions) ([]*types.Repo, error) {
-		if opt.NoCloned {
-			return repos[0:2], nil
-		}
-		if opt.OnlyCloned {
-			return repos[2:], nil
-		}
-
-		return repos, nil
-	}
-
+	db.Mocks.Repos.MockList(t, "repo1", "repo2", "repo3")
 	db.Mocks.Repos.Count = func(context.Context, db.ReposListOptions) (int, error) { return 3, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
@@ -39,34 +18,6 @@ func TestRepositories(t *testing.T) {
 			Query: `
 				{
 					repositories {
-						nodes { name }
-						totalCount
-						pageInfo { hasNextPage }
-					}
-				}
-			`,
-			ExpectedResult: `
-				{
-					"repositories": {
-						"nodes": [
-							{ "name": "repo1" },
-							{ "name": "repo2" },
-							{ "name": "repo3" }
-						],
-						"totalCount": null,
-						"pageInfo": {"hasNextPage": false}
-					}
-				}
-			`,
-		},
-		{
-			Schema: mustParseGraphQLSchema(t),
-			// cloned and notCloned are true by default
-			// this test ensures the behavior is the same
-			// when setting them explicitly
-			Query: `
-				{
-					repositories(cloned: true, notCloned: true) {
 						nodes { name }
 						totalCount
 						pageInfo { hasNextPage }
@@ -105,71 +56,6 @@ func TestRepositories(t *testing.T) {
 							{ "name": "repo2" }
 						],
 						"pageInfo": {"hasNextPage": true}
-					}
-				}
-			`,
-		},
-		{
-			Schema: mustParseGraphQLSchema(t),
-			Query: `
-				{
-					repositories(cloned: false) {
-						nodes { name }
-						pageInfo { hasNextPage }
-					}
-				}
-			`,
-			ExpectedResult: `
-				{
-					"repositories": {
-						"nodes": [
-							{ "name": "repo1" },
-							{ "name": "repo2" }
-						],
-						"pageInfo": {"hasNextPage": false}
-					}
-				}
-			`,
-		},
-		{
-			Schema: mustParseGraphQLSchema(t),
-			Query: `
-				{
-					repositories(notCloned: false) {
-						nodes { name }
-						pageInfo { hasNextPage }
-					}
-				}
-			`,
-			ExpectedResult: `
-				{
-					"repositories": {
-						"nodes": [
-							{ "name": "repo3" }
-						],
-						"pageInfo": {"hasNextPage": false}
-					}
-				}
-			`,
-		},
-		{
-			Schema: mustParseGraphQLSchema(t),
-			Query: `
-				{
-					repositories(notCloned: false, cloned: false) {
-						nodes { name }
-						pageInfo { hasNextPage }
-					}
-				}
-			`,
-			ExpectedResult: `
-				{
-					"repositories": {
-						"nodes": [
-							{ "name": "repo1" },
-							{ "name": "repo2" }
-						],
-						"pageInfo": {"hasNextPage": false}
 					}
 				}
 			`,

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -228,10 +228,6 @@ func (r *RepositoryResolver) Language(ctx context.Context) string {
 
 func (r *RepositoryResolver) Enabled() bool { return true }
 
-// No clients that we know of read this field. Additionally on performance profiles
-// the marshalling of timestamps is significant in our postgres client. So we
-// deprecate the fields and return fake data for created_at.
-// https://github.com/sourcegraph/sourcegraph/pull/4668
 func (r *RepositoryResolver) CreatedAt() DateTime {
 	return DateTime{Time: time.Now()}
 }

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -28,9 +28,6 @@ type RepoFields struct {
 
 	// Archived is whether this repository has been archived.
 	Archived bool
-
-	// Cloned is whether this repository is cloned.
-	Cloned bool
 }
 
 // Repo represents a source code repository.

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -259,15 +259,15 @@ func NewStoreMetrics() StoreMetrics {
 		CountNotClonedRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_duration_seconds",
-				Help: "Time spent counting not-cloned repos",
+				Help: "Time spent counting cloned repos",
 			}, []string{}),
 			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_total",
-				Help: "Total number of count not-cloned repos calls",
+				Help: "Total number of count cloned repos calls",
 			}, []string{}),
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_errors_total",
-				Help: "Total number of errors when counting not-cloned repos",
+				Help: "Total number of errors when counting cloned repos",
 			}, []string{}),
 		},
 	}

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -49,8 +49,6 @@ type StoreListReposArgs struct {
 	PerPage int64
 	// Only include private repositories.
 	PrivateOnly bool
-	// Only include cloned repositories.
-	ClonedOnly bool
 
 	// UseOr decides between ANDing or ORing the predicates together.
 	UseOr bool
@@ -384,10 +382,6 @@ func listReposQuery(args StoreListReposArgs) paginatedQuery {
 		preds = append(preds, sqlf.Sprintf("private = TRUE"))
 	}
 
-	if args.ClonedOnly {
-		preds = append(preds, sqlf.Sprintf("cloned = TRUE"))
-	}
-
 	if len(preds) == 0 {
 		preds = append(preds, sqlf.Sprintf("TRUE"))
 	}
@@ -417,43 +411,26 @@ func (s DBStore) SetClonedRepos(ctx context.Context, repoNames ...string) error 
 		return nil
 	}
 
-	names, err := json.Marshal(repoNames)
-	if err != nil {
-		return nil
+	names := make([]*sqlf.Query, len(repoNames))
+	for i, v := range repoNames {
+		names[i] = sqlf.Sprintf("%s", v)
 	}
+	q := sqlf.Sprintf(setClonedReposQueryFmtstr, sqlf.Join(names, ","))
 
-	q := sqlf.Sprintf(setClonedReposQueryFmtstr, sqlf.Sprintf("%s", string(names)))
-
-	_, err = s.db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	_, err := s.db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	return err
 }
 
 const setClonedReposQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.SetClonedRepos
-/*
-This query generates a diff by selecting only
-the repos that need to be updated.
-Selected repos will have their cloned column reversed if
-their cloned column is true but they are not in cloned_repos
-or they are in cloned_repos but their cloned column is false
-*/
-WITH cloned_repos AS (
-  SELECT jsonb_array_elements_text(%s)
-),
-diff AS (
-  SELECT id,
-    cloned
-  FROM repo
-  WHERE
-    NOT cloned
-      AND name IN (SELECT * FROM cloned_repos)
-    OR cloned
-      AND name NOT IN (SELECT * FROM cloned_repos)
-)
-UPDATE repo
-SET cloned = NOT diff.cloned
-FROM diff
-WHERE repo.id = diff.id;
+WITH c AS (
+	UPDATE repo SET cloned = true
+	WHERE NOT cloned AND name in (%s)
+	RETURNING id
+ )
+ UPDATE repo SET cloned = false
+ FROM c
+ WHERE cloned AND repo.id != c.id;
 `
 
 // CountNotClonedRepos returns the number of repos whose cloned column is true.
@@ -612,7 +589,6 @@ func batchReposQuery(fmtstr string, repos []*Repo) (_ *sqlf.Query, err error) {
 		Archived            bool            `json:"archived"`
 		Fork                bool            `json:"fork"`
 		Private             bool            `json:"private"`
-		Cloned              bool            `json:"cloned"`
 		Sources             json.RawMessage `json:"sources"`
 		Metadata            json.RawMessage `json:"metadata"`
 	}
@@ -642,7 +618,6 @@ func batchReposQuery(fmtstr string, repos []*Repo) (_ *sqlf.Query, err error) {
 			ExternalServiceID:   nullStringColumn(r.ExternalRepo.ServiceID),
 			ExternalID:          nullStringColumn(r.ExternalRepo.ID),
 			Archived:            r.Archived,
-			Cloned:              r.Cloned,
 			Fork:                r.Fork,
 			Private:             r.Private,
 			Sources:             sources,
@@ -687,7 +662,6 @@ WITH batch AS (
       external_service_id   text,
       external_id           text,
       archived              boolean,
-      cloned                boolean,
       fork                  boolean,
       private               boolean,
       sources               jsonb,
@@ -711,7 +685,6 @@ SET
   external_service_id   = batch.external_service_id,
   external_id           = batch.external_id,
   archived              = batch.archived,
-  cloned                = batch.cloned,
   fork                  = batch.fork,
   private               = batch.private,
   sources               = batch.sources,
@@ -749,7 +722,6 @@ INSERT INTO repo (
   external_service_id,
   external_id,
   archived,
-  cloned,
   fork,
   private,
   sources,
@@ -767,7 +739,6 @@ SELECT
   external_service_id,
   external_id,
   archived,
-  cloned,
   fork,
   private,
   sources,

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -263,9 +263,6 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 		if args.PrivateOnly {
 			preds = append(preds, r.Private)
 		}
-		if args.ClonedOnly {
-			preds = append(preds, r.Cloned)
-		}
 
 		if (args.UseOr && evalOr(preds...)) || (!args.UseOr && evalAnd(preds...)) {
 			repos = append(repos, r)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -271,6 +271,12 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 // update the scheduler with the list.
 func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store repos.Store) {
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(repos.GetUpdateInterval() / 2):
+		}
+
 		cloned, err := gitserverClient.ListCloned(ctx)
 		if err != nil {
 			log15.Warn("failed to update git fetch scheduler with list of cloned repositories", "error", err)
@@ -283,12 +289,6 @@ func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver
 		if err != nil {
 			log15.Warn("failed to set cloned repository list", "error", err)
 			continue
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(10 * time.Second):
 		}
 	}
 }


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#11932

I'm reverting this PR because it introduces a bug in the site-admin repository list. I will reapply it once the bug has been fixed.