### PR TITLE
docker-images: update script for zoekt versions

### DIFF
--- a/docker-images/indexed-searcher/build.sh
+++ b/docker-images/indexed-searcher/build.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
-version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($5, 2)}')
 
 docker pull index.docker.io/sourcegraph/zoekt-webserver:"$version"
 docker tag index.docker.io/sourcegraph/zoekt-webserver:"$version" "$IMAGE"

--- a/docker-images/search-indexer/build.sh
+++ b/docker-images/search-indexer/build.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
-version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($5, 2)}')
 
 docker pull index.docker.io/sourcegraph/zoekt-indexserver:"$version"
 docker tag index.docker.io/sourcegraph/zoekt-indexserver:"$version" "$IMAGE"


### PR DESCRIPTION
The line for zoekt in go.mod was moved to it's own replace directive.
This broke the sed script we use to extract the version to use.
