### PR TITLE
search: add experimental setting search.index.branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Recently firing critical alerts are now displayed to admins in site alerts.
 - Specific alerts can now be silenced using `observability.silenceAlerts`. [#12087](https://github.com/sourcegraph/sourcegraph/pull/12087)
 - Revisions listed in `experimentalFeatures.versionContext` will be indexed for faster searching. This is the first support towards indexing non-default branches. [#6728](https://github.com/sourcegraph/sourcegraph/issues/6728)
+- Revisions listed in `experimentalFeatures.versionContext` or `experimentalFeatures.search.index.branches` will be indexed for faster searching. This is the first support towards indexing non-default branches. [#6728](https://github.com/sourcegraph/sourcegraph/issues/6728)
 
 ### Changed
 

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -46,13 +46,17 @@ func GetIndexOptions(c *schema.SiteConfiguration, repoName string, getVersion fu
 	// Set of branch names. Always index HEAD
 	branches := map[string]struct{}{"HEAD": {}}
 
-	if c.ExperimentalFeatures != nil && len(c.ExperimentalFeatures.VersionContexts) > 0 {
+	if c.ExperimentalFeatures != nil {
 		for _, vc := range c.ExperimentalFeatures.VersionContexts {
 			for _, rev := range vc.Revisions {
 				if rev.Repo == repoName && rev.Rev != "" {
 					branches[rev.Rev] = struct{}{}
 				}
 			}
+		}
+
+		for _, rev := range c.ExperimentalFeatures.SearchIndexBranches[repoName] {
+			branches[rev] = struct{}{}
 		}
 	}
 

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -20,6 +20,13 @@ func TestGetIndexOptions(t *testing.T) {
 			},
 		}
 	}
+	withBranches := func(c schema.SiteConfiguration, b map[string][]string) schema.SiteConfiguration {
+		if c.ExperimentalFeatures == nil {
+			c.ExperimentalFeatures = &schema.ExperimentalFeatures{}
+		}
+		c.ExperimentalFeatures.SearchIndexBranches = b
+		return c
+	}
 
 	cases := []struct {
 		name string
@@ -104,6 +111,32 @@ func TestGetIndexOptions(t *testing.T) {
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
 				{Name: "a", Version: "!a"},
+			},
+		},
+	}, {
+		name: "conf index branches",
+		conf: withBranches(schema.SiteConfiguration{}, map[string][]string{"repo": {"a"}}),
+		repo: "repo",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+				{Name: "a", Version: "!a"},
+			},
+		},
+	}, {
+		name: "conf index branches and vc",
+		conf: withBranches(
+			vcConf(vc("foo", "repo", "repo@a", "repo@b")),
+			map[string][]string{"repo": {"b", "c"}}),
+		repo: "repo",
+		want: zoektIndexOptions{
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+				{Name: "a", Version: "!a"},
+				{Name: "b", Version: "!b"},
+				{Name: "c", Version: "!c"},
 			},
 		},
 	}}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -399,6 +399,8 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index HEAD and revisions in version contexts. This allows specifying additional revisions.
+	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -152,6 +152,20 @@
             ]
           ]
         },
+        "search.index.branches": {
+          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index HEAD and revisions in version contexts. This allows specifying additional revisions.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "examples": [
+            {
+              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
+              "name/of/repo": ["develop"]
+            }
+          ]
+        },
         "versionContexts": {
           "description": "JSON array of version context configuration",
           "type": "array",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -157,6 +157,20 @@ const SiteSchemaJSON = `{
             ]
           ]
         },
+        "search.index.branches": {
+          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index HEAD and revisions in version contexts. This allows specifying additional revisions.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "examples": [
+            {
+              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
+              "name/of/repo": ["develop"]
+            }
+          ]
+        },
         "versionContexts": {
           "description": "JSON array of version context configuration",
           "type": "array",


### PR DESCRIPTION
This is to allow experimenting with multiple branch indexing without
activating version contexts.