### PR TITLE
Revert "Revert "cloud: use the cloned column to filter by clone status""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Configuration for `observability.alerts` has changed and notifications are now provided by Prometheus Alertmanager. [#11832](https://github.com/sourcegraph/sourcegraph/pull/11832)
   - Removed: `observability.alerts.id`.
   - Removed: Slack notifiers no longer accept `mentionUsers`, `mentionGroups`, `mentionChannel`, and `token` options.
+-
 
 ### Fixed
 
@@ -46,6 +47,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue where valid search queries were improperly hinted as being invalid in the search field. [#11688](https://github.com/sourcegraph/sourcegraph/pull/11688)
 - Reduce frontend memory spikes by limiting the number of goroutines launched by our GraphQL resolvers. [#11736](https://github.com/sourcegraph/sourcegraph/pull/11736)
 - Fixed a bug affecting Sourcegraph icon display in our Phabricator native integration [#11825](https://github.com/sourcegraph/sourcegraph/pull/11825).
+- Improve performance of site-admin repositories status page. [#11932](https://github.com/sourcegraph/sourcegraph/pull/11932)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
@@ -93,23 +92,6 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 		}
 
-		if opt2.LimitOffset != nil {
-			tmp := *opt2.LimitOffset
-			opt2.LimitOffset = &tmp
-			// We purposefully load more repos into memory than requested in
-			// order to save roundtrips to gitserver in case we need to do
-			// filtering by clone status.
-			// The trade-off here is memory/cpu vs. network roundtrips to
-			// database/gitserver and we choose smaller latency over smaller
-			// memory footprint.
-			// At the end of this method we return the requested number of
-			// repos.
-			// As for the number: 1250 is the result of local benchmarks where
-			// it yielded the best performance/resources tradeoff, before
-			// diminishing returns set in
-			opt2.Limit += 1250
-		}
-
 		var indexed map[string]*zoekt.Repository
 		searchIndexEnabled := search.Indexed().Enabled()
 		isIndexed := func(repo api.RepoName) bool {
@@ -130,6 +112,15 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 		}
 
+		if !r.cloned {
+			opt2.NoCloned = true
+		} else if !r.notCloned || !r.cloneInProgress {
+			// notCloned and cloneInProgress are true by default.
+			// this condition is valid only if one of them has been
+			// explicitly set to false by the client.
+			opt2.OnlyCloned = true
+		}
+
 		for {
 			repos, err := backend.Repos.List(ctx, opt2)
 			if err != nil {
@@ -137,28 +128,6 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 				return
 			}
 			reposFromDB := len(repos)
-
-			if !r.cloned || !r.cloneInProgress || !r.notCloned {
-				// Query gitserver to filter by repository clone status.
-				repoNames := make([]api.RepoName, len(repos))
-				for i, repo := range repos {
-					repoNames[i] = repo.Name
-				}
-				response, err := gitserver.DefaultClient.RepoCloneProgress(ctx, repoNames...)
-				if err != nil {
-					r.err = err
-					return
-				}
-				keepRepos := repos[:0]
-				for _, repo := range repos {
-					if info := response.Results[repo.Name]; info == nil {
-						continue
-					} else if (r.cloned && info.Cloned && !info.CloneInProgress) || (r.cloneInProgress && info.CloneInProgress) || (r.notCloned && !info.Cloned && !info.CloneInProgress) {
-						keepRepos = append(keepRepos, repo)
-					}
-				}
-				repos = keepRepos
-			}
 
 			if !r.indexed || !r.notIndexed {
 				keepRepos := repos[:0]
@@ -176,22 +145,16 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if opt2.LimitOffset == nil {
 				break
 			} else {
-				if len(r.repos) > r.opt.Limit {
-					// Cut off the repos we additionally loaded to save
-					// roundtrips to `gitserver` and only return the number
-					// that was requested.
-					// But, when possible, we add one more so we can detect if
-					// there is a "next page" that could be loaded
-					r.repos = r.repos[:r.opt.Limit+1]
-					break
-				}
-				if reposFromDB < r.opt.Limit {
+				// check if we filtered some repos and if
+				// we need to get more from the DB
+				if len(repos) >= r.opt.Limit || reposFromDB < r.opt.Limit {
 					break
 				}
 				opt2.Offset += opt2.Limit
 			}
 		}
 	})
+
 	return r.repos, r.err
 }
 
@@ -257,7 +220,7 @@ func (r *repositoryConnectionResolver) PageInfo(ctx context.Context) (*graphqlut
 	if err != nil {
 		return nil, err
 	}
-	return graphqlutil.HasNextPage(r.opt.LimitOffset != nil && len(repos) > r.opt.Limit), nil
+	return graphqlutil.HasNextPage(r.opt.LimitOffset != nil && len(repos) >= r.opt.Limit), nil
 }
 
 func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -5,12 +5,33 @@ import (
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
 
 func TestRepositories(t *testing.T) {
 	resetMocks()
-	db.Mocks.Repos.MockList(t, "repo1", "repo2", "repo3")
+	repos := []*types.Repo{
+		{Name: "repo1"},
+		{Name: "repo2"},
+		{
+			Name: "repo3",
+			RepoFields: &types.RepoFields{
+				Cloned: true,
+			},
+		},
+	}
+	db.Mocks.Repos.List = func(ctx context.Context, opt db.ReposListOptions) ([]*types.Repo, error) {
+		if opt.NoCloned {
+			return repos[0:2], nil
+		}
+		if opt.OnlyCloned {
+			return repos[2:], nil
+		}
+
+		return repos, nil
+	}
+
 	db.Mocks.Repos.Count = func(context.Context, db.ReposListOptions) (int, error) { return 3, nil }
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
@@ -18,6 +39,34 @@ func TestRepositories(t *testing.T) {
 			Query: `
 				{
 					repositories {
+						nodes { name }
+						totalCount
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"repositories": {
+						"nodes": [
+							{ "name": "repo1" },
+							{ "name": "repo2" },
+							{ "name": "repo3" }
+						],
+						"totalCount": null,
+						"pageInfo": {"hasNextPage": false}
+					}
+				}
+			`,
+		},
+		{
+			Schema: mustParseGraphQLSchema(t),
+			// cloned and notCloned are true by default
+			// this test ensures the behavior is the same
+			// when setting them explicitly
+			Query: `
+				{
+					repositories(cloned: true, notCloned: true) {
 						nodes { name }
 						totalCount
 						pageInfo { hasNextPage }
@@ -56,6 +105,71 @@ func TestRepositories(t *testing.T) {
 							{ "name": "repo2" }
 						],
 						"pageInfo": {"hasNextPage": true}
+					}
+				}
+			`,
+		},
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+				{
+					repositories(cloned: false) {
+						nodes { name }
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"repositories": {
+						"nodes": [
+							{ "name": "repo1" },
+							{ "name": "repo2" }
+						],
+						"pageInfo": {"hasNextPage": false}
+					}
+				}
+			`,
+		},
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+				{
+					repositories(notCloned: false) {
+						nodes { name }
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"repositories": {
+						"nodes": [
+							{ "name": "repo3" }
+						],
+						"pageInfo": {"hasNextPage": false}
+					}
+				}
+			`,
+		},
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+				{
+					repositories(notCloned: false, cloned: false) {
+						nodes { name }
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"repositories": {
+						"nodes": [
+							{ "name": "repo1" },
+							{ "name": "repo2" }
+						],
+						"pageInfo": {"hasNextPage": false}
 					}
 				}
 			`,

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -228,6 +228,10 @@ func (r *RepositoryResolver) Language(ctx context.Context) string {
 
 func (r *RepositoryResolver) Enabled() bool { return true }
 
+// No clients that we know of read this field. Additionally on performance profiles
+// the marshalling of timestamps is significant in our postgres client. So we
+// deprecate the fields and return fake data for created_at.
+// https://github.com/sourcegraph/sourcegraph/pull/4668
 func (r *RepositoryResolver) CreatedAt() DateTime {
 	return DateTime{Time: time.Now()}
 }

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -28,6 +28,9 @@ type RepoFields struct {
 
 	// Archived is whether this repository has been archived.
 	Archived bool
+
+	// Cloned is whether this repository is cloned.
+	Cloned bool
 }
 
 // Repo represents a source code repository.

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -259,15 +259,15 @@ func NewStoreMetrics() StoreMetrics {
 		CountNotClonedRepos: &metrics.OperationMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_duration_seconds",
-				Help: "Time spent counting cloned repos",
+				Help: "Time spent counting not-cloned repos",
 			}, []string{}),
 			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_total",
-				Help: "Total number of count cloned repos calls",
+				Help: "Total number of count not-cloned repos calls",
 			}, []string{}),
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_errors_total",
-				Help: "Total number of errors when counting cloned repos",
+				Help: "Total number of errors when counting not-cloned repos",
 			}, []string{}),
 		},
 	}

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -731,6 +731,41 @@ func testStoreUpsertRepos(store repos.Store) func(*testing.T) {
 				t.Fatalf("ListRepos:\n%s", diff)
 			}
 		}))
+
+		t.Run("it shouldn't modify the cloned column", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+			// UpsertRepos shouldn't set the cloned column to true
+			r := mkRepos(1, repositories...)[0]
+			r.Cloned = true
+			if err := tx.UpsertRepos(ctx, r); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+
+			count, err := tx.CountNotClonedRepos(ctx)
+			if err != nil {
+				t.Fatalf("CountNotClonedRepos error: %s", err)
+			}
+			if count != 1 {
+				t.Fatalf("Wrong number of not cloned repos: %d", count)
+			}
+
+			// UpsertRepos shouldn't set the cloned column to false either
+			if err := tx.SetClonedRepos(ctx, r.Name); err != nil {
+				t.Fatalf("SetClonedRepos error: %s", err)
+			}
+			r = r.Clone()
+			r.Cloned = false
+			if err := tx.UpsertRepos(ctx, r); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+
+			count, err = tx.CountNotClonedRepos(ctx)
+			if err != nil {
+				t.Fatalf("CountNotClonedRepos error: %s", err)
+			}
+			if count != 0 {
+				t.Fatalf("Wrong number of not cloned repos: %d", count)
+			}
+		}))
 	}
 }
 
@@ -763,6 +798,22 @@ func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
 			})
 		}
 
+		check := func(t testing.TB, ctx context.Context, tx repos.Store, wantNames []string) {
+			t.Helper()
+
+			res, err := tx.ListRepos(ctx, repos.StoreListReposArgs{})
+			if err != nil {
+				t.Fatalf("ListRepos error: %s", err)
+			}
+
+			cloned := repos.Repos(res).Filter(isCloned).Names()
+			sort.Strings(cloned)
+
+			if got, want := cloned, wantNames; !cmp.Equal(got, want) {
+				t.Fatalf("got=%v, want=%v: %s", got, want, cmp.Diff(got, want))
+			}
+		}
+
 		ctx := context.Background()
 
 		t.Run("no repo name", func(t *testing.T) {
@@ -783,33 +834,17 @@ func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
 			names := stored[:3].Names()
 			sort.Strings(names)
 
-			check := func() {
-				t.Helper()
-
-				res, err := tx.ListRepos(ctx, repos.StoreListReposArgs{})
-				if err != nil {
-					t.Fatalf("ListRepos error: %s", err)
-				}
-
-				cloned := repos.Repos(res).Filter(isCloned).Names()
-				sort.Strings(cloned)
-
-				if got, want := cloned, names; !cmp.Equal(got, want) {
-					t.Fatalf("got=%v, want=%v: %s", got, want, cmp.Diff(got, want))
-				}
-			}
-
 			if err := tx.SetClonedRepos(ctx, names...); err != nil {
 				t.Fatalf("SetClonedRepos error: %s", err)
 			}
-			check()
+			check(t, ctx, tx, names)
 
 			// setClonedRepositories should be idempotent and have the same behavior
 			// when called with the same repos
 			if err := tx.SetClonedRepos(ctx, names...); err != nil {
 				t.Fatalf("SetClonedRepos error: %s", err)
 			}
-			check()
+			check(t, ctx, tx, names)
 
 			// when adding another repo to the list, the other repos must be set as well
 			names = stored[:4].Names()
@@ -818,7 +853,36 @@ func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
 				t.Fatalf("SetClonedRepos error: %s", err)
 			}
 
-			check()
+			check(t, ctx, tx, names)
+		}))
+
+		t.Run("repo names in mixed case", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+			stored := mkRepos(9, repositories...)
+			for i := range stored {
+				if i%2 == 0 {
+					stored[i].Name = strings.ToUpper(stored[i].Name)
+				}
+			}
+
+			if err := tx.UpsertRepos(ctx, stored...); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+
+			sort.Sort(stored)
+
+			originalNames := stored.Names()
+			sort.Strings(originalNames)
+
+			lowerCaseNames := make([]string, 0, len(originalNames))
+			for _, n := range originalNames {
+				lowerCaseNames = append(lowerCaseNames, strings.ToLower(n))
+			}
+
+			if err := tx.SetClonedRepos(ctx, lowerCaseNames...); err != nil {
+				t.Fatalf("SetClonedRepos error: %s", err)
+			}
+
+			check(t, ctx, tx, originalNames)
 		}))
 	}
 }
@@ -884,6 +948,38 @@ func testStoreCountNotClonedRepos(store repos.Store) func(*testing.T) {
 				t.Fatalf("CountNotClonedRepos:\n%s", diff)
 			}
 		}))
+
+		t.Run("deleted non cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+			stored := mkRepos(10, repositories...)
+
+			if err := tx.UpsertRepos(ctx, stored...); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+
+			sort.Sort(stored)
+			cloned := stored[:3].Names()
+
+			if err := tx.SetClonedRepos(ctx, cloned...); err != nil {
+				t.Fatalf("SetClonedRepos error: %s", err)
+			}
+
+			sort.Strings(cloned)
+			deletedCloned := stored[8:].With(func(r *repos.Repo) {
+				r.DeletedAt = time.Now()
+			})
+
+			if err := tx.UpsertRepos(ctx, deletedCloned...); err != nil {
+				t.Fatalf("UpsertRepos error: %s", err)
+			}
+
+			count, err := tx.CountNotClonedRepos(ctx)
+			if err != nil {
+				t.Fatalf("CountNotClonedRepos error: %s", err)
+			}
+			if diff := cmp.Diff(count, uint64(5)); diff != "" {
+				t.Fatalf("CountNotClonedRepos:\n%s", diff)
+			}
+		}))
 	}
 }
 
@@ -918,8 +1014,7 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 	}
 
 	github := repos.Repo{
-		Name:   "github.com/bar/foo",
-		Cloned: true,
+		Name: "github.com/bar/foo",
 		Sources: map[string]*repos.SourceInfo{
 			"extsvc:123": {
 				ID:       "extsvc:123",
@@ -1132,17 +1227,6 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 	})
 
 	testCases = append(testCases, testCase{
-		name: "only include cloned",
-		args: func(repos.Repos) repos.StoreListReposArgs {
-			return repos.StoreListReposArgs{
-				ClonedOnly: true,
-			}
-		},
-		stored: repositories,
-		repos:  repos.Assert.ReposEqual(&github),
-	})
-
-	testCases = append(testCases, testCase{
 		name:   "use or",
 		stored: repositories,
 		args: func(repos.Repos) repos.StoreListReposArgs {
@@ -1171,9 +1255,10 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
+		ctx := context.Background()
+
 		for _, tc := range testCases {
 			tc := tc
-			ctx := context.Background()
 
 			t.Run(tc.name, transact(ctx, store, func(t testing.TB, tx repos.Store) {
 				stored := tc.stored.Clone()
@@ -1196,6 +1281,35 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 				}
 			}))
 		}
+
+		t.Run("only include cloned", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+			stored := mkRepos(5, repositories...).Clone()
+			if err := tx.UpsertRepos(ctx, stored...); err != nil {
+				t.Fatalf("failed to setup store: %v", err)
+			}
+
+			sort.Sort(stored)
+
+			cloned := stored[:3]
+			if err := tx.SetClonedRepos(ctx, cloned.Names()...); err != nil {
+				t.Fatalf("failed to set cloned repos: %v", err)
+			}
+
+			args := repos.StoreListReposArgs{
+				ClonedOnly: true,
+			}
+
+			rs, err := tx.ListRepos(ctx, args)
+			if err != nil {
+				t.Errorf("failed to list repos: %v", err)
+			}
+
+			want := cloned.With(func(r *repos.Repo) {
+				r.Cloned = true
+			})
+
+			repos.Assert.ReposEqual(want...)(t, rs)
+		}))
 	}
 }
 

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -739,79 +739,28 @@ func isCloned(r *repos.Repo) bool {
 }
 
 func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
-	clock := repos.NewFakeClock(time.Now(), 0)
-	now := clock.Now()
-
 	return func(t *testing.T) {
 		t.Helper()
 
-		github := repos.Repo{
-			Name:        "github.com/foo/bar",
-			URI:         "github.com/foo/bar",
-			Description: "The description",
-			Language:    "barlang",
-			CreatedAt:   now,
-			Cloned:      true,
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "AAAAA==",
-				ServiceType: "github",
-				ServiceID:   "http://github.com",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:1": {
-					ID:       "extsvc:1",
-					CloneURL: "git@github.com:foo/bar.git",
+		var repositories repos.Repos
+		for i := 0; i < 3; i++ {
+			repositories = append(repositories, &repos.Repo{
+				Name:   fmt.Sprintf("github.com/%d/%d", i, i),
+				URI:    fmt.Sprintf("github.com/%d/%d", i, i),
+				Cloned: false,
+				ExternalRepo: api.ExternalRepoSpec{
+					ID:          fmt.Sprintf("%d", i),
+					ServiceType: extsvc.TypeGitHub,
+					ServiceID:   "http://github.com",
 				},
-			},
-			Metadata: new(github.Repository),
-		}
-
-		gitlab := repos.Repo{
-			Name:        "gitlab.com/foo/bar",
-			URI:         "gitlab.com/foo/bar",
-			Description: "The description",
-			Language:    "barlang",
-			CreatedAt:   now,
-			Cloned:      false,
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "1234",
-				ServiceType: extsvc.TypeGitLab,
-				ServiceID:   "http://gitlab.com",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:2": {
-					ID:       "extsvc:2",
-					CloneURL: "git@gitlab.com:foo/bar.git",
+				Sources: map[string]*repos.SourceInfo{
+					"extsvc:3": {
+						ID:       "extsvc:3",
+						CloneURL: "git@github.com:foo/bar.git",
+					},
 				},
-			},
-			Metadata: new(gitlab.Project),
-		}
-
-		bitbucketServer := repos.Repo{
-			Name:        "bitbucketserver.mycorp.com/foo/bar",
-			URI:         "bitbucketserver.mycorp.com/foo/bar",
-			Description: "The description",
-			Language:    "barlang",
-			CreatedAt:   now,
-			Cloned:      true,
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          "1234",
-				ServiceType: "bitbucketServer",
-				ServiceID:   "http://bitbucketserver.mycorp.com",
-			},
-			Sources: map[string]*repos.SourceInfo{
-				"extsvc:3": {
-					ID:       "extsvc:3",
-					CloneURL: "git@bitbucketserver.mycorp.com:foo/bar.git",
-				},
-			},
-			Metadata: new(bitbucketserver.Repo),
-		}
-
-		repositories := repos.Repos{
-			&github,
-			&gitlab,
-			&bitbucketServer,
+				Metadata: new(github.Repository),
+			})
 		}
 
 		ctx := context.Background()
@@ -832,23 +781,44 @@ func testStoreSetClonedRepos(store repos.Store) func(*testing.T) {
 			sort.Sort(stored)
 
 			names := stored[:3].Names()
+			sort.Strings(names)
+
+			check := func() {
+				t.Helper()
+
+				res, err := tx.ListRepos(ctx, repos.StoreListReposArgs{})
+				if err != nil {
+					t.Fatalf("ListRepos error: %s", err)
+				}
+
+				cloned := repos.Repos(res).Filter(isCloned).Names()
+				sort.Strings(cloned)
+
+				if got, want := cloned, names; !cmp.Equal(got, want) {
+					t.Fatalf("got=%v, want=%v: %s", got, want, cmp.Diff(got, want))
+				}
+			}
 
 			if err := tx.SetClonedRepos(ctx, names...); err != nil {
 				t.Fatalf("SetClonedRepos error: %s", err)
 			}
+			check()
 
-			stored, err := tx.ListRepos(ctx, repos.StoreListReposArgs{})
-			if err != nil {
-				t.Fatalf("ListRepos error: %s", err)
+			// setClonedRepositories should be idempotent and have the same behavior
+			// when called with the same repos
+			if err := tx.SetClonedRepos(ctx, names...); err != nil {
+				t.Fatalf("SetClonedRepos error: %s", err)
 			}
+			check()
 
-			cloned := stored.Filter(isCloned).Names()
-			sort.Strings(cloned)
+			// when adding another repo to the list, the other repos must be set as well
+			names = stored[:4].Names()
 			sort.Strings(names)
-
-			if got, want := cloned, names; !cmp.Equal(got, want) {
-				t.Fatalf("got=%v, want=%v: %s", got, want, cmp.Diff(got, want))
+			if err := tx.SetClonedRepos(ctx, names...); err != nil {
+				t.Fatalf("SetClonedRepos error: %s", err)
 			}
+
+			check()
 		}))
 	}
 }
@@ -948,7 +918,8 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 	}
 
 	github := repos.Repo{
-		Name: "github.com/bar/foo",
+		Name:   "github.com/bar/foo",
+		Cloned: true,
 		Sources: map[string]*repos.SourceInfo{
 			"extsvc:123": {
 				ID:       "extsvc:123",
@@ -1158,6 +1129,17 @@ func testStoreListRepos(store repos.Store) func(*testing.T) {
 		},
 		stored: repositories,
 		repos:  repos.Assert.ReposEqual(&gitlab),
+	})
+
+	testCases = append(testCases, testCase{
+		name: "only include cloned",
+		args: func(repos.Repos) repos.StoreListReposArgs {
+			return repos.StoreListReposArgs{
+				ClonedOnly: true,
+			}
+		},
+		stored: repositories,
+		repos:  repos.Assert.ReposEqual(&github),
 	})
 
 	testCases = append(testCases, testCase{

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -263,6 +263,9 @@ func (s FakeStore) ListRepos(ctx context.Context, args StoreListReposArgs) ([]*R
 		if args.PrivateOnly {
 			preds = append(preds, r.Private)
 		}
+		if args.ClonedOnly {
+			preds = append(preds, r.Cloned)
+		}
 
 		if (args.UseOr && evalOr(preds...)) || (!args.UseOr && evalAnd(preds...)) {
 			repos = append(repos, r)

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -331,12 +331,16 @@ func (s *FakeStore) UpsertRepos(ctx context.Context, upserts ...*Repo) error {
 		if repo == nil {
 			return errors.Errorf("upserting repo with non-existent ID: id=%v", r.ID)
 		}
+		// the cloned column shouldn't be modified by UpsertRepos
+		r.Cloned = repo.Cloned
 		s.repoByID[r.ID] = r
 	}
 
 	for _, r := range inserts {
 		s.repoIDSeq++
 		r.ID = s.repoIDSeq
+		// the cloned column shouldn't be modified by UpsertRepos
+		r.Cloned = false
 		s.repoByID[r.ID] = r
 	}
 
@@ -366,7 +370,7 @@ func (s *FakeStore) SetClonedRepos(ctx context.Context, repoNames ...string) err
 
 		var found bool
 		for _, repoName := range repoNames {
-			if repoName == r.Name {
+			if strings.ToLower(repoName) == strings.ToLower(r.Name) {
 				found = true
 				break
 			}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -669,11 +669,15 @@ func TestServer_StatusMessages(t *testing.T) {
 			gitserverClient := &fakeGitserverClient{listClonedResponse: tc.gitserverCloned}
 
 			stored := tc.stored.Clone()
+			var cloned []string
 			for i, r := range stored {
 				r.ExternalRepo = api.ExternalRepoSpec{
 					ID:          strconv.Itoa(i),
 					ServiceType: extsvc.TypeGitHub,
 					ServiceID:   "https://github.com/",
+				}
+				if r.Cloned {
+					cloned = append(cloned, r.Name)
 				}
 			}
 
@@ -682,6 +686,11 @@ func TestServer_StatusMessages(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			err = store.SetClonedRepos(ctx, cloned...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			err = store.UpsertExternalServices(ctx, githubService)
 			if err != nil {
 				t.Fatal(err)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -271,12 +271,6 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 // update the scheduler with the list.
 func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store repos.Store) {
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(repos.GetUpdateInterval() / 2):
-		}
-
 		cloned, err := gitserverClient.ListCloned(ctx)
 		if err != nil {
 			log15.Warn("failed to update git fetch scheduler with list of cloned repositories", "error", err)
@@ -289,6 +283,12 @@ func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver
 		if err != nil {
 			log15.Warn("failed to set cloned repository list", "error", err)
 			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(10 * time.Second):
 		}
 	}
 }

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -154,6 +154,7 @@ var getBySQLColumns = []string{
 	"language",
 	"fork",
 	"archived",
+	"cloned",
 }
 
 func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
@@ -222,6 +223,7 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		&r.Language,
 		&r.Fork,
 		&r.Archived,
+		&r.Cloned,
 	)
 }
 
@@ -263,6 +265,12 @@ type ReposListOptions struct {
 
 	// OnlyArchived excludes non-archived repositories from the list.
 	OnlyArchived bool
+
+	// NoCloned excludes cloned repositories from the list.
+	NoCloned bool
+
+	// OnlyCloned excludes non-cloned repositories from the list.
+	OnlyCloned bool
 
 	// NoPrivate excludes private repositories from the list.
 	NoPrivate bool
@@ -457,6 +465,12 @@ func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 	}
 	if opt.OnlyArchived {
 		conds = append(conds, sqlf.Sprintf("archived"))
+	}
+	if opt.NoCloned {
+		conds = append(conds, sqlf.Sprintf("NOT cloned"))
+	}
+	if opt.OnlyCloned {
+		conds = append(conds, sqlf.Sprintf("cloned"))
 	}
 	if opt.NoPrivate {
 		conds = append(conds, sqlf.Sprintf("NOT private"))

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -41,6 +41,8 @@ func createRepo(ctx context.Context, t *testing.T, repo *types.Repo) {
 	if repo.RepoFields != nil {
 		op.Description = repo.Description
 		op.Fork = repo.Fork
+		op.Cloned = repo.Cloned
+		op.Archived = repo.Archived
 	}
 
 	if err := Repos.Upsert(ctx, op); err != nil {
@@ -75,6 +77,7 @@ type InsertRepoOp struct {
 	Description  string
 	Fork         bool
 	Archived     bool
+	Cloned       bool
 	ExternalRepo api.ExternalRepoSpec
 }
 
@@ -88,7 +91,8 @@ WITH upsert AS (
     external_id           = NULLIF(BTRIM($4), ''),
     external_service_type = NULLIF(BTRIM($5), ''),
     external_service_id   = NULLIF(BTRIM($6), ''),
-    archived              = $8
+    archived              = $8,
+    cloned                = $9
   WHERE name = $1 OR (
     external_id IS NOT NULL
     AND external_service_type IS NOT NULL
@@ -111,7 +115,8 @@ INSERT INTO repo (
   external_id,
   external_service_type,
   external_service_id,
-  archived
+  archived,
+  cloned
 ) (
   SELECT
     $1 AS name,
@@ -121,7 +126,8 @@ INSERT INTO repo (
     NULLIF(BTRIM($4), '') AS external_id,
     NULLIF(BTRIM($5), '') AS external_service_type,
     NULLIF(BTRIM($6), '') AS external_service_id,
-    $8 AS archived
+    $8 AS archived,
+    $9 AS cloned
   WHERE NOT EXISTS (SELECT 1 FROM upsert)
 )`
 
@@ -167,6 +173,7 @@ func (s *repos) Upsert(ctx context.Context, op InsertRepoOp) error {
 		op.ExternalRepo.ServiceID,
 		language,
 		op.Archived,
+		op.Cloned,
 	)
 
 	return err
@@ -191,7 +198,14 @@ func TestRepos_Get(t *testing.T) {
 			ServiceType: "b",
 			ServiceID:   "c",
 		},
-		RepoFields: &types.RepoFields{URI: "u"},
+		RepoFields: &types.RepoFields{
+			URI:         "u",
+			Description: "d",
+			Language:    "l",
+			Fork:        true,
+			Archived:    true,
+			Cloned:      true,
+		},
 	})
 
 	repo, err := Repos.Get(ctx, want[0].ID)
@@ -303,6 +317,44 @@ func TestRepos_List_fork(t *testing.T) {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, append(append([]*types.Repo(nil), mine...), yours...), repos)
+	}
+}
+
+func TestRepos_List_cloned(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	MockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perms) ([]*types.Repo, error) {
+		return repos, nil
+	}
+	defer func() { MockAuthzFilter = nil }()
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+	ctx = actor.WithActor(ctx, &actor.Actor{})
+
+	mine := mustCreate(ctx, t, &types.Repo{Name: "a/r", RepoFields: &types.RepoFields{Cloned: false}})
+	yours := mustCreate(ctx, t, &types.Repo{Name: "b/r", RepoFields: &types.RepoFields{Cloned: true}})
+
+	tests := []struct {
+		name string
+		opt  ReposListOptions
+		want []*types.Repo
+	}{
+		{"OnlyCloned", ReposListOptions{OnlyCloned: true}, yours},
+		{"NoCloned", ReposListOptions{NoCloned: true}, mine},
+		{"NoCloned && OnlyCloned", ReposListOptions{NoCloned: true, OnlyCloned: true}, nil},
+		{"Default", ReposListOptions{}, append(append([]*types.Repo(nil), mine...), yours...)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repos, err := Repos.List(ctx, test.opt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertJSONEqual(t, test.want, repos)
+		})
 	}
 }
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#12128

This PR un-reverts #11932.  It will be merged once the fix will be reviewed (upcoming PR, TODO: link it here once it's created)

⚠️ This PR has already been reviewed in #11932