### PR TITLE
Fix cloned repositories listing and counting

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -515,6 +515,7 @@ func (s DBStore) list(ctx context.Context, q *sqlf.Query, scan scanFunc) (last, 
 // UpsertRepos updates or inserts the given repos in the Sourcegraph repository store.
 // The ID field is used to distinguish between Repos that need to be updated and Repos
 // that need to be inserted. On inserts, the _ID field of each given Repo is set on inserts.
+// The cloned column is not updated by this function.
 func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 	if len(repos) == 0 {
 		return nil
@@ -612,7 +613,6 @@ func batchReposQuery(fmtstr string, repos []*Repo) (_ *sqlf.Query, err error) {
 		Archived            bool            `json:"archived"`
 		Fork                bool            `json:"fork"`
 		Private             bool            `json:"private"`
-		Cloned              bool            `json:"cloned"`
 		Sources             json.RawMessage `json:"sources"`
 		Metadata            json.RawMessage `json:"metadata"`
 	}
@@ -642,7 +642,6 @@ func batchReposQuery(fmtstr string, repos []*Repo) (_ *sqlf.Query, err error) {
 			ExternalServiceID:   nullStringColumn(r.ExternalRepo.ServiceID),
 			ExternalID:          nullStringColumn(r.ExternalRepo.ID),
 			Archived:            r.Archived,
-			Cloned:              r.Cloned,
 			Fork:                r.Fork,
 			Private:             r.Private,
 			Sources:             sources,
@@ -687,7 +686,6 @@ WITH batch AS (
       external_service_id   text,
       external_id           text,
       archived              boolean,
-      cloned                boolean,
       fork                  boolean,
       private               boolean,
       sources               jsonb,
@@ -711,7 +709,6 @@ SET
   external_service_id   = batch.external_service_id,
   external_id           = batch.external_id,
   archived              = batch.archived,
-  cloned                = batch.cloned,
   fork                  = batch.fork,
   private               = batch.private,
   sources               = batch.sources,
@@ -749,7 +746,6 @@ INSERT INTO repo (
   external_service_id,
   external_id,
   archived,
-  cloned,
   fork,
   private,
   sources,
@@ -767,7 +763,6 @@ SELECT
   external_service_id,
   external_id,
   archived,
-  cloned,
   fork,
   private,
   sources,

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -446,9 +446,9 @@ diff AS (
   FROM repo
   WHERE
     NOT cloned
-      AND lower(name) IN (SELECT lower(name) FROM cloned_repos)
+      AND name IN (SELECT name::citext FROM cloned_repos)
     OR cloned
-      AND lower(name) NOT IN (SELECT lower(name) FROM cloned_repos)
+      AND name NOT IN (SELECT name::citext FROM cloned_repos)
 )
 UPDATE repo
 SET cloned = NOT diff.cloned

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -467,7 +467,7 @@ func (s DBStore) CountNotClonedRepos(ctx context.Context) (uint64, error) {
 
 const CountNotClonedReposQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.CountNotClonedRepos
-SELECT COUNT(*) FROM repo WHERE NOT cloned
+SELECT COUNT(*) FROM repo WHERE deleted_at IS NULL AND NOT cloned
 `
 
 // a paginatedQuery returns a query with the given pagination

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -430,13 +430,13 @@ func (s DBStore) SetClonedRepos(ctx context.Context, repoNames ...string) error 
 
 const setClonedReposQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.SetClonedRepos
-/*
-This query generates a diff by selecting only
-the repos that need to be updated.
-Selected repos will have their cloned column reversed if
-their cloned column is true but they are not in cloned_repos
-or they are in cloned_repos but their cloned column is false
-*/
+--
+-- This query generates a diff by selecting only
+-- the repos that need to be updated.
+-- Selected repos will have their cloned column reversed if
+-- their cloned column is true but they are not in cloned_repos
+-- or they are in cloned_repos but their cloned column is false.
+--
 WITH cloned_repos AS (
   SELECT jsonb_array_elements_text(%s) AS name
 ),

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -438,7 +438,7 @@ their cloned column is true but they are not in cloned_repos
 or they are in cloned_repos but their cloned column is false
 */
 WITH cloned_repos AS (
-  SELECT jsonb_array_elements_text(%s)
+  SELECT jsonb_array_elements_text(%s) AS name
 ),
 diff AS (
   SELECT id,
@@ -446,9 +446,9 @@ diff AS (
   FROM repo
   WHERE
     NOT cloned
-      AND name IN (SELECT * FROM cloned_repos)
+      AND lower(name) IN (SELECT lower(name) FROM cloned_repos)
     OR cloned
-      AND name NOT IN (SELECT * FROM cloned_repos)
+      AND lower(name) NOT IN (SELECT lower(name) FROM cloned_repos)
 )
 UPDATE repo
 SET cloned = NOT diff.cloned

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -920,7 +920,7 @@ func testStoreCountNotClonedRepos(store repos.Store) func(*testing.T) {
 			}
 		}))
 
-		t.Run("deleted cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("deleted non cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
 			stored := mkRepos(10, repositories...)
 
 			if err := tx.UpsertRepos(ctx, stored...); err != nil {

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -331,12 +331,16 @@ func (s *FakeStore) UpsertRepos(ctx context.Context, upserts ...*Repo) error {
 		if repo == nil {
 			return errors.Errorf("upserting repo with non-existent ID: id=%v", r.ID)
 		}
+		// the cloned column shouldn't be modified by UpsertRepos
+		r.Cloned = repo.Cloned
 		s.repoByID[r.ID] = r
 	}
 
 	for _, r := range inserts {
 		s.repoIDSeq++
 		r.ID = s.repoIDSeq
+		// the cloned column shouldn't be modified by UpsertRepos
+		r.Cloned = false
 		s.repoByID[r.ID] = r
 	}
 

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -370,7 +370,7 @@ func (s *FakeStore) SetClonedRepos(ctx context.Context, repoNames ...string) err
 
 		var found bool
 		for _, repoName := range repoNames {
-			if repoName == r.Name {
+			if strings.ToLower(repoName) == strings.ToLower(r.Name) {
 				found = true
 				break
 			}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -669,11 +669,15 @@ func TestServer_StatusMessages(t *testing.T) {
 			gitserverClient := &fakeGitserverClient{listClonedResponse: tc.gitserverCloned}
 
 			stored := tc.stored.Clone()
+			var cloned []string
 			for i, r := range stored {
 				r.ExternalRepo = api.ExternalRepoSpec{
 					ID:          strconv.Itoa(i),
 					ServiceType: extsvc.TypeGitHub,
 					ServiceID:   "https://github.com/",
+				}
+				if r.Cloned {
+					cloned = append(cloned, r.Name)
 				}
 			}
 
@@ -682,6 +686,11 @@ func TestServer_StatusMessages(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			err = store.SetClonedRepos(ctx, cloned...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			err = store.UpsertExternalServices(ctx, githubService)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This PR fixes three bugs introduced by #11932.

_First bug:_ In the site-admin repository status page, the list of not cloned repositories was displaying the wrong list or repos, from time to time. It was because a repo-updater synchronizer was overwriting the `repos.cloned` column, setting everything to false. I fixed it by preventing `Upsert` to upgrade that column. This is not the most elegant solution because one could expect using `UpsertRepos` to change that column and not see the expected result.

_Second bug_: The status indicator wasn't displaying the right not cloned repo count. It was because the query was also counting the deleted repos.

_Third bug_: The `SetClonedRepos` was case sensitive and wasn't updating repos with upper case letters. Thanks @mrnugget for the fix!