### PR TITLE
Use fork of ghodss/yaml to use 'on' as key in CampaignSpec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.3.0
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )
 
@@ -204,3 +204,6 @@ replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.
 replace github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+// See: https://github.com/ghodss/yaml/pull/65
+replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152

--- a/go.sum
+++ b/go.sum
@@ -1209,6 +1209,8 @@ github.com/sourcegraph/jsonx v0.0.0-20200625022044-c22a595bbad7 h1:G58fa9uWw59V5
 github.com/sourcegraph/jsonx v0.0.0-20200625022044-c22a595bbad7/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
+github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
+github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20200622101713-7b13614a083e h1:g7164BqqH/2SXaWaUjHtgUL3808yFfrbnKZ/JiWmiTI=
 github.com/sourcegraph/zoekt v0.0.0-20200622101713-7b13614a083e/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -24,6 +24,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/xeipuuv/gojsonschema"
+
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // SupportedExternalServices are the external service types currently supported
@@ -1541,7 +1543,7 @@ func (cs *CampaignSpec) UnmarshalValidate() error {
 		return errors.Wrap(err, "failed to compile CampaignSpec JSON schema")
 	}
 
-	normalized, err := yaml.YAMLToJSON([]byte(cs.RawSpec))
+	normalized, err := yaml.YAMLToJSONCustom([]byte(cs.RawSpec), yamlv3.Unmarshal)
 	if err != nil {
 		return errors.Wrapf(err, "failed to normalize JSON")
 	}

--- a/internal/campaigns/types_test.go
+++ b/internal/campaigns/types_test.go
@@ -562,7 +562,7 @@ func TestCampaignSpecUnmarshalValidate(t *testing.T) {
 			rawSpec: `
 name: my-unique-name
 description: My description
-'on':
+on:
 - repositoriesMatchingQuery: lang:go func main
 - repository: github.com/sourcegraph/src-cli
 steps:


### PR DESCRIPTION
As we noticed last week: we can't use `on` as a key in a `CampaignSpec`
because `yaml.YAMLToJSON` would convert that `on` into a `true` and that
in turn would fail when validated.

The solution here is to use a custom fork of `ghodss/yaml` that allows
passing in a custom unmarshal-function which does _not_ do the
conversion.

The function we're passing in comes from the yaml.v3 library which
changed its behavior when parsing boolean values (see
https://github.com/ghodss/yaml/pull/65).

We lose the ability to use `YAMLToJSONStrict` since that only works with
yaml.v2, but yaml.v3 already warns about duplicated keys and the JSON
schema validation gives us enough of a safety net for the rest.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
