### PR TITLE
monitoring: disable critical alerts banner by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
     - PagerDuty notifiers: `severity` and `apiUrl`
     - Webhook notifiers: `bearerToken`
   - A new `disableSendResolved` option disables notifications for when alerts resolve themselves.
-- Recently firing critical alerts can now displayed to admins via site alerts with the flag `alerts.hideObservabilitySiteAlerts` in user configuration.
+- Recently firing critical alerts can now be displayed to admins via site alerts, use the flag `{ "alerts.hideObservabilitySiteAlerts": false }` to enable these alerts in user configuration.
 - Specific alerts can now be silenced using `observability.silenceAlerts`. [#12087](https://github.com/sourcegraph/sourcegraph/pull/12087)
 - Revisions listed in `experimentalFeatures.versionContext` will be indexed for faster searching. This is the first support towards indexing non-default branches. [#6728](https://github.com/sourcegraph/sourcegraph/issues/6728)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
     - PagerDuty notifiers: `severity` and `apiUrl`
     - Webhook notifiers: `bearerToken`
   - A new `disableSendResolved` option disables notifications for when alerts resolve themselves.
-- Recently firing critical alerts are now displayed to admins in site alerts.
+- Recently firing critical alerts can now displayed to admins via site alerts with the flag `alerts.hideObservabilitySiteAlerts` in user configuration.
 - Specific alerts can now be silenced using `observability.silenceAlerts`. [#12087](https://github.com/sourcegraph/sourcegraph/pull/12087)
 - Revisions listed in `experimentalFeatures.versionContext` will be indexed for faster searching. This is the first support towards indexing non-default branches. [#6728](https://github.com/sourcegraph/sourcegraph/issues/6728)
 

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -175,7 +175,7 @@
     "alerts.hideObservabilitySiteAlerts": {
       "description": "Disables observability-related site alert banners.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "extensions": {
       "description": "The Sourcegraph extensions to use. Enable an extension by adding a property `\"my/extension\": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -180,7 +180,7 @@ const SettingsSchemaJSON = `{
     "alerts.hideObservabilitySiteAlerts": {
       "description": "Disables observability-related site alert banners.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "extensions": {
       "description": "The Sourcegraph extensions to use. Enable an extension by adding a property ` + "`" + `\"my/extension\": true` + "`" + ` (where ` + "`" + `my/extension` + "`" + ` is the extension ID). Override a previously enabled extension and disable it by setting its value to ` + "`" + `false` + "`" + `.",


### PR DESCRIPTION
This banner is currently a significant source of confusion, and since we're still working on dogfooding alerts in sourcegraph.com (https://github.com/sourcegraph/sourcegraph/issues/5370) it's hard to say we're confident about all our alerts enough to have it displayed so prominently (yet)

This changes the default of `alerts.hideObservabilitySiteAlerts` to `true`

Most recent Slack discussion: https://sourcegraph.slack.com/archives/C07KZF47K/p1594730258245600

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
