### PR TITLE
monitoring: use average in average_resolve_revision_duration alert

### DIFF
--- a/monitoring/zoekt_index_server.go
+++ b/monitoring/zoekt_index_server.go
@@ -13,7 +13,7 @@ func ZoektIndexServer() *Container {
 						{
 							Name:              "average_resolve_revision_duration",
 							Description:       "average resolve revision duration over 5m",
-							Query:             `sum(rate(resolve_revision_seconds_sum[5m]))`,
+							Query:             `sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_seconds_count[5m]))`,
 							DataMayNotExist:   true,
 							Warning:           Alert{GreaterOrEqual: 15},
 							Critical:          Alert{GreaterOrEqual: 30},


### PR DESCRIPTION
I think this may have been translated incorrectly from the previous
promql alerts. It seems to be missing the divide by number of events, so
we were alerting on total instead of average.