### PR TITLE
campaigns: hide YouTube from Percy

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style type="text/css">
+.percy-hide {
+    display: none;
+    visibility: hidden;
+}
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,8 @@
 <style type="text/css">
-.percy-hide {
-    display: none;
-    visibility: hidden;
+@media only percy {
+    .percy-hide {
+        display: none;
+        visibility: hidden;
+    }
 }
 </style>

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -200,7 +200,7 @@ When you submit the PR, Percy will fail until you approve the new snapshot.
 
 Flakiness in snapshot tests can be caused by the search response time, order of results, animations, premature snapshots while the page is still loading, etc.
 
-This can be solved with [Percy specific CSS](https://docs.percy.io/docs/percy-specific-css) that will be applied only when taking the snapshot and allow you to hide flaky elements with `display: none`.
+This can be solved with [Percy specific CSS](https://docs.percy.io/docs/percy-specific-css) that will be applied only when taking the snapshot and allow you to hide flaky elements with `display: none`. In simple cases, you can simply apply the `percy-hide` CSS class to the problematic element and it will be hidden from Percy.
 
 ## Continuous Integration
 

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -224,6 +224,14 @@ body,
     box-shadow: $btn-focus-box-shadow;
 }
 
+// Hide the given element from Percy.
+.percy-hide {
+    @media only percy {
+        visibility: hidden;
+        display: none;
+    }
+}
+
 // Pages
 @import './Layout';
 @import './api/ApiConsole';

--- a/web/src/enterprise/campaigns/global/marketing/CampaignsMarketing.tsx
+++ b/web/src/enterprise/campaigns/global/marketing/CampaignsMarketing.tsx
@@ -14,6 +14,7 @@ export const CampaignsMarketing: React.FunctionComponent<CampaignsMarketingProps
 
             <div className="text-center">
                 <iframe
+                    className="percy-hide"
                     width="560"
                     height="315"
                     src="https://www.youtube.com/embed/aqcCrqRB17w"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`CampaignsDotComPage renders 1`] = `
         <iframe
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen={true}
+          className="percy-hide"
           frameBorder="0"
           height="315"
           src="https://www.youtube.com/embed/aqcCrqRB17w"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsMarketing.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsMarketing.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`CampaignsMarketing renders 1`] = `
       <iframe
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen={true}
+        className="percy-hide"
         frameBorder="0"
         height="315"
         src="https://www.youtube.com/embed/aqcCrqRB17w"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsSiteAdminMarketingPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsSiteAdminMarketingPage.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`CampaignsSiteAdminMarketingPage renders 1`] = `
         <iframe
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen={true}
+          className="percy-hide"
           frameBorder="0"
           height="315"
           src="https://www.youtube.com/embed/aqcCrqRB17w"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsUserMarketingPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsUserMarketingPage.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`CampaignsUserMarketingPage renders for disabled 1`] = `
         <iframe
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen={true}
+          className="percy-hide"
           frameBorder="0"
           height="315"
           src="https://www.youtube.com/embed/aqcCrqRB17w"
@@ -233,6 +234,7 @@ exports[`CampaignsUserMarketingPage renders for enabled 1`] = `
         <iframe
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen={true}
+          className="percy-hide"
           frameBorder="0"
           height="315"
           src="https://www.youtube.com/embed/aqcCrqRB17w"

--- a/web/src/nav/StatusMessagesNavItem.scss
+++ b/web/src/nav/StatusMessagesNavItem.scss
@@ -3,12 +3,6 @@
         margin: 0.5rem 0;
     }
 
-    &__nav-link {
-        @media only percy {
-            visibility: hidden;
-            display: none;
-        }
-    }
     &__dropdown-menu {
         min-width: 22rem;
         max-width: 22rem;

--- a/web/src/nav/StatusMessagesNavItem.tsx
+++ b/web/src/nav/StatusMessagesNavItem.tsx
@@ -213,7 +213,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
             <ButtonDropdown
                 isOpen={this.state.isOpen}
                 toggle={this.toggleIsOpen}
-                className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+                className="nav-link py-0 px-0 percy-hide"
             >
                 <DropdownToggle caret={false} className="btn btn-link" nav={true}>
                     {this.renderIcon()}

--- a/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
   isSiteAdmin={false}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -15,7 +15,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -26,7 +26,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle
@@ -114,7 +114,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
   isSiteAdmin={false}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -122,7 +122,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -133,7 +133,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle
@@ -222,7 +222,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
   isSiteAdmin={true}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -230,7 +230,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -241,7 +241,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle
@@ -345,7 +345,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
   isSiteAdmin={false}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -353,7 +353,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -364,7 +364,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle
@@ -453,7 +453,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
   isSiteAdmin={true}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -461,7 +461,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -472,7 +472,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle
@@ -576,7 +576,7 @@ exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
   isSiteAdmin={false}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -584,7 +584,7 @@ exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -595,7 +595,7 @@ exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle
@@ -684,7 +684,7 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
   isSiteAdmin={true}
 >
   <ButtonDropdown
-    className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+    className="nav-link py-0 px-0 percy-hide"
     isOpen={false}
     toggle={[Function]}
   >
@@ -692,7 +692,7 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
       a11y={true}
       active={false}
       addonType={false}
-      className="nav-link py-0 px-0 status-messages-nav-item__nav-link"
+      className="nav-link py-0 px-0 percy-hide"
       direction="down"
       group={true}
       inNavbar={false}
@@ -703,7 +703,7 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
     >
       <Manager>
         <div
-          className="nav-link py-0 px-0 status-messages-nav-item__nav-link btn-group"
+          className="nav-link py-0 px-0 percy-hide btn-group"
           onKeyDown={[Function]}
         >
           <DropdownToggle


### PR DESCRIPTION
Fixes #12170.

This PR also unifies the one other test where we hide an element from Percy into the same CSS class, since we need to declare it in two places to be usable with Storybook and non-Storybook tests.

I have a support ticket open with Percy/BrowserStack right now to fix my account, but until that happens, I would appreciate someone hitting "approve" in Percy. :smiley: