### PR TITLE
Fix Bitbucket file path wrapping

### DIFF
--- a/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -28,11 +28,11 @@
     margin-left: 2px; // same as other buttons in the row
 }
 
+.sg-toolbar-mount-bitbucket-server,
 .code-view-toolbar--bitbucket {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    margin-top: -5px !important;
+    // Layout action item children within the .secondary wrapping context,
+    // so they wrap together with the native Bitbucket buttons
+    display: contents;
 }
 
 .action-nav-item--bitbucket {
@@ -43,12 +43,15 @@
 // Use flexbox instead of float, so we can handle wrapping action items
 .file-toolbar {
     display: flex;
-    > .primary {
-        flex: 1 0 auto;
-        order: 1;
+    align-items: center;
+    // Trigger a two-row layout if file path and action items don't fit all in one row.
+    flex-wrap: wrap;
 
-        display: flex;
-        align-items: center;
+    > .primary {
+        // Make sure file paths don't wrap to make space for buttons
+        // (instead trigger a two-row layout if it does not fit)
+        flex: 0 2 auto;
+        order: 1;
     }
     > .secondary {
         // Overrides
@@ -57,11 +60,25 @@
         line-height: initial;
 
         flex: 1 1 auto;
+        flex-wrap: wrap;
         order: 2;
 
         display: flex;
         align-items: center;
         justify-content: flex-end;
+
+        > .aui-buttons {
+            // Layout all child buttons within the parent wrapping context (.secondary),
+            // so they wrap together with our toolbar buttons.
+            display: contents;
+
+            > .aui-button {
+                // Reapply margins that are on the .aui-buttons element to the .aui-button elements,
+                // because the display: contents removes margins from the .aui-buttons element
+                margin-left: 5px;
+                margin-top: 5px;
+            }
+        }
     }
 }
 

--- a/browser/src/shared/code-hosts/github/style.scss
+++ b/browser/src/shared/code-hosts/github/style.scss
@@ -52,8 +52,12 @@
 // Diff views
 .diff-view {
     .file-header {
+        // Trigger a two-row layout if file path and action items don't fit all in one row.
         flex-wrap: wrap;
+
         .file-info {
+            // Make sure file paths don't wrap to make space for buttons
+            // (instead trigger a two-row layout if it does not fit)
             flex: 0 2 auto !important;
         }
         .file-actions {


### PR DESCRIPTION
This is a quick PoC to help fixing https://github.com/sourcegraph/sourcegraph/issues/11110 while maintaining wrapping capability when action items are long. It basically applies the same style as used for GitHub, with some use of `display: contents` to make nested buttons participate in a shared wrapping context.

I.e. the behavior is: When both file path and action items don't fit next to each other, use a two-row layout instead (using `flex-wrap: wrap` and by disallowing shrinking of the file path with `flex: 0`). Secondly both the file path and the action items are allowed to wrap within themselves if they are even longer than a single row.

A: Both fit in one row

<img width="1025" alt="Screen Shot 2020-07-14 at 23 44 07" src="https://user-images.githubusercontent.com/10532611/87480893-8e838280-c62e-11ea-9a8d-b88902939790.png">

B: Don't fit in one row, use two rows

<img width="1127" alt="Screen Shot 2020-07-14 at 23 42 47" src="https://user-images.githubusercontent.com/10532611/87480917-993e1780-c62e-11ea-8bc5-a86b80813cac.png">

B2: Blob view

![image](https://user-images.githubusercontent.com/10532611/87482954-d0162c80-c632-11ea-802c-49057aca0a5a.png)

C: File path and action items don't fit into one row each, have their own contents also wrap

<img width="689" alt="Screen Shot 2020-07-14 at 23 42 25" src="https://user-images.githubusercontent.com/10532611/87480925-9d6a3500-c62e-11ea-90cd-0292c5926a50.png">

For comparison, here's the same layout behavior on GitHub:

![image](https://user-images.githubusercontent.com/10532611/87481106-f5a13700-c62e-11ea-800c-c6983af2b092.png)

I only quickly hacked this together in dev tools and tried to copy it over into SCSS. @marekweb could you see if this works? I hope this helps!