### PR TITLE
search: wrap alerts in results resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -601,6 +601,14 @@ func addRegexpField(p syntax.ParseTree, field, pattern string) string {
 	return modified.String()
 }
 
+// Wrap an alert in a SearchResultsResolver. ElapsedMilliseconds() will
+// calculate a very large value for duration if start takes on the nil-value of
+// year 1. As a workaround, wrap instantiates start with time.now().
+// TODO(rvantonder): #10801.
+func (a searchAlert) wrap() *SearchResultsResolver {
+	return &SearchResultsResolver{alert: &a, start: time.Now()}
+}
+
 func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 	alert := &searchAlert{
 		prometheusType:  a.prometheusType,
@@ -608,8 +616,7 @@ func (a searchAlert) Results(context.Context) (*SearchResultsResolver, error) {
 		description:     a.description,
 		proposedQueries: a.proposedQueries,
 	}
-	// ElapsedMilliseconds() will calculate a very large value for duration if start takes on the nil-value of year 1. As a workaround, instantiate start with time.now(). TODO(rvantonder): #10801.
-	return &SearchResultsResolver{alert: alert, start: time.Now()}, nil
+	return alert.wrap(), nil
 }
 
 func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -836,7 +836,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 		tryCount *= tryCount
 		if tryCount > maxResultsForRetry {
 			// We've capped out what we're willing to do, throw alert.
-			return &SearchResultsResolver{alert: alertForCappedAndExpression()}, nil
+			return alertForCappedAndExpression().wrap(), nil
 		}
 	}
 	result.limitHit = !exhausted
@@ -939,7 +939,7 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopePar
 func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchResultsResolver, error) {
 	scopeParameters, pattern, err := query.PartitionSearchPattern(q)
 	if err != nil {
-		return &SearchResultsResolver{alert: alertForQuery("", err)}, nil
+		return alertForQuery("", err).wrap(), nil
 	}
 	if pattern == nil {
 		r.query.(*query.AndOrQuery).Query = scopeParameters
@@ -992,7 +992,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 	if shouldShowAlert {
 		usedTime := time.Since(start)
 		suggestTime := longer(2, usedTime)
-		return &SearchResultsResolver{alert: alertForTimeout(usedTime, suggestTime, r)}, nil
+		return alertForTimeout(usedTime, suggestTime, r).wrap(), nil
 	}
 	return rr, err
 }


### PR DESCRIPTION
Stacked on #12184. Applies some of the useful changes in #12086: Wrapping these alerts with a time nil-value that is more reasonable, stops some pollution of our metrics data (which I noticed was still happening on Looker, and probably due to these alerts).

