### PR TITLE
search: correctly merge token ranges

### DIFF
--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -196,9 +196,7 @@ loop:
 					if r, _ := utf8.DecodeRune([]byte{p.buf[p.pos-1]}); !unicode.IsSpace(r) {
 						if len(nodes) > 0 {
 							if previous, ok := nodes[len(nodes)-1].(Pattern); ok {
-								previous.Value += pattern.Value
-								previous.Annotation.Labels |= pattern.Annotation.Labels
-								nodes[len(nodes)-1] = previous
+								nodes[len(nodes)-1] = concatPatterns(previous, pattern)
 								continue
 							}
 						}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -822,3 +822,33 @@ func TestScanDelimited(t *testing.T) {
 		})
 	}
 }
+
+func TestMergePatterns(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "foo()bar",
+			want:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":8}}`,
+		},
+		{
+			input: "()bar",
+			want:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":5}}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run("merge pattern", func(t *testing.T) {
+			p := &parser{buf: []byte(tt.input), heuristics: parensAsPatterns}
+			nodes, err := p.parseParameterList()
+			got := nodes[0].(Pattern).Annotation.Range.String()
+			if err != nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #12188.

Some parts of the parser didn't correctly update pattern ranges for a merge operation. There was also one missing case where the range wasn't assigned. This PR fixes it.