### PR TITLE
Add SupportLabels() method to Changeset

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -20,8 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -326,12 +324,11 @@ func (r *changesetResolver) CheckState(ctx context.Context) (*campaigns.Changese
 }
 
 func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.ChangesetLabelResolver, error) {
-	// Only GitHub and Gitlab support labels on changesets so don't make a DB call unless we need to.
-	if _, ok := r.Changeset.Metadata.(*github.PullRequest); !ok {
-		if _, ok := r.Changeset.Metadata.(*gitlab.MergeRequest); !ok {
-			return []graphqlbackend.ChangesetLabelResolver{}, nil
-		}
+	// Not every code host supports labels on changesets so don't make a DB call unless we need to.
+	if ok := r.Changeset.SupportsLabels(); !ok {
+		return []graphqlbackend.ChangesetLabelResolver{}, nil
 	}
+
 	es, err := r.computeEvents(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -38,8 +38,10 @@ func IsRepoSupported(spec *api.ExternalRepoSpec) bool {
 	return ok
 }
 
-func IsKindSupported(kind string) bool {
-	_, ok := SupportedExternalServices[extsvc.KindToType(kind)]
+// IsKindSupported returns whether the given extsvc Kind is supported by
+// campaigns.
+func IsKindSupported(extSvcKind string) bool {
+	_, ok := SupportedExternalServices[extsvc.KindToType(extSvcKind)]
 	return ok
 }
 
@@ -737,6 +739,18 @@ func (c *Changeset) BaseRef() (string, error) {
 		return "refs/heads/" + m.TargetBranch, nil
 	default:
 		return "", errors.New("unknown changeset type")
+	}
+}
+
+// SupportsLabels returns whether the code host on which the changeset is
+// hosted supports labels and whether it's safe to call the
+// (*Changeset).Labels() method.
+func (c *Changeset) SupportsLabels() bool {
+	switch c.Metadata.(type) {
+	case *github.PullRequest, *gitlab.MergeRequest:
+		return true
+	default:
+		return false
 	}
 }
 


### PR DESCRIPTION
I prefer having the logic in about what's supported and what not in a central place.

And after I saw the addition of `gitlab.MergeRequest` in the recent PR I felt bad about introducing the check in the first place, so here we go :)

