### PR TITLE
Turn ChangsetEvents.Labels into ComputeLabels function

### DIFF
--- a/enterprise/internal/campaigns/changeset_events.go
+++ b/enterprise/internal/campaigns/changeset_events.go
@@ -1,9 +1,6 @@
 package campaigns
 
 import (
-	"sort"
-	"time"
-
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -18,49 +15,6 @@ func (ce ChangesetEvents) Swap(i, j int) { ce[i], ce[j] = ce[j], ce[i] }
 // Less sorts changeset events by their Timestamps
 func (ce ChangesetEvents) Less(i, j int) bool {
 	return ce[i].Timestamp().Before(ce[j].Timestamp())
-}
-
-// UpdateLabelsSince returns the set of current labels based the starting set of labels and looking at events
-// that have occurred after "since".
-func (ce *ChangesetEvents) UpdateLabelsSince(cs *cmpgn.Changeset) []cmpgn.ChangesetLabel {
-	var current []cmpgn.ChangesetLabel
-	var since time.Time
-	if cs != nil {
-		current = cs.Labels()
-		since = cs.UpdatedAt
-	}
-	// Copy slice so that we don't mutate ce
-	sorted := make(ChangesetEvents, len(*ce))
-	copy(sorted, *ce)
-	sort.Sort(sorted)
-
-	// Iterate through all label events to get the current set
-	set := make(map[string]cmpgn.ChangesetLabel)
-	for _, l := range current {
-		set[l.Name] = l
-	}
-	for _, event := range sorted {
-		switch e := event.Metadata.(type) {
-		case *github.LabelEvent:
-			if e.CreatedAt.Before(since) {
-				continue
-			}
-			if e.Removed {
-				delete(set, e.Label.Name)
-				continue
-			}
-			set[e.Label.Name] = cmpgn.ChangesetLabel{
-				Name:        e.Label.Name,
-				Color:       e.Label.Color,
-				Description: e.Label.Description,
-			}
-		}
-	}
-	labels := make([]cmpgn.ChangesetLabel, 0, len(set))
-	for _, label := range set {
-		labels = append(labels, label)
-	}
-	return labels
 }
 
 // FindMergeCommit will return the merge commit from the given set of events, stopping

--- a/enterprise/internal/campaigns/changeset_events_test.go
+++ b/enterprise/internal/campaigns/changeset_events_test.go
@@ -1,107 +1,14 @@
 package campaigns
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
-	"sort"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
-
-func TestChangesetEventsLabels(t *testing.T) {
-	now := time.Now()
-	labelEvent := func(name string, kind cmpgn.ChangesetEventKind, when time.Time) *cmpgn.ChangesetEvent {
-		removed := kind == cmpgn.ChangesetEventKindGitHubUnlabeled
-		return &cmpgn.ChangesetEvent{
-			Kind:      kind,
-			UpdatedAt: when,
-			Metadata: &github.LabelEvent{
-				Actor: github.Actor{},
-				Label: github.Label{
-					Name: name,
-				},
-				CreatedAt: when,
-				Removed:   removed,
-			},
-		}
-	}
-	changeset := func(names []string, updated time.Time) *cmpgn.Changeset {
-		meta := &github.PullRequest{}
-		for _, name := range names {
-			meta.Labels.Nodes = append(meta.Labels.Nodes, github.Label{
-				Name: name,
-			})
-		}
-		return &cmpgn.Changeset{
-			UpdatedAt: updated,
-			Metadata:  meta,
-		}
-	}
-	labels := func(names ...string) []cmpgn.ChangesetLabel {
-		var ls []cmpgn.ChangesetLabel
-		for _, name := range names {
-			ls = append(ls, cmpgn.ChangesetLabel{Name: name})
-		}
-		return ls
-	}
-
-	tests := []struct {
-		name      string
-		changeset *cmpgn.Changeset
-		events    ChangesetEvents
-		want      []cmpgn.ChangesetLabel
-	}{
-		{
-			name: "zero values",
-		},
-		{
-			name:      "no events",
-			changeset: changeset([]string{"label1"}, time.Time{}),
-			events:    ChangesetEvents{},
-			want:      labels("label1"),
-		},
-		{
-			name:      "remove event",
-			changeset: changeset([]string{"label1"}, time.Time{}),
-			events: ChangesetEvents{
-				labelEvent("label1", cmpgn.ChangesetEventKindGitHubUnlabeled, now),
-			},
-			want: []cmpgn.ChangesetLabel{},
-		},
-		{
-			name:      "add event",
-			changeset: changeset([]string{"label1"}, time.Time{}),
-			events: ChangesetEvents{
-				labelEvent("label2", cmpgn.ChangesetEventKindGitHubLabeled, now),
-			},
-			want: labels("label1", "label2"),
-		},
-		{
-			name:      "old add event",
-			changeset: changeset([]string{"label1"}, now.Add(5*time.Minute)),
-			events: ChangesetEvents{
-				labelEvent("label2", cmpgn.ChangesetEventKindGitHubLabeled, now),
-			},
-			want: labels("label1"),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			have := tc.events.UpdateLabelsSince(tc.changeset)
-			want := tc.want
-			sort.Slice(have, func(i, j int) bool { return have[i].Name < have[j].Name })
-			sort.Slice(want, func(i, j int) bool { return want[i].Name < want[j].Name })
-			if diff := cmp.Diff(have, want, cmpopts.EquateEmpty()); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
 
 func TestFindMergeCommitID(t *testing.T) {
 	now := time.Now()

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -183,7 +183,7 @@ type changesetResolver struct {
 
 	// cache changeset events as they are used more than once
 	eventsOnce sync.Once
-	events     []*campaigns.ChangesetEvent
+	events     ee.ChangesetEvents
 	eventsErr  error
 
 	// When the next sync is scheduled
@@ -239,7 +239,10 @@ func (r *changesetResolver) computeEvents(ctx context.Context) ([]*campaigns.Cha
 			Limit:        -1,
 		}
 		es, _, err := r.store.ListChangesetEvents(ctx, opts)
+
 		r.events = es
+		sort.Sort(r.events)
+
 		r.eventsErr = err
 	})
 	return r.events, r.eventsErr
@@ -334,15 +337,11 @@ func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.Change
 		return nil, err
 	}
 
-	events := make(ee.ChangesetEvents, len(es))
-	copy(events, es)
-	sort.Sort(events)
-
 	// We use changeset labels as the source of truth as they can be renamed
 	// or removed but we'll also take into account any changeset events that
 	// have happened since the last sync in order to reflect changes that
 	// have come in via webhooks
-	labels := ee.ComputeLabels(r.Changeset, events)
+	labels := ee.ComputeLabels(r.Changeset, es)
 	resolvers := make([]graphqlbackend.ChangesetLabelResolver, 0, len(labels))
 	for _, l := range labels {
 		resolvers = append(resolvers, &changesetLabelResolver{label: l})

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -604,3 +604,49 @@ func changesetGitserverRepo(ctx context.Context, c *campaigns.Changeset) (*gitse
 func unixMilliToTime(ms int64) time.Time {
 	return time.Unix(0, ms*int64(time.Millisecond))
 }
+
+// ComputeLabels returns a sorted list of current labels based the starting set
+// of labels found in the Changeset and looking at ChangesetEvents that have
+// occurred after the Changeset.UpdatedAt.
+// The events should be presorted.
+func ComputeLabels(c *campaigns.Changeset, events ChangesetEvents) []campaigns.ChangesetLabel {
+	var current []campaigns.ChangesetLabel
+	var since time.Time
+	if c != nil {
+		current = c.Labels()
+		since = c.UpdatedAt
+	}
+
+	// Iterate through all label events to get the current set
+	set := make(map[string]campaigns.ChangesetLabel)
+	for _, l := range current {
+		set[l.Name] = l
+	}
+	for _, event := range events {
+		switch e := event.Metadata.(type) {
+		case *github.LabelEvent:
+			if e.CreatedAt.Before(since) {
+				continue
+			}
+			if e.Removed {
+				delete(set, e.Label.Name)
+				continue
+			}
+			set[e.Label.Name] = campaigns.ChangesetLabel{
+				Name:        e.Label.Name,
+				Color:       e.Label.Color,
+				Description: e.Label.Description,
+			}
+		}
+	}
+	labels := make([]campaigns.ChangesetLabel, 0, len(set))
+	for _, label := range set {
+		labels = append(labels, label)
+	}
+
+	sort.Slice(labels, func(i, j int) bool {
+		return labels[i].Name < labels[j].Name
+	})
+
+	return labels
+}


### PR DESCRIPTION
I think it makes more sense to follow the same style for all of these "compute a state based on the changeset and its events" methods/functions. `(*ChangesetEvents).Labels` was the last one that we didn't convert.

Since I've been looking at it in #12198 I decided to change it to a `ComputeLabels` function (that also does the sorting)

This also changes the `changesetResolver` to always sort events and use the slice type.
