### PR TITLE
docs: improve alerting docs

### DIFF
--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -2,17 +2,19 @@
 
 Alerts can be configured to notify site admins when there is something wrong or noteworthy on the Sourcegraph instance.
 
-## Setting up alerting
+## Understanding alerts
 
-### Sourcegraph 3.17+
+See [alert solutions](alert_solutions.md) for possible solutions when alerts are firing.
+
+## Setting up alerting
 
 Visit your site configuration (e.g. `https://sourcegraph.example.com/site-admin/configuration`) to configure alerts using the `observability.alerts` field. As always, you can use `Ctrl+Space` at any time to get hints about allowed fields as well as relevant documentation inside the configuration editor.
 
 Once configured, Sourcegraph alerts will automatically be routed to the appropriate notification channels by severity level.
 
-#### Example notifiers
+### Example notifiers
 
-##### Slack
+#### Slack
 
 ```json
 "observability.alerts": [
@@ -27,7 +29,7 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
 ]
 ```
 
-##### PagerDuty
+#### PagerDuty
 
 ```json
 "observability.alerts": [
@@ -42,7 +44,7 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
 ]
 ```
 
-##### Webhook
+#### Webhook
 
 ```json
 "observability.alerts": [
@@ -57,7 +59,7 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
 ]
 ```
 
-##### Email
+#### Email
 
 Note that to receive email notifications, the [`email.address`](../config/site_config.md#email-address) and [`email.smtp`](../config/site_config.md#email-smtp) fields must be configured in site configuration.
 
@@ -74,7 +76,7 @@ Note that to receive email notifications, the [`email.address`](../config/site_c
 ]
 ```
 
-#### Silencing alerts
+### Silencing alerts
 
 If there is an alert you are aware of and you wish to silence notifications for it, add an entry to the `observability.silenceAlerts` field. For example:
 
@@ -88,7 +90,9 @@ If there is an alert you are aware of and you wish to silence notifications for 
 
 You can find the appropriate identifier for each alert in [alert solutions](./alert_solutions.md).
 
-### Before 3.17: Configure alert channels in Grafana
+## Setting up alerting: before Sourcegraph 3.17
+
+### Configure alert channels in Grafana
 
 Before configuring specific alerts in Grafana, you must set up alert channels. Each channel
 corresponds to an external service to which Grafana will push alerts.
@@ -121,7 +125,7 @@ corresponds to an external service to which Grafana will push alerts.
 > earlier). Set the environment variable `GF_SERVER_ROOT_URL` to your Sourcegraph instance external URL followed
 > by the path `/-/debug/grafana`.
 
-### Before 3.17: Set up an individual alert
+### Set up an individual alert
 
 After adding the appropriate notification channels, configure individual alerts to notify those channels.
 
@@ -137,7 +141,3 @@ After adding the appropriate notification channels, configure individual alerts 
 1. Verify your rule by clicking `Test Rule` or viewing `State History`.
 1. Return to the dashboard page by clicking the left arrow in the upper left. Save the dashboard by
    clicking the save icon in the upper right.
-
-### Understanding alerts
-
-See [alert solutions](alert_solutions.md) for possible solutions when alerts are firing.

--- a/doc/admin/observability/alerting_custom_consumption.md
+++ b/doc/admin/observability/alerting_custom_consumption.md
@@ -2,23 +2,13 @@
 
 If Sourcegraph's builtin [alerting](alerting.md) (which can notify you via email, Slack, PagerDuty, webhook, and more) is not sufficient for you, or if you just prefer to consume the alerts programatically for some reason, then this page is for you.
 
-Below are examples of how to query alerts that are being monitored or are currently firing in Sourcegraph.
+For more information about Sourcegraph alerts, see: [high level alerting metrics](metrics_guide.md#high-level-alerting-metrics).
 
-## The difference between "critical" and "warning" alerts
+## Prometheus queries
 
-Please note that there is a key difference between Sourcegraph's "critical" and "warning" alerts:
+Below are examples of how to query alerts that are being monitored or are currently firing in Sourcegraph. If you do wish to query warning alerts, too, then simply replace `critical` with `warning` in any of the below query examples.
 
-- _Critical_ alerts are guaranteed to be a real issue with Sourcegraph.
-  - If you see one, it means something is definitely wrong.
-  - We suggest e.g. emailing the site admin when these occur.
-- _Warning_ alerts are worth looking into, but may not be a real issue with Sourcegraph.
-  - We suggest checking in on these periodically, or using a notification channel that will not bother anyone if it is spammed.
-  - If you see warning alerts firing, please let us know so that we can improve them.
-  - Over time, as warning alerts become stable and reliable across many Sourcegraph deployments, they will also be promoted to critical alerts in an update by Sourcegraph.
-
-For more information about the differences, see the: [high level alerting metrics](metrics_guide.md#high-level-alerting-metrics)
-
-## "How many critical alerts were firing in the last minute?"
+### "How many critical alerts were firing in the last minute?"
 
 Prometheus query:
 
@@ -54,7 +44,7 @@ Example response:
 
 This only ever returns a single result, representing the maximum number of critical alerts firing across all Sourcegraph services in the last minute (relative to the time the query executed / the returned unix timestamp `1585250319.243`). The above shows that `"0"` alerts were firing, and if the number was non-zero, it would represent the max number of alerts firing across all services in the last minute.
 
-## "How many critical alerts were firing in the last minute, per service?"
+### "How many critical alerts were firing in the last minute, per service?"
 
 Prometheus query:
 
@@ -102,8 +92,7 @@ Example response:
 
 This returns a `result` for each service of Sourcegraph where at least one critical alert is defined and being monitored. For example, the first result (`frontend`) indicates that in the last minute (relative to the time the query executed / the returned unix timestamp `1585250083.874`) that `"0"` alerts for the `frontend` service were firing. If the number was non-zero, it would represent the max number of alerts firing on that service in the last minute.
 
-
-## "How many critical alerts were firing in the last minute, per defined alert?"
+### "How many critical alerts were firing in the last minute, per defined alert?"
 
 Prometheus query:
 
@@ -154,7 +143,3 @@ Example response:
 ```
 
 This returns a `result` for each defined critical alert that Sourcegraph is monitoring. For example, the first result (`high_concurrent_execs`) indicates that in the last minute (relative to the time the query executed / the returned unix timestamp `1585249844.475`) that `"0"` alerts were firing. Any value >= 1 here, would indicate that alert has fired in the last minute.
-
-## Warning alerts
-
-If you do wish to query warning alerts, too, then simply replace `critical` with `warning` in any of the above query examples.

--- a/doc/admin/observability/metrics_guide.md
+++ b/doc/admin/observability/metrics_guide.md
@@ -6,16 +6,18 @@ Sourcegraph's metrics include a single high-level metric `alert_count` which ind
 
 ![Overview Grafana dashboard screenshot](https://user-images.githubusercontent.com/3173176/71050700-21912400-2103-11ea-86fb-cf6d2dbd3d0a.png)
 
+To set up notifications for these alerts, see: [alerting](alerting.md).
+
 ### `alert_count`
 
 **Description:** The number of alerts each service has fired and their severity level. The severity levels are defined as follows:
 
-- `critical`: something is _definitively_ wrong with Sourcegraph.
+- `critical`: something is _definitively_ wrong with Sourcegraph. We suggest using a high-visibility notification channel for these alerts.
   - **Examples:** Database inaccessible, running out of disk space, running out of memory.
   - **Suggested action:** Page a site administrator to investigate.
-- `warning`: something _could_ be wrong with Sourcegraph.
+- `warning`: something _could_ be wrong with Sourcegraph. We suggest checking in on these periodically, or using a notification channel that will not bother anyone if it is spammed. Over time, as warning alerts become stable and reliable across many Sourcegraph deployments, they will also be promoted to critical alerts in an update by Sourcegraph.
   - **Examples:** High latency, high search timeouts.
-  - **Suggested action:** Email a site administrator to investigate and monitor when convenient.
+  - **Suggested action:** Email a site administrator to investigate and monitor when convenient, and please let us know so that we can improve them.
 
 **Values:**
 


### PR DESCRIPTION
This PR tries to clean up the alerting docs a bit:

* unify definition of critical vs warning in one place
* improve hierarchy of how to set up alerting
   * 3.17+ setup as "default"
   * separate section for the old methods

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
