### PR TITLE
dev: check version of bash on startup

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -2,6 +2,13 @@
 
 set -euf -o pipefail
 
+if [[ ${BASH_VERSION:0:1} -lt 5 ]]; then
+    echo "Please upgrade bash to version 5. Currently on ${BASH_VERSION}."
+    echo
+    echo "  brew install bash"
+    exit 1
+fi
+
 unset CDPATH
 cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -3,10 +3,10 @@
 set -euf -o pipefail
 
 if [[ ${BASH_VERSION:0:1} -lt 5 ]]; then
-    echo "Please upgrade bash to version 5. Currently on ${BASH_VERSION}."
-    echo
-    echo "  brew install bash"
-    exit 1
+  echo "Please upgrade bash to version 5. Currently on ${BASH_VERSION}."
+  echo
+  echo "  brew install bash"
+  exit 1
 fi
 
 unset CDPATH


### PR DESCRIPTION
If you are using an old version of bash our dev scripts fails in subtle
ways. For example we will detect file changes, but recompilation will
fail. This check ensures a dev is on version 5 of bash. If not it
fails the script and informs them how to upgrade.