### PR TITLE
enable reload endpoint for prometheus

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/cmd.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/cmd.go
@@ -22,6 +22,7 @@ func runCmd(log log15.Logger, errs chan<- error, cmd *exec.Cmd) {
 func NewPrometheusCmd(promArgs []string, promPort string) *exec.Cmd {
 	promFlags := []string{
 		fmt.Sprintf("--web.listen-address=0.0.0.0:%s", promPort),
+		("--web.enable-lifecycle"),
 	}
 	cmd := exec.Command("/prometheus.sh", append(promFlags, promArgs...)...)
 	cmd.Env = os.Environ()


### PR DESCRIPTION
Enables the reload endpoint on prometheus allowing updates to configfiles (speficically those to configmaps) to be reloaded without killing the prometheus pod. 