### PR TITLE
Remove openChangesets resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -168,7 +168,6 @@ type CampaignResolver interface {
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
 	Changesets(ctx context.Context, args *ListChangesetsArgs) (ChangesetsConnectionResolver, error)
-	OpenChangesets(ctx context.Context) (ChangesetsConnectionResolver, error)
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
 	Status(context.Context) (BackgroundProcessStatus, error)
 	ClosedAt() *DateTime

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -686,9 +686,6 @@ type Campaign implements Node {
         checkState: ChangesetCheckState
     ): ChangesetConnection!
 
-    # All the changesets in this campaign whose state is ChangesetState.OPEN.
-    openChangesets: ChangesetConnection!
-
     # The changeset counts over time, in 1-day intervals backwards from the point in time given in
     # the "to" parameter.
     changesetCountsOverTime(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -693,9 +693,6 @@ type Campaign implements Node {
         checkState: ChangesetCheckState
     ): ChangesetConnection!
 
-    # All the changesets in this campaign whose state is ChangesetState.OPEN.
-    openChangesets: ChangesetConnection!
-
     # The changeset counts over time, in 1-day intervals backwards from the point in time given in
     # the "to" parameter.
     changesetCountsOverTime(

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -119,7 +119,6 @@ type Campaign struct {
 	Patches                 PatchConnection
 	HasUnpublishedPatches   bool
 	Changesets              ChangesetConnection
-	OpenChangesets          ChangesetConnection
 	ChangesetCountsOverTime []ChangesetCounts
 	DiffStat                DiffStat
 	PatchSet                PatchSet

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -144,19 +144,6 @@ func (r *campaignResolver) Changesets(
 	}, nil
 }
 
-func (r *campaignResolver) OpenChangesets(ctx context.Context) (graphqlbackend.ChangesetsConnectionResolver, error) {
-	state := campaigns.ChangesetStateOpen
-	return &changesetsConnectionResolver{
-		store: r.store,
-		opts: ee.ListChangesetsOpts{
-			CampaignID:    r.Campaign.ID,
-			ExternalState: &state,
-			Limit:         -1,
-		},
-		optsSafe: true,
-	}, nil
-}
-
 func (r *campaignResolver) ChangesetCountsOverTime(
 	ctx context.Context,
 	args *graphqlbackend.ChangesetCountsArgs,

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -489,9 +489,8 @@ func TestRepositoryPermissions(t *testing.T) {
 		"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
 	}
 	testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
-		changesetTypes:     map[string]int{"ExternalChangeset": 2},
-		changesetsCount:    2,
-		openChangesetTypes: map[string]int{"ExternalChangeset": 2},
+		changesetTypes:  map[string]int{"ExternalChangeset": 2},
+		changesetsCount: 2,
 		campaignDiffStat: apitest.DiffStat{
 			Added:   2 * changesetDiffStat.Added,
 			Changed: 2 * changesetDiffStat.Changed,
@@ -532,10 +531,6 @@ func TestRepositoryPermissions(t *testing.T) {
 			"HiddenExternalChangeset": 1,
 		},
 		changesetsCount: 2,
-		openChangesetTypes: map[string]int{
-			"ExternalChangeset":       1,
-			"HiddenExternalChangeset": 1,
-		},
 		campaignDiffStat: apitest.DiffStat{
 			Added:   1 * changesetDiffStat.Added,
 			Changed: 1 * changesetDiffStat.Changed,
@@ -582,10 +577,9 @@ func TestRepositoryPermissions(t *testing.T) {
 }
 
 type wantCampaignResponse struct {
-	changesetTypes     map[string]int
-	changesetsCount    int
-	openChangesetTypes map[string]int
-	campaignDiffStat   apitest.DiffStat
+	changesetTypes   map[string]int
+	changesetsCount  int
+	campaignDiffStat apitest.DiffStat
 }
 
 func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, in map[string]interface{}, w wantCampaignResponse) {

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -610,14 +610,6 @@ func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, 
 		t.Fatalf("unexpected changesettypes (-want +got):\n%s", diff)
 	}
 
-	openChangesetTypes := map[string]int{}
-	for _, c := range response.Node.OpenChangesets.Nodes {
-		openChangesetTypes[c.Typename]++
-	}
-	if diff := cmp.Diff(w.openChangesetTypes, openChangesetTypes); diff != "" {
-		t.Fatalf("unexpected open changeset types (-want +got):\n%s", diff)
-	}
-
 	if diff := cmp.Diff(w.campaignDiffStat, response.Node.DiffStat); diff != "" {
 		t.Fatalf("unexpected campaign diff stat (-want +got):\n%s", diff)
 	}
@@ -636,22 +628,6 @@ query($campaign: ID!, $state: ChangesetState, $reviewState: ChangesetReviewState
 
       changesets(first: 100, state: $state, reviewState: $reviewState, checkState: $checkState) {
         totalCount
-        nodes {
-          __typename
-          ... on HiddenExternalChangeset {
-            id
-          }
-          ... on ExternalChangeset {
-            id
-            repository {
-              id
-              name
-            }
-          }
-        }
-      }
-
-      openChangesets {
         nodes {
           __typename
           ... on HiddenExternalChangeset {


### PR DESCRIPTION
**My first PR ist stuck in some weird state, so opened a second one.**

We don't need it for the new UI anymore, so reducing the headache of maintaining it.