### PR TITLE
Increase contrast of placeholders to meet WCAG

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -185,10 +185,6 @@ body,
     }
 }
 
-.form-control::placeholder {
-    opacity: 0.5;
-}
-
 .spacer {
     flex: 1;
 }

--- a/web/src/global-styles/forms.scss
+++ b/web/src/global-styles/forms.scss
@@ -7,7 +7,7 @@
     --input-disabled-bg: #2b3750;
     --input-border-color: #2b3750;
     --input-color: #f2f4f8;
-    --input-placeholder-color: rgba(#f2f4f8, 0.5);
+    --input-placeholder-color: #{rgba($color-text, 0.5)};
     --input-group-addon-color: #{$color-text-1};
     --input-group-addon-bg: #{$color-bg-5};
     --input-group-addon-border-color: #{$color-bg-5};
@@ -18,7 +18,7 @@
     --input-disabled-bg: #e4e9f1;
     --input-border-color: #e4e9f1;
     --input-color: #2b3750;
-    --input-placeholder-color: rgba(#2b3750, 0.5);
+    --input-placeholder-color: #{rgba($color-light-text-1, 0.7)};
     --input-group-addon-color: #{$color-light-text-1};
     --input-group-addon-bg: #{$color-light-bg-4};
     --input-group-addon-border-color: #{$color-light-bg-4};


### PR DESCRIPTION
Fixes #11963. I kept the RGB the same (just referenced the existing variables) but bumped the alpha channel from 50% to 70%.
