### PR TITLE
Implement minimal resolvers to incorporate schema changes

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -412,14 +412,20 @@ func (r *NodeResolver) ToCampaignSpec() (CampaignSpecResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToChangesetSpec() (ChangesetSpecResolver, bool) {
+func (r *NodeResolver) ToHiddenChangesetSpec() (HiddenChangesetSpecResolver, bool) {
 	n, ok := r.Node.(ChangesetSpecResolver)
-	return n, ok
+	if !ok {
+		return nil, ok
+	}
+	return n.ToHiddenChangesetSpec()
 }
 
-func (r *NodeResolver) ToCampaignDelta() (CampaignDeltaResolver, bool) {
-	n, ok := r.Node.(CampaignDeltaResolver)
-	return n, ok
+func (r *NodeResolver) ToVisibleChangesetSpec() (VisibleChangesetSpecResolver, bool) {
+	n, ok := r.Node.(ChangesetSpecResolver)
+	if !ok {
+		return nil, ok
+	}
+	return n.ToVisibleChangesetSpec()
 }
 
 func (r *NodeResolver) ToProductLicense() (ProductLicense, bool) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -430,8 +430,7 @@ type Mutation {
     ): ChangesetSpec!
 
     # Create a campaign spec that will be used to create a campaign (with the createCampaign
-    # mutation), to update to a campaign (with the applyCampaign mutation), or to preview either
-    # operation (with the campaignDelta query).
+    # mutation), or to update a campaign (with the applyCampaign mutation).
     #
     # The returned CampaignSpec is immutable and expires after a certain period of time (if not used
     # in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
@@ -451,9 +450,28 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 }
 
+# The type of the changeset spec.
+enum ChangesetSpecType {
+    # References an existing changeset on a code host to be imported.
+    EXISTING
+    # References a branch and a patch to be applied to create the changeset from.
+    BRANCH
+}
+
 # A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
 # create a changeset spec, use the createChangesetSpec mutation.
-type ChangesetSpec implements Node {
+interface ChangesetSpec {
+    # The type of changeset spec.
+    type: ChangesetSpecType!
+
+    # The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    # spec never expires (and this field is null) if its campaign spec has been applied.
+    expiresAt: DateTime
+}
+
+# A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+# create a changeset spec, use the createChangesetSpec mutation.
+type HiddenChangesetSpec implements ChangesetSpec & Node {
     # The unique ID for a changeset spec.
     #
     # The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
@@ -463,6 +481,30 @@ type ChangesetSpec implements Node {
     # campaign author may prefer to prepare all of the changesets in private so that the window
     # between revealing the problem and merging the fixes is as short as possible.
     id: ID!
+
+    # The type of changeset spec.
+    type: ChangesetSpecType!
+
+    # The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    # spec never expires (and this field is null) if its campaign spec has been applied.
+    expiresAt: DateTime
+}
+
+# A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+# create a changeset spec, use the createChangesetSpec mutation.
+type VisibleChangesetSpec implements ChangesetSpec & Node {
+    # The unique ID for a changeset spec.
+    #
+    # The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    # even though repository permissions also apply to viewers of changeset specs, because being
+    # allowed to view a repository should not entitle a person to view all not-yet-published
+    # changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    # campaign author may prefer to prepare all of the changesets in private so that the window
+    # between revealing the problem and merging the fixes is as short as possible.
+    id: ID!
+
+    # The type of changeset spec.
+    type: ChangesetSpecType!
 
     # The description of the changeset.
     description: ChangesetDescription!
@@ -479,7 +521,7 @@ union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDesc
 # campaign).
 type ExistingChangesetReference {
     # The repository that contains the existing changeset on the code host.
-    baseRepository: ID!
+    baseRepository: Repository!
 
     # The ID that uniquely identifies the existing changeset on the code host.
     #
@@ -493,7 +535,7 @@ type ExistingChangesetReference {
 # This is used to describe a pull request (on GitHub and Bitbucket Server).
 type GitBranchChangesetDescription {
     # The repository that this changeset spec is proposing to change.
-    baseRepository: ID!
+    baseRepository: Repository!
 
     # The full name of the Git ref in the base repository that this changeset is based on (and is
     # proposing to be merged into). This ref must exist on the base repository. For example,
@@ -509,7 +551,7 @@ type GitBranchChangesetDescription {
     #
     # Fork repositories and cross-repository changesets are not yet supported. Therefore,
     # headRepository must be equal to baseRepository.
-    headRepository: ID!
+    headRepository: Repository!
 
     # The full name of the Git ref that holds the changes proposed by this changeset. This ref will
     # be created or updated with the commits. For example, "refs/heads/fix-foo" (for
@@ -530,6 +572,9 @@ type GitBranchChangesetDescription {
     #
     # Only 1 commit is supported.
     commits: [GitCommitDescription!]!
+
+    # The total diff of the changeset diff.
+    diff: PreviewRepositoryComparison!
 
     # Whether or not the changeset described here should be created right after
     # applying the ChangesetSpec this description belongs to.
@@ -556,6 +601,25 @@ type GitCommitDescription {
     diff: String!
 }
 
+# A list of changeset specs.
+type ChangesetSpecConnection {
+    # The total number of changeset specs in the connection.
+    totalCount: Int!
+    # Pagination information.
+    pageInfo: PageInfo!
+    # A list of changeset specs.
+    nodes: [ChangesetSpec!]!
+}
+
+# A CampaignDescription describes a campaign.
+type CampaignDescription {
+    # The name as parsed from the input.
+    name: String!
+
+    # The description as parsed from the input.
+    description: String!
+}
+
 # A campaign spec is an immutable description of the desired state of a campaign. To create a
 # campaign spec, use the createCampaignSpec mutation.
 type CampaignSpec implements Node {
@@ -571,14 +635,17 @@ type CampaignSpec implements Node {
     # converted to the equivalent JSON.
     parsedInput: JSONValue!
 
+    # The CampaignDescription that describes this campaign.
+    description: CampaignDescription!
+
     # The specs for changesets associated with this campaign.
-    changesetSpecs: [ChangesetSpec!]!
+    changesetSpecs(first: Int, after: String): ChangesetSpecConnection!
 
     # The user who created this campaign spec (or null if the user no longer exists).
     creator: User
 
     # The date when this campaign spec was created.
-    createdAt: DateTime
+    createdAt: DateTime!
 
     # The namespace (either a user or organization) of the campaign spec.
     namespace: Namespace
@@ -587,27 +654,11 @@ type CampaignSpec implements Node {
     # never expires if it has been applied.
     expiresAt: DateTime
 
-    # The URL of a web page that displays a preview of applying this campaign spec. If the campaign
-    # spec's name refers to an existing campaign in the namespace, the preview shows what will be
-    # updated. Otherwise it shows what will be created.
+    # The URL of a web page that displays a preview of creating a campaign from this spec.
     previewURL: String!
-}
 
-# The delta (difference) between a campaign's desired state (spec) and its actual state (status) at
-# a given point in time. Because the campaign delta is computed based on external state, it may
-# become out-of-date immediately after creation (e.g., if the external state changes), so it must be
-# treated as a snapshot only and not as a definitive plan.
-type CampaignDelta {
-    # TODO(sqs): add more fields here to describe the delta
-
-    # The point in time when the delta was created and the actual state was captured. Since this
-    # time, the actual state may have changed; those changes are not captured in this delta.
-    createdAt: DateTime!
-
-    # The date when this campaign delta expires and is automatically purged. Campaign deltas are
-    # temporary to avoid consuming resources when they are no longer relevant. Purging a campaign
-    # delta does not modify the campaign or any changesets.
-    expiresAt: DateTime!
+    # When true, the viewing user can apply this spec.
+    viewerCanAdminister: Boolean!
 }
 
 # A user (identified either by username or email address) with its repository permission.

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -198,9 +198,9 @@ type CampaignSpec struct {
 	Namespace UserOrg
 	Creator   User
 
-	ChangesetSpecs []ChangesetSpec
+	ChangesetSpecs ChangesetSpecConnection
 
-	CreatedAt *graphqlbackend.DateTime
+	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 }
 
@@ -213,14 +213,23 @@ type ChangesetSpec struct {
 	ExpiresAt *graphqlbackend.DateTime
 }
 
+type ChangesetSpecConnection struct {
+	Nodes      []ChangesetSpec
+	TotalCount int
+	PageInfo   struct {
+		HasNextPage bool
+		EndCursor   *string
+	}
+}
+
 type ChangesetSpecDescription struct {
 	Typename string `json:"__typename"`
 
-	BaseRepository string
+	BaseRepository Repository
 	ExternalID     string
 	BaseRef        string
 
-	HeadRepository string
+	HeadRepository Repository
 	HeadRef        string
 
 	Title string

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -69,7 +69,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		PreviewURL: "/campaigns/new?spec=" + apiID,
 		Namespace:  apitest.UserOrg{ID: userApiID, DatabaseID: userID},
 		Creator:    apitest.User{ID: userApiID, DatabaseID: userID},
-		CreatedAt:  &graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
+		CreatedAt:  graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
 		ExpiresAt:  &graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second).Add(2 * time.Hour)},
 	}
 

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -53,17 +53,21 @@ func TestChangesetSpecResolver(t *testing.T) {
 			rawSpec: ct.NewRawChangesetSpecGitBranch(repoID),
 			want: func(spec *campaigns.ChangesetSpec) apitest.ChangesetSpec {
 				return apitest.ChangesetSpec{
-					Typename: "ChangesetSpec",
+					Typename: "VisibleChangesetSpec",
 					ID:       string(marshalChangesetSpecRandID(spec.RandID)),
 					Description: apitest.ChangesetSpecDescription{
-						Typename:       "GitBranchChangesetDescription",
-						BaseRepository: string(spec.Spec.BaseRepository),
-						ExternalID:     "",
-						BaseRef:        spec.Spec.BaseRef,
-						HeadRepository: string(spec.Spec.HeadRepository),
-						HeadRef:        spec.Spec.HeadRef,
-						Title:          spec.Spec.Title,
-						Body:           spec.Spec.Body,
+						Typename: "GitBranchChangesetDescription",
+						BaseRepository: apitest.Repository{
+							ID: string(spec.Spec.BaseRepository),
+						},
+						ExternalID: "",
+						BaseRef:    spec.Spec.BaseRef,
+						HeadRepository: apitest.Repository{
+							ID: string(spec.Spec.HeadRepository),
+						},
+						HeadRef: spec.Spec.HeadRef,
+						Title:   spec.Spec.Title,
+						Body:    spec.Spec.Body,
 						Commits: []apitest.GitCommitDescription{
 							{Diff: spec.Spec.Commits[0].Diff, Message: spec.Spec.Commits[0].Message},
 						},
@@ -80,13 +84,15 @@ func TestChangesetSpecResolver(t *testing.T) {
 			rawSpec: ct.NewRawChangesetSpecExisting(repoID, "9999"),
 			want: func(spec *campaigns.ChangesetSpec) apitest.ChangesetSpec {
 				return apitest.ChangesetSpec{
-					Typename: "ChangesetSpec",
+					Typename: "VisibleChangesetSpec",
 					ID:       string(marshalChangesetSpecRandID(spec.RandID)),
 					Description: apitest.ChangesetSpecDescription{
-						Typename:       "ExistingChangesetReference",
-						BaseRepository: string(spec.Spec.BaseRepository),
-						ExternalID:     spec.Spec.ExternalID,
-						Published:      false,
+						Typename: "ExistingChangesetReference",
+						BaseRepository: apitest.Repository{
+							ID: string(spec.Spec.BaseRepository),
+						},
+						ExternalID: spec.Spec.ExternalID,
+						Published:  false,
 					},
 					ExpiresAt: &graphqlbackend.DateTime{
 						Time: spec.CreatedAt.Truncate(time.Second).Add(2 * time.Hour),
@@ -126,23 +132,29 @@ query($id: ID!) {
   node(id: $id) {
     __typename
 
-    ... on ChangesetSpec {
+    ... on VisibleChangesetSpec {
       id
 
       description {
         __typename
 
         ... on ExistingChangesetReference {
-          baseRepository
+          baseRepository {
+			  id
+		  }
           externalID
         }
 
         ... on GitBranchChangesetDescription {
-          baseRepository
+          baseRepository {
+			  id
+		  }
           baseRef
           baseRev
 
-          headRepository
+          headRepository {
+			  id
+		  }
           headRef
 
           title

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -925,8 +925,10 @@ func TestCreateCampaignSpec(t *testing.T) {
 		PreviewURL:    "/campaigns/new?spec=",
 		Namespace:     apitest.UserOrg{ID: userApiID, DatabaseID: userID, SiteAdmin: true},
 		Creator:       apitest.User{ID: userApiID, DatabaseID: userID, SiteAdmin: true},
-		ChangesetSpecs: []apitest.ChangesetSpec{
-			{ID: string(changesetSpecID)},
+		ChangesetSpecs: apitest.ChangesetSpecConnection{
+			Nodes: []apitest.ChangesetSpec{
+				{ID: string(changesetSpecID)},
+			},
 		},
 	}
 	have := response.CreateCampaignSpec
@@ -960,7 +962,11 @@ mutation($namespace: ID!, $campaignSpec: String!, $changesetSpecs: [ID!]!){
     previewURL
 
 	changesetSpecs {
-	  id
+	  nodes {
+		  ... on VisibleChangesetSpec {
+			  id
+		  }
+	  }
 	}
 
     createdAt
@@ -1006,7 +1012,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	have := response.CreateChangesetSpec
 
 	want := apitest.ChangesetSpec{
-		Typename:  "ChangesetSpec",
+		Typename:  "VisibleChangesetSpec",
 		ID:        have.ID,
 		ExpiresAt: have.ExpiresAt,
 	}
@@ -1033,9 +1039,11 @@ func TestCreateChangesetSpec(t *testing.T) {
 const mutationCreateChangesetSpec = `
 mutation($changesetSpec: String!){
   createChangesetSpec(changesetSpec: $changesetSpec) {
-    __typename
-    id
-    expiresAt
+	__typename
+	... on VisibleChangesetSpec {
+		id
+		expiresAt
+	}
   }
 }
 `

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1592,6 +1592,15 @@ type ChangesetSpec struct {
 	UpdatedAt time.Time
 }
 
+// ChangesetSpecType tells about the type of the changeset spec without including the description. Useful for HiddenChangesetSpecs in the API.
+type ChangesetSpecType string
+
+// Valid ChangesetEvent kinds
+const (
+	ChangesetSpecTypeExisting ChangesetSpecType = "EXISTING"
+	ChangesetSpecTypeBranch   ChangesetSpecType = "BRANCH"
+)
+
 // Clone returns a clone of a ChangesetSpec.
 func (cs *ChangesetSpec) Clone() *ChangesetSpec {
 	cc := *cs
@@ -1640,6 +1649,11 @@ type ChangesetSpecDescription struct {
 	Commits []GitCommitDescription `json:"commits,omitempty"`
 
 	Published bool `json:"published,omitempty"`
+}
+
+// IsExistingChangesetRef returns true when the changeset spec is referencing an existing changeset on a codehost.
+func (d *ChangesetSpecDescription) IsExistingChangesetRef() bool {
+	return d.ExternalID != ""
 }
 
 type GitCommitDescription struct {


### PR DESCRIPTION
First half of the changes required to incorporate the GraphQL schema, as discussed today.