### PR TITLE
CODEOWNERS: campaigns should own docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -144,6 +144,7 @@
 
 # Campaigns
 /cmd/frontend/graphqlbackend/campaigns.go @sourcegraph/campaigns
+/doc/user/campaigns @sourcegraph/campaigns
 /enterprise/internal/campaigns @sourcegraph/campaigns
 /internal/campaigns @sourcegraph/campaigns
 /web/**/campaigns/** @sourcegraph/campaigns


### PR DESCRIPTION
Something I noticed when #12217 popped up: campaigns docs should probably have a more specific rule than going to distribution via the catch-all for review.