### PR TITLE
docs: Add DocForge annotations and introduce Sourcegraph link monitoring

### DIFF
--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -36,6 +36,7 @@ By default, Sourcegraph also aggregates usage and performance metrics for some p
   - Code intelligence events (e.g., hover tooltips) 
   - Searches using each search mode (interactive search, plain-text search)
   - Searches using each search filter (e.g. "type:", "repo:", "file:", "lang:", etc.)
+<!-- depends-on-source: ~/cmd/frontend/internal/usagestats/campaigns.go -->
 - Campaign usage data
   - Total count of created campaigns
   - Total count of changesets created by campaigns

--- a/doc/dev/campaigns_development.md
+++ b/doc/dev/campaigns_development.md
@@ -17,6 +17,8 @@ Before diving into the technical part of campaigns, make sure to read up on what
 
 The code campaigns feature introduces a lot of new names, GraphQL queries and mutations and database tables. This section tries to explain the most common names and provide a mapping between the GraphQL types and their internal counterpart in the Go backend.
 
+<!-- depends-on-source: ~/internal/campaigns/types.go -->
+
 | GraphQL type        | Go type              | Database table     | Description |
 | ------------------- | -------------------- | -------------------| ----------- |
 | `Campaign`          | `campaigns.Campaign`       | `campaigns`        | A campaign is a collection of changesets on code hosts. The central entity. |


### PR DESCRIPTION
Hello Sourcegraph team!

My name is Jackson Roberts and I’m a founder at DocForge. Keeping docs up-to-date as code changes is hard, so we've built a tool to help fast moving software teams keep everything fresh. You can see a brief description of how it works at https://docforge.dev/monitor. This pull request contains a couple sample annotations.

Additionally, we’ve built a new feature to work with the **code referencing technique you already use: links to Sourcegraph searches**. DocForge scans all your docs for Sourcegraph links that return no results. Then, it flags them allowing you to find these bad links and eliminate them. There are currently nine Sourcegraph searches in your documentation which return 0 results. Here’s one of them in the UI:
![image](https://user-images.githubusercontent.com/1147244/87589596-b14f7e80-c6a2-11ea-9565-4b3bf0608ff0.png)

We’ve spun up an instance of DocForge at https://sourcegraph.app.docforge.dev/
Thanks for being willing to try out our tool, we’re really looking forward to hearing your feedback!