### PR TITLE
search: unify parser routines

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -230,7 +230,7 @@ var patternTypeRegex = lazyregexp.New(`(?i)patterntype:([a-zA-Z"']+)`)
 
 func overrideSearchType(input string, searchType query.SearchType, useNewParser bool) query.SearchType {
 	if useNewParser {
-		q, err := query.ParseAndOrLiteral(input)
+		q, err := query.ParseAndOr(input, query.SearchTypeLiteral)
 		q = query.LowercaseFieldNames(q)
 		if err != nil {
 			// If parsing fails, return the default search type. Any actual

--- a/internal/search/query/literal_parser_test.go
+++ b/internal/search/query/literal_parser_test.go
@@ -362,7 +362,7 @@ func TestParseAndOrLiteral(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run("literal search parse", func(t *testing.T) {
-			result, err := ParseAndOrLiteral(tt.Input)
+			result, err := ParseAndOr(tt.Input, SearchTypeLiteral)
 			if err != nil {
 				if diff := cmp.Diff(tt.WantError, err.Error()); diff != "" {
 					t.Error(diff)

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -97,7 +97,7 @@ func TestParseParameterList(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			parser := &parser{buf: []byte(tt.Input)}
-			result, err := parser.parseParameterList()
+			result, err := parser.parseLeavesRegexp()
 			if err != nil {
 				t.Fatal(fmt.Sprintf("Unexpected error: %s", err))
 			}
@@ -248,8 +248,8 @@ func parseAndOrGrammar(in string) ([]Node, error) {
 		return nil, nil
 	}
 	parser := &parser{
-		buf: []byte(in),
-		// heuristics: map[heuristic]bool{parensAsPatterns: false},
+		buf:        []byte(in),
+		leafParser: SearchTypeRegex,
 	}
 	nodes, err := parser.parseOr()
 	if err != nil {
@@ -723,7 +723,7 @@ func TestParse(t *testing.T) {
 			var err error
 			result, err = parseAndOrGrammar(tt.Input) // Parse without heuristic.
 			check(result, err, string(tt.WantGrammar))
-			result, err = ParseAndOr(tt.Input)
+			result, err = ParseAndOr(tt.Input, SearchTypeRegex)
 			if tt.WantHeuristic == Same {
 				check(result, err, string(tt.WantGrammar))
 			} else {
@@ -841,7 +841,7 @@ func TestMergePatterns(t *testing.T) {
 	for _, tt := range cases {
 		t.Run("merge pattern", func(t *testing.T) {
 			p := &parser{buf: []byte(tt.input), heuristics: parensAsPatterns}
-			nodes, err := p.parseParameterList()
+			nodes, err := p.parseLeavesRegexp()
 			got := nodes[0].(Pattern).Annotation.Range.String()
 			if err != nil {
 				t.Error(err)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -18,7 +18,7 @@ func prettyPrint(nodes []Node) string {
 func TestSubstituteAliases(t *testing.T) {
 	input := "r:repo g:repogroup f:file"
 	want := `(and "repo:repo" "repogroup:repogroup" "file:file")`
-	query, _ := ParseAndOr(input)
+	query, _ := ParseAndOr(input, SearchTypeRegex)
 	got := prettyPrint(SubstituteAliases(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -28,7 +28,7 @@ func TestSubstituteAliases(t *testing.T) {
 func TestLowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`
-	query, _ := ParseAndOr(input)
+	query, _ := ParseAndOr(input, SearchTypeRegex)
 	got := prettyPrint(LowercaseFieldNames(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -106,6 +106,7 @@ func TestHoist(t *testing.T) {
 				parser := &parser{
 					buf:        []byte(in),
 					heuristics: parensAsPatterns,
+					leafParser: SearchTypeRegex,
 				}
 				nodes, _ := parser.parseOr()
 				return newOperator(nodes, And)
@@ -174,7 +175,7 @@ func TestSearchUppercase(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("searchUppercase", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input, SearchTypeRegex)
 			got := prettyPrint(SearchUppercase(SubstituteAliases(query)))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -219,7 +220,7 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input, SearchTypeRegex)
 			got := prettyPrint(substituteOrForRegexp(query))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -252,7 +253,7 @@ func TestSubstituteConcat(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input, SearchTypeRegex)
 			got := prettyPrint(substituteConcat(query, " "))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -277,7 +278,7 @@ func TestConvertEmptyGroupsToLiteral(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input, SearchTypeRegex)
 			got := EmptyGroupsToLiteral(query)[0].(Pattern)
 			if diff := cmp.Diff(c.wantLabels, got.Annotation.Labels); diff != "" {
 				t.Fatal(diff)
@@ -305,7 +306,7 @@ func TestMap(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input)
+			query, _ := ParseAndOr(c.input, SearchTypeRegex)
 			got := prettyPrint(Map(query, c.fns...))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -226,7 +226,7 @@ func TestPartitionSearchPattern(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run("partition search pattern", func(t *testing.T) {
-			q, _ := ParseAndOr(tt.input)
+			q, _ := ParseAndOr(tt.input, SearchTypeRegex)
 			scopeParameters, pattern, err := PartitionSearchPattern(q)
 			if err != nil {
 				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {


### PR DESCRIPTION
Dealing with some long-awaited cleanup. Currently there are code paths for the regex/literal parsers, and for simplicity when I implemented [RFC 176](ument/d/11hJ12V996Edyo9mguWcVp_5qT5vpbq3hEdcOBhpLS58/edit#heading=h.trqab8y0kufp) I created two separate parsers, duplicating common code. But these two parsers really only differ in handling the leaf node patterns. This PR makes it so that the parser for the leaf nodes are chosen only when different code paths is taken, deleting the redundant parts.

The tidying is not quite done yet, because the two functions `parseLeavesRegexp` and `parseLeavesLiteral` contain a lot of common code that I will factor out in a next PR.

Going by commit is only kind of useful.