### PR TITLE
Auto-retry Chromatic step in CI

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -126,6 +126,7 @@ func addSharedTests(pipeline *bk.Pipeline) {
 
 	// Upload storybook to Chromatic
 	pipeline.AddStep(":chromatic:",
+		bk.AutomaticRetry(5),
 		bk.Cmd("dev/ci/yarn-run.sh chromatic"))
 }
 


### PR DESCRIPTION
There were some reports yesterday of 503s from Chromatic. Don't know if these were just a one-time outage, but would like to proactively defend against it, the same way Codecov retries. Note this is just an upload step, this cannot cause any tests to become false positives.