### PR TITLE
Skip TLS Verify check if TLS is disabled

### DIFF
--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -118,7 +118,7 @@ func Send(ctx context.Context, message Message) error {
 	}
 
 	if conf.EmailSmtp.DisableTLS {
-		return m.SendWithTLS(
+		return m.SendWithStartTLS(
 			net.JoinHostPort(conf.EmailSmtp.Host, strconv.Itoa(conf.EmailSmtp.Port)),
 			smtpAuth,
 			&tls.Config{

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -3,6 +3,7 @@ package txemail
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -114,6 +115,16 @@ func Send(ctx context.Context, message Message) error {
 		smtpAuth = smtp.CRAMMD5Auth(conf.EmailSmtp.Username, conf.EmailSmtp.Password)
 	default:
 		return fmt.Errorf("invalid SMTP authentication type %q", conf.EmailSmtp.Authentication)
+	}
+
+	if conf.EmailSmtp.DisableTLS {
+		return m.SendWithTLS(
+			net.JoinHostPort(conf.EmailSmtp.Host, strconv.Itoa(conf.EmailSmtp.Port)),
+			smtpAuth,
+			&tls.Config{
+				InsecureSkipVerify: true,
+			},
+		)
 	}
 
 	return m.Send(

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -934,7 +934,7 @@ type SAMLAuthProvider struct {
 type SMTPServerConfig struct {
 	// Authentication description: The type of authentication to use for the SMTP server.
 	Authentication string `json:"authentication"`
-	// DisableTLS description: Disable TLS verification - only compatible with observability.alerts today, see https://github.com/sourcegraph/sourcegraph/issues/10702
+	// DisableTLS description: Disable TLS verification
 	DisableTLS bool `json:"disableTLS,omitempty"`
 	// Domain description: The HELO domain to provide to the SMTP server (if needed).
 	Domain string `json:"domain,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -491,7 +491,7 @@
           "type": "string"
         },
         "disableTLS": {
-          "description": "Disable TLS verification - only compatible with observability.alerts today, see https://github.com/sourcegraph/sourcegraph/issues/10702",
+          "description": "Disable TLS verification",
           "type": "boolean"
         }
       },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -496,7 +496,7 @@ const SiteSchemaJSON = `{
           "type": "string"
         },
         "disableTLS": {
-          "description": "Disable TLS verification - only compatible with observability.alerts today, see https://github.com/sourcegraph/sourcegraph/issues/10702",
+          "description": "Disable TLS verification",
           "type": "boolean"
         }
       },


### PR DESCRIPTION
This PR fixes #10702 by skipping the TLS Verify check if `email.smtp.disableTLS` is set to true.