### PR TITLE
search: set input rev for indexed results

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -362,6 +362,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 			symbols:      symbols,
 			Repo:         repoResolver,
 			CommitID:     api.CommitID(file.Version),
+			InputRev:     &inputRev,
 		}
 	}
 


### PR DESCRIPTION
Missed this when implementing multi branch search for indexed search. We
go through all the effort to find the input revision for generating the
resource URL. However, we forget to set the input revision leading to it
not being shown in search results.

Note: This will be cherry-picked onto the 3.18 release branch.