### PR TITLE
Implement missing bits in CampaignSpec/ChangesetSpec resolvers

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -114,7 +114,7 @@ type ChangesetSpecConnectionResolver interface {
 type ChangesetSpecResolver interface {
 	ID() graphql.ID
 
-	Type() campaigns.ChangesetSpecType
+	Type() campaigns.ChangesetSpecDescriptionType
 
 	ExpiresAt() *DateTime
 

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -97,7 +97,7 @@ type CampaignSpecResolver interface {
 
 	PreviewURL() (string, error)
 
-	ViewerCanAdminister() bool
+	ViewerCanAdminister(context.Context) (bool, error)
 }
 
 type CampaignDescriptionResolver interface {

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -197,6 +197,8 @@ type CampaignSpec struct {
 
 	ChangesetSpecs ChangesetSpecConnection
 
+	ViewerCanAdminister bool
+
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 }

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -237,6 +237,10 @@ type ChangesetSpecDescription struct {
 	Commits []GitCommitDescription
 
 	Published bool
+
+	Diff struct {
+		FileDiffs FileDiffs
+	}
 }
 
 type GitCommitDescription struct {

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -109,9 +109,8 @@ func (r *campaignSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
 	return &graphqlbackend.DateTime{Time: r.campaignSpec.ExpiresAt()}
 }
 
-func (r *campaignSpecResolver) ViewerCanAdminister() bool {
-	// TODO: Implement.
-	return true
+func (r *campaignSpecResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
+	return checkSiteAdminOrSameUser(ctx, r.campaignSpec.UserID)
 }
 
 type campaignDescriptionResolver struct {

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -49,8 +50,13 @@ func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphql
 	if args.First != nil {
 		opts.Limit = int(*args.First)
 	}
-
-	// TODO: args.After
+	if args.After != nil {
+		id, err := strconv.Atoi(*args.After)
+		if err != nil {
+			return nil, err
+		}
+		opts.Cursor = int64(id)
+	}
 
 	return &changesetSpecConnectionResolver{
 		store:       r.store,

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -58,6 +58,7 @@ func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphql
 			store:         r.store,
 			httpFactory:   r.httpFactory,
 			changesetSpec: c,
+			repoCtx:       ctx,
 		})
 	}
 
@@ -97,7 +98,6 @@ func (r *campaignSpecResolver) Namespace(ctx context.Context) (*graphqlbackend.N
 }
 
 func (r *campaignSpecResolver) PreviewURL() (string, error) {
-	// TODO: this needs to take the namespace into account
 	return "/campaigns/new?spec=" + string(r.ID()), nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -66,11 +66,13 @@ func TestCampaignSpecResolver(t *testing.T) {
 		OriginalInput: spec.RawSpec,
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 
-		PreviewURL: "/campaigns/new?spec=" + apiID,
-		Namespace:  apitest.UserOrg{ID: userApiID, DatabaseID: userID},
-		Creator:    apitest.User{ID: userApiID, DatabaseID: userID},
-		CreatedAt:  graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
-		ExpiresAt:  &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+		PreviewURL:          "/campaigns/new?spec=" + apiID,
+		Namespace:           apitest.UserOrg{ID: userApiID, DatabaseID: userID},
+		Creator:             apitest.User{ID: userApiID, DatabaseID: userID},
+		ViewerCanAdminister: true,
+
+		CreatedAt: graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
+		ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 	}
 
 	if diff := cmp.Diff(want, response.Node); diff != "" {
@@ -98,6 +100,7 @@ query($campaignSpec: ID!) {
       }
 
       previewURL
+      viewerCanAdminister
 
       createdAt
       expiresAt

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -142,7 +142,7 @@ query($campaignSpec: ID!) {
       createdAt
       expiresAt
 
-	  changesetSpecs(first: 100) {
+      changesetSpecs(first: 100) {
         totalCount
 
         nodes {

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -49,7 +49,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changesetSpec, err := campaigns.NewChangesetSpecFromRaw(ct.NewRawChangesetSpecGitBranch(repoID))
+	changesetSpec, err := campaigns.NewChangesetSpecFromRaw(ct.NewRawChangesetSpecGitBranch(repoID, "deadb33f"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
@@ -27,6 +29,14 @@ func TestCampaignSpecResolver(t *testing.T) {
 
 	store := ee.NewStore(dbconn.Global)
 
+	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+
+	repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)
+	if err := reposStore.UpsertRepos(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+	repoID := graphqlbackend.MarshalRepositoryID(repo.ID)
+
 	userID := insertTestUser(t, dbconn.Global, "campaign-spec-by-id", false)
 
 	spec, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawCampaignSpec)
@@ -35,8 +45,19 @@ func TestCampaignSpecResolver(t *testing.T) {
 	}
 	spec.UserID = userID
 	spec.NamespaceUserID = userID
-
 	if err := store.CreateCampaignSpec(ctx, spec); err != nil {
+		t.Fatal(err)
+	}
+
+	changesetSpec, err := campaigns.NewChangesetSpecFromRaw(ct.NewRawChangesetSpecGitBranch(repoID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	changesetSpec.CampaignSpecID = spec.ID
+	changesetSpec.UserID = userID
+	changesetSpec.RepoID = repo.ID
+
+	if err := store.CreateChangesetSpec(ctx, changesetSpec); err != nil {
 		t.Fatal(err)
 	}
 
@@ -73,6 +94,22 @@ func TestCampaignSpecResolver(t *testing.T) {
 
 		CreatedAt: graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
 		ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+
+		ChangesetSpecs: apitest.ChangesetSpecConnection{
+			TotalCount: 1,
+			Nodes: []apitest.ChangesetSpec{
+				{
+					ID:       string(marshalChangesetSpecRandID(changesetSpec.RandID)),
+					Typename: "VisibleChangesetSpec",
+					Description: apitest.ChangesetSpecDescription{
+						BaseRepository: apitest.Repository{
+							ID:   string(repoID),
+							Name: repo.Name,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	if diff := cmp.Diff(want, response.Node); diff != "" {
@@ -104,6 +141,39 @@ query($campaignSpec: ID!) {
 
       createdAt
       expiresAt
+
+	  changesetSpecs(first: 100) {
+        totalCount
+
+        nodes {
+          __typename
+          type
+
+          ... on HiddenChangesetSpec {
+            id
+          }
+
+          ... on VisibleChangesetSpec {
+            id
+
+            description {
+              ... on ExistingChangesetReference {
+                baseRepository {
+                  id
+                  name
+                }
+              }
+
+              ... on GitBranchChangesetDescription {
+                baseRepository {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+	  }
     }
   }
 }

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -96,7 +96,7 @@ func (r *campaignResolver) Author(ctx context.Context) (*graphqlbackend.UserReso
 }
 
 func (r *campaignResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	return currentUserCanAdministerCampaign(ctx, r.Campaign)
+	return checkSiteAdminOrSameUser(ctx, r.Campaign.AuthorID)
 }
 
 func (r *campaignResolver) URL(ctx context.Context) (string, error) {

--- a/enterprise/internal/campaigns/resolvers/changeset_events.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_events.go
@@ -87,11 +87,10 @@ func (r *changesetEventResolver) CreatedAt() graphqlbackend.DateTime {
 
 func (r *changesetEventResolver) Changeset(ctx context.Context) (graphqlbackend.ExternalChangesetResolver, error) {
 	return &changesetResolver{
-		// Just to be explicit we always return external changesets here.
-		isHidden:    false,
 		store:       r.store,
 		httpFactory: r.httpFactory,
 		changeset:   r.changeset,
+		repoCtx:     ctx,
 	}, nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -108,8 +108,11 @@ func (r *changesetDescriptionResolver) Body() string    { return r.desc.Body }
 func (r *changesetDescriptionResolver) Published() bool { return r.desc.Published }
 
 func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
-	patch := r.desc.Commits[0].Diff
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.repoResolver, r.desc.BaseRev, patch)
+	diff, err := r.desc.Diff()
+	if err != nil {
+		return nil, err
+	}
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.repoResolver, r.desc.BaseRev, diff)
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -52,11 +52,8 @@ func (r *changesetSpecResolver) ID() graphql.ID {
 	return marshalChangesetSpecRandID(r.changesetSpec.RandID)
 }
 
-func (r *changesetSpecResolver) Type() campaigns.ChangesetSpecType {
-	if r.changesetSpec.Spec.IsExistingChangesetRef() {
-		return campaigns.ChangesetSpecTypeExisting
-	}
-	return campaigns.ChangesetSpecTypeBranch
+func (r *changesetSpecResolver) Type() campaigns.ChangesetSpecDescriptionType {
+	return r.changesetSpec.Spec.Type()
 }
 
 func (r *changesetSpecResolver) computeRepo() (*graphqlbackend.RepositoryResolver, error) {
@@ -153,16 +150,16 @@ type changesetDescriptionResolver struct {
 }
 
 func (r *changesetDescriptionResolver) ToExistingChangesetReference() (graphqlbackend.ExistingChangesetReferenceResolver, bool) {
-	if r.desc.IsExistingChangesetRef() {
+	if r.desc.IsExisting() {
 		return r, true
 	}
 	return nil, false
 }
 func (r *changesetDescriptionResolver) ToGitBranchChangesetDescription() (graphqlbackend.GitBranchChangesetDescriptionResolver, bool) {
-	if r.desc.IsExistingChangesetRef() {
-		return nil, false
+	if r.desc.IsBranch() {
+		return r, true
 	}
-	return r, true
+	return nil, false
 }
 
 func (r *changesetDescriptionResolver) BaseRepository() *graphqlbackend.RepositoryResolver {

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strconv"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -46,7 +47,13 @@ func (r *changesetSpecConnectionResolver) PageInfo(ctx context.Context) (*graphq
 		return nil, err
 	}
 
-	return graphqlutil.HasNextPage(next != 0), nil
+	if next != 0 {
+		// We don't use the RandID for pagination, because we can't paginate database
+		// entries based on the RandID.
+		return graphqlutil.NextPageCursor(strconv.Itoa(int(next))), nil
+	}
+
+	return graphqlutil.HasNextPage(false), nil
 }
 
 func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetSpecResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -1,0 +1,104 @@
+package resolvers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+var _ graphqlbackend.ChangesetSpecConnectionResolver = &changesetSpecConnectionResolver{}
+
+type changesetSpecConnectionResolver struct {
+	store       *ee.Store
+	httpFactory *httpcli.Factory
+
+	opts ee.ListChangesetSpecsOpts
+
+	// Cache results because they are used by multiple fields
+	once           sync.Once
+	changesetSpecs []*campaigns.ChangesetSpec
+	reposByID      map[api.RepoID]*types.Repo
+	next           int64
+	err            error
+}
+
+func (r *changesetSpecConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	count, err := r.store.CountChangesetSpecs(ctx, ee.CountChangesetSpecsOpts{
+		CampaignSpecID: r.opts.CampaignSpecID,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int32(count), nil
+}
+
+func (r *changesetSpecConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, _, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return graphqlutil.HasNextPage(next != 0), nil
+}
+
+func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ChangesetSpecResolver, error) {
+	changesetSpecs, reposByID, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := make([]graphqlbackend.ChangesetSpecResolver, 0, len(changesetSpecs))
+	for _, c := range changesetSpecs {
+		repo, _ := reposByID[c.RepoID]
+		// If it's not in reposByID the repository was either deleted or
+		// filtered out by the authz-filter.
+		resolvers = append(resolvers, &changesetSpecResolver{
+			store:         r.store,
+			httpFactory:   r.httpFactory,
+			changesetSpec: c,
+
+			preloadedRepo:        repo,
+			attemptedPreloadRepo: true,
+			repoCtx:              ctx,
+		})
+	}
+
+	return resolvers, nil
+}
+
+func (r *changesetSpecConnectionResolver) compute(ctx context.Context) ([]*campaigns.ChangesetSpec, map[api.RepoID]*types.Repo, int64, error) {
+	r.once.Do(func() {
+		r.changesetSpecs, r.next, r.err = r.store.ListChangesetSpecs(ctx, r.opts)
+		if r.err != nil {
+			return
+		}
+
+		repoIDs := make([]api.RepoID, len(r.changesetSpecs))
+		for i, c := range r.changesetSpecs {
+			repoIDs[i] = c.RepoID
+		}
+
+		// 🚨 SECURITY: db.Repos.GetByIDs uses the authzFilter under the hood and
+		// filters out repositories that the user doesn't have access to.
+		rs, err := db.Repos.GetByIDs(ctx, repoIDs...)
+		if err != nil {
+			r.err = err
+			return
+		}
+
+		r.reposByID = make(map[api.RepoID]*types.Repo, len(rs))
+		for _, repo := range rs {
+			r.reposByID[repo.ID] = repo
+		}
+	})
+
+	return r.changesetSpecs, r.reposByID, r.next, r.err
+}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -65,8 +65,11 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 	resolvers := make([]graphqlbackend.ChangesetSpecResolver, 0, len(changesetSpecs))
 	for _, c := range changesetSpecs {
 		repo, _ := reposByID[c.RepoID]
-		// If it's not in reposByID the repository was either deleted or
-		// filtered out by the authz-filter.
+		// If it's not in reposByID the repository was filtered out by the
+		// authz-filter.
+		// In that case we'll set it anyway to nil and changesetSpecResolver
+		// will treat it as "hidden".
+
 		resolvers = append(resolvers, &changesetSpecResolver{
 			store:         r.store,
 			httpFactory:   r.httpFactory,

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -53,7 +53,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 	changesetSpecs := make([]*campaigns.ChangesetSpec, 0, len(repos))
 	for _, r := range repos {
 		repoID := graphqlbackend.MarshalRepositoryID(r.ID)
-		s, err := campaigns.NewChangesetSpecFromRaw(ct.NewRawChangesetSpecGitBranch(repoID))
+		s, err := campaigns.NewChangesetSpecFromRaw(ct.NewRawChangesetSpecGitBranch(repoID, "d34db33f"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -1,0 +1,127 @@
+package resolvers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestChangesetSpecConnectionResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	userID := insertTestUser(t, dbconn.Global, "changeset-spec-connection-resolver", false)
+
+	store := ee.NewStore(dbconn.Global)
+
+	campaignSpec := &campaigns.CampaignSpec{
+		UserID:          userID,
+		NamespaceUserID: userID,
+	}
+	if err := store.CreateCampaignSpec(ctx, campaignSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+
+	repos := make([]*repos.Repo, 0, 3)
+	for i := 0; i < cap(repos); i++ {
+		name := fmt.Sprintf("github.com/sourcegraph/repo-%d", i)
+		r := newGitHubTestRepo(name, i)
+		if err := reposStore.UpsertRepos(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		repos = append(repos, r)
+	}
+
+	changesetSpecs := make([]*campaigns.ChangesetSpec, 0, len(repos))
+	for _, r := range repos {
+		repoID := graphqlbackend.MarshalRepositoryID(r.ID)
+		s, err := campaigns.NewChangesetSpecFromRaw(ct.NewRawChangesetSpecGitBranch(repoID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.CampaignSpecID = campaignSpec.ID
+		s.UserID = userID
+		s.RepoID = r.ID
+
+		if err := store.CreateChangesetSpec(ctx, s); err != nil {
+			t.Fatal(err)
+		}
+
+		changesetSpecs = append(changesetSpecs, s)
+	}
+
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+
+	}
+
+	apiID := string(marshalCampaignSpecRandID(campaignSpec.RandID))
+
+	tests := []struct {
+		first int
+
+		wantTotalCount  int
+		wantHasNextPage bool
+	}{
+		{first: 1, wantTotalCount: 3, wantHasNextPage: true},
+		{first: 2, wantTotalCount: 3, wantHasNextPage: true},
+		{first: 3, wantTotalCount: 3, wantHasNextPage: false},
+	}
+
+	for _, tc := range tests {
+		input := map[string]interface{}{"campaignSpec": apiID, "first": tc.first}
+		var response struct{ Node apitest.CampaignSpec }
+		apitest.MustExec(ctx, t, s, input, &response, queryChangesetSpecConnection)
+
+		specs := response.Node.ChangesetSpecs
+		if diff := cmp.Diff(tc.wantTotalCount, specs.TotalCount); diff != "" {
+			t.Fatalf("first=%d, unexpected total count (-want +got):\n%s", tc.first, diff)
+		}
+
+		if diff := cmp.Diff(tc.wantHasNextPage, specs.PageInfo.HasNextPage); diff != "" {
+			t.Fatalf("first=%d, unexpected hasNextPage (-want +got):\n%s", tc.first, diff)
+		}
+	}
+}
+
+const queryChangesetSpecConnection = `
+query($campaignSpec: ID!, $first: Int!) {
+  node(id: $campaignSpec) {
+    __typename
+
+    ... on CampaignSpec {
+      id
+
+      changesetSpecs(first: $first) {
+        totalCount
+        pageInfo { hasNextPage }
+
+        nodes {
+          __typename
+          ... on HiddenChangesetSpec { id }
+          ... on VisibleChangesetSpec { id }
+        }
+      }
+    }
+  }
+}
+`

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -136,21 +136,21 @@ query($id: ID!) {
 
         ... on ExistingChangesetReference {
           baseRepository {
-			  id
-		  }
+              id
+          }
           externalID
         }
 
         ... on GitBranchChangesetDescription {
           baseRepository {
-			  id
-		  }
+              id
+          }
           baseRef
           baseRev
 
           headRepository {
-			  id
-		  }
+              id
+          }
           headRef
 
           title
@@ -166,7 +166,7 @@ query($id: ID!) {
       }
 
       expiresAt
-	}
+    }
   }
 }
 `

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -136,7 +136,7 @@ query($id: ID!) {
 
         ... on ExistingChangesetReference {
           baseRepository {
-              id
+             id
           }
           externalID
         }

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -80,9 +80,9 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 		}
 
 		repo, repoFound := reposByID[c.RepoID]
-		// If it's not in reposByID the repository was either deleted or
-		// filtered out by the authz-filter.
-		// In both cases: isHidden: true.
+		// If it's not in reposByID the repository was filtered out by the
+		// authz-filter. In that case we want to return a changesetResolver
+		// that doesn't reveal all information.
 		// But if the filter opts would leak information about the hidden
 		// changesets, we skip the hidden changeset.
 		if !repoFound && !r.optsSafe {
@@ -90,7 +90,6 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 		}
 
 		resolvers = append(resolvers, &changesetResolver{
-			isHidden:             !repoFound,
 			store:                r.store,
 			httpFactory:          r.httpFactory,
 			changeset:            c,
@@ -188,7 +187,6 @@ func (r *changesetsConnectionResolver) Stats(ctx context.Context) (graphqlbacken
 }
 
 type changesetResolver struct {
-	isHidden    bool
 	store       *ee.Store
 	httpFactory *httpcli.Factory
 

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -240,10 +240,9 @@ func (r *changesetResolver) computeRepo(ctx context.Context) (*graphqlbackend.Re
 		if r.preloadedRepo != nil {
 			r.repo = graphqlbackend.NewRepositoryResolver(r.preloadedRepo)
 		} else {
+			// 🚨 SECURITY: graphqlbackend.RepositoryByIDInt32 uses the authzFilter under the hood and
+			// filters out repositories that the user doesn't have access to.
 			r.repo, r.repoErr = graphqlbackend.RepositoryByIDInt32(ctx, r.changeset.RepoID)
-			if r.repoErr != nil {
-				return
-			}
 		}
 	})
 	return r.repo, r.repoErr

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -89,12 +90,13 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 		}
 
 		resolvers = append(resolvers, &changesetResolver{
-			isHidden:            !repoFound,
-			store:               r.store,
-			httpFactory:         r.httpFactory,
-			changeset:           c,
-			preloadedRepo:       repo,
-			preloadedNextSyncAt: preloadedNextSyncAt,
+			isHidden:             !repoFound,
+			store:                r.store,
+			httpFactory:          r.httpFactory,
+			changeset:            c,
+			preloadedRepo:        repo,
+			attemptedPreloadRepo: true,
+			preloadedNextSyncAt:  preloadedNextSyncAt,
 		})
 	}
 
@@ -190,13 +192,20 @@ type changesetResolver struct {
 	store       *ee.Store
 	httpFactory *httpcli.Factory
 
-	changeset     *campaigns.Changeset
-	preloadedRepo *types.Repo
+	changeset *campaigns.Changeset
+
+	attemptedPreloadRepo bool
+	preloadedRepo        *types.Repo
 
 	// cache repo because it's called more than once
 	repoOnce sync.Once
 	repo     *graphqlbackend.RepositoryResolver
 	repoErr  error
+	// The context with which we try to load the repository if it's not
+	// preloaded. We need an extra field for that, because the
+	// ToExternalChangeset/ToHiddenExternalChangeset methods cannot take a
+	// context.Context without graphql-go panic'ing.
+	repoCtx context.Context
 
 	// cache changeset events as they are used more than once
 	eventsOnce sync.Once
@@ -222,27 +231,58 @@ func unmarshalChangesetID(id graphql.ID) (cid int64, err error) {
 }
 
 func (r *changesetResolver) ToExternalChangeset() (graphqlbackend.ExternalChangesetResolver, bool) {
-	if r.isHidden {
+	accessible, err := r.repoAccessible()
+	if err != nil {
+		return r, true
+	}
+
+	if !accessible {
 		return nil, false
 	}
+
 	return r, true
 }
 
 func (r *changesetResolver) ToHiddenExternalChangeset() (graphqlbackend.HiddenExternalChangesetResolver, bool) {
-	if !r.isHidden {
+	accessible, err := r.repoAccessible()
+	if err != nil {
+		return r, true
+	}
+
+	if accessible {
 		return nil, false
 	}
+
 	return r, true
 }
 
-func (r *changesetResolver) computeRepo(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
+func (r *changesetResolver) repoAccessible() (bool, error) {
+	repo, err := r.computeRepo()
+	if err != nil {
+		// In case we couldn't load the repository because of an error, we
+		// return the error
+		return false, err
+	}
+
+	// If the repository is not nil, it's accessible
+	return repo != nil, nil
+}
+
+func (r *changesetResolver) computeRepo() (*graphqlbackend.RepositoryResolver, error) {
 	r.repoOnce.Do(func() {
-		if r.preloadedRepo != nil {
-			r.repo = graphqlbackend.NewRepositoryResolver(r.preloadedRepo)
+		if r.attemptedPreloadRepo {
+			if r.preloadedRepo != nil {
+				r.repo = graphqlbackend.NewRepositoryResolver(r.preloadedRepo)
+			}
 		} else {
+			if r.repoCtx == nil {
+				r.repoErr = fmt.Errorf("no context available to query repository")
+				return
+			}
+
 			// 🚨 SECURITY: graphqlbackend.RepositoryByIDInt32 uses the authzFilter under the hood and
 			// filters out repositories that the user doesn't have access to.
-			r.repo, r.repoErr = graphqlbackend.RepositoryByIDInt32(ctx, r.changeset.RepoID)
+			r.repo, r.repoErr = graphqlbackend.RepositoryByIDInt32(r.repoCtx, r.changeset.RepoID)
 		}
 	})
 	return r.repo, r.repoErr
@@ -299,7 +339,7 @@ func (r *changesetResolver) ExternalID() *string {
 }
 
 func (r *changesetResolver) Repository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
-	return r.computeRepo(ctx)
+	return r.computeRepo()
 }
 
 func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
@@ -440,7 +480,7 @@ func (r *changesetResolver) Events(ctx context.Context, args *struct {
 func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.RepositoryComparisonInterface, error) {
 	// TODO: Return previewRepositoryConnection from the spec, when changeset doesn't yet exist on the codehost.
 	if r.changeset == nil {
-		repo, err := r.computeRepo(ctx)
+		repo, err := r.computeRepo()
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +493,7 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 		return nil, nil
 	}
 
-	repo, err := r.computeRepo(ctx)
+	repo, err := r.computeRepo()
 	if err != nil {
 		return nil, err
 	}
@@ -557,7 +597,7 @@ func (r *changesetResolver) Base(ctx context.Context) (*graphqlbackend.GitRefRes
 }
 
 func (r *changesetResolver) gitRef(ctx context.Context, name, oid string) (*graphqlbackend.GitRefResolver, error) {
-	repo, err := r.computeRepo(ctx)
+	repo, err := r.computeRepo()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -6,21 +6,18 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -429,7 +426,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		t.Skip()
 	}
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	// now := time.Now().UTC().Truncate(time.Microsecond)
 
 	// We need to enable read access so that non-site-admin users can access
 	// the API and we can check for their admin rights.
@@ -471,188 +468,130 @@ func TestRepositoryPermissions(t *testing.T) {
 		repos = append(repos, r)
 	}
 
-	// Create 2 changesets for 2 repositories
-	changesetBaseRefOid := "f00b4r"
-	changesetHeadRefOid := "b4rf00"
-	mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid, testDiff)
-	changesetDiffStat := apitest.DiffStat{Added: 0, Changed: 2, Deleted: 0}
+	t.Run("Campaign and changesets", func(t *testing.T) {
+		// Create 2 changesets for 2 repositories
+		changesetBaseRefOid := "f00b4r"
+		changesetHeadRefOid := "b4rf00"
+		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid, testDiff)
+		changesetDiffStat := apitest.DiffStat{Added: 0, Changed: 2, Deleted: 0}
 
-	changesets := make([]*campaigns.Changeset, 0, 2)
-	changesetIDs := make([]int64, 0, cap(changesets))
-	for _, r := range repos[0:2] {
-		c := &campaigns.Changeset{
-			RepoID:              r.ID,
-			ExternalServiceType: extsvc.TypeGitHub,
-			ExternalID:          fmt.Sprintf("external-%d", r.ID),
-			ExternalState:       campaigns.ChangesetExternalStateOpen,
-			ExternalCheckState:  campaigns.ChangesetCheckStatePassed,
-			ExternalReviewState: campaigns.ChangesetReviewStateChangesRequested,
-			Metadata: &github.PullRequest{
-				BaseRefOid: changesetBaseRefOid,
-				HeadRefOid: changesetHeadRefOid,
-			},
-		}
-		c.SetDiffStat(changesetDiffStat.ToDiffStat())
-		if err := store.CreateChangesets(ctx, c); err != nil {
-			t.Fatal(err)
-		}
-		changesets = append(changesets, c)
-		changesetIDs = append(changesetIDs, c.ID)
-	}
-
-	patchSet := &campaigns.PatchSet{UserID: userID}
-	if err := store.CreatePatchSet(ctx, patchSet); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create 2 patches for the other repositories
-	patches := make([]*campaigns.Patch, 0, 2)
-	patchesDiffStat := apitest.DiffStat{Added: 88, Changed: 66, Deleted: 22}
-	for _, r := range repos[2:4] {
-		p := &campaigns.Patch{
-			PatchSetID:      patchSet.ID,
-			RepoID:          r.ID,
-			Rev:             testRev,
-			BaseRef:         "refs/heads/master",
-			Diff:            "+ foo - bar",
-			DiffStatAdded:   &patchesDiffStat.Added,
-			DiffStatChanged: &patchesDiffStat.Changed,
-			DiffStatDeleted: &patchesDiffStat.Deleted,
-		}
-		if err := store.CreatePatch(ctx, p); err != nil {
-			t.Fatal(err)
-		}
-		patches = append(patches, p)
-	}
-
-	campaign := &campaigns.Campaign{
-		PatchSetID:      patchSet.ID,
-		Name:            "my campaign",
-		AuthorID:        userID,
-		NamespaceUserID: userID,
-		// We attach the two changesets to the campaign
-		ChangesetIDs: changesetIDs,
-	}
-	if err := store.CreateCampaign(ctx, campaign); err != nil {
-		t.Fatal(err)
-	}
-	for _, c := range changesets {
-		c.CampaignIDs = []int64{campaign.ID}
-	}
-	if err := store.UpdateChangesets(ctx, changesets...); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create 2 failed ChangesetJobs for the patchess to produce error messages
-	// on the campaign.
-	changesetJobs := make([]*campaigns.ChangesetJob, 0, 2)
-	for _, p := range patches {
-		job := &campaigns.ChangesetJob{
-			CampaignID: campaign.ID,
-			PatchID:    p.ID,
-			Error:      fmt.Sprintf("error patch %d", p.ID),
-			StartedAt:  now,
-			FinishedAt: now,
-		}
-		if err := store.CreateChangesetJob(ctx, job); err != nil {
-			t.Fatal(err)
-		}
-
-		changesetJobs = append(changesetJobs, job)
-	}
-
-	// Query campaign and check that we get all changesets and all patches
-	userCtx := actor.WithActor(ctx, actor.FromUser(userID))
-
-	input := map[string]interface{}{
-		"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
-	}
-	testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
-		changesetTypes:  map[string]int{"ExternalChangeset": 2},
-		changesetsCount: 2,
-		campaignDiffStat: apitest.DiffStat{
-			Added:   2 * changesetDiffStat.Added,
-			Changed: 2 * changesetDiffStat.Changed,
-			Deleted: 2 * changesetDiffStat.Deleted,
-		},
-	})
-
-	for _, c := range changesets {
-		// Both changesets are visible still, so both should be ExternalChangesets
-		testChangesetResponse(t, s, userCtx, c.ID, "ExternalChangeset")
-	}
-
-	// Now we add the authzFilter and filter out 2 repositories
-	filteredRepoIDs := map[api.RepoID]bool{
-		changesets[0].RepoID: true,
-	}
-
-	db.MockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perms) ([]*types.Repo, error) {
-		var filtered []*types.Repo
-		for _, r := range repos {
-			if _, ok := filteredRepoIDs[r.ID]; ok {
-				continue
+		changesets := make([]*campaigns.Changeset, 0, 2)
+		changesetIDs := make([]int64, 0, cap(changesets))
+		for _, r := range repos[0:2] {
+			c := &campaigns.Changeset{
+				RepoID:              r.ID,
+				ExternalServiceType: extsvc.TypeGitHub,
+				ExternalID:          fmt.Sprintf("external-%d", r.ID),
+				ExternalState:       campaigns.ChangesetExternalStateOpen,
+				ExternalCheckState:  campaigns.ChangesetCheckStatePassed,
+				ExternalReviewState: campaigns.ChangesetReviewStateChangesRequested,
+				Metadata: &github.PullRequest{
+					BaseRefOid: changesetBaseRefOid,
+					HeadRefOid: changesetHeadRefOid,
+				},
 			}
-			filtered = append(filtered, r)
+			c.SetDiffStat(changesetDiffStat.ToDiffStat())
+			if err := store.CreateChangesets(ctx, c); err != nil {
+				t.Fatal(err)
+			}
+			changesets = append(changesets, c)
+			changesetIDs = append(changesetIDs, c.ID)
 		}
-		return filtered, nil
-	}
-	defer func() { db.MockAuthzFilter = nil }()
 
-	// Send query again and check that for each filtered repository we get a
-	// HiddenChangeset/HiddenPatch and that errors are filtered out
-	input = map[string]interface{}{
-		"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
-	}
-	want := wantCampaignResponse{
-		changesetTypes: map[string]int{
-			"ExternalChangeset":       1,
-			"HiddenExternalChangeset": 1,
-		},
-		changesetsCount: 2,
-		campaignDiffStat: apitest.DiffStat{
-			Added:   1 * changesetDiffStat.Added,
-			Changed: 1 * changesetDiffStat.Changed,
-			Deleted: 1 * changesetDiffStat.Deleted,
-		},
-	}
-	testCampaignResponse(t, s, userCtx, input, want)
+		campaign := &campaigns.Campaign{
+			Name:            "my campaign",
+			AuthorID:        userID,
+			NamespaceUserID: userID,
+			// We attach the two changesets to the campaign
+			ChangesetIDs: changesetIDs,
+		}
+		if err := store.CreateCampaign(ctx, campaign); err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range changesets {
+			c.CampaignIDs = []int64{campaign.ID}
+		}
+		if err := store.UpdateChangesets(ctx, changesets...); err != nil {
+			t.Fatal(err)
+		}
 
-	for _, c := range changesets {
-		// The changeset whose repository has been filtered should be hidden
-		if _, ok := filteredRepoIDs[c.RepoID]; ok {
-			testChangesetResponse(t, s, userCtx, c.ID, "HiddenExternalChangeset")
-		} else {
+		// Query campaign and check that we get all changesets
+		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
+		input := map[string]interface{}{
+			"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
+		}
+		testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
+			changesetTypes:  map[string]int{"ExternalChangeset": 2},
+			changesetsCount: 2,
+			campaignDiffStat: apitest.DiffStat{
+				Added:   2 * changesetDiffStat.Added,
+				Changed: 2 * changesetDiffStat.Changed,
+				Deleted: 2 * changesetDiffStat.Deleted,
+			},
+		})
+
+		for _, c := range changesets {
+			// Both changesets are visible still, so both should be ExternalChangesets
 			testChangesetResponse(t, s, userCtx, c.ID, "ExternalChangeset")
 		}
-	}
 
-	// Now we query with more filters for the changesets. The hidden changesets
-	// should not be returned, since that would leak information about the
-	// hidden changesets.
-	input = map[string]interface{}{
-		"campaign":   string(campaigns.MarshalCampaignID(campaign.ID)),
-		"checkState": string(campaigns.ChangesetCheckStatePassed),
-	}
-	wantCheckStateResponse := want
-	wantCheckStateResponse.changesetsCount = 1
-	wantCheckStateResponse.changesetTypes = map[string]int{
-		"ExternalChangeset": 1,
-		// No HiddenExternalChangeset
-	}
-	testCampaignResponse(t, s, userCtx, input, wantCheckStateResponse)
+		// Now we add the authzFilter and filter out the repository of one changeset
+		filteredRepo := changesets[0].RepoID
+		ct.AuthzFilterRepos(t, filteredRepo)
 
-	input = map[string]interface{}{
-		"campaign":    string(campaigns.MarshalCampaignID(campaign.ID)),
-		"reviewState": string(campaigns.ChangesetReviewStateChangesRequested),
-	}
-	wantReviewStateResponse := want
-	wantReviewStateResponse.changesetsCount = 1
-	wantReviewStateResponse.changesetTypes = map[string]int{
-		"ExternalChangeset": 1,
-		// No HiddenExternalChangeset
-	}
-	testCampaignResponse(t, s, userCtx, input, wantReviewStateResponse)
+		// Send query again and check that for each filtered repository we get a
+		// HiddenChangeset/HiddenPatch and that errors are filtered out
+		want := wantCampaignResponse{
+			changesetTypes: map[string]int{
+				"ExternalChangeset":       1,
+				"HiddenExternalChangeset": 1,
+			},
+			changesetsCount: 2,
+			campaignDiffStat: apitest.DiffStat{
+				Added:   1 * changesetDiffStat.Added,
+				Changed: 1 * changesetDiffStat.Changed,
+				Deleted: 1 * changesetDiffStat.Deleted,
+			},
+		}
+		testCampaignResponse(t, s, userCtx, input, want)
+
+		for _, c := range changesets {
+			// The changeset whose repository has been filtered should be hidden
+			if c.RepoID == filteredRepo {
+				testChangesetResponse(t, s, userCtx, c.ID, "HiddenExternalChangeset")
+			} else {
+				testChangesetResponse(t, s, userCtx, c.ID, "ExternalChangeset")
+			}
+		}
+
+		// Now we query with more filters for the changesets. The hidden changesets
+		// should not be returned, since that would leak information about the
+		// hidden changesets.
+		input = map[string]interface{}{
+			"campaign":   string(campaigns.MarshalCampaignID(campaign.ID)),
+			"checkState": string(campaigns.ChangesetCheckStatePassed),
+		}
+		wantCheckStateResponse := want
+		wantCheckStateResponse.changesetsCount = 1
+		wantCheckStateResponse.changesetTypes = map[string]int{
+			"ExternalChangeset": 1,
+			// No HiddenExternalChangeset
+		}
+		testCampaignResponse(t, s, userCtx, input, wantCheckStateResponse)
+
+		input = map[string]interface{}{
+			"campaign":    string(campaigns.MarshalCampaignID(campaign.ID)),
+			"reviewState": string(campaigns.ChangesetReviewStateChangesRequested),
+		}
+		wantReviewStateResponse := want
+		wantReviewStateResponse.changesetsCount = 1
+		wantReviewStateResponse.changesetTypes = map[string]int{
+			"ExternalChangeset": 1,
+			// No HiddenExternalChangeset
+		}
+		testCampaignResponse(t, s, userCtx, input, wantReviewStateResponse)
+	})
 }
 
 type wantCampaignResponse struct {

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -457,8 +457,8 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 
-	// Create 4 repositories
-	repos := make([]*repos.Repo, 0, 4)
+	// Create 2 repositories
+	repos := make([]*repos.Repo, 0, 2)
 	for i := 0; i < cap(repos); i++ {
 		name := fmt.Sprintf("github.com/sourcegraph/repo-%d", i)
 		r := newGitHubTestRepo(name, i)
@@ -475,9 +475,9 @@ func TestRepositoryPermissions(t *testing.T) {
 		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid, testDiff)
 		changesetDiffStat := apitest.DiffStat{Added: 0, Changed: 2, Deleted: 0}
 
-		changesets := make([]*campaigns.Changeset, 0, 2)
+		changesets := make([]*campaigns.Changeset, 0, len(repos))
 		changesetIDs := make([]int64, 0, cap(changesets))
-		for _, r := range repos[0:2] {
+		for _, r := range repos {
 			c := &campaigns.Changeset{
 				RepoID:              r.ID,
 				ExternalServiceType: extsvc.TypeGitHub,
@@ -602,8 +602,8 @@ func TestRepositoryPermissions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		changesetSpecs := make([]*campaigns.ChangesetSpec, 0, 2)
-		for _, r := range repos[0:2] {
+		changesetSpecs := make([]*campaigns.ChangesetSpec, 0, len(repos))
+		for _, r := range repos {
 			c := &campaigns.ChangesetSpec{
 				RepoID:         r.ID,
 				UserID:         userID,

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -77,7 +77,6 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 	}
 
 	return &changesetResolver{
-		isHidden:             errcode.IsNotFound(err),
 		store:                r.store,
 		httpFactory:          r.httpFactory,
 		changeset:            changeset,

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -520,9 +520,10 @@ func parseCampaignState(s *string) (campaigns.CampaignState, error) {
 	}
 }
 
-func currentUserCanAdministerCampaign(ctx context.Context, c *campaigns.Campaign) (bool, error) {
-	// 🚨 SECURITY: Only site admins or the authors of a campaign have campaign admin rights.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, c.AuthorID); err != nil {
+func checkSiteAdminOrSameUser(ctx context.Context, userID int32) (bool, error) {
+	// 🚨 SECURITY: Only site admins or the authors of a campaign have campaign
+	// admin rights.
+	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		if _, ok := err.(*backend.InsufficientAuthorizationError); ok {
 			return false, nil
 		}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -77,11 +77,12 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 	}
 
 	return &changesetResolver{
-		isHidden:      errcode.IsNotFound(err),
-		store:         r.store,
-		httpFactory:   r.httpFactory,
-		changeset:     changeset,
-		preloadedRepo: repo,
+		isHidden:             errcode.IsNotFound(err),
+		store:                r.store,
+		httpFactory:          r.httpFactory,
+		changeset:            changeset,
+		attemptedPreloadRepo: true,
+		preloadedRepo:        repo,
 	}, nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -192,11 +192,6 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		tr.Finish()
 	}()
 
-	// 🚨 SECURITY: Only site admins may apply campaigns for now.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
-	}
-
 	opts := ee.ApplyCampaignOpts{}
 
 	opts.CampaignSpecRandID, err = unmarshalCampaignSpecID(args.CampaignSpec)

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -162,7 +162,12 @@ func (r *Resolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (graphq
 		return nil, err
 	}
 
-	return &changesetSpecResolver{store: r.store, httpFactory: r.httpFactory, changesetSpec: changesetSpec}, nil
+	return &changesetSpecResolver{
+		store:         r.store,
+		httpFactory:   r.httpFactory,
+		changesetSpec: changesetSpec,
+		repoCtx:       ctx,
+	}, nil
 }
 
 func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.CreateCampaignArgs) (graphqlbackend.CampaignResolver, error) {
@@ -301,6 +306,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 		store:         r.store,
 		httpFactory:   r.httpFactory,
 		changesetSpec: spec,
+		repoCtx:       ctx,
 	}
 	return resolver, nil
 }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -927,7 +927,10 @@ func TestCreateCampaignSpec(t *testing.T) {
 		Creator:       apitest.User{ID: userApiID, DatabaseID: userID, SiteAdmin: true},
 		ChangesetSpecs: apitest.ChangesetSpecConnection{
 			Nodes: []apitest.ChangesetSpec{
-				{ID: string(changesetSpecID)},
+				{
+					Typename: "VisibleChangesetSpec",
+					ID:       string(changesetSpecID),
+				},
 			},
 		},
 	}
@@ -963,6 +966,7 @@ mutation($namespace: ID!, $campaignSpec: String!, $changesetSpecs: [ID!]!){
 
 	changesetSpecs {
 	  nodes {
+		  __typename
 		  ... on VisibleChangesetSpec {
 			  id
 		  }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -1005,7 +1005,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	input := map[string]interface{}{
-		"changesetSpec": ct.NewRawChangesetSpecGitBranch(graphqlbackend.MarshalRepositoryID(repo.ID)),
+		"changesetSpec": ct.NewRawChangesetSpecGitBranch(graphqlbackend.MarshalRepositoryID(repo.ID), "d34db33f"),
 	}
 
 	var response struct{ CreateChangesetSpec apitest.ChangesetSpec }
@@ -1073,7 +1073,7 @@ func TestApplyCampaign(t *testing.T) {
 	repoApiID := graphqlbackend.MarshalRepositoryID(repo.ID)
 
 	changesetSpec := &campaigns.ChangesetSpec{
-		RawSpec: ct.NewRawChangesetSpecGitBranch(repoApiID),
+		RawSpec: ct.NewRawChangesetSpecGitBranch(repoApiID, "d34db33f"),
 		Spec: campaigns.ChangesetSpecDescription{
 			BaseRepository: repoApiID,
 		},

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -621,7 +621,7 @@ func TestService(t *testing.T) {
 		svc := NewServiceWithClock(store, cf, clock)
 
 		repo := rs[0]
-		rawSpec := ct.NewRawChangesetSpecGitBranch(graphqlbackend.MarshalRepositoryID(repo.ID))
+		rawSpec := ct.NewRawChangesetSpecGitBranch(graphqlbackend.MarshalRepositoryID(repo.ID), "d34db33f")
 
 		t.Run("success", func(t *testing.T) {
 			spec, err := svc.CreateChangesetSpec(ctx, rawSpec, user.ID)

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -62,7 +62,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 	}
 
 	t.Run("Count", func(t *testing.T) {
-		count, err := s.CountChangesetSpecs(ctx)
+		count, err := s.CountChangesetSpecs(ctx, CountChangesetSpecsOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -70,6 +70,30 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 		if have, want := count, int64(len(changesetSpecs)); have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
+
+		t.Run("WithCampaignSpecID", func(t *testing.T) {
+			testsRan := false
+			for _, c := range changesetSpecs {
+				if c.CampaignSpecID == 0 {
+					continue
+				}
+
+				opts := CountChangesetSpecsOpts{CampaignSpecID: c.CampaignSpecID}
+				subCount, err := s.CountChangesetSpecs(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := subCount, int64(1); have != want {
+					t.Fatalf("have count: %d, want: %d", have, want)
+				}
+				testsRan = true
+			}
+
+			if !testsRan {
+				t.Fatal("no changesetSpec has a non-zero CampaignSpecID")
+			}
+		})
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -257,7 +281,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 				t.Fatal(err)
 			}
 
-			count, err := s.CountChangesetSpecs(ctx)
+			count, err := s.CountChangesetSpecs(ctx, CountChangesetSpecsOpts{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -7,27 +7,49 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
-func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock clock) {
+func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs repos.Store, clock clock) {
+	repo := testRepo(1, extsvc.TypeGitHub)
+	deletedRepo := testRepo(2, extsvc.TypeGitHub).With(repos.Opt.RepoDeletedAt(clock.now()))
+
+	if err := rs.UpsertRepos(ctx, deletedRepo, repo); err != nil {
+		t.Fatal(err)
+	}
+
 	changesetSpecs := make([]*cmpgn.ChangesetSpec, 0, 3)
+	for i := 0; i < cap(changesetSpecs); i++ {
+		c := &cmpgn.ChangesetSpec{
+			RawSpec:        `{}`,
+			UserID:         int32(i + 1234),
+			CampaignSpecID: int64(i + 910),
+			RepoID:         repo.ID,
+		}
+
+		if i == cap(changesetSpecs)-1 {
+			c.CampaignSpecID = 0
+		}
+		changesetSpecs = append(changesetSpecs, c)
+	}
+
+	// We create this ChangesetSpec to make sure that it's not returned when
+	// listing or getting ChangesetSpecs, since we don't want to load
+	// ChangesetSpecs whose repository has been (soft-)deleted.
+	changesetSpecDeletedRepo := &cmpgn.ChangesetSpec{
+		UserID:         int32(424242),
+		CampaignSpecID: int64(424242),
+		RawSpec:        `{}`,
+		RepoID:         deletedRepo.ID,
+	}
 
 	t.Run("Create", func(t *testing.T) {
-		for i := 0; i < cap(changesetSpecs); i++ {
-			c := &cmpgn.ChangesetSpec{
-				RawSpec:        `{"repoID": "abc", "rev": "d34db33f"}`,
-				Spec:           cmpgn.ChangesetSpecDescription{},
-				UserID:         int32(i + 1234),
-				RepoID:         api.RepoID(i + 5678),
-				CampaignSpecID: int64(i + 910),
-			}
+		toCreate := make([]*cmpgn.ChangesetSpec, 0, len(changesetSpecs)+1)
+		toCreate = append(toCreate, changesetSpecDeletedRepo)
+		toCreate = append(toCreate, changesetSpecs...)
 
-			if i == cap(changesetSpecs)-1 {
-				c.CampaignSpecID = 0
-			}
-
+		for _, c := range toCreate {
 			want := c.Clone()
 			have := c
 
@@ -52,14 +74,8 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 			if diff := cmp.Diff(have, want); diff != "" {
 				t.Fatal(diff)
 			}
-
-			changesetSpecs = append(changesetSpecs, c)
 		}
 	})
-
-	if len(changesetSpecs) != cap(changesetSpecs) {
-		t.Fatalf("changesetSpecs is empty. creation failed")
-	}
 
 	t.Run("Count", func(t *testing.T) {
 		count, err := s.CountChangesetSpecs(ctx, CountChangesetSpecsOpts{})
@@ -215,6 +231,8 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 				t.Fatal(err)
 			}
 
+			// ListChangesetSpecs should not return ChangesetSpecs whose
+			// repository was (soft-)deleted.
 			if diff := cmp.Diff(have, changesetSpecs); diff != "" {
 				t.Fatalf("opts: %+v, diff: %s", opts, diff)
 			}
@@ -318,7 +336,9 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, _ repo
 
 			changesetSpec := &cmpgn.ChangesetSpec{
 				CampaignSpecID: campaignSpec.ID,
-				CreatedAt:      tc.createdAt,
+				// Need to set a RepoID otherwise GetChangesetSpec filters it out.
+				RepoID:    repo.ID,
+				CreatedAt: tc.createdAt,
 			}
 
 			if err := s.CreateChangesetSpec(ctx, changesetSpec); err != nil {

--- a/enterprise/internal/campaigns/testing/mock_authzfilter.go
+++ b/enterprise/internal/campaigns/testing/mock_authzfilter.go
@@ -1,0 +1,31 @@
+package testing
+
+import (
+	"context"
+	test "testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/authz"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+)
+
+// AuthzFilterRepos sets up a mock for the authzFilter in the db package that
+// filters out the repositories with the given IDs IDs.
+func AuthzFilterRepos(t *test.T, ids ...api.RepoID) {
+	toFilter := map[api.RepoID]struct{}{}
+	for _, id := range ids {
+		toFilter[id] = struct{}{}
+	}
+	db.MockAuthzFilter = func(ctx context.Context, repos []*types.Repo, p authz.Perms) ([]*types.Repo, error) {
+		var result []*types.Repo
+		for _, r := range repos {
+			if _, ok := toFilter[r.ID]; ok {
+				continue
+			}
+			result = append(result, r)
+		}
+		return result, nil
+	}
+	t.Cleanup(func() { db.MockAuthzFilter = nil })
+}

--- a/enterprise/internal/campaigns/testing/specs.go
+++ b/enterprise/internal/campaigns/testing/specs.go
@@ -53,10 +53,30 @@ changesetTemplate:
   published: false
 `
 
-func NewRawChangesetSpecGitBranch(repo graphql.ID) string {
+func NewRawChangesetSpecGitBranch(repo graphql.ID, baseRev string) string {
+	diff := `diff --git INSTALL.md INSTALL.md
+index e5af166..d44c3fc 100644
+--- INSTALL.md
++++ INSTALL.md
+@@ -3,10 +3,10 @@
+ Line 1
+ Line 2
+ Line 3
+-Line 4
++This is cool: Line 4
+ Line 5
+ Line 6
+-Line 7
+-Line 8
++Another Line 7
++Foobar Line 8
+ Line 9
+ Line 10
+`
 	tmpl := `{
+
 		"baseRepository": %q,
-		"baseRev":"d34db33f",
+		"baseRev": %q,
 		"baseRef":"refs/heads/master",
 
 		"headRepository": %q,
@@ -68,11 +88,10 @@ func NewRawChangesetSpecGitBranch(repo graphql.ID) string {
 		"published": false,
 
 		"commits": [
-		  {"message": "git commit message", "diff": "+/- diff"}
-		]
+		  {"message": "git commit message", "diff": %q}]
 	}`
 
-	return fmt.Sprintf(tmpl, repo, repo)
+	return fmt.Sprintf(tmpl, repo, baseRev, repo, diff)
 }
 
 func NewRawChangesetSpecExisting(repo graphql.ID, externalID string) string {

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1712,15 +1712,6 @@ type ChangesetSpec struct {
 	UpdatedAt time.Time
 }
 
-// ChangesetSpecType tells about the type of the changeset spec without including the description. Useful for HiddenChangesetSpecs in the API.
-type ChangesetSpecType string
-
-// Valid ChangesetEvent kinds
-const (
-	ChangesetSpecTypeExisting ChangesetSpecType = "EXISTING"
-	ChangesetSpecTypeBranch   ChangesetSpecType = "BRANCH"
-)
-
 // Clone returns a clone of a ChangesetSpec.
 func (cs *ChangesetSpec) Clone() *ChangesetSpec {
 	cc := *cs
@@ -1785,11 +1776,36 @@ type ChangesetSpecDescription struct {
 	Published bool `json:"published,omitempty"`
 }
 
-// IsExistingChangesetRef returns true when the changeset spec is referencing
-// an existing changeset on a codehost.
-func (d *ChangesetSpecDescription) IsExistingChangesetRef() bool {
-	return d.ExternalID != ""
+// Type returns the ChangesetSpecDescriptionType of the ChangesetSpecDescription.
+func (d *ChangesetSpecDescription) Type() ChangesetSpecDescriptionType {
+	if d.ExternalID != "" {
+		return ChangesetSpecDescriptionTypeExisting
+	}
+	return ChangesetSpecDescriptionTypeBranch
 }
+
+// IsExisting returns whether the description is of type
+// ChangesetSpecDescriptionTypeExisting.
+func (d *ChangesetSpecDescription) IsExisting() bool {
+	return d.Type() == ChangesetSpecDescriptionTypeExisting
+}
+
+// IsBranch returns whether the description is of type
+// ChangesetSpecDescriptionTypeBranch.
+func (d *ChangesetSpecDescription) IsBranch() bool {
+	return d.Type() == ChangesetSpecDescriptionTypeBranch
+}
+
+// ChangesetSpecDescriptionType tells the consumer what the type of a
+// ChangesetSpecDescription is without having to look into the description.
+// Useful in the GraphQL when a HiddenChangesetSpec is returned.
+type ChangesetSpecDescriptionType string
+
+// Valid ChangesetSpecDescriptionTypes kinds
+const (
+	ChangesetSpecDescriptionTypeExisting ChangesetSpecDescriptionType = "EXISTING"
+	ChangesetSpecDescriptionTypeBranch   ChangesetSpecDescriptionType = "BRANCH"
+)
 
 // ErrNoCommits is returned by (*ChangesetSpecDescription).Diff if the
 // description doesn't have any commits descriptions.

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1785,9 +1785,26 @@ type ChangesetSpecDescription struct {
 	Published bool `json:"published,omitempty"`
 }
 
-// IsExistingChangesetRef returns true when the changeset spec is referencing an existing changeset on a codehost.
+// IsExistingChangesetRef returns true when the changeset spec is referencing
+// an existing changeset on a codehost.
 func (d *ChangesetSpecDescription) IsExistingChangesetRef() bool {
 	return d.ExternalID != ""
+}
+
+// ErrNoCommits is returned by (*ChangesetSpecDescription).Diff if the
+// description doesn't have any commits descriptions.
+var ErrNoCommits = errors.New("changeset description doesn't contain commit descriptions")
+
+// Diff returns the Diff of the first GitCommitDescription in Commits. If the
+// ChangesetSpecDescription doesn't have Commits it returns ErrNoCommits.
+//
+// We currently only support a single commit in Commits. Once we support more,
+// this method will need to be revisited.
+func (d *ChangesetSpecDescription) Diff() (string, error) {
+	if len(d.Commits) == 0 {
+		return "", ErrNoCommits
+	}
+	return d.Commits[0].Diff, nil
 }
 
 type GitCommitDescription struct {


### PR DESCRIPTION
This is the next step in https://github.com/sourcegraph/sourcegraph/pull/11675 and implements the missing bits and pieces in the `ChangesetSpec` and `CampaignSpec` resolvers, after they've been extended in the GraphQL schema.