### PR TITLE
dev: ignore changes to _test.go files

### DIFF
--- a/dev/changewatch.sh
+++ b/dev/changewatch.sh
@@ -52,7 +52,9 @@ execWatchman() {
   exec dev/watchmanwrapper/watchmanwrapper dev/handle-change.sh <<-EOT
 ["subscribe", ".", "gochangewatch", {
   "expression": ["allof",
-    ["not", ["match", ".*"]],
+    ["not", ["anyof",
+      ["match", ".*"],
+      ["suffix", "_test.go"]]],
     ["anyof",
       ["suffix", "go"],
       ["dirname", "cmd/symbols"],


### PR DESCRIPTION
We don't need to recompile if a _test.go file is changed since they
don't contribute to main. This change updates watchman to exclude
triggering updates in that case. We only do this for watchman since the
other file watchers do not make it as easy to express these sorts of
rules. I also want to one day make watchman the only way to do this.