### PR TITLE
ci: run shared tests sooner

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -103,11 +103,6 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 
 // Adds the shared frontend tests (shared between the web app and browser extension).
 func addSharedTests(pipeline *bk.Pipeline) {
-	// Shared tests
-	pipeline.AddStep(":jest:",
-		bk.Cmd("dev/ci/yarn-test.sh shared"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
-
 	// Client integration tests
 	pipeline.AddStep(":puppeteer::electric_plug:",
 		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
@@ -128,6 +123,11 @@ func addSharedTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":chromatic:",
 		bk.AutomaticRetry(5),
 		bk.Cmd("dev/ci/yarn-run.sh chromatic"))
+
+	// Shared tests
+	pipeline.AddStep(":jest:",
+		bk.Cmd("dev/ci/yarn-test.sh shared"),
+		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
 }
 
 // Adds PostgreSQL backcompat tests.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -120,9 +120,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
-			addLint,               // ~3.5m
+			addLint,               // ~4.5m
+			addSharedTests,        // ~4.5m
 			addWebApp,             // ~3m
-			addSharedTests,        // ~3m
 			addBrowserExt,         // ~2m
 			addGoTests,            // ~1.5m
 			addCheck,              // ~1m


### PR DESCRIPTION
In particular I've seen client integration tests be the slowest build step.
