### PR TITLE
web: remove regex anchors if globbing is active

### DIFF
--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -10,11 +10,6 @@ import (
 
 // SearchFilterSuggestions provides search filter and default value suggestions.
 func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFilterSuggestions, error) {
-	settings, err := decodedViewerFinalSettings(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	groupsByName, err := resolveRepoGroups(ctx)
 	if err != nil {
 		return nil, err
@@ -34,15 +29,8 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 		return nil, err
 	}
 	repoNames := make([]string, len(repos))
-
-	if getBoolPtr(settings.SearchGlobbing, false) {
-		for i := range repos {
-			repoNames[i] = string(repos[i].Name)
-		}
-	} else {
-		for i := range repos {
-			repoNames[i] = "^" + regexp.QuoteMeta(string(repos[i].Name)) + "$"
-		}
+	for i := range repos {
+		repoNames[i] = "^" + regexp.QuoteMeta(string(repos[i].Name)) + "$"
 	}
 
 	return &searchFilterSuggestions{

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -10,6 +10,11 @@ import (
 
 // SearchFilterSuggestions provides search filter and default value suggestions.
 func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFilterSuggestions, error) {
+	settings, err := decodedViewerFinalSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	groupsByName, err := resolveRepoGroups(ctx)
 	if err != nil {
 		return nil, err
@@ -29,8 +34,15 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 		return nil, err
 	}
 	repoNames := make([]string, len(repos))
-	for i := range repos {
-		repoNames[i] = "^" + regexp.QuoteMeta(string(repos[i].Name)) + "$"
+
+	if getBoolPtr(settings.SearchGlobbing, false) {
+		for i := range repos {
+			repoNames[i] = string(repos[i].Name)
+		}
+	} else {
+		for i := range repos {
+			repoNames[i] = "^" + regexp.QuoteMeta(string(repos[i].Name)) + "$"
+		}
 	}
 
 	return &searchFilterSuggestions{

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -201,27 +201,37 @@ func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 // commonFileFilters are common filters used. It is used by DynamicFilters to
 // propose them if they match shown results.
 var commonFileFilters = []struct {
-	Regexp *lazyregexp.Regexp
-	Filter string
+	regexp      *lazyregexp.Regexp
+	regexFilter string
+	globFilter  string
 }{
 	// Exclude go tests
 	{
-		Regexp: lazyregexp.New(`_test\.go$`),
-		Filter: `-file:_test\.go$`,
+		regexp:      lazyregexp.New(`_test\.go$`),
+		regexFilter: `-file:_test\.go$`,
+		globFilter:  `-file:**_test.go`,
 	},
 	// Exclude go vendor
 	{
-		Regexp: lazyregexp.New(`(^|/)vendor/`),
-		Filter: `-file:(^|/)vendor/`,
+		regexp:      lazyregexp.New(`(^|/)vendor/`),
+		regexFilter: `-file:(^|/)vendor/`,
+		globFilter:  `-file:vendor/** -file:**/vendor/**`,
 	},
 	// Exclude node_modules
 	{
-		Regexp: lazyregexp.New(`(^|/)node_modules/`),
-		Filter: `-file:(^|/)node_modules/`,
+		regexp:      lazyregexp.New(`(^|/)node_modules/`),
+		regexFilter: `-file:(^|/)node_modules/`,
+		globFilter:  `-file:node_modules/** -file:**/node_modules/**`,
 	},
 }
 
-func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
+func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
+
+	globbing := false
+	if settings, err := decodedViewerFinalSettings(ctx); err == nil {
+		globbing = getBoolPtr(settings.SearchGlobbing, false)
+	}
+
 	filters := map[string]*searchFilterResolver{}
 	repoToMatchCount := make(map[string]int)
 	add := func(value string, label string, count int, limitHit bool, kind string, score score) {
@@ -243,7 +253,13 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 	}
 
 	addRepoFilter := func(uri string, rev string, lineMatchCount int) {
-		filter := fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(uri))
+		var filter string
+		if globbing {
+			filter = fmt.Sprintf(`repo:%s`, uri)
+		} else {
+			filter = fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(uri))
+		}
+
 		if rev != "" {
 			// We don't need to quote rev. The only special characters we interpret
 			// are @ and :, both of which are disallowed in git refs
@@ -257,8 +273,14 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 
 	addFileFilter := func(fileMatchPath string, lineMatchCount int, limitHit bool) {
 		for _, ff := range commonFileFilters {
-			if ff.Regexp.MatchString(fileMatchPath) {
-				add(ff.Filter, ff.Filter, lineMatchCount, limitHit, "file", scoreDefault)
+			// use regexp to match file paths unconditionally, whether globbing is enabled or not,
+			// since we have no native library call to match `**` for globs.
+			if ff.regexp.MatchString(fileMatchPath) {
+				if globbing {
+					add(ff.globFilter, ff.globFilter, lineMatchCount, limitHit, "file", scoreDefault)
+				} else {
+					add(ff.regexFilter, ff.regexFilter, lineMatchCount, limitHit, "file", scoreDefault)
+				}
 			}
 		}
 	}
@@ -958,14 +980,6 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	case *query.OrdinaryQuery:
 		return r.evaluateLeaf(ctx)
 	case *query.AndOrQuery:
-		// Get settings to check if `search.uppercase` is active. If so, run transformer.
-		settings, err := decodedViewerFinalSettings(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if v := settings.SearchUppercase; v != nil && *v {
-			q.Query = query.SearchUppercase(q.Query)
-		}
 		return r.evaluate(ctx, q.Query)
 	}
 	// Unreachable.

--- a/shared/src/search/parser/completion.test.ts
+++ b/shared/src/search/parser/completion.test.ts
@@ -28,7 +28,8 @@ describe('getCompletionItems()', () => {
                                 },
                             },
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -82,7 +83,8 @@ describe('getCompletionItems()', () => {
                                 },
                             },
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -118,7 +120,8 @@ describe('getCompletionItems()', () => {
     test('returns suggestions for an empty query', async () => {
         expect(
             (
-                await getCompletionItems((parseSearchQuery('') as ParseSuccess<Sequence>).token, { column: 1 }, NEVER)
+                await getCompletionItems((parseSearchQuery('') as ParseSuccess<Sequence>).token, { column: 1 },
+                    NEVER, false)
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
             'after',
@@ -159,7 +162,8 @@ describe('getCompletionItems()', () => {
                             __typename: 'Repository',
                             name: 'github.com/sourcegraph/jsonrpc2',
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -197,7 +201,8 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     (parseSearchQuery('rE') as ParseSuccess<Sequence>).token,
                     { column: 3 },
-                    of([])
+                    of([]),
+                    false
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -234,7 +239,8 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     (parseSearchQuery('case:y') as ParseSuccess<Sequence>).token,
                     { column: 7 },
-                    NEVER
+                    NEVER,
+                    false
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual(['yes', 'no'])
@@ -248,7 +254,8 @@ describe('getCompletionItems()', () => {
                     {
                         column: 6,
                     },
-                    of([])
+                    of([]),
+                    false
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -291,7 +298,8 @@ describe('getCompletionItems()', () => {
                                 name: 'github.com/sourcegraph/jsonrpc2',
                             },
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions.map(({ label, insertText }) => ({ label, insertText }))
         ).toStrictEqual([{ label: 'connect.go', insertText: '^connect\\.go$' }])
@@ -316,7 +324,8 @@ describe('getCompletionItems()', () => {
                             __typename: 'Repository',
                             name: 'github.com/sourcegraph/jsonrpc2.go',
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions
                 .filter(
@@ -342,7 +351,8 @@ describe('getCompletionItems()', () => {
                                 name: 'github.com/sourcegraph/jsonrpc2',
                             },
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions.map(({ filterText }) => filterText)
         ).toStrictEqual(['^jsonrpc'])
@@ -363,7 +373,8 @@ describe('getCompletionItems()', () => {
                                 name: 'github.com/sourcegraph/jsonrpc2',
                             },
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions
                 .filter(({ insertText }) => insertText.includes('some/path'))
@@ -386,7 +397,8 @@ describe('getCompletionItems()', () => {
                                 name: 'github.com/sourcegraph/jsonrpc2',
                             },
                         },
-                    ] as SearchSuggestion[])
+                    ] as SearchSuggestion[]),
+                    false
                 )
             )?.suggestions.map(({ insertText }) => insertText)
         ).toStrictEqual(['^some/path/main\\.go$'])

--- a/shared/src/search/parser/completion.test.ts
+++ b/shared/src/search/parser/completion.test.ts
@@ -120,8 +120,12 @@ describe('getCompletionItems()', () => {
     test('returns suggestions for an empty query', async () => {
         expect(
             (
-                await getCompletionItems((parseSearchQuery('') as ParseSuccess<Sequence>).token, { column: 1 },
-                    NEVER, false)
+                await getCompletionItems(
+                    (parseSearchQuery('') as ParseSuccess<Sequence>).token,
+                    { column: 1 },
+                    NEVER,
+                    false
+                )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
             'after',
@@ -302,7 +306,7 @@ describe('getCompletionItems()', () => {
                     false
                 )
             )?.suggestions.map(({ label, insertText }) => ({ label, insertText }))
-        ).toStrictEqual([{ label: 'connect.go', insertText: '^connect\\.go$' }])
+        ).toStrictEqual([{ label: 'connect.go', insertText: '^connect\\.go$ ' }])
     })
 
     test('inserts valid filters when selecting a file or repository suggestion', async () => {
@@ -401,6 +405,6 @@ describe('getCompletionItems()', () => {
                     false
                 )
             )?.suggestions.map(({ insertText }) => insertText)
-        ).toStrictEqual(['^some/path/main\\.go$'])
+        ).toStrictEqual(['^some/path/main\\.go$ '])
     })
 })

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -52,32 +52,35 @@ const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] 
         sortText: `0${index}`,
     }))
 
-const insertText = (name: string, isFilterValue: boolean, globbing: boolean, filter: string): string => {
-    const text = globbing ? name : `^${escapeRegExp(name)}$`
-    return isFilterValue ? text : `${filter}:${text}`
-}
-
 const repositoryToCompletion = (
     { name }: IRepository,
     options: { isFilterValue: boolean; globbing: boolean }
-): PartialCompletionItem => ({
-    label: name,
-    kind: repositoryCompletionItemKind,
-    insertText: insertText(name, options.isFilterValue, options.globbing, 'repo'),
-    filterText: name,
-    detail: options.isFilterValue ? undefined : 'Repository',
-})
+): PartialCompletionItem => {
+    let insertText = options.globbing ? name : `^${escapeRegExp(name)}$`
+    insertText = (options.isFilterValue ? insertText : `${FilterType.repo}:${insertText}`) + ' '
+    return {
+        label: name,
+        kind: repositoryCompletionItemKind,
+        insertText,
+        filterText: name,
+        detail: options.isFilterValue ? undefined : 'Repository',
+    }
+}
 
 const fileToCompletion = (
     { name, path, repository, isDirectory }: IFile,
     options: { isFilterValue: boolean; globbing: boolean }
-): PartialCompletionItem => ({
-    label: name,
-    kind: isDirectory ? Monaco.languages.CompletionItemKind.Folder : Monaco.languages.CompletionItemKind.File,
-    insertText: insertText(name, options.isFilterValue, options.globbing, 'file'),
-    filterText: name,
-    detail: `${path} - ${repository.name}`,
-})
+): PartialCompletionItem => {
+    let insertText = options.globbing ? path : `^${escapeRegExp(name)}$`
+    insertText = (options.isFilterValue ? insertText : `${FilterType.file}:${insertText}`) + ' '
+    return {
+        label: name,
+        kind: isDirectory ? Monaco.languages.CompletionItemKind.Folder : Monaco.languages.CompletionItemKind.File,
+        insertText,
+        filterText: name,
+        detail: `${path} - ${repository.name}`,
+    }
+}
 
 /**
  * Maps Sourcegraph SymbolKinds to Monaco CompletionItemKinds.

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -175,7 +175,7 @@ export async function getCompletionItems(
     { members }: Pick<Sequence, 'members'>,
     { column }: Pick<Monaco.Position, 'column'>,
     dynamicSuggestions: Observable<SearchSuggestion[]>,
-    globbing: Observable<boolean>
+    globbing: boolean
 ): Promise<Monaco.languages.CompletionList | null> {
     const defaultRange = {
         startLineNumber: 1,
@@ -183,8 +183,6 @@ export async function getCompletionItems(
         startColumn: column,
         endColumn: column,
     }
-
-    const glob = await globbing.toPromise()
 
     // Show all filter suggestions on the first column.
     if (column === 1) {
@@ -229,7 +227,7 @@ export async function getCompletionItems(
             suggestions: [
                 ...staticSuggestions,
                 ...(await dynamicSuggestions.pipe(first()).toPromise())
-                    .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: false, globbing: glob }))
+                    .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: false, globbing }))
                     .filter(isDefined)
                     .map(completionItem => ({
                         ...completionItem,
@@ -268,7 +266,7 @@ export async function getCompletionItems(
             return {
                 suggestions: suggestions
                     .filter(({ __typename }) => __typename === resolvedFilter.definition.suggestions)
-                    .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: true, globbing: glob }))
+                    .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: true, globbing }))
                     .filter(isDefined)
                     .map(partialCompletionItem => ({
                         ...partialCompletionItem,

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -54,7 +54,7 @@ const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] 
 
 const insertText = (name: string, isFilterValue: boolean, globbing: boolean, filter: string): string => {
     const text = globbing ? name : `^${escapeRegExp(name)}$`
-    return isFilterValue ? text : `{filter}:${text}`
+    return isFilterValue ? text : `${filter}:${text}`
 }
 
 const repositoryToCompletion = ({name}: IRepository, options: { isFilterValue: boolean, globbing: boolean }): PartialCompletionItem => ({

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -53,12 +53,7 @@ const FILTER_TYPE_COMPLETIONS: Omit<Monaco.languages.CompletionItem, 'range'>[] 
     }))
 
 const insertText = (name: string, isFilterValue: boolean, globbing: boolean, filter: string): string => {
-    let text: string;
-    if (globbing) {
-        text = `${name}`
-    } else {
-        text = `^${escapeRegExp(name)}$`
-    }
+    const text = globbing ? name : `^${escapeRegExp(name)}$`
     return isFilterValue ? text : `{filter}:${text}`
 }
 

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -71,7 +71,7 @@ const fileToCompletion = (
     { name, path, repository, isDirectory }: IFile,
     options: { isFilterValue: boolean; globbing: boolean }
 ): PartialCompletionItem => {
-    let insertText = options.globbing ? path : `^${escapeRegExp(name)}$`
+    let insertText = options.globbing ? path : `^${escapeRegExp(path)}$`
     insertText = (options.isFilterValue ? insertText : `${FilterType.file}:${insertText}`) + ' '
     return {
         label: name,

--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -75,13 +75,18 @@ export function getProviders(
             // An explicit list of trigger characters is needed for the Monaco editor to show completions.
             triggerCharacters: [':', '-', ...alphabet, ...alphabet.toUpperCase()],
             provideCompletionItems: (textModel, position, context, token) =>
-                parsedQueries
+                combineLatest([parsedQueries, globbing])
                     .pipe(
                         first(),
-                        switchMap(({ parsed }) =>
-                            parsed.type === 'error'
+                        switchMap(([parsedQueries, globbing]) =>
+                            parsedQueries.parsed.type === 'error'
                                 ? of(null)
-                                : getCompletionItems(parsed.token, position, debouncedDynamicSuggestions, globbing)
+                                : getCompletionItems(
+                                      parsedQueries.parsed.token,
+                                      position,
+                                      debouncedDynamicSuggestions,
+                                      globbing
+                                  )
                         ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )

--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -33,7 +33,8 @@ const alphabet = 'abcdefghijklmnopqrstuvwxyz'
 export function getProviders(
     searchQueries: Observable<string>,
     patternTypes: Observable<SearchPatternType>,
-    fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>
+    fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>,
+    globbing: boolean
 ): SearchFieldProviders {
     const parsedQueries = searchQueries.pipe(
         map(rawQuery => {
@@ -78,7 +79,7 @@ export function getProviders(
                         switchMap(({ parsed }) =>
                             parsed.type === 'error'
                                 ? of(null)
-                                : getCompletionItems(parsed.token, position, debouncedDynamicSuggestions)
+                                : getCompletionItems(parsed.token, position, debouncedDynamicSuggestions, globbing)
                         ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )

--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -34,7 +34,7 @@ export function getProviders(
     searchQueries: Observable<string>,
     patternTypes: Observable<SearchPatternType>,
     fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>,
-    globbing: boolean
+    globbing: Observable<boolean>
 ): SearchFieldProviders {
     const parsedQueries = searchQueries.pipe(
         map(rawQuery => {
@@ -44,7 +44,9 @@ export function getProviders(
         publishReplay(1),
         refCount()
     )
+
     const debouncedDynamicSuggestions = searchQueries.pipe(debounceTime(300), switchMap(fetchSuggestions), share())
+
     return {
         tokens: {
             getInitialState: () => PARSER_STATE,

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -123,7 +123,7 @@ export interface LayoutProps
     setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
     previousVersionContext: string | null
-
+    globbing: boolean
     isSourcegraphDotCom: boolean
     showCampaigns: boolean
     children?: never

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -64,6 +64,7 @@ import { generateFiltersQuery } from '../../shared/src/util/url'
 import { NotificationType } from '../../shared/src/api/client/services/notifications'
 import { SettingsExperimentalFeatures } from './schema/settings.schema'
 import { VersionContext } from './schema/site.schema'
+import { globbingEnabledFromSettings } from './util/globbing'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
     exploreSections: readonly ExploreSectionDescriptor[]
@@ -167,6 +168,11 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
     previousVersionContext: string | null
 
     showRepogroupHomepage: boolean
+
+    /**
+     * Whether globbing is enabled for filters.
+     */
+    globbing: boolean
 }
 
 const notificationClassNames = {
@@ -253,6 +259,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             availableVersionContexts,
             previousVersionContext,
             showRepogroupHomepage: false,
+            globbing: false,
         }
     }
 
@@ -292,6 +299,12 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
 
         this.subscriptions.add(
             from(this.platformContext.settings).subscribe(settingsCascade => this.setState({ settingsCascade }))
+        )
+
+        this.subscriptions.add(
+            from(this.platformContext.settings).subscribe(settingsCascade =>
+                this.setState({ globbing: globbingEnabledFromSettings(settingsCascade) })
+            )
         )
 
         this.subscriptions.add(
@@ -457,6 +470,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     availableVersionContexts={this.state.availableVersionContexts}
                                     previousVersionContext={this.state.previousVersionContext}
                                     showRepogroupHomepage={this.state.showRepogroupHomepage}
+                                    globbing={this.state.globbing}
                                 />
                             )}
                         />

--- a/web/src/nav/GlobalNavbar.test.tsx
+++ b/web/src/nav/GlobalNavbar.test.tsx
@@ -40,6 +40,7 @@ const PROPS: GlobalNavbar['props'] = {
     setVersionContext: () => undefined,
     availableVersionContexts: [],
     variant: 'default',
+    globbing: false,
 }
 
 describe('GlobalNavbar', () => {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -56,6 +56,9 @@ interface Props
     isSearchRelatedPage: boolean
     showCampaigns: boolean
 
+    // Whether globbing is enabled for filters.
+    globbing: boolean
+
     /**
      * Which variation of the global navbar to render.
      *

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -41,7 +41,7 @@ import { QueryState } from '../search/helpers'
 import { FiltersToTypeAndValue, FilterType } from '../../../shared/src/search/interactive/util'
 import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
-import {isGlobbingActive} from "../util/globbing";
+import {globbingEnabledFromSettings} from "../util/globbing";
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -140,7 +140,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
     }
 
     public componentDidMount(): void {
-        const globbing = isGlobbingActive(this.props.settingsCascade)
+        const globbing = globbingEnabledFromSettings(this.props.settingsCascade)
 
         const parsedRouteChanges = this.componentUpdates.pipe(
             map(props => props.match.params.repoRevAndRest),

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -41,7 +41,6 @@ import { QueryState } from '../search/helpers'
 import { FiltersToTypeAndValue, FilterType } from '../../../shared/src/search/interactive/util'
 import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
-import { globbingEnabledFromSettings } from '../util/globbing'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -41,6 +41,7 @@ import { QueryState } from '../search/helpers'
 import { FiltersToTypeAndValue, FilterType } from '../../../shared/src/search/interactive/util'
 import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
+import {isGlobbingActive} from "../util/globbing";
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -139,9 +140,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
     }
 
     public componentDidMount(): void {
-        const globbing: boolean = this.props.settingsCascade.final &&
-            !isErrorLike(this.props.settingsCascade.final) &&
-            this.props.settingsCascade.final['search.globbing']
+        const globbing = isGlobbingActive(this.props.settingsCascade)
 
         const parsedRouteChanges = this.componentUpdates.pipe(
             map(props => props.match.params.repoRevAndRest),

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -139,6 +139,10 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
     }
 
     public componentDidMount(): void {
+        const globbing: boolean = this.props.settingsCascade.final &&
+            !isErrorLike(this.props.settingsCascade.final) &&
+            this.props.settingsCascade.final['search.globbing']
+
         const parsedRouteChanges = this.componentUpdates.pipe(
             map(props => props.match.params.repoRevAndRest),
             distinctUntilChanged(),
@@ -181,9 +185,9 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
         )
 
         this.subscriptions.add(
-            parsedRouteChanges.subscribe(({ repoName, revision, rawRevision }) => {
-                this.setState({ repoName, revision, rawRevision })
-                const query = searchQueryForRepoRevision(repoName, revision)
+            parsedRouteChanges.subscribe(({repoName, revision, rawRevision}) => {
+                this.setState({repoName, revision, rawRevision})
+                const query = searchQueryForRepoRevision(repoName, globbing, revision)
                 this.props.onNavbarQueryChange({
                     query,
                     cursorPosition: query.length,
@@ -237,14 +241,14 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                         const filters: FiltersToTypeAndValue = {
                             [uniqueId('repo')]: {
                                 type: FilterType.repo,
-                                value: repoFilterForRepoRevision(repoName, revision),
+                                value: repoFilterForRepoRevision(repoName, globbing, revision),
                                 editable: false,
                             },
                         }
                         if (filePath) {
                             filters[uniqueId('file')] = {
                                 type: FilterType.file,
-                                value: `^${escapeRegExp(filePath)}`,
+                                value: globbing ? filePath : `^${escapeRegExp(filePath)}`,
                                 editable: false,
                             }
                         }
@@ -254,9 +258,9 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             cursorPosition: 0,
                         })
                     } else {
-                        let query = searchQueryForRepoRevision(repoName, revision)
+                        let query = searchQueryForRepoRevision(repoName, globbing, revision)
                         if (filePath) {
-                            query = `${query.trimEnd()} file:^${escapeRegExp(filePath)}`
+                            query = `${query.trimEnd()} file:${globbing? filePath: '^'+escapeRegExp(filePath)}`
                         }
                         this.props.onNavbarQueryChange({
                             query,

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -41,7 +41,7 @@ import { QueryState } from '../search/helpers'
 import { FiltersToTypeAndValue, FilterType } from '../../../shared/src/search/interactive/util'
 import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
-import {globbingEnabledFromSettings} from "../util/globbing";
+import { globbingEnabledFromSettings } from '../util/globbing'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -98,6 +98,7 @@ interface RepoContainerProps
     authenticatedUser: GQL.IUser | null
     onNavbarQueryChange: (state: QueryState) => void
     history: H.History
+    globbing: boolean
 }
 
 interface RepoRevContainerState extends ParsedRepoRevision {
@@ -140,8 +141,6 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
     }
 
     public componentDidMount(): void {
-        const globbing = globbingEnabledFromSettings(this.props.settingsCascade)
-
         const parsedRouteChanges = this.componentUpdates.pipe(
             map(props => props.match.params.repoRevAndRest),
             distinctUntilChanged(),
@@ -184,9 +183,9 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
         )
 
         this.subscriptions.add(
-            parsedRouteChanges.subscribe(({repoName, revision, rawRevision}) => {
-                this.setState({repoName, revision, rawRevision})
-                const query = searchQueryForRepoRevision(repoName, globbing, revision)
+            parsedRouteChanges.subscribe(({ repoName, revision, rawRevision }) => {
+                this.setState({ repoName, revision, rawRevision })
+                const query = searchQueryForRepoRevision(repoName, this.props.globbing, revision)
                 this.props.onNavbarQueryChange({
                     query,
                     cursorPosition: query.length,
@@ -240,14 +239,14 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                         const filters: FiltersToTypeAndValue = {
                             [uniqueId('repo')]: {
                                 type: FilterType.repo,
-                                value: repoFilterForRepoRevision(repoName, globbing, revision),
+                                value: repoFilterForRepoRevision(repoName, this.props.globbing, revision),
                                 editable: false,
                             },
                         }
                         if (filePath) {
                             filters[uniqueId('file')] = {
                                 type: FilterType.file,
-                                value: globbing ? filePath : `^${escapeRegExp(filePath)}`,
+                                value: this.props.globbing ? filePath : `^${escapeRegExp(filePath)}`,
                                 editable: false,
                             }
                         }
@@ -257,9 +256,11 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
                             cursorPosition: 0,
                         })
                     } else {
-                        let query = searchQueryForRepoRevision(repoName, globbing, revision)
+                        let query = searchQueryForRepoRevision(repoName, this.props.globbing, revision)
                         if (filePath) {
-                            query = `${query.trimEnd()} file:${globbing? filePath: '^'+escapeRegExp(filePath)}`
+                            query = `${query.trimEnd()} file:${
+                                this.props.globbing ? filePath : '^' + escapeRegExp(filePath)
+                            }`
                         }
                         this.props.onNavbarQueryChange({
                             query,

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -67,6 +67,8 @@ export interface RepoContainerContext
 
     onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
     onDidUpdateExternalLinks: (externalLinks: GQL.IExternalLink[] | undefined) => void
+
+    globbing: boolean
 }
 
 /** A sub-route of {@link RepoContainer}. */
@@ -327,6 +329,7 @@ export class RepoContainer extends React.Component<RepoContainerProps, RepoRevCo
             repoSettingsSidebarGroups: this.props.repoSettingsSidebarGroups,
             copyQueryButton: this.props.copyQueryButton,
             versionContext: this.props.versionContext,
+            globbing: this.props.globbing,
         }
 
         return (

--- a/web/src/repo/RepoRevisionContainer.tsx
+++ b/web/src/repo/RepoRevisionContainer.tsx
@@ -64,6 +64,8 @@ export interface RepoRevisionContainerContext
 
     /** The URL route match for {@link RepoRevisionContainer}. */
     routePrefix: string
+
+    globbing: boolean
 }
 
 /** A sub-route of {@link RepoRevisionContainer}. */
@@ -99,6 +101,8 @@ interface RepoRevisionContainerProps
     /** Called when the resolvedRevOrError state in this component's parent should be updated. */
     onResolvedRevisionOrError: (v: ResolvedRevision | ErrorLike | undefined) => void
     history: H.History
+
+    globbing: boolean
 }
 
 interface RepoRevisionContainerState {}
@@ -240,6 +244,7 @@ export class RepoRevisionContainer extends React.PureComponent<RepoRevisionConta
             repoSettingsSidebarGroups: this.props.repoSettingsSidebarGroups,
             copyQueryButton: this.props.copyQueryButton,
             versionContext: this.props.versionContext,
+            globbing: this.props.globbing,
         }
 
         return (

--- a/web/src/repo/routes.tsx
+++ b/web/src/repo/routes.tsx
@@ -99,6 +99,7 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
             setCaseSensitivity,
             copyQueryButton,
             versionContext,
+            globbing,
             ...context
         }: RepoRevisionContainerContext &
             RouteComponentProps<{
@@ -142,6 +143,7 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                 setCaseSensitivity,
                 copyQueryButton,
                 versionContext,
+                globbing,
             }
 
             return (

--- a/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -24,6 +24,7 @@ interface Props
         RepoHeaderContributionsLifecycleProps,
         Omit<PatternTypeProps, 'setPatternType'> {
     repo: GQL.IRepository
+    globbing: boolean
 }
 
 /**
@@ -72,6 +73,7 @@ export class RepositoryStatsArea extends React.Component<Props> {
                                 {...routeComponentProps}
                                 {...transferProps}
                                 patternType={this.props.patternType}
+                                globbing={this.props.globbing}
                             />
                         )}
                     />

--- a/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -29,6 +29,7 @@ interface QuerySpec {
 interface RepositoryContributorNodeProps extends QuerySpec, Omit<PatternTypeProps, 'setPatternType'> {
     node: GQL.IRepositoryContributor
     repoName: string
+    globbing: boolean
 }
 
 const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNodeProps> = ({
@@ -38,11 +39,12 @@ const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNo
     after,
     path,
     patternType,
+    globbing,
 }) => {
     const commit = node.commits.nodes[0] as GQL.IGitCommit | undefined
 
     const query: string = [
-        searchQueryForRepoRevision(repoName),
+        searchQueryForRepoRevision(repoName, globbing),
         'type:diff',
         `author:${quoteIfNeeded(node.person.email)}`,
         after ? `after:${quoteIfNeeded(after)}` : '',
@@ -160,11 +162,13 @@ const equalOrEmpty = (a: string | null, b: string | null): boolean => a === b ||
 interface Props
     extends RepositoryStatsAreaPageProps,
         RouteComponentProps<{}>,
-        Omit<PatternTypeProps, 'setPatternType'> {}
+        Omit<PatternTypeProps, 'setPatternType'> {
+    globbing: boolean
+}
 
 class FilteredContributorsConnection extends FilteredConnection<
     GQL.IRepositoryContributor,
-    Pick<RepositoryContributorNodeProps, 'repoName' | 'revisionRange' | 'after' | 'path' | 'patternType'>
+    Pick<RepositoryContributorNodeProps, 'repoName' | 'revisionRange' | 'after' | 'path' | 'patternType' | 'globbing'>
 > {}
 
 interface State extends QuerySpec {}
@@ -354,6 +358,7 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                         after,
                         path,
                         patternType: this.props.patternType,
+                        globbing: this.props.globbing,
                     }}
                     defaultFirst={20}
                     hideSearch={true}

--- a/web/src/repo/tree/TreePage.tsx
+++ b/web/src/repo/tree/TreePage.tsx
@@ -163,6 +163,7 @@ interface Props
     revision: string
     location: H.Location
     history: H.History
+    globbing: boolean
 }
 
 export const TreePage: React.FunctionComponent<Props> = ({

--- a/web/src/repogroups/RepogroupPage.story.tsx
+++ b/web/src/repogroups/RepogroupPage.story.tsx
@@ -169,6 +169,7 @@ const commonProps: RepogroupPageProps = {
     authenticatedUser: authUser,
     repogroupMetadata: python2To3Metadata,
     autoFocus: false,
+    globbing: false,
 }
 
 add('Repogroup page with smart search field', () => (

--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -61,6 +61,9 @@ export interface RepogroupPageProps
 
     // Repogroup page metadata
     repogroupMetadata: RepogroupMetadata
+
+    /** Whether globbing is enabled for filters. */
+    globbing: boolean
 }
 
 export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props: RepogroupPageProps) => {

--- a/web/src/search/ScopePage.test.tsx
+++ b/web/src/search/ScopePage.test.tsx
@@ -37,6 +37,7 @@ describe('ScopePage', () => {
                             location={location}
                             copyQueryButton={false}
                             versionContext={undefined}
+                            globbing={false}
                         />
                     </MemoryRouter>
                 )

--- a/web/src/search/ScopePage.tsx
+++ b/web/src/search/ScopePage.tsx
@@ -50,6 +50,9 @@ interface Props
     authenticatedUser: GQL.IUser | null
     onNavbarQueryChange: (queryState: QueryState) => void
     history: H.History
+
+    /** Whether globbing is enabled for filters. */
+    globbing: boolean
 }
 
 /**

--- a/web/src/search/__snapshots__/ScopePage.test.tsx.snap
+++ b/web/src/search/__snapshots__/ScopePage.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`ScopePage renders 1`] = `
         autoFocus={true}
         caseSensitive={false}
         copyQueryButton={false}
+        globbing={false}
         history={
           Object {
             "action": "POP",

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -108,12 +108,15 @@ export function parseSearchURL(
     }
 }
 
-export function repoFilterForRepoRevision(repoName: string, revision?: string): string {
+export function repoFilterForRepoRevision(repoName: string, globbing: boolean, revision?: string): string {
+    if (globbing) {
+        return `${quoteIfNeeded(`${repoName}${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
+    }
     return `${quoteIfNeeded(`^${escapeRegExp(repoName)}$${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
 }
 
-export function searchQueryForRepoRevision(repoName: string, revision?: string): string {
-    return `repo:${repoFilterForRepoRevision(repoName, revision)} `
+export function searchQueryForRepoRevision(repoName: string, globbing: boolean, revision?: string): string {
+    return `repo:${repoFilterForRepoRevision(repoName, globbing, revision)} `
 }
 
 function abbreviateOID(oid: string): string {

--- a/web/src/search/input/LazyMonacoQueryInput.test.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.test.tsx
@@ -28,6 +28,7 @@ describe('PlainQueryInput', () => {
                         settingsCascade={{ subjects: [], final: {} }}
                         copyQueryButton={false}
                         versionContext={undefined}
+                        globbing={false}
                     />
                 )
                 .toJSON()
@@ -54,6 +55,7 @@ describe('PlainQueryInput', () => {
                         settingsCascade={{ subjects: [], final: {} }}
                         copyQueryButton={false}
                         versionContext={undefined}
+                        globbing={false}
                     />
                 )
                 .toJSON()

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -17,7 +17,6 @@ import { hasProperty, isDefined } from '../../../../shared/src/util/types'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import { observeResize } from '../../util/dom'
-import { globbingEnabledFromSettings } from '../../util/globbing'
 
 export interface MonacoQueryInputProps
     extends Omit<TogglesProps, 'navbarSearchQuery' | 'filtersInQuery'>,

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -17,7 +17,7 @@ import { hasProperty, isDefined } from '../../../../shared/src/util/types'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import { observeResize } from '../../util/dom'
-import {isErrorLike} from "../../../../shared/src/util/errors";
+import {isGlobbingActive} from '../../util/globbing';
 
 export interface MonacoQueryInputProps
     extends Omit<TogglesProps, 'navbarSearchQuery' | 'filtersInQuery'>,
@@ -233,10 +233,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
 
     private editorWillMount = (monaco: typeof Monaco): void => {
         // Register themes and code intelligence providers.
-        const globbing: boolean = this.props.settingsCascade.final &&
-            !isErrorLike(this.props.settingsCascade.final) &&
-            this.props.settingsCascade.final['search.globbing']
-
+        const globbing = isGlobbingActive(this.props.settingsCascade)
         this.subscriptions.add(addSouregraphSearchCodeIntelligence(monaco, this.searchQueries, this.patternTypes, globbing))
     }
 

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -17,7 +17,7 @@ import { hasProperty, isDefined } from '../../../../shared/src/util/types'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import { observeResize } from '../../util/dom'
-import {isGlobbingActive} from '../../util/globbing';
+import {globbingEnabledFromSettings} from '../../util/globbing';
 
 export interface MonacoQueryInputProps
     extends Omit<TogglesProps, 'navbarSearchQuery' | 'filtersInQuery'>,
@@ -233,7 +233,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
 
     private editorWillMount = (monaco: typeof Monaco): void => {
         // Register themes and code intelligence providers.
-        const globbing = isGlobbingActive(this.props.settingsCascade)
+        const globbing = globbingEnabledFromSettings(this.props.settingsCascade)
         this.subscriptions.add(addSouregraphSearchCodeIntelligence(monaco, this.searchQueries, this.patternTypes, globbing))
     }
 

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -27,11 +27,13 @@ export interface MonacoQueryInputProps
     location: H.Location
     history: H.History
     queryState: QueryState
-    globbing: boolean
     onChange: (newState: QueryState) => void
     onSubmit: () => void
     autoFocus?: boolean
     keyboardShortcutForFocus?: KeyboardShortcut
+
+    // Whether globbing is enabled for filters.
+    globbing: boolean
 }
 
 const SOURCEGRAPH_SEARCH = 'sourcegraphSearch' as const

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -39,9 +39,8 @@ import { Toggles } from './toggles/Toggles'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { Shortcut } from '@slimsag/react-shortcuts'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
-import {isErrorLike} from '../../../../shared/src/util/errors';
-import {SearchSuggestion} from "../../../../shared/src/search/suggestions";
-import {globbingEnabledFromSettings} from "../../util/globbing";
+import { isErrorLike } from '../../../../shared/src/util/errors'
+import { SearchSuggestion } from '../../../../shared/src/search/suggestions'
 
 interface Props
     extends PatternTypeProps,
@@ -93,6 +92,8 @@ interface Props
 
     /** Keyboard shortcut to focus the query input. */
     keyboardShortcutForFocus?: KeyboardShortcut
+
+    globbing: boolean
 }
 
 /**
@@ -147,8 +148,6 @@ export class QueryInput extends React.Component<Props, State> {
 
     constructor(props: Props) {
         super(props)
-
-        const globbing = globbingEnabledFromSettings(this.props.settingsCascade)
 
         // Update parent component
         // (will be used in next PR to push to queryHistory (undo/redo))
@@ -218,7 +217,7 @@ export class QueryInput extends React.Component<Props, State> {
                             const fuzzySearchSuggestions = fetchSuggestions(fullQuery).pipe(
                                 map((suggestions): Suggestion[] =>
                                     suggestions
-                                        .map((item: SearchSuggestion) => createSuggestion(item, globbing))
+                                        .map((item: SearchSuggestion) => createSuggestion(item, this.props.globbing))
                                         .filter(isDefined)
                                         .map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true }))
                                         .filter(suggestion => {

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -39,7 +39,6 @@ import { Toggles } from './toggles/Toggles'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { Shortcut } from '@slimsag/react-shortcuts'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
-import { isErrorLike } from '../../../../shared/src/util/errors'
 import { SearchSuggestion } from '../../../../shared/src/search/suggestions'
 
 interface Props

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -39,6 +39,8 @@ import { Toggles } from './toggles/Toggles'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { Shortcut } from '@slimsag/react-shortcuts'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
+import {isErrorLike} from '../../../../shared/src/util/errors';
+import {SearchSuggestion} from "../../../../shared/src/search/suggestions";
 
 interface Props
     extends PatternTypeProps,
@@ -145,6 +147,10 @@ export class QueryInput extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
 
+        const globbing: boolean = this.props.settingsCascade.final &&
+            !isErrorLike(this.props.settingsCascade.final) &&
+            this.props.settingsCascade.final['search.globbing']
+
         // Update parent component
         // (will be used in next PR to push to queryHistory (undo/redo))
         this.subscriptions.add(this.inputValues.subscribe(queryState => this.props.onChange(queryState)))
@@ -213,7 +219,7 @@ export class QueryInput extends React.Component<Props, State> {
                             const fuzzySearchSuggestions = fetchSuggestions(fullQuery).pipe(
                                 map((suggestions): Suggestion[] =>
                                     suggestions
-                                        .map(createSuggestion)
+                                        .map((item: SearchSuggestion) => createSuggestion(item, globbing))
                                         .filter(isDefined)
                                         .map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true }))
                                         .filter(suggestion => {

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -41,7 +41,7 @@ import { Shortcut } from '@slimsag/react-shortcuts'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import {isErrorLike} from '../../../../shared/src/util/errors';
 import {SearchSuggestion} from "../../../../shared/src/search/suggestions";
-import {isGlobbingActive} from "../../util/globbing";
+import {globbingEnabledFromSettings} from "../../util/globbing";
 
 interface Props
     extends PatternTypeProps,
@@ -148,7 +148,7 @@ export class QueryInput extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
 
-        const globbing = isGlobbingActive(this.props.settingsCascade)
+        const globbing = globbingEnabledFromSettings(this.props.settingsCascade)
 
         // Update parent component
         // (will be used in next PR to push to queryHistory (undo/redo))

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -41,6 +41,7 @@ import { Shortcut } from '@slimsag/react-shortcuts'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import {isErrorLike} from '../../../../shared/src/util/errors';
 import {SearchSuggestion} from "../../../../shared/src/search/suggestions";
+import {isGlobbingActive} from "../../util/globbing";
 
 interface Props
     extends PatternTypeProps,
@@ -147,9 +148,7 @@ export class QueryInput extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
 
-        const globbing: boolean = this.props.settingsCascade.final &&
-            !isErrorLike(this.props.settingsCascade.final) &&
-            this.props.settingsCascade.final['search.globbing']
+        const globbing = isGlobbingActive(this.props.settingsCascade)
 
         // Update parent component
         // (will be used in next PR to push to queryHistory (undo/redo))

--- a/web/src/search/input/QueryInput.tsx
+++ b/web/src/search/input/QueryInput.tsx
@@ -92,6 +92,7 @@ interface Props
     /** Keyboard shortcut to focus the query input. */
     keyboardShortcutForFocus?: KeyboardShortcut
 
+    /** Whether globbing is enabled for filters. */
     globbing: boolean
 }
 

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -25,6 +25,7 @@ interface Props
     history: H.History
     navbarSearchState: QueryState
     onChange: (newValue: QueryState) => void
+    globbing: boolean
 }
 
 /**

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -53,13 +53,15 @@ interface Props
     location: H.Location
     history: H.History
     isSourcegraphDotCom: boolean
-    globbing: boolean
     setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 
     // For NavLinks
     authRequired?: boolean
     showCampaigns: boolean
+
+    // Whether globbing is enabled for filters.
+    globbing: boolean
 }
 
 /**

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -53,6 +53,7 @@ interface Props
     location: H.Location
     history: H.History
     isSourcegraphDotCom: boolean
+    globbing: boolean
     setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
 

--- a/web/src/search/input/SearchPageInput.tsx
+++ b/web/src/search/input/SearchPageInput.tsx
@@ -54,6 +54,7 @@ interface Props
     isSourcegraphDotCom: boolean
     setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
+    /** Whether globbing is enabled for filters. */
     globbing: boolean
     /** Whether to display the interactive mode input centered on the page, as on the search homepage. */
     interactiveModeHomepageMode?: boolean

--- a/web/src/search/input/SearchPageInput.tsx
+++ b/web/src/search/input/SearchPageInput.tsx
@@ -54,7 +54,7 @@ interface Props
     isSourcegraphDotCom: boolean
     setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
-
+    globbing: boolean
     /** Whether to display the interactive mode input centered on the page, as on the search homepage. */
     interactiveModeHomepageMode?: boolean
     /** A query fragment to appear at the beginning of the input. */

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -73,14 +73,14 @@ interface SuggestionIconProps {
  */
 const formatRegExp = (value: string): string => '^' + escapeRegExp(value) + '$'
 
-export function createSuggestion(item: SearchSuggestion): Suggestion | undefined {
+export function createSuggestion(item: SearchSuggestion, globbing:boolean): Suggestion | undefined {
     switch (item.__typename) {
         case 'Repository': {
             return {
                 type: FilterType.repo,
                 // Add "regex start and end boundaries" to
                 // correctly scope additional suggestions
-                value: formatRegExp(item.name),
+                value: globbing ? item.name : formatRegExp(item.name),
                 displayValue: item.name,
                 url: `/${item.name}`,
                 label: 'go to repository',
@@ -96,7 +96,7 @@ export function createSuggestion(item: SearchSuggestion): Suggestion | undefined
             if (item.isDirectory) {
                 return {
                     type: NonFilterSuggestionType.Directory,
-                    value: '^' + escapeRegExp(item.path),
+                    value: globbing ? item.path :'^' + escapeRegExp(item.path),
                     description: descriptionParts.join(' — '),
                     url: appendSubtreeQueryParameter(item.url),
                     label: 'go to dir',
@@ -104,7 +104,7 @@ export function createSuggestion(item: SearchSuggestion): Suggestion | undefined
             }
             return {
                 type: FilterType.file,
-                value: formatRegExp(item.path),
+                value: globbing ? item.path : formatRegExp(item.path),
                 displayValue: item.name,
                 description: descriptionParts.join(' — '),
                 url: appendSubtreeQueryParameter(item.url),

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -73,7 +73,7 @@ interface SuggestionIconProps {
  */
 const formatRegExp = (value: string): string => '^' + escapeRegExp(value) + '$'
 
-export function createSuggestion(item: SearchSuggestion, globbing:boolean): Suggestion | undefined {
+export function createSuggestion(item: SearchSuggestion, globbing: boolean): Suggestion | undefined {
     switch (item.__typename) {
         case 'Repository': {
             return {
@@ -96,7 +96,7 @@ export function createSuggestion(item: SearchSuggestion, globbing:boolean): Sugg
             if (item.isDirectory) {
                 return {
                     type: NonFilterSuggestionType.Directory,
-                    value: globbing ? item.path :'^' + escapeRegExp(item.path),
+                    value: globbing ? item.path : '^' + escapeRegExp(item.path),
                     description: descriptionParts.join(' — '),
                     url: appendSubtreeQueryParameter(item.url),
                     label: 'go to dir',

--- a/web/src/search/input/interactive/FilterInput.test.tsx
+++ b/web/src/search/input/interactive/FilterInput.test.tsx
@@ -21,6 +21,7 @@ const defaultProps = {
     editable: true,
     negated: false,
     isHomepage: false,
+    globbing: true,
     onSubmit: sinon.spy(),
     onFilterEdited: sinon.spy(),
     onFilterDeleted: sinon.spy(),

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -74,6 +74,8 @@ interface Props extends Pick<InteractiveSearchProps, 'filtersInQuery'> {
 
     isHomepage: boolean
 
+    globbing: boolean
+
     /**
      * Callback that handles a filter input being submitted. Triggers a search
      * with the new query value.
@@ -190,7 +192,7 @@ export class FilterInput extends React.Component<Props, State> {
                         const suggestions = fetchSuggestions(fullQuery).pipe(
                             map((suggestions): Suggestion[] =>
                                 suggestions
-                                    .map(createSuggestion)
+                                    .map(item =>  createSuggestion(item, props.globbing))
                                     .filter(isDefined)
                                     .map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true }))
                                     .filter(suggestion => {

--- a/web/src/search/input/interactive/FilterInput.tsx
+++ b/web/src/search/input/interactive/FilterInput.tsx
@@ -74,6 +74,9 @@ interface Props extends Pick<InteractiveSearchProps, 'filtersInQuery'> {
 
     isHomepage: boolean
 
+    /**
+     * Whether globbing is enabled for filters.
+     */
     globbing: boolean
 
     /**
@@ -192,7 +195,7 @@ export class FilterInput extends React.Component<Props, State> {
                         const suggestions = fetchSuggestions(fullQuery).pipe(
                             map((suggestions): Suggestion[] =>
                                 suggestions
-                                    .map(item =>  createSuggestion(item, props.globbing))
+                                    .map(item => createSuggestion(item, props.globbing))
                                     .filter(isDefined)
                                     .map((suggestion): Suggestion => ({ ...suggestion, fromFuzzySearch: true }))
                                     .filter(suggestion => {

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -33,7 +33,7 @@ import { isSingularFilter } from '../../../../../shared/src/search/parser/filter
 import { VersionContextDropdown } from '../../../nav/VersionContextDropdown'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
 import { VersionContext } from '../../../schema/site.schema'
-import {isGlobbingActive} from '../../../util/globbing';
+import {globbingEnabledFromSettings} from '../../../util/globbing';
 
 interface InteractiveModeProps
     extends SettingsCascadeProps,
@@ -276,7 +276,7 @@ export class InteractiveModeInput extends React.Component<InteractiveModeProps, 
                 {!this.props.lowProfile && (
                     <div>
                         <SelectedFiltersRow
-                            globbing={isGlobbingActive(this.props.settingsCascade)}
+                            globbing={globbingEnabledFromSettings(this.props.settingsCascade)}
                             filtersInQuery={this.props.filtersInQuery}
                             navbarQuery={this.props.navbarSearchState}
                             onSubmit={this.onSubmit}

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -33,7 +33,7 @@ import { isSingularFilter } from '../../../../../shared/src/search/parser/filter
 import { VersionContextDropdown } from '../../../nav/VersionContextDropdown'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
 import { VersionContext } from '../../../schema/site.schema'
-import {isErrorLike} from "../../../../../shared/src/util/errors";
+import {isGlobbingActive} from '../../../util/globbing';
 
 interface InteractiveModeProps
     extends SettingsCascadeProps,
@@ -276,9 +276,7 @@ export class InteractiveModeInput extends React.Component<InteractiveModeProps, 
                 {!this.props.lowProfile && (
                     <div>
                         <SelectedFiltersRow
-                            globbing={this.props.settingsCascade.final &&
-                            !isErrorLike(this.props.settingsCascade.final) &&
-                            this.props.settingsCascade.final['search.globbing']}
+                            globbing={isGlobbingActive(this.props.settingsCascade)}
                             filtersInQuery={this.props.filtersInQuery}
                             navbarQuery={this.props.navbarSearchState}
                             onSubmit={this.onSubmit}

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -33,6 +33,7 @@ import { isSingularFilter } from '../../../../../shared/src/search/parser/filter
 import { VersionContextDropdown } from '../../../nav/VersionContextDropdown'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
 import { VersionContext } from '../../../schema/site.schema'
+import {isErrorLike} from "../../../../../shared/src/util/errors";
 
 interface InteractiveModeProps
     extends SettingsCascadeProps,
@@ -275,6 +276,9 @@ export class InteractiveModeInput extends React.Component<InteractiveModeProps, 
                 {!this.props.lowProfile && (
                     <div>
                         <SelectedFiltersRow
+                            globbing={this.props.settingsCascade.final &&
+                            !isErrorLike(this.props.settingsCascade.final) &&
+                            this.props.settingsCascade.final['search.globbing']}
                             filtersInQuery={this.props.filtersInQuery}
                             navbarQuery={this.props.navbarSearchState}
                             onSubmit={this.onSubmit}

--- a/web/src/search/input/interactive/InteractiveModeInput.tsx
+++ b/web/src/search/input/interactive/InteractiveModeInput.tsx
@@ -33,7 +33,7 @@ import { isSingularFilter } from '../../../../../shared/src/search/parser/filter
 import { VersionContextDropdown } from '../../../nav/VersionContextDropdown'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
 import { VersionContext } from '../../../schema/site.schema'
-import {globbingEnabledFromSettings} from '../../../util/globbing';
+import { globbingEnabledFromSettings } from '../../../util/globbing'
 
 interface InteractiveModeProps
     extends SettingsCascadeProps,
@@ -53,6 +53,10 @@ interface InteractiveModeProps
     history: H.History
     navbarSearchState: QueryState
     onNavbarQueryChange: (userQuery: QueryState) => void
+
+    /** Whether globbing is enabled for filters. */
+    globbing: boolean
+
     /** Whether to hide the selected filters and add filter rows. */
     lowProfile: boolean
 

--- a/web/src/search/input/interactive/SelectedFiltersRow.tsx
+++ b/web/src/search/input/interactive/SelectedFiltersRow.tsx
@@ -39,6 +39,8 @@ interface Props extends Pick<InteractiveSearchProps, 'filtersInQuery'> {
      * Whether we're on the search homepage.
      */
     isHomepage: boolean
+
+    globbing: boolean
 }
 
 /**
@@ -53,6 +55,7 @@ export const SelectedFiltersRow: React.FunctionComponent<Props> = ({
     toggleFilterEditable,
     toggleFilterNegated,
     isHomepage,
+    globbing
 }) => {
     const filterKeys = Object.keys(filtersInQuery)
     return (
@@ -63,6 +66,7 @@ export const SelectedFiltersRow: React.FunctionComponent<Props> = ({
                         filterKeys.map(field => (
                             /** Replace this with new input component, which can be an input when editable, and button when non-editable */
                             <FilterInput
+                                globbing={globbing}
                                 key={field}
                                 mapKey={field}
                                 filterType={filtersInQuery[field].type as Exclude<FilterType, FilterType.patterntype>}

--- a/web/src/search/input/interactive/SelectedFiltersRow.tsx
+++ b/web/src/search/input/interactive/SelectedFiltersRow.tsx
@@ -40,6 +40,9 @@ interface Props extends Pick<InteractiveSearchProps, 'filtersInQuery'> {
      */
     isHomepage: boolean
 
+    /**
+     * Whether globbing is enabled for filters.
+     */
     globbing: boolean
 }
 
@@ -55,7 +58,7 @@ export const SelectedFiltersRow: React.FunctionComponent<Props> = ({
     toggleFilterEditable,
     toggleFilterNegated,
     isHomepage,
-    globbing
+    globbing,
 }) => {
     const filterKeys = Object.keys(filtersInQuery)
     return (

--- a/web/src/util/globbing.ts
+++ b/web/src/util/globbing.ts
@@ -4,6 +4,6 @@ import {isErrorLike} from '../../../shared/src/util/errors';
 /**
  * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise
  */
-export const isGlobbingActive = (settings: SettingsCascadeOrError): boolean => settings.final &&
+export const globbingEnabledFromSettings = (settings: SettingsCascadeOrError): boolean => settings.final &&
     !isErrorLike(settings.final) &&
     settings.final['search.globbing']

--- a/web/src/util/globbing.ts
+++ b/web/src/util/globbing.ts
@@ -1,9 +1,8 @@
-import {SettingsCascadeOrError,} from '../../../shared/src/settings/settings'
-import {isErrorLike} from '../../../shared/src/util/errors';
+import { SettingsCascadeOrError } from '../../../shared/src/settings/settings'
+import { isErrorLike } from '../../../shared/src/util/errors'
 
 /**
  * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise
  */
-export const globbingEnabledFromSettings = (settings: SettingsCascadeOrError): boolean => settings.final &&
-    !isErrorLike(settings.final) &&
-    settings.final['search.globbing']
+export const globbingEnabledFromSettings = (settings: SettingsCascadeOrError): boolean =>
+    settings.final && !isErrorLike(settings.final) && settings.final['search.globbing']

--- a/web/src/util/globbing.ts
+++ b/web/src/util/globbing.ts
@@ -1,0 +1,9 @@
+import {SettingsCascadeOrError,} from '../../../shared/src/settings/settings'
+import {isErrorLike} from '../../../shared/src/util/errors';
+
+/**
+ * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise
+ */
+export const isGlobbingActive = (settings: SettingsCascadeOrError): boolean => settings.final &&
+    !isErrorLike(settings.final) &&
+    settings.final['search.globbing']

--- a/web/src/views/QueryInputInViewContent.tsx
+++ b/web/src/views/QueryInputInViewContent.tsx
@@ -18,6 +18,9 @@ interface Props
 
     location: H.Location
     history: H.History
+
+    /** Whether globbing is enabled for filters. */
+    globbing: true
 }
 
 /**

--- a/web/src/views/QueryInputInViewContent.tsx
+++ b/web/src/views/QueryInputInViewContent.tsx
@@ -20,7 +20,7 @@ interface Props
     history: H.History
 
     /** Whether globbing is enabled for filters. */
-    globbing: true
+    globbing: boolean
 }
 
 /**

--- a/web/src/views/ViewContent.tsx
+++ b/web/src/views/ViewContent.tsx
@@ -24,6 +24,7 @@ export interface ViewContentProps
     viewContent: View['content']
     location: H.Location
     history: H.History
+    globbing: boolean
 }
 
 /**

--- a/web/src/views/ViewPage.test.tsx
+++ b/web/src/views/ViewPage.test.tsx
@@ -21,6 +21,7 @@ const commonProps: Omit<React.ComponentProps<typeof ViewPage>, 'viewID' | 'extra
     extensionsController: { services: { contribution: { getContributions: () => ({}) } } } as Controller,
     copyQueryButton: false,
     versionContext: undefined,
+    globbing: false,
 }
 
 describe('ViewPage', () => {

--- a/web/src/views/ViewsArea.tsx
+++ b/web/src/views/ViewsArea.tsx
@@ -13,7 +13,9 @@ interface Props
         PatternTypeProps,
         CaseSensitivityProps,
         CopyQueryButtonProps,
-        VersionContextProps {}
+        VersionContextProps {
+    globbing: boolean
+}
 
 /**
  * The area that handles /views routes, displaying the requested view (contributed by an extension)

--- a/web/src/views/__snapshots__/ViewPage.test.tsx.snap
+++ b/web/src/views/__snapshots__/ViewPage.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`ViewPage renders view 1`] = `
     <QueryInputInViewContent
       caseSensitive={false}
       copyQueryButton={false}
+      globbing={false}
       history={
         Object {
           "action": "POP",


### PR DESCRIPTION
This PR builds on top of https://github.com/sourcegraph/sourcegraph/pull/12093 and #12365

For additional context see [RFC198](https://docs.google.com/document/d/1OPyX4KbgUgdeRxvVkm1gRS0PiUtxfO9hAgaNUoMdd2Y/edit#heading=h.trqab8y0kufp)

We want to support globbing for fields repo, file, and repohasfile. #12093 contains the changes in the backend. However, the frontend still adds regex anchors `^` and `$` when navigating the UI. This essentially breaks search when globbing is active.

![image](https://user-images.githubusercontent.com/26413131/87770408-4aa39f80-c81f-11ea-8b86-cca1f94583f4.png)

This PR adds globbing awareness to
- completion
- suggestion
- filters

To test locally, set the following settings:

```
{
    "search.globbing": true,
    "search.migrateParser": true
}
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
