### PR TITLE
leader: Add a leader election package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -216,6 +216,7 @@ Dockerfile @sourcegraph/distribution
 # Backend shared packages
 /internal/endpoint/ @keegancsmith @slimsag
 /internal/rcache/ @keegancsmith
+/internal/leader @sourcegraph/cloud
 /internal/redispool/ @keegancsmith
 /internal/store/ @keegancsmith
 /internal/metrics @keegancsmith @slimsag

--- a/internal/leader/leader.go
+++ b/internal/leader/leader.go
@@ -1,0 +1,45 @@
+package leader
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+)
+
+const (
+	defaultAcquireInterval = 30 * time.Second
+)
+
+type Options struct {
+	// AcquireInterval defines how frequently we should attempt to acquire
+	// leadership when not the leader.
+	AcquireInterval time.Duration
+	MutexOptions    rcache.MutexOptions
+}
+
+// Do will ensure that only one instance of workFn is running globally per key at any point using a mutex
+// stored in Redis.
+// workFn could lose leadership at any point so it is important that the supplied context is checked before performing
+// any work that should not run in parallel with another worker.
+// release can be called from within workFn to explicitly release the lock.
+func Do(ctx context.Context, key string, workFn func(ctx context.Context, release func()), options Options) {
+	if options.AcquireInterval == 0 {
+		options.AcquireInterval = defaultAcquireInterval
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		ctx, cancel, ok := rcache.TryAcquireMutex(ctx, key, options.MutexOptions)
+		if !ok {
+			time.Sleep(options.AcquireInterval)
+			continue
+		}
+
+		workFn(ctx, cancel)
+	}
+}

--- a/internal/leader/leader.go
+++ b/internal/leader/leader.go
@@ -24,7 +24,7 @@ type Options struct {
 // workFn could lose leadership at any point so it is important that the supplied context is checked before performing
 // any work that should not run in parallel with another worker.
 // release can be called from within workFn to explicitly release the lock.
-func Do(parentCtx context.Context, key string, workFn func(ctx context.Context), options Options) {
+func Do(parentCtx context.Context, key string, options Options, workFn func(ctx context.Context)) {
 	if options.AcquireInterval == 0 {
 		options.AcquireInterval = defaultAcquireInterval
 	}

--- a/internal/leader/leader_test.go
+++ b/internal/leader/leader_test.go
@@ -1,0 +1,50 @@
+package leader
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+)
+
+func TestDoWhileLeader(t *testing.T) {
+	rcache.SetupForTest(t)
+
+	key := "test-leader"
+	ctx, cancel := context.WithCancel(context.Background())
+	// In case we don't make it to cancel lower down
+	t.Cleanup(cancel)
+
+	var count int64
+
+	fn := func(ctx context.Context, release func()) {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		atomic.AddInt64(&count, 1)
+		defer release()
+		<-ctx.Done()
+	}
+
+	options := Options{
+		AcquireInterval: 50 * time.Millisecond,
+		MutexOptions: rcache.MutexOptions{
+			Tries:      1,
+			RetryDelay: 10 * time.Millisecond,
+		},
+	}
+
+	go Do(ctx, key, fn, options)
+	go Do(ctx, key, fn, options)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	if count != 1 {
+		t.Fatalf("Count > 1: %d", count)
+	}
+}

--- a/internal/leader/leader_test.go
+++ b/internal/leader/leader_test.go
@@ -37,8 +37,8 @@ func TestDoWhileLeader(t *testing.T) {
 		},
 	}
 
-	go Do(ctx, key, fn, options)
-	go Do(ctx, key, fn, options)
+	go Do(ctx, key, options, fn)
+	go Do(ctx, key, options, fn)
 
 	time.Sleep(500 * time.Millisecond)
 	cancel()

--- a/internal/leader/leader_test.go
+++ b/internal/leader/leader_test.go
@@ -19,14 +19,13 @@ func TestDoWhileLeader(t *testing.T) {
 
 	var count int64
 
-	fn := func(ctx context.Context, release func()) {
+	fn := func(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 		}
 		atomic.AddInt64(&count, 1)
-		defer release()
 		<-ctx.Done()
 	}
 

--- a/internal/rcache/mutex_test.go
+++ b/internal/rcache/mutex_test.go
@@ -8,12 +8,17 @@ import (
 func TestTryAcquireMutex(t *testing.T) {
 	SetupForTest(t)
 
-	ctx, release, ok := TryAcquireMutex(context.Background(), "test")
+	options := MutexOptions{
+		// Make mutex fails faster
+		Tries: 1,
+	}
+
+	ctx, release, ok := TryAcquireMutex(context.Background(), "test", options)
 	if !ok {
 		t.Fatalf("expected to acquire mutex")
 	}
 
-	if _, _, ok = TryAcquireMutex(context.Background(), "test"); ok {
+	if _, _, ok = TryAcquireMutex(context.Background(), "test", options); ok {
 		t.Fatalf("expected to fail to acquire mutex")
 	}
 
@@ -24,14 +29,14 @@ func TestTryAcquireMutex(t *testing.T) {
 
 	// Test out if cancelling the parent context allows us to still release
 	ctx, cancel := context.WithCancel(context.Background())
-	_, release, ok = TryAcquireMutex(ctx, "test")
+	_, release, ok = TryAcquireMutex(ctx, "test", options)
 	if !ok {
 		t.Fatalf("expected to acquire mutex")
 	}
 	cancel()
 	release()
 
-	_, release, ok = TryAcquireMutex(context.Background(), "test")
+	_, release, ok = TryAcquireMutex(context.Background(), "test", options)
 	if !ok {
 		t.Fatalf("expected to acquire mutex")
 	}

--- a/internal/rcache/mutex_test.go
+++ b/internal/rcache/mutex_test.go
@@ -9,7 +9,7 @@ func TestTryAcquireMutex(t *testing.T) {
 	SetupForTest(t)
 
 	options := MutexOptions{
-		// Make mutex fails faster
+		// Make mutex fail faster
 		Tries: 1,
 	}
 

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -195,8 +195,6 @@ func SetupForTest(t TB) {
 	}
 
 	globalPrefix = "__test__" + t.Name()
-	// Make mutex fails faster
-	mutexTries = 1
 	c := pool.Get()
 	defer c.Close()
 


### PR DESCRIPTION
This adds a small package to help with leader election around our Redis based mutex.

An example of how it could be used:

In `repo-updater`, instead of:

```go
go syncCloned(ctx, scheduler, gitserver.DefaultClient, store)
```

We would run:

```go
go leader.Do(ctx, "repo-updater:syncCloned", func(ctx context.Context, release func()) {
    defer release()
    syncCloned(ctx, scheduler, gitserver.DefaultClient, store)
}, leader.Options{})
```
