### PR TITLE
Add integration tests for spaces in paths

### DIFF
--- a/web/src/integration/graphQlResponseHelpers.ts
+++ b/web/src/integration/graphQlResponseHelpers.ts
@@ -57,27 +57,27 @@ export const createFileExternalLinksResult = (
 })
 
 export const createRepositoryRedirectResult = (
-    repoUrl: string,
+    repoName: string,
     serviceType: string = 'github'
 ): RepositoryRedirectResult => ({
     repositoryRedirect: {
         __typename: 'Repository',
-        id: 'UmVwb3NpdG9yeTo0MDk1Mzg=', // TODO is this ok to be hardcoded?
-        name: repoUrl,
-        url: `/${repoUrl}`,
-        externalURLs: [{ url: `https://${repoUrl}`, serviceType }],
+        id: `RepositoryID:${repoName}`,
+        name: repoName,
+        url: `/${repoName}`,
+        externalURLs: [{ url: new URL(`https://${repoName}`).href, serviceType }],
         description: 'bla',
         viewerCanAdminister: false,
         defaultBranch: { displayName: 'master' },
     },
 })
 
-export const createResolveRevisionResult = (treeUrl: string): ResolveRevResult => ({
+export const createResolveRevisionResult = (treeUrl: string, oid = '1'.repeat(40)): ResolveRevResult => ({
     repositoryRedirect: {
         __typename: 'Repository',
         mirrorInfo: { cloneInProgress: false, cloneProgress: '', cloned: true },
         commit: {
-            oid: '15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81', // TODO is this ok to be hardcoded?
+            oid,
             tree: { url: treeUrl },
         },
         defaultBranch: { abbrevName: 'master' },

--- a/web/src/integration/repository.test.ts
+++ b/web/src/integration/repository.test.ts
@@ -437,11 +437,13 @@ describe('Repository', () => {
             await driver.page.waitForSelector('.test-repo-blob')
 
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelector('.breadcrumb .part-directory')?.textContent),
+                await driver.page.evaluate(
+                    () => document.querySelector('.test-breadcrumb-part-directory')?.textContent
+                ),
                 directoryName
             )
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelector('.breadcrumb .part-last')?.textContent),
+                await driver.page.evaluate(() => document.querySelector('.test-breadcrumb-part-last')?.textContent),
                 fileName
             )
 

--- a/web/src/integration/repository.test.ts
+++ b/web/src/integration/repository.test.ts
@@ -10,6 +10,7 @@ import {
     createBlobContentResult,
 } from './graphQlResponseHelpers'
 import { saveScreenshotsUponFailures } from '../../../shared/src/testing/screenshotReporter'
+import * as path from 'path'
 
 describe('Repository', () => {
     let driver: Driver
@@ -378,6 +379,92 @@ describe('Repository', () => {
             await driver.findElementWithText(clickedCommit, { selector: '.git-commit-node__oid', action: 'click' })
             await driver.page.waitForSelector('.git-commit-node__message-subject')
             await assertSelectorHasText('.git-commit-node__message-subject', 'update LSIF indexing CI workflow')
+        })
+
+        it('works with files with spaces in the name', async () => {
+            const fileName = '% token.4288249258.sql'
+            const directoryName = "Geoffrey's random queries.32r242442bf"
+            const filePath = path.posix.join(directoryName, fileName)
+
+            testContext.overrideGraphQL({
+                ...commonWebGraphQlResults,
+                RepositoryRedirect: ({ repoName }) => createRepositoryRedirectResult(repoName),
+                ResolveRev: ({ repoName }) => createResolveRevisionResult(repoName),
+                FileExternalLinks: ({ filePath, repoName, revision }) =>
+                    createFileExternalLinksResult(
+                        `https://${repoName}/blob/${revision}/${filePath.split('/').map(encodeURIComponent).join('/')}`
+                    ),
+                TreeEntries: () => ({
+                    repository: {
+                        commit: {
+                            tree: {
+                                isRoot: false,
+                                url: '/github.com/ggilmore/q-test/-/tree/Geoffrey%27s%20random%20queries.32r242442bf',
+                                entries: [
+                                    {
+                                        name: fileName,
+                                        path: filePath,
+                                        isDirectory: false,
+                                        url:
+                                            '/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql',
+                                        submodule: null,
+                                        isSingleChild: false,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                }),
+                TreeCommits: () => ({
+                    node: {
+                        __typename: 'Repository',
+                        commit: { ancestors: { nodes: [], pageInfo: { hasNextPage: false } } },
+                    },
+                }),
+                Blob: ({ filePath }) => createBlobContentResult(`content for: ${filePath}`),
+            })
+
+            await driver.page.goto(
+                `${driver.sourcegraphBaseUrl}/github.com/ggilmore/q-test/-/tree/Geoffrey's%20random%20queries.32r242442bf`
+            )
+            await driver.page.waitForSelector('.test-tree-file-link')
+            assert.strictEqual(
+                await driver.page.evaluate(() => document.querySelector('.test-tree-file-link')?.textContent),
+                fileName
+            )
+
+            await driver.page.click('.test-tree-file-link')
+            await driver.page.waitForSelector('.test-repo-blob')
+
+            assert.strictEqual(
+                await driver.page.evaluate(() => document.querySelector('.breadcrumb .part-directory')?.textContent),
+                directoryName
+            )
+            assert.strictEqual(
+                await driver.page.evaluate(() => document.querySelector('.breadcrumb .part-last')?.textContent),
+                fileName
+            )
+
+            // TODO, broken: https://github.com/sourcegraph/sourcegraph/issues/12296
+            // await driver.page.waitForSelector('#monaco-query-input .view-lines')
+            // const searchQuery = await driver.page.evaluate(
+            //     () => document.querySelector('#monaco-query-input .view-lines')?.textContent
+            // )
+            // assert.strictEqual(
+            //     searchQuery,
+            //     'repo:^github\\.com/ggilmore/q-test$ file:"^Geoffrey\'s random queries\\.32r242442bf/% token\\.4288249258\\.sql$"'
+            // )
+
+            await driver.page.waitForSelector('.test-go-to-code-host')
+            assert.strictEqual(
+                await driver.page.evaluate(
+                    () => document.querySelector<HTMLAnchorElement>('.test-go-to-code-host')?.href
+                ),
+                "https://github.com/ggilmore/q-test/blob/master/Geoffrey's%20random%20queries.32r242442bf/%25%20token.4288249258.sql"
+            )
+
+            const blobContent = await driver.page.evaluate(() => document.querySelector('.test-repo-blob')?.textContent)
+            assert.strictEqual(blobContent, `content for: ${filePath}`)
         })
     })
 })

--- a/web/src/repo/FilePathBreadcrumb.tsx
+++ b/web/src/repo/FilePathBreadcrumb.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
 import { RepoRev, toPrettyBlobURL } from '../../../shared/src/util/url'
 import { toTreeURL } from '../util/url'
+import classNames from 'classnames'
 
 interface Props {
     path: string
@@ -13,14 +14,12 @@ interface Props {
  * A breadcrumb where each path component is a separate link. Use this sparingly. Usually having the entire path be
  * a single link target is more usable; in that case, use RepoFileLink.
  */
-const Breadcrumb: React.FunctionComponent<Props> = props => {
-    const parts = props.path.split('/')
+const Breadcrumb: React.FunctionComponent<Props> = ({ path, partToUrl, partToClassName }) => {
+    const parts = path.split('/')
     const spans: JSX.Element[] = []
     for (const [index, part] of parts.entries()) {
-        const link = props.partToUrl(index)
-        const className = `part ${props.partToClassName ? props.partToClassName(index) : ''} ${
-            index === parts.length - 1 ? 'part-last' : ''
-        }`
+        const link = partToUrl(index)
+        const className = classNames('part', partToClassName?.(index))
         spans.push(
             <LinkOrSpan key={index} className={className} to={link}>
                 {part}
@@ -62,7 +61,11 @@ export const FilePathBreadcrumb: React.FunctionComponent<
                 }
                 return toPrettyBlobURL({ repoName, revision, filePath: partPath })
             }}
-            partToClassName={index => (index === parts.length - 1 ? 'part-last' : 'part-directory')}
+            partToClassName={index =>
+                index === parts.length - 1
+                    ? 'part-last test-breadcrumb-part-last'
+                    : 'part-directory test-breadcrumb-part-directory'
+            }
         />
         /* eslint-enable react/jsx-no-bind */
     )

--- a/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -134,7 +134,12 @@ export class GoToCodeHostAction extends React.PureComponent<Props, State> {
         }
 
         return (
-            <LinkOrButton to={url} target="_self" data-tooltip={`View on ${displayName}`}>
+            <LinkOrButton
+                className="nav-link test-go-to-code-host"
+                to={url}
+                target="_self"
+                data-tooltip={`View on ${displayName}`}
+            >
                 <Icon className="icon-inline" />
             </LinkOrButton>
         )

--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -95,10 +95,10 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI {
     const blobSeparator = pathname.indexOf('/-/blob/')
     const comparisonSeparator = pathname.indexOf('/-/compare/')
     if (treeSeparator !== -1) {
-        filePath = pathname.slice(treeSeparator + '/-/tree/'.length)
+        filePath = decodeURIComponent(pathname.slice(treeSeparator + '/-/tree/'.length))
     }
     if (blobSeparator !== -1) {
-        filePath = pathname.slice(blobSeparator + '/-/blob/'.length)
+        filePath = decodeURIComponent(pathname.slice(blobSeparator + '/-/blob/'.length))
     }
     if (comparisonSeparator !== -1) {
         commitRange = pathname.slice(comparisonSeparator + '/-/compare/'.length)


### PR DESCRIPTION
This is something that breaks a lot and is perfect to be tested with integration tests.
One motivation for adding this to easily verify on the Renovate PR whether `history` v5 still has bugs with %-encoding or whether they are fixed.