### PR TITLE
Monitoring/provisioning peaks

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -187,7 +187,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_frontend_provisioning_container_cpu_usage_7d`)
+- _frontend: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_frontend_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -200,7 +200,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_frontend_provisioning_container_memory_usage_7d`)
+- _frontend: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_frontend_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -213,7 +213,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_frontend_provisioning_container_cpu_usage_5m`)
+- _frontend: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_frontend_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -224,7 +224,7 @@ for assistance.
 
 **Descriptions:**
 
-- _frontend: 90%+ container memory usage (5m average) by instance_ (`warning_frontend_provisioning_container_memory_usage_5m`)
+- _frontend: 90%+ container memory usage (5m maximum) by instance_ (`warning_frontend_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -354,7 +354,7 @@ for assistance.
 
 **Descriptions:**
 
-- _gitserver: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_gitserver_provisioning_container_cpu_usage_7d`)
+- _gitserver: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_gitserver_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -367,7 +367,7 @@ for assistance.
 
 **Descriptions:**
 
-- _gitserver: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_gitserver_provisioning_container_memory_usage_7d`)
+- _gitserver: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_gitserver_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -380,7 +380,7 @@ for assistance.
 
 **Descriptions:**
 
-- _gitserver: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_gitserver_provisioning_container_cpu_usage_5m`)
+- _gitserver: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_gitserver_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -391,7 +391,7 @@ for assistance.
 
 **Descriptions:**
 
-- _gitserver: 90%+ container memory usage (5m average) by instance_ (`warning_gitserver_provisioning_container_memory_usage_5m`)
+- _gitserver: 90%+ container memory usage (5m maximum) by instance_ (`warning_gitserver_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -439,7 +439,7 @@ for assistance.
 
 **Descriptions:**
 
-- _github-proxy: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_github-proxy_provisioning_container_cpu_usage_7d`)
+- _github-proxy: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_github-proxy_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -452,7 +452,7 @@ for assistance.
 
 **Descriptions:**
 
-- _github-proxy: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_github-proxy_provisioning_container_memory_usage_7d`)
+- _github-proxy: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_github-proxy_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -465,7 +465,7 @@ for assistance.
 
 **Descriptions:**
 
-- _github-proxy: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_github-proxy_provisioning_container_cpu_usage_5m`)
+- _github-proxy: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_github-proxy_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -476,7 +476,7 @@ for assistance.
 
 **Descriptions:**
 
-- _github-proxy: 90%+ container memory usage (5m average) by instance_ (`warning_github-proxy_provisioning_container_memory_usage_5m`)
+- _github-proxy: 90%+ container memory usage (5m maximum) by instance_ (`warning_github-proxy_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -553,7 +553,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_cpu_usage_7d`)
+- _precise-code-intel-bundle-manager: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -566,7 +566,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_memory_usage_7d`)
+- _precise-code-intel-bundle-manager: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -579,7 +579,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_cpu_usage_5m`)
+- _precise-code-intel-bundle-manager: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -590,7 +590,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 90%+ container memory usage (5m average) by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_memory_usage_5m`)
+- _precise-code-intel-bundle-manager: 90%+ container memory usage (5m maximum) by instance_ (`warning_precise-code-intel-bundle-manager_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -654,7 +654,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_precise-code-intel-worker_provisioning_container_cpu_usage_7d`)
+- _precise-code-intel-worker: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_precise-code-intel-worker_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -667,7 +667,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_precise-code-intel-worker_provisioning_container_memory_usage_7d`)
+- _precise-code-intel-worker: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_precise-code-intel-worker_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -680,7 +680,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_precise-code-intel-worker_provisioning_container_cpu_usage_5m`)
+- _precise-code-intel-worker: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_precise-code-intel-worker_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -691,7 +691,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 90%+ container memory usage (5m average) by instance_ (`warning_precise-code-intel-worker_provisioning_container_memory_usage_5m`)
+- _precise-code-intel-worker: 90%+ container memory usage (5m maximum) by instance_ (`warning_precise-code-intel-worker_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -755,7 +755,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_precise-code-intel-indexer_provisioning_container_cpu_usage_7d`)
+- _precise-code-intel-indexer: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_precise-code-intel-indexer_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -768,7 +768,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_precise-code-intel-indexer_provisioning_container_memory_usage_7d`)
+- _precise-code-intel-indexer: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_precise-code-intel-indexer_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -781,7 +781,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_precise-code-intel-indexer_provisioning_container_cpu_usage_5m`)
+- _precise-code-intel-indexer: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_precise-code-intel-indexer_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -792,7 +792,7 @@ for assistance.
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 90%+ container memory usage (5m average) by instance_ (`warning_precise-code-intel-indexer_provisioning_container_memory_usage_5m`)
+- _precise-code-intel-indexer: 90%+ container memory usage (5m maximum) by instance_ (`warning_precise-code-intel-indexer_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -856,7 +856,7 @@ for assistance.
 
 **Descriptions:**
 
-- _query-runner: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_query-runner_provisioning_container_cpu_usage_7d`)
+- _query-runner: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_query-runner_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -869,7 +869,7 @@ for assistance.
 
 **Descriptions:**
 
-- _query-runner: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_query-runner_provisioning_container_memory_usage_7d`)
+- _query-runner: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_query-runner_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -882,7 +882,7 @@ for assistance.
 
 **Descriptions:**
 
-- _query-runner: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_query-runner_provisioning_container_cpu_usage_5m`)
+- _query-runner: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_query-runner_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -893,7 +893,7 @@ for assistance.
 
 **Descriptions:**
 
-- _query-runner: 90%+ container memory usage (5m average) by instance_ (`warning_query-runner_provisioning_container_memory_usage_5m`)
+- _query-runner: 90%+ container memory usage (5m maximum) by instance_ (`warning_query-runner_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -957,7 +957,7 @@ for assistance.
 
 **Descriptions:**
 
-- _replacer: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_replacer_provisioning_container_cpu_usage_7d`)
+- _replacer: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_replacer_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -970,7 +970,7 @@ for assistance.
 
 **Descriptions:**
 
-- _replacer: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_replacer_provisioning_container_memory_usage_7d`)
+- _replacer: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_replacer_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -983,7 +983,7 @@ for assistance.
 
 **Descriptions:**
 
-- _replacer: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_replacer_provisioning_container_cpu_usage_5m`)
+- _replacer: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_replacer_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -994,7 +994,7 @@ for assistance.
 
 **Descriptions:**
 
-- _replacer: 90%+ container memory usage (5m average) by instance_ (`warning_replacer_provisioning_container_memory_usage_5m`)
+- _replacer: 90%+ container memory usage (5m maximum) by instance_ (`warning_replacer_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -1058,7 +1058,7 @@ for assistance.
 
 **Descriptions:**
 
-- _repo-updater: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_repo-updater_provisioning_container_cpu_usage_7d`)
+- _repo-updater: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_repo-updater_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -1071,7 +1071,7 @@ for assistance.
 
 **Descriptions:**
 
-- _repo-updater: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_repo-updater_provisioning_container_memory_usage_7d`)
+- _repo-updater: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_repo-updater_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -1084,7 +1084,7 @@ for assistance.
 
 **Descriptions:**
 
-- _repo-updater: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_repo-updater_provisioning_container_cpu_usage_5m`)
+- _repo-updater: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_repo-updater_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -1095,7 +1095,7 @@ for assistance.
 
 **Descriptions:**
 
-- _repo-updater: 90%+ container memory usage (5m average) by instance_ (`warning_repo-updater_provisioning_container_memory_usage_5m`)
+- _repo-updater: 90%+ container memory usage (5m maximum) by instance_ (`warning_repo-updater_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -1159,7 +1159,7 @@ for assistance.
 
 **Descriptions:**
 
-- _searcher: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_searcher_provisioning_container_cpu_usage_7d`)
+- _searcher: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_searcher_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -1172,7 +1172,7 @@ for assistance.
 
 **Descriptions:**
 
-- _searcher: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_searcher_provisioning_container_memory_usage_7d`)
+- _searcher: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_searcher_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -1185,7 +1185,7 @@ for assistance.
 
 **Descriptions:**
 
-- _searcher: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_searcher_provisioning_container_cpu_usage_5m`)
+- _searcher: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_searcher_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -1196,7 +1196,7 @@ for assistance.
 
 **Descriptions:**
 
-- _searcher: 90%+ container memory usage (5m average) by instance_ (`warning_searcher_provisioning_container_memory_usage_5m`)
+- _searcher: 90%+ container memory usage (5m maximum) by instance_ (`warning_searcher_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -1260,7 +1260,7 @@ for assistance.
 
 **Descriptions:**
 
-- _symbols: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_symbols_provisioning_container_cpu_usage_7d`)
+- _symbols: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_symbols_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -1273,7 +1273,7 @@ for assistance.
 
 **Descriptions:**
 
-- _symbols: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_symbols_provisioning_container_memory_usage_7d`)
+- _symbols: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_symbols_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -1286,7 +1286,7 @@ for assistance.
 
 **Descriptions:**
 
-- _symbols: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_symbols_provisioning_container_cpu_usage_5m`)
+- _symbols: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_symbols_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -1297,7 +1297,7 @@ for assistance.
 
 **Descriptions:**
 
-- _symbols: 90%+ container memory usage (5m average) by instance_ (`warning_symbols_provisioning_container_memory_usage_5m`)
+- _symbols: 90%+ container memory usage (5m maximum) by instance_ (`warning_symbols_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -1345,7 +1345,7 @@ for assistance.
 
 **Descriptions:**
 
-- _syntect-server: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_syntect-server_provisioning_container_cpu_usage_7d`)
+- _syntect-server: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_syntect-server_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -1358,7 +1358,7 @@ for assistance.
 
 **Descriptions:**
 
-- _syntect-server: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_syntect-server_provisioning_container_memory_usage_7d`)
+- _syntect-server: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_syntect-server_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -1371,7 +1371,7 @@ for assistance.
 
 **Descriptions:**
 
-- _syntect-server: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_syntect-server_provisioning_container_cpu_usage_5m`)
+- _syntect-server: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_syntect-server_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -1382,7 +1382,7 @@ for assistance.
 
 **Descriptions:**
 
-- _syntect-server: 90%+ container memory usage (5m average) by instance_ (`warning_syntect-server_provisioning_container_memory_usage_5m`)
+- _syntect-server: 90%+ container memory usage (5m maximum) by instance_ (`warning_syntect-server_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -1430,7 +1430,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_zoekt-indexserver_provisioning_container_cpu_usage_7d`)
+- _zoekt-indexserver: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_zoekt-indexserver_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -1443,7 +1443,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_zoekt-indexserver_provisioning_container_memory_usage_7d`)
+- _zoekt-indexserver: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_zoekt-indexserver_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -1456,7 +1456,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_zoekt-indexserver_provisioning_container_cpu_usage_5m`)
+- _zoekt-indexserver: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_zoekt-indexserver_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -1467,7 +1467,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-indexserver: 90%+ container memory usage (5m average) by instance_ (`warning_zoekt-indexserver_provisioning_container_memory_usage_5m`)
+- _zoekt-indexserver: 90%+ container memory usage (5m maximum) by instance_ (`warning_zoekt-indexserver_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 
@@ -1515,7 +1515,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-webserver: 80%+ or less than 30% container cpu usage total (7d average) across all cores by instance_ (`warning_zoekt-webserver_provisioning_container_cpu_usage_7d`)
+- _zoekt-webserver: 80%+ or less than 30% container cpu usage total (7d maximum) across all cores by instance_ (`warning_zoekt-webserver_provisioning_container_cpu_usage_7d`)
 
 **Possible solutions:**
 
@@ -1528,7 +1528,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-webserver: 80%+ or less than 30% container memory usage (7d average) by instance_ (`warning_zoekt-webserver_provisioning_container_memory_usage_7d`)
+- _zoekt-webserver: 80%+ or less than 30% container memory usage (7d maximum) by instance_ (`warning_zoekt-webserver_provisioning_container_memory_usage_7d`)
 
 **Possible solutions:**
 
@@ -1541,7 +1541,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-webserver: 90%+ container cpu usage total (5m average) across all cores by instance_ (`warning_zoekt-webserver_provisioning_container_cpu_usage_5m`)
+- _zoekt-webserver: 90%+ container cpu usage total (5m maximum) across all cores by instance_ (`warning_zoekt-webserver_provisioning_container_cpu_usage_5m`)
 
 **Possible solutions:**
 
@@ -1552,7 +1552,7 @@ for assistance.
 
 **Descriptions:**
 
-- _zoekt-webserver: 90%+ container memory usage (5m average) by instance_ (`warning_zoekt-webserver_provisioning_container_memory_usage_5m`)
+- _zoekt-webserver: 90%+ container memory usage (5m maximum) by instance_ (`warning_zoekt-webserver_provisioning_container_memory_usage_5m`)
 
 **Possible solutions:**
 

--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -295,6 +295,7 @@ type panelOptions struct {
 	minAuto      bool
 	legendFormat string
 	unitType     UnitType
+	interval     string
 }
 
 // Min sets the minimum value of the Y axis on the panel. The default is zero.
@@ -328,6 +329,11 @@ func (p panelOptions) LegendFormat(format string) panelOptions {
 // Unit sets the panel's Y axis unit type.
 func (p panelOptions) Unit(t UnitType) panelOptions {
 	p.unitType = t
+	return p
+}
+
+func (p panelOptions) Interval(ms int) panelOptions {
+	p.interval = fmt.Sprintf("%dms", ms)
 	return p
 }
 
@@ -566,6 +572,7 @@ func (c *Container) dashboard() *sdk.Board {
 				panel.AddTarget(&sdk.Target{
 					Expr:         o.Query,
 					LegendFormat: opt.legendFormat,
+					Interval:     opt.interval,
 				})
 				if rowPanel != nil && group.Hidden {
 					rowPanel.RowPanel.Panels = append(rowPanel.RowPanel.Panels, *panel)

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -112,8 +112,8 @@ var sharedContainerCPUUsage sharedObservable = func(containerName string) Observ
 var sharedProvisioningCPUUsage5m sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_cpu_usage_5m",
-		Description:     "container cpu usage total (5m average) across all cores by instance",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container cpu usage total (5m maximum) across all cores by instance",
+		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -127,8 +127,8 @@ var sharedProvisioningCPUUsage5m sharedObservable = func(containerName string) O
 var sharedProvisioningMemoryUsage5m sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_memory_usage_5m",
-		Description:     "container memory usage (5m average) by instance",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container memory usage (5m maximum) by instance",
+		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -144,8 +144,8 @@ var sharedProvisioningMemoryUsage5m sharedObservable = func(containerName string
 var sharedProvisioningCPUUsage7d sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_cpu_usage_7d",
-		Description:     "container cpu usage total (7d average) across all cores by instance",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[7d])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container cpu usage total (7d maximum) across all cores by instance",
+		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[7d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
@@ -161,8 +161,8 @@ var sharedProvisioningCPUUsage7d sharedObservable = func(containerName string) O
 var sharedProvisioningMemoryUsage7d sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:            "provisioning_container_memory_usage_7d",
-		Description:     "container memory usage (7d average) by instance",
-		Query:           fmt.Sprintf(`avg_over_time(cadvisor_container_memory_usage_percentage_total{%s}[7d])`, promCadvisorContainerMatchers(containerName)),
+		Description:     "container memory usage (7d maximum) by instance",
+		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_memory_usage_percentage_total{%s}[7d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -84,7 +84,7 @@ var sharedContainerMemoryUsage sharedObservable = func(containerName string) Obs
 		Query:           fmt.Sprintf(`cadvisor_container_memory_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 99},
-		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
+		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Interval(100),
 		PossibleSolutions: strings.Replace(`
 			- **Kubernetes:** Consider increasing memory limit in relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'memory:' of {{CONTAINER_NAME}} container in 'docker-compose.yml'.
@@ -99,7 +99,7 @@ var sharedContainerCPUUsage sharedObservable = func(containerName string) Observ
 		Query:           fmt.Sprintf(`cadvisor_container_cpu_usage_percentage_total{%s}`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 99},
-		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
+		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Interval(100),
 		PossibleSolutions: strings.Replace(`
 			- **Kubernetes:** Consider increasing CPU limits in the the relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
@@ -116,7 +116,7 @@ var sharedProvisioningCPUUsage5m sharedObservable = func(containerName string) O
 		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
-		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
+		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Interval(100),
 		PossibleSolutions: strings.Replace(`
 			- **Kubernetes:** Consider increasing CPU limits in the the relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
@@ -131,7 +131,7 @@ var sharedProvisioningMemoryUsage5m sharedObservable = func(containerName string
 		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_memory_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
 		Warning:         Alert{GreaterOrEqual: 90},
-		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage),
+		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Interval(100),
 		PossibleSolutions: strings.Replace(`
 			- **Kubernetes:** Consider increasing memory limit in relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'memory:' of {{CONTAINER_NAME}} container in 'docker-compose.yml'.


### PR DESCRIPTION
* use max_over_time instead of avg_over_time for provisioning indicators
* add configurable interval size for panels
* set interval size to 100ms for short-term provisioning indicators

closes #12032

I don't see an option for steps in panel UI, just minimum interval - but unsure if it means the same thing, will investigate further

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/23356519/87898518-eaac3380-ca80-11ea-968c-4dfdd86a73e8.png">
