### PR TITLE
Rename MockGitHubChangesetSync to more generic name

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -288,7 +288,7 @@ func TestCampaigns(t *testing.T) {
 		graphqlBBSRepoID, "2",
 	)
 
-	state := ct.MockGitHubChangesetSync(&protocol.RepoInfo{
+	state := ct.MockChangesetSyncState(&protocol.RepoInfo{
 		Name: api.RepoName(githubRepo.Name),
 		VCS:  protocol.VCSInfo{URL: githubRepo.URI},
 	})
@@ -727,7 +727,7 @@ func TestChangesetCountsOverTime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockState := ct.MockGitHubChangesetSync(&protocol.RepoInfo{
+	mockState := ct.MockChangesetSyncState(&protocol.RepoInfo{
 		Name: api.RepoName(githubRepo.Name),
 		VCS:  protocol.VCSInfo{URL: githubRepo.URI},
 	})
@@ -1207,7 +1207,7 @@ func TestCreateCampaignWithPatchSet(t *testing.T) {
 		FakeMetadata: fakePR,
 	})
 
-	state := ct.MockGitHubChangesetSync(&protocol.RepoInfo{
+	state := ct.MockChangesetSyncState(&protocol.RepoInfo{
 		Name: api.RepoName(repo.Name),
 		VCS:  protocol.VCSInfo{URL: repo.URI},
 	})

--- a/enterprise/internal/campaigns/testing/mock_sync_state.go
+++ b/enterprise/internal/campaigns/testing/mock_sync_state.go
@@ -12,19 +12,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-type MockedGitHubChangesetSyncState struct {
+type MockedChangesetSyncState struct {
 	execReader      func([]string) (io.ReadCloser, error)
 	mockRepoLookup  func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
 	resolveRevision func(string, git.ResolveRevisionOptions) (api.CommitID, error)
 }
 
-// MockGitHubChangesetSync sets up mocks such that invoking LoadChangesets() on
-// one or more GitHub changesets will always return succeed, and return the same
-// diff (+1, ~1, -3).
+// MockChangesetSyncState sets up mocks such that invoking SetDerivedState() with
+// a Changeset will use the same diff (+1, ~1, -3) when setting the SyncState
+// on a Changeset.
 //
 // state.Unmock() must called to clean up, usually via defer.
-func MockGitHubChangesetSync(repo *protocol.RepoInfo) *MockedGitHubChangesetSyncState {
-	state := &MockedGitHubChangesetSyncState{
+func MockChangesetSyncState(repo *protocol.RepoInfo) *MockedChangesetSyncState {
+	state := &MockedChangesetSyncState{
 		execReader:      git.Mocks.ExecReader,
 		mockRepoLookup:  repoupdater.MockRepoLookup,
 		resolveRevision: git.Mocks.ResolveRevision,
@@ -73,7 +73,7 @@ index 884601b..c4886d5 100644
 }
 
 // Unmock resets the mocks set up by MockGitHubChangesetSync.
-func (state *MockedGitHubChangesetSyncState) Unmock() {
+func (state *MockedChangesetSyncState) Unmock() {
 	git.Mocks.ExecReader = state.execReader
 	git.Mocks.ResolveRevision = state.resolveRevision
 	repoupdater.MockRepoLookup = state.mockRepoLookup

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -113,7 +113,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		// Set up mocks to prevent the diffstat computation from trying to
 		// use a real gitserver, and so we can control what diff is used to
 		// create the diffstat.
-		state := ct.MockGitHubChangesetSync(&protocol.RepoInfo{
+		state := ct.MockChangesetSyncState(&protocol.RepoInfo{
 			Name: "repo",
 			VCS:  protocol.VCSInfo{URL: "https://example.com/repo/"},
 		})


### PR DESCRIPTION
We've talked about this when the mock was introduced, but I think it got
lost.

So, here we go: this mock is not tied to GitHub, since its mocks are
called in `SetDerivedState` when computing the `SyncState`, let's get
rid of the `GitHub` in the name.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
