### PR TITLE
Remove unneeded context and error from CheckState method

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -273,7 +273,7 @@ type ExternalChangesetResolver interface {
 	Body() (string, error)
 	ExternalURL() (*externallink.Resolver, error)
 	ReviewState(context.Context) campaigns.ChangesetReviewState
-	CheckState(context.Context) (*campaigns.ChangesetCheckState, error)
+	CheckState() *campaigns.ChangesetCheckState
 	Repository(ctx context.Context) (*RepositoryResolver, error)
 
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)

--- a/enterprise/internal/campaigns/resolvers/changesets.go
+++ b/enterprise/internal/campaigns/resolvers/changesets.go
@@ -318,12 +318,12 @@ func (r *changesetResolver) ReviewState(ctx context.Context) campaigns.Changeset
 	return r.ExternalReviewState
 }
 
-func (r *changesetResolver) CheckState(ctx context.Context) (*campaigns.ChangesetCheckState, error) {
+func (r *changesetResolver) CheckState() *campaigns.ChangesetCheckState {
 	state := r.ExternalCheckState
 	if state == campaigns.ChangesetCheckStateUnknown {
-		return nil, nil
+		return nil
 	}
-	return &state, nil
+	return &state
 }
 
 func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.ChangesetLabelResolver, error) {


### PR DESCRIPTION
Just noticed this in the other branch.