### PR TITLE
honey: sample 1 in 16 events

### DIFF
--- a/internal/honey/honey.go
+++ b/internal/honey/honey.go
@@ -39,13 +39,20 @@ func init() {
 	}
 	err := libhoney.Init(libhoney.Config{
 		APIKey: apiKey,
-		// Send 1 in 4 events. This is hardcoded since we only use this for
-		// Sourcegraph.com. 2020-05-29 We are currently at the top tier for
-		// honeycomb (before enterprise) and using double our quota. This
-		// gives us room to grow. If you find we keep bumping this / missing
-		// data we care about we can look into more dynamic ways to sample in
-		// our application code.
-		SampleRate: 4,
+		// Send 1 in 16 events. This is hardcoded since we only use this for
+		// Sourcegraph.com.
+		//
+		// 2020-05-29 1 in 4. We are currently at the top tier for honeycomb
+		// (before enterprise) and using double our quota. This gives us room
+		// to grow. If you find we keep bumping this / missing data we care
+		// about we can look into more dynamic ways to sample in our
+		// application code.
+		//
+		// 2020-07-20 1 in 16. Again hitting very high usage. Likely due to
+		// recent scaling up of the indexed search cluster. Will require more
+		// investigation, but we should probably segment user request path
+		// traffic vs internal batch traffic.
+		SampleRate: 16,
 	})
 	if err != nil {
 		log.Println("Failed to init libhoney:", err)


### PR DESCRIPTION
Band-aid solution until we can investigate further. Again hitting very
high usage. Likely due to recent scaling up of the indexed search
cluster. Will require more investigation, but we should probably segment
user request path.

![image](https://user-images.githubusercontent.com/187831/87913069-c2b3d480-ca6e-11ea-8119-a170ba45354d.png)
