### PR TITLE
zoekt: improve logs and resource usage when loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200714221025-dea986a54d01
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200720095407-6597aebe357e
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1207,6 +1207,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/zoekt v0.0.0-20200714221025-dea986a54d01 h1:Qp+BmPgBkC4e0J5hAXS+UpdoPhQTkCrxYxkoyrxQ1nI=
 github.com/sourcegraph/zoekt v0.0.0-20200714221025-dea986a54d01/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200720095407-6597aebe357e h1:qbLJk6WfgKtPsgPau7sU+Lw2rzJikjUaelk3BCPK4n0=
+github.com/sourcegraph/zoekt v0.0.0-20200720095407-6597aebe357e/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
When an instance has a lot of shards it can take a while to start. This
update includes two improvements to zoekt:

- shards: throttle loading in watcher https://gerrit-review.googlesource.com/c/zoekt/+/275902
- shards: a progress message every 10s when loading https://gerrit-review.googlesource.com/c/zoekt/+/275903

Note: a future change should make it possible to use k8s ready and health checks. For example we could then start exporting prometheus metrics on startup.