### PR TITLE
Automatically accept Chromatic baseline on master

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -102,32 +102,39 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 }
 
 // Adds the shared frontend tests (shared between the web app and browser extension).
-func addSharedTests(pipeline *bk.Pipeline) {
-	// Client integration tests
-	pipeline.AddStep(":puppeteer::electric_plug:",
-		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-		bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-web"),
-		bk.Cmd("yarn run cover-integration"),
-		bk.Cmd("yarn nyc report -r json"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F integration"))
+func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
+	return func(pipeline *bk.Pipeline) {
+		// Client integration tests
+		pipeline.AddStep(":puppeteer::electric_plug:",
+			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+			bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-web"),
+			bk.Cmd("yarn run cover-integration"),
+			bk.Cmd("yarn nyc report -r json"),
+			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F integration"))
 
-	// Storybook coverage
-	pipeline.AddStep(":storybook::codecov:",
-		bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
-		bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-storybook"),
-		bk.Cmd("yarn run cover-storybook"),
-		bk.Cmd("yarn nyc report -r json"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F storybook"))
+		// Storybook coverage
+		pipeline.AddStep(":storybook::codecov:",
+			bk.Env("PUPPETEER_SKIP_CHROMIUM_DOWNLOAD", ""),
+			bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-storybook"),
+			bk.Cmd("yarn run cover-storybook"),
+			bk.Cmd("yarn nyc report -r json"),
+			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F storybook"))
 
-	// Upload storybook to Chromatic
-	pipeline.AddStep(":chromatic:",
-		bk.AutomaticRetry(5),
-		bk.Cmd("dev/ci/yarn-run.sh chromatic"))
+		// Upload storybook to Chromatic
+		chromaticCommand := "yarn chromatic --exit-zero-on-changes --exit-once-uploaded"
+		if c.branch == "master" || c.releaseBranch || c.isBextReleaseBranch {
+			chromaticCommand += " --auto-accept-changes"
+		}
+		pipeline.AddStep(":chromatic:",
+			bk.AutomaticRetry(5),
+			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000"),
+			bk.Cmd(chromaticCommand))
 
-	// Shared tests
-	pipeline.AddStep(":jest:",
-		bk.Cmd("dev/ci/yarn-test.sh shared"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+		// Shared tests
+		pipeline.AddStep(":jest:",
+			bk.Cmd("dev/ci/yarn-test.sh shared"),
+			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+	}
 }
 
 // Adds PostgreSQL backcompat tests.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -92,7 +92,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		pipelineOperations = []func(*bk.Pipeline){
 			addLint,
 			addBrowserExt,
-			addSharedTests,
+			addSharedTests(c),
 			wait,
 			addBrowserExtensionReleaseSteps,
 		}
@@ -103,7 +103,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		pipelineOperations = []func(*bk.Pipeline){
 			addLint,
 			addBrowserExt,
-			addSharedTests,
+			addSharedTests(c),
 			wait,
 			addBrowserExtensionE2ESteps,
 		}
@@ -115,7 +115,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addLint,
 			addBrowserExt,
 			addWebApp,
-			addSharedTests,
+			addSharedTests(c),
 			addGoTests,
 			addGoBuild,
 			addDockerfileLint,
@@ -131,7 +131,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
 			addLint,               // ~4.5m
-			addSharedTests,        // ~4.5m
+			addSharedTests(c),     // ~4.5m
 			addWebApp,             // ~3m
 			addBrowserExt,         // ~2m
 			addGoTests,            // ~1.5m

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "build-storybook": "build-storybook -c .storybook",
     "cover-storybook": "nyc --hook-require=false yarn jest .storybook/coverage",
-    "chromatic": "chromatic --exit-zero-on-changes",
     "deduplicate": "yarn-deduplicate -s fewer"
   },
   "browserslist": [


### PR DESCRIPTION
This is needed when using a squash merge workflow, otherwise commits on master are yellow again even if the branch was approved.