### PR TITLE
ci: skip db-backcompat check if branch is out of date

### DIFF
--- a/dev/ci/ci-db-backcompat.sh
+++ b/dev/ci/ci-db-backcompat.sh
@@ -29,7 +29,7 @@ EOF
 # longer lived branches (release branches) will fail. We should avoid this
 # check in those cases. If this PR does indeed contain a failure, we will pick
 # it up in the master CI run.
-if ! git merge-base --is-ancestor ${CURRENTLY_DEPLOYED} ${HEAD}; then
+if ! git merge-base --is-ancestor "${CURRENTLY_DEPLOYED}" "${HEAD}"; then
   echo
   echo "This branch is out of date with sourcegraph.com."
   echo "SKIPPED"

--- a/dev/ci/ci-db-backcompat.sh
+++ b/dev/ci/ci-db-backcompat.sh
@@ -25,6 +25,17 @@ Running ci-db-backcompat.sh with the following parameters:
   current deployed commit:         ${CURRENTLY_DEPLOYED}
 EOF
 
+# Older branches will fail leading to a PR requiring rebasing. Additionally
+# longer lived branches (release branches) will fail. We should avoid this
+# check in those cases. If this PR does indeed contain a failure, we will pick
+# it up in the master CI run.
+if ! git merge-base --is-ancestor ${CURRENTLY_DEPLOYED} ${HEAD}; then
+  echo
+  echo "This branch is out of date with sourcegraph.com."
+  echo "SKIPPED"
+  exit 0
+fi
+
 # Recreate the test DB and run TestMigrations once to ensure that the schema version is the latest.
 set -ex
 asdf install # in case the go version has changed in between these two commits


### PR DESCRIPTION
Older branches will fail leading to a PR requiring rebasing. Additionally
longer lived branches (release branches) will fail. We should avoid this
check in those cases. If this PR does indeed contain a failure, we will pick
it up in the master CI run.

Part of https://github.com/sourcegraph/sourcegraph/issues/12302