### PR TITLE
Another set of small follow-ups after introducing ExternalChangesetState

### DIFF
--- a/enterprise/internal/campaigns/changeset_history.go
+++ b/enterprise/internal/campaigns/changeset_history.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 
-// changesetHistory is a collection of a changesets states (open/closed/merged
-// state and review state) over time.
+// changesetHistory is a collection of external changeset states
+// (open/closed/merged state and review state) over time.
 type changesetHistory []changesetStatesAtTime
 
 // StatesAtTime returns the changeset's states valid at the given time. If the
@@ -37,9 +37,9 @@ func (h changesetHistory) StatesAtTime(t time.Time) (changesetStatesAtTime, bool
 }
 
 type changesetStatesAtTime struct {
-	t           time.Time
-	state       campaigns.ChangesetExternalState
-	reviewState campaigns.ChangesetReviewState
+	t             time.Time
+	externalState campaigns.ChangesetExternalState
+	reviewState   campaigns.ChangesetReviewState
 }
 
 // computeHistory calculates the changesetHistory for the given Changeset and
@@ -53,7 +53,7 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 	var (
 		states = []changesetStatesAtTime{}
 
-		currentState       = campaigns.ChangesetExternalStateOpen
+		currentExtState    = campaigns.ChangesetExternalStateOpen
 		currentReviewState = campaigns.ChangesetReviewStatePending
 
 		lastReviewByAuthor = map[string]campaigns.ChangesetReviewState{}
@@ -61,9 +61,9 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 
 	pushStates := func(t time.Time) {
 		states = append(states, changesetStatesAtTime{
-			t:           t,
-			state:       currentState,
-			reviewState: currentReviewState,
+			t:             t,
+			externalState: currentExtState,
+			reviewState:   currentReviewState,
 		})
 	}
 
@@ -82,19 +82,19 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 		switch e.Kind {
 		case campaigns.ChangesetEventKindGitHubClosed, campaigns.ChangesetEventKindBitbucketServerDeclined:
 			// Merged is a final state. We can ignore everything after.
-			if currentState != campaigns.ChangesetExternalStateMerged {
-				currentState = campaigns.ChangesetExternalStateClosed
+			if currentExtState != campaigns.ChangesetExternalStateMerged {
+				currentExtState = campaigns.ChangesetExternalStateClosed
 				pushStates(et)
 			}
 
 		case campaigns.ChangesetEventKindGitHubMerged, campaigns.ChangesetEventKindBitbucketServerMerged:
-			currentState = campaigns.ChangesetExternalStateMerged
+			currentExtState = campaigns.ChangesetExternalStateMerged
 			pushStates(et)
 
 		case campaigns.ChangesetEventKindGitHubReopened, campaigns.ChangesetEventKindBitbucketServerReopened:
 			// Merged is a final state. We can ignore everything after.
-			if currentState != campaigns.ChangesetExternalStateMerged {
-				currentState = campaigns.ChangesetExternalStateOpen
+			if currentExtState != campaigns.ChangesetExternalStateMerged {
+				currentExtState = campaigns.ChangesetExternalStateOpen
 				pushStates(et)
 			}
 
@@ -136,7 +136,7 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 				lastReviewByAuthor[author] = s
 			}
 
-			newReviewState := computeReviewState(lastReviewByAuthor)
+			newReviewState := reduceReviewStates(lastReviewByAuthor)
 
 			if newReviewState != oldReviewState {
 				currentReviewState = newReviewState
@@ -186,7 +186,7 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 			// recompute overall review state
 			oldReviewState := currentReviewState
 			delete(lastReviewByAuthor, author)
-			newReviewState := computeReviewState(lastReviewByAuthor)
+			newReviewState := reduceReviewStates(lastReviewByAuthor)
 
 			if newReviewState != oldReviewState {
 				currentReviewState = newReviewState
@@ -199,9 +199,19 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 	// ExternalDeletedAt manually in the Syncer.
 	deletedAt := ch.ExternalDeletedAt
 	if !deletedAt.IsZero() {
-		currentState = campaigns.ChangesetExternalStateClosed
+		currentExtState = campaigns.ChangesetExternalStateClosed
 		pushStates(deletedAt)
 	}
 
 	return states, nil
+}
+
+// reduceReviewStates reduces the given a map of review per author down to a
+// single overall ChangesetReviewState.
+func reduceReviewStates(statesByAuthor map[string]campaigns.ChangesetReviewState) campaigns.ChangesetReviewState {
+	states := make(map[campaigns.ChangesetReviewState]bool)
+	for _, s := range statesByAuthor {
+		states[s] = true
+	}
+	return selectReviewState(states)
 }

--- a/enterprise/internal/campaigns/counts.go
+++ b/enterprise/internal/campaigns/counts.go
@@ -80,7 +80,7 @@ func CalcCounts(start, end time.Time, cs []*campaigns.Changeset, es ...*campaign
 			}
 
 			c.Total++
-			switch states.state {
+			switch states.externalState {
 			case campaigns.ChangesetExternalStateOpen:
 				c.Open += 1
 				switch states.reviewState {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -929,13 +929,13 @@ func testCampaign(user int32, patchSet int64) *campaigns.Campaign {
 	return c
 }
 
-func testChangeset(repoID api.RepoID, campaign int64, changesetJob int64, state campaigns.ChangesetExternalState) *campaigns.Changeset {
+func testChangeset(repoID api.RepoID, campaign int64, changesetJob int64, extState campaigns.ChangesetExternalState) *campaigns.Changeset {
 	changeset := &campaigns.Changeset{
 		RepoID:              repoID,
 		ExternalServiceType: extsvc.TypeGitHub,
 		ExternalID:          fmt.Sprintf("ext-id-%d", changesetJob),
-		Metadata:            &github.PullRequest{State: string(state)},
-		ExternalState:       state,
+		Metadata:            &github.PullRequest{State: string(extState)},
+		ExternalState:       extState,
 	}
 
 	if campaign != 0 {

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -29,7 +29,7 @@ func SetDerivedState(ctx context.Context, c *campaigns.Changeset, es []*campaign
 	copy(events, es)
 	sort.Sort(events)
 
-	c.ExternalCheckState = ComputeCheckState(c, events)
+	c.ExternalCheckState = computeCheckState(c, events)
 
 	history, err := computeHistory(c, events)
 	if err != nil {
@@ -37,12 +37,12 @@ func SetDerivedState(ctx context.Context, c *campaigns.Changeset, es []*campaign
 		return
 	}
 
-	if state, err := ComputeExternalState(c, history); err != nil {
+	if state, err := computeExternalState(c, history); err != nil {
 		log15.Warn("Computing external changeset state", "err", err)
 	} else {
 		c.ExternalState = state
 	}
-	if state, err := ComputeReviewState(c, history); err != nil {
+	if state, err := computeReviewState(c, history); err != nil {
 		log15.Warn("Computing changeset review state", "err", err)
 	} else {
 		c.ExternalReviewState = state
@@ -91,9 +91,10 @@ func SetDerivedState(ctx context.Context, c *campaigns.Changeset, es []*campaign
 	}
 }
 
-// ComputeCheckState computes the overall check state based on the current synced check state
-// and any webhook events that have arrived after the most recent sync
-func ComputeCheckState(c *campaigns.Changeset, events ChangesetEvents) campaigns.ChangesetCheckState {
+// computeCheckState computes the overall check state based on the current
+// synced check state and any webhook events that have arrived after the most
+// recent sync.
+func computeCheckState(c *campaigns.Changeset, events ChangesetEvents) campaigns.ChangesetCheckState {
 	switch m := c.Metadata.(type) {
 	case *github.PullRequest:
 		return computeGitHubCheckState(c.UpdatedAt, m, events)
@@ -108,9 +109,9 @@ func ComputeCheckState(c *campaigns.Changeset, events ChangesetEvents) campaigns
 	return campaigns.ChangesetCheckStateUnknown
 }
 
-// ComputeExternalState computes the overall state for the changeset and its
-// associated events. The events should be presorted.
-func ComputeExternalState(c *campaigns.Changeset, history []changesetStatesAtTime) (campaigns.ChangesetExternalState, error) {
+// computeExternalState computes the external state for the changeset and its
+// associated events.
+func computeExternalState(c *campaigns.Changeset, history []changesetStatesAtTime) (campaigns.ChangesetExternalState, error) {
 	if len(history) == 0 {
 		return computeSingleChangesetExternalState(c)
 	}
@@ -118,12 +119,12 @@ func ComputeExternalState(c *campaigns.Changeset, history []changesetStatesAtTim
 	if c.UpdatedAt.After(newestDataPoint.t) {
 		return computeSingleChangesetExternalState(c)
 	}
-	return newestDataPoint.state, nil
+	return newestDataPoint.externalState, nil
 }
 
-// ComputeReviewState computes the review state for the changeset and its
+// computeReviewState computes the review state for the changeset and its
 // associated events. The events should be presorted.
-func ComputeReviewState(c *campaigns.Changeset, history []changesetStatesAtTime) (campaigns.ChangesetReviewState, error) {
+func computeReviewState(c *campaigns.Changeset, history []changesetStatesAtTime) (campaigns.ChangesetReviewState, error) {
 	if len(history) == 0 {
 		return computeSingleChangesetReviewState(c)
 	}
@@ -433,7 +434,7 @@ func computeSingleChangesetExternalState(c *campaigns.Changeset) (s campaigns.Ch
 // GitHub doesn't keep the review state on a changeset, so a GitHub Changeset
 // will always return ChangesetReviewStatePending.
 //
-// This method should NOT be called directly. Use ComputeReviewState instead.
+// This method should NOT be called directly. Use computeReviewState instead.
 func computeSingleChangesetReviewState(c *campaigns.Changeset) (s campaigns.ChangesetReviewState, err error) {
 	states := map[campaigns.ChangesetReviewState]bool{}
 
@@ -501,16 +502,6 @@ func selectReviewState(states map[campaigns.ChangesetReviewState]bool) campaigns
 	}
 
 	return campaigns.ChangesetReviewStatePending
-}
-
-// computeOverallReviewState returns the overall review state given a map of
-// reviews per author.
-func computeReviewState(statesByAuthor map[string]campaigns.ChangesetReviewState) campaigns.ChangesetReviewState {
-	states := make(map[campaigns.ChangesetReviewState]bool)
-	for _, s := range statesByAuthor {
-		states[s] = true
-	}
-	return selectReviewState(states)
 }
 
 // computeDiffStat computes the up to date diffstat for the changeset, based on

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -485,7 +485,7 @@ func TestComputeReviewState(t *testing.T) {
 	}
 }
 
-func TestComputeChangesetExternalState(t *testing.T) {
+func TestComputeExternalState(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	daysAgo := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
@@ -607,7 +607,7 @@ func TestComputeChangesetExternalState(t *testing.T) {
 			}
 
 			if have, want := have, tc.want; have != want {
-				t.Errorf("%d: wrong changeset state. have=%s, want=%s", i, have, want)
+				t.Errorf("%d: wrong external state. have=%s, want=%s", i, have, want)
 			}
 		})
 	}

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -473,7 +473,7 @@ func TestComputeReviewState(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			changeset := tc.changeset
 
-			have, err := ComputeReviewState(changeset, tc.history)
+			have, err := computeReviewState(changeset, tc.history)
 			if err != nil {
 				t.Fatalf("got error: %s", err)
 			}
@@ -505,7 +505,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "github - changeset older than events",
 			changeset: githubChangeset(daysAgo(10), "OPEN"),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(0), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(0), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateClosed,
 		},
@@ -513,7 +513,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "github - changeset newer than events",
 			changeset: githubChangeset(daysAgo(0), "OPEN"),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(10), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateOpen,
 		},
@@ -521,7 +521,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "github - changeset newer and deleted",
 			changeset: setDeletedAt(githubChangeset(daysAgo(0), "OPEN"), daysAgo(0)),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(10), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateDeleted,
 		},
@@ -535,7 +535,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "bitbucketserver - changeset older than events",
 			changeset: bitbucketChangeset(daysAgo(10), "OPEN", "NEEDS_WORK"),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(0), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(0), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateClosed,
 		},
@@ -543,7 +543,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "bitbucketserver - changeset newer than events",
 			changeset: bitbucketChangeset(daysAgo(0), "OPEN", "NEEDS_WORK"),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(10), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateOpen,
 		},
@@ -551,7 +551,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "bitbucketserver - changeset newer and deleted",
 			changeset: setDeletedAt(bitbucketChangeset(daysAgo(0), "OPEN", "NEEDS_WORK"), daysAgo(0)),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(10), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateDeleted,
 		},
@@ -583,7 +583,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "gitlab - changeset older than events",
 			changeset: gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateMerged, nil),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(0), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(0), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateClosed,
 		},
@@ -591,7 +591,7 @@ func TestComputeExternalState(t *testing.T) {
 			name:      "gitlab - changeset newer than events",
 			changeset: gitLabChangeset(daysAgo(0), gitlab.MergeRequestStateMerged, nil),
 			history: []changesetStatesAtTime{
-				{t: daysAgo(10), state: campaigns.ChangesetExternalStateClosed},
+				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},
 			want: cmpgn.ChangesetExternalStateMerged,
 		},
@@ -601,7 +601,7 @@ func TestComputeExternalState(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			changeset := tc.changeset
 
-			have, err := ComputeExternalState(changeset, tc.history)
+			have, err := computeExternalState(changeset, tc.history)
 			if err != nil {
 				t.Fatalf("got error: %s", err)
 			}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -194,6 +194,19 @@ const (
 	ChangesetStateSynced      ChangesetState = "SYNCED"
 )
 
+// Valid returns true if the given ChangesetState is valid.
+func (s ChangesetState) Valid() bool {
+	switch s {
+	case ChangesetStateUnpublished,
+		ChangesetStatePublishing,
+		ChangesetStateErrored,
+		ChangesetStateSynced:
+		return true
+	default:
+		return false
+	}
+}
+
 // ChangesetExternalState defines the possible states of a Changeset on a code host.
 type ChangesetExternalState string
 
@@ -205,7 +218,7 @@ const (
 	ChangesetExternalStateDeleted ChangesetExternalState = "DELETED"
 )
 
-// Valid returns true if the given Changeset is valid.
+// Valid returns true if the given ChangesetExternalState is valid.
 func (s ChangesetExternalState) Valid() bool {
 	switch s {
 	case ChangesetExternalStateOpen,


### PR DESCRIPTION
Some tiny updates/renames/un-exports after we introduced the new `ChangesetState` and `ChangesetExternalState` fields.