### PR TITLE
Make schema for env more strict to only accept strings

### DIFF
--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -77,7 +77,10 @@
           },
           "env": {
             "type": "object",
-            "description": "Environment variables to set in the environment when running this command."
+            "description": "Environment variables to set in the environment when running this command.",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -82,7 +82,10 @@ const CampaignSpecSchemaJSON = `{
           },
           "env": {
             "type": "object",
-            "description": "Environment variables to set in the environment when running this command."
+            "description": "Environment variables to set in the environment when running this command.",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       }


### PR DESCRIPTION
Environment variables can only be strings, so we shouldn't accept int, bool etc.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
