### PR TITLE
Disable TestIgnoreGitSubmodules because it is flaky

### DIFF
--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -167,6 +167,8 @@ func gitInitRepos(t *testing.T, names ...string) string {
 }
 
 func TestIgnoreGitSubmodules(t *testing.T) {
+	t.Skipf("This test is disabled because it was identified as flaky. See https://github.com/sourcegraph/sourcegraph/issues/12351.")
+
 	root, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Filed https://github.com/sourcegraph/sourcegraph/issues/12351 for fixing the test.