### PR TITLE
gqltest: migrate commit, diff and global text search

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -423,4 +423,35 @@ func TestSearch(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("diff search", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			query      string
+			zeroResult bool
+		}{
+			{
+				name:  "diff search, nonzero result",
+				query: `repo:^github\.com/sgtest/go-diff$ type:diff main count:1`,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if test.zeroResult {
+					if len(results.Results) > 0 {
+						t.Fatalf("Want zero result but got %d", len(results.Results))
+					}
+				} else {
+					if len(results.Results) == 0 {
+						t.Fatal("Want non-zero results but got 0")
+					}
+				}
+			})
+		}
+	})
 }

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -289,8 +289,21 @@ func TestSearch(t *testing.T) {
 				query: "fork:only router",
 			},
 			{
+				name:  "double-quoted pattern, nonzero result",
+				query: `"func main() {\n" patterntype:regexp count:1 stable:yes`,
+			},
+			{
+				name:  "exclude repo, nonzero result",
+				query: `"func main() {\n" -repo:go-diff patterntype:regexp count:1 stable:yes`,
+			},
+			{
 				name:       "fork:no",
 				query:      "fork:no FORK_SENTINEL",
+				zeroResult: true,
+			},
+			{
+				name:       "random characters, zero results",
+				query:      "asdfalksd+jflaksjdfklas patterntype:literal -repo:sourcegraph",
 				zeroResult: true,
 			},
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -392,4 +392,35 @@ func TestSearch(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("commit search", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			query      string
+			zeroResult bool
+		}{
+			{
+				name:  "commit search, nonzero result",
+				query: `repo:^github\.com/sgtest/go-diff$ type:commit count:1`,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if test.zeroResult {
+					if len(results.Results) > 0 {
+						t.Fatalf("Want zero result but got %d", len(results.Results))
+					}
+				} else {
+					if len(results.Results) == 0 {
+						t.Fatal("Want non-zero results but got 0")
+					}
+				}
+			})
+		}
+	})
 }

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -454,4 +454,15 @@ func TestSearch(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("timeout search options", func(t *testing.T) {
+		alert, err := client.SearchAlert(`router index:no timeout:1ns`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if alert == nil {
+			t.Fatal("Want search alert but got nil")
+		}
+	})
 }

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -169,6 +169,55 @@ query Search($query: String!) {
 	return resp.Data.Search.Results.SearchCommitResults, nil
 }
 
+// SearchAlert is an alert specific to searches (i.e. not site alert).
+type SearchAlert struct {
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	ProposedQueries []struct {
+		Description string `json:"description"`
+		Query       string `json:"query"`
+	} `json:"proposedQueries"`
+}
+
+// SearchAlert returns the alert returned by searching for given query.
+// It returns both nil values if no alert raised and no error occurred.
+func (c *Client) SearchAlert(query string) (*SearchAlert, error) {
+	const gqlQuery = `
+query Search($query: String!) {
+	search(query: $query) {
+		results {
+			alert {
+				title
+				description
+				proposedQueries {
+					description
+					query
+				}
+			}
+		}
+	}
+}
+`
+	variables := map[string]interface{}{
+		"query": query,
+	}
+	var resp struct {
+		Data struct {
+			Search struct {
+				Results struct {
+					*SearchAlert `json:"alert"`
+				} `json:"results"`
+			} `json:"search"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", gqlQuery, variables, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.Search.Results.SearchAlert, nil
+}
+
 type SearchStatsResult struct {
 	Languages []struct {
 		Name       string `json:"name"`


### PR DESCRIPTION
Migrated following tests to `dev/gqltest`:

https://github.com/sourcegraph/sourcegraph/blob/5ce8ae587d734252af7d8ab439510a8fddb4f421/internal/cmd/search-integration-tester/search_tests.go#L48-L75

Easier to review by commit.

Part of #12143.