### PR TITLE
src-expose: disable background updates in tests

### DIFF
--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -43,6 +43,8 @@ func TestReposHandler(t *testing.T) {
 				Debug: discardLogger,
 				Addr:  testAddress,
 				Root:  root,
+
+				updatingServerInfo: 2, // disables background updates
 			}).handler()
 			if err != nil {
 				t.Fatal(err)
@@ -74,6 +76,8 @@ func TestReposHandler(t *testing.T) {
 				Debug: discardLogger,
 				Addr:  testAddress,
 				Root:  root,
+
+				updatingServerInfo: 2, // disables background updates
 			}).handler()
 			if err != nil {
 				t.Fatal(err)
@@ -167,8 +171,6 @@ func gitInitRepos(t *testing.T, names ...string) string {
 }
 
 func TestIgnoreGitSubmodules(t *testing.T) {
-	t.Skipf("This test is disabled because it was identified as flaky. See https://github.com/sourcegraph/sourcegraph/issues/12351.")
-
 	root, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)
@@ -187,6 +189,8 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		Info:  testLogger(t),
 		Debug: discardLogger,
 		Root:  root,
+
+		updatingServerInfo: 2, // disables background updates
 	}).configureRepos()
 	if len(repos) != 0 {
 		t.Fatalf("expected no repos, got %v", repos)


### PR DESCRIPTION
We could complicate the design of Serve such that we wait for background
updates to stop. However, this would be for the benefit of tests
only. Instead we just disable background updates in tests.

Fixes https://github.com/sourcegraph/sourcegraph/issues/12351