### PR TITLE
Check namespace perms in CreateCampaignSpec/MoveCampaign

### DIFF
--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -56,7 +56,8 @@ type InsufficientAuthorizationError struct {
 	Message string
 }
 
-func (e *InsufficientAuthorizationError) Error() string { return e.Message }
+func (e *InsufficientAuthorizationError) Error() string      { return e.Message }
+func (e *InsufficientAuthorizationError) Unauthorized() bool { return true }
 
 // CheckSiteAdminOrSameUser returns an error if the user is NEITHER (1) a
 // site admin NOR (2) the user specified by subjectUserID.

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -235,7 +235,7 @@ func (r *Resolver) CreateCampaignSpec(ctx context.Context, args *graphqlbackend.
 		return nil, backend.ErrMustBeSiteAdmin
 	}
 
-	opts := ee.CreateCampaignSpecOpts{RawSpec: args.CampaignSpec, UserID: user.ID}
+	opts := ee.CreateCampaignSpecOpts{RawSpec: args.CampaignSpec}
 
 	switch relay.UnmarshalKind(args.Namespace) {
 	case "User":


### PR DESCRIPTION
(This is part #11675 and the new workflow)

Before this, every user could create a campaign spec in any org or user
namespace. And the same was true for moveCampaign: a user could move a
campaign into namespace they wanted.

This changes both implementations in the service layer to check for the
permissions of the current user (saved in the ctx):

1. If it's a site admin, they can create/move things in any namespace.
2. If not and the target namespace is an org, we check for org
   membership.
3. If not and the target namespace is a user, we check that it's the
   same as the current user.

