### PR TITLE
search: support globbing for filters

### DIFF
--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -10,6 +10,11 @@ import (
 
 // SearchFilterSuggestions provides search filter and default value suggestions.
 func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFilterSuggestions, error) {
+	settings, err := decodedViewerFinalSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	groupsByName, err := resolveRepoGroups(ctx)
 	if err != nil {
 		return nil, err
@@ -29,8 +34,15 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 		return nil, err
 	}
 	repoNames := make([]string, len(repos))
-	for i := range repos {
-		repoNames[i] = "^" + regexp.QuoteMeta(string(repos[i].Name)) + "$"
+
+	if getBoolPtr(settings.SearchGlobbing, false) {
+		for i := range repos {
+			repoNames[i] = string(repos[i].Name)
+		}
+	} else {
+		for i := range repos {
+			repoNames[i] = "^" + regexp.QuoteMeta(string(repos[i].Name)) + "$"
+		}
 	}
 
 	return &searchFilterSuggestions{

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestSearchFilterSuggestions(t *testing.T) {
@@ -27,19 +28,38 @@ func TestSearchFilterSuggestions(t *testing.T) {
 	}
 	defer func() { db.Mocks.Repos.List = nil }()
 
-	r, err := (&schemaResolver{}).SearchFilterSuggestions(context.Background())
-	if err != nil {
-		t.Fatal("SearchFilterSuggestions:", err)
+	tests := []struct {
+		want     *searchFilterSuggestions
+		globbing bool
+	}{
+		{want: &searchFilterSuggestions{
+			repogroups: []string{"repogroup1", "repogroup2"},
+			repos:      []string{"^bar-repo$", `^github\.com/foo/repo$`}},
+			globbing: false,
+		},
+		{want: &searchFilterSuggestions{
+			repogroups: []string{"repogroup1", "repogroup2"},
+			repos:      []string{"bar-repo", `github.com/foo/repo`}},
+			globbing: true,
+		},
 	}
 
-	want := &searchFilterSuggestions{
-		repogroups: []string{"repogroup1", "repogroup2"},
-		repos:      []string{"^bar-repo$", `^github\.com/foo/repo$`},
+	mockDecodedViewerFinalSettings = &schema.Settings{}
+	defer func() { mockDecodedViewerFinalSettings = nil }()
+
+	for _, tt := range tests {
+		mockDecodedViewerFinalSettings.SearchGlobbing = &tt.globbing
+
+		r, err := (&schemaResolver{}).SearchFilterSuggestions(context.Background())
+		if err != nil {
+			t.Fatal("SearchFilterSuggestions:", err)
+		}
+
+		sort.Strings(r.repogroups)
+		sort.Strings(r.repos)
+		if !reflect.DeepEqual(r, tt.want) {
+			t.Errorf("got != want\ngot:  %v\nwant: %v", r, tt.want)
+		}
 	}
 
-	sort.Strings(r.repogroups)
-	sort.Strings(r.repos)
-	if !reflect.DeepEqual(r, want) {
-		t.Errorf("got != want\ngot:  %v\nwant: %v", r, want)
-	}
 }

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions_test.go
@@ -61,5 +61,4 @@ func TestSearchFilterSuggestions(t *testing.T) {
 			t.Errorf("got != want\ngot:  %v\nwant: %v", r, tt.want)
 		}
 	}
-
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -291,7 +291,6 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 				} else {
 					add(ff.regexFilter, ff.regexFilter, lineMatchCount, limitHit, "file", scoreDefault)
 				}
-
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -201,27 +201,40 @@ func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 // commonFileFilters are common filters used. It is used by DynamicFilters to
 // propose them if they match shown results.
 var commonFileFilters = []struct {
-	Regexp *lazyregexp.Regexp
-	Filter string
+	regexp      *lazyregexp.Regexp
+	regexFilter string
+	globFilter  string
 }{
 	// Exclude go tests
 	{
-		Regexp: lazyregexp.New(`_test\.go$`),
-		Filter: `-file:_test\.go$`,
+		regexp:      lazyregexp.New(`_test\.go$`),
+		regexFilter: `-file:_test\.go$`,
+		globFilter:  `-file:**_test.go`,
 	},
 	// Exclude go vendor
 	{
-		Regexp: lazyregexp.New(`(^|/)vendor/`),
-		Filter: `-file:(^|/)vendor/`,
+		regexp:      lazyregexp.New(`(^|/)vendor/`),
+		regexFilter: `-file:(^|/)vendor/`,
+		globFilter:  `-file:vendor/** -file:**/vendor/**`,
 	},
 	// Exclude node_modules
 	{
-		Regexp: lazyregexp.New(`(^|/)node_modules/`),
-		Filter: `-file:(^|/)node_modules/`,
+		regexp:      lazyregexp.New(`(^|/)node_modules/`),
+		regexFilter: `-file:(^|/)node_modules/`,
+		globFilter:  `-file:node_modules/** -file:**/node_modules/**`,
 	},
 }
 
-func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
+func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
+
+	var globbing bool
+	settings, err := decodedViewerFinalSettings(ctx)
+	if err != nil {
+		globbing = false
+	} else {
+		globbing = getBoolPtr(settings.SearchGlobbing, false)
+	}
+
 	filters := map[string]*searchFilterResolver{}
 	repoToMatchCount := make(map[string]int)
 	add := func(value string, label string, count int, limitHit bool, kind string, score score) {
@@ -243,7 +256,13 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 	}
 
 	addRepoFilter := func(uri string, rev string, lineMatchCount int) {
-		filter := fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(uri))
+		var filter string
+		if globbing {
+			filter = fmt.Sprintf(`repo:%s`, uri)
+		} else {
+			filter = fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(uri))
+		}
+
 		if rev != "" {
 			// We don't need to quote rev. The only special characters we interpret
 			// are @ and :, both of which are disallowed in git refs
@@ -257,8 +276,22 @@ func (sr *SearchResultsResolver) DynamicFilters() []*searchFilterResolver {
 
 	addFileFilter := func(fileMatchPath string, lineMatchCount int, limitHit bool) {
 		for _, ff := range commonFileFilters {
-			if ff.Regexp.MatchString(fileMatchPath) {
-				add(ff.Filter, ff.Filter, lineMatchCount, limitHit, "file", scoreDefault)
+
+			// We match against the regex pattern regardless of whether globbing is enabled or not.
+			// Why?
+			// To match glob patterns, the most obvious choice would be golang's path.Match. However Match does
+			// not support **, which means we would have to map between golang's standard patterns and the patterns we support.
+			// Since we anyway have to map, we might as well map to regex.
+			//
+			// In the future we might want to evaluate external matchers or roll our own, in which case we can
+			// update the code here.
+			if ff.regexp.MatchString(fileMatchPath) {
+				if globbing {
+					add(ff.globFilter, ff.globFilter, lineMatchCount, limitHit, "file", scoreDefault)
+				} else {
+					add(ff.regexFilter, ff.regexFilter, lineMatchCount, limitHit, "file", scoreDefault)
+				}
+
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -477,10 +477,10 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 	}
 
 	type testCase struct {
-		descr                     string
-		searchResults             []SearchResultResolver
-		expectedDynamicFilterStrs map[string]struct{}
-		globbing                  bool
+		descr                             string
+		searchResults                     []SearchResultResolver
+		expectedDynamicFilterStrsRegexp   map[string]struct{}
+		expectedDynamicFilterStrsGlobbing map[string]struct{}
 	}
 
 	tests := []testCase{
@@ -488,180 +488,151 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		{
 			descr:         "single repo match",
 			searchResults: []SearchResultResolver{repoMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
 				`repo:^testRepo$`: {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo`: {},
 			},
 		},
 
 		{
 			descr:         "single file match without revision in query",
 			searchResults: []SearchResultResolver{fileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
 				`repo:^testRepo$`: {},
 				`lang:markdown`:   {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo`: {},
+				`lang:markdown`: {},
 			},
 		},
 
 		{
 			descr:         "single file match with specified revision",
 			searchResults: []SearchResultResolver{fileMatchRev},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
 				`repo:^testRepo$@develop3.0`: {},
 				`lang:markdown`:              {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo@develop3.0`: {},
+				`lang:markdown`:            {},
 			},
 		},
 		{
 			descr:         "file match from a language with two file extensions, using first extension",
 			searchResults: []SearchResultResolver{tsFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
 				`repo:^testRepo$`: {},
+				`lang:typescript`: {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo`:   {},
 				`lang:typescript`: {},
 			},
 		},
 		{
 			descr:         "file match from a language with two file extensions, using second extension",
 			searchResults: []SearchResultResolver{tsxFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
 				`repo:^testRepo$`: {},
 				`lang:typescript`: {},
 			},
-		},
-
-		// If there are no search results, no filters should be displayed.
-		{
-			descr:                     "no results",
-			searchResults:             []SearchResultResolver{},
-			expectedDynamicFilterStrs: map[string]struct{}{},
-		},
-		{
-			descr:         "values containing spaces are quoted",
-			searchResults: []SearchResultResolver{ignoreListFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:^testRepo$`:    {},
-				`lang:"ignore list"`: {},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo`:   {},
+				`lang:typescript`: {},
 			},
 		},
 		{
 			descr:         "file match which matches one of the common file filters",
 			searchResults: []SearchResultResolver{nodeModulesMatchSub},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
 				`repo:^testRepo$`:          {},
 				`-file:(^|/)node_modules/`: {},
 				`lang:markdown`:            {},
 			},
-		},
-
-		// globbing: true
-
-		{
-			descr:         "single repo match",
-			searchResults: []SearchResultResolver{repoMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:testRepo`: {},
-			},
-			globbing: true,
-		},
-
-		{
-			descr:         "single file match without revision in query",
-			searchResults: []SearchResultResolver{fileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:testRepo`: {},
-				`lang:markdown`: {},
-			},
-			globbing: true,
-		},
-
-		{
-			descr:         "single file match with specified revision",
-			searchResults: []SearchResultResolver{fileMatchRev},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:testRepo@develop3.0`: {},
-				`lang:markdown`:            {},
-			},
-			globbing: true,
-		},
-		{
-			descr:         "file match from a language with two file extensions, using first extension",
-			searchResults: []SearchResultResolver{tsFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:testRepo`:   {},
-				`lang:typescript`: {},
-			},
-			globbing: true,
-		},
-		{
-			descr:         "file match from a language with two file extensions, using second extension",
-			searchResults: []SearchResultResolver{tsxFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:testRepo`:   {},
-				`lang:typescript`: {},
-			},
-			globbing: true,
-		},
-		{
-			descr:         "file match which matches one of the common file filters",
-			searchResults: []SearchResultResolver{goTestFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
-				`repo:testRepo`:    {},
-				`-file:**_test.go`: {},
-				`lang:go`:          {},
-			},
-			globbing: true,
-		},
-		{
-			descr:         "file match which matches one of the common file filters",
-			searchResults: []SearchResultResolver{nodeModulesMatchSub},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
 				`repo:testRepo`: {},
 				`-file:node_modules/** -file:**/node_modules/**`: {},
 				`lang:markdown`: {},
 			},
-			globbing: true,
 		},
 		{
 			descr:         "file match which matches one of the common file filters",
 			searchResults: []SearchResultResolver{nodeModulesMatchRoot},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
+				`repo:^testRepo$`:          {},
+				`-file:(^|/)node_modules/`: {},
+				`lang:markdown`:            {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
 				`repo:testRepo`: {},
 				`-file:node_modules/** -file:**/node_modules/**`: {},
 				`lang:markdown`: {},
 			},
-			globbing: true,
 		},
+		{
+			descr:         "file match which matches one of the common file filters",
+			searchResults: []SearchResultResolver{goTestFileMatch},
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
+				`repo:^testRepo$`:  {},
+				`-file:_test\.go$`: {},
+				`lang:go`:          {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo`:    {},
+				`-file:**_test.go`: {},
+				`lang:go`:          {},
+			},
+		},
+
 		// If there are no search results, no filters should be displayed.
 		{
-			descr:                     "no results",
-			searchResults:             []SearchResultResolver{},
-			expectedDynamicFilterStrs: map[string]struct{}{},
-			globbing:                  true,
+			descr:                             "no results",
+			searchResults:                     []SearchResultResolver{},
+			expectedDynamicFilterStrsRegexp:   map[string]struct{}{},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{},
 		},
 		{
 			descr:         "values containing spaces are quoted",
 			searchResults: []SearchResultResolver{ignoreListFileMatch},
-			expectedDynamicFilterStrs: map[string]struct{}{
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
+				`repo:^testRepo$`:    {},
+				`lang:"ignore list"`: {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
 				`repo:testRepo`:      {},
 				`lang:"ignore list"`: {},
 			},
-			globbing: true,
 		},
 	}
 
 	mockDecodedViewerFinalSettings = &schema.Settings{}
 	defer func() { mockDecodedViewerFinalSettings = nil }()
 
+	var expectedDynamicFilterStrs map[string]struct{}
 	for _, test := range tests {
 		t.Run(test.descr, func(t *testing.T) {
-			mockDecodedViewerFinalSettings.SearchGlobbing = &test.globbing
-			actualDynamicFilters := (&SearchResultsResolver{SearchResults: test.searchResults}).DynamicFilters(context.Background())
-			actualDynamicFilterStrs := make(map[string]struct{})
+			for _, globbing := range []bool{true, false} {
+				mockDecodedViewerFinalSettings.SearchGlobbing = &globbing
+				actualDynamicFilters := (&SearchResultsResolver{SearchResults: test.searchResults}).DynamicFilters(context.Background())
+				actualDynamicFilterStrs := make(map[string]struct{})
 
-			for _, filter := range actualDynamicFilters {
-				actualDynamicFilterStrs[filter.Value()] = struct{}{}
-			}
+				for _, filter := range actualDynamicFilters {
+					actualDynamicFilterStrs[filter.Value()] = struct{}{}
+				}
 
-			if diff := cmp.Diff(test.expectedDynamicFilterStrs, actualDynamicFilterStrs); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				if globbing {
+					expectedDynamicFilterStrs = test.expectedDynamicFilterStrsGlobbing
+				} else {
+					expectedDynamicFilterStrs = test.expectedDynamicFilterStrsRegexp
+				}
+
+				if diff := cmp.Diff(expectedDynamicFilterStrs, actualDynamicFilterStrs); diff != "" {
+					t.Errorf("mismatch (-want, +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -454,6 +454,21 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		Repo:  repoMatch,
 	}
 
+	goTestFileMatch := &FileMatchResolver{
+		JPath: "/foo_test.go",
+		Repo:  repoMatch,
+	}
+
+	nodeModulesMatchSub := &FileMatchResolver{
+		JPath: "/anything/node_modules/testFile.md",
+		Repo:  repoMatch,
+	}
+
+	nodeModulesMatchRoot := &FileMatchResolver{
+		JPath: "/node_modules/testFile.md",
+		Repo:  repoMatch,
+	}
+
 	rev := "develop3.0"
 	fileMatchRev := &FileMatchResolver{
 		JPath:    "/testFile.md",
@@ -526,8 +541,17 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 				`lang:"ignore list"`: {},
 			},
 		},
+		{
+			descr:         "file match which matches one of the common file filters",
+			searchResults: []SearchResultResolver{nodeModulesMatchSub},
+			expectedDynamicFilterStrs: map[string]struct{}{
+				`repo:^testRepo$`:          {},
+				`-file:(^|/)node_modules/`: {},
+				`lang:markdown`:            {},
+			},
+		},
 
-		// globbing
+		// globbing: true
 
 		{
 			descr:         "single repo match",
@@ -575,7 +599,36 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 			},
 			globbing: true,
 		},
-
+		{
+			descr:         "file match which matches one of the common file filters",
+			searchResults: []SearchResultResolver{goTestFileMatch},
+			expectedDynamicFilterStrs: map[string]struct{}{
+				`repo:testRepo`:    {},
+				`-file:**_test.go`: {},
+				`lang:go`:          {},
+			},
+			globbing: true,
+		},
+		{
+			descr:         "file match which matches one of the common file filters",
+			searchResults: []SearchResultResolver{nodeModulesMatchSub},
+			expectedDynamicFilterStrs: map[string]struct{}{
+				`repo:testRepo`: {},
+				`-file:node_modules/** -file:**/node_modules/**`: {},
+				`lang:markdown`: {},
+			},
+			globbing: true,
+		},
+		{
+			descr:         "file match which matches one of the common file filters",
+			searchResults: []SearchResultResolver{nodeModulesMatchRoot},
+			expectedDynamicFilterStrs: map[string]struct{}{
+				`repo:testRepo`: {},
+				`-file:node_modules/** -file:**/node_modules/**`: {},
+				`lang:markdown`: {},
+			},
+			globbing: true,
+		},
 		// If there are no search results, no filters should be displayed.
 		{
 			descr:                     "no results",


### PR DESCRIPTION
Related to #10094, #12287, and RFC198

This PR contains the backend changes necessary to support globbing for filters. Filters will only contain regex anchors if globbing is deactivated (default) in the settings.

This PR should be merged before #12287.

**Background**
We add regex anchors whenever users click on repo or file filters. For filters, the anchors get added in the backend. For completion and suggestions, the anchors are added by web. The changes for web are done separately in #12287.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
