### PR TITLE
Add schema for importing existing changesets

### DIFF
--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -85,6 +85,30 @@
         }
       }
     },
+    "importChangesets": {
+      "type": "array",
+      "description": "Import existing changesets on code hosts.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repo", "externalIDs"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "The repository name as configured on your Sourcegraph instance."
+          },
+          "externalIDs": {
+            "type": "array",
+            "description": "The changesets to import from the code host. For GitHub this is the PR number, for Gitlab this is the MR number, for Bitbucket server this is the PR number.",
+            "uniqueItems": true,
+            "items": {
+              "oneOf": [{ "type": "string" }, { "type": "integer" }]
+            },
+            "examples": [120, "120", "!120", "#120"]
+          }
+        }
+      }
+    },
     "changesetTemplate": {
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -99,7 +99,7 @@
           },
           "externalIDs": {
             "type": "array",
-            "description": "The changesets to import from the code host. For GitHub this is the PR number, for Gitlab this is the MR number, for Bitbucket server this is the PR number.",
+            "description": "The changesets to import from the code host. For GitHub this is the PR number, for GitLab this is the MR number, for Bitbucket Server this is the PR number.",
             "uniqueItems": true,
             "items": {
               "oneOf": [{ "type": "string" }, { "type": "integer" }]

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -91,9 +91,9 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["repo", "externalIDs"],
+        "required": ["repository", "externalIDs"],
         "properties": {
-          "repo": {
+          "repository": {
             "type": "string",
             "description": "The repository name as configured on your Sourcegraph instance."
           },
@@ -104,7 +104,7 @@
             "items": {
               "oneOf": [{ "type": "string" }, { "type": "integer" }]
             },
-            "examples": [120, "120", "!120", "#120"]
+            "examples": [120, "120"]
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -96,9 +96,9 @@ const CampaignSpecSchemaJSON = `{
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["repo", "externalIDs"],
+        "required": ["repository", "externalIDs"],
         "properties": {
-          "repo": {
+          "repository": {
             "type": "string",
             "description": "The repository name as configured on your Sourcegraph instance."
           },
@@ -109,7 +109,7 @@ const CampaignSpecSchemaJSON = `{
             "items": {
               "oneOf": [{ "type": "string" }, { "type": "integer" }]
             },
-            "examples": [120, "120", "!120", "#120"]
+            "examples": [120, "120"]
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -90,6 +90,30 @@ const CampaignSpecSchemaJSON = `{
         }
       }
     },
+    "importChangesets": {
+      "type": "array",
+      "description": "Import existing changesets on code hosts.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repo", "externalIDs"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "The repository name as configured on your Sourcegraph instance."
+          },
+          "externalIDs": {
+            "type": "array",
+            "description": "The changesets to import from the code host. For GitHub this is the PR number, for Gitlab this is the MR number, for Bitbucket server this is the PR number.",
+            "uniqueItems": true,
+            "items": {
+              "oneOf": [{ "type": "string" }, { "type": "integer" }]
+            },
+            "examples": [120, "120", "!120", "#120"]
+          }
+        }
+      }
+    },
     "changesetTemplate": {
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -104,7 +104,7 @@ const CampaignSpecSchemaJSON = `{
           },
           "externalIDs": {
             "type": "array",
-            "description": "The changesets to import from the code host. For GitHub this is the PR number, for Gitlab this is the MR number, for Bitbucket server this is the PR number.",
+            "description": "The changesets to import from the code host. For GitHub this is the PR number, for GitLab this is the MR number, for Bitbucket Server this is the PR number.",
             "uniqueItems": true,
             "items": {
               "oneOf": [{ "type": "string" }, { "type": "integer" }]

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -317,6 +317,8 @@ type CampaignSpec struct {
 	ChangesetTemplate *ChangesetTemplate `json:"changesetTemplate,omitempty"`
 	// Description description: The description of the campaign.
 	Description string `json:"description,omitempty"`
+	// ImportChangesets description: Import existing changesets on code hosts.
+	ImportChangesets []*ImportChangesets `json:"importChangesets,omitempty"`
 	// Name description: The name of the campaign, which is unique among all campaigns in the namespace. A campaign's name is case-preserving.
 	Name string `json:"name"`
 	// On description: The set of repositories (and branches) to run the campaign on, specified as a list of search queries (that match repositories) and/or specific repositories.
@@ -723,6 +725,13 @@ func (v *IdentityProvider) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, &v.Username)
 	}
 	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"oauth", "username", "external"})
+}
+
+type ImportChangesets struct {
+	// ExternalIDs description: The changesets to import from the code host. For GitHub this is the PR number, for GitLab this is the MR number, for Bitbucket Server this is the PR number.
+	ExternalIDs []interface{} `json:"externalIDs"`
+	// Repository description: The repository name as configured on your Sourcegraph instance.
+	Repository string `json:"repository"`
 }
 
 // Log description: Configuration for logging and alerting, including to external services.

--- a/shared/gulpfile.js
+++ b/shared/gulpfile.js
@@ -104,7 +104,7 @@ async function schema() {
   await mkdirp(outputDirectory)
   const schemaDirectory = path.join(__dirname, '..', 'schema')
   await Promise.all(
-    ['json-schema-draft-07', 'settings', 'site', 'campaign_spec', 'changeset_spec'].map(async file => {
+    ['json-schema-draft-07', 'settings', 'site'].map(async file => {
       let schema = await readFile(path.join(schemaDirectory, `${file}.schema.json`), 'utf8')
       // HACK: Rewrite absolute $refs to be relative. They need to be absolute for Monaco to resolve them
       // when the schema is in a oneOf (to be merged with extension schemas).

--- a/shared/gulpfile.js
+++ b/shared/gulpfile.js
@@ -104,7 +104,7 @@ async function schema() {
   await mkdirp(outputDirectory)
   const schemaDirectory = path.join(__dirname, '..', 'schema')
   await Promise.all(
-    ['json-schema-draft-07', 'settings', 'site'].map(async file => {
+    ['json-schema-draft-07', 'settings', 'site', 'campaign_spec', 'changeset_spec'].map(async file => {
       let schema = await readFile(path.join(schemaDirectory, `${file}.schema.json`), 'utf8')
       // HACK: Rewrite absolute $refs to be relative. They need to be absolute for Monaco to resolve them
       // when the schema is in a oneOf (to be merged with extension schemas).


### PR DESCRIPTION
Usage example:

```yaml
name: awesome-campaign
...
importChangesets:
- repo: github.com/sourcegraph/sourcegraph
  externalIDs: [110, "#113", 119]
- repo: gitlab.com/sourcegraph/sourcegraph
  externalIDs: [110, "!113", 119]
- repo: bitbucket.sourcegraph.com/sourcegraph/sourcegraph
  externalIDs: [110, 113, 119]
- repo: github.com/sourcegraph/sourcegraph
  externalIDs:
    - 110
    - 113
    - 119
...
```

or programmatically from an external tool: 

```bash
for repo in repos:
  externalID=$(my-awesome-tool --output-pr-id)
  jq --arg repo "$repo" --arg externalID "$externalID" '.importChangesets += [{ "repo": "$repo", "externalIDs": ["$externalID"] }]' campaign_spec.json
```

I think for the programmatic use-case, it makes sense to not have a keyed object to ensure uniqueness of "repo", but rather allow it being used multiple times.