### PR TITLE
search: add DNF conversion for hierarchical search

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -324,6 +324,65 @@ func partition(nodes []Node, fn func(node Node) bool) (left, right []Node) {
 	return left, right
 }
 
+// product appends the list of n elements in right to each of the m rows in
+// left. If left is empty, it is initialized with right.
+func product(left [][]Node, right []Node) [][]Node {
+	result := [][]Node{}
+	if len(left) == 0 {
+		return append(result, right)
+	}
+
+	for _, row := range left {
+		result = append(result, append(row, right...))
+	}
+	return result
+}
+
+// distribute applies the distributed property to nodes. See the dnf function
+// for context. Its first argument takes the current set of prefixes to prepend
+// to each term in an or-expression.
+func distribute(prefixes [][]Node, nodes []Node) [][]Node {
+	for _, node := range nodes {
+		switch v := node.(type) {
+		case Operator:
+			switch v.Kind {
+			case Or:
+				result := [][]Node{}
+				for _, o := range v.Operands {
+					var newPrefixes [][]Node
+					newPrefixes = distribute(newPrefixes, []Node{o})
+					for _, newPrefix := range newPrefixes {
+						result = append(result, product(prefixes, newPrefix)...)
+					}
+				}
+				prefixes = result
+			case And, Concat:
+				prefixes = distribute(prefixes, v.Operands)
+			}
+		case Parameter, Pattern:
+			prefixes = product(prefixes, []Node{v})
+		}
+	}
+	return prefixes
+}
+
+// dnf returns the Disjunctive Normal Form of a query (a flat sequence of
+// or-expressions) by applying the distributive property on (possibly nested)
+// or-expressions. For example, the query:
+//
+// (repo:a (file:b OR file:c))
+// in DNF becomes:
+// (repo:a file:b) OR (repo:a file:c)
+//
+// Using the DNF expression makes it easy to support general nested queries that
+// imply scope, like the one above: We simply evaluate all disjuncts and union
+// the results. Note that various optimizations are possible
+// during evaluation, but those are separate query pre- or postprocessing steps
+// separate from this general transformation.
+func dnf(query []Node) [][]Node {
+	return distribute([][]Node{}, query)
+}
+
 func substituteOrForRegexp(nodes []Node) []Node {
 	isPattern := func(node Node) bool {
 		if pattern, ok := node.(Pattern); ok && !pattern.Negated {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -333,7 +333,9 @@ func product(left [][]Node, right []Node) [][]Node {
 	}
 
 	for _, row := range left {
-		result = append(result, append(row, right...))
+		newRow := make([]Node, len(row))
+		copy(newRow, row)
+		result = append(result, append(newRow, right...))
 	}
 	return result
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -316,6 +316,14 @@ func TestExpandOr(t *testing.T) {
 			input: `a and b AND c or d and (e OR f) g h i or j`,
 			want:  `("a" "b" "c") OR ("d" "e" "g" "h" "i") OR ("d" "f" "g" "h" "i") OR ("j")`,
 		},
+		{
+			input: "(repo:a (file:b (file:c or file:d) (file:e or file:f)))",
+			want:  `("repo:a" "file:b" "file:c" "file:e") OR ("repo:a" "file:b" "file:d" "file:e") OR ("repo:a" "file:b" "file:c" "file:f") OR ("repo:a" "file:b" "file:d" "file:f")`,
+		},
+		{
+			input: "(repo:a (file:b (file:c or file:d) file:q (file:e or file:f)))",
+			want:  `("repo:a" "file:b" "file:c" "file:q" "file:e") OR ("repo:a" "file:b" "file:d" "file:q" "file:e") OR ("repo:a" "file:b" "file:c" "file:q" "file:f") OR ("repo:a" "file:b" "file:d" "file:q" "file:f")`,
+		},
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {


### PR DESCRIPTION
First main part of hierarchical search: adds a way to expand scoped/nested queries for evaluation. Copying the doc comment:

```
dnf returns the Disjunctive Normal Form of a query (a flat sequence of
or-expressions) by applying the distributive property on (possibly nested)
or-expressions. For example, the query:

(repo:a (file:b OR file:c))
in DNF becomes:
(repo:a file:b) OR (repo:a file:c)

Using the DNF expression makes it easy to support general nested queries that
imply scope, like the one above: We simply evaluate all disjuncts and union
the results. Note that various optimizations are possible
during evaluation, but those are separate query pre- or postprocessing steps
separate from this general transformation.
```

`dnf` isn't used or validated by the search code yet: I need to still make changes for evaluating these queries (next PRs).

---

Some notes:

**Why DNF?**

Queries can be evaluated in various ways (e.g., directly without DNF expansion, or by doing CNF expansion, etc.) depending how a system or engine is architected, size of the queries, and what is considered 'typical' for the domain of inputs. My assessment is that using DNF is the most appropriate choice based on our current search architecture right now--it's simple to evaluate, the sorts queries we expect will remain efficient, and the expressions are compatible with partial evaluation (i.e., for streaming). The foremost reason I see why we can't evaluate queries with scope directly is because we have both an indexed and unindexed code path, which can be toggled--evaluating directly would mean bookkeeping things like whether a repo is indexed or not as we evaluate expressions for files or content, and then calling those endpoints, which would substantially complicate the top-level evaluator logic. When we use a general DNF form it acts as a fallback that always works, and can rely on some properties of our regex support to simplify certain or-expressions directly, which would avoid DNF expansion in many cases:

**What about regex OR support which we already have?**

We can exploit the fact that `file:b OR file:c` is equivalent to regex `repo:b|c`, but that is something we can process before calling this function. We will always need a general way to evaluate scoped/nested expressions because not all params have an exploitable property like a shared regex expression. For example, this plausible query cannot be simplified in that way:

`repo:a (file:b OR "match me")` => `repo:a file:b OR repo:a "match me"`

another example is:

`repo:a (lang:ts OR lang:go)` 

which will work out of the box, without needing to, for example, first convert these to `file:` equivalents and then construct a regex (which would be a nice optimization, but it is tedious to go after nice optimizations before supporting the general capability).

