### PR TITLE
web: add storybook for SiteAdminExternalServicePage

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "eslint-formatter-lsif": "^1.0.3",
     "execa": "^4.0.2",
     "fancy-log": "^1.3.3",
-    "fetch-mock": "^9.10.4",
     "get-port": "^5.1.1",
     "googleapis": "^47.0.0",
     "gql2ts": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "eslint-formatter-lsif": "^1.0.3",
     "execa": "^4.0.2",
     "fancy-log": "^1.3.3",
+    "fetch-mock": "^9.10.4",
     "get-port": "^5.1.1",
     "googleapis": "^47.0.0",
     "gql2ts": "^1.10.1",

--- a/web/src/site-admin/SiteAdminExternalServicePage.story.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.story.tsx
@@ -1,0 +1,87 @@
+import { storiesOf } from '@storybook/react'
+import { radios, boolean } from '@storybook/addon-knobs'
+import React from 'react'
+import * as GQL from '../../../shared/src/graphql/schema'
+import { SiteAdminExternalServicePage } from './SiteAdminExternalServicePage'
+import { createMemoryHistory } from 'history'
+import webStyles from '../SourcegraphWebApp.scss'
+import { MemoryRouter } from 'react-router'
+import fetchMock from 'fetch-mock'
+
+const { add } = storiesOf('web/site-admin/SiteAdminExternalServicePage', module).addDecorator(story => {
+    const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')
+    document.body.classList.toggle('theme-light', theme === 'light')
+    document.body.classList.toggle('theme-dark', theme === 'dark')
+    return (
+        <MemoryRouter>
+            <style>{webStyles}</style>
+            <div className="p-3 container">{story()}</div>
+        </MemoryRouter>
+    )
+})
+
+const hosts: { [key: string]: object } = {
+    GitHub: {
+        data: {
+            node: {
+                __typename: 'ExternalService',
+                id: 'RXh0ZXJuYWxTZXJ2aWNlOjQ=',
+                kind: 'GITHUB',
+                displayName: 'GitHub Public',
+                config:
+                    '{\n  "url": "https://github.com",\n  // This token is from sourcegraph-dotcom-bot. It only has the public repo scope.\n  // IMPORTANT: If you change the token, you need to restart repo-updater\n  "token": "XXX",\n  // Sync no repositories. We only want the token to raise rate limits.\n  "repositoryQuery": [\n    "none"\n  ],\n  "exclude": [\n    {\n      "id": "MDEwOlJlcG9zaXRvcnkxOTI2MDUxODY=",\n      "name": "creachadair/jrpc2"\n    }\n  ]\n}',
+                warning: null,
+                webhookURL: null,
+            },
+        },
+    },
+    GitLab: {
+        data: {
+            node: {
+                __typename: 'ExternalService',
+                id: 'RXh0ZXJuYWxTZXJ2aWNlOjg=',
+                kind: 'GITLAB',
+                displayName: 'GitLab.com',
+                config:
+                    '{\n  "url": "https://gitlab.com",\n  // This token is from sourcegraph-dotcom-bot.\n  // IMPORTANT: If you change the token, you need to restart repo-updater\n  "token": "XXX",\n  // Sync no repositories. We only want the token to raise rate limits.\n  "projectQuery": [\n    "none",\n    "groups/sourcegraph/projects"\n  ]\n}',
+                warning: null,
+                webhookURL: null,
+            },
+        },
+    },
+}
+
+for (const name of Object.keys(hosts).sort()) {
+    add(name, () => {
+        fetchMock
+            .restore()
+            .post('/.api/graphql?ExternalService', {
+                body: hosts[name],
+                status: 200,
+            })
+            .post('begin:/.api/graphql', {
+                body: { data: { logUserEvent: null } },
+                status: 200,
+            })
+
+        return (
+            <SiteAdminExternalServicePage
+                history={createMemoryHistory()}
+                location={createMemoryHistory().location}
+                isLightTheme={true}
+                match={{
+                    isExact: true,
+                    path: '/site-admin/external/FOO',
+                    url: 'http://test.test/site-admin/external/FOO',
+                    params: { id: 'FOO' },
+                }}
+                mode="edit"
+                input={{
+                    kind: GQL.ExternalServiceKind.GITLAB,
+                    displayName: 'GitLab',
+                    config: '{}',
+                }}
+            />
+        )
+    })
+}

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -656,3 +656,59 @@ export function fetchMonitoringStats(days: number): Observable<GQL.IMonitoringSt
         })
     )
 }
+
+const externalServiceFragment = gql`
+    fragment externalServiceFields on ExternalService {
+        id
+        kind
+        displayName
+        config
+        warning
+        webhookURL
+    }
+`
+
+export function updateExternalService(input: GQL.IUpdateExternalServiceInput): Observable<GQL.IExternalService> {
+    return mutateGraphQL(
+        gql`
+            mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
+                updateExternalService(input: $input) {
+                    ...externalServiceFields
+                }
+            }
+
+            ${externalServiceFragment}
+        `,
+        { input }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.updateExternalService)
+    )
+}
+
+export function fetchExternalService(id: GQL.ID): Observable<GQL.IExternalService> {
+    return queryGraphQL(
+        gql`
+            query ExternalService($id: ID!) {
+                node(id: $id) {
+                    __typename
+                    ...externalServiceFields
+                }
+            }
+
+            ${externalServiceFragment}
+        `,
+        { id }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(({ node }) => {
+            if (!node) {
+                throw new Error('External service not found')
+            }
+            if (node.__typename !== 'ExternalService') {
+                throw new Error(`Node is a ${node.__typename}, not a ExternalService`)
+            }
+            return node
+        })
+    )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,7 +2302,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -7447,7 +7448,7 @@ core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.5:
+core-js@^3.0.0, core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
@@ -10011,6 +10012,21 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-mock@^9.10.4:
+  version "9.10.4"
+  resolved "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.10.4.tgz#e5f98c7d56d57b29caec55d928930150f39519ba"
+  integrity sha512-1ExE0cyv4+wHH/4NlSnh8tBBfVMUt6QFIRcuAGN7L4a0SAj7vOXh2z2G9XlEZS2qzgbj9ixDXFFE8gDmsCZ83g==
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^3.0.0"
+    debug "^4.1.1"
+    glob-to-regexp "^0.4.0"
+    is-subset "^0.1.1"
+    lodash.isequal "^4.5.0"
+    path-to-regexp "^2.2.1"
+    querystring "^0.2.0"
+    whatwg-url "^6.5.0"
+
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -10807,6 +10823,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob-to-regexp@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob-watcher@^5.0.3:
   version "5.0.3"
@@ -16886,6 +16907,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -20272,7 +20298,8 @@ sourcegraph@^24.0.0:
   integrity sha512-PlGvkdBy5r5iHdKAVNY/jsPgWb3oY+2iAdIQ3qR83UHhvBFVgoctDAnyfJ1eMstENY3etBWtAJ8Kleoar3ecaA==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.7.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -22793,7 +22820,7 @@ whatwg-url@8.0.0:
     tr46 "^2.0.0"
     webidl-conversions "^5.0.0"
 
-whatwg-url@^6.4.1:
+whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7448,7 +7448,7 @@ core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.0.0, core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.5:
+core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
@@ -10012,21 +10012,6 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-fetch-mock@^9.10.4:
-  version "9.10.4"
-  resolved "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.10.4.tgz#e5f98c7d56d57b29caec55d928930150f39519ba"
-  integrity sha512-1ExE0cyv4+wHH/4NlSnh8tBBfVMUt6QFIRcuAGN7L4a0SAj7vOXh2z2G9XlEZS2qzgbj9ixDXFFE8gDmsCZ83g==
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^3.0.0"
-    debug "^4.1.1"
-    glob-to-regexp "^0.4.0"
-    is-subset "^0.1.1"
-    lodash.isequal "^4.5.0"
-    path-to-regexp "^2.2.1"
-    querystring "^0.2.0"
-    whatwg-url "^6.5.0"
-
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -10823,11 +10808,6 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
-
-glob-to-regexp@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob-watcher@^5.0.3:
   version "5.0.3"
@@ -16907,11 +16887,6 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
-  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
-
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -22820,7 +22795,7 @@ whatwg-url@8.0.0:
     tr46 "^2.0.0"
     webidl-conversions "^5.0.0"
 
-whatwg-url@^6.4.1, whatwg-url@^6.5.0:
+whatwg-url@^6.4.1:
   version "6.5.0"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==


### PR DESCRIPTION
As SiteAdminExternalServicePage is tightly coupled to fetching its data from GraphQL, I've used fetch-mock to pre-populate it with interesting external service configurations. I am currently unsure how I actually feel about this.

Unfortunately, I need the full page to be able to render and test the webhook configuration blocks, which is my _actual_ goal, as part of #12139.

@eseliger, I'm particularly interested in your thoughts on this. Is this too icky to merge? Should I refactor the page to make it easier to test the bits I need? And, more broadly, since this is my very first time using storybooks, any other feedback would also be greatly appreciated. :smiley: