### PR TITLE
search: informative alert for comby out of memory

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -479,6 +479,12 @@ func alertForStructuralSearch(multiErr *multierror.Error) (newMultiErr *multierr
 					title:          "Structural search needs more memory",
 					description:    "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
 				}
+			} else if strings.Contains(err.Error(), "Out of memory") {
+				alert = &searchAlert{
+					prometheusType: "structural_search_needs_more_memory__give_searcher_more_memory",
+					title:          "Structural search needs more memory",
+					description:    `Running your structural search requires more memory. You could try reducing the number of repositories with the "repo:" filter. If you are an administrator, try double the memory allocated for the "searcher" service. If you're unsure, reach out to us at support@sourcegraph.com.`,
+				}
 			} else if strings.Contains(err.Error(), "no indexed repositories for structural search") {
 				var msg string
 				if envvar.SourcegraphDotComMode() {


### PR DESCRIPTION
Stacked on #12384

While I'm looking at alerts, I want to add this one.

Context: [1](https://sourcegraph.slack.com/archives/CTNA0E80K/p1588941262049500), [2](https://sourcegraph.slack.com/archives/CJX299FGE/p1589395012453700?thread_ts=1588960025.377500)