### PR TITLE
search: move search.Uppercase logic

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -101,6 +101,10 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 		if err != nil {
 			return alertForQuery(args.Query, err), nil
 		}
+		if getBoolPtr(settings.SearchUppercase, false) {
+			q := queryInfo.(*query.AndOrQuery)
+			q.Query = query.SearchUppercase(q.Query)
+		}
 	} else {
 		var queryString string
 		if searchType == query.SearchTypeLiteral {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -958,14 +958,6 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	case *query.OrdinaryQuery:
 		return r.evaluateLeaf(ctx)
 	case *query.AndOrQuery:
-		// Get settings to check if `search.uppercase` is active. If so, run transformer.
-		settings, err := decodedViewerFinalSettings(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if v := settings.SearchUppercase; v != nil && *v {
-			q.Query = query.SearchUppercase(q.Query)
-		}
 		return r.evaluate(ctx, q.Query)
 	}
 	// Unreachable.


### PR DESCRIPTION
Because `settings` is exposed in `search.go`, we can now concentrate all the query options/transformation logic there.