### PR TITLE
Badge design

### DIFF
--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -62,6 +62,13 @@ $alert-color-level-light: 6;
 $alert-padding-y: 0.75rem;
 $alert-padding-x: 0.75rem;
 
+// Badges
+
+$badge-font-size: 'max(50%, 10.5px)';
+$badge-font-weight: 600;
+$badge-padding-y: 0.34em;
+$badge-padding-x: 0.6em;
+
 // Forms
 
 $form-check-input-margin-y: 0.2em;

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -64,7 +64,7 @@ $alert-padding-x: 0.75rem;
 
 // Badges
 
-$badge-font-size: 'max(50%, 10.5px)';
+$badge-font-size: var(--badge-font-size);
 $badge-font-weight: 600;
 $badge-padding-y: 0.34em;
 $badge-padding-x: 0.6em;

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -64,7 +64,7 @@ $alert-padding-x: 0.75rem;
 
 // Badges
 
-$badge-font-size: var(--badge-font-size);
+$badge-font-size: 0.75em;
 $badge-font-weight: 600;
 $badge-padding-y: 0.34em;
 $badge-padding-x: 0.6em;

--- a/web/src/components/diff/FileDiffNode.story.tsx
+++ b/web/src/components/diff/FileDiffNode.story.tsx
@@ -160,6 +160,29 @@ export const FILE_DIFF_NODES: IFileDiff[] = [
     },
     {
         __typename: 'FileDiff',
+        hunks: DEMO_HUNKS,
+        internalID: 'abcdef123',
+        stat: { __typename: 'DiffStat', added: 0, changed: 1, deleted: 0 },
+        oldFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'dir1/from.md',
+        } as IVirtualFile,
+        newFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'dir2/to.md',
+        } as IVirtualFile,
+        mostRelevantFile: {
+            __typename: 'VirtualFile',
+            binary: false,
+            name: 'dir2/to.md',
+        } as IVirtualFile,
+        newPath: 'dir2/to.md',
+        oldPath: 'dir1/from.md',
+    },
+    {
+        __typename: 'FileDiff',
         hunks: [],
         internalID: 'abcdef123',
         stat: { __typename: 'DiffStat', added: 0, changed: 0, deleted: 0 },

--- a/web/src/components/diff/FileDiffNode.tsx
+++ b/web/src/components/diff/FileDiffNode.tsx
@@ -14,6 +14,7 @@ import { ThemeProps } from '../../../../shared/src/theme'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import classNames from 'classnames'
+import { dirname } from '../../util/path'
 
 export interface FileDiffNodeProps extends ThemeProps {
     node: GQL.IFileDiff
@@ -97,10 +98,12 @@ export class FileDiffNode extends React.PureComponent<FileDiffNodeProps, State> 
                             )}
                         </button>
                         <div className="file-diff-node__header-path-stat align-items-baseline">
-                            {!node.oldPath && <span className="badge badge-success mr-2">Added file</span>}
-                            {!node.newPath && <span className="badge badge-danger mr-2">Deleted file</span>}
+                            {!node.oldPath && <span className="badge badge-success mr-2">Added</span>}
+                            {!node.newPath && <span className="badge badge-danger mr-2">Deleted</span>}
                             {node.newPath && node.oldPath && node.newPath !== node.oldPath && (
-                                <span className="badge badge-merged mr-2">Moved file</span>
+                                <span className="badge badge-warning mr-2">
+                                    {dirname(node.newPath) !== dirname(node.oldPath) ? 'Moved' : 'Renamed'}
+                                </span>
                             )}
                             {stat}
                             <Link to={{ ...this.props.location, hash: anchor }} className="file-diff-node__header-path">

--- a/web/src/components/diff/FileDiffNode.tsx
+++ b/web/src/components/diff/FileDiffNode.tsx
@@ -98,10 +98,10 @@ export class FileDiffNode extends React.PureComponent<FileDiffNodeProps, State> 
                             )}
                         </button>
                         <div className="file-diff-node__header-path-stat align-items-baseline">
-                            {!node.oldPath && <span className="badge badge-success mr-2">Added</span>}
-                            {!node.newPath && <span className="badge badge-danger mr-2">Deleted</span>}
+                            {!node.oldPath && <span className="badge badge-success text-uppercase mr-2">Added</span>}
+                            {!node.newPath && <span className="badge badge-danger text-uppercase mr-2">Deleted</span>}
                             {node.newPath && node.oldPath && node.newPath !== node.oldPath && (
-                                <span className="badge badge-warning mr-2">
+                                <span className="badge badge-warning text-uppercase mr-2">
                                     {dirname(node.newPath) !== dirname(node.oldPath) ? 'Moved' : 'Renamed'}
                                 </span>
                             )}

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -32,13 +32,13 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({ campaign })
             </div>
             <div className="d-flex mb-2 position-relative">
                 <div>
-                    <h1 className="m-0">{campaign.name}</h1>
-                    <h2 className="m-0">
+                    <h1 className="mb-1">{campaign.name}</h1>
+                    <div>
                         <CampaignStateBadge isClosed={campaignClosed} />
                         <small className="text-muted">
                             {0}% complete. {campaign.changesets.totalCount} changesets total
                         </small>
-                    </h2>
+                    </div>
                 </div>
             </div>
         </>
@@ -48,13 +48,13 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({ campaign })
 const CampaignStateBadge: React.FunctionComponent<{ isClosed: boolean }> = ({ isClosed }) => {
     if (isClosed) {
         return (
-            <span className="badge badge-danger mr-2">
+            <span className="badge badge-danger text-uppercase mr-2">
                 <CampaignsIcon className="icon-inline campaign-actions-bar__campaign-icon" /> Closed
             </span>
         )
     }
     return (
-        <span className="badge badge-success mr-2">
+        <span className="badge badge-success text-uppercase mr-2">
             <CampaignsIcon className="icon-inline campaign-actions-bar__campaign-icon" /> Open
         </span>
     )

--- a/web/src/enterprise/campaigns/detail/CampaignHeader.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignHeader.tsx
@@ -14,7 +14,7 @@ export const CampaignHeader: React.FunctionComponent<Props> = ({ className }) =>
         <CampaignsIcon className="icon-inline mr-2" />
         Campaigns
         <sup>
-            <span className="ml-2 badge badge-primary">Beta</span>
+            <span className="ml-2 badge badge-primary text-uppercase">Beta</span>
         </sup>
     </h1>
 )

--- a/web/src/enterprise/campaigns/detail/CampaignHeader.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignHeader.tsx
@@ -14,9 +14,7 @@ export const CampaignHeader: React.FunctionComponent<Props> = ({ className }) =>
         <CampaignsIcon className="icon-inline mr-2" />
         Campaigns
         <sup>
-            <small>
-                <span className="ml-2 badge badge-primary">BETA</span>
-            </small>
+            <span className="ml-2 badge badge-primary">Beta</span>
         </sup>
     </h1>
 )

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -158,18 +158,16 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
     >
       <div>
         <h1
-          className="m-0"
+          className="mb-1"
         >
           n
         </h1>
-        <h2
-          className="m-0"
-        >
+        <div>
           <CampaignStateBadge
             isClosed={false}
           >
             <span
-              className="badge badge-success mr-2"
+              className="badge badge-success text-uppercase mr-2"
             >
               <CampaignsIcon
                 className="icon-inline campaign-actions-bar__campaign-icon"
@@ -185,7 +183,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
             2
              changesets total
           </small>
-        </h2>
+        </div>
       </div>
     </div>
   </CampaignActionsBar>
@@ -397,18 +395,16 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
     >
       <div>
         <h1
-          className="m-0"
+          className="mb-1"
         >
           n
         </h1>
-        <h2
-          className="m-0"
-        >
+        <div>
           <CampaignStateBadge
             isClosed={false}
           >
             <span
-              className="badge badge-success mr-2"
+              className="badge badge-success text-uppercase mr-2"
             >
               <CampaignsIcon
                 className="icon-inline campaign-actions-bar__campaign-icon"
@@ -424,7 +420,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
             2
              changesets total
           </small>
-        </h2>
+        </div>
       </div>
     </div>
   </CampaignActionsBar>

--- a/web/src/enterprise/campaigns/global/create/CampaignCliHelp.tsx
+++ b/web/src/enterprise/campaigns/global/create/CampaignCliHelp.tsx
@@ -40,7 +40,10 @@ interface Props {
 export const CampaignCliHelp: React.FunctionComponent<Props> = ({ className }) => (
     <div className={className}>
         <h1>
-            Create a campaign <span className="badge badge-info">Beta</span>
+            Create a campaign{' '}
+            <sup>
+                <span className="badge badge-info">Beta</span>
+            </sup>
         </h1>
         <div className="card">
             <div className="card-body p-3">

--- a/web/src/enterprise/campaigns/global/create/CampaignCliHelp.tsx
+++ b/web/src/enterprise/campaigns/global/create/CampaignCliHelp.tsx
@@ -42,7 +42,7 @@ export const CampaignCliHelp: React.FunctionComponent<Props> = ({ className }) =
         <h1>
             Create a campaign{' '}
             <sup>
-                <span className="badge badge-info">Beta</span>
+                <span className="badge badge-info text-uppercase">Beta</span>
             </sup>
         </h1>
         <div className="card">

--- a/web/src/enterprise/campaigns/global/create/CreateCampaign.tsx
+++ b/web/src/enterprise/campaigns/global/create/CreateCampaign.tsx
@@ -12,7 +12,10 @@ interface Props {
 export const CreateCampaign: React.FunctionComponent<Props> = ({ className }) => (
     <div className={className}>
         <h1>
-            Create a new campaign <span className="badge badge-info">Beta</span>
+            Create a new campaign{' '}
+            <sup>
+                <span className="badge badge-info">Beta</span>
+            </sup>
         </h1>
         <ul className="list-group">
             <li className="list-group-item p-3">

--- a/web/src/enterprise/campaigns/global/create/CreateCampaign.tsx
+++ b/web/src/enterprise/campaigns/global/create/CreateCampaign.tsx
@@ -14,7 +14,7 @@ export const CreateCampaign: React.FunctionComponent<Props> = ({ className }) =>
         <h1>
             Create a new campaign{' '}
             <sup>
-                <span className="badge badge-info">Beta</span>
+                <span className="badge badge-info text-uppercase">Beta</span>
             </sup>
         </h1>
         <ul className="list-group">

--- a/web/src/enterprise/campaigns/global/create/__snapshots__/CampaignCliHelp.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/create/__snapshots__/CampaignCliHelp.test.tsx.snap
@@ -8,12 +8,15 @@ exports[`CampaignCliHelp renders 1`] = `
     className="test"
   >
     <h1>
-      Create a campaign 
-      <span
-        className="badge badge-info"
-      >
-        Beta
-      </span>
+      Create a campaign
+       
+      <sup>
+        <span
+          className="badge badge-info"
+        >
+          Beta
+        </span>
+      </sup>
     </h1>
     <div
       className="card"

--- a/web/src/enterprise/campaigns/global/create/__snapshots__/CampaignCliHelp.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/create/__snapshots__/CampaignCliHelp.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`CampaignCliHelp renders 1`] = `
        
       <sup>
         <span
-          className="badge badge-info"
+          className="badge badge-info text-uppercase"
         >
           Beta
         </span>

--- a/web/src/enterprise/campaigns/global/create/__snapshots__/CreateCampaign.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/create/__snapshots__/CreateCampaign.test.tsx.snap
@@ -4,12 +4,15 @@ exports[`CreateCampaign renders 1`] = `
 <CreateCampaign>
   <div>
     <h1>
-      Create a new campaign 
-      <span
-        className="badge badge-info"
-      >
-        Beta
-      </span>
+      Create a new campaign
+       
+      <sup>
+        <span
+          className="badge badge-info"
+        >
+          Beta
+        </span>
+      </sup>
     </h1>
     <ul
       className="list-group"

--- a/web/src/enterprise/campaigns/global/create/__snapshots__/CreateCampaign.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/create/__snapshots__/CreateCampaign.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CreateCampaign renders 1`] = `
        
       <sup>
         <span
-          className="badge badge-info"
+          className="badge badge-info text-uppercase"
         >
           Beta
         </span>

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -45,7 +45,10 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
             <div className="d-flex justify-content-between align-items-end mb-3">
                 <div>
                     <h1 className="mb-2">
-                        Campaigns <span className="badge badge-info">Beta</span>
+                        Campaigns{' '}
+                        <sup>
+                            <span className="badge badge-info">Beta</span>
+                        </sup>
                     </h1>
                     <p className="mb-0">
                         Perform and track large-scale code changes.{' '}

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -59,9 +59,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
 
             <div className="card mt-4 mb-4">
                 <div className="card-body p-3">
-                    <h3>
-                        Welcome to campaigns <span className="badge badge-info text-uppercase">Beta</span>!
-                    </h3>
+                    <h3>Welcome to campaigns!</h3>
                     <p className="mb-1">
                         We're excited for you to use campaigns to remove legacy code, fix critical security issues, pay
                         down tech debt, and more. We look forward to hearing about campaigns you run inside your

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -60,11 +60,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
             <div className="card mt-4 mb-4">
                 <div className="card-body p-3">
                     <h3>
-                        Welcome to campaigns{' '}
-                        <sup>
-                            <span className="badge badge-info text-uppercase">Beta</span>
-                        </sup>
-                        !
+                        Welcome to campaigns <span className="badge badge-info text-uppercase">Beta</span>!
                     </h3>
                     <p className="mb-1">
                         We're excited for you to use campaigns to remove legacy code, fix critical security issues, pay

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -47,7 +47,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
                     <h1 className="mb-2">
                         Campaigns{' '}
                         <sup>
-                            <span className="badge badge-info">Beta</span>
+                            <span className="badge badge-info text-uppercase">Beta</span>
                         </sup>
                     </h1>
                     <p className="mb-0">
@@ -62,7 +62,7 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
                     <h3>
                         Welcome to campaigns{' '}
                         <sup>
-                            <span className="badge badge-info">Beta</span>
+                            <span className="badge badge-info text-uppercase">Beta</span>
                         </sup>
                         !
                     </h3>

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -60,7 +60,11 @@ export const GlobalCampaignListPage: React.FunctionComponent<Props> = ({
             <div className="card mt-4 mb-4">
                 <div className="card-body p-3">
                     <h3>
-                        Welcome to campaigns <span className="badge badge-info">Beta</span>!
+                        Welcome to campaigns{' '}
+                        <sup>
+                            <span className="badge badge-info">Beta</span>
+                        </sup>
+                        !
                     </h3>
                     <p className="mb-1">
                         We're excited for you to use campaigns to remove legacy code, fix critical security issues, pay

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -9,12 +9,15 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
       <h1
         className="mb-2"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <p
         className="mb-0"
@@ -130,12 +133,15 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
       <h1
         className="mb-2"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <p
         className="mb-0"
@@ -251,12 +257,15 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
       <h1
         className="mb-2"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <p
         className="mb-0"
@@ -372,12 +381,15 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
       <h1
         className="mb-2"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <p
         className="mb-0"

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -39,12 +39,15 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Welcome to campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
         !
       </h3>
       <p
@@ -163,12 +166,15 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Welcome to campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
         !
       </h3>
       <p
@@ -287,12 +293,15 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Welcome to campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
         !
       </h3>
       <p
@@ -411,12 +420,15 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Welcome to campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
         !
       </h3>
       <p

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -39,15 +39,12 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns
-         
-        <sup>
-          <span
-            className="badge badge-info text-uppercase"
-          >
-            Beta
-          </span>
-        </sup>
+        Welcome to campaigns 
+        <span
+          className="badge badge-info text-uppercase"
+        >
+          Beta
+        </span>
         !
       </h3>
       <p
@@ -166,15 +163,12 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns
-         
-        <sup>
-          <span
-            className="badge badge-info text-uppercase"
-          >
-            Beta
-          </span>
-        </sup>
+        Welcome to campaigns 
+        <span
+          className="badge badge-info text-uppercase"
+        >
+          Beta
+        </span>
         !
       </h3>
       <p
@@ -293,15 +287,12 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns
-         
-        <sup>
-          <span
-            className="badge badge-info text-uppercase"
-          >
-            Beta
-          </span>
-        </sup>
+        Welcome to campaigns 
+        <span
+          className="badge badge-info text-uppercase"
+        >
+          Beta
+        </span>
         !
       </h3>
       <p
@@ -420,15 +411,12 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns
-         
-        <sup>
-          <span
-            className="badge badge-info text-uppercase"
-          >
-            Beta
-          </span>
-        </sup>
+        Welcome to campaigns 
+        <span
+          className="badge badge-info text-uppercase"
+        >
+          Beta
+        </span>
         !
       </h3>
       <p

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -43,7 +43,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -140,7 +140,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -170,7 +170,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -267,7 +267,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -297,7 +297,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -394,7 +394,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -424,7 +424,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -39,13 +39,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info text-uppercase"
-        >
-          Beta
-        </span>
-        !
+        Welcome to campaigns!
       </h3>
       <p
         className="mb-1"
@@ -163,13 +157,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info text-uppercase"
-        >
-          Beta
-        </span>
-        !
+        Welcome to campaigns!
       </h3>
       <p
         className="mb-1"
@@ -287,13 +275,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info text-uppercase"
-        >
-          Beta
-        </span>
-        !
+        Welcome to campaigns!
       </h3>
       <p
         className="mb-1"
@@ -411,13 +393,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
       className="card-body p-3"
     >
       <h3>
-        Welcome to campaigns 
-        <span
-          className="badge badge-info text-uppercase"
-        >
-          Beta
-        </span>
-        !
+        Welcome to campaigns!
       </h3>
       <p
         className="mb-1"

--- a/web/src/enterprise/campaigns/global/marketing/CampaignsMarketing.tsx
+++ b/web/src/enterprise/campaigns/global/marketing/CampaignsMarketing.tsx
@@ -14,7 +14,10 @@ export const CampaignsMarketing: React.FunctionComponent<CampaignsMarketingProps
     <>
         <section className="mt-3 mb-5">
             <h1 className="font-weight-bold display-4">
-                Campaigns <span className="badge badge-info">Beta</span>
+                Campaigns{' '}
+                <sup>
+                    <span className="badge badge-info">Beta</span>
+                </sup>
             </h1>
             <h2 className="mb-5">Make and track large-scale changes across all code</h2>
 

--- a/web/src/enterprise/campaigns/global/marketing/CampaignsMarketing.tsx
+++ b/web/src/enterprise/campaigns/global/marketing/CampaignsMarketing.tsx
@@ -16,7 +16,7 @@ export const CampaignsMarketing: React.FunctionComponent<CampaignsMarketingProps
             <h1 className="font-weight-bold display-4">
                 Campaigns{' '}
                 <sup>
-                    <span className="badge badge-info">Beta</span>
+                    <span className="badge badge-info text-uppercase">Beta</span>
                 </sup>
             </h1>
             <h2 className="mb-5">Make and track large-scale changes across all code</h2>

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
@@ -106,12 +106,15 @@ exports[`CampaignsDotComPage renders 1`] = `
       <h1
         className="font-weight-bold display-4"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <h2
         className="mb-5"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`CampaignsDotComPage renders 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsMarketing.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsMarketing.test.tsx.snap
@@ -14,12 +14,15 @@ exports[`CampaignsMarketing renders 1`] = `
     <h1
       className="font-weight-bold display-4"
     >
-      Campaigns 
-      <span
-        className="badge badge-info"
-      >
-        Beta
-      </span>
+      Campaigns
+       
+      <sup>
+        <span
+          className="badge badge-info"
+        >
+          Beta
+        </span>
+      </sup>
     </h1>
     <h2
       className="mb-5"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsMarketing.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsMarketing.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`CampaignsMarketing renders 1`] = `
        
       <sup>
         <span
-          className="badge badge-info"
+          className="badge badge-info text-uppercase"
         >
           Beta
         </span>

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsSiteAdminMarketingPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsSiteAdminMarketingPage.test.tsx.snap
@@ -59,12 +59,15 @@ exports[`CampaignsSiteAdminMarketingPage renders 1`] = `
       <h1
         className="font-weight-bold display-4"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <h2
         className="mb-5"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsSiteAdminMarketingPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsSiteAdminMarketingPage.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`CampaignsSiteAdminMarketingPage renders 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsUserMarketingPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsUserMarketingPage.test.tsx.snap
@@ -50,12 +50,15 @@ exports[`CampaignsUserMarketingPage renders for disabled 1`] = `
       <h1
         className="font-weight-bold display-4"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <h2
         className="mb-5"
@@ -216,12 +219,15 @@ exports[`CampaignsUserMarketingPage renders for enabled 1`] = `
       <h1
         className="font-weight-bold display-4"
       >
-        Campaigns 
-        <span
-          className="badge badge-info"
-        >
-          Beta
-        </span>
+        Campaigns
+         
+        <sup>
+          <span
+            className="badge badge-info"
+          >
+            Beta
+          </span>
+        </sup>
       </h1>
       <h2
         className="mb-5"

--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsUserMarketingPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsUserMarketingPage.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`CampaignsUserMarketingPage renders for disabled 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>
@@ -223,7 +223,7 @@ exports[`CampaignsUserMarketingPage renders for enabled 1`] = `
          
         <sup>
           <span
-            className="badge badge-info"
+            className="badge badge-info text-uppercase"
           >
             Beta
           </span>

--- a/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -50,7 +50,7 @@ export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node,
                             <span data-tooltip={<Timestamp date={node.createdAt} />}>
                                 {formatDistance(parseISO(node.createdAt), now)} ago
                             </span>{' '}
-                            by <span className="badge badge-secondary">{node.author.username}</span>
+                            by {node.author.username}
                         </small>
                     </div>
                     <Markdown

--- a/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -50,7 +50,7 @@ export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node,
                             <span data-tooltip={<Timestamp date={node.createdAt} />}>
                                 {formatDistance(parseISO(node.createdAt), now)} ago
                             </span>{' '}
-                            by {node.author.username}
+                            by <strong>{node.author.username}</strong>
                         </small>
                     </div>
                     <Markdown

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -74,7 +74,9 @@ exports[`CampaignNode campaign without description 1`] = `
             </span>
              
             by 
-            alice
+            <strong>
+              alice
+            </strong>
           </small>
         </div>
         <Markdown
@@ -242,7 +244,9 @@ exports[`CampaignNode closed campaign 1`] = `
             </span>
              
             by 
-            alice
+            <strong>
+              alice
+            </strong>
           </small>
         </div>
         <Markdown
@@ -418,7 +422,9 @@ exports[`CampaignNode open campaign 1`] = `
             </span>
              
             by 
-            alice
+            <strong>
+              alice
+            </strong>
           </small>
         </div>
         <Markdown

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -74,11 +74,7 @@ exports[`CampaignNode campaign without description 1`] = `
             </span>
              
             by 
-            <span
-              className="badge badge-secondary"
-            >
-              alice
-            </span>
+            alice
           </small>
         </div>
         <Markdown
@@ -246,11 +242,7 @@ exports[`CampaignNode closed campaign 1`] = `
             </span>
              
             by 
-            <span
-              className="badge badge-secondary"
-            >
-              alice
-            </span>
+            alice
           </small>
         </div>
         <Markdown
@@ -426,11 +418,7 @@ exports[`CampaignNode open campaign 1`] = `
             </span>
              
             by 
-            <span
-              className="badge badge-secondary"
-            >
-              alice
-            </span>
+            alice
           </small>
         </div>
         <Markdown

--- a/web/src/enterprise/search/stats/SearchStatsPage.tsx
+++ b/web/src/enterprise/search/stats/SearchStatsPage.tsx
@@ -55,7 +55,7 @@ export const SearchStatsPage: React.FunctionComponent<Props> = ({
             <header className="d-flex align-items-center justify-content-between mb-3">
                 <h2 className="d-flex align-items-center mb-0">
                     <ChartLineIcon className="icon-inline mr-2" /> Code statistics{' '}
-                    <small className="badge badge-secondary ml-2">Experimental</small>
+                    <small className="badge badge-secondary text-uppercase ml-2">Experimental</small>
                 </h2>
             </header>
             <Form onSubmit={onSubmit} className="form">

--- a/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`SearchStatsPage limitHit 1`] = `
        Code statistics
        
       <small
-        className="badge badge-secondary ml-2"
+        className="badge badge-secondary text-uppercase ml-2"
       >
         Experimental
       </small>
@@ -92,7 +92,7 @@ exports[`SearchStatsPage renders 1`] = `
        Code statistics
        
       <small
-        className="badge badge-secondary ml-2"
+        className="badge badge-secondary text-uppercase ml-2"
       >
         Experimental
       </small>

--- a/web/src/global-styles/badge.scss
+++ b/web/src/global-styles/badge.scss
@@ -1,5 +1,9 @@
 @import 'bootstrap/scss/badge';
 
+.badge {
+    text-transform: uppercase;
+}
+
 // Light theme badge variants
 .theme-light {
     @each $color, $value in $theme-colors-light {

--- a/web/src/global-styles/badge.scss
+++ b/web/src/global-styles/badge.scss
@@ -4,6 +4,18 @@
     text-transform: uppercase;
 }
 
+:root {
+    // Fallback for Chrome <82, Firefox <69, iOS Safari.
+    // Effective font-size is 18px for a <sup> in an <h1> (24px) and 10.5px for regular text (14px).
+    --badge-font-size: 75%;
+    @supports (font-size: unquote('max(0.5em, 10.5px)')) {
+        // Scale badge linearly with the parent font size,
+        // but not smaller than a certain threshold for accessibility reasons.
+        // Effective font-size is 12px for a <sup> in an <h1> (24px) and 10.5px for regular text (14px).
+        --badge-font-size: max(0.5em, 10.5px);
+    }
+}
+
 // Light theme badge variants
 .theme-light {
     @each $color, $value in $theme-colors-light {

--- a/web/src/global-styles/badge.scss
+++ b/web/src/global-styles/badge.scss
@@ -1,21 +1,5 @@
 @import 'bootstrap/scss/badge';
 
-.badge {
-    text-transform: uppercase;
-}
-
-:root {
-    // Fallback for Chrome <82, Firefox <69, iOS Safari.
-    // Effective font-size is 18px for a <sup> in an <h1> (24px) and 10.5px for regular text (14px).
-    --badge-font-size: 75%;
-    @supports (font-size: unquote('max(0.5em, 10.5px)')) {
-        // Scale badge linearly with the parent font size,
-        // but not smaller than a certain threshold for accessibility reasons.
-        // Effective font-size is 12px for a <sup> in an <h1> (24px) and 10.5px for regular text (14px).
-        --badge-font-size: max(0.5em, 10.5px);
-    }
-}
-
 // Light theme badge variants
 .theme-light {
     @each $color, $value in $theme-colors-light {

--- a/web/src/global-styles/global-styles.story.tsx
+++ b/web/src/global-styles/global-styles.story.tsx
@@ -407,6 +407,11 @@ add(
                             <small>
                                 Lorem <span className="badge badge-secondary">ipsum</span>
                             </small>
+                            <p>
+                                <small className="text-danger">
+                                    Discouraged because the text becomes too small to read.
+                                </small>
+                            </p>
                         </td>
                     </tr>
                 </tbody>

--- a/web/src/global-styles/global-styles.story.tsx
+++ b/web/src/global-styles/global-styles.story.tsx
@@ -361,30 +361,30 @@ add(
                 <code>em</code> units for padding.
             </p>
             <p>
-                Use a superscript <code>{'<sup></sup>'}</code> if the badge should be positioned top-right of another
-                word.
+                Use a superscript <code>{'<sup></sup>'}</code> to position the badge top-right of a word in{' '}
+                <code>h1</code> headings. Do not use a superscript for smaller text, because the font size would become
+                too small.
             </p>
             <table className="table">
-                <thead>
-                    <tr>
-                        <th>Level</th>
-                        <th>Superscript</th>
-                        <th>Baseline</th>
-                    </tr>
-                </thead>
                 <tbody>
-                    {(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const).map(Heading => (
+                    <tr>
+                        <td>
+                            <code>{'<h1>'}</code> + <code>{'<sup>'}</code>
+                        </td>
+                        <td>
+                            <h1>
+                                Lorem{' '}
+                                <sup>
+                                    <span className="badge badge-secondary">ipsum</span>
+                                </sup>
+                            </h1>
+                            <small>Use a superscript to align the badge top-right of the heading text.</small>
+                        </td>
+                    </tr>
+                    {(['h2', 'h3', 'h4', 'h5', 'h6'] as const).map(Heading => (
                         <tr key={Heading}>
                             <td>
                                 <code>{`<${Heading}>`}</code>
-                            </td>
-                            <td>
-                                <Heading>
-                                    Lorem{' '}
-                                    <sup>
-                                        <span className="badge badge-secondary">ipsum</span>
-                                    </sup>
-                                </Heading>
                             </td>
                             <td>
                                 <Heading>
@@ -396,26 +396,12 @@ add(
                     <tr>
                         <td>Regular text</td>
                         <td>
-                            Lorem{' '}
-                            <sup>
-                                <span className="badge badge-secondary">ipsum</span>
-                            </sup>
-                        </td>
-                        <td>
                             Lorem <span className="badge badge-secondary">ipsum</span>
                         </td>
                     </tr>
                     <tr>
                         <td>
                             <code>{'<small>'}</code>
-                        </td>
-                        <td>
-                            <small>
-                                Lorem{' '}
-                                <sup>
-                                    <span className="badge badge-secondary">ipsum</span>
-                                </sup>
-                            </small>
                         </td>
                         <td>
                             <small>
@@ -476,7 +462,7 @@ add(
             <p>
                 <span className="badge badge-warning text-uppercase">moved</span> <code>path/to/file.ts</code>
             </p>
-            <p>Do not use it for user-supplied text like badges or usernames.</p>
+            <p>Do not use it for user-supplied text like labels (tags) or usernames.</p>
 
             <h2>Pill badges</h2>
             <p>Pill badges are commonly used to display counts.</p>

--- a/web/src/global-styles/global-styles.story.tsx
+++ b/web/src/global-styles/global-styles.story.tsx
@@ -59,6 +59,14 @@ add('Text', () => (
         </p>
 
         <p>
+            Text can have superscripts<sup>sup</sup> with <code>{'<sup>'}</code>.
+        </p>
+
+        <p>
+            Text can have subscripts<sub>sub</sub> with <code>{'<sub>'}</code>.
+        </p>
+
+        <p>
             <small>
                 You can use <code>{'<small>'}</code> to make small text. Use sparingly.
             </small>
@@ -345,17 +353,25 @@ add(
                 </a>{' '}
                 | <a href="https://getbootstrap.com/docs/4.5/components/badge/">Bootstrap Documentation</a>{' '}
             </p>
-            <p>
-                Badges are used for labelling and displaying small counts. Badges scale to match the size of the
-                immediate parent element by using relative font sizing and <code>em</code> units for padding. Text in
-                badges is automatically uppercased with CSS.
-            </p>
+            <p>Badges are used for labelling and displaying small counts.</p>
 
-            <h2>Headings</h2>
+            <h2>Scaling</h2>
             <p>
-                Badges can be used in headings within a superscript <code>{'<sup></sup>'}</code>:
+                Badges scale to match the size of the immediate parent element by using relative font sizing and{' '}
+                <code>em</code> units for padding.
+            </p>
+            <p>
+                Use a superscript <code>{'<sup></sup>'}</code> if the badge should be positioned top-right of another
+                word.
             </p>
             <table className="table">
+                <thead>
+                    <tr>
+                        <th>Level</th>
+                        <th>Superscript</th>
+                        <th>Baseline</th>
+                    </tr>
+                </thead>
                 <tbody>
                     {(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const).map(Heading => (
                         <tr key={Heading}>
@@ -364,16 +380,52 @@ add(
                             </td>
                             <td>
                                 <Heading>
-                                    Blockchain support{' '}
+                                    Lorem{' '}
                                     <sup>
-                                        <span className="badge badge-info">Beta</span>
+                                        <span className="badge badge-secondary">ipsum</span>
                                     </sup>
+                                </Heading>
+                            </td>
+                            <td>
+                                <Heading>
+                                    Lorem <span className="badge badge-secondary">ipsum</span>
                                 </Heading>
                             </td>
                         </tr>
                     ))}
+                    <tr>
+                        <td>Regular text</td>
+                        <td>
+                            Lorem{' '}
+                            <sup>
+                                <span className="badge badge-secondary">ipsum</span>
+                            </sup>
+                        </td>
+                        <td>
+                            Lorem <span className="badge badge-secondary">ipsum</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>{'<small>'}</code>
+                        </td>
+                        <td>
+                            <small>
+                                Lorem{' '}
+                                <sup>
+                                    <span className="badge badge-secondary">ipsum</span>
+                                </sup>
+                            </small>
+                        </td>
+                        <td>
+                            <small>
+                                Lorem <span className="badge badge-secondary">ipsum</span>
+                            </small>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
+
             <h2>Semantic variations</h2>
             <p>Change the appearance of any badge with modifier classes for semantic colors.</p>
             <p>
@@ -383,6 +435,48 @@ add(
                     </React.Fragment>
                 ))}
             </p>
+
+            <h2>Uppercase</h2>
+            <p>
+                Badges can be visually uppercased by combining them with the <code>text-uppercase</code> class.
+                Examples:
+            </p>
+            <div>
+                <h1>
+                    Blockchain support{' '}
+                    <sup>
+                        <span className="badge badge-primary text-uppercase">Beta</span>
+                    </sup>
+                </h1>
+                <h1>
+                    Blockchain support{' '}
+                    <sup>
+                        <span className="badge badge-primary text-uppercase">Preview</span>
+                    </sup>
+                </h1>
+                <h1>
+                    Blockchain support{' '}
+                    <sup>
+                        <span className="badge badge-primary text-uppercase">Experimental</span>
+                    </sup>
+                </h1>
+                <h1>
+                    Blockchain support{' '}
+                    <sup>
+                        <span className="badge badge-primary text-uppercase">Prototype</span>
+                    </sup>
+                </h1>
+            </div>
+            <p>
+                <span className="badge badge-success text-uppercase">added</span> <code>path/to/file.ts</code>
+            </p>
+            <p>
+                <span className="badge badge-danger text-uppercase">deleted</span> <code>path/to/file.ts</code>
+            </p>
+            <p>
+                <span className="badge badge-warning text-uppercase">moved</span> <code>path/to/file.ts</code>
+            </p>
+            <p>Do not use it for user-supplied text like badges or usernames.</p>
 
             <h2>Pill badges</h2>
             <p>Pill badges are commonly used to display counts.</p>

--- a/web/src/global-styles/global-styles.story.tsx
+++ b/web/src/global-styles/global-styles.story.tsx
@@ -436,25 +436,25 @@ add(
                 <h1>
                     Blockchain support{' '}
                     <sup>
-                        <span className="badge badge-primary text-uppercase">Beta</span>
+                        <span className="badge badge-warning text-uppercase">Beta</span>
                     </sup>
                 </h1>
                 <h1>
                     Blockchain support{' '}
                     <sup>
-                        <span className="badge badge-primary text-uppercase">Preview</span>
+                        <span className="badge badge-info text-uppercase">Preview</span>
                     </sup>
                 </h1>
                 <h1>
                     Blockchain support{' '}
                     <sup>
-                        <span className="badge badge-primary text-uppercase">Experimental</span>
+                        <span className="badge badge-info text-uppercase">Experimental</span>
                     </sup>
                 </h1>
                 <h1>
                     Blockchain support{' '}
                     <sup>
-                        <span className="badge badge-primary text-uppercase">Prototype</span>
+                        <span className="badge badge-info text-uppercase">Prototype</span>
                     </sup>
                 </h1>
             </div>

--- a/web/src/global-styles/type.scss
+++ b/web/src/global-styles/type.scss
@@ -36,3 +36,11 @@ h5 {
 small {
     font-size: 12px;
 }
+
+sup,
+sub {
+    font-size: 0.5em;
+}
+sup {
+    top: -1em;
+}

--- a/web/src/global-styles/type.scss
+++ b/web/src/global-styles/type.scss
@@ -26,7 +26,7 @@ h4 {
 }
 
 h5 {
-    font-size: 13px + (1/3);
+    font-size: 14px;
     letter-spacing: 1px;
     font-weight: 500;
     text-transform: uppercase;

--- a/web/src/global-styles/type.scss
+++ b/web/src/global-styles/type.scss
@@ -26,7 +26,7 @@ h4 {
 }
 
 h5 {
-    font-size: 12px;
+    font-size: 13px + (1/3);
     letter-spacing: 1px;
     font-weight: 500;
     text-transform: uppercase;

--- a/web/src/insights/InsightsPage.tsx
+++ b/web/src/insights/InsightsPage.tsx
@@ -29,7 +29,7 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
                 <h1 className="flex-grow-1 text-nowrap">
                     <InsightsIcon className="icon-inline" /> Insights{' '}
                     <sup>
-                        <span className="badge badge-primary">prototype</span>
+                        <span className="badge badge-primary text-uppercase">prototype</span>
                     </sup>
                 </h1>
                 {/* These buttons are just links until there is a proper configuration UI */}

--- a/web/src/snippets/SnippetsPage.tsx
+++ b/web/src/snippets/SnippetsPage.tsx
@@ -98,7 +98,7 @@ export const SnippetsPage: React.FunctionComponent<Props> = ({ location, history
     return (
         <div className="container mt-3">
             <h1>
-                Snippet editor <span className="badge badge-warning">Experimental</span>
+                Snippet editor <span className="badge badge-warning text-uppercase">Experimental</span>
             </h1>
             {viewerId && modelUri && (
                 <>


### PR DESCRIPTION
Updates the badge design as in Figma and discussed with @AlicjaSuska over Zoom and extends the Storybook for them.
Also updates our `info` color to a lighter cyan (as in Figma).
See diff in Chromatic.