### PR TITLE
reposource: ParseConfig function to simplify callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue where search autocomplete for files didn't add the right path. [#12241](https://github.com/sourcegraph/sourcegraph/pull/12241)
 - Fixed site admins are getting errors when visiting user settings page in OSS version. [#12313](https://github.com/sourcegraph/sourcegraph/pull/12313)
 - `github-proxy` now respects the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` (or the lowercase versions thereof). Other services already respect these variables, but this was missed. If you need a proxy to access github.com set the environment variable for the github-proxy container. [#12377](https://github.com/sourcegraph/sourcegraph/issues/12377)
+- Git submodule entries in the file tree now link to for all external service types. Previously we did not link for Bitbucket Cloud External Services or Other External Services. [#12399](https://github.com/sourcegraph/sourcegraph/pull/12399)
 
 ### Removed
 

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -457,89 +457,12 @@ func (e *ExternalServicesStore) listConfigs(ctx context.Context, kind string, re
 	return nil
 }
 
-// ListAWSCodeCommitConnections returns a list of AWSCodeCommit configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context) ([]*types.AWSCodeCommitConnection, error) {
-	var connections []*types.AWSCodeCommitConnection
-	if err := e.listConfigs(ctx, extsvc.KindAWSCodeCommit, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListBitbucketCloudConnections returns a list of BitbucketCloud configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Context) ([]*types.BitbucketCloudConnection, error) {
-	var connections []*types.BitbucketCloudConnection
-	if err := e.listConfigs(ctx, extsvc.KindBitbucketCloud, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListBitbucketServerConnections returns a list of BitbucketServer configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Context) ([]*types.BitbucketServerConnection, error) {
-	var connections []*types.BitbucketServerConnection
-	if err := e.listConfigs(ctx, extsvc.KindBitbucketServer, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListGitHubConnections returns a list of GitHubConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*types.GitHubConnection, error) {
-	var connections []*types.GitHubConnection
-	if err := e.listConfigs(ctx, extsvc.KindGitHub, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListGitLabConnections returns a list of GitLabConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*types.GitLabConnection, error) {
-	var connections []*types.GitLabConnection
-	if err := e.listConfigs(ctx, extsvc.KindGitLab, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListGitoliteConnections returns a list of GitoliteConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]*types.GitoliteConnection, error) {
-	var connections []*types.GitoliteConnection
-	if err := e.listConfigs(ctx, extsvc.KindGitolite, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
 // ListPhabricatorConnections returns a list of PhabricatorConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
 func (e *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) ([]*types.PhabricatorConnection, error) {
 	var connections []*types.PhabricatorConnection
 	if err := e.listConfigs(ctx, extsvc.KindPhabricator, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListOtherExternalServicesConnections returns a list of OtherExternalServiceConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListOtherExternalServicesConnections(ctx context.Context) ([]*types.OtherExternalServiceConnection, error) {
-	var connections []*types.OtherExternalServiceConnection
-	if err := e.listConfigs(ctx, extsvc.KindOther, &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil


### PR DESCRIPTION
RepoSource is only used by reposourceCloneURLToRepoName in the
graphqlbackend. It uses it for resolving submodules and repository
redirects. Previously we created a List* for each external service type
in the ExternalServices store. These functions are also only used by
reposourceCloneURLToRepoName.

This commit simplifies this logic by using extsvc.ParseConfig and
listing all external services rather than individually by type.

This also fixes some bugs. For example previously this functionality did
not work for Bitbucket Cloud or Other external services (since the code
forgot to call it).

We do change the order in which we check external services. However,
given we match on hostnames in the clone URL it shouldn't affect
functionality.

As we scale out external services this approach will no longer
work. However, that requires more work. This commit helps us along that
path since it reduces the coupling we had.

Note: The OtherExternalServiceConnection also uses its repo source, but
doesn't need to. That is not solved in this commit.

Co-Author: @tsenart