### PR TITLE
codeintel: Add commit graph utilities

### DIFF
--- a/enterprise/internal/codeintel/store/commit_graph.go
+++ b/enterprise/internal/codeintel/store/commit_graph.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"github.com/pkg/errors"
+)
+
+// UploadMeta contains the subset of fields from the lsif_uploads table that are used
+// to determine visibility of an upload from a particular commit.
+type UploadMeta struct {
+	UploadID int
+	Root     string
+	Indexer  string
+
+	// Distance is the number of commits between the reference to definition commits.
+	Distance int
+}
+
+// calculateVisibleUploads transforms the given commit graph and the set of LSIF uploads
+// defined on each commit with LSIF upload into a map from a commit to the set of uploads
+// which are visible from that commit.
+func calculateVisibleUploads(graph map[string][]string, uploads map[string][]UploadMeta) (map[string][]UploadMeta, error) {
+	// Calculate an ordering of vertices so that all children come before parents.
+	// Iterating this order will walk you "up" the commit graph.
+	ordering, err := topologicalSort(graph)
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate the reverse graph so we can efficiently look up the set of children
+	// for each vertex.
+	reverseGraph := reverseGraph(graph)
+
+	// Create two distinct mappings commits to the set of visible uploads populated at
+	// first with only the uploads that the commit defines. We will then "push" these
+	// uploads up to ancestors and down to descendants by traversing twice.
+	forwardUploads := map[string][]UploadMeta{}
+	reverseUploads := map[string][]UploadMeta{}
+	for commit := range graph {
+		for _, uploadMeta := range uploads[commit] {
+			forwardUploads[commit] = append(forwardUploads[commit], uploadMeta)
+			reverseUploads[commit] = append(reverseUploads[commit], uploadMeta)
+		}
+	}
+
+	// Forward direction:
+	// Iterate the vertices in topological order (children before parents) and push the
+	// set of visible uploads "down" the tree. Each upload a vertex can see is the set of
+	// uploads its parents can see with an increased distance. If two parents can see an
+	// upload for the same root and indexer, we keep only the one with the minimum distance.
+	for _, commit := range ordering {
+		uploads := forwardUploads[commit]
+		for _, parent := range graph[commit] {
+			for _, upload := range forwardUploads[parent] {
+				uploads = addUploadMeta(uploads, upload.UploadID, upload.Root, upload.Indexer, upload.Distance+1)
+			}
+		}
+
+		forwardUploads[commit] = uploads
+	}
+
+	// Reverse direction:
+	// Iterate the vertices in reverse topological order (parents before children) and push
+	// the set of visible uploads "up" the tree. Each upload a vertex can see is the set of
+	// uploads its children can see with an increased distance. If two children can see an
+	// upload for the same root and indexer, we keep only the one with the minimum distance.
+	for i := len(ordering) - 1; i >= 0; i-- {
+		commit := ordering[i]
+		uploads := reverseUploads[commit]
+		for _, child := range reverseGraph[commit] {
+			for _, upload := range reverseUploads[child] {
+				uploads = addUploadMeta(uploads, upload.UploadID, upload.Root, upload.Indexer, upload.Distance+1)
+			}
+		}
+
+		reverseUploads[commit] = uploads
+	}
+
+	// Combine directions:
+	// Merge the set of visible upload for each commit with the same rules as above: for each
+	// pair of uploads with the same root and indexer, keep only the one with the minimum distance.
+	// After this merge, each commit can see uploads defined by any direct ancestor or descendant,
+	// but cannot see uploads which are defined by relatives which require you to reverse traversal
+	// direction to find.
+	for commit, uploads := range forwardUploads {
+		for _, upload := range reverseUploads[commit] {
+			uploads = addUploadMeta(uploads, upload.UploadID, upload.Root, upload.Indexer, upload.Distance)
+		}
+
+		forwardUploads[commit] = uploads
+	}
+
+	return forwardUploads, nil
+}
+
+// addUploadMeta adds the given upload metadata to the given list. If there already exists an upload
+// with the same root and indexer, then that upload will be replaced if it has a greater distance.
+// The list is returned unmodified if such an upload has a smaller distance.
+func addUploadMeta(uploads []UploadMeta, uploadID int, root, indexer string, distance int) []UploadMeta {
+	for i, x := range uploads {
+		if root == x.Root && indexer == x.Indexer {
+			if distance < x.Distance || (distance == x.Distance && uploadID < x.UploadID) {
+				uploads[i].UploadID = uploadID
+				uploads[i].Distance = distance
+			}
+
+			return uploads
+		}
+	}
+
+	return append(uploads, UploadMeta{
+		UploadID: uploadID,
+		Root:     root,
+		Indexer:  indexer,
+		Distance: distance,
+	})
+}
+
+// reverseGraph returns the reverse of the given graph by flipping all the edges.
+func reverseGraph(graph map[string][]string) map[string][]string {
+	reverse := map[string][]string{}
+	for child := range graph {
+		reverse[child] = nil
+	}
+
+	for child, parents := range graph {
+		for _, parent := range parents {
+			reverse[parent] = append(reverse[parent], child)
+		}
+	}
+
+	return reverse
+}
+
+type sortMarker int
+
+const (
+	markTemp sortMarker = iota
+	markPermenant
+)
+
+var ErrCyclicCommitGraph = errors.New("commit graph contains cycles")
+
+// topologicalSort returns an ordering of the vertices of the given graph such that
+// each vertex occurs before all of its children. The input graph is expected to be
+// represented as a mapping from a vertex to its parents (a la git log) rather than
+// a mapping of children. If the graph is not acyclic an error is returned as no
+// such ordering can exist.
+func topologicalSort(graph map[string][]string) (_ []string, err error) {
+	commits := make([]string, 0, len(graph))
+	visited := make(map[string]sortMarker, len(graph))
+
+	for commit := range graph {
+		if commits, err = visitForTopologicalSort(graph, commits, visited, commit); err != nil {
+			return nil, err
+		}
+	}
+
+	return commits, nil
+}
+
+// visitForTopologicalSort performs a post-order DFS traversal of the given graph
+// from the given target commit. Commits are uniquely appended to the commits slice
+// only after all of their descendants have been added.
+func visitForTopologicalSort(graph map[string][]string, commits []string, visited map[string]sortMarker, commit string) (_ []string, err error) {
+	if mark, ok := visited[commit]; ok {
+		if mark == markTemp {
+			return nil, ErrCyclicCommitGraph
+		}
+
+		return commits, nil
+	}
+
+	parents, ok := graph[commit]
+	if !ok {
+		return commits, nil
+	}
+
+	visited[commit] = markTemp
+
+	for _, parent := range parents {
+		if commits, err = visitForTopologicalSort(graph, commits, visited, parent); err != nil {
+			return nil, err
+		}
+	}
+
+	visited[commit] = markPermenant
+	commits = append(commits, commit)
+	return commits, nil
+}

--- a/enterprise/internal/codeintel/store/commit_graph_test.go
+++ b/enterprise/internal/codeintel/store/commit_graph_test.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var testGraph = map[string][]string{
+	"e66e8f9b": {},
+	"0c5a779c": {"e66e8f9b"},
+	"f635b8d1": {"e66e8f9b"},
+	"4d36f88b": {"f635b8d1"},
+	"026b8df9": {"f635b8d1"},
+	"6c301adb": {"026b8df9"},
+	"d6e54842": {"026b8df9"},
+	"5340d471": {"d6e54842"},
+	"cbc5cf7c": {"5340d471"},
+	"95dd4b2b": {"d6e54842"},
+	"5971b083": {"0c5a779c", "95dd4b2b"},
+	"7cb4a974": {"95dd4b2b"},
+	"0ed556d3": {"7cb4a974"},
+}
+
+func TestInternalCalculateVisibleUploads(t *testing.T) {
+	uploads := map[string][]UploadMeta{
+		"e66e8f9b": {{UploadID: 50, Root: "sub1/", Indexer: "lsif-go"}},
+		"f635b8d1": {{UploadID: 52, Root: "sub3/", Indexer: "lsif-go"}},
+		"d6e54842": {{UploadID: 53, Root: "sub3/", Indexer: "lsif-go"}},
+		"5340d471": {{UploadID: 54, Root: "sub3/", Indexer: "lsif-go"}},
+		"95dd4b2b": {{UploadID: 55, Root: "sub3/", Indexer: "lsif-go"}},
+		"5971b083": {{UploadID: 51, Root: "sub2/", Indexer: "lsif-go"}},
+		"0ed556d3": {{UploadID: 56, Root: "sub3/", Indexer: "lsif-go"}},
+	}
+
+	visibleUploads, err := calculateVisibleUploads(testGraph, uploads)
+	if err != nil {
+		t.Fatalf("unexpected error calculating visible uploads: %s", err)
+	}
+
+	for _, visibleUploads := range visibleUploads {
+		sort.Slice(visibleUploads, func(i, j int) bool {
+			return visibleUploads[i].UploadID-visibleUploads[j].UploadID < 0
+		})
+	}
+
+	expectedVisibleUploads := map[string][]UploadMeta{
+		"e66e8f9b": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 0},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 2},
+			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
+		},
+		"0c5a779c": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 1},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 1},
+		},
+		"f635b8d1": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 1},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 4},
+			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
+		},
+		"4d36f88b": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 2},
+			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
+		},
+		"026b8df9": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 2},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 3},
+			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
+		},
+		"6c301adb": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 3},
+			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 2},
+		},
+		"d6e54842": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 3},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 2},
+			{UploadID: 53, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
+		},
+		"5340d471": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 4},
+			{UploadID: 54, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
+		},
+		"cbc5cf7c": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 5},
+			{UploadID: 54, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
+		},
+		"95dd4b2b": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 4},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 1},
+			{UploadID: 55, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
+		},
+		"5971b083": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 2},
+			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 0},
+			{UploadID: 55, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
+		},
+		"7cb4a974": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 5},
+			{UploadID: 55, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
+		},
+		"0ed556d3": {
+			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 6},
+			{UploadID: 56, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
+		},
+	}
+	if diff := cmp.Diff(expectedVisibleUploads, visibleUploads); diff != "" {
+		t.Errorf("unexpected graph (-want +got):\n%s", diff)
+	}
+}
+
+func TestReverseGraph(t *testing.T) {
+	reverseGraph := reverseGraph(testGraph)
+	for _, parents := range reverseGraph {
+		sort.Strings(parents)
+	}
+
+	expectedReverseGraph := map[string][]string{
+		"e66e8f9b": {"0c5a779c", "f635b8d1"},
+		"0c5a779c": {"5971b083"},
+		"f635b8d1": {"026b8df9", "4d36f88b"},
+		"4d36f88b": nil,
+		"026b8df9": {"6c301adb", "d6e54842"},
+		"6c301adb": nil,
+		"d6e54842": {"5340d471", "95dd4b2b"},
+		"5340d471": {"cbc5cf7c"},
+		"cbc5cf7c": nil,
+		"95dd4b2b": {"5971b083", "7cb4a974"},
+		"5971b083": nil,
+		"7cb4a974": {"0ed556d3"},
+		"0ed556d3": nil,
+	}
+	if diff := cmp.Diff(expectedReverseGraph, reverseGraph); diff != "" {
+		t.Errorf("unexpected graph (-want +got):\n%s", diff)
+	}
+}
+
+func TestTopologicalSort(t *testing.T) {
+	ordering, err := topologicalSort(testGraph)
+	if err != nil {
+		t.Fatalf("unexpected error sorting graph: %s", err)
+	}
+
+	for commit, parents := range testGraph {
+		i, ok := indexOf(ordering, commit)
+		if !ok {
+			t.Errorf("commit %s missing from ordering", commit)
+			continue
+		}
+
+		for _, parent := range parents {
+			j, ok := indexOf(ordering, parent)
+			if !ok {
+				t.Errorf("commit %s missing from ordering", commit)
+				continue
+			}
+
+			if j > i {
+				t.Errorf("commit %s and %s are inverted", commit, parent)
+			}
+		}
+	}
+}
+
+func TestTopologicalSortCycles(t *testing.T) {
+	cyclicTestGraph := map[string][]string{
+		"a": nil,
+		"b": {"c"},
+		"c": {"d"},
+		"d": {"d"},
+	}
+	if _, err := topologicalSort(cyclicTestGraph); err != ErrCyclicCommitGraph {
+		t.Fatalf("unexpected error sorting graph. want=%q have=%q", ErrCyclicCommitGraph, err)
+	}
+}
+
+func indexOf(ordering []string, commit string) (int, bool) {
+	for i, v := range ordering {
+		if v == commit {
+			return i, true
+		}
+	}
+
+	return 0, false
+}


### PR DESCRIPTION
This PR adds utilities used to calculate which uploads are visible to which commits given a commit graph and the complete set of uploads for a repository. This will be used to re-calculate visibility on each update of a repository's LSIF data, and on-demand when an unknown (newer) commit is requested. We currently do the same thing but at query time using the recursively defined CTEs in cte.go.

This is part of a larger effort towards https://github.com/sourcegraph/sourcegraph/issues/12098.