### PR TITLE
codeintel: Add CommitGraph to gitserver client

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -17,6 +17,10 @@ type Client interface {
 	// map are the MaxCommitsPerUpdate closest ancestors from the given commit.
 	CommitsNear(ctx context.Context, store store.Store, repositoryID int, commit string) (map[string][]string, error)
 
+	// CommitGraph returns the commit graph for the given repository as a mapping from a commit
+	// to its parents.
+	CommitGraph(ctx context.Context, store store.Store, repositoryID int) (map[string][]string, error)
+
 	// DirectoryChildren determines all children known to git for the given directory names via an invocation
 	// of git ls-tree. The keys of the resulting map are the input (unsanitized) dirnames, and the value of
 	// that key are the files nested under that directory.
@@ -44,6 +48,10 @@ func (c *defaultClient) Head(ctx context.Context, store store.Store, repositoryI
 
 func (c *defaultClient) CommitsNear(ctx context.Context, store store.Store, repositoryID int, commit string) (map[string][]string, error) {
 	return CommitsNear(ctx, store, repositoryID, commit)
+}
+
+func (c *defaultClient) CommitGraph(ctx context.Context, store store.Store, repositoryID int) (map[string][]string, error) {
+	return CommitGraph(ctx, store, repositoryID)
 }
 
 func (c *defaultClient) DirectoryChildren(ctx context.Context, store store.Store, repositoryID int, commit string, dirnames []string) (map[string][]string, error) {

--- a/enterprise/internal/codeintel/gitserver/commits.go
+++ b/enterprise/internal/codeintel/gitserver/commits.go
@@ -24,13 +24,24 @@ func CommitsNear(ctx context.Context, store store.Store, repositoryID int, commi
 		return nil, err
 	}
 
-	return parseCommitsNear(strings.Split(out, "\n")), nil
+	return parseParents(strings.Split(out, "\n")), nil
 }
 
-// parseCommitsNear converts the output of git log into a map from commits to parent commits.
+// CommitGraph returns the commit graph for the given repository as a mapping from a commit
+// to its parents.
+func CommitGraph(ctx context.Context, store store.Store, repositoryID int) (map[string][]string, error) {
+	out, err := execGitCommand(ctx, store, repositoryID, "log", "--all", "--pretty=%H %P")
+	if err != nil {
+		return nil, err
+	}
+
+	return parseParents(strings.Split(out, "\n")), nil
+}
+
+// parseParents converts the output of git log into a map from commits to parent commits.
 // If a commit is listed but has no ancestors then its parent slice is empty but is still
 // present in the map.
-func parseCommitsNear(pair []string) map[string][]string {
+func parseParents(pair []string) map[string][]string {
 	commits := map[string][]string{}
 
 	for _, pair := range pair {

--- a/enterprise/internal/codeintel/gitserver/commits_test.go
+++ b/enterprise/internal/codeintel/gitserver/commits_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestParseCommitsNear(t *testing.T) {
+func TestParseParents(t *testing.T) {
 	commits := []string{
 		"9ad62c7ec68e377b41a8b8dd846e573b76634172 1afa9c06d8bb8b2c5746e539ed4eb80c23b21db3 683cafd122632142bda6e36563f5719e5b0fa37d",
 		"683cafd122632142bda6e36563f5719e5b0fa37d 1afa9c06d8bb8b2c5746e539ed4eb80c23b21db3",
@@ -53,7 +53,7 @@ func TestParseCommitsNear(t *testing.T) {
 		"8c25906a7dbc904acc96b5435ec42fa5da8b232c": {},
 	}
 
-	if diff := cmp.Diff(expected, parseCommitsNear(commits)); diff != "" {
+	if diff := cmp.Diff(expected, parseParents(commits)); diff != "" {
 		t.Errorf("unexpected commit mapping (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/internal/codeintel/gitserver/mocks/mock_client.go
+++ b/enterprise/internal/codeintel/gitserver/mocks/mock_client.go
@@ -18,6 +18,9 @@ type MockClient struct {
 	// ArchiveFunc is an instance of a mock function object controlling the
 	// behavior of the method Archive.
 	ArchiveFunc *ClientArchiveFunc
+	// CommitGraphFunc is an instance of a mock function object controlling
+	// the behavior of the method CommitGraph.
+	CommitGraphFunc *ClientCommitGraphFunc
 	// CommitsNearFunc is an instance of a mock function object controlling
 	// the behavior of the method CommitsNear.
 	CommitsNearFunc *ClientCommitsNearFunc
@@ -41,6 +44,11 @@ func NewMockClient() *MockClient {
 	return &MockClient{
 		ArchiveFunc: &ClientArchiveFunc{
 			defaultHook: func(context.Context, store.Store, int, string) (io.Reader, error) {
+				return nil, nil
+			},
+		},
+		CommitGraphFunc: &ClientCommitGraphFunc{
+			defaultHook: func(context.Context, store.Store, int) (map[string][]string, error) {
 				return nil, nil
 			},
 		},
@@ -78,6 +86,9 @@ func NewMockClientFrom(i gitserver.Client) *MockClient {
 	return &MockClient{
 		ArchiveFunc: &ClientArchiveFunc{
 			defaultHook: i.Archive,
+		},
+		CommitGraphFunc: &ClientCommitGraphFunc{
+			defaultHook: i.CommitGraph,
 		},
 		CommitsNearFunc: &ClientCommitsNearFunc{
 			defaultHook: i.CommitsNear,
@@ -208,6 +219,117 @@ func (c ClientArchiveFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientArchiveFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ClientCommitGraphFunc describes the behavior when the CommitGraph method
+// of the parent MockClient instance is invoked.
+type ClientCommitGraphFunc struct {
+	defaultHook func(context.Context, store.Store, int) (map[string][]string, error)
+	hooks       []func(context.Context, store.Store, int) (map[string][]string, error)
+	history     []ClientCommitGraphFuncCall
+	mutex       sync.Mutex
+}
+
+// CommitGraph delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockClient) CommitGraph(v0 context.Context, v1 store.Store, v2 int) (map[string][]string, error) {
+	r0, r1 := m.CommitGraphFunc.nextHook()(v0, v1, v2)
+	m.CommitGraphFunc.appendCall(ClientCommitGraphFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CommitGraph method
+// of the parent MockClient instance is invoked and the hook queue is empty.
+func (f *ClientCommitGraphFunc) SetDefaultHook(hook func(context.Context, store.Store, int) (map[string][]string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CommitGraph method of the parent MockClient instance inovkes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *ClientCommitGraphFunc) PushHook(hook func(context.Context, store.Store, int) (map[string][]string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *ClientCommitGraphFunc) SetDefaultReturn(r0 map[string][]string, r1 error) {
+	f.SetDefaultHook(func(context.Context, store.Store, int) (map[string][]string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *ClientCommitGraphFunc) PushReturn(r0 map[string][]string, r1 error) {
+	f.PushHook(func(context.Context, store.Store, int) (map[string][]string, error) {
+		return r0, r1
+	})
+}
+
+func (f *ClientCommitGraphFunc) nextHook() func(context.Context, store.Store, int) (map[string][]string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ClientCommitGraphFunc) appendCall(r0 ClientCommitGraphFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ClientCommitGraphFuncCall objects
+// describing the invocations of this function.
+func (f *ClientCommitGraphFunc) History() []ClientCommitGraphFuncCall {
+	f.mutex.Lock()
+	history := make([]ClientCommitGraphFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ClientCommitGraphFuncCall is an object that describes an invocation of
+// method CommitGraph on an instance of MockClient.
+type ClientCommitGraphFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 store.Store
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[string][]string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ClientCommitGraphFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ClientCommitGraphFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
This PR adds a method to the codeintel gitserver client that requests the parents of each commit known to the gitserver's clone. This will be used to construct a full commit graph for a repository.

This is part of a larger effort towards https://github.com/sourcegraph/sourcegraph/issues/12098.