### PR TITLE
workerutil: Fix nil-deref in when using worker store transactionally

### DIFF
--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -187,7 +187,7 @@ func (s *store) Transact(ctx context.Context) (*store, error) {
 		return nil, err
 	}
 
-	return &store{Store: txBase, options: s.options}, nil
+	return &store{Store: txBase, options: s.options, columnReplacer: s.columnReplacer}, nil
 }
 
 // Dequeue selects the first unlocked record matching the given conditions and locks it in a new transaction that


### PR DESCRIPTION
@uwedeportivo noticed a crashloop backoff in the worker/indexer:

```
│ t=2020-07-22T16:52:08+0000 lvl=dbug msg="TRACE gitserver" host=gitserver-6.gitserver:3178 path=/exec code=200 duration=689.332µs                                                                                     │
│ panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                              │
│ [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4fbbf6]                                                                                                                                               │
│ goroutine 156 [running]:                                                                                                                                                                                             │
│ strings.(*Replacer).Replace(0x0, 0xdbbe28, 0xb7, 0xc2b5a0, 0xc000558a00)                                                                                                                                             │
│     strings/replace.go:96 +0x26                                                                                                                                                                                      │
│ github.com/sourcegraph/sourcegraph/internal/workerutil.(*store).formatQuery(0xc0002def50, 0xdbbe28, 0xb7, 0xc0005fbc88, 0x2, 0x2, 0x0)                                                                               │
│     github.com/sourcegraph/sourcegraph/internal/workerutil/store.go:436 +0x43                                                                                                                                        │
│ github.com/sourcegraph/sourcegraph/internal/workerutil.(*store).MarkComplete(0xc0002def50, 0xf15d00, 0xc0002af320, 0x8e8, 0xc0002def50, 0xeff960, 0xc0004e62d0)                                                      │
│     github.com/sourcegraph/sourcegraph/internal/workerutil/store.go:338 +0xe0                                                                                                                                        │
│ github.com/sourcegraph/sourcegraph/internal/workerutil.(*Worker).handle(0xc0002ac1b0, 0xf1cae0, 0xc0002def50, 0xeff960, 0xc0004e62d0, 0xc0004cf750, 0xc0004cf750)                                                    │
│     github.com/sourcegraph/sourcegraph/internal/workerutil/worker.go:254 +0x6e7                                                                                                                                      │
│ github.com/sourcegraph/sourcegraph/internal/workerutil.(*Worker).dequeueAndHandle.func2(0xc0002ac1b0, 0xeff960, 0xc0004e62d0, 0xf1cae0, 0xc0002def50)                                                                │
│     github.com/sourcegraph/sourcegraph/internal/workerutil/worker.go:221 +0xb8                                                                                                                                       │
│ created by github.com/sourcegraph/sourcegraph/internal/workerutil.(*Worker).dequeueAndHandle                                                                                                                         │
│     github.com/sourcegraph/sourcegraph/internal/workerutil/worker.go:211 +0x46e                                                                                                                                      │
│ stream closed                                                                                                                                                                                                        │
```

When returning a transactional store I wasn't copying over the string replacer, which made queries fail in the copied struct.