### PR TITLE
codeintel: Add CalculateVisibleUploads to store

### DIFF
--- a/enterprise/internal/codeintel/store/commits.go
+++ b/enterprise/internal/codeintel/store/commits.go
@@ -35,6 +35,33 @@ func scanCommits(rows *sql.Rows, queryErr error) (_ map[string][]string, err err
 	return commits, nil
 }
 
+// scanUploadMeta scans upload metadata grouped by commit from the return value of `*store.query`.
+func scanUploadMeta(rows *sql.Rows, queryErr error) (_ map[string][]UploadMeta, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = closeRows(rows, err) }()
+
+	uploadMeta := map[string][]UploadMeta{}
+	for rows.Next() {
+		var uploadID int
+		var commit string
+		var root string
+		var indexer string
+		if err := rows.Scan(&uploadID, &commit, &root, &indexer); err != nil {
+			return nil, err
+		}
+
+		uploadMeta[commit] = append(uploadMeta[commit], UploadMeta{
+			UploadID: uploadID,
+			Root:     root,
+			Indexer:  indexer,
+		})
+	}
+
+	return uploadMeta, nil
+}
+
 // HasCommit determines if the given commit is known for the given repository.
 func (s *store) HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error) {
 	count, _, err := scanFirstInt(s.query(ctx, sqlf.Sprintf(`
@@ -136,4 +163,171 @@ func diff(left, right []string) []string {
 	}
 
 	return diff
+}
+
+// MarkRepositoryAsDirty marks the given repository's commit graph as out of date.
+func (s *store) MarkRepositoryAsDirty(ctx context.Context, repositoryID int) error {
+	return s.queryForEffect(
+		ctx,
+		sqlf.Sprintf(`
+			INSERT INTO lsif_dirty_repositories (repository_id, dirty_token, update_token)
+			VALUES (%s, 1, 0)
+			ON CONFLICT (repository_id) DO UPDATE SET dirty_token = lsif_dirty_repositories.dirty_token + 1
+		`, repositoryID),
+	)
+}
+
+func scanIntPairs(rows *sql.Rows, queryErr error) (_ map[int]int, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = closeRows(rows, err) }()
+
+	values := map[int]int{}
+	for rows.Next() {
+		var value1 int
+		var value2 int
+		if err := rows.Scan(&value1, &value2); err != nil {
+			return nil, err
+		}
+
+		values[value1] = value2
+	}
+
+	return values, nil
+}
+
+// DirtyRepositories returns a map from repository identifiers to a dirty token for each repository whose commit
+// graph is out of date. This token should be passed to CalculateVisibleUploads in order to unmark the repository.
+func (s *store) DirtyRepositories(ctx context.Context) (map[int]int, error) {
+	return scanIntPairs(s.query(ctx, sqlf.Sprintf(`SELECT repository_id, dirty_token FROM lsif_dirty_repositories WHERE dirty_token > update_token`)))
+}
+
+// CalculateVisibleUploads uses the given commit graph and the tip commit of the default branch to determine the set
+// of LSIF uploads that are visible for each commit, and the set of uploads which are visible at the tip. The decorated
+// commit graph is serialized to Postgres for use by find closest dumps queries.
+//
+// If dirtyToken is supplied, the repository will be unmarked when the supplied token does matches the most recent
+// token stored in the database, the flag will not be cleared as another request for update has come in since this
+// token has been read.
+func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, graph map[string][]string, tipCommit string, dirtyToken int) (err error) {
+	tx, err := s.transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	// Pull all queryable upload metadata known to this repository so we can correlate
+	// it with the current  commit graph.
+	uploadMeta, err := scanUploadMeta(tx.query(ctx, sqlf.Sprintf(`
+		SELECT id, commit, root, indexer
+		FROM lsif_uploads
+		WHERE state = 'completed' AND repository_id = %s
+	`, repositoryID)))
+	if err != nil {
+		return err
+	}
+
+	// Determine which uploads are visible to which commits for this repository
+	visibleUploads, err := calculateVisibleUploads(graph, uploadMeta)
+	if err != nil {
+		return err
+	}
+
+	// Clear all old visibility data for this repository
+	for _, query := range []string{
+		`DELETE FROM lsif_nearest_uploads WHERE repository_id = %s`,
+		`DELETE FROM lsif_uploads_visible_at_tip WHERE repository_id = %s`,
+	} {
+		if err := tx.queryForEffect(ctx, sqlf.Sprintf(query, repositoryID)); err != nil {
+			return err
+		}
+	}
+
+	n := 0
+	for _, uploads := range visibleUploads {
+		n += len(uploads)
+	}
+	nearestUploadsRows := make([]*sqlf.Query, 0, n)
+
+	for commit, uploads := range visibleUploads {
+		for _, uploadMeta := range uploads {
+			nearestUploadsRows = append(nearestUploadsRows, sqlf.Sprintf(
+				"(%s, %s, %s, %s)",
+				repositoryID,
+				commit,
+				uploadMeta.UploadID,
+				uploadMeta.Distance,
+			))
+		}
+	}
+
+	// Insert new data for this repository in batches - it's likely we'll exceed the maximum
+	// number of placeholders per query so we need to break it into several queries below this
+	// size.
+	for _, batch := range batchQueries(nearestUploadsRows, MaxPostgresNumParameters/4) {
+		if err := tx.queryForEffect(ctx, sqlf.Sprintf(
+			`INSERT INTO lsif_nearest_uploads (repository_id, "commit", upload_id, distance) VALUES %s`,
+			sqlf.Join(batch, ","),
+		)); err != nil {
+			return err
+		}
+	}
+
+	visibleAtTipRows := make([]*sqlf.Query, 0, len(visibleUploads[tipCommit]))
+	for _, uploadMeta := range visibleUploads[tipCommit] {
+		visibleAtTipRows = append(visibleAtTipRows, sqlf.Sprintf("(%s, %s)", repositoryID, uploadMeta.UploadID))
+	}
+
+	// Update which repositories are visible from the tip of the default branch. This
+	// flag is used to determine which bundles for a repository we open during a global
+	// find references query.
+	if len(visibleAtTipRows) > 0 {
+		for _, batch := range batchQueries(visibleAtTipRows, MaxPostgresNumParameters/2) {
+			if err := tx.queryForEffect(ctx, sqlf.Sprintf(
+				`INSERT INTO lsif_uploads_visible_at_tip (repository_id, upload_id) VALUES %s`,
+				sqlf.Join(batch, ","),
+			)); err != nil {
+				return err
+			}
+		}
+	}
+
+	if dirtyToken != 0 {
+		// If the user requests us to clear a dirty token, set the updated_token value to
+		// the dirty token if it wouldn't decrease the value. Dirty repositories are determined
+		// by having a non-equal dirty and update token, and we want the most recent upload
+		// token to win this write.
+		if err := tx.queryForEffect(ctx, sqlf.Sprintf(
+			`UPDATE lsif_dirty_repositories SET update_token = GREATEST(update_token, %s) WHERE repository_id = %s`,
+			dirtyToken,
+			repositoryID,
+		)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MaxPostgresNumParameters is the maximum number of parameters per query that Postgres
+// will allow. Exceeding this number of parameters will cause the query to be rejected
+// by the server.
+const MaxPostgresNumParameters = 65535
+
+// batchQueries cuts the given query slice into batches of a maximum size. This function
+// will allocate only the outer array to hold each batch, and the data for each batch
+// will refer to the given slice.
+func batchQueries(queries []*sqlf.Query, batchSize int) (batches [][]*sqlf.Query) {
+	for len(queries) > 0 {
+		if len(queries) > batchSize {
+			batches = append(batches, queries[:batchSize])
+			queries = queries[batchSize:]
+		} else {
+			batches = append(batches, queries)
+			queries = nil
+		}
+	}
+
+	return batches
 }

--- a/enterprise/internal/codeintel/store/commits_test.go
+++ b/enterprise/internal/codeintel/store/commits_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,7 +16,7 @@ func TestHasCommit(t *testing.T) {
 		t.Skip()
 	}
 	dbtesting.SetupGlobalTestDB(t)
-	store := rawTestStore()
+	store := testStore()
 
 	testCases := []struct {
 		repositoryID int
@@ -201,4 +202,367 @@ func TestUpdateCommitsNoUnknownData(t *testing.T) {
 
 func strPtr(v string) *string {
 	return &v
+}
+
+func TestMarkRepositoryAsDirty(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	for _, repositoryID := range []int{50, 51, 52, 51, 52} {
+		if err := store.MarkRepositoryAsDirty(context.Background(), repositoryID); err != nil {
+			t.Errorf("unexpected error marking repository as dirty: %s", err)
+		}
+	}
+
+	repositoryIDs, err := store.DirtyRepositories(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error listing dirty repositories: %s", err)
+	}
+
+	var keys []int
+	for repositoryID := range repositoryIDs {
+		keys = append(keys, repositoryID)
+	}
+	sort.Ints(keys)
+
+	if diff := cmp.Diff([]int{50, 51, 52}, keys); diff != "" {
+		t.Errorf("unexpected repository ids (-want +got):\n%s", diff)
+	}
+}
+
+func TestCalculateVisibleUploads(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	// This database has the following commit graph:
+	//
+	// [1] --+--- 2 --------+--5 -- 6 --+-- [7]
+	//       |              |           |
+	//       +-- [3] -- 4 --+           +--- 8
+
+	uploads := []Upload{
+		{ID: 1, Commit: makeCommit(1)},
+		{ID: 2, Commit: makeCommit(3)},
+		{ID: 3, Commit: makeCommit(7)},
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	graph := map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(1)},
+		makeCommit(4): {makeCommit(3)},
+		makeCommit(5): {makeCommit(2), makeCommit(4)},
+		makeCommit(6): {makeCommit(5)},
+		makeCommit(7): {makeCommit(6)},
+		makeCommit(8): {makeCommit(6)},
+	}
+
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(8), 0); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	expectedVisibleUploads := map[string][]UploadMeta{
+		makeCommit(1): {{UploadID: 1, Distance: 0}},
+		makeCommit(2): {{UploadID: 1, Distance: 1}},
+		makeCommit(3): {{UploadID: 2, Distance: 0}},
+		makeCommit(4): {{UploadID: 2, Distance: 1}},
+		makeCommit(5): {{UploadID: 1, Distance: 2}},
+		makeCommit(6): {{UploadID: 3, Distance: 1}},
+		makeCommit(7): {{UploadID: 3, Distance: 0}},
+		makeCommit(8): {{UploadID: 1, Distance: 4}},
+	}
+	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
+		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]int{1}, getUploadsVisibleAtTip(t, dbconn.Global, 50)); diff != "" {
+		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
+	}
+}
+
+func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	// This database has the following commit graph:
+	//
+	// 1 --+-- [2] ---- 3
+	//     |
+	//     +--- 4 --+-- 5 -- 6
+	//              |
+	//              +-- 7 -- 8
+
+	uploads := []Upload{
+		{ID: 1, Commit: makeCommit(2)},
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	graph := map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(2)},
+		makeCommit(4): {makeCommit(1)},
+		makeCommit(5): {makeCommit(4)},
+		makeCommit(6): {makeCommit(5)},
+		makeCommit(7): {makeCommit(4)},
+		makeCommit(8): {makeCommit(7)},
+	}
+
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 0); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	expectedVisibleUploads := map[string][]UploadMeta{
+		makeCommit(1): {{UploadID: 1, Distance: 1}},
+		makeCommit(2): {{UploadID: 1, Distance: 0}},
+		makeCommit(3): {{UploadID: 1, Distance: 1}},
+	}
+	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
+		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]int{1}, getUploadsVisibleAtTip(t, dbconn.Global, 50)); diff != "" {
+		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
+	}
+}
+
+func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	// This database has the following commit graph:
+	//
+	// 1 --+-- [2]
+
+	uploads := []Upload{
+		{ID: 1, Commit: makeCommit(2), Root: "root1/"},
+		{ID: 2, Commit: makeCommit(2), Root: "root2/"},
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	graph := map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+	}
+
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(2), 0); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	expectedVisibleUploads := map[string][]UploadMeta{
+		makeCommit(1): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}},
+		makeCommit(2): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}},
+	}
+	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
+		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]int{1, 2}, getUploadsVisibleAtTip(t, dbconn.Global, 50)); diff != "" {
+		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
+	}
+}
+
+func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	// This database has the following commit graph:
+	//
+	// 1 -- 2 --+-- 3 --+-- 5 -- 6
+	//          |       |
+	//          +-- 4 --+
+	//
+	// With the following LSIF dumps:
+	//
+	// | UploadID | Commit | Root    | Indexer |
+	// | -------- + ------ + ------- + ------- |
+	// | 1        | 1      | root3/  | lsif-go |
+	// | 2        | 1      | root4/  | lsif-py |
+	// | 3        | 2      | root1/  | lsif-go |
+	// | 4        | 2      | root2/  | lsif-go |
+	// | 5        | 2      |         | lsif-py | (overwrites root4/ at commit 1)
+	// | 6        | 3      | root1/  | lsif-go | (overwrites root1/ at commit 2)
+	// | 7        | 4      |         | lsif-py | (overwrites (root) at commit 2)
+	// | 8        | 5      | root2/  | lsif-go | (overwrites root2/ at commit 2)
+	// | 9        | 6      | root1/  | lsif-go | (overwrites root1/ at commit 2)
+
+	uploads := []Upload{
+		{ID: 1, Commit: makeCommit(1), Indexer: "lsif-go", Root: "root3/"},
+		{ID: 2, Commit: makeCommit(1), Indexer: "lsif-py", Root: "root4/"},
+		{ID: 3, Commit: makeCommit(2), Indexer: "lsif-go", Root: "root1/"},
+		{ID: 4, Commit: makeCommit(2), Indexer: "lsif-go", Root: "root2/"},
+		{ID: 5, Commit: makeCommit(2), Indexer: "lsif-py", Root: ""},
+		{ID: 6, Commit: makeCommit(3), Indexer: "lsif-go", Root: "root1/"},
+		{ID: 7, Commit: makeCommit(4), Indexer: "lsif-py", Root: ""},
+		{ID: 8, Commit: makeCommit(5), Indexer: "lsif-go", Root: "root2/"},
+		{ID: 9, Commit: makeCommit(6), Indexer: "lsif-go", Root: "root1/"},
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	graph := map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(2)},
+		makeCommit(4): {makeCommit(2)},
+		makeCommit(5): {makeCommit(3), makeCommit(4)},
+		makeCommit(6): {makeCommit(5)},
+	}
+
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(6), 0); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	expectedVisibleUploads := map[string][]UploadMeta{
+		makeCommit(1): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}},
+		makeCommit(2): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 0}, {UploadID: 5, Distance: 0}},
+		makeCommit(3): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}},
+		makeCommit(4): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 7, Distance: 0}},
+		makeCommit(5): {{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 3}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0}},
+		makeCommit(6): {{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 4}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1}, {UploadID: 9, Distance: 0}},
+	}
+	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
+		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]int{1, 2, 7, 8, 9}, getUploadsVisibleAtTip(t, dbconn.Global, 50)); diff != "" {
+		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
+	}
+}
+
+func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	// This database has the following commit graph:
+	//
+	// [1] --+-- [2] --+-- [3] --+-- [4] --+-- 5
+
+	uploads := []Upload{
+		{ID: 1, Commit: makeCommit(1), Root: "root1/", Indexer: "idx1"},
+		{ID: 2, Commit: makeCommit(2), Root: "root2/", Indexer: "idx1"},
+		{ID: 3, Commit: makeCommit(3), Root: "root3/", Indexer: "idx1"},
+		{ID: 4, Commit: makeCommit(4), Root: "root4/", Indexer: "idx1"},
+		{ID: 5, Commit: makeCommit(1), Root: "root1/", Indexer: "idx2"},
+		{ID: 6, Commit: makeCommit(2), Root: "root2/", Indexer: "idx2"},
+		{ID: 7, Commit: makeCommit(3), Root: "root3/", Indexer: "idx2"},
+		{ID: 8, Commit: makeCommit(4), Root: "root4/", Indexer: "idx2"},
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	graph := map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(2)},
+		makeCommit(4): {makeCommit(3)},
+		makeCommit(5): {makeCommit(4)},
+	}
+
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(5), 0); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	expectedVisibleUploads := map[string][]UploadMeta{
+		makeCommit(1): {
+			{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 3},
+			{UploadID: 5, Distance: 0}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 3},
+		},
+		makeCommit(2): {
+			{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 2},
+			{UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 2},
+		},
+		makeCommit(3): {
+			{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 1},
+			{UploadID: 5, Distance: 2}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 0}, {UploadID: 8, Distance: 1},
+		},
+		makeCommit(4): {
+			{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 0},
+			{UploadID: 5, Distance: 3}, {UploadID: 6, Distance: 2}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0},
+		},
+		makeCommit(5): {
+			{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 3}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 1},
+			{UploadID: 5, Distance: 4}, {UploadID: 6, Distance: 3}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1},
+		},
+	}
+	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
+		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]int{1, 2, 3, 4, 5, 6, 7, 8}, getUploadsVisibleAtTip(t, dbconn.Global, 50)); diff != "" {
+		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
+	}
+}
+
+func TestCalculateVisibleUploadsResetsDirtyFlag(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	uploads := []Upload{
+		{ID: 1, Commit: makeCommit(1)},
+		{ID: 2, Commit: makeCommit(2)},
+		{ID: 3, Commit: makeCommit(3)},
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	graph := map[string][]string{
+		makeCommit(1): {},
+		makeCommit(2): {makeCommit(1)},
+		makeCommit(3): {makeCommit(2)},
+	}
+
+	for i := 0; i < 3; i++ {
+		// Set dirty token to 3
+		if err := store.MarkRepositoryAsDirty(context.Background(), 50); err != nil {
+			t.Fatalf("unexpected error marking repository as dirty: %s", err)
+		}
+	}
+
+	// Non-latest dirty token - should not clear flag
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 2); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	repositoryIDs, err := store.DirtyRepositories(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error listing dirty repositories: %s", err)
+	}
+
+	if len(repositoryIDs) == 0 {
+		t.Errorf("did not expect repository to be unmarked")
+	}
+
+	// Latest dirty token - should clear flag
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 3); err != nil {
+		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
+	}
+
+	repositoryIDs, err = store.DirtyRepositories(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error listing dirty repositories: %s", err)
+	}
+
+	if len(repositoryIDs) != 0 {
+		t.Errorf("expected repository to be unmarked")
+	}
 }

--- a/enterprise/internal/codeintel/store/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/store/mocks/mock_store.go
@@ -19,6 +19,9 @@ type MockStore struct {
 	// AddUploadPartFunc is an instance of a mock function object
 	// controlling the behavior of the method AddUploadPart.
 	AddUploadPartFunc *StoreAddUploadPartFunc
+	// CalculateVisibleUploadsFunc is an instance of a mock function object
+	// controlling the behavior of the method CalculateVisibleUploads.
+	CalculateVisibleUploadsFunc *StoreCalculateVisibleUploadsFunc
 	// DeleteIndexByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteIndexByID.
 	DeleteIndexByIDFunc *StoreDeleteIndexByIDFunc
@@ -45,6 +48,9 @@ type MockStore struct {
 	// DequeueIndexFunc is an instance of a mock function object controlling
 	// the behavior of the method DequeueIndex.
 	DequeueIndexFunc *StoreDequeueIndexFunc
+	// DirtyRepositoriesFunc is an instance of a mock function object
+	// controlling the behavior of the method DirtyRepositories.
+	DirtyRepositoriesFunc *StoreDirtyRepositoriesFunc
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *StoreDoneFunc
@@ -108,6 +114,9 @@ type MockStore struct {
 	// MarkQueuedFunc is an instance of a mock function object controlling
 	// the behavior of the method MarkQueued.
 	MarkQueuedFunc *StoreMarkQueuedFunc
+	// MarkRepositoryAsDirtyFunc is an instance of a mock function object
+	// controlling the behavior of the method MarkRepositoryAsDirty.
+	MarkRepositoryAsDirtyFunc *StoreMarkRepositoryAsDirtyFunc
 	// PackageReferencePagerFunc is an instance of a mock function object
 	// controlling the behavior of the method PackageReferencePager.
 	PackageReferencePagerFunc *StorePackageReferencePagerFunc
@@ -173,6 +182,11 @@ func NewMockStore() *MockStore {
 				return nil
 			},
 		},
+		CalculateVisibleUploadsFunc: &StoreCalculateVisibleUploadsFunc{
+			defaultHook: func(context.Context, int, map[string][]string, string, int) error {
+				return nil
+			},
+		},
 		DeleteIndexByIDFunc: &StoreDeleteIndexByIDFunc{
 			defaultHook: func(context.Context, int) (bool, error) {
 				return false, nil
@@ -211,6 +225,11 @@ func NewMockStore() *MockStore {
 		DequeueIndexFunc: &StoreDequeueIndexFunc{
 			defaultHook: func(context.Context) (store.Index, store.Store, bool, error) {
 				return store.Index{}, nil, false, nil
+			},
+		},
+		DirtyRepositoriesFunc: &StoreDirtyRepositoriesFunc{
+			defaultHook: func(context.Context) (map[int]int, error) {
+				return nil, nil
 			},
 		},
 		DoneFunc: &StoreDoneFunc{
@@ -318,6 +337,11 @@ func NewMockStore() *MockStore {
 				return nil
 			},
 		},
+		MarkRepositoryAsDirtyFunc: &StoreMarkRepositoryAsDirtyFunc{
+			defaultHook: func(context.Context, int) error {
+				return nil
+			},
+		},
 		PackageReferencePagerFunc: &StorePackageReferencePagerFunc{
 			defaultHook: func(context.Context, string, string, string, int, int) (int, store.ReferencePager, error) {
 				return 0, nil, nil
@@ -413,6 +437,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		AddUploadPartFunc: &StoreAddUploadPartFunc{
 			defaultHook: i.AddUploadPart,
 		},
+		CalculateVisibleUploadsFunc: &StoreCalculateVisibleUploadsFunc{
+			defaultHook: i.CalculateVisibleUploads,
+		},
 		DeleteIndexByIDFunc: &StoreDeleteIndexByIDFunc{
 			defaultHook: i.DeleteIndexByID,
 		},
@@ -436,6 +463,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		DequeueIndexFunc: &StoreDequeueIndexFunc{
 			defaultHook: i.DequeueIndex,
+		},
+		DirtyRepositoriesFunc: &StoreDirtyRepositoriesFunc{
+			defaultHook: i.DirtyRepositories,
 		},
 		DoneFunc: &StoreDoneFunc{
 			defaultHook: i.Done,
@@ -499,6 +529,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		MarkQueuedFunc: &StoreMarkQueuedFunc{
 			defaultHook: i.MarkQueued,
+		},
+		MarkRepositoryAsDirtyFunc: &StoreMarkRepositoryAsDirtyFunc{
+			defaultHook: i.MarkRepositoryAsDirty,
 		},
 		PackageReferencePagerFunc: &StorePackageReferencePagerFunc{
 			defaultHook: i.PackageReferencePager,
@@ -659,6 +692,122 @@ func (c StoreAddUploadPartFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreAddUploadPartFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// StoreCalculateVisibleUploadsFunc describes the behavior when the
+// CalculateVisibleUploads method of the parent MockStore instance is
+// invoked.
+type StoreCalculateVisibleUploadsFunc struct {
+	defaultHook func(context.Context, int, map[string][]string, string, int) error
+	hooks       []func(context.Context, int, map[string][]string, string, int) error
+	history     []StoreCalculateVisibleUploadsFuncCall
+	mutex       sync.Mutex
+}
+
+// CalculateVisibleUploads delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) CalculateVisibleUploads(v0 context.Context, v1 int, v2 map[string][]string, v3 string, v4 int) error {
+	r0 := m.CalculateVisibleUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.CalculateVisibleUploadsFunc.appendCall(StoreCalculateVisibleUploadsFuncCall{v0, v1, v2, v3, v4, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// CalculateVisibleUploads method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Context, int, map[string][]string, string, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CalculateVisibleUploads method of the parent MockStore instance inovkes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context, int, map[string][]string, string, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreCalculateVisibleUploadsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, map[string][]string, string, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreCalculateVisibleUploadsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, map[string][]string, string, int) error {
+		return r0
+	})
+}
+
+func (f *StoreCalculateVisibleUploadsFunc) nextHook() func(context.Context, int, map[string][]string, string, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreCalculateVisibleUploadsFunc) appendCall(r0 StoreCalculateVisibleUploadsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreCalculateVisibleUploadsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreCalculateVisibleUploadsFunc) History() []StoreCalculateVisibleUploadsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreCalculateVisibleUploadsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreCalculateVisibleUploadsFuncCall is an object that describes an
+// invocation of method CalculateVisibleUploads on an instance of MockStore.
+type StoreCalculateVisibleUploadsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 map[string][]string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreCalculateVisibleUploadsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreCalculateVisibleUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -1555,6 +1704,112 @@ func (c StoreDequeueIndexFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreDequeueIndexFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+}
+
+// StoreDirtyRepositoriesFunc describes the behavior when the
+// DirtyRepositories method of the parent MockStore instance is invoked.
+type StoreDirtyRepositoriesFunc struct {
+	defaultHook func(context.Context) (map[int]int, error)
+	hooks       []func(context.Context) (map[int]int, error)
+	history     []StoreDirtyRepositoriesFuncCall
+	mutex       sync.Mutex
+}
+
+// DirtyRepositories delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) DirtyRepositories(v0 context.Context) (map[int]int, error) {
+	r0, r1 := m.DirtyRepositoriesFunc.nextHook()(v0)
+	m.DirtyRepositoriesFunc.appendCall(StoreDirtyRepositoriesFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the DirtyRepositories
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreDirtyRepositoriesFunc) SetDefaultHook(hook func(context.Context) (map[int]int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DirtyRepositories method of the parent MockStore instance inovkes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreDirtyRepositoriesFunc) PushHook(hook func(context.Context) (map[int]int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreDirtyRepositoriesFunc) SetDefaultReturn(r0 map[int]int, r1 error) {
+	f.SetDefaultHook(func(context.Context) (map[int]int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreDirtyRepositoriesFunc) PushReturn(r0 map[int]int, r1 error) {
+	f.PushHook(func(context.Context) (map[int]int, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreDirtyRepositoriesFunc) nextHook() func(context.Context) (map[int]int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreDirtyRepositoriesFunc) appendCall(r0 StoreDirtyRepositoriesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreDirtyRepositoriesFuncCall objects
+// describing the invocations of this function.
+func (f *StoreDirtyRepositoriesFunc) History() []StoreDirtyRepositoriesFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreDirtyRepositoriesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreDirtyRepositoriesFuncCall is an object that describes an invocation
+// of method DirtyRepositories on an instance of MockStore.
+type StoreDirtyRepositoriesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[int]int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreDirtyRepositoriesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreDirtyRepositoriesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreDoneFunc describes the behavior when the Done method of the parent
@@ -3845,6 +4100,112 @@ func (c StoreMarkQueuedFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreMarkQueuedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// StoreMarkRepositoryAsDirtyFunc describes the behavior when the
+// MarkRepositoryAsDirty method of the parent MockStore instance is invoked.
+type StoreMarkRepositoryAsDirtyFunc struct {
+	defaultHook func(context.Context, int) error
+	hooks       []func(context.Context, int) error
+	history     []StoreMarkRepositoryAsDirtyFuncCall
+	mutex       sync.Mutex
+}
+
+// MarkRepositoryAsDirty delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) MarkRepositoryAsDirty(v0 context.Context, v1 int) error {
+	r0 := m.MarkRepositoryAsDirtyFunc.nextHook()(v0, v1)
+	m.MarkRepositoryAsDirtyFunc.appendCall(StoreMarkRepositoryAsDirtyFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// MarkRepositoryAsDirty method of the parent MockStore instance is invoked
+// and the hook queue is empty.
+func (f *StoreMarkRepositoryAsDirtyFunc) SetDefaultHook(hook func(context.Context, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// MarkRepositoryAsDirty method of the parent MockStore instance inovkes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreMarkRepositoryAsDirtyFunc) PushHook(hook func(context.Context, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreMarkRepositoryAsDirtyFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreMarkRepositoryAsDirtyFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+func (f *StoreMarkRepositoryAsDirtyFunc) nextHook() func(context.Context, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreMarkRepositoryAsDirtyFunc) appendCall(r0 StoreMarkRepositoryAsDirtyFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreMarkRepositoryAsDirtyFuncCall objects
+// describing the invocations of this function.
+func (f *StoreMarkRepositoryAsDirtyFunc) History() []StoreMarkRepositoryAsDirtyFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreMarkRepositoryAsDirtyFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreMarkRepositoryAsDirtyFuncCall is an object that describes an
+// invocation of method MarkRepositoryAsDirty on an instance of MockStore.
+type StoreMarkRepositoryAsDirtyFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreMarkRepositoryAsDirtyFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreMarkRepositoryAsDirtyFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/store/observability.go
+++ b/enterprise/internal/codeintel/store/observability.go
@@ -40,6 +40,9 @@ type ObservedStore struct {
 	packageReferencePagerOperation          *observation.Operation
 	hasCommitOperation                      *observation.Operation
 	updateCommitsOperation                  *observation.Operation
+	markRepositoryAsDirtyOperation          *observation.Operation
+	dirtyRepositoriesOperation              *observation.Operation
+	fixCommitsOperation                     *observation.Operation
 	indexableRepositoriesOperation          *observation.Operation
 	updateIndexableRepositoryOperation      *observation.Operation
 	resetIndexableRepositoriesOperation     *observation.Operation
@@ -207,6 +210,21 @@ func NewObserved(store Store, observationContext *observation.Context) Store {
 			MetricLabels: []string{"update_commits"},
 			Metrics:      metrics,
 		}),
+		markRepositoryAsDirtyOperation: observationContext.Operation(observation.Op{
+			Name:         "store.MarkRepositoryAsDirty",
+			MetricLabels: []string{"mark_repository_as_dirty"},
+			Metrics:      metrics,
+		}),
+		dirtyRepositoriesOperation: observationContext.Operation(observation.Op{
+			Name:         "store.DirtyRepositories",
+			MetricLabels: []string{"dirty_repositories"},
+			Metrics:      metrics,
+		}),
+		fixCommitsOperation: observationContext.Operation(observation.Op{
+			Name:         "store.FixCommits",
+			MetricLabels: []string{"fix_commits"},
+			Metrics:      metrics,
+		}),
 		indexableRepositoriesOperation: observationContext.Operation(observation.Op{
 			Name:         "store.IndexableRepositories",
 			MetricLabels: []string{"indexable_repositories"},
@@ -330,6 +348,9 @@ func (s *ObservedStore) wrap(other Store) Store {
 		packageReferencePagerOperation:          s.packageReferencePagerOperation,
 		hasCommitOperation:                      s.hasCommitOperation,
 		updateCommitsOperation:                  s.updateCommitsOperation,
+		markRepositoryAsDirtyOperation:          s.markRepositoryAsDirtyOperation,
+		dirtyRepositoriesOperation:              s.dirtyRepositoriesOperation,
+		fixCommitsOperation:                     s.fixCommitsOperation,
 		indexableRepositoriesOperation:          s.indexableRepositoriesOperation,
 		updateIndexableRepositoryOperation:      s.updateIndexableRepositoryOperation,
 		resetIndexableRepositoriesOperation:     s.resetIndexableRepositoriesOperation,
@@ -573,6 +594,27 @@ func (s *ObservedStore) UpdateCommits(ctx context.Context, repositoryID int, com
 	ctx, endObservation := s.updateCommitsOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 	return s.store.UpdateCommits(ctx, repositoryID, commits)
+}
+
+// MarkRepositoryAsDirty calls into the inner store and registers the observed results.
+func (s *ObservedStore) MarkRepositoryAsDirty(ctx context.Context, repositoryID int) (err error) {
+	ctx, endObservation := s.markRepositoryAsDirtyOperation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+	return s.store.MarkRepositoryAsDirty(ctx, repositoryID)
+}
+
+// DirtyRepositories calls into the inner store and registers the observed results.
+func (s *ObservedStore) DirtyRepositories(ctx context.Context) (repositoryIDs map[int]int, err error) {
+	ctx, endObservation := s.dirtyRepositoriesOperation.With(ctx, &err, observation.Args{})
+	defer func() { endObservation(float64(len(repositoryIDs)), observation.Args{}) }()
+	return s.store.DirtyRepositories(ctx)
+}
+
+// CalculateVisibleUploads calls into the inner store and registers the observed results.
+func (s *ObservedStore) CalculateVisibleUploads(ctx context.Context, repositoryID int, graph map[string][]string, tipCommit string, dirtyToken int) (err error) {
+	ctx, endObservation := s.fixCommitsOperation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+	return s.store.CalculateVisibleUploads(ctx, repositoryID, graph, tipCommit, dirtyToken)
 }
 
 // IndexableRepositories calls into the inner store and registers the observed results.

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -126,6 +126,22 @@ type Store interface {
 	// UpdateCommits upserts commits/parent-commit relations for the given repository ID.
 	UpdateCommits(ctx context.Context, repositoryID int, commits map[string][]string) error
 
+	// MarkRepositoryAsDirty marks the given repository's commit graph as out of date.
+	MarkRepositoryAsDirty(ctx context.Context, repositoryID int) error
+
+	// DirtyRepositories returns a map from repository identifiers to a dirty token for each repository whose commit
+	// graph is out of date. This token should be passed to CalculateVisibleUploads in order to unmark the repository.
+	DirtyRepositories(ctx context.Context) (map[int]int, error)
+
+	// CalculateVisibleUploads uses the given commit graph and the tip commit of the default branch to determine the set
+	// of LSIF uploads that are visible for each commit, and the set of uploads which are visible at the tip. The decorated
+	// commit graph is serialized to Postgres for use by find closest dumps queries.
+	//
+	// If dirtyToken is supplied, the repository will be unmarked when the supplied token does matches the most recent
+	// token stored in the database, the flag will not be cleared as another request for update has come in since this
+	// token has been read.
+	CalculateVisibleUploads(ctx context.Context, repositoryID int, graph map[string][]string, tipCommit string, dirtyToken int) error
+
 	// IndexableRepositories returns the identifiers of all indexable repositories.
 	IndexableRepositories(ctx context.Context, opts IndexableRepositoryQueryOptions) ([]IndexableRepository, error)
 


### PR DESCRIPTION
This PR adds methods to the store that populate/read some of the nearest upload data in the new tables defined in [RFC 186](https://docs.google.com/document/d/1NiAQG4muTljgk8qirYs2aN5Zt3lfk4lgwNqOm9WOH4s).

This is part of a larger effort towards https://github.com/sourcegraph/sourcegraph/issues/12098.