### PR TITLE
cmd(server): always build grafana

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -68,7 +68,7 @@ RUN set -ex && \
     apk add --no-cache libc6-compat ca-certificates su-exec
 
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/grafana:61407_2020-04-18_9aa5791@sha256:27845c4e03643f2a774873abfe549956bdbb3a19508a6e3f96f83c80eb24d81f /usr/share/grafana /usr/share/grafana
+COPY --from=sourcegraph/grafana:server /usr/share/grafana /usr/share/grafana
 
 # hadolint ignore=DL3022
 COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so
@@ -76,7 +76,7 @@ ENV LIBSQLITE3_PCRE /libsqlite3-pcre.so
 COPY . /
 
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/grafana:61407_2020-04-18_9aa5791@sha256:27845c4e03643f2a774873abfe549956bdbb3a19508a6e3f96f83c80eb24d81f /sg_config_grafana/provisioning/dashboards /sg_config_grafana/provisioning/dashboards
+COPY --from=sourcegraph/grafana:server /sg_config_grafana/provisioning/dashboards /sg_config_grafana/provisioning/dashboards
 
 # hadolint ignore=DL3022
 COPY --from=wrouesnel/postgres_exporter:v0.7.0@sha256:785c919627c06f540d515aac88b7966f352403f73e931e70dc2cbf783146a98b /postgres_exporter /usr/local/bin/postgres_exporter

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -94,9 +94,10 @@ mkdir "$OUTPUT/sg_prometheus_add_ons"
 cp dev/prometheus/linux/prometheus_targets.yml "$OUTPUT/sg_prometheus_add_ons"
 IMAGE=sourcegraph/prometheus:server CACHE=true docker-images/prometheus/build.sh
 
-echo "--- grafana config"
+echo "--- grafana"
 cp -r docker-images/grafana/config "$OUTPUT/sg_config_grafana"
 cp -r dev/grafana/linux "$OUTPUT/sg_config_grafana/provisioning/datasources"
+IMAGE=sourcegraph/grafana:server CACHE=true docker-images/grafana/build.sh
 
 echo "--- jaeger-all-in-one binary"
 cmd/server/jaeger.sh

--- a/docker-images/grafana/config/grafana-single-container.ini
+++ b/docker-images/grafana/config/grafana-single-container.ini
@@ -279,7 +279,11 @@ enabled = true
 org_name = Main Org.
 
 # specify role for unauthenticated users
-org_role = Admin
+#
+# We use Editor and not Admin here because Admin would be shown an annoying
+# onboarding user flow injected into our home dashboard. See:
+# https://github.com/grafana/grafana/issues/8402#issuecomment-343270072
+org_role = Editor
 
 #################################### Github Auth ##########################
 [auth.github]


### PR DESCRIPTION
Ensures dashboard, grafana version is always up to date. Also sets editor rule to remove onboarding flow, as indicated in the comment and already in use by the non-single-container Grafana configuration.

Closes https://github.com/sourcegraph/sourcegraph/issues/12421

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
