### PR TITLE
Add cleanup step to Grafana and Prometheus ignored files

### DIFF
--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -866,6 +866,7 @@ func main() {
 		ZoektIndexServer(),
 		ZoektWebServer(),
 	}
+	var filelist []string
 	for _, container := range containers {
 		if err := container.validate(); err != nil {
 			log.Fatal(err)
@@ -881,6 +882,8 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
+			filelist = append(filelist, container.Name+".json")
+
 			if reload {
 				ctx := context.Background()
 				client := sdk.NewClient("http://127.0.0.1:3370", "admin:admin", sdk.DefaultHTTPClient)
@@ -898,6 +901,7 @@ func main() {
 				log.Fatal(err)
 			}
 			fileName := strings.Replace(container.Name, "-", "_", -1) + "_alert_rules.yml"
+			filelist = append(filelist, fileName)
 			// #nosec G306  grafana runs as UID 472
 			err = ioutil.WriteFile(filepath.Join(prometheusDir, fileName), data, 0666)
 			if err != nil {
@@ -905,6 +909,7 @@ func main() {
 			}
 		}
 	}
+	deleteRemnants(filelist, grafanaDir, prometheusDir)
 
 	if prometheusDir != "" && reload {
 		resp, err := http.Post("http://127.0.0.1:9090/-/reload", "", nil)
@@ -927,6 +932,51 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+	}
+}
+
+func deleteRemnants(filelist []string, grafanaDir, promDir string) {
+
+	err := filepath.Walk(grafanaDir, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) != ".json" || info.IsDir() {
+			return nil
+		}
+		for _, f := range filelist {
+			if filepath.Ext(f) != ".json" || filepath.Ext(path) != ".json" || info.IsDir() {
+				continue
+			}
+			if filepath.Base(path) == f {
+				return nil
+			}
+		}
+		err = os.Remove(path)
+		log.Println("Removed orphan grafana file: ", path)
+		return err
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = filepath.Walk(promDir, func(path string, info os.FileInfo, err error) error {
+
+		if !strings.Contains(filepath.Base(path), "_alert_rules.yml") || info.IsDir() {
+			return nil
+		}
+
+		for _, f := range filelist {
+			if filepath.Ext(f) != ".yml" {
+				continue
+			}
+			if filepath.Base(path) == f {
+				return nil
+			}
+		}
+		err = os.Remove(path)
+		log.Println("Removed orphan prometheus alert file: ", path)
+		return err
+	})
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This adds cleanup to the generated Grafana and Prometheus files located in docker-images/grafana/provisioning/dashboards/sourcegraph/ and docker-images/prometheus/config/

I found this when I realized my local dev environment was not being refreshed. This means that even though we were not generating a config it would still be visible due to not being cleaned up. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/12280 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->