### PR TITLE
search: limit indexed branches per repository to 64

### DIFF
--- a/doc/user/search/index.md
+++ b/doc/user/search/index.md
@@ -133,7 +133,7 @@ After setting some version contexts, users can select version contexts in the dr
 
 > NOTE: This feature is still in active development and must be enabled by a Sourcegraph site admin in site configuration.
 
-The most common branch to search is your default branch. To speed up this common operation Sourcegraph maintains an index of the source code on your default branch. Some organizations have other branches which are regularly searched. To speed up search for those branches Sourcegraph can be configured to index them.
+The most common branch to search is your default branch. To speed up this common operation Sourcegraph maintains an index of the source code on your default branch. Some organizations have other branches which are regularly searched. To speed up search for those branches Sourcegraph can be configured to index up to 64 branches per repository.
 
 Your site admin can configure indexed branches in site configuration under the `experimentalFeatures.search.index.branches` setting. For example:
 

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -92,6 +92,11 @@ func GetIndexOptions(c *schema.SiteConfiguration, repoName string, getVersion fu
 		o.Branches = nil
 	}
 
+	// Zoekt has a limit of 64 branches
+	if len(o.Branches) > 64 {
+		o.Branches = o.Branches[:64]
+	}
+
 	return json.Marshal(o)
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -433,7 +433,7 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
-	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph index up to 64 branches per repository.
+	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -433,7 +433,7 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
-	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions.
+	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph index up to 64 branches per repository.
 	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -153,11 +153,12 @@
           ]
         },
         "search.index.branches": {
-          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions.",
+          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph index up to 64 branches per repository.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": "string" },
+            "maxItems": 64
           },
           "examples": [
             {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -153,7 +153,7 @@
           ]
         },
         "search.index.branches": {
-          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph index up to 64 branches per repository.",
+          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
           "type": "object",
           "additionalProperties": {
             "type": "array",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -158,7 +158,7 @@ const SiteSchemaJSON = `{
           ]
         },
         "search.index.branches": {
-          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph index up to 64 branches per repository.",
+          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
           "type": "object",
           "additionalProperties": {
             "type": "array",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -158,11 +158,12 @@ const SiteSchemaJSON = `{
           ]
         },
         "search.index.branches": {
-          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions.",
+          "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph index up to 64 branches per repository.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": "string" },
+            "maxItems": 64
           },
           "examples": [
             {


### PR DESCRIPTION
Zoekt only supports indexing up to 64 repositories. This commit enforces
this in the JSON schema for "search.index.branches". Enforcing this for
Version Contexts will require adding a custom validator, which I'll
leave for a later improvement.

Since we don't enforce this everywhere, the options we generate will
deterministically only return up to 64 branches. If an admin specifies
more, it is likely better to index 64 branches than index none and fail.
