### PR TITLE
endpoint: prom metric and debug logs for k8s service discovery

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -193,13 +193,8 @@ func inform(client *k8s.Client, m *Map, u *k8sURL) error {
 		}
 		urls, err := endpointsToMap(u, &endpoints)
 		m.mu.Lock()
-		oldURLs, oldErr := m.urls, m.err
 		m.urls, m.err = urls, err
 		m.mu.Unlock()
-
-		if !reflect.Equal(urls, oldURLs) {
-			log15.Debug("kubernetes endpoint changed", "service", u.Service, "oldUrls", oldUrls, "urls", urls, "oldErr", oldErr, "err", err)
-		}
 	}
 }
 
@@ -215,6 +210,7 @@ func endpointsToMap(u *k8sURL, eps *corev1.Endpoints) (*hashMap, error) {
 		}
 	}
 	sort.Strings(urls)
+	log15.Debug("kubernetes endpoints", "service", u.Service, "urls", urls)
 	metricEndpointSize.WithLabelValues(u.Service).Set(float64(len(urls)))
 	if len(urls) == 0 {
 		return nil, errors.Errorf("no %s endpoints could be found (this may indicate more %s replicas are needed, contact support@sourcegraph.com for assistance)", u.Service, u.Service)


### PR DESCRIPTION
We add some observability around what we get back from k8s service discovery. This is to help us debug issues around service discovery at a large instance.