### PR TITLE
Run code scanning in parallel for Go and JavaScript

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@
 /.prettierignore @felixfbecker
 /.github @beyang
 /.github/workflows/lsif.yml @efritz
+/.github/workflows/codeql.yml @sourcegraph/security
 /.gitmodules @beyang
 /.gitattributes @beyang
 /.yarnrc @felixfbecker

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,16 @@
 name: "Code Scanning - Action"
 
 on:
-  schedule:
-    - cron: '0 * * * *'
+  push:
+    branches: [master]
 
 jobs:
   CodeQL-Build:
 
     strategy:
       fail-fast: false
-
+      matrix:
+        languages: [ 'go', 'javascript']
 
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
@@ -21,25 +22,13 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      with:
+        languages: ${{ matrix.languages }}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below).
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Recommended in https://github.com/sourcegraph/sourcegraph/pull/10239#issuecomment-655549876

This also switches running CodeQL to every commit on master instead of just every hour. We can go back to hourly if this turns into an issue.