### PR TITLE
search: fix field value scanner

### DIFF
--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -93,7 +93,7 @@ loop:
 			result = append(result, r)
 		case r == '\\':
 			// Handle escape sequence.
-			if len(buf) > 0 && len(buf[advance:]) > 0 {
+			if len(buf) > advance {
 				r = next()
 				// Accept anything anything escaped. The point
 				// is to consume escaped spaces like "\ " so

--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -91,6 +91,18 @@ loop:
 			// We see a space and the pattern is unbalanced, so assume this
 			// this space is still part of the pattern.
 			result = append(result, r)
+		case r == '\\':
+			// Handle escape sequence.
+			if len(buf) > 0 && len(buf[advance:]) > 0 {
+				r = next()
+				// Accept anything anything escaped. The point
+				// is to consume escaped spaces like "\ " so
+				// that we don't recognize it as terminating a
+				// pattern.
+				result = append(result, '\\', r)
+				continue
+			}
+			result = append(result, r)
 		default:
 			token = append(token, []byte(string(r))...)
 			result = append(result, r)

--- a/internal/search/query/literal_parser_test.go
+++ b/internal/search/query/literal_parser_test.go
@@ -279,11 +279,10 @@ func TestParseAndOrLiteral(t *testing.T) {
 			Want:       `(and "type:commit" "message:a com" "after:10 days ago" (concat "mit" "message\""))`,
 			WantLabels: "Literal",
 		},
-		// For better or worse, escaping parentheses is not supported until we decide to do so.
 		{
 			Input:      `bar and (foo or x\) ()`,
-			WantError:  `i'm having trouble understanding that query. The combination of parentheses is the problem. Try using the content: filter to quote patterns that contain parentheses`,
-			WantLabels: "None",
+			Want:       `(or (and "bar" "(foo") (concat "x\\)" "()"))`,
+			WantLabels: "HeuristicDanglingParens,HeuristicHoisted,HeuristicParensAsPatterns,Literal",
 		},
 		// For implementation simplicity, behavior preserves whitespace
 		// inside parentheses.

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -700,6 +700,16 @@ func TestParse(t *testing.T) {
 			WantGrammar:   `(and "repo:foo\\ bar" "\\:\\\\")`,
 			WantHeuristic: Same,
 		},
+		{
+			Input:         `a file:\.(ts(?:(?:)|x)|js(?:(?:)|x))(?m:$)`,
+			WantGrammar:   `(and "file:\\.(ts(?:(?:)|x)|js(?:(?:)|x))(?m:$)" "a")`,
+			WantHeuristic: Same,
+		},
+		{
+			Input:         `(file:(a) file:(b))`,
+			WantGrammar:   `(and "file:(a)" "file:(b)")`,
+			WantHeuristic: Same,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
Addresses #12360: 

New parser thinks that parenthesized expressions after fields, like `file:(...)` could mean a start of a grouped expression, and passes off logic to other functions that end up treating it like a pattern. We should assume that parenthesized expressions after fields are never the start of a grouped expression.

Side note: I'll be tidying things in this code to make it more clear how the scanning/parsing works in the next couple of PRs, since there's kinda a lot going on.