### PR TITLE
search: error on breaking concat invariant

### DIFF
--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -201,13 +201,17 @@ loop:
 
 				// Heuristic: This right paren may be one we should associate with a previous pattern, and not
 				// just a dangling one. Check if a pattern occurred before it and append it if so.
-				if p.pos > 0 {
+				if pattern.Annotation.Range.Start.Column > 0 {
 					// Heuristic is imprecise and that's OK: It will only look for a 1-byte whitespace
 					// character (not any unicode whitespace) before this paren.
-					if r, _ := utf8.DecodeRune([]byte{p.buf[p.pos-1]}); !unicode.IsSpace(r) {
+					if r, _ := utf8.DecodeRune([]byte{p.buf[pattern.Annotation.Range.Start.Column-1]}); !unicode.IsSpace(r) {
 						if len(nodes) > 0 {
 							if previous, ok := nodes[len(nodes)-1].(Pattern); ok {
-								nodes[len(nodes)-1] = concatPatterns(previous, pattern)
+								result, err := concatPatterns(previous, pattern)
+								if err != nil {
+									return nil, err
+								}
+								nodes[len(nodes)-1] = result
 								continue
 							}
 						}

--- a/internal/search/query/literal_parser_test.go
+++ b/internal/search/query/literal_parser_test.go
@@ -358,6 +358,17 @@ func TestParseAndOrLiteral(t *testing.T) {
 			WantError:  "unterminated literal: expected '",
 			WantLabels: "None",
 		},
+		// Fringe tests cases at the boundary of heuristics and invalid syntax.
+		{
+			Input:      `)(0 )0`,
+			Want:       `(concat ")(0" ")0")`,
+			WantLabels: "HeuristicDanglingParens,Literal",
+		},
+		{
+			Input:      `((R:)0))0`,
+			WantError:  `invalid query syntax`,
+			WantLabels: "None",
+		},
 	}
 	for _, tt := range cases {
 		t.Run("literal search parse", func(t *testing.T) {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/inconshreveable/log15"
 )
 
 /*
@@ -584,16 +586,18 @@ func partitionParameters(nodes []Node) []Node {
 
 // concatPatterns extends the left pattern with the right pattern, appropriately
 // updating the ranges and annotations.
-func concatPatterns(left, right Pattern) Pattern {
+func concatPatterns(left, right Pattern) (Pattern, error) {
 	if left.Annotation.Range.End.Column != right.Annotation.Range.Start.Column {
-		panic(fmt.Sprintf("Expected contiguous patterns to concatenate, but %s ends at %d and %s starts at %d",
-			left, left.Annotation.Range.End.Column,
-			right, right.Annotation.Range.Start.Column))
+		log15.Warn("parser can't process concatPatterns",
+			"left", left, "right", right,
+			"leftEnd", left.Annotation.Range.End.Column,
+			"rightBegin", right.Annotation.Range.Start.Column)
+		return Pattern{}, &UnsupportedError{Msg: "invalid query syntax"}
 	}
 	left.Value += right.Value
 	left.Annotation.Labels |= right.Annotation.Labels
 	left.Annotation.Range.End.Column += len(right.Value)
-	return left
+	return left, nil
 }
 
 // parseLeavesRegexp scans for consecutive leaf nodes when interpreting the
@@ -629,7 +633,11 @@ loop:
 							if len(nodes) > 0 {
 								if previous, ok := nodes[len(nodes)-1].(Pattern); ok {
 									previous.Annotation.Labels = Regexp | HeuristicParensAsPatterns
-									nodes[len(nodes)-1] = concatPatterns(previous, pattern)
+									result, err := concatPatterns(previous, pattern)
+									if err != nil {
+										return nil, err
+									}
+									nodes[len(nodes)-1] = result
 									p.pos += advance
 									continue
 								}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -710,6 +710,18 @@ func TestParse(t *testing.T) {
 			WantGrammar:   `(and "file:(a)" "file:(b)")`,
 			WantHeuristic: Same,
 		},
+		// Fringe tests cases at the boundary of heuristics and invalid syntax.
+		{
+			Input:         `(0(F)(:())(:())(<0)0()`,
+			WantGrammar:   Spec(`unbalanced expression`),
+			WantHeuristic: `invalid query syntax`,
+		},
+		// The space-looking character below is U+00A0.
+		{
+			Input:         `00 (000)`,
+			WantGrammar:   `(concat "00" "000")`,
+			WantHeuristic: `invalid query syntax`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
Stacked on  #12446.

The test cases in this PR previously made the parser crash, found by fuzzing. The reason these crash is because these inputs succeed at breaking an assertion where we want to concat contiguous patterns that contain parentheses (versus parentheses that we try our best to guess are part of a group). 

The only way to trigger this is if the pattern(s) are in some way unbalanced, or use unconventional unicode space characters. Thus, these are fringe and unusual inputs that would need some more heavy changes to support (which I am open to doing, but not in this PR). So for now, I add the crashing inputs as tests, demoted the strong `panic` to instead just return error and give up, saying this is invalid syntax, and log the offending inputs. 

Modulo #12456, the parser doesn't crash anymore with more fuzzing, which is the state I need this code to be in to do more refactors.

