### PR TITLE
go: Update our graphql-go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ replace (
 
 	// We need our fork until https://github.com/graph-gophers/graphql-go/pull/400 is merged upstream
 	// Our change limits the number of goroutines spawned by resolvers which was causing memory spikes on our frontend
-	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20200723081120-8462b0b708c4
+	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 
 	// prom-wrapper needs to be able to write alertmanager configuration with secrets - https://github.com/prometheus/alertmanager/pull/2316

--- a/go.sum
+++ b/go.sum
@@ -1207,6 +1207,8 @@ github.com/sourcegraph/graphql-go v0.0.0-20200626080007-7fa8b67cbb1d h1:a3EEtOsV
 github.com/sourcegraph/graphql-go v0.0.0-20200626080007-7fa8b67cbb1d/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/sourcegraph/graphql-go v0.0.0-20200723081120-8462b0b708c4 h1:w3lLhAnBWmcImnrcANpgylh29D6Pc5TvX/C8gh6NwL0=
 github.com/sourcegraph/graphql-go v0.0.0-20200723081120-8462b0b708c4/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
+github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484 h1:oMnbwXPJDRDfUjEuFHlO6u1MY6O64G2TrDBOXTgVX58=
+github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/sourcegraph/jsonx v0.0.0-20200625022044-c22a595bbad7 h1:G58fa9uWw59V5l92ijZKpT49lbAdv0JdruZUUZmjdeI=
 github.com/sourcegraph/jsonx v0.0.0-20200625022044-c22a595bbad7/go.mod h1:7jkSQ2sdxwXMaIDxKJotTt+hwKnT9b/wbJFU7/ObUEY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=


### PR DESCRIPTION
This reverses a change we made to pool some buffers as it didn't help in practice and the code was more complicated
