### PR TITLE
Wrap basestore.Store in campaigns.Store

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -46,8 +46,7 @@ type Service struct {
 }
 
 // CreateCampaign creates the Campaign.
-func (s *Service) CreateCampaign(ctx context.Context, c *campaigns.Campaign) error {
-	var err error
+func (s *Service) CreateCampaign(ctx context.Context, c *campaigns.Campaign) (err error) {
 	tr, ctx := trace.New(ctx, "Service.CreateCampaign", fmt.Sprintf("Name: %q", c.Name))
 	defer func() {
 		tr.SetError(err)
@@ -62,7 +61,7 @@ func (s *Service) CreateCampaign(ctx context.Context, c *campaigns.Campaign) err
 	if err != nil {
 		return err
 	}
-	defer tx.Done(&err)
+	defer func() { err = tx.Done(err) }()
 
 	c.CreatedAt = s.clock()
 	c.UpdatedAt = c.CreatedAt
@@ -151,7 +150,7 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Done(&err)
+	defer func() { err = tx.Done(err) }()
 
 	if err := tx.CreateCampaignSpec(ctx, spec); err != nil {
 		return nil, err
@@ -236,7 +235,7 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Done(&err)
+	defer func() { err = tx.Done(err) }()
 
 	campaignSpec, err := tx.GetCampaignSpec(ctx, GetCampaignSpecOpts{
 		RandID: opts.CampaignSpecRandID,
@@ -326,7 +325,7 @@ func (s *Service) MoveCampaign(ctx context.Context, opts MoveCampaignOpts) (camp
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Done(&err)
+	defer func() { err = tx.Done(err) }()
 
 	campaign, err = tx.GetCampaign(ctx, GetCampaignOpts{ID: opts.CampaignID})
 	if err != nil {
@@ -384,7 +383,7 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 		if err != nil {
 			return err
 		}
-		defer tx.Done(&err)
+		defer func() { err = tx.Done(err) }()
 
 		campaign, err = tx.GetCampaign(ctx, GetCampaignOpts{ID: id})
 		if err != nil {
@@ -470,7 +469,7 @@ func (s *Service) DeleteCampaign(ctx context.Context, id int64) (err error) {
 		if err != nil {
 			return err
 		}
-		defer tx.Done(&err)
+		defer func() { err = tx.Done(err) }()
 
 		// TODO: Implement logic to find changesets in PUBLISHING state.
 		processing := false

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -144,7 +144,7 @@ func (s *Store) CreateChangesets(ctx context.Context, cs ...*campaigns.Changeset
 
 	exist := []int64{}
 	i := -1
-	err = s.exec(ctx, q, func(sc scanner) (err error) {
+	err = s.query(ctx, q, func(sc scanner) (err error) {
 		i++
 
 		createdAt := cs[i].CreatedAt
@@ -452,7 +452,7 @@ func (s *Store) GetChangeset(ctx context.Context, opts GetChangesetOpts) (*campa
 	q := getChangesetQuery(&opts)
 
 	var c campaigns.Changeset
-	err := s.exec(ctx, q, func(sc scanner) error { return scanChangeset(&c, sc) })
+	err := s.query(ctx, q, func(sc scanner) error { return scanChangeset(&c, sc) })
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +711,7 @@ func (s *Store) UpdateChangesets(ctx context.Context, cs ...*campaigns.Changeset
 	}
 
 	i := -1
-	return s.exec(ctx, q, func(sc scanner) (err error) {
+	return s.query(ctx, q, func(sc scanner) (err error) {
 		i++
 		return scanChangeset(cs[i], sc)
 	})
@@ -796,7 +796,7 @@ func (s *Store) GetChangesetEvent(ctx context.Context, opts GetChangesetEventOpt
 	q := getChangesetEventQuery(&opts)
 
 	var c campaigns.ChangesetEvent
-	err := s.exec(ctx, q, func(sc scanner) error {
+	err := s.query(ctx, q, func(sc scanner) error {
 		return scanChangesetEvent(&c, sc)
 	})
 	if err != nil {
@@ -962,7 +962,7 @@ func (s *Store) UpsertChangesetEvents(ctx context.Context, cs ...*campaigns.Chan
 	}
 
 	i := -1
-	return s.exec(ctx, q, func(sc scanner) (err error) {
+	return s.query(ctx, q, func(sc scanner) (err error) {
 		i++
 		return scanChangesetEvent(cs[i], sc)
 	})
@@ -1091,7 +1091,7 @@ func (s *Store) CreateCampaign(ctx context.Context, c *campaigns.Campaign) error
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) (err error) {
+	return s.query(ctx, q, func(sc scanner) (err error) {
 		return scanCampaign(c, sc)
 	})
 }
@@ -1192,7 +1192,7 @@ func (s *Store) UpdateCampaign(ctx context.Context, c *campaigns.Campaign) error
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) (err error) { return scanCampaign(c, sc) })
+	return s.query(ctx, q, func(sc scanner) (err error) { return scanCampaign(c, sc) })
 }
 
 var updateCampaignQueryFmtstr = `
@@ -1321,7 +1321,7 @@ func (s *Store) GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaig
 	q := getCampaignQuery(&opts)
 
 	var c campaigns.Campaign
-	err := s.exec(ctx, q, func(sc scanner) error {
+	err := s.query(ctx, q, func(sc scanner) error {
 		return scanCampaign(&c, sc)
 	})
 	if err != nil {
@@ -1505,10 +1505,6 @@ func (s *Store) GetChangesetExternalIDs(ctx context.Context, spec api.ExternalRe
 
 	q := sqlf.Sprintf(queryFmtString, spec.ServiceType, sqlf.Join(inClause, ","), spec.ID, spec.ServiceType, spec.ServiceID)
 	return basestore.ScanStrings(s.Store.Query(ctx, q))
-}
-
-func (s *Store) exec(ctx context.Context, q *sqlf.Query, sc scanFunc) error {
-	return s.query(ctx, q, sc)
 }
 
 func (s *Store) query(ctx context.Context, q *sqlf.Query, sc scanFunc) error {

--- a/enterprise/internal/campaigns/store_campaign_specs.go
+++ b/enterprise/internal/campaigns/store_campaign_specs.go
@@ -35,7 +35,7 @@ func (s *Store) CreateCampaignSpec(ctx context.Context, c *campaigns.CampaignSpe
 	if err != nil {
 		return err
 	}
-	err = s.exec(ctx, q, func(sc scanner) error {
+	err = s.query(ctx, q, func(sc scanner) error {
 		return scanCampaignSpec(c, sc)
 	})
 
@@ -92,7 +92,7 @@ func (s *Store) UpdateCampaignSpec(ctx context.Context, c *campaigns.CampaignSpe
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) error {
+	return s.query(ctx, q, func(sc scanner) error {
 		return scanCampaignSpec(c, sc)
 	})
 }
@@ -158,7 +158,7 @@ func (s *Store) GetCampaignSpec(ctx context.Context, opts GetCampaignSpecOpts) (
 	q := getCampaignSpecQuery(&opts)
 
 	var c campaigns.CampaignSpec
-	err := s.exec(ctx, q, func(sc scanner) (err error) {
+	err := s.query(ctx, q, func(sc scanner) (err error) {
 		return scanCampaignSpec(&c, sc)
 	})
 	if err != nil {

--- a/enterprise/internal/campaigns/store_campaign_specs_test.go
+++ b/enterprise/internal/campaigns/store_campaign_specs_test.go
@@ -79,7 +79,7 @@ func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(len(campaignSpecs)); have != want {
+		if have, want := count, len(campaignSpecs); have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 	})
@@ -229,7 +229,7 @@ func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos
 				t.Fatal(err)
 			}
 
-			if have, want := count, int64(len(campaignSpecs)-(i+1)); have != want {
+			if have, want := count, len(campaignSpecs)-(i+1); have != want {
 				t.Fatalf("have count: %d, want: %d", have, want)
 			}
 		}

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -51,10 +51,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, c *campaigns.ChangesetS
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
-		err = scanChangesetSpec(c, sc)
-		return c.ID, 1, err
-	})
+	return s.exec(ctx, q, func(sc scanner) error { return scanChangesetSpec(c, sc) })
 }
 
 var createChangesetSpecQueryFmtstr = `
@@ -106,9 +103,8 @@ func (s *Store) UpdateChangesetSpec(ctx context.Context, c *campaigns.ChangesetS
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) (last, count int64, err error) {
-		err = scanChangesetSpec(c, sc)
-		return c.ID, 1, err
+	return s.exec(ctx, q, func(sc scanner) error {
+		return scanChangesetSpec(c, sc)
 	})
 }
 
@@ -146,13 +142,7 @@ func (s *Store) updateChangesetSpecQuery(c *campaigns.ChangesetSpec) (*sqlf.Quer
 
 // DeleteChangesetSpec deletes the ChangesetSpec with the given ID.
 func (s *Store) DeleteChangesetSpec(ctx context.Context, id int64) error {
-	q := sqlf.Sprintf(deleteChangesetSpecQueryFmtstr, id)
-
-	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	if err != nil {
-		return err
-	}
-	return rows.Close()
+	return s.Store.Exec(ctx, sqlf.Sprintf(deleteChangesetSpecQueryFmtstr, id))
 }
 
 var deleteChangesetSpecQueryFmtstr = `
@@ -167,12 +157,8 @@ type CountChangesetSpecsOpts struct {
 }
 
 // CountChangesetSpecs returns the number of changeset specs in the database.
-func (s *Store) CountChangesetSpecs(ctx context.Context, opts CountChangesetSpecsOpts) (count int64, _ error) {
-	q := countChangesetSpecsQuery(&opts)
-	return count, s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
-		err = sc.Scan(&count)
-		return 0, count, err
-	})
+func (s *Store) CountChangesetSpecs(ctx context.Context, opts CountChangesetSpecsOpts) (int, error) {
+	return s.queryCount(ctx, countChangesetSpecsQuery(&opts))
 }
 
 var countChangesetSpecsQueryFmtstr = `
@@ -211,8 +197,8 @@ func (s *Store) GetChangesetSpec(ctx context.Context, opts GetChangesetSpecOpts)
 	q := getChangesetSpecQuery(&opts)
 
 	var c campaigns.ChangesetSpec
-	err := s.exec(ctx, q, func(sc scanner) (_, _ int64, err error) {
-		return 0, 0, scanChangesetSpec(&c, sc)
+	err := s.exec(ctx, q, func(sc scanner) error {
+		return scanChangesetSpec(&c, sc)
 	})
 	if err != nil {
 		return nil, err
@@ -269,13 +255,13 @@ func (s *Store) ListChangesetSpecs(ctx context.Context, opts ListChangesetSpecsO
 	q := listChangesetSpecsQuery(&opts)
 
 	cs = make([]*campaigns.ChangesetSpec, 0, opts.Limit)
-	_, _, err = s.query(ctx, q, func(sc scanner) (last, count int64, err error) {
+	err = s.query(ctx, q, func(sc scanner) error {
 		var c campaigns.ChangesetSpec
-		if err = scanChangesetSpec(&c, sc); err != nil {
-			return 0, 0, err
+		if err := scanChangesetSpec(&c, sc); err != nil {
+			return err
 		}
 		cs = append(cs, &c)
-		return c.ID, 1, err
+		return nil
 	})
 
 	if opts.Limit != 0 && len(cs) == opts.Limit {
@@ -335,12 +321,7 @@ func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
 func (s *Store) DeleteExpiredChangesetSpecs(ctx context.Context) error {
 	expirationTime := s.now().Add(-campaigns.ChangesetSpecTTL)
 	q := sqlf.Sprintf(deleteExpiredChangesetSpecsQueryFmtstr, expirationTime)
-
-	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	if err != nil {
-		return err
-	}
-	return rows.Close()
+	return s.Store.Exec(ctx, q)
 }
 
 var deleteExpiredChangesetSpecsQueryFmtstr = `

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -51,7 +51,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, c *campaigns.ChangesetS
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) error { return scanChangesetSpec(c, sc) })
+	return s.query(ctx, q, func(sc scanner) error { return scanChangesetSpec(c, sc) })
 }
 
 var createChangesetSpecQueryFmtstr = `
@@ -103,7 +103,7 @@ func (s *Store) UpdateChangesetSpec(ctx context.Context, c *campaigns.ChangesetS
 		return err
 	}
 
-	return s.exec(ctx, q, func(sc scanner) error {
+	return s.query(ctx, q, func(sc scanner) error {
 		return scanChangesetSpec(c, sc)
 	})
 }
@@ -197,7 +197,7 @@ func (s *Store) GetChangesetSpec(ctx context.Context, opts GetChangesetSpecOpts)
 	q := getChangesetSpecQuery(&opts)
 
 	var c campaigns.ChangesetSpec
-	err := s.exec(ctx, q, func(sc scanner) error {
+	err := s.query(ctx, q, func(sc scanner) error {
 		return scanChangesetSpec(&c, sc)
 	})
 	if err != nil {

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -87,7 +87,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(len(changesetSpecs)); have != want {
+		if have, want := count, len(changesetSpecs); have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 
@@ -104,7 +104,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 					t.Fatal(err)
 				}
 
-				if have, want := subCount, int64(1); have != want {
+				if have, want := subCount, 1; have != want {
 					t.Fatalf("have count: %d, want: %d", have, want)
 				}
 				testsRan = true
@@ -311,7 +311,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 				t.Fatal(err)
 			}
 
-			if have, want := count, int64(len(changesetSpecs)-(i+1)); have != want {
+			if have, want := count, len(changesetSpecs)-(i+1); have != want {
 				t.Fatalf("have count: %d, want: %d", have, want)
 			}
 		}

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -111,7 +111,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(len(campaigns)); have != want {
+		if have, want := count, len(campaigns); have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 
@@ -120,7 +120,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(1); have != want {
+		if have, want := count, 1; have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 
@@ -130,7 +130,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				if err != nil {
 					t.Fatal(err)
 				}
-				if have, want := count, int64(1); have != want {
+				if have, want := count, 1; have != want {
 					t.Fatalf("Incorrect number of campaigns counted, want=%d have=%d", want, have)
 				}
 			}
@@ -449,7 +449,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				t.Fatal(err)
 			}
 
-			if have, want := count, int64(len(campaigns)-(i+1)); have != want {
+			if have, want := count, len(campaigns)-(i+1); have != want {
 				t.Fatalf("have count: %d, want: %d", have, want)
 			}
 		}
@@ -577,7 +577,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := []string{}
+		var want []string
 		if diff := cmp.Diff(want, have); diff != "" {
 			t.Fatal(diff)
 		}
@@ -593,7 +593,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := []string{}
+		var want []string
 		if diff := cmp.Diff(want, have); diff != "" {
 			t.Fatal(diff)
 		}
@@ -609,7 +609,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := []string{}
+		var want []string
 		if diff := cmp.Diff(want, have); diff != "" {
 			t.Fatal(diff)
 		}
@@ -671,7 +671,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(len(changesets)); have != want {
+		if have, want := count, len(changesets); have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 
@@ -680,7 +680,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(1); have != want {
+		if have, want := count, 1; have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 	})
@@ -1168,7 +1168,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(len(events)); have != want {
+		if have, want := count, len(events); have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 
@@ -1177,7 +1177,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 			t.Fatal(err)
 		}
 
-		if have, want := count, int64(1); have != want {
+		if have, want := count, 1; have != want {
 			t.Fatalf("have count: %d, want: %d", have, want)
 		}
 	})

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -583,7 +583,7 @@ func syncChangesetsWithSources(ctx context.Context, store SyncStore, bySource []
 	if err != nil {
 		return err
 	}
-	defer tx.Done(&err)
+	defer func() { err = tx.Done(err) }()
 
 	if err = tx.UpdateChangesets(ctx, cs...); err != nil {
 		return err

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -105,7 +105,7 @@ func (h Webhook) upsertChangesetEvent(
 	if tx, err = h.Store.Transact(ctx); err != nil {
 		return err
 	}
-	defer tx.Done(&err)
+	defer func() { err = tx.Done(err) }()
 
 	r, err := h.getRepoForPR(ctx, tx, pr, externalServiceID)
 	if err != nil {

--- a/internal/db/basestore/handle.go
+++ b/internal/db/basestore/handle.go
@@ -30,6 +30,9 @@ func NewHandleWithDB(db dbutil.DB) *TransactableHandle {
 	return &TransactableHandle{db: db}
 }
 
+// DB returns the underlying database handle.
+func (h *TransactableHandle) DB() dbutil.DB { return h.db }
+
 // InTransaction returns true if the underlying database handle is in a transaction.
 func (h *TransactableHandle) InTransaction() bool {
 	_, ok := h.db.(dbutil.Tx)


### PR DESCRIPTION
This changes the `campaigns.Store` implementation to use the new `*basestore.Store` as the underlying connection to the database.

I'm not yet sure whether we should switch to the way `codeintel/store` does scanning of rows, but it would make working with the `workerutils` easier.