### PR TITLE
Fix: low contrast search examples in dark theme

### DIFF
--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -167,12 +167,6 @@
             color: $gray-11;
         }
 
-        &__example-searches {
-            a {
-                color: $gray-19;
-            }
-        }
-
         &__web-link {
             color: #1c7cd6;
         }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/12460.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
