### PR TITLE
search: fix panic in globToRegex when input string has trailing backslash

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -160,9 +160,15 @@ func globToRegex(value string) (string, error) {
 		case '?':
 			sb.WriteRune('.')
 		case '\\':
-			// Handle escaped special characters.
+			// trailing backslashes are not allowed
+			if i == l-1 {
+				return "", ErrBadGlobPattern
+			}
+
 			sb.WriteRune('\\')
 			i++
+
+			// we only support escaping of special characters
 			if _, ok := globSpecialSymbols[r[i]]; !ok {
 				return "", ErrBadGlobPattern
 			}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -494,6 +494,7 @@ func TestTranslateBadGlobPattern(t *testing.T) {
 		{input: "fo[o"},
 		{input: "[z-a]"},
 		{input: "[a-z--0]"},
+		{input: "0[0300z0_0]\\"},
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {


### PR DESCRIPTION
Fixes #12456

func `globToRegex` did not handle a trailing backslash and for inputs like `"anything\"` it panicked with `index out of range`. This PR fixes the issue. In the case of trailing backslashes, `globToRegex` now returns a proper error that is handled by the caller.

![image](https://user-images.githubusercontent.com/26413131/88383045-0168c800-cdaa-11ea-9781-8d97d058b4ee.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
