### PR TITLE
zoekt: indexserver removes repos from queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200720095407-6597aebe357e
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200724160933-3e5f0f39e0d9
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1217,6 +1217,8 @@ github.com/sourcegraph/zoekt v0.0.0-20200714221025-dea986a54d01 h1:Qp+BmPgBkC4e0
 github.com/sourcegraph/zoekt v0.0.0-20200714221025-dea986a54d01/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/sourcegraph/zoekt v0.0.0-20200720095407-6597aebe357e h1:qbLJk6WfgKtPsgPau7sU+Lw2rzJikjUaelk3BCPK4n0=
 github.com/sourcegraph/zoekt v0.0.0-20200720095407-6597aebe357e/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200724160933-3e5f0f39e0d9 h1:lFwtlZslppl4cIb0ZKbCqosOOHxiMZqtgEUs4r77/VM=
+github.com/sourcegraph/zoekt v0.0.0-20200724160933-3e5f0f39e0d9/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
This includes several changes to zoekt indexserver which improve
observability as well as make us behave better during rebalancing. In
particular we would try to index all repos on a replica if we ever
rebalanced. We will still do that, but as soon as the replica comes back
up we will stop doing that.

- https://github.com/sourcegraph/zoekt/commit/3e5f0f3 indexserver: track last index state as a metric
- https://github.com/sourcegraph/zoekt/commit/cfdfeff indexserver: metrics for queue
- https://github.com/sourcegraph/zoekt/commit/a453878 indexserver: stop indexing repositories if not listed