### PR TITLE
search: log search inputs for differential testing

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/rand"
 	"regexp"
 	regexpsyntax "regexp/syntax"
 	"sort"
@@ -88,6 +89,13 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 
 	if searchType == query.SearchTypeStructural && !conf.StructuralSearchEnabled() {
 		return nil, errors.New("Structural search is disabled in the site configuration.")
+	}
+
+	if envvar.SourcegraphDotComMode() {
+		// Instrumentation to log 1 in 10 search inputs for differential testing, see #12477.
+		if rand.Intn(10) == 0 {
+			log15.Info("search input", "type", searchType, "magic-887c6d4c", args.Query)
+		}
 	}
 
 	var queryInfo query.QueryInfo


### PR DESCRIPTION
I want to log some live DotCom search queries to build a test corpus of inputs. Once collected, we will run these inputs through both the old and new parsers and then test that all outputs of the [query interface](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/query/types.go#L38-46) are equal. Any discrepancies will indicate a potential bug in how the new parser interprets input. The thought occurred to me to do the equivalence testing live, and log discrepancies, but I would rather not and just do this offline.

Chatted with @slimsag about doing it this way, and it'll work. Even though we could log everything according to him, I'll just sample 1 in 10, because I noticed there's a large volume of `type:symbol` queries that don't matter as much. 

I'll pipe the output to some file once this is live and then remove the instrumentation in a weeks time probably, we want to close #12477 this iteration 🤞 