### PR TITLE
monitoring: base alert_count only on state=firing alerts

### DIFF
--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -1056,7 +1056,7 @@ func (g *promGroup) AppendRow(alertQuery string, labels map[string]string, durat
 		promRule{
 			Record: "alert_count",
 			Labels: labels,
-			Expr:   fmt.Sprintf(`max(ALERTS{alertname=%q} OR on() vector(0))`, alertName),
+			Expr:   fmt.Sprintf(`max(ALERTS{alertname=%q,state="firing"} OR on() vector(0))`, alertName),
 		})
 }
 


### PR DESCRIPTION
ALERTS can be either "pending" or "firing", and we only care about the latter for alert_count

I believe this is causing us to over-count alerts - see: https://sourcegraph.slack.com/archives/CMBA8F926/p1595742704207800, caused by https://github.com/sourcegraph/sourcegraph/pull/12395


[Comparison](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(ALERTS%7Balertname%3D%5C%22critical_frontend_hard_error_search_responses%5C%22,state%3D%5C%22firing%5C%22%7D%20OR%20on()%20vector(0))%22%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D&right=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(ALERTS%7Balertname%3D%5C%22critical_frontend_hard_error_search_responses%5C%22%7D%20OR%20on()%20vector(0))%22%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D):

<img width="1713" alt="image" src="https://user-images.githubusercontent.com/23356519/88473831-f81b5f00-cf53-11ea-8af2-393616e7f2ab.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
