### PR TITLE
monitoring: increase alert repeat interval to 7d

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -57,7 +57,7 @@ func changeReceivers(ctx context.Context, log log15.Logger, change ChangeContext
 		// How long to wait before sending a notification about new alerts that are added to a group of alerts - in this case,
 		// equivalent to how long to wait until notifying about an alert re-firing
 		GroupInterval:  duration(1 * time.Minute),
-		RepeatInterval: duration(48 * time.Hour),
+		RepeatInterval: duration(7 * 24 * time.Hour),
 
 		// Route alerts to notifications
 		Routes: []*amconfig.Route{


### PR DESCRIPTION
#alerts is super noisy, leading to a lot of [silenced alerts](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Asilenced-alert) - 7d ought to be sufficient for a repeat interval

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
