### PR TITLE
monitoring: fix alert state query, fix alert firing threshold

### DIFF
--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -1045,7 +1045,7 @@ func (g *promGroup) AppendRow(alertQuery string, labels map[string]string, durat
 		promRule{
 			Alert:  alertName,
 			Labels: labels,
-			Expr:   fmt.Sprintf(`%s > 1`, alertQuery),
+			Expr:   fmt.Sprintf(`%s >= 1`, alertQuery),
 			For:    forDuration,
 		},
 		// Record for generated alert, useful for indicating in Grafana dashboards if this alert

--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -1045,7 +1045,7 @@ func (g *promGroup) AppendRow(alertQuery string, labels map[string]string, durat
 		promRule{
 			Alert:  alertName,
 			Labels: labels,
-			Expr:   fmt.Sprintf(`%s > 0`, alertQuery),
+			Expr:   fmt.Sprintf(`%s > 1`, alertQuery),
 			For:    forDuration,
 		},
 		// Record for generated alert, useful for indicating in Grafana dashboards if this alert

--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -1049,14 +1049,14 @@ func (g *promGroup) AppendRow(alertQuery string, labels map[string]string, durat
 			For:    forDuration,
 		},
 		// Record for generated alert, useful for indicating in Grafana dashboards if this alert
-		// is defined at all. Prometheus's ALERTS metric does not track alerts with state="inactive".
+		// is defined at all. Prometheus's ALERTS metric does not track alerts with alertstate="inactive".
 		//
 		// Since ALERTS{alertname="value"} does not exist if the alert has never fired, we add set
 		// the series to vector(0) instead.
 		promRule{
 			Record: "alert_count",
 			Labels: labels,
-			Expr:   fmt.Sprintf(`max(ALERTS{alertname=%q,state="firing"} OR on() vector(0))`, alertName),
+			Expr:   fmt.Sprintf(`max(ALERTS{alertname=%q,alertstate="firing"} OR on() vector(0))`, alertName),
 		})
 }
 


### PR DESCRIPTION
Follows up https://github.com/sourcegraph/sourcegraph/pull/12395, https://github.com/sourcegraph/sourcegraph/pull/12483 both of which contained mistakes:

* the field for alert state is `alertstate`, not `state`
* `alertQuery` should only fire on `>= 1` - see [this query](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(((((sum%20by%20(status)(increase(src_graphql_search_response%7Bstatus%3D~%5C%22error%5C%22,source%3D%5C%22browser%5C%22,name!%3D%5C%22CodeIntelSearch%5C%22%7D%5B5m%5D)))%20%2F%2020)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%20%5Cn%3E%200%20%3C%201%22,%22hide%22:false%7D,%7B%22expr%22:%22max(((((sum%20by%20(status)(increase(src_graphql_search_response%7Bstatus%3D~%5C%22error%5C%22,source%3D%5C%22browser%5C%22,name!%3D%5C%22CodeIntelSearch%5C%22%7D%5B5m%5D)))%20%2F%2020)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%20%5Cn%3E%3D%201%22,%22hide%22:false%7D,%7B%22expr%22:%22sum%20by%20(status)(increase(src_graphql_search_response%7Bstatus%3D~%5C%22error%5C%22,source%3D%5C%22browser%5C%22,name!%3D%5C%22CodeIntelSearch%5C%22%7D%5B5m%5D))%20%3E%3D%2020%22,%22hide%22:false%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D):

<img width="1711" alt="image" src="https://user-images.githubusercontent.com/23356519/88497837-15076f00-cff4-11ea-8702-69e0eaff9e42.png">

The above is `critical_frontend_hard_error_search_responses`, and:

* green line indicates actual value above critical threshold
* blue line indicates current, incorrectly triggered alerts (excluding times when it should actually be triggered)
* orange line indicates new query that correctly aligns with the value actually being above the critical threshold

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

Some more examples for sanity checks:

* [`warning_gitserver_running_git_commands`](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-30m%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(((((max(src_gitserver_exec_running))%20%2F%2050)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%5Cn%3E%200%20%3C%201%22,%22hide%22:false%7D,%7B%22expr%22:%22max(((((max(src_gitserver_exec_running))%20%2F%2050)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%5Cn%3E%3D%201%22,%22hide%22:false%7D,%7B%22expr%22:%22max(src_gitserver_exec_running)%20%3E%3D%2050%22,%22hide%22:false%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)
* [`warning_syntect-server_syntax_highlighting_timeouts`](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-30m%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(((((sum(increase(src_syntax_highlighting_requests%7Bstatus%3D%5C%22timeout%5C%22%7D%5B5m%5D)))%20%2F%205)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%5Cn%3E%200%20%3C%3D%201%22,%22hide%22:false%7D,%7B%22expr%22:%22max(((((sum(increase(src_syntax_highlighting_requests%7Bstatus%3D%5C%22timeout%5C%22%7D%5B5m%5D)))%20%2F%205)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%5Cn%3E%201%22,%22hide%22:false%7D,%7B%22expr%22:%22sum(increase(src_syntax_highlighting_requests%7Bstatus%3D%5C%22timeout%5C%22%7D%5B5m%5D))%20%3E%3D%205%22,%22hide%22:false%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)
