### PR TITLE
zoekt: prevent indexserver stalling

### DIFF
--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -7,7 +7,13 @@ export GO111MODULE=on
 upstream=github.com/google/zoekt
 fork=github.com/sourcegraph/zoekt
 
+oldsha="$(go mod edit -print | grep "$fork" | grep -o '[a-f0-9]*$')"
 module="$(go get ${fork}@master 2>&1 | grep -E -o ${fork}'@v0.0.0-[0-9a-z-]+')"
+newsha="$(echo "$module" | grep -o '[a-f0-9]*$')"
+
+echo "https://github.com/sourcegraph/zoekt/compare/$oldsha...$newsha"
+echo "git log --pretty=format:'- https://github.com/sourcegraph/zoekt/commit/%h %s' $oldsha...$newsha"
+echo "git log --pretty=format:'- %h %s' $oldsha...$newsha"
 
 go mod edit "-replace=${upstream}=${module}"
 go mod download ${upstream}

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200724162241-6ed80895db7e
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1211,6 +1211,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20200724162241-6ed80895db7e h1:BrYWJw2LeDDCgf99FpfMRdnzzbAjqKsEgaqhlIuxd7c=
 github.com/sourcegraph/zoekt v0.0.0-20200724162241-6ed80895db7e/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041 h1:feJ8Ngh1WsB8ruFwloAFzpyJ3jhqvN/j5lsPoyNsFCs=
+github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
See https://github.com/sourcegraph/zoekt/compare/6ed80895db7e...a99799fdc041

- https://github.com/sourcegraph/zoekt/commit/a99799f ctags: handle fatal ctags errors
- https://github.com/sourcegraph/zoekt/commit/5fcad78 ctags: skip commands that are too large
- https://github.com/sourcegraph/zoekt/commit/cf36be0 ctags: use file basename
- https://github.com/sourcegraph/zoekt/commit/d4fecb4 indexserver: timeout if no output for 5m
- https://github.com/sourcegraph/zoekt/commit/34a0dd6 indexserver: coarse 1h timeout on index job
- https://github.com/sourcegraph/zoekt/commit/fdc9c2c Merge remote-tracking branch 'gerrit/master'
- https://github.com/sourcegraph/zoekt/commit/b48e35d shards: a progress message every 10s when loading
- https://github.com/sourcegraph/zoekt/commit/4481f7b shards: throttle loading in watcher