### PR TITLE
schema: allow personal repos on Bitbucket Server

### DIFF
--- a/enterprise/internal/db/external_services_test.go
+++ b/enterprise/internal/db/external_services_test.go
@@ -496,7 +496,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid exclude item name",
 			config: `{"exclude": [{"name": "bar"}]}`,
-			assert: includes(`exclude.0.name: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+			assert: includes(`exclude.0.name: Does not match pattern '^~?[\w-]+/[\w.-]+$'`),
 		},
 		{
 			kind:   extsvc.KindBitbucketServer,
@@ -521,6 +521,22 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			assert: equals(`<nil>`),
 		},
 		{
+			kind: extsvc.KindBitbucketServer,
+			desc: "personal repos may be excluded",
+			config: `
+			{
+				"url": "https://bitbucketserver.corp.com",
+				"username": "admin",
+				"token": "very-secret-token",
+				"repositoryQuery": ["none"],
+				"exclude": [
+					{"name": "~FOO/bar", "id": 1234},
+					{"pattern": "^private/.*"}
+				]
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
 			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid empty repos",
 			config: `{"repos": []}`,
@@ -530,7 +546,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   extsvc.KindBitbucketServer,
 			desc:   "invalid empty repos item",
 			config: `{"repos": [""]}`,
-			assert: includes(`repos.0: Does not match pattern '^[\w-]+/[\w.-]+$'`),
+			assert: includes(`repos.0: Does not match pattern '^~?[\w-]+/[\w.-]+$'`),
 		},
 		{
 			kind: extsvc.KindBitbucketServer,
@@ -559,6 +575,22 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				"repos": [
 					"foo/bar",
 					"bar/baz"
+				]
+			}`,
+			assert: equals(`<nil>`),
+		},
+		{
+			kind: extsvc.KindBitbucketServer,
+			desc: "valid personal repos",
+			config: `
+			{
+				"url": "https://bitbucketserver.corp.com",
+				"username": "admin",
+				"token": "very-secret-token",
+				"repositoryQuery": ["none"],
+				"repos": [
+					"~FOO/bar",
+					"~FOO/baz"
 				]
 			}`,
 			assert: equals(`<nil>`),

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -151,9 +151,9 @@
       "minItems": 1,
       "items": {
         "type": "string",
-        "pattern": "^[\\w-]+/[\\w.-]+$"
+        "pattern": "^~?[\\w-]+/[\\w.-]+$"
       },
-      "examples": [["myproject/myrepo", "myproject/myotherrepo"]]
+      "examples": [["myproject/myrepo", "myproject/myotherrepo", "~USER/theirrepo"]]
     },
     "exclude": {
       "description": "A list of repositories to never mirror from this Bitbucket Server instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
@@ -168,7 +168,7 @@
           "name": {
             "description": "The name of a Bitbucket Server repo (\"projectKey/repositorySlug\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w-]+/[\\w.-]+$"
+            "pattern": "^~?[\\w-]+/[\\w.-]+$"
           },
           "id": {
             "description": "The ID of a Bitbucket Server repo (as returned by the Bitbucket Server instance's API) to exclude from mirroring.",
@@ -183,7 +183,12 @@
       },
       "examples": [
         [{ "name": "myproject/myrepo" }, { "id": 42 }],
-        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
+        [
+          { "name": "myproject/myrepo" },
+          { "name": "myproject/myotherrepo" },
+          { "name": "~USER/theirrepo" },
+          { "pattern": "^topsecretproject/.*" }
+        ]
       ]
     },
     "initialRepositoryEnablement": {

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -156,9 +156,9 @@ const BitbucketServerSchemaJSON = `{
       "minItems": 1,
       "items": {
         "type": "string",
-        "pattern": "^[\\w-]+/[\\w.-]+$"
+        "pattern": "^~?[\\w-]+/[\\w.-]+$"
       },
-      "examples": [["myproject/myrepo", "myproject/myotherrepo"]]
+      "examples": [["myproject/myrepo", "myproject/myotherrepo", "~USER/theirrepo"]]
     },
     "exclude": {
       "description": "A list of repositories to never mirror from this Bitbucket Server instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
@@ -173,7 +173,7 @@ const BitbucketServerSchemaJSON = `{
           "name": {
             "description": "The name of a Bitbucket Server repo (\"projectKey/repositorySlug\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w-]+/[\\w.-]+$"
+            "pattern": "^~?[\\w-]+/[\\w.-]+$"
           },
           "id": {
             "description": "The ID of a Bitbucket Server repo (as returned by the Bitbucket Server instance's API) to exclude from mirroring.",
@@ -188,7 +188,12 @@ const BitbucketServerSchemaJSON = `{
       },
       "examples": [
         [{ "name": "myproject/myrepo" }, { "id": 42 }],
-        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
+        [
+          { "name": "myproject/myrepo" },
+          { "name": "myproject/myotherrepo" },
+          { "name": "~USER/theirrepo" },
+          { "pattern": "^topsecretproject/.*" }
+        ]
       ]
     },
     "initialRepositoryEnablement": {


### PR DESCRIPTION
Unlike GitHub and GitLab, personal repos are additionally namespaced with a tilde on Bitbucket Server. We should be able to specify these in the repository and exclusion configuration.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
