### PR TITLE
monitoring: use prometheus model.Duration

### DIFF
--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -23,6 +23,7 @@ import (
 	"unicode"
 
 	"github.com/grafana-tools/sdk"
+	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 )
 
@@ -1035,9 +1036,10 @@ type promGroup struct {
 
 func (g *promGroup) AppendRow(alertQuery string, labels map[string]string, duration time.Duration) {
 	labels["alert_type"] = "builtin" // indicate alert is generated
-	var forDuration *time.Duration
+	var forDuration *model.Duration
 	if duration > 0 {
-		forDuration = &duration
+		d := model.Duration(duration)
+		forDuration = &d
 	}
 
 	alertName := prometheusAlertName(labels["level"], labels["service_name"], labels["name"])
@@ -1070,7 +1072,7 @@ type promRule struct {
 	Expr   string
 
 	// for Alert only
-	For *time.Duration `yaml:",omitempty"`
+	For *model.Duration `yaml:",omitempty"`
 }
 
 // setPanelSize is a helper to set a panel's size.


### PR DESCRIPTION
time.Duration marshals into a format not accepted by prometheus, this change updates the generator to use the prometheus duration format.

Confirmed that `./dev/prometheus.sh` was broken by https://github.com/sourcegraph/sourcegraph/pull/12391, since that introduced our first usage of `for` - this PR fixes that

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
