### PR TITLE
frontend: speed up needs index site admin page

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -110,6 +110,10 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 				r.err = err
 				return
 			}
+			// ensure we fetch atleast as many repos as we have indexed.
+			if opt2.LimitOffset != nil && opt2.LimitOffset.Limit < len(indexed) {
+				opt2.LimitOffset.Limit = len(indexed) * 2
+			}
 		}
 
 		if !r.cloned {


### PR DESCRIPTION
This page can be slow since we will only fetch a small number of repos
from the db at a time. By fetching twice as many repos we have indexed
we are gaurenteed to only need to fetch the list once from the DB.