### PR TITLE
web: update tooltips to be agnostic of regex and globbing

### DIFF
--- a/shared/src/search/parser/filters.ts
+++ b/shared/src/search/parser/filters.ts
@@ -86,7 +86,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         alias: 'f',
         negatable: true,
         description: negated =>
-            `${negated ? 'Exclude' : 'Include only'} results from files matching the given regex pattern.`,
+            `${negated ? 'Exclude' : 'Include only'} results from files matching the given search pattern.`,
         suggestions: 'File',
     },
     [FilterType.fork]: {
@@ -116,7 +116,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         alias: 'r',
         negatable: true,
         description: negated =>
-            `${negated ? 'Exclude' : 'Include only'} results from repositories matching the given regex pattern.`,
+            `${negated ? 'Exclude' : 'Include only'} results from repositories matching the given search pattern.`,
         suggestions: 'Repository',
     },
     [FilterType.repogroup]: {

--- a/shared/src/search/parser/hover.test.ts
+++ b/shared/src/search/parser/hover.test.ts
@@ -8,7 +8,7 @@ describe('getHoverResult()', () => {
         expect(getHoverResult(parsedQuery, { column: 4 })).toStrictEqual({
             contents: [
                 {
-                    value: 'Include only results from repositories matching the given regex pattern.',
+                    value: 'Include only results from repositories matching the given search pattern.',
                 },
             ],
             range: {
@@ -21,7 +21,7 @@ describe('getHoverResult()', () => {
         expect(getHoverResult(parsedQuery, { column: 30 })).toStrictEqual({
             contents: [
                 {
-                    value: 'Include only results from files matching the given regex pattern.',
+                    value: 'Include only results from files matching the given search pattern.',
                 },
             ],
             range: {


### PR DESCRIPTION
Relates to #12476 

The tooltips of `repo` and `file` contain the word `regex`. Since we want to support globbing and regex for both of these fields in the future, it seems to be the easiest solution to change the tooltips to a text that covers both.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
