### PR TITLE
search: trace and observe each zoekt host

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 type indexedRequestType string
@@ -239,15 +238,6 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		return nil, false, nil, err
 	}
 	finalQuery := zoektquery.NewAnd(&zoektquery.RepoBranches{Set: repos.repoBranches}, queryExceptRepos)
-
-	tr, ctx := trace.New(ctx, "zoekt.Search", finalQuery.String())
-	defer func() {
-		tr.SetError(err)
-		if len(fm) > 0 {
-			tr.LazyPrintf("%d file matches", len(fm))
-		}
-		tr.Finish()
-	}()
 
 	k := zoektResultCountFactor(len(repos.repoBranches), args.PatternInfo)
 	searchOpts := zoektSearchOpts(k, args.PatternInfo)

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -23,7 +23,7 @@ func TestHorizontalSearcher(t *testing.T) {
 		Dial: func(endpoint string) zoekt.Searcher {
 			var rle zoekt.RepoListEntry
 			rle.Repository.Name = endpoint
-			return &mockSearcher{
+			client := &mockSearcher{
 				searchResult: &zoekt.SearchResult{
 					Files: []zoekt.FileMatch{{
 						Repository: endpoint,
@@ -32,6 +32,8 @@ func TestHorizontalSearcher(t *testing.T) {
 				},
 				listResult: &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{&rle}},
 			}
+			// Return metered searcher to test that codepath
+			return NewMeteredSearcher(endpoint, client)
 		},
 	}
 	defer searcher.Close()

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
+	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "src_zoekt_request_duration_seconds",
 	Help:    "Time (in seconds) spent on request.",
 	Buckets: prometheus.DefBuckets,
-}, []string{"category", "code"})
+}, []string{"hostname", "category", "code"})
 
 func init() {
 	prometheus.MustRegister(requestDuration)
@@ -21,37 +23,77 @@ func init() {
 
 type meteredSearcher struct {
 	zoekt.Searcher
+
+	hostname string
 }
 
-func NewMeteredSearcher(z zoekt.Searcher) zoekt.Searcher {
-	return &meteredSearcher{z}
+func NewMeteredSearcher(hostname string, z zoekt.Searcher) zoekt.Searcher {
+	return &meteredSearcher{
+		Searcher: z,
+		hostname: hostname,
+	}
 }
 
 func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
 	start := time.Now()
+
+	cat := "SearchAll"
+	if m.hostname != "" {
+		cat = "Search"
+	}
+
+	tr, ctx := trace.New(ctx, "zoekt."+cat, q.String())
+	tr.LogFields(
+		log.String("hostname", m.hostname),
+		log.Object("options", opts),
+	)
+
 	zsr, err := m.Searcher.Search(ctx, q, opts)
-	d := time.Since(start)
 
 	code := "200"
 	if err != nil {
 		code = "error"
 	}
 
-	// TODO(uwedeportivo): host label for horizontally scaled zoekt case
-	requestDuration.WithLabelValues("Search", code).Observe(d.Seconds())
+	requestDuration.WithLabelValues(m.hostname, cat, code).Observe(time.Since(start).Seconds())
+
+	tr.SetError(err)
+	if zsr != nil {
+		tr.LogFields(
+			log.Int("filematches", len(zsr.Files)),
+			log.Object("stats", &zsr.Stats),
+		)
+	}
+	tr.Finish()
+
 	return zsr, err
 }
 
 func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
 	start := time.Now()
-	zrl, err := m.Searcher.List(ctx, q)
-	d := time.Since(start)
+
+	cat := "ListAll"
+	if m.hostname != "" {
+		cat = "List"
+	}
+
+	tr, ctx := trace.New(ctx, "zoekt."+cat, q.String())
+	tr.LogFields(log.String("hostname", m.hostname))
+
+	zsl, err := m.Searcher.List(ctx, q)
 
 	code := "200"
 	if err != nil {
 		code = "error"
 	}
 
-	requestDuration.WithLabelValues("List", code).Observe(d.Seconds())
-	return zrl, err
+	requestDuration.WithLabelValues(m.hostname, cat, code).Observe(time.Since(start).Seconds())
+
+	tr.SetError(err)
+	if zsl != nil {
+		tr.LogFields(log.Int("repos", len(zsl.Repos)))
+	}
+	tr.Finish()
+
+	return zsl, err
 }

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -42,7 +42,7 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 		cat = "Search"
 	}
 
-	tr, ctx := trace.New(ctx, "zoekt."+cat, q.String())
+	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q))
 	tr.LogFields(
 		log.String("hostname", m.hostname),
 		log.Object("options", opts),
@@ -77,7 +77,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 		cat = "List"
 	}
 
-	tr, ctx := trace.New(ctx, "zoekt."+cat, q.String())
+	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q))
 	tr.LogFields(log.String("hostname", m.hostname))
 
 	zsl, err := m.Searcher.List(ctx, q)
@@ -96,4 +96,11 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 	tr.Finish()
 
 	return zsl, err
+}
+
+func queryString(q query.Q) string {
+	if q == nil {
+		return "<nil>"
+	}
+	return q.String()
 }


### PR DESCRIPTION
This commit moves tracing and observability from being around the
aggregated zoekt client to being both the aggregated client and a trace
per zoekt replica.

To do this we adjust the prometheus metric to have a hostname label. We
also change the category / family name to indicate if its a search
against a specific zoekt replica or its the aggregation.