### PR TITLE
zoekt: update to ignore non-fatal ctag errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200728073129-dae6fc7ecc8f
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1214,6 +1214,8 @@ github.com/sourcegraph/zoekt v0.0.0-20200724162241-6ed80895db7e h1:BrYWJw2LeDDCg
 github.com/sourcegraph/zoekt v0.0.0-20200724162241-6ed80895db7e/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041 h1:feJ8Ngh1WsB8ruFwloAFzpyJ3jhqvN/j5lsPoyNsFCs=
 github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200728073129-dae6fc7ecc8f h1:pZbZQ6gVeseML5rd0GKRSeFFEubuM7w35sqeCQTXpfI=
+github.com/sourcegraph/zoekt v0.0.0-20200728073129-dae6fc7ecc8f/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
We recently introduced hard failures when encountering a ctags
error. However, there are a small number of repos (2 at the moment)
which output a non-fatal error that we can ignore. For example:

  ignoring null tag in keybinding-emacs.js(line: 831)

https://github.com/sourcegraph/zoekt/compare/a99799fdc041...dae6fc7ecc8f