### PR TITLE
Check return value of computeDiffStat

### DIFF
--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1565,14 +1565,12 @@ type CommitTemplate struct {
 
 func NewChangesetSpecFromRaw(rawSpec string) (*ChangesetSpec, error) {
 	c := &ChangesetSpec{RawSpec: rawSpec}
-	err := c.UnmarshalValidate()
-	if err != nil {
+
+	if err := c.UnmarshalValidate(); err != nil {
 		return nil, err
 	}
 
-	c.computeDiffStat()
-
-	return c, nil
+	return c, c.computeDiffStat()
 }
 
 type ChangesetSpec struct {


### PR DESCRIPTION
Saw the linter warning about this in #12139.