### PR TITLE
Add platform to code host integration event logs

### DIFF
--- a/browser/src/shared/backend/userEvents.tsx
+++ b/browser/src/shared/backend/userEvents.tsx
@@ -43,7 +43,7 @@ export const logUserEvent = (
  * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
  */
 export const logEvent = (
-    event: { name: string; userCookieID: string; url: string; argument?: string },
+    event: { name: string; userCookieID: string; url: string; argument?: string | {} },
     requestGraphQL: PlatformContext['requestGraphQL']
 ): void => {
     // Only send the request if this is a private, self-hosted Sourcegraph instance.

--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -134,7 +134,7 @@ export type MountGetter = (container: HTMLElement) => HTMLElement | null
  */
 export type CodeHostContext = RawRepoSpec & Partial<RevisionSpec> & { privateRepository: boolean }
 
-type CodeHostType = 'github' | 'phabricator' | 'bitbucket-server' | 'gitlab'
+export type CodeHostType = 'github' | 'phabricator' | 'bitbucket-server' | 'gitlab'
 
 /** Information for adding code intelligence to code views on arbitrary code hosts. */
 export interface CodeHost extends ApplyLinkPreviewOptions {

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -8,12 +8,14 @@ import { TelemetryService } from '../../../../shared/src/telemetry/telemetryServ
 import { storage } from '../../browser-extension/web-extension-api/storage'
 import { isInPage } from '../context'
 import { logUserEvent, logEvent } from '../backend/userEvents'
-import { observeSourcegraphURL } from '../util/context'
+import { observeSourcegraphURL, getPlatformName } from '../util/context'
 
 const uidKey = 'sourcegraphAnonymousUid'
 
 export class EventLogger implements TelemetryService {
     private uid: string | null = null
+
+    private platform = getPlatformName()
 
     /**
      * Buffered Observable for the latest Sourcegraph URL
@@ -78,7 +80,12 @@ export class EventLogger implements TelemetryService {
         const sourcegraphURL = await this.sourcegraphURLs.pipe(take(1)).toPromise()
         logUserEvent(userEvent, anonUserId, sourcegraphURL, this.requestGraphQL)
         logEvent(
-            { name: event, userCookieID: anonUserId, url: sourcegraphURL, argument: eventProperties },
+            {
+                name: event,
+                userCookieID: anonUserId,
+                url: sourcegraphURL,
+                argument: { platform: this.platform, ...eventProperties },
+            },
             this.requestGraphQL
         )
     }
@@ -111,6 +118,14 @@ export class EventLogger implements TelemetryService {
     public async logViewEvent(pageTitle: string): Promise<void> {
         const anonUserId = await this.getAnonUserID()
         const sourcegraphURL = await this.sourcegraphURLs.pipe(take(1)).toPromise()
-        logEvent({ name: `View${pageTitle}`, userCookieID: anonUserId, url: sourcegraphURL }, this.requestGraphQL)
+        logEvent(
+            {
+                name: `View${pageTitle}`,
+                userCookieID: anonUserId,
+                url: sourcegraphURL,
+                argument: { platform: this.platform },
+            },
+            this.requestGraphQL
+        )
     }
 }


### PR DESCRIPTION
Rel. #11447

Adds platform argument to `CODEHOSTINTEGRATION` events, where platform will be one of:

`firefox-extension`, `chrome-extension`, `phabricator-integration`, `bitbucket-integration`, `gitlab-integration`
