### PR TITLE
Code host integrations: always add utm_source

### DIFF
--- a/browser/src/shared/code-hosts/shared/SignInButton.tsx
+++ b/browser/src/shared/code-hosts/shared/SignInButton.tsx
@@ -3,6 +3,7 @@ import { SourcegraphIconButton } from '../../components/SourcegraphIconButton'
 import { interval, Observable } from 'rxjs'
 import { switchMap, filter, take, tap } from 'rxjs/operators'
 import { useEventObservable } from '../../../../../shared/src/util/useObservable'
+import { getPlatformName } from '../../util/context'
 
 export const SignInButton: React.FunctionComponent<{
     className?: string
@@ -14,7 +15,7 @@ export const SignInButton: React.FunctionComponent<{
      */
     onSignInClose?: () => void
 }> = ({ className, iconClassName, sourcegraphURL, onSignInClose }) => {
-    const signInUrl = new URL('/sign-in?close=true', sourcegraphURL).href
+    const signInUrl = new URL(`/sign-in?close=true&utm_source=${getPlatformName()}`, sourcegraphURL).href
 
     const [nextSignInClick] = useEventObservable(
         useCallback(

--- a/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -7,6 +7,7 @@ import { isHTTPAuthError } from '../../../../../shared/src/backend/fetch'
 import { SignInButton } from './SignInButton'
 import { isPrivateRepoPublicSourcegraphComErrorLike } from '../../../../../shared/src/backend/errors'
 import { snakeCase } from 'lodash'
+import { getPlatformName } from '../../util/context'
 
 export interface ViewOnSourcegraphButtonClassProps {
     className?: string
@@ -56,7 +57,10 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     }
 
     const { rawRepoName, revision } = getContext()
-    const url = new URL(`/${rawRepoName}${revision ? `@${revision}` : ''}`, sourcegraphURL).href
+    const url = new URL(
+        `/${rawRepoName}${revision ? `@${revision}` : ''}?utm_source=${getPlatformName()}`,
+        sourcegraphURL
+    ).href
 
     if (isErrorLike(repoExistsOrError)) {
         // If the problem is the user is not signed in, show a sign in CTA (if not shown elsewhere)

--- a/browser/src/shared/code-hosts/shared/__snapshots__/ViewOnSourcegraphButton.test.tsx.snap
+++ b/browser/src/shared/code-hosts/shared/__snapshots__/ViewOnSourcegraphButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<ViewOnSourcegraphButton /> existence could not be determined  because 
 <a
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
-  href="https://test.com/sign-in?close=true"
+  href="https://test.com/sign-in?close=true&utm_source=chrome-extension"
   onClick={[Function]}
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
@@ -38,7 +38,7 @@ exports[`<ViewOnSourcegraphButton /> existence could not be determined  because 
 <a
   aria-label="Sign into Sourcegraph to get hover tooltips, go to definition and more"
   className="open-on-sourcegraph test"
-  href="https://test.com/sign-in?close=true"
+  href="https://test.com/sign-in?close=true&utm_source=chrome-extension"
   onClick={[Function]}
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
@@ -72,7 +72,7 @@ exports[`<ViewOnSourcegraphButton /> existence could not be determined  because 
 <a
   aria-label="Something unknown happened!"
   className="open-on-sourcegraph test"
-  href="https://test.com/test@test"
+  href="https://test.com/test@test?utm_source=chrome-extension"
   rel="noopener noreferrer"
   target="_blank"
   title="Something unknown happened!"
@@ -108,7 +108,7 @@ exports[`<ViewOnSourcegraphButton /> repository does not exist on the instance r
 <a
   aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
   className="open-on-sourcegraph test"
-  href="https://sourcegraph.com/test@test"
+  href="https://sourcegraph.com/test@test?utm_source=chrome-extension"
   rel="noopener noreferrer"
   target="_blank"
   title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.com"
@@ -144,7 +144,7 @@ exports[`<ViewOnSourcegraphButton /> repository does not exist on the instance r
 <a
   aria-label="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
   className="open-on-sourcegraph test"
-  href="https://sourcegraph.test/test@test"
+  href="https://sourcegraph.test/test@test?utm_source=chrome-extension"
   rel="noopener noreferrer"
   target="_blank"
   title="The repository does not exist on the configured Sourcegraph instance https://sourcegraph.test"
@@ -180,7 +180,7 @@ exports[`<ViewOnSourcegraphButton /> repository exists on the instance renders a
 <a
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
-  href="https://test.com/test"
+  href="https://test.com/test?utm_source=chrome-extension"
   rel="noopener noreferrer"
   target="_blank"
   title="View repository on Sourcegraph"
@@ -214,7 +214,7 @@ exports[`<ViewOnSourcegraphButton /> repository exists on the instance renders a
 <a
   aria-label="View repository on Sourcegraph"
   className="open-on-sourcegraph test"
-  href="https://test.com/test@test"
+  href="https://test.com/test@test?utm_source=chrome-extension"
   rel="noopener noreferrer"
   target="_blank"
   title="View repository on Sourcegraph"

--- a/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/browser/src/shared/components/CodeViewToolbar.tsx
@@ -82,11 +82,6 @@ export const CodeViewToolbar: React.FunctionComponent<CodeViewToolbarProps> = pr
                                 repoName: props.fileInfoOrError.base.repoName,
                                 filePath: props.fileInfoOrError.base.filePath,
                                 revision: defaultRevisionToCommitID(props.fileInfoOrError.base).revision,
-                                query: {
-                                    diff: {
-                                        revision: props.fileInfoOrError.base.commitID,
-                                    },
-                                },
                                 commit: {
                                     baseRev: defaultRevisionToCommitID(props.fileInfoOrError.base).revision,
                                     headRev: defaultRevisionToCommitID(props.fileInfoOrError.head).revision,

--- a/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -8,44 +8,11 @@ interface Props extends SourcegraphIconButtonProps {
     openProps: OpenInSourcegraphProps
 }
 
-export class OpenOnSourcegraph extends React.Component<Props, {}> {
-    public render(): JSX.Element {
-        const url = this.getOpenInSourcegraphUrl(this.props.openProps)
-        return (
-            <SourcegraphIconButton
-                {...this.props}
-                className={classNames('open-on-sourcegraph', this.props.className)}
-                href={url}
-            />
-        )
-    }
-
-    private getOpenInSourcegraphUrl(props: OpenInSourcegraphProps): string {
-        const baseUrl = props.sourcegraphURL
-        // Build URL for Web
-        let url = `${baseUrl}/${props.repoName}`
-        if (props.commit) {
-            return `${url}/-/compare/${props.commit.baseRev}...${props.commit.headRev}?utm_source=${getPlatformName()}`
-        }
-        if (props.revision) {
-            url = `${url}@${props.revision}`
-        }
-        if (props.filePath) {
-            url = `${url}/-/blob/${props.filePath}`
-        }
-        if (props.query) {
-            if (props.query.diff) {
-                url = `${url}?diff=${props.query.diff.revision}&utm_source=${getPlatformName()}`
-            } else if (props.query.search) {
-                url = `${url}?q=${props.query.search}&utm_source=${getPlatformName()}`
-            }
-        }
-        if (props.coords) {
-            url = `${url}#L${props.coords.line}:${props.coords.char}`
-        }
-        if (props.fragment) {
-            url = `${url}$${props.fragment}`
-        }
-        return url
-    }
+export const OpenOnSourcegraph: React.FunctionComponent<Props> = ({
+    openProps: { sourcegraphURL, repoName, revision, filePath },
+    className,
+    ...props
+}) => {
+    const url = `${sourcegraphURL}/${repoName}@${revision}}/-/blob/${filePath}?utm_source=${getPlatformName()}`
+    return <SourcegraphIconButton {...props} className={classNames('open-on-sourcegraph', className)} href={url} />
 }

--- a/browser/src/shared/repo/index.tsx
+++ b/browser/src/shared/repo/index.tsx
@@ -7,23 +7,7 @@ export interface DiffResolvedRevSpec {
 
 export interface OpenInSourcegraphProps extends RepoSpec, RevisionSpec {
     sourcegraphURL: string
-    filePath?: string
-    commit?: {
-        baseRev: string
-        headRev: string
-    }
-    coords?: {
-        line: number
-        char: number
-    }
-    fragment?: 'references'
-    query?: {
-        search?: string
-        diff?: {
-            revision: string
-        }
-    }
-    withModifierKey?: boolean
+    filePath: string
 }
 
 export interface OpenDiffInSourcegraphProps


### PR DESCRIPTION
Rel. #11447

Ensures we always add `?utm_source=platform_name` to links pointing back to the Sourcegraph instance from code host integrations, where the platform name is one of:

`firefox-extension`, `chrome-extension`, `phabricator-integration`, `bitbucket-integration`, `gitlab-integration`

As a side-effect, simplifies `<OpenOnSourcegraph/>` and cleans up `OpenInSourcegraphProps` to remove unused properties.
