### PR TITLE
Add platform to BrowserExtensionConnectedToServer event log

### DIFF
--- a/browser/src/shared/code-hosts/sourcegraph/inject.tsx
+++ b/browser/src/shared/code-hosts/sourcegraph/inject.tsx
@@ -1,3 +1,5 @@
+import { PlatformName, getPlatformName } from '../../util/context'
+
 export const EXTENSION_MARKER_ID = 'sourcegraph-app-background'
 
 /**
@@ -19,6 +21,7 @@ export const NATIVE_INTEGRATION_ACTIVATED = 'sourcegraph:native-integration-acti
 export function injectExtensionMarker(): void {
     const extensionMarker = document.createElement('div')
     extensionMarker.id = EXTENSION_MARKER_ID
+    extensionMarker.dataset.platform = getPlatformName()
     extensionMarker.style.display = 'none'
     document.body.append(extensionMarker)
 }
@@ -37,7 +40,11 @@ export function signalBrowserExtensionInstalled(): void {
 
 function dispatchSourcegraphEvents(): void {
     // Send custom webapp <-> extension registration event in case webapp listener is attached first.
-    document.dispatchEvent(new CustomEvent<{}>('sourcegraph:browser-extension-registration'))
+    document.dispatchEvent(
+        new CustomEvent<{ platform: PlatformName }>('sourcegraph:browser-extension-registration', {
+            detail: { platform: getPlatformName() },
+        })
+    )
 }
 
 export const checkIsSourcegraph = (

--- a/browser/src/shared/util/context.tsx
+++ b/browser/src/shared/util/context.tsx
@@ -28,7 +28,10 @@ export function getAssetsURL(sourcegraphURL: string): string {
     return assetsURL.endsWith('/') ? assetsURL : assetsURL + '/'
 }
 
-type PlatformName = NonNullable<typeof globalThis.SOURCEGRAPH_INTEGRATION> | 'firefox-extension' | 'chrome-extension'
+export type PlatformName =
+    | NonNullable<typeof globalThis.SOURCEGRAPH_INTEGRATION>
+    | 'firefox-extension'
+    | 'chrome-extension'
 
 export function getPlatformName(): PlatformName {
     if (window.SOURCEGRAPH_PHABRICATOR_EXTENSION) {

--- a/web/src/tracking/eventLogger.ts
+++ b/web/src/tracking/eventLogger.ts
@@ -24,8 +24,8 @@ export class EventLogger implements TelemetryService {
     constructor() {
         // EventLogger is never teared down
         // eslint-disable-next-line rxjs/no-ignored-subscription
-        browserExtensionMessageReceived.subscribe(() => {
-            this.log('BrowserExtensionConnectedToServer')
+        browserExtensionMessageReceived.subscribe(({ platform }) => {
+            this.log('BrowserExtensionConnectedToServer', { platform })
 
             if (localStorage && localStorage.getItem('eventLogDebug') === 'true') {
                 console.debug('%cBrowser extension detected, sync completed', 'color: #aaa')


### PR DESCRIPTION
Rel. #11447

Last piece of the solution to track browser extension usage, for users who never click any injected links or take any code intelligence action, but visit the Sourcegraph instance with the browser extension connected.

I could have just added a `browser` argument parsed from the user agent string here, but figured standardizing on the `platform` sent by the browser extension like in other logs (#12533) or utm_sources (#12534) would be better for consistency.
