### PR TITLE
zoekt: binary encoder for repo branches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200728073129-dae6fc7ecc8f
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200729195846-c908c13fd7a9
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1216,6 +1216,8 @@ github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041 h1:feJ8Ngh1WsB8r
 github.com/sourcegraph/zoekt v0.0.0-20200727220907-a99799fdc041/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/sourcegraph/zoekt v0.0.0-20200728073129-dae6fc7ecc8f h1:pZbZQ6gVeseML5rd0GKRSeFFEubuM7w35sqeCQTXpfI=
 github.com/sourcegraph/zoekt v0.0.0-20200728073129-dae6fc7ecc8f/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
+github.com/sourcegraph/zoekt v0.0.0-20200729195846-c908c13fd7a9 h1:EAbQUPfLgHWRrH9GsNnsapL7YP9rHHNHHEt9gQw04Tc=
+github.com/sourcegraph/zoekt v0.0.0-20200729195846-c908c13fd7a9/go.mod h1:WleTVLMEfvGF6uZ/mSWXVUH1H4NPxAcu6YbJ0TORdWc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
This updates zoekt to include a custom binary marshaller for repo
branches. When CPU profiling two of the major contributors is Gob
encoding and garbage collection. This should significantly improve time
spent gob encoding (~4x faster). It also will only allocate one large
buffer vs 2 per key, value in gob. This should help reduce pressure on
frontend.

For example on Sourcegraph.com we have 100k repos indexed with 12 search
replicas. This means when marshalling the repobranches for default we
will go from allocating 100k * 2 * 12 = 2.4 million objects to 12.

This commit requires zoekt and sourcegraph-frontend to have the same
version of query.RepoBranches. For customers this will require a small
amount of downtime when upgrading. For sourcegraph.com I will ensure
they roll out at the same time.

Changes:

- https://github.com/sourcegraph/zoekt/pull/54 shards: optimize RepoBranches when all branches are the same
- https://github.com/sourcegraph/zoekt/pull/53 query: binary encoder for repo branches
- https://github.com/sourcegraph/zoekt/commit/2a821ee query: exactly match on repobranch branches