### PR TITLE
Convert RepoContainer to function component

### DIFF
--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -1,6 +1,6 @@
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react'
+import React, { useMemo, useState, useEffect, useCallback } from 'react'
 import { escapeRegExp, uniqueId } from 'lodash'
 import { Route, RouteComponentProps, Switch } from 'react-router'
 import { Observable, NEVER, ObservableInput, of } from 'rxjs'
@@ -162,7 +162,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
     >()
 
     // The breadcrumbs and breadcrumb props for the repo header.
-    const { breadcrumbs, pushBreadcrumb } = useBreadcrumbs()
+    const { /* breadcrumbs,  */ pushBreadcrumb } = useBreadcrumbs()
 
     // Update the workspace roots service to reflect the current repo / resolved revision
     useEffect(() => {

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -171,7 +171,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                 ? [
                       {
                           uri: makeRepoURI({
-                              repoName: repoName,
+                              repoName,
                               revision: resolvedRevisionOrError.commitID,
                           }),
                           inputRevision: revision || '',
@@ -181,7 +181,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         )
         // Clear the Sourcegraph extensions model's roots when navigating away.
         return () => props.extensionsController.services.workspace.roots.next([])
-    }, [resolvedRevisionOrError])
+    }, [props.extensionsController.services.workspace.roots, repoName, resolvedRevisionOrError, revision])
 
     // Update the navbar query to reflect the current repo / revision
     useEffect(() => {
@@ -215,7 +215,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                 cursorPosition: query.length,
             })
         }
-    }, [revision, filePath, props.globbing, props.splitSearchModes, props.interactiveSearchMode])
+    }, [revision, filePath, props, repoName])
 
     if (!repoOrError) {
         // Render nothing while loading
@@ -269,11 +269,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                                 key="go-to-code-host"
                                 repo={repoOrError}
                                 // We need a revision to generate code host URLs, if revision isn't available, we use the default branch or HEAD.
-                                revision={
-                                    rawRevision ||
-                                    (repoOrError.defaultBranch && repoOrError.defaultBranch.displayName) ||
-                                    'HEAD'
-                                }
+                                revision={rawRevision || repoOrError.defaultBranch?.displayName || 'HEAD'}
                                 filePath={filePath}
                                 commitRange={commitRange}
                                 position={position}

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -1,10 +1,10 @@
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import * as React from 'react'
+import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { escapeRegExp, uniqueId } from 'lodash'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import { Subject, Subscription, concat, combineLatest } from 'rxjs'
-import { catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators'
+import { Observable, NEVER, ObservableInput, of } from 'rxjs'
+import { catchError, map, startWith } from 'rxjs/operators'
 import { redirectToExternalHost } from '.'
 import { isRepoNotFoundErrorLike, isRepoSeeOtherErrorLike } from '../../../shared/src/backend/errors'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
@@ -26,11 +26,10 @@ import {
 } from '../search'
 import { EventLoggerProps } from '../tracking/eventLogger'
 import { RouteDescriptor } from '../util/contributions'
-import { parseBrowserRepoURL, ParsedRepoRevision, parseRepoRevision } from '../util/url'
+import { parseBrowserRepoURL } from '../util/url'
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { fetchRepository, ResolvedRevision } from './backend'
 import { RepoHeader, RepoHeaderActionButton, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
-import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { RepoRevisionContainer, RepoRevisionContainerRoute } from './RepoRevisionContainer'
 import { RepositoryNotFoundPage } from './RepositoryNotFoundPage'
 import { ThemeProps } from '../../../shared/src/theme'
@@ -41,6 +40,8 @@ import { QueryState } from '../search/helpers'
 import { FiltersToTypeAndValue, FilterType } from '../../../shared/src/search/interactive/util'
 import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
+import { UpdateBreadcrumbsProps, useBreadcrumbs } from '../components/Breadcrumbs'
+import { useObservable, useEventObservable } from '../../../shared/src/util/useObservable'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -56,7 +57,8 @@ export interface RepoContainerContext
         PatternTypeProps,
         CaseSensitivityProps,
         CopyQueryButtonProps,
-        VersionContextProps {
+        VersionContextProps,
+        UpdateBreadcrumbsProps {
     repo: GQL.IRepository
     authenticatedUser: GQL.IUser | null
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
@@ -102,342 +104,230 @@ interface RepoContainerProps
     globbing: boolean
 }
 
-interface RepoRevContainerState extends ParsedRepoRevision {
-    filePath?: string
-
-    /**
-     * The fetched repository or an error if occurred.
-     * `undefined` while loading.
-     */
-    repoOrError?: GQL.IRepository | ErrorLike
-
-    /**
-     * The resolved revision or an error if it could not be resolved. `undefined` while loading. This value comes from
-     * this component's child RepoRevisionContainer, but it lives here because it's used by other children than just
-     * RepoRevisionContainer.
-     */
-    resolvedRevisionOrError?: ResolvedRevision | ErrorLike
-
-    /** The external links to show in the repository header, if any. */
-    externalLinks?: GQL.IExternalLink[]
-
-    repoHeaderContributionsLifecycleProps?: RepoHeaderContributionsLifecycleProps
-}
-
 /**
  * Renders a horizontal bar and content for a repository page.
  */
-export class RepoContainer extends React.Component<RepoContainerProps, RepoRevContainerState> {
-    private componentUpdates = new Subject<RepoContainerProps>()
-    private repositoryUpdates = new Subject<Partial<GQL.IRepository>>()
-    private revResolves = new Subject<ResolvedRevision | ErrorLike | undefined>()
-    private subscriptions = new Subscription()
+export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props => {
+    const { repoName, revision, rawRevision, filePath, commitRange, position, range } = parseBrowserRepoURL(
+        location.pathname + location.search + location.hash
+    )
 
-    constructor(props: RepoContainerProps) {
-        super(props)
-
-        this.state = {
-            ...parseURLPath(props.match.params.repoRevAndRest),
-        }
-    }
-
-    public componentDidMount(): void {
-        const parsedRouteChanges = this.componentUpdates.pipe(
-            map(props => props.match.params.repoRevAndRest),
-            distinctUntilChanged(),
-            map(parseURLPath)
-        )
-
-        // Fetch repository.
-        const repositoryChanges = parsedRouteChanges.pipe(
-            map(({ repoName }) => repoName),
-            distinctUntilChanged()
-        )
-        this.subscriptions.add(
-            repositoryChanges
-                .pipe(
-                    tap(() => this.setState({ repoOrError: undefined })),
-                    switchMap(repoName =>
-                        concat(
-                            [undefined],
-                            fetchRepository({ repoName }).pipe(
-                                catchError(error => {
-                                    const redirect = isRepoSeeOtherErrorLike(error)
-                                    if (redirect) {
-                                        redirectToExternalHost(redirect)
-                                        return []
-                                    }
-                                    return [asError(error)]
-                                })
-                            )
-                        )
+    // Fetch repository upon mounting the component.
+    const initialRepoOrError = useObservable(
+        useMemo(
+            () =>
+                fetchRepository({ repoName }).pipe(
+                    catchError(
+                        (error): ObservableInput<ErrorLike> => {
+                            const redirect = isRepoSeeOtherErrorLike(error)
+                            if (redirect) {
+                                redirectToExternalHost(redirect)
+                                return NEVER
+                            }
+                            return of(asError(error))
+                        }
                     )
-                )
-                .subscribe(repoOrError => {
-                    this.setState({ repoOrError })
-                })
+                ),
+            [repoName]
         )
+    )
 
-        // Update resolved revision in state
-        this.subscriptions.add(
-            this.revResolves.subscribe(resolvedRevisionOrError => this.setState({ resolvedRevisionOrError }))
+    // Allow partial updates of the repository from components further down the tree.
+    const [nextRepoOrErrorUpdate, repoOrError] = useEventObservable(
+        useCallback(
+            (repoOrErrorUpdates: Observable<Partial<GQL.IRepository>>) =>
+                repoOrErrorUpdates.pipe(
+                    map((update): GQL.IRepository | ErrorLike | undefined =>
+                        isErrorLike(initialRepoOrError) || initialRepoOrError === undefined
+                            ? initialRepoOrError
+                            : { ...initialRepoOrError, ...update }
+                    ),
+                    startWith(initialRepoOrError)
+                ),
+            [initialRepoOrError]
         )
+    )
 
-        this.subscriptions.add(
-            parsedRouteChanges.subscribe(({ repoName, revision, rawRevision }) => {
-                this.setState({ repoName, revision, rawRevision })
-                const query = searchQueryForRepoRevision(repoName, this.props.globbing, revision)
-                this.props.onNavbarQueryChange({
-                    query,
-                    cursorPosition: query.length,
-                })
-            })
-        )
+    // The resolved revision or an error if it could not be resolved. `undefined` while loading. This value comes from
+    // this component's child RepoRevisionContainer, but it lives here because it's used by other children than just
+    // RepoRevisionContainer.
+    const [resolvedRevisionOrError, setResolvedRevisionOrError] = useState<ResolvedRevision | ErrorLike>()
 
-        // Merge in repository updates.
-        this.subscriptions.add(
-            this.repositoryUpdates.subscribe(update =>
-                this.setState(({ repoOrError }) => ({ repoOrError: { ...repoOrError, ...update } as GQL.IRepository }))
-            )
-        )
+    // The external links to show in the repository header, if any.
+    const [externalLinks, setExternalLinks] = useState<GQL.IExternalLink[] | undefined>()
 
-        // Update the Sourcegraph extensions model to reflect the current workspace root.
-        this.subscriptions.add(
-            this.revResolves
-                .pipe(
-                    map(resolvedRevisionOrError => {
-                        this.props.extensionsController.services.workspace.roots.next(
-                            resolvedRevisionOrError && !isErrorLike(resolvedRevisionOrError)
-                                ? [
-                                      {
-                                          uri: makeRepoURI({
-                                              repoName: this.state.repoName,
-                                              revision: resolvedRevisionOrError.commitID,
-                                          }),
-                                          inputRevision: this.state.revision || '',
-                                      },
-                                  ]
-                                : []
-                        )
-                    })
-                )
-                .subscribe()
+    // The lifecycle props for repo header contributions.
+    const [repoHeaderContributionsLifecycleProps, setRepoHeaderContributionsLifecycleProps] = useState<
+        RepoHeaderContributionsLifecycleProps
+    >()
+
+    // The breadcrumbs and breadcrumb props for the repo header.
+    const { breadcrumbs, pushBreadcrumb } = useBreadcrumbs()
+
+    // Update the workspace roots service to reflect the current repo / resolved revision
+    useEffect(() => {
+        props.extensionsController.services.workspace.roots.next(
+            resolvedRevisionOrError && !isErrorLike(resolvedRevisionOrError)
+                ? [
+                      {
+                          uri: makeRepoURI({
+                              repoName: repoName,
+                              revision: resolvedRevisionOrError.commitID,
+                          }),
+                          inputRevision: revision || '',
+                      },
+                  ]
+                : []
         )
         // Clear the Sourcegraph extensions model's roots when navigating away.
-        this.subscriptions.add(() => this.props.extensionsController.services.workspace.roots.next([]))
+        return () => props.extensionsController.services.workspace.roots.next([])
+    }, [resolvedRevisionOrError])
 
-        this.componentUpdates.next(this.props)
-
-        // Scope the search query to the current tree or file
-        const parsedFilePathChanges = this.componentUpdates.pipe(
-            map(({ location }) => parseBrowserRepoURL(location.pathname + location.search + location.hash).filePath),
-            distinctUntilChanged()
-        )
-        this.subscriptions.add(
-            combineLatest([parsedRouteChanges, parsedFilePathChanges]).subscribe(
-                ([{ repoName, revision }, filePath]) => {
-                    if (this.props.splitSearchModes && this.props.interactiveSearchMode) {
-                        const filters: FiltersToTypeAndValue = {
-                            [uniqueId('repo')]: {
-                                type: FilterType.repo,
-                                value: repoFilterForRepoRevision(repoName, this.props.globbing, revision),
-                                editable: false,
-                            },
-                        }
-                        if (filePath) {
-                            filters[uniqueId('file')] = {
-                                type: FilterType.file,
-                                value: this.props.globbing ? filePath : `^${escapeRegExp(filePath)}`,
-                                editable: false,
-                            }
-                        }
-                        this.props.onFiltersInQueryChange(filters)
-                        this.props.onNavbarQueryChange({
-                            query: '',
-                            cursorPosition: 0,
-                        })
-                    } else {
-                        let query = searchQueryForRepoRevision(repoName, this.props.globbing, revision)
-                        if (filePath) {
-                            query = `${query.trimEnd()} file:${
-                                this.props.globbing ? filePath : '^' + escapeRegExp(filePath)
-                            }`
-                        }
-                        this.props.onNavbarQueryChange({
-                            query,
-                            cursorPosition: query.length,
-                        })
-                    }
-                }
-            )
-        )
-    }
-
-    public componentDidUpdate(): void {
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public render(): JSX.Element | null {
-        if (!this.state.repoOrError) {
-            // Render nothing while loading
-            return null
-        }
-
-        const { repoName, filePath, commitRange, position, range } = parseBrowserRepoURL(
-            location.pathname + location.search + location.hash
-        )
-        const viewerCanAdminister = !!this.props.authenticatedUser && this.props.authenticatedUser.siteAdmin
-
-        if (isErrorLike(this.state.repoOrError)) {
-            // Display error page
-            if (isRepoNotFoundErrorLike(this.state.repoOrError)) {
-                return <RepositoryNotFoundPage repo={repoName} viewerCanAdminister={viewerCanAdminister} />
+    // Update the navbar query to reflect the current repo / revision
+    useEffect(() => {
+        if (props.splitSearchModes && props.interactiveSearchMode) {
+            const filters: FiltersToTypeAndValue = {
+                [uniqueId('repo')]: {
+                    type: FilterType.repo,
+                    value: repoFilterForRepoRevision(repoName, props.globbing, revision),
+                    editable: false,
+                },
             }
-            return (
-                <HeroPage
-                    icon={AlertCircleIcon}
-                    title="Error"
-                    subtitle={<ErrorMessage error={this.state.repoOrError} history={this.props.history} />}
-                />
-            )
+            if (filePath) {
+                filters[uniqueId('file')] = {
+                    type: FilterType.file,
+                    value: props.globbing ? filePath : `^${escapeRegExp(filePath)}`,
+                    editable: false,
+                }
+            }
+            props.onFiltersInQueryChange(filters)
+            props.onNavbarQueryChange({
+                query: '',
+                cursorPosition: 0,
+            })
+        } else {
+            let query = searchQueryForRepoRevision(repoName, props.globbing, revision)
+            if (filePath) {
+                query = `${query.trimEnd()} file:${props.globbing ? filePath : '^' + escapeRegExp(filePath)}`
+            }
+            props.onNavbarQueryChange({
+                query,
+                cursorPosition: query.length,
+            })
         }
+    }, [revision, filePath, props.globbing, props.splitSearchModes, props.interactiveSearchMode])
 
-        const repoMatchURL = `/${this.state.repoOrError.name}`
+    if (!repoOrError) {
+        // Render nothing while loading
+        return null
+    }
 
-        const context: RepoContainerContext = {
-            repo: this.state.repoOrError,
-            authenticatedUser: this.props.authenticatedUser,
-            isLightTheme: this.props.isLightTheme,
-            activation: this.props.activation,
-            telemetryService: this.props.telemetryService,
-            routePrefix: repoMatchURL,
-            settingsCascade: this.props.settingsCascade,
-            platformContext: this.props.platformContext,
-            extensionsController: this.props.extensionsController,
-            ...this.state.repoHeaderContributionsLifecycleProps,
-            onDidUpdateExternalLinks: this.onDidUpdateExternalLinks,
-            onDidUpdateRepository: this.onDidUpdateRepository,
-            patternType: this.props.patternType,
-            setPatternType: this.props.setPatternType,
-            caseSensitive: this.props.caseSensitive,
-            setCaseSensitivity: this.props.setCaseSensitivity,
-            repoSettingsAreaRoutes: this.props.repoSettingsAreaRoutes,
-            repoSettingsSidebarGroups: this.props.repoSettingsSidebarGroups,
-            copyQueryButton: this.props.copyQueryButton,
-            versionContext: this.props.versionContext,
-            globbing: this.props.globbing,
+    const viewerCanAdminister = !!props.authenticatedUser && props.authenticatedUser.siteAdmin
+
+    if (isErrorLike(repoOrError)) {
+        // Display error page
+        if (isRepoNotFoundErrorLike(repoOrError)) {
+            return <RepositoryNotFoundPage repo={repoName} viewerCanAdminister={viewerCanAdminister} />
         }
-
         return (
-            <div className="repo-container test-repo-container w-100 d-flex flex-column">
-                <RepoHeader
-                    {...this.props}
-                    actionButtons={this.props.repoHeaderActionButtons}
-                    revision={this.state.revision}
-                    repo={this.state.repoOrError}
-                    resolvedRev={this.state.resolvedRevisionOrError}
-                    onLifecyclePropsChange={this.onRepoHeaderContributionsLifecyclePropsChange}
-                    contributions={[
-                        {
-                            position: 'right',
-                            priority: 2,
-                            element: (
-                                <GoToCodeHostAction
-                                    key="go-to-code-host"
-                                    repo={this.state.repoOrError}
-                                    // We need a revision to generate code host URLs, if revision isn't available, we use the default branch or HEAD.
-                                    revision={
-                                        this.state.revision ||
-                                        (!isErrorLike(this.state.repoOrError) &&
-                                            this.state.repoOrError.defaultBranch &&
-                                            this.state.repoOrError.defaultBranch.displayName) ||
-                                        'HEAD'
-                                    }
-                                    filePath={filePath}
-                                    commitRange={commitRange}
-                                    position={position}
-                                    range={range}
-                                    externalLinks={this.state.externalLinks}
-                                />
-                            ),
-                        },
-                    ]}
-                />
-                <ErrorBoundary location={this.props.location}>
-                    <Switch>
-                        {/* eslint-disable react/jsx-no-bind */}
-                        {[
-                            '',
-                            ...(this.state.rawRevision ? [`@${this.state.rawRevision}`] : []), // must exactly match how the revision was encoded in the URL
-                            '/-/blob',
-                            '/-/tree',
-                            '/-/commits',
-                        ].map(routePath => (
-                            <Route
-                                path={`${repoMatchURL}${routePath}`}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                exact={routePath === ''}
-                                render={routeComponentProps => (
-                                    <RepoRevisionContainer
-                                        {...routeComponentProps}
-                                        {...context}
-                                        routes={this.props.repoRevisionContainerRoutes}
-                                        revision={this.state.revision || ''}
-                                        resolvedRevisionOrError={this.state.resolvedRevisionOrError}
-                                        onResolvedRevisionOrError={this.onResolvedRevOrError}
-                                        // must exactly match how the revision was encoded in the URL
-                                        routePrefix={`${repoMatchURL}${
-                                            this.state.rawRevision ? `@${this.state.rawRevision}` : ''
-                                        }`}
-                                    />
-                                )}
-                            />
-                        ))}
-                        {this.props.repoContainerRoutes.map(
-                            ({ path, render, exact, condition = () => true }) =>
-                                condition(context) && (
-                                    <Route
-                                        path={context.routePrefix + path}
-                                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                        exact={exact}
-                                        // RouteProps.render is an exception
-                                        render={routeComponentProps => render({ ...context, ...routeComponentProps })}
-                                    />
-                                )
-                        )}
-                        <Route key="hardcoded-key" component={RepoPageNotFound} />
-                        {/* eslint-enable react/jsx-no-bind */}
-                    </Switch>
-                </ErrorBoundary>
-            </div>
+            <HeroPage
+                icon={AlertCircleIcon}
+                title="Error"
+                subtitle={<ErrorMessage error={repoOrError} history={props.history} />}
+            />
         )
     }
 
-    private onDidUpdateRepository = (update: Partial<GQL.IRepository>): void => this.repositoryUpdates.next(update)
+    const repoMatchURL = `/${repoOrError.name}`
 
-    private onDidUpdateExternalLinks = (externalLinks: GQL.IExternalLink[] | undefined): void =>
-        this.setState({ externalLinks })
+    const context: RepoContainerContext = {
+        ...props,
+        ...repoHeaderContributionsLifecycleProps,
+        pushBreadcrumb,
+        repo: repoOrError,
+        routePrefix: repoMatchURL,
+        onDidUpdateExternalLinks: setExternalLinks,
+        onDidUpdateRepository: nextRepoOrErrorUpdate,
+    }
 
-    private onResolvedRevOrError = (value: ResolvedRevision | ErrorLike | undefined): void =>
-        this.revResolves.next(value)
-
-    private onRepoHeaderContributionsLifecyclePropsChange = (
-        lifecycleProps: RepoHeaderContributionsLifecycleProps
-    ): void => this.setState({ repoHeaderContributionsLifecycleProps: lifecycleProps })
-}
-
-/**
- * Parses the URL path (without the leading slash).
- *
- * TODO(sqs): replace with parseBrowserRepoURL?
- *
- * @param repoRevisionAndRest a string like /my/repo@myrev/-/blob/my/file.txt
- */
-function parseURLPath(repoRevisionAndRest: string): ParsedRepoRevision & { rest?: string } {
-    const [repoRevision, rest] = repoRevisionAndRest.split('/-/', 2)
-    return { ...parseRepoRevision(repoRevision), rest }
+    return (
+        <div className="repo-container test-repo-container w-100 d-flex flex-column">
+            <RepoHeader
+                {...props}
+                actionButtons={props.repoHeaderActionButtons}
+                revision={revision}
+                repo={repoOrError}
+                resolvedRev={resolvedRevisionOrError}
+                onLifecyclePropsChange={setRepoHeaderContributionsLifecycleProps}
+                contributions={[
+                    { position: 'right', priority: 1, element: <span>Hello world</span> },
+                    {
+                        position: 'right',
+                        priority: 2,
+                        element: (
+                            <GoToCodeHostAction
+                                key="go-to-code-host"
+                                repo={repoOrError}
+                                // We need a revision to generate code host URLs, if revision isn't available, we use the default branch or HEAD.
+                                revision={
+                                    rawRevision ||
+                                    (repoOrError.defaultBranch && repoOrError.defaultBranch.displayName) ||
+                                    'HEAD'
+                                }
+                                filePath={filePath}
+                                commitRange={commitRange}
+                                position={position}
+                                range={range}
+                                externalLinks={externalLinks}
+                            />
+                        ),
+                    },
+                ]}
+            />
+            <ErrorBoundary location={props.location}>
+                <Switch>
+                    {/* eslint-disable react/jsx-no-bind */}
+                    {[
+                        '',
+                        ...(rawRevision ? [`@${rawRevision}`] : []), // must exactly match how the revision was encoded in the URL
+                        '/-/blob',
+                        '/-/tree',
+                        '/-/commits',
+                    ].map(routePath => (
+                        <Route
+                            path={`${repoMatchURL}${routePath}`}
+                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                            exact={routePath === ''}
+                            render={routeComponentProps => (
+                                <RepoRevisionContainer
+                                    {...routeComponentProps}
+                                    {...context}
+                                    routes={props.repoRevisionContainerRoutes}
+                                    revision={revision || ''}
+                                    resolvedRevisionOrError={resolvedRevisionOrError}
+                                    onResolvedRevisionOrError={setResolvedRevisionOrError}
+                                    // must exactly match how the revision was encoded in the URL
+                                    routePrefix={`${repoMatchURL}${rawRevision ? `@${rawRevision}` : ''}`}
+                                />
+                            )}
+                        />
+                    ))}
+                    {props.repoContainerRoutes.map(
+                        ({ path, render, exact, condition = () => true }) =>
+                            condition(context) && (
+                                <Route
+                                    path={context.routePrefix + path}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={exact}
+                                    // RouteProps.render is an exception
+                                    render={routeComponentProps => render({ ...context, ...routeComponentProps })}
+                                />
+                            )
+                    )}
+                    <Route key="hardcoded-key" component={RepoPageNotFound} />
+                    {/* eslint-enable react/jsx-no-bind */}
+                </Switch>
+            </ErrorBoundary>
+        </div>
+    )
 }

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -181,11 +181,13 @@ export class RepoHeader extends React.PureComponent<Props, State> {
 
     constructor(props: Props) {
         super(props)
-        props.onLifecyclePropsChange(this.repoHeaderContributionStore.props)
-
         this.state = {
             repoHeaderContributions: [...(props.contributions || [])],
         }
+    }
+
+    public componentDidMount(): void {
+        this.props.onLifecyclePropsChange(this.repoHeaderContributionStore.props)
     }
 
     public render(): JSX.Element | null {

--- a/web/src/repo/RepoRevisionContainer.tsx
+++ b/web/src/repo/RepoRevisionContainer.tsx
@@ -40,6 +40,7 @@ import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
 import { RevisionSpec } from '../../../shared/src/util/url'
 import { RepoSettingsSideBarGroup } from './settings/RepoSettingsSidebar'
+import { UpdateBreadcrumbsProps } from '../components/Breadcrumbs'
 
 /** Props passed to sub-routes of {@link RepoRevisionContainer}. */
 export interface RepoRevisionContainerContext
@@ -58,7 +59,8 @@ export interface RepoRevisionContainerContext
         CaseSensitivityProps,
         CopyQueryButtonProps,
         VersionContextProps,
-        RevisionSpec {
+        RevisionSpec,
+        UpdateBreadcrumbsProps {
     repo: GQL.IRepository
     resolvedRev: ResolvedRevision
 
@@ -84,7 +86,8 @@ interface RepoRevisionContainerProps
         CaseSensitivityProps,
         CopyQueryButtonProps,
         VersionContextProps,
-        RevisionSpec {
+        RevisionSpec,
+        UpdateBreadcrumbsProps {
     routes: readonly RepoRevisionContainerRoute[]
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
@@ -224,27 +227,8 @@ export class RepoRevisionContainer extends React.PureComponent<RepoRevisionConta
         }
 
         const context: RepoRevisionContainerContext = {
-            platformContext: this.props.platformContext,
-            extensionsController: this.props.extensionsController,
-            isLightTheme: this.props.isLightTheme,
-            telemetryService: this.props.telemetryService,
-            activation: this.props.activation,
-            repo: this.props.repo,
-            repoHeaderContributionsLifecycleProps: this.props.repoHeaderContributionsLifecycleProps,
+            ...this.props,
             resolvedRev: this.props.resolvedRevisionOrError,
-            revision: this.props.revision,
-            routePrefix: this.props.routePrefix,
-            authenticatedUser: this.props.authenticatedUser,
-            settingsCascade: this.props.settingsCascade,
-            patternType: this.props.patternType,
-            setPatternType: this.props.setPatternType,
-            caseSensitive: this.props.caseSensitive,
-            setCaseSensitivity: this.props.setCaseSensitivity,
-            repoSettingsAreaRoutes: this.props.repoSettingsAreaRoutes,
-            repoSettingsSidebarGroups: this.props.repoSettingsSidebarGroups,
-            copyQueryButton: this.props.copyQueryButton,
-            versionContext: this.props.versionContext,
-            globbing: this.props.globbing,
         }
 
         return (

--- a/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -39,8 +39,9 @@ export const RepositoryBranchesArea: React.FunctionComponent<Props> = props => {
         repo: props.repo,
     }
 
-    useEffect(() =>
-        props.pushBreadcrumb(<RepoHeaderBreadcrumbNavItem key="branches">Branches</RepoHeaderBreadcrumbNavItem>, [])
+    useEffect(
+        () => props.pushBreadcrumb(<RepoHeaderBreadcrumbNavItem key="branches">Branches</RepoHeaderBreadcrumbNavItem>),
+        []
     )
 
     return (

--- a/web/src/util/url.test.ts
+++ b/web/src/util/url.test.ts
@@ -42,6 +42,7 @@ describe('parseBrowserRepoURL', () => {
     test('should parse github repo with revision', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@branch')
         assertDeepStrictEqual(parsed, {
+            rawRevision: 'branch',
             repoName: 'github.com/gorilla/mux',
             revision: 'branch',
         })
@@ -49,6 +50,7 @@ describe('parseBrowserRepoURL', () => {
     test('should parse repo with revision', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@branch')
         assertDeepStrictEqual(parsed, {
+            rawRevision: 'branch',
             repoName: 'gorilla/mux',
             revision: 'branch',
         })
@@ -57,6 +59,7 @@ describe('parseBrowserRepoURL', () => {
     test('should parse github repo with multi-path-part revision', () => {
         const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/gorilla/mux@foo/baz/bar')
         assertDeepStrictEqual(parsed, {
+            rawRevision: 'foo/baz/bar',
             repoName: 'github.com/gorilla/mux',
             revision: 'foo/baz/bar',
         })
@@ -64,6 +67,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed2, {
             repoName: 'github.com/gorilla/mux',
             revision: 'foo/baz/bar',
+            rawRevision: 'foo/baz/bar',
             filePath: 'mux.go',
         })
     })
@@ -72,11 +76,13 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'gorilla/mux',
             revision: 'foo/baz/bar',
+            rawRevision: 'foo/baz/bar',
         })
         const parsed2 = parseBrowserRepoURL('https://sourcegraph.com/gorilla/mux@foo/baz/bar/-/blob/mux.go')
         assertDeepStrictEqual(parsed2, {
             repoName: 'gorilla/mux',
             revision: 'foo/baz/bar',
+            rawRevision: 'foo/baz/bar',
             filePath: 'mux.go',
         })
     })
@@ -86,6 +92,7 @@ describe('parseBrowserRepoURL', () => {
             'https://sourcegraph.com/github.com/gorilla/mux@24fca303ac6da784b9e8269f724ddeb0b2eea5e7'
         )
         assertDeepStrictEqual(parsed, {
+            rawRevision: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             repoName: 'github.com/gorilla/mux',
             revision: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
@@ -96,6 +103,7 @@ describe('parseBrowserRepoURL', () => {
             'https://sourcegraph.com/gorilla/mux@24fca303ac6da784b9e8269f724ddeb0b2eea5e7'
         )
         assertDeepStrictEqual(parsed, {
+            rawRevision: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             repoName: 'gorilla/mux',
             revision: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
             commitID: '24fca303ac6da784b9e8269f724ddeb0b2eea5e7',
@@ -107,6 +115,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'github.com/gorilla/mux',
             revision: 'branch',
+            rawRevision: 'branch',
             filePath: 'mux.go',
         })
     })
@@ -115,6 +124,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'gorilla/mux',
             revision: 'branch',
+            rawRevision: 'branch',
             filePath: 'mux.go',
         })
     })
@@ -124,6 +134,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'github.com/gorilla/mux',
             revision: 'branch',
+            rawRevision: 'branch',
             filePath: 'mux.go',
             position: {
                 line: 3,
@@ -136,6 +147,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'gorilla/mux',
             revision: 'branch',
+            rawRevision: 'branch',
             filePath: 'mux.go',
             position: {
                 line: 3,
@@ -149,6 +161,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'github.com/gorilla/mux',
             revision: 'branch',
+            rawRevision: 'branch',
             filePath: 'mux.go',
             position: {
                 line: 3,
@@ -161,6 +174,7 @@ describe('parseBrowserRepoURL', () => {
         assertDeepStrictEqual(parsed, {
             repoName: 'gorilla/mux',
             revision: 'branch',
+            rawRevision: 'branch',
             filePath: 'mux.go',
             position: {
                 line: 3,

--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -61,7 +61,7 @@ export function replaceRevisionInURL(href: string, newRevision: string): string 
 /**
  * Parses the properties of a blob URL.
  */
-export function parseBrowserRepoURL(href: string): ParsedRepoURI {
+export function parseBrowserRepoURL(href: string): ParsedRepoURI & Pick<ParsedRepoRevision, 'rawRevision'> {
     const url = new URL(href, window.location.href)
     let pathname = url.pathname.slice(1) // trim leading '/'
     if (pathname.endsWith('/')) {
@@ -83,7 +83,7 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI {
     } else {
         repoRevision = pathname.slice(0, indexOfSeparator) // the whole string leading up to the separator (allows revision to be multiple path parts)
     }
-    const { repoName, revision } = parseRepoRevision(repoRevision)
+    const { repoName, revision, rawRevision } = parseRepoRevision(repoRevision)
     if (!repoName) {
         throw new Error('unexpected repo url: ' + href)
     }
@@ -124,7 +124,7 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI {
         }
     }
 
-    return { repoName, revision, commitID, filePath, commitRange, position, range }
+    return { repoName, revision, rawRevision, commitID, filePath, commitRange, position, range }
 }
 
 /** The results of parsing a repo-revision string like "my/repo@my/revision". */


### PR DESCRIPTION
Necessary to allow us to use `useBreadcrumbs()` from `<RepoContainer>`. It also makes the component quite a bit simpler 😅 

The refactor works well in my manual testing, with the exception of the following warning:

```
Warning: Cannot update a component from inside the function body of a different component.
    in RepoHeader (created by RepoContainer)
    in div (created by RepoContainer)
    in RepoContainer (created by Context.Consumer)
```

This is due to [`<RepoHeader/>` calling `onLifecyclePropsChange()` immediately in its constructor](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@9997438a8ba2fdc54920f1f6ad22dd08d4a37215/-/blob/web/src/repo/RepoHeader.tsx?subtree=true#L181:9). I think we should change that store pattern too...