### PR TITLE
conf: Cancel timer to free goroutine

### DIFF
--- a/internal/conf/store.go
+++ b/internal/conf/store.go
@@ -131,12 +131,15 @@ func (s *store) WaitUntilInitialized() {
 			}
 		}
 
+		timer := time.NewTimer(deadlockTimeout)
+		defer timer.Stop()
+
 		select {
 		// Frontend has initialized its configuration server.
 		case <-configurationServerFrontendOnlyInitialized:
 		// We assume that we're in an unrecoverable deadlock if frontend hasn't
 		// started its configuration server after a while.
-		case <-time.After(deadlockTimeout):
+		case <-timer.C:
 			// The running goroutine is not necessarily the cause of the
 			// deadlock, so ask Go to dump all goroutine stack traces.
 			debug.SetTraceback("all")


### PR DESCRIPTION
Previously all calls to WaitUntilInitialized via conf.Get, would spawn a
timer that would leave a pending goroutine running, even if config had already
been initialised.

The default timeout period is 5 minutes so this can lead to a large number
of pending routines.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
