### PR TITLE
search: more trace logging

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -667,8 +667,55 @@ type resolveRepoOp struct {
 	query              query.QueryInfo
 }
 
+func (op *resolveRepoOp) String() string {
+	var b strings.Builder
+	if len(op.repoFilters) == 0 {
+		b.WriteString("r=[]")
+	}
+	for i, r := range op.repoFilters {
+		if i != 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(strconv.Quote(r))
+	}
+
+	if len(op.minusRepoFilters) > 0 {
+		_, _ = fmt.Fprintf(&b, " -r=%v", op.minusRepoFilters)
+	}
+	if len(op.repoGroupFilters) > 0 {
+		_, _ = fmt.Fprintf(&b, " groups=%v", op.repoGroupFilters)
+	}
+	if op.versionContextName != "" {
+		_, _ = fmt.Fprintf(&b, " versionContext=%q", op.versionContextName)
+	}
+	if op.commitAfter != "" {
+		_, _ = fmt.Fprintf(&b, " commitAfter=%q", op.commitAfter)
+	}
+
+	if op.noForks {
+		b.WriteString(" noForks")
+	}
+	if op.onlyForks {
+		b.WriteString(" onlyForks")
+	}
+	if op.noArchived {
+		b.WriteString(" noArchived")
+	}
+	if op.onlyArchived {
+		b.WriteString(" onlyArchived")
+	}
+	if op.onlyPrivate {
+		b.WriteString(" onlyPrivate")
+	}
+	if op.onlyPublic {
+		b.WriteString(" onlyPublic")
+	}
+
+	return b.String()
+}
+
 func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, missingRepoRevisions []*search.RepositoryRevisions, overLimit bool, excludedRepos *excludedRepos, err error) {
-	tr, ctx := trace.New(ctx, "resolveRepositories", fmt.Sprintf("%+v", op))
+	tr, ctx := trace.New(ctx, "resolveRepositories", op.String())
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -698,6 +745,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 				patterns = append(patterns, "^"+regexp.QuoteMeta(string(repo.Name))+"$")
 			}
 		}
+		tr.LazyPrintf("repogroups: adding %d repos to include pattern", len(patterns))
 		includePatterns = append(includePatterns, unionRegExps(patterns))
 
 		// Ensure we don't omit any repos explicitly included via a repo group.
@@ -731,10 +779,12 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 
 	var defaultRepos []*types.Repo
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 {
+		start := time.Now()
 		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, search.Indexed(), excludePatterns)
 		if err != nil {
 			return nil, nil, false, nil, errors.Wrap(err, "getting list of default repos")
 		}
+		tr.LazyPrintf("defaultrepos: took %s to add %d repos", time.Since(start), len(defaultRepos))
 
 		// Search all default repos since indexed search is fast.
 		if len(defaultRepos) > maxRepoListSize {
@@ -765,6 +815,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 			OnlyPrivate:  op.onlyPrivate,
 		}
 		excludedRepos = computeExcludedRepositories(ctx, op.query, options)
+		tr.LazyPrintf("excluded repos: %+v", excludedRepos)
 		repos, err = db.Repos.List(ctx, options)
 		tr.LazyPrintf("Repos.List - done")
 		if err != nil {
@@ -848,7 +899,10 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (repoRevisions, 
 	tr.LazyPrintf("Associate/validate revs - done")
 
 	if op.commitAfter != "" {
+		start := time.Now()
+		before := len(repoRevisions)
 		repoRevisions, err = filterRepoHasCommitAfter(ctx, repoRevisions, op.commitAfter)
+		tr.LazyPrintf("repohascommitafter removed %d repos in %s", before-len(repoRevisions), time.Since(start))
 	}
 
 	return repoRevisions, missingRepoRevisions, overLimit, excludedRepos, err

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -46,14 +46,14 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 	tr.LogFields(log.String("hostname", m.hostname))
 	if opts != nil {
 		tr.LogFields(
-			log.Bool("opts.EstimateDocCount", opts.EstimateDocCount),
-			log.Bool("opts.Whole", opts.Whole),
-			log.Int("opts.ShardMaxMatchCount", opts.ShardMaxMatchCount),
-			log.Int("opts.TotalMaxMatchCount", opts.TotalMaxMatchCount),
-			log.Int("opts.ShardMaxImportantMatch", opts.ShardMaxImportantMatch),
-			log.Int("opts.TotalMaxImportantMatch", opts.TotalMaxImportantMatch),
-			log.Int64("opts.MaxWallTimeMS", opts.MaxWallTime.Milliseconds()),
-			log.Int("opts.MaxDocDisplayCount", opts.MaxDocDisplayCount),
+			log.Bool("opts.estimate_doc_count", opts.EstimateDocCount),
+			log.Bool("opts.whole", opts.Whole),
+			log.Int("opts.shard_max_match_count", opts.ShardMaxMatchCount),
+			log.Int("opts.total_max_match_count", opts.TotalMaxMatchCount),
+			log.Int("opts.shard_max_important_match", opts.ShardMaxImportantMatch),
+			log.Int("opts.total_max_important_match", opts.TotalMaxImportantMatch),
+			log.Int64("opts.max_wall_time_ms", opts.MaxWallTime.Milliseconds()),
+			log.Int("opts.max_doc_display_count", opts.MaxDocDisplayCount),
 		)
 	}
 
@@ -71,20 +71,20 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 	if zsr != nil {
 		tr.LogFields(
 			log.Int("filematches", len(zsr.Files)),
-			log.Int64("rpc.latencyms", (d-zsr.Stats.Duration-zsr.Stats.Wait).Milliseconds()),
-			log.Int64("stats.ContentBytesLoaded", zsr.Stats.ContentBytesLoaded),
-			log.Int64("stats.IndexBytesLoaded", zsr.Stats.IndexBytesLoaded),
-			log.Int("stats.Crashes", zsr.Stats.Crashes),
-			log.Int64("stats.DurationMS", zsr.Stats.Duration.Milliseconds()),
-			log.Int("stats.FileCount", zsr.Stats.FileCount),
-			log.Int("stats.ShardFilesConsidered", zsr.Stats.ShardFilesConsidered),
-			log.Int("stats.FilesConsidered", zsr.Stats.FilesConsidered),
-			log.Int("stats.FilesLoaded", zsr.Stats.FilesLoaded),
-			log.Int("stats.FilesSkipped", zsr.Stats.FilesSkipped),
-			log.Int("stats.ShardsSkipped", zsr.Stats.ShardsSkipped),
-			log.Int("stats.MatchCount", zsr.Stats.MatchCount),
-			log.Int("stats.NgramMatches", zsr.Stats.NgramMatches),
-			log.Int64("stats.WaitMS", zsr.Stats.Wait.Milliseconds()),
+			log.Int64("rpc.latency_ms", (d-zsr.Stats.Duration-zsr.Stats.Wait).Milliseconds()),
+			log.Int64("stats.content_bytes_loaded", zsr.Stats.ContentBytesLoaded),
+			log.Int64("stats.index_bytes_loaded", zsr.Stats.IndexBytesLoaded),
+			log.Int("stats.crashes", zsr.Stats.Crashes),
+			log.Int64("stats.duration_ms", zsr.Stats.Duration.Milliseconds()),
+			log.Int("stats.file_count", zsr.Stats.FileCount),
+			log.Int("stats.shard_files_considered", zsr.Stats.ShardFilesConsidered),
+			log.Int("stats.files_considered", zsr.Stats.FilesConsidered),
+			log.Int("stats.files_loaded", zsr.Stats.FilesLoaded),
+			log.Int("stats.files_skipped", zsr.Stats.FilesSkipped),
+			log.Int("stats.shards_skipped", zsr.Stats.ShardsSkipped),
+			log.Int("stats.match_count", zsr.Stats.MatchCount),
+			log.Int("stats.ngram_matches", zsr.Stats.NgramMatches),
+			log.Int64("stats.wait_ms", zsr.Stats.Wait.Milliseconds()),
 		)
 	}
 	tr.Finish()

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -64,12 +64,14 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 		code = "error"
 	}
 
-	requestDuration.WithLabelValues(m.hostname, cat, code).Observe(time.Since(start).Seconds())
+	d := time.Since(start)
+	requestDuration.WithLabelValues(m.hostname, cat, code).Observe(d.Seconds())
 
 	tr.SetError(err)
 	if zsr != nil {
 		tr.LogFields(
 			log.Int("filematches", len(zsr.Files)),
+			log.Int64("rpc.latencyms", (d-zsr.Stats.Duration-zsr.Stats.Wait).Milliseconds()),
 			log.Int64("stats.ContentBytesLoaded", zsr.Stats.ContentBytesLoaded),
 			log.Int64("stats.IndexBytesLoaded", zsr.Stats.IndexBytesLoaded),
 			log.Int("stats.Crashes", zsr.Stats.Crashes),

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -22,9 +22,9 @@ var NoopSpanURL = func(span opentracing.Span) string {
 var SpanURL = NoopSpanURL
 
 // New returns a new Trace with the specified family and title.
-func New(ctx context.Context, family, title string) (*Trace, context.Context) {
+func New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
 	tr := Tracer{Tracer: ot.GetTracer(ctx)}
-	return tr.New(ctx, family, title)
+	return tr.New(ctx, family, title, tags...)
 }
 
 // A Tracer for trace creation, parameterised over an
@@ -35,18 +35,21 @@ type Tracer struct {
 }
 
 // New returns a new Trace with the specified family and title.
-func (t Tracer) New(ctx context.Context, family, title string) (*Trace, context.Context) {
+func (t Tracer) New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
 	span, ctx := ot.StartSpanFromContextWithTracer(
 		ctx,
 		t.Tracer,
 		family,
-		opentracing.Tag{Key: "title", Value: title},
+		tagsOpt{title: title, tags: tags},
 	)
 	tr := nettrace.New(family, title)
 	trace := &Trace{span: span, trace: tr, family: family}
 	if parent := TraceFromContext(ctx); parent != nil {
 		tr.LazyPrintf("parent: %s", parent.family)
 		trace.family = parent.family + " > " + family
+	}
+	for _, t := range tags {
+		tr.LazyPrintf("%s: %s", t.Key, t.Value)
 	}
 	return trace, ContextWithTrace(ctx, trace)
 }
@@ -109,6 +112,36 @@ func (t *Trace) SetError(err error) {
 func (t *Trace) Finish() {
 	t.trace.Finish()
 	t.span.Finish()
+}
+
+// Tag may be passed when creating a new span. See
+// https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+// for common tags.
+type Tag struct {
+	Key   string
+	Value string
+}
+
+// tagsOpt is an opentracing.StartSpanOption which applies all the tags
+type tagsOpt struct {
+	tags  []Tag
+	title string
+}
+
+// Apply satisfies the StartSpanOption interface.
+func (t tagsOpt) Apply(o *opentracing.StartSpanOptions) {
+	if len(t.tags) == 0 && t.title == "" {
+		return
+	}
+	if o.Tags == nil {
+		o.Tags = make(map[string]interface{}, len(t.tags)+1)
+	}
+	if t.title != "" {
+		o.Tags["title"] = t.title
+	}
+	for _, t := range t.tags {
+		o.Tags[t.Key] = t.Value
+	}
 }
 
 // Printf is an opentracing log.Field which is a LazyLogger. So the format


### PR DESCRIPTION
I am investigating traces on Sourcegraph.com. Resolving repositories is half the time, so added more detailed trace logging for it. Additionally I improved how we log for Zoekt to make it more pleasant (and efficient) to read those traces.