### PR TITLE
search: reactivate dead code path in alertForOverRepoLimit

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -406,7 +406,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 		defer cancel()
 	outer:
 		for i, repoParent := range pathParentsByFrequency(paths) {
-			if i >= maxParentsToPropose || ctx.Err() == nil {
+			if i >= maxParentsToPropose || ctx.Err() != nil {
 				break
 			}
 			repoParentPattern := "^" + regexp.QuoteMeta(repoParent) + "/"


### PR DESCRIPTION
The default path in `func alertForOverRepoLimit` was never active due to a context check that (almost) always resolves to `true`.

### Background
As part of #12476, we need to enable `func alertForOverRepoLimit` for globbing. However, during refactoring, I found a bug I want to fix first.

func `alertForOverRepoLimit` returns a smart alert whenever the user's query resolves to too many repositories. The function has two execution paths, default and fallback. The default path was never active due to a context check that always resolves to `true`. The only case where it doesn't resolve to true is if `alertForOverRepoLimit` is called with a canceled context.

Looking at the code and the commit history I don't believe the deactivation of the code path was intentional. I see two options: Either we remove the dead code and keep the alert's behavior as is, or we fix the context check.

This PR fixes the context check and the corresponding test.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
