### PR TITLE
db: in-memory cache of default repos

### DIFF
--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -23,7 +23,7 @@ type defaultRepos struct {
 
 func (s *defaultRepos) List(ctx context.Context) (results []*types.Repo, err error) {
 	s.mu.Lock()
-	cached, fetched := cache, fetched
+	cached, fetched := s.cache, s.fetched
 	s.mu.Unlock()
 
 	if time.Since(fetched) < defaultReposMaxAge {
@@ -61,4 +61,11 @@ ON default_repos.repo_id = repo.id
 
 	// Return a copy since the cached slice may be mutated
 	return append([]*types.Repo{}, repos...), nil
+}
+
+func (s *defaultRepos) resetCache() {
+	s.mu.Lock()
+	s.cache = nil
+	s.fetched = time.Unix(0, 0)
+	s.mu.Unlock()
 }

--- a/internal/db/default_repos_test.go
+++ b/internal/db/default_repos_test.go
@@ -2,9 +2,10 @@ package db
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -59,14 +60,15 @@ func Test_defaultRepos_List(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+			DefaultRepos.resetCache()
 
 			repos, err := DefaultRepos.List(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(repos, tc.repos) {
-				t.Errorf("repos = %v, want %v", repos, tc.repos)
+			if diff := cmp.Diff(repos, tc.repos, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This is a sourcegraph.com specific optimization. We add an in-memory
cache of the list of repos search on Sourcegraph.com when no repo
filters are specified. Currently retrieving this list from the database
takes 350ms. It is a very rarely changing value and is shared across
users/requests.