### PR TITLE
search: add annotation to VisitField

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -249,7 +249,7 @@ func overrideSearchType(input string, searchType query.SearchType, useNewParser 
 			// parse errors will be raised by subsequent parser calls.
 			return searchType
 		}
-		query.VisitField(q, "patterntype", func(value string, _ bool) {
+		query.VisitField(q, "patterntype", func(value string, _ bool, _ query.Annotation) {
 			switch value {
 			case "regex", "regexp":
 				searchType = query.SearchTypeRegex

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -814,7 +814,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 	want := 5
 
 	var countStr string
-	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
+	query.VisitField(scopeParameters, "count", func(value string, _ bool, _ query.Annotation) {
 		countStr = value
 	})
 	if countStr != "" {
@@ -886,7 +886,7 @@ func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query
 
 	var countStr string
 	wantCount := defaultMaxSearchResults
-	query.VisitField(scopeParameters, "count", func(value string, _ bool) {
+	query.VisitField(scopeParameters, "count", func(value string, _ bool, _ query.Annotation) {
 		countStr = value
 	})
 	if countStr != "" {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -84,7 +84,7 @@ func (q OrdinaryQuery) IsCaseSensitive() bool {
 
 // AndOrQuery satisfies the interface for QueryInfo close to that of OrdinaryQuery.
 func (q AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string) {
-	VisitField(q.Query, field, func(visitedValue string, negated bool) {
+	VisitField(q.Query, field, func(visitedValue string, negated bool, _ Annotation) {
 		if negated {
 			negatedValues = append(negatedValues, visitedValue)
 		} else {
@@ -95,7 +95,7 @@ func (q AndOrQuery) RegexpPatterns(field string) (values, negatedValues []string
 }
 
 func (q AndOrQuery) StringValues(field string) (values, negatedValues []string) {
-	VisitField(q.Query, field, func(visitedValue string, negated bool) {
+	VisitField(q.Query, field, func(visitedValue string, negated bool, _ Annotation) {
 		if negated {
 			negatedValues = append(negatedValues, visitedValue)
 		} else {
@@ -106,7 +106,7 @@ func (q AndOrQuery) StringValues(field string) (values, negatedValues []string) 
 }
 
 func (q AndOrQuery) StringValue(field string) (value, negatedValue string) {
-	VisitField(q.Query, field, func(visitedValue string, negated bool) {
+	VisitField(q.Query, field, func(visitedValue string, negated bool, _ Annotation) {
 		if negated {
 			negatedValue = visitedValue
 		} else {
@@ -123,7 +123,7 @@ func (q AndOrQuery) Values(field string) []*types.Value {
 			values = append(values, q.valueToTypedValue(field, value, annotation.Labels)...)
 		})
 	} else {
-		VisitField(q.Query, field, func(value string, _ bool) {
+		VisitField(q.Query, field, func(value string, _ bool, _ Annotation) {
 			values = append(values, q.valueToTypedValue(field, value, None)...)
 		})
 	}
@@ -135,7 +135,7 @@ func (q AndOrQuery) Fields() map[string][]*types.Value {
 	VisitPattern(q.Query, func(value string, _ bool, _ Annotation) {
 		fields[""] = q.Values("")
 	})
-	VisitParameter(q.Query, func(field, _ string, _ bool) {
+	VisitParameter(q.Query, func(field, _ string, _ bool, _ Annotation) {
 		fields[field] = q.Values(field)
 	})
 	return fields
@@ -154,7 +154,7 @@ func (q AndOrQuery) ParseTree() syntax.ParseTree {
 		}
 		tree = append(tree, expr)
 	})
-	VisitParameter(q.Query, func(field, value string, negated bool) {
+	VisitParameter(q.Query, func(field, value string, negated bool, _ Annotation) {
 		expr := &syntax.Expr{
 			Field: field,
 			Value: value,
@@ -167,7 +167,7 @@ func (q AndOrQuery) ParseTree() syntax.ParseTree {
 
 func (q AndOrQuery) BoolValue(field string) bool {
 	result := false
-	VisitField(q.Query, field, func(value string, _ bool) {
+	VisitField(q.Query, field, func(value string, _ bool, _ Annotation) {
 		result, _ = parseBool(value) // err was checked during parsing and validation.
 	})
 	return result

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -314,7 +314,7 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 func validate(nodes []Node) error {
 	var err error
 	seen := map[string]struct{}{}
-	VisitParameter(nodes, func(field, value string, negated bool) {
+	VisitParameter(nodes, func(field, value string, negated bool, _ Annotation) {
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Relates to #12476 

With this PR we can use `annotation.Range` when calling `VisitField` to extract the glob pattern from the original query string.

### Background
To enable `alertForOverRepoLimit` for globbing, we need to access the patterns of all `repo:` filters. This is already [implemented for regex](https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/graphqlbackend/search_alert.go#L413), but it is not that easy for glob patterns because we don't store them after converting them from glob to regex. To retrieve the patterns, we could either store the original glob pattern in the annotation or use `annotation.Range` to extract them from the query string. Either way, it would we great to have access to annotations in `VisitField`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
