### PR TITLE
Fix URL for open on sourcegraph button

### DIFF
--- a/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -13,6 +13,6 @@ export const OpenOnSourcegraph: React.FunctionComponent<Props> = ({
     className,
     ...props
 }) => {
-    const url = `${sourcegraphURL}/${repoName}@${revision}}/-/blob/${filePath}?utm_source=${getPlatformName()}`
+    const url = `${sourcegraphURL}/${repoName}@${revision}/-/blob/${filePath}?utm_source=${getPlatformName()}`
     return <SourcegraphIconButton {...props} className={classNames('open-on-sourcegraph', className)} href={url} />
 }


### PR DESCRIPTION
Was broken by https://github.com/sourcegraph/sourcegraph/pull/12534 and discovered by our nightly running test suite