### PR TITLE
monitoring: let opsgenie apiurl be optional

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -790,7 +790,7 @@ type NotifierEmail struct {
 // NotifierOpsGenie description: OpsGenie notifier
 type NotifierOpsGenie struct {
 	ApiKey   string `json:"apiKey"`
-	ApiUrl   string `json:"apiUrl"`
+	ApiUrl   string `json:"apiUrl,omitempty"`
 	Priority string `json:"priority,omitempty"`
 	// Responders description: List of responders responsible for notifications.
 	Responders []*Responders `json:"responders,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1119,7 +1119,7 @@
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": ["type", "apiKey", "apiUrl"],
+      "required": ["type", "apiKey"],
       "properties": {
         "type": {
           "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -1124,7 +1124,7 @@ const SiteSchemaJSON = `{
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": ["type", "apiKey", "apiUrl"],
+      "required": ["type", "apiKey"],
       "properties": {
         "type": {
           "type": "string",


### PR DESCRIPTION
The default is valid :)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
