### PR TITLE
search: recognize visibility parameter in new parser

### DIFF
--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -146,6 +146,10 @@ var tests = []test{
 		Name:  `Global search, exclude counts for fork and archive`,
 		Query: `repo:mux|archive|caddy`,
 	},
+	{
+		Name:  `Repo visibility`,
+		Query: `repo:github.com/rvantonderp/adjust-go-wrk visibility:public`,
+	},
 	// And/Or queries.
 	{
 		Name:  `And operator, basic`,

--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -18,6 +18,7 @@ var allFields = map[string]struct{}{
 	FieldType:               empty,
 	FieldPatternType:        empty,
 	FieldContent:            empty,
+	FieldVisibility:         empty,
 	FieldRepoHasFile:        empty,
 	FieldRepoHasCommitAfter: empty,
 	FieldBefore:             empty,

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -273,7 +273,8 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		return satisfies(isNotNegated)
 	case
 		FieldPatternType,
-		FieldContent:
+		FieldContent,
+		FieldVisibility:
 		return satisfies(isSingular, isNotNegated)
 	case
 		FieldRepoHasFile:


### PR DESCRIPTION
`visibility` is a sort of recent addition, I think I just missed it. Noticed a query with `visibility` wasn't behaving like I expected it to with new parser.

Integration test tracks that we should test for this, but I think it's already part of the new integration test suite. I will audit the test suite later.