### PR TITLE
Stop word-count extension from breaking extensions and command palette

### DIFF
--- a/shared/src/api/client/services/contribution.ts
+++ b/shared/src/api/client/services/contribution.ts
@@ -210,10 +210,16 @@ export function mergeContributions(contributions: Evaluated<Contributions>[]): E
             }
         }
         if (contribution.views) {
-            if (!merged.views) {
-                merged.views = [...contribution.views]
-            } else {
-                merged.views = [...merged.views, ...contribution.views]
+            // swallow errors from malformed manifests so the sqs/word-count extension doesn't
+            // break other extensions: https://github.com/sourcegraph/sourcegraph/issues/10600
+            try {
+                if (!merged.views) {
+                    merged.views = [...contribution.views]
+                } else {
+                    merged.views = [...merged.views, ...contribution.views]
+                }
+            } catch {
+                continue
             }
         }
         if (contribution.searchFilters) {


### PR DESCRIPTION
Fix #10600 

Can now safely use the word-count extension. I implemented @felixfbecker's idea to [swallow errors](https://github.com/sourcegraph/sourcegraph/issues/10600#issuecomment-627372556) from spreading view contributions that are not iterable. 

I have a 'backwards compatibility' fix for the word-count view schema stashed away, but I didn't include it because views were documented as [arrays since they were introduced](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/c71b4c33aa7095651307a4abcc5fd5b2c60cadfc#diff-a8286dc0916091f2616d4ca5339fa2a0).

<img width="1198" alt="word_count_fix" src="https://user-images.githubusercontent.com/37420160/88993362-ba9c3600-d2b3-11ea-9c87-b6aa48152e0b.png">