### PR TITLE
search: deny negated structural search

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -954,8 +954,15 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		return nil, err
 	}
 
+	query = Map(query, LowercaseFieldNames, SubstituteAliases)
+
 	switch options.SearchType {
-	case SearchTypeLiteral, SearchTypeStructural:
+	case SearchTypeLiteral:
+		query = substituteConcat(query, " ")
+	case SearchTypeStructural:
+		if containsNegatedPattern(query) {
+			return nil, errors.New("The query contains a negated search pattern. Structural search does not support negated search patterns at the moment.")
+		}
 		query = substituteConcat(query, " ")
 	case SearchTypeRegex:
 		query = EmptyGroupsToLiteral(query)
@@ -968,7 +975,6 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		}
 	}
 
-	query = Map(query, LowercaseFieldNames, SubstituteAliases)
 	err = validate(query)
 	if err != nil {
 		return nil, err

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -63,6 +63,18 @@ func containsAndOrExpression(nodes []Node) bool {
 	})
 }
 
+// containsNegatedPattern returns true if any search pattern is negated in nodes.
+func containsNegatedPattern(nodes []Node) bool {
+	return exists(nodes, func(node Node) bool {
+		if p, ok := node.(Pattern); ok {
+			if p.Negated {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 // ContainsAndOrKeyword returns true if this query contains or- or and-
 // keywords. It is a temporary signal to determine whether we can fallback to
 // the older existing search functionality.

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestAndOrQuery_Validation(t *testing.T) {
 	cases := []struct {
-		input string
-		want  string
+		input      string
+		searchType SearchType // nil value is regexp
+		want       string
 	}{
 		{
 			input: "case:yes case:no",
@@ -53,10 +54,20 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			input: `\\\`,
 			want:  "error parsing regexp: trailing backslash at end of expression: ``",
 		},
+		{
+			input:      `-content:"foo"`,
+			want:       "The query contains a negated search pattern. Structural search does not support negated search patterns at the moment.",
+			searchType: SearchTypeStructural,
+		},
+		{
+			input:      `NOT foo`,
+			want:       "The query contains a negated search pattern. Structural search does not support negated search patterns at the moment.",
+			searchType: SearchTypeStructural,
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
-			_, err := ProcessAndOr(c.input, ParserOptions{SearchTypeRegex, false})
+			_, err := ProcessAndOr(c.input, ParserOptions{c.searchType, false})
 			if err == nil {
 				t.Fatal("expected test to fail")
 			}


### PR DESCRIPTION
Can't support negation on structural search right now. I think the separate code path queries Zoekt for candidate files for structural search pans out if we convert it into a `Not` query like we do currently, but it will probably suffer big perf issues if the result set is big. Let's not support it right now.