### PR TITLE
search: fix count for queries with trailing spaces

### DIFF
--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -66,6 +66,7 @@ loop:
 		case unicode.IsSpace(r) && balanced == 0:
 			// Stop scanning a potential pattern when we see
 			// whitespace in a balanced state.
+			count = start
 			break loop
 		case r == '(':
 			balanced++

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -26,6 +26,13 @@ func TestParseParameterList(t *testing.T) {
 			WantLabels: None,
 		},
 		{
+			Name:       "Normal field:value with trailing space",
+			Input:      `file:README.md    `,
+			Want:       `{"field":"file","value":"README.md","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
+			WantLabels: None,
+		},
+		{
 			Name:       "First char is colon",
 			Input:      `:foo`,
 			Want:       `{"value":":foo","negated":false}`,


### PR DESCRIPTION
For queries with trailing spaces, `func ScanBalancedPatternLiteral` counts the final trailing space which means `annotation.Range.End.Column` is off by +1.
 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
