### PR TITLE
db: Use mutex around cache

### DIFF
--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -39,7 +39,7 @@ func (s *defaultRepos) List(ctx context.Context) (results []*types.Repo, err err
 	if cached != nil {
 		return cached, nil
 	}
-	// We continue to hold the lock here so that only one process goroutine performs the query
+	// We continue to hold the lock here so that only one goroutine performs the query
 
 	const q = `
 SELECT default_repos.repo_id, repo.name

--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -39,7 +39,7 @@ func (s *defaultRepos) List(ctx context.Context) (results []*types.Repo, err err
 	if cached != nil {
 		return cached, nil
 	}
-	// We continue to hold the lock here so that only one process actually performs the query
+	// We continue to hold the lock here so that only one process goroutine performs the query
 
 	const q = `
 SELECT default_repos.repo_id, repo.name


### PR DESCRIPTION
This ensures that when the cache has expired, only one goroutine will
refresh it while others will block until the it has refreshed.