### PR TITLE
monitoring: sync dot-com alerts to generator

### DIFF
--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -76,8 +76,6 @@ func Frontend() *Container {
 							Owner:             ObservableOwnerSearch,
 							PossibleSolutions: "none",
 						},
-					},
-					{
 						{
 							Name:            "search_alert_user_suggestions",
 							Description:     "search alert user suggestions shown every 5m",
@@ -90,12 +88,27 @@ func Frontend() *Container {
 								- This indicates your user's are making syntax errors or similar user errors.
 							`,
 						},
+					},
+					{
 						{
 							Name:            "page_load_latency",
 							Description:     "90th percentile page load latency over all routes over 10m",
-							Query:           `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{job="sourcegraph-frontend",route!="raw"}[10m])))`,
+							Query:           `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route!="raw",route!="blob",route!~"graphql.*"}[10m])))`,
 							DataMayNotExist: true,
-							Critical:        Alert{GreaterOrEqual: 20},
+							Critical:        Alert{GreaterOrEqual: 2},
+							PanelOptions:    PanelOptions().LegendFormat("latency"),
+							Owner:           ObservableOwnerSearch,
+							PossibleSolutions: `
+								- Confirm that the Sourcegraph frontend has enough CPU/memory using the provisioning panels.
+								- Trace a request to see what is the slowest part - refer to: https://docs.sourcegraph.com/admin/observability/tracing
+							`,
+						},
+						{
+							Name:            "blob_load_latency",
+							Description:     "90th percentile blob load latency over 10m",
+							Query:           `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`,
+							DataMayNotExist: true,
+							Critical:        Alert{GreaterOrEqual: 2},
 							PanelOptions:    PanelOptions().LegendFormat("latency"),
 							Owner:           ObservableOwnerSearch,
 							PossibleSolutions: `

--- a/monitoring/github_proxy.go
+++ b/monitoring/github_proxy.go
@@ -7,6 +7,33 @@ func GitHubProxy() *Container {
 		Description: "Proxies all requests to github.com, keeping track of and managing rate limits.",
 		Groups: []Group{
 			{
+				Title: "GitHub API monitoring",
+				Rows: []Row{
+					{
+						{
+							Name:              "github_core_rate_limit_remaining",
+							Description:       "remaining calls to GitHub before hitting the rate limit",
+							Query:             `src_github_rate_limit_remaining{resource="core"}`,
+							DataMayNotExist:   true,
+							Critical:          Alert{LessOrEqual: 1000},
+							PanelOptions:      PanelOptions().LegendFormat("calls remaining"),
+							Owner:             ObservableOwnerSearch,
+							PossibleSolutions: `Try restarting the pod to get a different public IP.`,
+						},
+						{
+							Name:              "github_search_rate_limit_remaining",
+							Description:       "remaining calls to GitHub search before hitting the rate limit",
+							Query:             `src_github_rate_limit_remaining{resource="search"}`,
+							DataMayNotExist:   true,
+							Warning:           Alert{LessOrEqual: 5},
+							PanelOptions:      PanelOptions().LegendFormat("calls remaining"),
+							Owner:             ObservableOwnerSearch,
+							PossibleSolutions: `Try restarting the pod to get a different public IP.`,
+						},
+					},
+				},
+			},
+			{
 				Title:  "Container monitoring (not available on server)",
 				Hidden: true,
 				Rows: []Row{

--- a/monitoring/searcher.go
+++ b/monitoring/searcher.go
@@ -1,7 +1,5 @@
 package main
 
-import "time"
-
 func Searcher() *Container {
 	return &Container{
 		Name:        "searcher",
@@ -23,10 +21,11 @@ func Searcher() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "error_ratio",
-							Description:       "error ratio over 10m",
-							Query:             `searcher_errors:ratio10m`,
-							Warning:           Alert{GreaterOrEqual: 0.1, For: 20 * time.Minute},
+							Name:              "replica_traffic",
+							Description:       "requests per second over 10m",
+							Query:             "sum by(instance) (rate(searcher_service_request_total[10m]))",
+							Warning:           Alert{GreaterOrEqual: 5},
+							PanelOptions:      PanelOptions().LegendFormat("{{instance}}"),
 							Owner:             ObservableOwnerSearch,
 							PossibleSolutions: "none",
 						},


### PR DESCRIPTION
Syncs additional alerts from `deploy-sourcegraph-dot-com`:

* `ProdLandingPageLatencyGoal` -> removed - seems similar to `page_load_latency`? But updated `page_load_latency` to exclude GraphQL requests
* `ProdBlobLatencyGoal` -> `blob_load_latency`, updated `page_load_latency` to exclude blob and give it a more realistic critical threshold (?) based on the threshold set for `ProdBlobLatencyGoal`
* `SearcherErrorRatioTooHigh` -> removed because seems similar to `unindexed_search_request_errors`, also removed `error_ratio` because it seems very similar to `unindexed_search_request_errors` as well (?)
* `SearcherHighTraffic` -> `replica_traffic`, inlined the record into the alert 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
