### PR TITLE
search: return basic alert in alertForOverRepoLimit if globbing is active

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -392,6 +392,12 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 		}
 	}
 
+	// If globbing is active we return a simple alert for now. The alert is still
+	// helpful but it doesn't contain any proposed queries.
+	if settings, err := decodedViewerFinalSettings(ctx); err != nil || getBoolPtr(settings.SearchGlobbing, false) {
+		return buildAlert(proposedQueries, description)
+	}
+
 	repos, _, _, _, _ := r.resolveRepositories(ctx, nil)
 	if len(repos) > 0 {
 		paths := make([]string, len(repos))


### PR DESCRIPTION
Relates to #12476 

with this PR `alertForOverRepoLimit` will return a basic alert if we hit the repo limit and globbing is activated. This way the users will not be presented with query suggestions containing regex syntax.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
