### PR TITLE
search:handle ^ as first character in character class

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -46,80 +46,66 @@ func translateCharacterClass(r []rune, startIx int) (int, string, error) {
 	sb := strings.Builder{}
 	i := startIx
 	lenR := len(r)
-Loop:
+
+	switch r[i] {
+	case '!':
+		if i < lenR-1 && r[i+1] == ']' {
+			// the character class cannot contain just "!"
+			return -1, "", ErrBadGlobPattern
+		}
+		sb.WriteRune('^')
+		i++
+	case '^':
+		sb.WriteString("//^")
+		i++
+	}
+
 	for i < lenR {
-		switch r[i] {
-		case '!':
-			if i == startIx {
-				sb.WriteRune('^')
-			} else {
-				sb.WriteRune(r[i])
-			}
-			i++
-		case ']':
+		if r[i] == ']' {
 			if i > startIx {
-				break Loop
+				break
 			}
 			sb.WriteRune(r[i])
 			i++
-		default: // translate character range lo-hi.
-
-			// '-' is treated literally at the start and end of
-			// of a character class.
-			if r[i] == '-' {
-				if i == lenR-1 {
-					// no closing bracket
-					return -1, "", ErrBadGlobPattern
-				}
-
-				if i > startIx && r[i+1] != ']' {
-					// '-' cannot be the lower end of a range
-					// unless it is the first character within
-					// the character class.
-					return -1, "", ErrBadGlobPattern
-				}
-			}
-			lo := r[i]
-			sb.WriteRune(r[i]) // lo
-			i++
-
-			if i == lenR {
-				// no closing bracket
-				return -1, "", ErrBadGlobPattern
-			}
-
-			// lo = hi
-			if r[i] != '-' {
-				continue
-			}
-
-			sb.WriteRune(r[i]) // -
-			i++
-
-			if i == lenR {
-				// no closing bracket
-				return -1, "", ErrBadGlobPattern
-			}
-
-			if r[i] == ']' {
-				continue
-			}
-
-			hi := r[i]
-			if lo > hi {
-				// range is reversed
-				return -1, "", ErrBadGlobPattern
-			}
-			sb.WriteRune(r[i]) // hi
-			i++
+			continue
 		}
+
+		lo := r[i]
+		sb.WriteRune(r[i]) // lo
+		i++
+		if i == lenR {
+			// no closing bracket
+			return -1, "", ErrBadGlobPattern
+		}
+
+		// lo = hi
+		if r[i] != '-' {
+			continue
+		}
+
+		sb.WriteRune(r[i]) // -
+		i++
+		if i == lenR {
+			// no closing bracket
+			return -1, "", ErrBadGlobPattern
+		}
+
+		if r[i] == ']' {
+			continue
+		}
+
+		hi := r[i]
+		if lo > hi {
+			// range is reversed
+			return -1, "", ErrBadGlobPattern
+		}
+		sb.WriteRune(r[i]) // hi
+		i++
 	}
 	if i == lenR {
 		return -1, "", ErrBadGlobPattern
 	}
-
 	return i - startIx, sb.String(), nil
-
 }
 
 var globSpecialSymbols = map[rune]struct{}{
@@ -174,6 +160,9 @@ func globToRegex(value string) (string, error) {
 			}
 			sb.WriteRune(r[i])
 		case '[':
+			if i == l-1 {
+				return "", ErrBadGlobPattern
+			}
 			sb.WriteRune('[')
 			i++
 


### PR DESCRIPTION
Relates to #12476 

Previously we did not handle `^` within character classes so that `[^-b]` (glob) was translated to `^[^-b]$` (regex) which is not the same.

Additionally, we handled `-` very strictly, [following the UNIX man page for glob](https://man7.org/linux/man-pages/man7/glob.7.html). However, we can be much more forgiving because google re2 can handle even those cases we previously excluded, like `[a-b-c]` or `[a-z--0]`.

Because of the code change, a switch block in `translateCharacterClass` became obsolete and I removed it, which unfortunately bloats the diff. However, I didn't change the tests apart from adding new ones and moving `[a-b-c]` or `[a-z--0]` from "not allowed" to "allowed".

Note: I fuzzed the parser without any crashers.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
