### PR TITLE
docs: correct note about testing alerts

### DIFF
--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -88,7 +88,7 @@ mutation {
 }
 ```
 
-Once you have verified your notifiers are configured correctly, make sure to set the alert state to `firing: false` with another API request.
+The test alert may take up to a minute to fire. The triggered alert will automatically resolve itself as well.
 
 ### Silencing alerts
 


### PR DESCRIPTION
Minor follow-up to https://github.com/sourcegraph/sourcegraph/pull/12532 to correct the alerting documentation
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
