### PR TITLE
codeintel: Index queue API

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer/env.go
@@ -22,6 +22,10 @@ var (
 	rawIndexMinimumSearchRatio          = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_RATIO", "50", "Minimum ratio of search events to total events to trigger indexing for a repo.")
 	rawIndexMinimumPreciseCount         = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_PRECISE_COUNT", "1", "Minimum number of precise events to trigger indexing for a repo.")
 	rawDisableJanitor                   = env.Get("PRECISE_CODE_INTEL_DISABLE_JANITOR", "false", "Set to true to disable the janitor process during system migrations.")
+	rawMaxTransactions                  = env.Get("PRECISE_CODE_INTEL_MAXIMUM_TRANSACTIONS", "10", "Number of index jobs that can be active at once.")
+	rawRequeueDelay                     = env.Get("PRECISE_CODE_INTEL_REQUEUE_DELAY", "1m", "The requeue delay of index jobs assigned to an unreachable indexer.")
+	rawCleanupInterval                  = env.Get("PRECISE_CODE_INTEL_CLEANUP_INTERVAL", "10s", "Interval between cleanup runs.")
+	rawMissedHeartbeats                 = env.Get("PRECISE_CODE_INTEL_MAXIMUM_MISSED_HEARTBEATS", "5", "The number of heartbeats an indexer must miss to be considered unreachable.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.

--- a/enterprise/cmd/precise-code-intel-indexer/internal/index_manager/manager.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/index_manager/manager.go
@@ -25,9 +25,8 @@ type Manager interface {
 	// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
 	Stop()
 
-	// Stop will cause Start to exit after the current request. This method blocks until Start has
-	// returned. All active transactions known by the manager will be rolled back. Requests to the
-	// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
+	// Dequeue pulls an unprocessed index record from the database and assigns the transaction that
+	// locks that record to the given indexer.
 	Dequeue(ctx context.Context, indexerName string) (store.Index, bool, error)
 
 	// Complete marks the target index record as complete or errored depending on the existence of
@@ -184,9 +183,8 @@ func (m *manager) Stop() {
 	<-m.finished
 }
 
-// Stop will cause Start to exit after the current request. This method blocks until Start has
-// returned. All active transactions known by the manager will be rolled back. Requests to the
-// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
+// Dequeue pulls an unprocessed index record from the database and assigns the transaction that
+// locks that record to the given indexer.
 func (m *manager) Dequeue(ctx context.Context, indexerName string) (_ store.Index, dequeued bool, _ error) {
 	ctx, cancel := onecontext.Merge(ctx, m.ctx)
 	defer cancel()

--- a/enterprise/cmd/precise-code-intel-indexer/internal/index_manager/manager.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/index_manager/manager.go
@@ -1,0 +1,355 @@
+package indexmanager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/efritz/glock"
+	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/teivah/onecontext"
+)
+
+// Manager tracks which index records are assigned to which indexers.
+type Manager interface {
+	// Start runs the routine that handles expiration of transactions for indexers which have become
+	// unresponsive. This method blocks until Stop has been called.
+	Start()
+
+	// Stop will cause Start to exit after the current request. This method blocks until Start has
+	// returned. All active transactions known by the manager will be rolled back. Requests to the
+	// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
+	Stop()
+
+	// Stop will cause Start to exit after the current request. This method blocks until Start has
+	// returned. All active transactions known by the manager will be rolled back. Requests to the
+	// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
+	Dequeue(ctx context.Context, indexerName string) (store.Index, bool, error)
+
+	// Complete marks the target index record as complete or errored depending on the existence of
+	// an error message, then finalizes the transaction that locks that record.
+	Complete(ctx context.Context, indexerName string, indexID int, errorMessage string) (bool, error)
+
+	// Heartbeat bumps the last updated time of the indexer and closes any transactions locking
+	// records whose identifiers were not supplied.
+	Heartbeat(ctx context.Context, indexerName string, indexIDs []int) error
+}
+
+// ThreadedManager is a manager that handles requests that modify database transactions from a single
+// goroutine to simplify bookkeeping of live transactions.
+type ThreadedManager interface {
+	Manager
+}
+
+type ManagerOptions struct {
+	// MaximumTransactions is the maximum number of active records that can be given out to indexers. The
+	// manager dequeue method will stop returning records while the number of outstanding transactions is
+	// at this threshold.
+	MaximumTransactions int
+
+	// RequeueDelay controls how far into the future to make an indexer's records visible to another
+	// agent once it becomes unresponsive.
+	RequeueDelay time.Duration
+
+	// CleanupInterval is the duration between cleanup invocations, in which the index records assigned
+	// to dead indexers are requeued.
+	CleanupInterval time.Duration
+
+	// UnreportedMaxAge is the maximum time between an index record being dequeued and it appearing in
+	// the indexer's heartbeat requests before it being considered lost.
+	UnreportedIndexMaxAge time.Duration
+
+	// DeathThreshold is the minimum time since the last indexerheartbeat before the indexer can be
+	// considered as unresponsive. This should be configured to be longer than the indexer's heartbeat
+	// interval.
+	DeathThreshold time.Duration
+}
+
+type manager struct {
+	store            workerutil.Store
+	options          ManagerOptions
+	clock            glock.Clock
+	indexers         map[string]*indexerMeta
+	dequeueSemaphore chan struct{}   // tracks available dequeue slots
+	m                sync.Mutex      // protects indexers
+	ctx              context.Context // root context passed to the database
+	cancel           func()          // cancels the root context
+	finished         chan struct{}   // signals that Start has finished
+}
+
+var _ Manager = &manager{}
+
+// indexerMeta tracks the last request time of an indexer along with the set of index records which it
+// is currently processing.
+type indexerMeta struct {
+	lastUpdate time.Time
+	metas      []indexMeta
+}
+
+// indexMeta wraps an index record and the tranaction that is currently locking it for processing.
+type indexMeta struct {
+	index   store.Index
+	tx      workerutil.Store
+	started time.Time
+}
+
+// New creates a new manager with the given store and options.
+func New(store workerutil.Store, options ManagerOptions) ThreadedManager {
+	return newManager(store, options, glock.NewRealClock())
+}
+
+func newManager(store workerutil.Store, options ManagerOptions, clock glock.Clock) ThreadedManager {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dequeueSemaphore := make(chan struct{}, options.MaximumTransactions)
+	for i := 0; i < options.MaximumTransactions; i++ {
+		dequeueSemaphore <- struct{}{}
+	}
+
+	return &manager{
+		store:            store,
+		options:          options,
+		clock:            clock,
+		dequeueSemaphore: dequeueSemaphore,
+		indexers:         map[string]*indexerMeta{},
+		ctx:              ctx,
+		cancel:           cancel,
+		finished:         make(chan struct{}),
+	}
+}
+
+// Start runs the routine that handles expiration of transactions for indexers which have become
+// unresponsive. This method blocks until Stop has been called.
+func (m *manager) Start() {
+	defer close(m.finished)
+
+loop:
+	for {
+		m.cleanup()
+
+		select {
+		case <-m.clock.After(m.options.CleanupInterval):
+		case <-m.ctx.Done():
+			break loop
+		}
+	}
+
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	for _, indexer := range m.indexers {
+		for _, meta := range indexer.metas {
+			if err := meta.tx.Done(m.ctx.Err()); err != nil && err != m.ctx.Err() {
+				log15.Error(fmt.Sprintf("Failed to close transaction holding index %d", meta.index.ID), "err", err)
+			}
+		}
+	}
+}
+
+// cleanup requeues every locked index record assigned to indexers which have not been updated
+// for longer than the death threshold.
+func (m *manager) cleanup() {
+	if err := m.requeueIndexes(m.ctx, m.pruneIndexers()); err != nil {
+		log15.Error("Failed to requeue indexes", "err", err)
+	}
+}
+
+// pruneIndexers removes the data associated with indexers which have not been updated for longer
+// than the death threshold and returns all index meta values assigned to removed indexers.
+func (m *manager) pruneIndexers() (metas []indexMeta) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	for name, indexer := range m.indexers {
+		if m.clock.Now().Sub(indexer.lastUpdate) <= m.options.DeathThreshold {
+			continue
+		}
+
+		metas = append(metas, indexer.metas...)
+		delete(m.indexers, name)
+	}
+
+	return metas
+}
+
+// Stop will cause Start to exit after the current request. This method blocks until Start has
+// returned. All active transactions known by the manager will be rolled back. Requests to the
+// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
+func (m *manager) Stop() {
+	m.cancel()
+	<-m.finished
+}
+
+// Stop will cause Start to exit after the current request. This method blocks until Start has
+// returned. All active transactions known by the manager will be rolled back. Requests to the
+// Dequeue, Complete, or Heartbeat methods should not occur after this method has been called.
+func (m *manager) Dequeue(ctx context.Context, indexerName string) (_ store.Index, dequeued bool, _ error) {
+	ctx, cancel := onecontext.Merge(ctx, m.ctx)
+	defer cancel()
+
+	select {
+	case <-m.dequeueSemaphore:
+	default:
+		return store.Index{}, false, nil
+	}
+	defer func() {
+		if !dequeued {
+			// Ensure that if we do not dequeue a record successfully we do not
+			// leak from the semaphore. This will happen if the dequeue call fails
+			// or if there are no records to process
+			m.dequeueSemaphore <- struct{}{}
+		}
+	}()
+
+	record, tx, dequeued, err := m.store.DequeueWithIndependentTransactionContext(ctx, nil)
+	if err != nil {
+		return store.Index{}, false, err
+	}
+	if !dequeued {
+		return store.Index{}, false, nil
+	}
+
+	now := m.clock.Now()
+	index := record.(store.Index)
+	m.addMeta(indexerName, indexMeta{index: index, tx: tx, started: now})
+	return index, true, nil
+}
+
+// addMeta removes the given index to the given indexer. This method also updates the last
+// updated time of the indexer.
+func (m *manager) addMeta(indexerName string, meta indexMeta) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	indexer, ok := m.indexers[indexerName]
+	if !ok {
+		indexer = &indexerMeta{}
+		m.indexers[indexerName] = indexer
+	}
+
+	now := m.clock.Now()
+	indexer.metas = append(indexer.metas, meta)
+	indexer.lastUpdate = now
+}
+
+// Complete marks the target index record as complete or errored depending on the existence of
+// an error message, then finalizes the transaction that locks that record.
+func (m *manager) Complete(ctx context.Context, indexerName string, indexID int, errorMessage string) (bool, error) {
+	ctx, cancel := onecontext.Merge(ctx, m.ctx)
+	defer cancel()
+
+	index, ok := m.findMeta(indexerName, indexID)
+	if !ok {
+		return false, nil
+	}
+
+	if err := m.completeIndex(ctx, index, errorMessage); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// findMeta finds and returns an index meta value matching the given index identifier. If found,
+// the meta value is removed from the indexer.
+func (m *manager) findMeta(indexerName string, indexID int) (indexMeta, bool) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	indexer, ok := m.indexers[indexerName]
+	if !ok {
+		return indexMeta{}, false
+	}
+
+	for i, meta := range indexer.metas {
+		if meta.index.ID != indexID {
+			continue
+		}
+
+		l := len(indexer.metas) - 1
+		indexer.metas[i] = indexer.metas[l]
+		indexer.metas = indexer.metas[:l]
+		return meta, true
+	}
+
+	return indexMeta{}, false
+}
+
+// completeIndex marks the target index record as complete or errored depending on the existence
+// of an error message, then finalizes the transaction that locks that record.
+func (m *manager) completeIndex(ctx context.Context, meta indexMeta, errorMessage string) (err error) {
+	defer func() { m.dequeueSemaphore <- struct{}{} }()
+
+	if errorMessage == "" {
+		_, err = meta.tx.MarkComplete(ctx, meta.index.ID)
+	} else {
+		_, err = meta.tx.MarkErrored(ctx, meta.index.ID, errorMessage)
+	}
+
+	return meta.tx.Done(err)
+}
+
+// Heartbeat bumps the last updated time of the indexer and closes any transactions locking
+// records whose identifiers were not supplied.
+func (m *manager) Heartbeat(ctx context.Context, indexerName string, indexIDs []int) error {
+	return m.requeueIndexes(ctx, m.pruneIndexes(indexerName, indexIDs))
+}
+
+// pruneIndexes removes the indexes whose identifier is not in the given list from the given indexer.
+// This method returns the index meta values which were removed. Index meta values which were created
+// very recently will be counted as live to account for the time between when the record is dequeued
+// in this service and when it is added to the heartbeat requests from the indexer. This method also
+// updates the last updated time of the indexer.
+func (m *manager) pruneIndexes(indexerName string, ids []int) (dead []indexMeta) {
+	now := m.clock.Now()
+
+	idMap := map[int]struct{}{}
+	for _, id := range ids {
+		idMap[id] = struct{}{}
+	}
+
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	indexer, ok := m.indexers[indexerName]
+	if !ok {
+		indexer = &indexerMeta{}
+		m.indexers[indexerName] = indexer
+	}
+
+	var live []indexMeta
+	for _, meta := range indexer.metas {
+		if _, ok := idMap[meta.index.ID]; ok || now.Sub(meta.started) < m.options.UnreportedIndexMaxAge {
+			live = append(live, meta)
+		} else {
+			dead = append(dead, meta)
+		}
+	}
+
+	indexer.metas = live
+	indexer.lastUpdate = now
+	return dead
+}
+
+// requeueIndexes requeues the given index records.
+func (m *manager) requeueIndexes(ctx context.Context, metas []indexMeta) (errs error) {
+	for _, meta := range metas {
+		if err := m.requeueIndex(ctx, meta); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// requeueIndex requeues the given index record , then finalizes the transaction that locks that record.
+func (m *manager) requeueIndex(ctx context.Context, meta indexMeta) error {
+	defer func() { m.dequeueSemaphore <- struct{}{} }()
+
+	err := meta.tx.Requeue(ctx, meta.index.ID, m.clock.Now().Add(m.options.RequeueDelay))
+	return meta.tx.Done(err)
+}

--- a/enterprise/cmd/precise-code-intel-indexer/internal/index_manager/manager_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/index_manager/manager_test.go
@@ -1,0 +1,331 @@
+package indexmanager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/efritz/glock"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	storemocks "github.com/sourcegraph/sourcegraph/internal/workerutil/store/mocks"
+)
+
+func TestProcessSuccess(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockStore.DequeueWithIndependentTransactionContextFunc.PushReturn(store.Index{ID: 42}, mockStore, true, nil)
+	mockStore.MarkCompleteFunc.SetDefaultReturn(true, nil)
+	clock := glock.NewMockClock()
+
+	manager := newManager(mockStore, ManagerOptions{
+		MaximumTransactions:   10,
+		RequeueDelay:          time.Second,
+		CleanupInterval:       time.Second,
+		UnreportedIndexMaxAge: time.Second,
+		DeathThreshold:        time.Second,
+	}, clock)
+
+	index, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing record: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a record")
+	}
+	if index.ID != 42 {
+		t.Fatalf("unexpected record id. want=%d have=%d", 42, index.ID)
+	}
+
+	found, err := manager.Complete(context.Background(), "deadbeef", 42, "")
+	if err != nil {
+		t.Fatalf("unexpected error marking record as complete: %s", err)
+	}
+	if !found {
+		t.Fatalf("expected record to be tracked: %s", err)
+	}
+
+	if callCount := len(mockStore.MarkCompleteFunc.History()); callCount != 1 {
+		t.Errorf("unexpected mark complete call count. want=%d have=%d", 1, callCount)
+	} else if id := mockStore.MarkCompleteFunc.History()[0].Arg1; id != 42 {
+		t.Errorf("unexpected id argument to markge. want=%v have=%v", 42, id)
+	}
+
+	if callCount := len(mockStore.DoneFunc.History()); callCount != 1 {
+		t.Errorf("unexpected done call count. want=%d have=%d", 1, callCount)
+	} else if err := mockStore.DoneFunc.History()[0].Arg0; err != nil {
+		t.Errorf("unexpected error argument to done. want=%v have=%v", nil, err)
+	}
+}
+
+func TestProcessFailure(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockStore.DequeueWithIndependentTransactionContextFunc.PushReturn(store.Index{ID: 42}, mockStore, true, nil)
+	mockStore.MarkErroredFunc.SetDefaultReturn(true, nil)
+	clock := glock.NewMockClock()
+
+	manager := newManager(mockStore, ManagerOptions{
+		MaximumTransactions:   10,
+		RequeueDelay:          time.Second,
+		CleanupInterval:       time.Second,
+		UnreportedIndexMaxAge: time.Second,
+		DeathThreshold:        time.Second,
+	}, clock)
+
+	index, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing record: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a record")
+	}
+	if index.ID != 42 {
+		t.Fatalf("unexpected record id. want=%d have=%d", 42, index.ID)
+	}
+
+	found, err := manager.Complete(context.Background(), "deadbeef", 42, "oops")
+	if err != nil {
+		t.Fatalf("unexpected error marking record as complete: %s", err)
+	}
+	if !found {
+		t.Fatalf("expected record to be tracked: %s", err)
+	}
+
+	if callCount := len(mockStore.MarkErroredFunc.History()); callCount != 1 {
+		t.Errorf("unexpected mark errored call count. want=%d have=%d", 1, callCount)
+	} else if id := mockStore.MarkErroredFunc.History()[0].Arg1; id != 42 {
+		t.Errorf("unexpected id argument to mark errored. want=%v have=%v", 42, id)
+	}
+
+	if callCount := len(mockStore.DoneFunc.History()); callCount != 1 {
+		t.Errorf("unexpected done call count. want=%d have=%d", 1, callCount)
+	} else if err := mockStore.DoneFunc.History()[0].Arg0; err != nil {
+		t.Errorf("unexpected error argument to done. want=%v have=%v", nil, err)
+	}
+}
+
+func TestProcessIndexerMismatch(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockStore.DequeueWithIndependentTransactionContextFunc.PushReturn(store.Index{ID: 42}, mockStore, true, nil)
+	clock := glock.NewMockClock()
+
+	manager := newManager(mockStore, ManagerOptions{
+		MaximumTransactions:   10,
+		RequeueDelay:          time.Second,
+		CleanupInterval:       time.Second,
+		UnreportedIndexMaxAge: time.Second,
+		DeathThreshold:        time.Second,
+	}, clock)
+
+	index, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing record: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a record")
+	}
+	if index.ID != 42 {
+		t.Fatalf("unexpected record id. want=%d have=%d", 42, index.ID)
+	}
+
+	found, err := manager.Complete(context.Background(), "livebeef", 42, "oops")
+	if err != nil {
+		t.Fatalf("unexpected error marking record as complete: %s", err)
+	}
+	if found {
+		t.Fatalf("expected record to belong to a different indexer: %s", err)
+	}
+
+	if callCount := len(mockStore.DoneFunc.History()); callCount != 0 {
+		t.Errorf("unexpected done call count. want=%d have=%d", 0, callCount)
+	}
+}
+
+func TestBoundedTransactions(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockStore.MarkCompleteFunc.SetDefaultReturn(true, nil)
+	clock := glock.NewMockClock()
+
+	calls := 0
+	mockStore.DequeueWithIndependentTransactionContextFunc.SetDefaultHook(func(ctx context.Context, conds []*sqlf.Query) (workerutil.Record, workerutil.Store, bool, error) {
+		calls++
+		return store.Index{ID: calls + 10}, mockStore, true, nil
+	})
+
+	manager := newManager(mockStore, ManagerOptions{
+		MaximumTransactions:   10,
+		RequeueDelay:          time.Second,
+		CleanupInterval:       time.Second,
+		UnreportedIndexMaxAge: time.Second,
+		DeathThreshold:        time.Second,
+	}, clock)
+
+	for i := 1; i <= 10; i++ {
+		index, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+		if err != nil {
+			t.Fatalf("unexpected error dequeueing record: %s", err)
+		}
+		if !dequeued {
+			t.Fatalf("expected a record")
+		}
+		if index.ID != i+10 {
+			t.Fatalf("unexpected record id. want=%d have=%d", i+10, index.ID)
+		}
+	}
+
+	_, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing record: %s", err)
+	}
+	if dequeued {
+		t.Fatalf("expected to hit dequeue limit")
+	}
+
+	// Complete one outstanding record
+	found, err := manager.Complete(context.Background(), "deadbeef", 15, "")
+	if err != nil {
+		t.Fatalf("unexpected error marking record as complete: %s", err)
+	}
+	if !found {
+		t.Fatalf("expected record to be tracked: %s", err)
+	}
+
+	_, dequeued, err = manager.Dequeue(context.Background(), "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing record: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected complete to free up a record slot")
+	}
+}
+
+func TestHeartbeatRemovesUnknownIndexes(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockStore.MarkCompleteFunc.SetDefaultReturn(true, nil)
+	clock := glock.NewMockClock()
+
+	calls := 0
+	mockStore.DequeueWithIndependentTransactionContextFunc.SetDefaultHook(func(ctx context.Context, conds []*sqlf.Query) (workerutil.Record, workerutil.Store, bool, error) {
+		calls++
+		return store.Index{ID: calls + 10}, mockStore, true, nil
+	})
+
+	manager := newManager(mockStore, ManagerOptions{
+		MaximumTransactions:   10,
+		RequeueDelay:          time.Second,
+		CleanupInterval:       time.Second,
+		UnreportedIndexMaxAge: time.Second,
+		DeathThreshold:        time.Second,
+	}, clock)
+
+	for i := 0; i < 5; i++ {
+		_, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+		if err != nil {
+			t.Fatalf("unexpected error dequeueing record: %s", err)
+		}
+		if !dequeued {
+			t.Fatalf("expected a record")
+		}
+	}
+
+	// Advance by UnreportedIndexMaxAge
+	clock.Advance(time.Second)
+
+	if err := manager.Heartbeat(context.Background(), "deadbeef", []int{12, 14, 15}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+
+	if callCount := len(mockStore.RequeueFunc.History()); callCount != 2 {
+		t.Errorf("unexpected requeue call count. want=%d have=%d", 2, callCount)
+	}
+	if callCount := len(mockStore.DoneFunc.History()); callCount != 2 {
+		t.Errorf("unexpected done call count. want=%d have=%d", 2, callCount)
+	}
+
+	testCases := map[int]bool{
+		11: false,
+		12: true,
+		13: false,
+		14: true,
+		15: true,
+	}
+
+	for id, expected := range testCases {
+		name := fmt.Sprintf("id=%d", id)
+
+		t.Run(name, func(t *testing.T) {
+			found, err := manager.Complete(context.Background(), "deadbeef", id, "")
+			if err != nil {
+				t.Fatalf("unexpected error marking record as complete: %s", err)
+			}
+			if found != expected {
+				t.Errorf("unexpected flag value. want=%v have=%v", expected, found)
+			}
+		})
+	}
+
+}
+
+func TestUnresponsiveIndexer(t *testing.T) {
+	mockStore := storemocks.NewMockStore()
+	mockStore.MarkCompleteFunc.SetDefaultReturn(true, nil)
+	clock := glock.NewMockClock()
+
+	calls := 0
+	mockStore.DequeueWithIndependentTransactionContextFunc.SetDefaultHook(func(ctx context.Context, conds []*sqlf.Query) (workerutil.Record, workerutil.Store, bool, error) {
+		calls++
+		return store.Index{ID: calls + 10}, mockStore, true, nil
+	})
+
+	manager := newManager(mockStore, ManagerOptions{
+		MaximumTransactions:   10,
+		RequeueDelay:          time.Second,
+		CleanupInterval:       time.Second,
+		UnreportedIndexMaxAge: time.Second,
+		DeathThreshold:        time.Second,
+	}, clock)
+
+	for i := 0; i < 5; i++ {
+		_, dequeued, err := manager.Dequeue(context.Background(), "deadbeef")
+		if err != nil {
+			t.Fatalf("unexpected error dequeueing record: %s", err)
+		}
+		if !dequeued {
+			t.Fatalf("expected a record")
+		}
+
+		_, dequeued, err = manager.Dequeue(context.Background(), "livebeef")
+		if err != nil {
+			t.Fatalf("unexpected error dequeueing record: %s", err)
+		}
+		if !dequeued {
+			t.Fatalf("expected a record")
+		}
+	}
+
+	// Advance by 75% of DeathThreshold
+	clock.Advance(time.Second * 3 / 4)
+
+	// Keep one indexer alive
+	if err := manager.Heartbeat(context.Background(), "livebeef", []int{12, 14, 16, 18, 20}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+
+	// Advance by 75% of DeathThreshold
+	clock.Advance(time.Second * 3 / 4)
+
+	go manager.Start()
+	defer manager.Stop()
+
+	// Advance by CleanupInterval
+	// Blocking here ensures we completed at least one cleanup run
+	clock.BlockingAdvance(time.Second)
+
+	if callCount := len(mockStore.RequeueFunc.History()); callCount != 5 {
+		t.Errorf("unexpected requeue call count. want=%d have=%d", 5, callCount)
+	}
+	if callCount := len(mockStore.DoneFunc.History()); callCount != 5 {
+		t.Errorf("unexpected done call count. want=%d have=%d", 5, callCount)
+	}
+}

--- a/enterprise/cmd/precise-code-intel-indexer/internal/server/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/server/handler.go
@@ -1,15 +1,79 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/queue/types"
 )
 
 func (s *Server) handler() http.Handler {
 	mux := mux.NewRouter()
+	mux.Path("/dequeue").Methods("POST").HandlerFunc(s.handleDequeue)
+	mux.Path("/complete").Methods("POST").HandlerFunc(s.handleComplete)
+	mux.Path("/heartbeat").Methods("POST").HandlerFunc(s.handleHeartbeat)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux
+}
+
+// POST /dequeue
+func (s *Server) handleDequeue(w http.ResponseWriter, r *http.Request) {
+	var payload types.DequeueRequest
+	if !decodeBody(w, r, &payload) {
+		return
+	}
+
+	index, dequeued, err := s.indexManager.Dequeue(r.Context(), payload.IndexerName)
+	if err != nil {
+		log15.Error("Failed to dequeue index", "err", err)
+		http.Error(w, fmt.Sprintf("failed to dequeue index: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if !dequeued {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	writeJSON(w, index)
+}
+
+// POST /complete
+func (s *Server) handleComplete(w http.ResponseWriter, r *http.Request) {
+	var payload types.CompleteRequest
+	if !decodeBody(w, r, &payload) {
+		return
+	}
+
+	found, err := s.indexManager.Complete(r.Context(), payload.IndexerName, payload.IndexID, payload.ErrorMessage)
+	if err != nil {
+		log15.Error("Failed to complete index job", "err", err)
+		http.Error(w, fmt.Sprintf("failed to complete index job: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// POST /heartbeat
+func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	var payload types.HeartbeatRequest
+	if !decodeBody(w, r, &payload) {
+		return
+	}
+
+	if err := s.indexManager.Heartbeat(r.Context(), payload.IndexerName, payload.IndexIDs); err != nil {
+		log15.Error("Failed to acknowledge heartbeat", "err", err)
+		http.Error(w, fmt.Sprintf("failed to acknowledge heartbeat: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/enterprise/cmd/precise-code-intel-indexer/internal/server/server.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
+	indexmanager "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer/internal/index_manager"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -16,17 +17,20 @@ import (
 const Port = 3189
 
 type Server struct {
-	server *http.Server
-	once   sync.Once
+	indexManager indexmanager.Manager
+	server       *http.Server
+	once         sync.Once
 }
 
-func New() *Server {
+func New(indexManager indexmanager.Manager) *Server {
 	host := ""
 	if env.InsecureDev {
 		host = "127.0.0.1"
 	}
 
-	s := &Server{}
+	s := &Server{
+		indexManager: indexManager,
+	}
 
 	s.server = &http.Server{
 		Addr:    net.JoinHostPort(host, strconv.FormatInt(int64(Port), 10)),

--- a/enterprise/cmd/precise-code-intel-indexer/internal/server/util.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/server/util.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/inconshreveable/log15"
+)
+
+func decodeBody(w http.ResponseWriter, r *http.Request, payload interface{}) bool {
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, fmt.Sprintf("failed to unmarshal payload: %s", err.Error()), http.StatusBadRequest)
+		return false
+	}
+
+	return true
+}
+
+// copyAll writes the contents of r to w and logs on write failure.
+func copyAll(w http.ResponseWriter, r io.Reader) {
+	if _, err := io.Copy(w, r); err != nil {
+		log15.Error("Failed to write payload to client", "err", err)
+	}
+}
+
+// writeJSON writes the JSON-encoded payload to w and logs on write failure.
+// If there is an encoding error, then a 500-level status is written to w.
+func writeJSON(w http.ResponseWriter, payload interface{}) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log15.Error("Failed to serialize result", "err", err)
+		http.Error(w, fmt.Sprintf("failed to serialize result: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	copyAll(w, bytes.NewReader(data))
+}

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	indexmanager "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer/internal/index_manager"
 	indexabilityupdater "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer/internal/indexer"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer/internal/janitor"
@@ -43,6 +45,10 @@ func main() {
 		indexMinimumSearchRatio          = mustParsePercent(rawIndexMinimumSearchRatio, "PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_RATIO")
 		indexMinimumPreciseCount         = mustParseInt(rawIndexMinimumPreciseCount, "PRECISE_CODE_INTEL_INDEX_MINIMUM_PRECISE_COUNT")
 		disableJanitor                   = mustParseBool(rawDisableJanitor, "PRECISE_CODE_INTEL_DISABLE_JANITOR")
+		maximumTransactions              = mustParseInt(rawMaxTransactions, "PRECISE_CODE_INTEL_MAXIMUM_TRANSACTIONS")
+		requeueDelay                     = mustParseInterval(rawRequeueDelay, "PRECISE_CODE_INTEL_REQUEUE_DELAY")
+		cleanupInterval                  = mustParseInterval(rawCleanupInterval, "PRECISE_CODE_INTEL_CLEANUP_INTERVAL")
+		maximumMissedHeartbeats          = mustParseInt(rawMissedHeartbeats, "PRECISE_CODE_INTEL_MAXIMUM_MISSED_HEARTBEATS")
 	)
 
 	observationContext := &observation.Context{
@@ -51,24 +57,31 @@ func main() {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	store := store.NewObserved(mustInitializeStore(), observationContext)
-	MustRegisterQueueMonitor(observationContext.Registerer, store)
+	s := store.NewObserved(mustInitializeStore(), observationContext)
+	MustRegisterQueueMonitor(observationContext.Registerer, s)
 	resetterMetrics := resetter.NewResetterMetrics(prometheus.DefaultRegisterer)
 	indexabilityUpdaterMetrics := indexabilityupdater.NewUpdaterMetrics(prometheus.DefaultRegisterer)
 	schedulerMetrics := scheduler.NewSchedulerMetrics(prometheus.DefaultRegisterer)
 	indexerMetrics := indexer.NewIndexerMetrics(observationContext)
-	server := server.New()
-	indexResetter := resetter.NewIndexResetter(store, resetInterval, resetterMetrics)
+	indexManager := indexmanager.New(store.WorkerutilIndexStore(s), indexmanager.ManagerOptions{
+		MaximumTransactions:   maximumTransactions,
+		RequeueDelay:          requeueDelay,
+		CleanupInterval:       cleanupInterval,
+		UnreportedIndexMaxAge: cleanupInterval * time.Duration(maximumMissedHeartbeats),
+		DeathThreshold:        cleanupInterval * time.Duration(maximumMissedHeartbeats),
+	})
+	server := server.New(indexManager)
+	indexResetter := resetter.NewIndexResetter(s, resetInterval, resetterMetrics)
 
 	indexabilityUpdater := indexabilityupdater.NewUpdater(
-		store,
+		s,
 		gitserver.DefaultClient,
 		indexabilityUpdaterInterval,
 		indexabilityUpdaterMetrics,
 	)
 
 	scheduler := scheduler.NewScheduler(
-		store,
+		s,
 		gitserver.DefaultClient,
 		schedulerInterval,
 		indexBatchSize,
@@ -80,7 +93,7 @@ func main() {
 	)
 
 	indexer := indexer.NewIndexer(
-		store,
+		s,
 		gitserver.DefaultClient,
 		frontendURL,
 		indexerPollInterval,
@@ -88,7 +101,7 @@ func main() {
 	)
 
 	janitorMetrics := janitor.NewJanitorMetrics(prometheus.DefaultRegisterer)
-	janitor := janitor.New(store, janitorInterval, janitorMetrics)
+	janitor := janitor.New(s, janitorInterval, janitorMetrics)
 
 	go server.Start()
 	go indexResetter.Start()

--- a/enterprise/internal/codeintel/queue/types/types.go
+++ b/enterprise/internal/codeintel/queue/types/types.go
@@ -1,0 +1,32 @@
+package types
+
+// DequeueRequest is sent to the index manager API to lock and retrieve a
+// queued index record for processing.
+type DequeueRequest struct {
+	// IndexerName is a unique name identifying the requesting indexer.
+	IndexerName string `json:"indexerName"`
+}
+
+// CompleteRequest is sent to the index manager API once an index request
+// has finished. This request is used both on success and failure.
+type CompleteRequest struct {
+	// IndexerName is a unique name identifying the requesting indexer.
+	IndexerName string `json:"indexerName"`
+
+	// IndexID is the identifier of the index record that was processed.
+	IndexID int `json:"indexId"`
+
+	// ErrorMessage a description of the job failure, if indexing did not succeed.
+	ErrorMessage string `json:"errorMessage"`
+}
+
+// HeartbeatRequest is sent to the index manager API periodically to keep
+// the transactions held for a particular indexer alive.
+type HeartbeatRequest struct {
+	// IndexerName is a unique name identifying the requesting indexer.
+	IndexerName string `json:"indexerName"`
+
+	// IndexIDs is a list of index identifiers which are currently being processed
+	// by the indexer.
+	IndexIDs []int `json:"indexIds"`
+}

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,7 @@ require (
 	github.com/src-d/enry/v2 v2.1.0
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/stripe/stripe-go v70.15.0+incompatible
+	github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775
 	github.com/temoto/robotstxt v1.1.1
 	github.com/tinylib/msgp v1.1.2 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80

--- a/go.sum
+++ b/go.sum
@@ -1272,6 +1272,8 @@ github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08Yu
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775 h1:BLNsFR8l/hj/oGjnJXkd4Vi3s4kQD3/3x8HSAE4bzN0=
+github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775/go.mod h1:XUZ4x3oGhWfiOnUvTslnKKs39AWUct3g3yJvXTQSJOQ=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
This PR implements part of [RFC 199: Arbitrary code execution in the auto-indexer](https://docs.google.com/document/d/1rCduWqaLAbMu2s43RwJTBbRlhL6qS3oqq4iawiGdoVE) and closes https://github.com/sourcegraph/sourcegraph/issues/12664.

This PR exposes additional endpoints in the precise-code-intel-indexer API that will allow downstream (internal) consumers to dequeue index job records for processing, mark them as complete or errored (possibly eventually streaming progress for visibility by end users), and keep actively processed jobs alive via heartbeat requests.