### PR TITLE
search: fuzzify regex patterns for suggestions if globbing is active

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -512,3 +512,12 @@ func Map(query []Node, fns ...func([]Node) []Node) []Node {
 	}
 	return query
 }
+
+func FuzzifyRegexPatterns(nodes []Node) []Node {
+	return MapParameter(nodes, func(field string, value string, negated bool, annotation Annotation) Node {
+		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {
+			value = strings.TrimSuffix(value, "$")
+		}
+		return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
+	})
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -584,3 +584,26 @@ func TestReporevToRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestFuzzifyRegexPatterns(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "repo:foo$", want: `"repo:foo"`},
+		{in: "file:foo$", want: `"file:foo"`},
+		{in: "repohasfile:foo$", want: `"repohasfile:foo"`},
+		{in: "repo:foo$ file:bar$ author:foo", want: `(and "repo:foo" "file:bar" "author:foo")`},
+		{in: "repo:foo$ ^bar$", want: `(and "repo:foo" "^bar$")`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			query, _ := ParseAndOr(tt.in, SearchTypeRegex)
+			got := prettyPrint(FuzzifyRegexPatterns(query))
+			if got != tt.want {
+				t.Fatalf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Relates to #12476 

globs without a suffix `*` do not match substrings, which limits the number of suggestions returned by the backend.

#### Example
Assume we have a repo `foo` with a file, `bar.txt`. Currently the query `repo:foo file:bar` will not show any suggestions, because the glob pattern `bar` does not match `bar.txt`. 

With this PR we pre-process the suggestion-query in the backend to get a behavior for suggestions similar to regexp patterns.

Search results are not affected.  

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
