### PR TITLE
web: include * and ] in trigger characters

### DIFF
--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -25,6 +25,7 @@ const PARSER_STATE: Monaco.languages.IState = {
 }
 
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'
+const specialCharacters = ':-*]'
 
 /**
  * Returns the providers used by the Monaco query input to provide syntax highlighting,
@@ -73,7 +74,7 @@ export function getProviders(
         },
         completion: {
             // An explicit list of trigger characters is needed for the Monaco editor to show completions.
-            triggerCharacters: [':', '-', ...alphabet, ...alphabet.toUpperCase()],
+            triggerCharacters: [...specialCharacters, ...alphabet, ...alphabet.toUpperCase()],
             provideCompletionItems: (textModel, position, context, token) =>
                 combineLatest([parsedQueries, globbing])
                     .pipe(


### PR DESCRIPTION
Relates to #12476 

Once globbing is enabled, we expect users to use `*` very frequently, especially as a suffix. Currently `*` does not trigger a suggestion-query. 

This PR adds `*` and `]` (closing bracket of character classes, like [a-z]) to the list of special characters triggering a query.
 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
