### PR TITLE
URL-persist changeset filters

### DIFF
--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.test.tsx
@@ -3,14 +3,14 @@ import { CampaignChangesets } from './CampaignChangesets'
 import * as H from 'history'
 import { of, Subject } from 'rxjs'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../../shared/src/telemetry/telemetryService'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import { ChangesetExternalState, ChangesetState } from '../../../../graphql-operations'
 
 describe('CampaignChangesets', () => {
     const history = H.createMemoryHistory()
     test('renders', () =>
         expect(
-            shallow(
+            mount(
                 <CampaignChangesets
                     queryChangesets={() =>
                         of({

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -29,6 +29,7 @@ import { TelemetryProps } from '../../../../../../shared/src/telemetry/telemetry
 import { property, isDefined } from '../../../../../../shared/src/util/types'
 import { useObservable } from '../../../../../../shared/src/util/useObservable'
 import { ChangesetFields } from '../../../../graphql-operations'
+import { isValidChangesetExternalState, isValidChangesetReviewState, isValidChangesetCheckState } from '../../utils'
 
 interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
     campaign: Pick<GQL.ICampaign, 'id' | 'closedAt' | 'viewerCanAdminister'>
@@ -41,17 +42,10 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     queryChangesets?: typeof _queryChangesets
 }
 
-function getLSPTextDocumentPositionParameters(
-    hoveredToken: HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
-): RepoSpec & RevisionSpec & ResolvedRevisionSpec & FileSpec & UIPositionSpec & ModeSpec {
-    return {
-        repoName: hoveredToken.repoName,
-        revision: hoveredToken.revision,
-        filePath: hoveredToken.filePath,
-        commitID: hoveredToken.commitID,
-        position: hoveredToken,
-        mode: getModeFromPath(hoveredToken.filePath || ''),
-    }
+interface ChangesetFilters {
+    externalState: GQL.ChangesetExternalState | null
+    reviewState: GQL.ChangesetReviewState | null
+    checkState: GQL.ChangesetCheckState | null
 }
 
 /**
@@ -69,24 +63,23 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
     telemetryService,
     queryChangesets = _queryChangesets,
 }) => {
-    const [externalState, setExternalState] = useState<GQL.ChangesetExternalState | undefined>()
-    const [reviewState, setReviewState] = useState<GQL.ChangesetReviewState | undefined>()
-    const [checkState, setCheckState] = useState<GQL.ChangesetCheckState | undefined>()
-
+    const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
+        checkState: null,
+        externalState: null,
+        reviewState: null,
+    })
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArgs) =>
             merge(of(undefined), changesetUpdates).pipe(
                 switchMap(() =>
                     queryChangesets({
+                        ...changesetFilters,
                         first: args.first ?? null,
                         campaign: campaign.id,
-                        externalState: externalState ?? null,
-                        reviewState: reviewState ?? null,
-                        checkState: checkState ?? null,
                     }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000))))
                 )
             ),
-        [campaign.id, externalState, reviewState, checkState, queryChangesets, changesetUpdates]
+        [campaign.id, changesetFilters, queryChangesets, changesetUpdates]
     )
 
     const containerElements = useMemo(() => new Subject<HTMLElement | null>(), [])
@@ -143,62 +136,9 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
         componentRerenders.next()
     }, [componentRerenders, hoverState])
 
-    const changesetFiltersRow = (
-        <div className="form-inline mb-0 mt-2">
-            <label htmlFor="changeset-state-filter">State</label>
-            <select
-                className="form-control mx-2"
-                value={externalState}
-                onChange={event =>
-                    setExternalState((event.target.value || undefined) as GQL.ChangesetExternalState | undefined)
-                }
-                id="changeset-state-filter"
-            >
-                <option value="">All</option>
-                {Object.values(GQL.ChangesetExternalState).map(state => (
-                    <option value={state} key={state}>
-                        {upperFirst(lowerCase(state))}
-                    </option>
-                ))}
-            </select>
-            <label htmlFor="changeset-review-state-filter">Review state</label>
-            <select
-                className="form-control mx-2"
-                value={reviewState}
-                onChange={event =>
-                    setReviewState((event.target.value || undefined) as GQL.ChangesetReviewState | undefined)
-                }
-                id="changeset-review-state-filter"
-            >
-                <option value="">All</option>
-                {Object.values(GQL.ChangesetReviewState).map(state => (
-                    <option value={state} key={state}>
-                        {upperFirst(lowerCase(state))}
-                    </option>
-                ))}
-            </select>
-            <label htmlFor="changeset-check-state-filter">Check state</label>
-            <select
-                className="form-control mx-2"
-                value={checkState}
-                onChange={event =>
-                    setCheckState((event.target.value || undefined) as GQL.ChangesetCheckState | undefined)
-                }
-                id="changeset-check-state-filter"
-            >
-                <option value="">All</option>
-                {Object.values(GQL.ChangesetCheckState).map(state => (
-                    <option value={state} key={state}>
-                        {upperFirst(lowerCase(state))}
-                    </option>
-                ))}
-            </select>
-        </div>
-    )
-
     return (
         <>
-            {changesetFiltersRow}
+            <ChangesetFilterRow history={history} location={location} onFiltersChange={setChangesetFilters} />
             <div className="list-group position-relative" ref={nextContainerElement}>
                 <FilteredConnection<ChangesetFields, Omit<ChangesetNodeProps, 'node'>>
                     className="mt-2"
@@ -218,7 +158,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                     pluralNoun="changesets"
                     history={history}
                     location={location}
-                    useURLQuery={false}
+                    useURLQuery={true}
                 />
                 {hoverState?.hoverOverlayProps && (
                     <WebHoverOverlay
@@ -235,4 +175,128 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
             </div>
         </>
     )
+}
+
+interface ChangesetFilterRowProps {
+    history: H.History
+    location: H.Location
+    onFiltersChange: (newFilters: ChangesetFilters) => void
+}
+
+const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
+    history,
+    location,
+    onFiltersChange,
+}) => {
+    const searchParameters = new URLSearchParams(location.search)
+    const [externalState, setExternalState] = useState<GQL.ChangesetExternalState | undefined>(() => {
+        const value = searchParameters.get('external_state')
+        return value && isValidChangesetExternalState(value) ? value : undefined
+    })
+    const [reviewState, setReviewState] = useState<GQL.ChangesetReviewState | undefined>(() => {
+        const value = searchParameters.get('review_state')
+        return value && isValidChangesetReviewState(value) ? value : undefined
+    })
+    const [checkState, setCheckState] = useState<GQL.ChangesetCheckState | undefined>(() => {
+        const value = searchParameters.get('check_state')
+        return value && isValidChangesetCheckState(value) ? value : undefined
+    })
+    useEffect(() => {
+        const searchParameters = new URLSearchParams(location.search)
+        if (externalState) {
+            searchParameters.set('external_state', externalState)
+        } else {
+            searchParameters.delete('external_state')
+        }
+        if (reviewState) {
+            searchParameters.set('review_state', reviewState)
+        } else {
+            searchParameters.delete('review_state')
+        }
+        if (checkState) {
+            searchParameters.set('check_state', checkState)
+        } else {
+            searchParameters.delete('check_state')
+        }
+        history.replace({ ...location, search: searchParameters.toString() })
+        // Update the filters in the parent component.
+        onFiltersChange({
+            externalState: externalState || null,
+            reviewState: reviewState || null,
+            checkState: checkState || null,
+        })
+        // We cannot depend on the history, since it's modified by this hook and that would cause an infinite render loop.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [externalState, reviewState, checkState])
+    return (
+        <div className="form-inline mb-0 mt-2">
+            <ChangesetFilter<GQL.ChangesetExternalState>
+                values={Object.values(GQL.ChangesetExternalState)}
+                label="State"
+                htmlID="changeset-state-filter"
+                selected={externalState}
+                onChange={setExternalState}
+            />
+            <ChangesetFilter<GQL.ChangesetReviewState>
+                values={Object.values(GQL.ChangesetReviewState)}
+                label="Review state"
+                htmlID="changeset-review-state-filter"
+                selected={reviewState}
+                onChange={setReviewState}
+            />
+            <ChangesetFilter<GQL.ChangesetCheckState>
+                values={Object.values(GQL.ChangesetCheckState)}
+                label="Check state"
+                htmlID="changeset-check-state-filter"
+                selected={checkState}
+                onChange={setCheckState}
+            />
+        </div>
+    )
+}
+
+interface ChangesetFilterProps<T extends string> {
+    label: string
+    htmlID: string
+    values: T[]
+    selected: T | undefined
+    onChange: (value: T | undefined) => void
+}
+
+export const ChangesetFilter = <T extends string>({
+    htmlID,
+    label,
+    values,
+    selected,
+    onChange,
+}: ChangesetFilterProps<T>): React.ReactElement<ChangesetFilterProps<T>> => (
+    <>
+        <label htmlFor={htmlID}>{label}</label>
+        <select
+            className="form-control mx-2"
+            value={selected}
+            onChange={event => onChange((event.target.value ?? undefined) as T | undefined)}
+            id={htmlID}
+        >
+            <option value="">All</option>
+            {values.map(state => (
+                <option value={state} key={state}>
+                    {upperFirst(lowerCase(state))}
+                </option>
+            ))}
+        </select>
+    </>
+)
+
+function getLSPTextDocumentPositionParameters(
+    hoveredToken: HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
+): RepoSpec & RevisionSpec & ResolvedRevisionSpec & FileSpec & UIPositionSpec & ModeSpec {
+    return {
+        repoName: hoveredToken.repoName,
+        revision: hoveredToken.revision,
+        filePath: hoveredToken.filePath,
+        commitID: hoveredToken.commitID,
+        position: hoveredToken,
+        mode: getModeFromPath(hoveredToken.filePath || ''),
+    }
 }

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/CampaignChangesets.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/CampaignChangesets.test.tsx.snap
@@ -1,131 +1,199 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CampaignChangesets renders 1`] = `
-<Fragment>
-  <div
-    className="form-inline mb-0 mt-2"
+<CampaignChangesets
+  campaign={
+    Object {
+      "closedAt": null,
+      "id": "123",
+      "viewerCanAdminister": true,
+    }
+  }
+  campaignUpdates="[Subject]"
+  changesetUpdates="[Subject]"
+  history="[History]"
+  isLightTheme={true}
+  location="[Location path=/]"
+  queryChangesets={[Function]}
+  telemetryService={
+    Object {
+      "log": [Function],
+      "logViewEvent": [Function],
+    }
+  }
+>
+  <ChangesetFilterRow
+    history="[History]"
+    location="[Location path=/]"
+    onFiltersChange={[Function]}
   >
-    <label
-      htmlFor="changeset-state-filter"
+    <div
+      className="form-inline mb-0 mt-2"
     >
-      State
-    </label>
-    <select
-      className="form-control mx-2"
-      id="changeset-state-filter"
-      onChange={[Function]}
-    >
-      <option
-        value=""
+      <ChangesetFilter
+        htmlID="changeset-state-filter"
+        label="State"
+        onChange={[Function]}
+        values={
+          Array [
+            "OPEN",
+            "CLOSED",
+            "MERGED",
+            "DELETED",
+          ]
+        }
       >
-        All
-      </option>
-      <option
-        key="OPEN"
-        value="OPEN"
+        <label
+          htmlFor="changeset-state-filter"
+        >
+          State
+        </label>
+        <select
+          className="form-control mx-2"
+          id="changeset-state-filter"
+          onChange={[Function]}
+        >
+          <option
+            value=""
+          >
+            All
+          </option>
+          <option
+            key="OPEN"
+            value="OPEN"
+          >
+            Open
+          </option>
+          <option
+            key="CLOSED"
+            value="CLOSED"
+          >
+            Closed
+          </option>
+          <option
+            key="MERGED"
+            value="MERGED"
+          >
+            Merged
+          </option>
+          <option
+            key="DELETED"
+            value="DELETED"
+          >
+            Deleted
+          </option>
+        </select>
+      </ChangesetFilter>
+      <ChangesetFilter
+        htmlID="changeset-review-state-filter"
+        label="Review state"
+        onChange={[Function]}
+        values={
+          Array [
+            "APPROVED",
+            "CHANGES_REQUESTED",
+            "PENDING",
+            "COMMENTED",
+            "DISMISSED",
+          ]
+        }
       >
-        Open
-      </option>
-      <option
-        key="CLOSED"
-        value="CLOSED"
+        <label
+          htmlFor="changeset-review-state-filter"
+        >
+          Review state
+        </label>
+        <select
+          className="form-control mx-2"
+          id="changeset-review-state-filter"
+          onChange={[Function]}
+        >
+          <option
+            value=""
+          >
+            All
+          </option>
+          <option
+            key="APPROVED"
+            value="APPROVED"
+          >
+            Approved
+          </option>
+          <option
+            key="CHANGES_REQUESTED"
+            value="CHANGES_REQUESTED"
+          >
+            Changes requested
+          </option>
+          <option
+            key="PENDING"
+            value="PENDING"
+          >
+            Pending
+          </option>
+          <option
+            key="COMMENTED"
+            value="COMMENTED"
+          >
+            Commented
+          </option>
+          <option
+            key="DISMISSED"
+            value="DISMISSED"
+          >
+            Dismissed
+          </option>
+        </select>
+      </ChangesetFilter>
+      <ChangesetFilter
+        htmlID="changeset-check-state-filter"
+        label="Check state"
+        onChange={[Function]}
+        values={
+          Array [
+            "PENDING",
+            "PASSED",
+            "FAILED",
+          ]
+        }
       >
-        Closed
-      </option>
-      <option
-        key="MERGED"
-        value="MERGED"
-      >
-        Merged
-      </option>
-      <option
-        key="DELETED"
-        value="DELETED"
-      >
-        Deleted
-      </option>
-    </select>
-    <label
-      htmlFor="changeset-review-state-filter"
-    >
-      Review state
-    </label>
-    <select
-      className="form-control mx-2"
-      id="changeset-review-state-filter"
-      onChange={[Function]}
-    >
-      <option
-        value=""
-      >
-        All
-      </option>
-      <option
-        key="APPROVED"
-        value="APPROVED"
-      >
-        Approved
-      </option>
-      <option
-        key="CHANGES_REQUESTED"
-        value="CHANGES_REQUESTED"
-      >
-        Changes requested
-      </option>
-      <option
-        key="PENDING"
-        value="PENDING"
-      >
-        Pending
-      </option>
-      <option
-        key="COMMENTED"
-        value="COMMENTED"
-      >
-        Commented
-      </option>
-      <option
-        key="DISMISSED"
-        value="DISMISSED"
-      >
-        Dismissed
-      </option>
-    </select>
-    <label
-      htmlFor="changeset-check-state-filter"
-    >
-      Check state
-    </label>
-    <select
-      className="form-control mx-2"
-      id="changeset-check-state-filter"
-      onChange={[Function]}
-    >
-      <option
-        value=""
-      >
-        All
-      </option>
-      <option
-        key="PENDING"
-        value="PENDING"
-      >
-        Pending
-      </option>
-      <option
-        key="PASSED"
-        value="PASSED"
-      >
-        Passed
-      </option>
-      <option
-        key="FAILED"
-        value="FAILED"
-      >
-        Failed
-      </option>
-    </select>
-  </div>
+        <label
+          htmlFor="changeset-check-state-filter"
+        >
+          Check state
+        </label>
+        <select
+          className="form-control mx-2"
+          id="changeset-check-state-filter"
+          onChange={[Function]}
+        >
+          <option
+            value=""
+          >
+            All
+          </option>
+          <option
+            key="PENDING"
+            value="PENDING"
+          >
+            Pending
+          </option>
+          <option
+            key="PASSED"
+            value="PASSED"
+          >
+            Passed
+          </option>
+          <option
+            key="FAILED"
+            value="FAILED"
+          >
+            Failed
+          </option>
+        </select>
+      </ChangesetFilter>
+    </div>
+  </ChangesetFilterRow>
   <div
     className="list-group position-relative"
   >
@@ -163,8 +231,256 @@ exports[`CampaignChangesets renders 1`] = `
       noun="changeset"
       pluralNoun="changesets"
       queryConnection={[Function]}
-      useURLQuery={false}
-    />
+      useURLQuery={true}
+    >
+      <div
+        className="filtered-connection test-filtered-connection filtered-connection--noncompact mt-2"
+      >
+        <ConnectionNodes
+          connection={
+            Object {
+              "nodes": Array [
+                Object {
+                  "__typename": "HiddenExternalChangeset",
+                  "createdAt": "2020-01-03T00:00:00.000Z",
+                  "externalState": "OPEN",
+                  "id": "0",
+                  "nextSyncAt": null,
+                  "state": "SYNCED",
+                  "updatedAt": "2020-01-04T00:00:00.000Z",
+                },
+              ],
+              "totalCount": 1,
+            }
+          }
+          connectionQuery=""
+          first={15}
+          loading={false}
+          location="[Location path=/]"
+          nodeComponent={[Function]}
+          nodeComponentProps={
+            Object {
+              "campaignUpdates": "[Subject]",
+              "extensionInfo": Object {
+                "extensionsController": undefined,
+                "hoverifier": Object {
+                  "hoverState": Object {
+                    "actionsOrError": undefined,
+                    "highlightedRange": undefined,
+                    "hoverOverlayProps": undefined,
+                    "hoveredTokenElement": undefined,
+                    "selectedPosition": undefined,
+                  },
+                  "hoverStateUpdates": "[Subject]",
+                  "hoverify": [Function],
+                  "unsubscribe": [Function],
+                },
+              },
+              "history": "[History]",
+              "isLightTheme": true,
+              "location": "[Location path=/]",
+              "viewerCanAdminister": true,
+            }
+          }
+          noun="changeset"
+          onShowMore={[Function]}
+          pluralNoun="changesets"
+          query=""
+        >
+          <ul
+            className="filtered-connection__nodes "
+          >
+            <ChangesetNode
+              campaignUpdates="[Subject]"
+              extensionInfo={
+                Object {
+                  "extensionsController": undefined,
+                  "hoverifier": Object {
+                    "hoverState": Object {
+                      "actionsOrError": undefined,
+                      "highlightedRange": undefined,
+                      "hoverOverlayProps": undefined,
+                      "hoveredTokenElement": undefined,
+                      "selectedPosition": undefined,
+                    },
+                    "hoverStateUpdates": "[Subject]",
+                    "hoverify": [Function],
+                    "unsubscribe": [Function],
+                  },
+                }
+              }
+              history="[History]"
+              isLightTheme={true}
+              key="0"
+              location="[Location path=/]"
+              node={
+                Object {
+                  "__typename": "HiddenExternalChangeset",
+                  "createdAt": "2020-01-03T00:00:00.000Z",
+                  "externalState": "OPEN",
+                  "id": "0",
+                  "nextSyncAt": null,
+                  "state": "SYNCED",
+                  "updatedAt": "2020-01-04T00:00:00.000Z",
+                }
+              }
+              viewerCanAdminister={true}
+            >
+              <HiddenExternalChangesetNode
+                campaignUpdates="[Subject]"
+                extensionInfo={
+                  Object {
+                    "extensionsController": undefined,
+                    "hoverifier": Object {
+                      "hoverState": Object {
+                        "actionsOrError": undefined,
+                        "highlightedRange": undefined,
+                        "hoverOverlayProps": undefined,
+                        "hoveredTokenElement": undefined,
+                        "selectedPosition": undefined,
+                      },
+                      "hoverStateUpdates": "[Subject]",
+                      "hoverify": [Function],
+                      "unsubscribe": [Function],
+                    },
+                  }
+                }
+                history="[History]"
+                isLightTheme={true}
+                location="[Location path=/]"
+                node={
+                  Object {
+                    "__typename": "HiddenExternalChangeset",
+                    "createdAt": "2020-01-03T00:00:00.000Z",
+                    "externalState": "OPEN",
+                    "id": "0",
+                    "nextSyncAt": null,
+                    "state": "SYNCED",
+                    "updatedAt": "2020-01-04T00:00:00.000Z",
+                  }
+                }
+                viewerCanAdminister={true}
+              >
+                <li
+                  className="list-group-item test-changeset-node"
+                >
+                  <div
+                    className="changeset-node__content changeset-node__content--no-collapse flex-fill"
+                  >
+                    <div
+                      className="d-flex align-items-start m-1 ml-2"
+                    >
+                      <div
+                        className="changeset-node__content flex-fill"
+                      >
+                        <div
+                          className="d-flex flex-column"
+                        >
+                          <div
+                            className="m-0 mb-2"
+                          >
+                            <h3
+                              className="m-0 d-inline"
+                            >
+                              <ChangesetStateIcon
+                                externalState="OPEN"
+                              >
+                                <Memo(SourcePullIcon)
+                                  className="mr-1 icon-inline text-success"
+                                  data-tooltip="open"
+                                >
+                                  <svg
+                                    className="mdi-icon mr-1 icon-inline text-success"
+                                    data-tooltip="open"
+                                    fill="currentColor"
+                                    height={24}
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                  >
+                                    <path
+                                      d="M6,3A3,3 0 0,1 9,6C9,7.31 8.17,8.42 7,8.83V15.17C8.17,15.58 9,16.69 9,18A3,3 0 0,1 6,21A3,3 0 0,1 3,18C3,16.69 3.83,15.58 5,15.17V8.83C3.83,8.42 3,7.31 3,6A3,3 0 0,1 6,3M6,5A1,1 0 0,0 5,6A1,1 0 0,0 6,7A1,1 0 0,0 7,6A1,1 0 0,0 6,5M6,17A1,1 0 0,0 5,18A1,1 0 0,0 6,19A1,1 0 0,0 7,18A1,1 0 0,0 6,17M21,18A3,3 0 0,1 18,21A3,3 0 0,1 15,18C15,16.69 15.83,15.58 17,15.17V7H15V10.25L10.75,6L15,1.75V5H17A2,2 0 0,1 19,7V15.17C20.17,15.58 21,16.69 21,18M18,17A1,1 0 0,0 17,18A1,1 0 0,0 18,19A1,1 0 0,0 19,18A1,1 0 0,0 18,17Z"
+                                    />
+                                  </svg>
+                                </Memo(SourcePullIcon)>
+                              </ChangesetStateIcon>
+                              <span
+                                className="text-muted"
+                              >
+                                Changeset in a private repository
+                              </span>
+                            </h3>
+                          </div>
+                          <div>
+                            <ChangesetLastSynced
+                              changeset={
+                                Object {
+                                  "__typename": "HiddenExternalChangeset",
+                                  "createdAt": "2020-01-03T00:00:00.000Z",
+                                  "externalState": "OPEN",
+                                  "id": "0",
+                                  "nextSyncAt": null,
+                                  "state": "SYNCED",
+                                  "updatedAt": "2020-01-04T00:00:00.000Z",
+                                }
+                              }
+                              viewerCanAdminister={false}
+                            >
+                              <small
+                                className="text-muted"
+                              >
+                                Last synced 
+                                about 14 years
+                                 ago.
+                                 
+                                <span
+                                  data-tooltip="Not scheduled for syncing."
+                                >
+                                  <Memo(InfoCircleOutlineIcon)
+                                    className="icon-inline"
+                                    onClick={[Function]}
+                                  >
+                                    <svg
+                                      className="mdi-icon icon-inline"
+                                      fill="currentColor"
+                                      height={24}
+                                      onClick={[Function]}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                    >
+                                      <path
+                                        d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
+                                      />
+                                    </svg>
+                                  </Memo(InfoCircleOutlineIcon)>
+                                </span>
+                              </small>
+                            </ChangesetLastSynced>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              </HiddenExternalChangesetNode>
+            </ChangesetNode>
+          </ul>
+          <p
+            className="filtered-connection__summary"
+          >
+            <small>
+              <span>
+                1
+                 
+                changeset
+                 
+                total
+              </span>
+               
+            </small>
+          </p>
+        </ConnectionNodes>
+      </div>
+    </FilteredConnection>
   </div>
-</Fragment>
+</CampaignChangesets>
 `;

--- a/web/src/enterprise/campaigns/utils.ts
+++ b/web/src/enterprise/campaigns/utils.ts
@@ -1,0 +1,22 @@
+import {
+    ChangesetExternalState,
+    ChangesetCheckState,
+    ChangesetReviewState,
+    ChangesetState,
+} from '../../graphql-operations'
+
+export function isValidChangesetState(input: string): input is ChangesetState {
+    return Object.values<string>(ChangesetState).includes(input)
+}
+
+export function isValidChangesetExternalState(input: string): input is ChangesetExternalState {
+    return Object.values<string>(ChangesetExternalState).includes(input)
+}
+
+export function isValidChangesetReviewState(input: string): input is ChangesetReviewState {
+    return Object.values<string>(ChangesetReviewState).includes(input)
+}
+
+export function isValidChangesetCheckState(input: string): input is ChangesetCheckState {
+    return Object.values<string>(ChangesetCheckState).includes(input)
+}


### PR DESCRIPTION
This also refactors the filters into a separate component, which will make it easier to implement the new UI components based on this.

Closes #12472 