### PR TITLE
update docs for more verbose watchman instructions

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -184,7 +184,13 @@ The following are two recommendations for installing these dependencies:
     curl -L https://github.com/comby-tools/comby/releases/download/0.11.3/comby-0.11.3-x86_64-linux.tar.gz | tar xvz
 
     # install watchman (you must put the binary and shared libraries on your $PATH and $LD_LIBRARY_PATH)
-    curl -L https://github.com/facebook/watchman/releases/download/v2020.07.13.00/watchman-v2020.07.13.00-linux.zip
+    curl -LO https://github.com/facebook/watchman/releases/download/v2020.07.13.00/watchman-v2020.07.13.00-linux.zip
+    unzip watchman-*-linux.zip
+    sudo mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
+    sudo cp bin/* /usr/local/bin
+    sudo cp lib/* /usr/local/lib
+    sudo chmod 755 /usr/local/bin/watchman
+    sudo chmod 2777 /usr/local/var/run/watchman
 
     # nvm (to manage Node.js)
     NVM_VERSION="$(curl https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name)"


### PR DESCRIPTION
Just a small update to clarify the watchman instructions. The curl command was broken and the following commands make it a bit quicker and easier for those not as confident with those environment variables 