### PR TITLE
search: specify branch for zoektSearchHEADOnlyFiles

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -164,7 +164,7 @@ func (s *indexedSearchRequest) Search(ctx context.Context) (fm []*FileMatchResol
 	case symbolRequest:
 		return zoektSearch(ctx, s.args, s.repos, s.typ, since)
 	case fileRequest:
-		return zoektSearchHEADOnlyFiles(ctx, s.args, s.repos.repoRevs, false, since)
+		return zoektSearchHEADOnlyFiles(ctx, s.args, s.repos, false, since)
 	default:
 		return nil, false, nil, fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
 	}


### PR DESCRIPTION
Structural search expects to only search HEAD (currently). However, it
was using a RepoSet which will return results for any branch we have
indexed. I believe this would result in potential benign false positives
for files to search. We switch to instead passing in the computed
RepoBranches (which should be limited to HEAD).

Part of https://github.com/sourcegraph/sourcegraph/issues/11902