### PR TITLE
search: trace zoekt when count or timeout is specified

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 type indexedRequestType string
@@ -440,6 +441,11 @@ func contextWithoutDeadline(cOld context.Context) (context.Context, context.Canc
 		case <-cNew.Done():
 		}
 	}()
+
+	// Set trace context so we still get spans propagated
+	if tr := trace.TraceFromContext(cOld); tr != nil {
+		cNew = trace.ContextWithTrace(cNew, tr)
+	}
 
 	return cNew, cancel
 }

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -253,15 +253,8 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		// We'll create a new context that gets cancelled if the other context is cancelled for any
 		// reason other than the deadline being exceeded. This essentially means the deadline for the new context
 		// will be `deadline + time for zoekt to cancel + network latency`.
-		cNew, cancel := context.WithCancel(context.Background())
-		go func(cOld context.Context) {
-			<-cOld.Done()
-			// cancel the new context if the old one is done for some reason other than the deadline passing.
-			if cOld.Err() != context.DeadlineExceeded {
-				cancel()
-			}
-		}(ctx)
-		ctx = cNew
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithoutDeadline(ctx)
 		defer cancel()
 	}
 
@@ -431,6 +424,21 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 	}
 
 	return symbols
+}
+
+// contextWithoutDeadline returns a context which will cancel if the cOld is
+// canceled.
+func contextWithoutDeadline(cOld context.Context) (context.Context, context.CancelFunc) {
+	cNew, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-cOld.Done()
+		// cancel the new context if the old one is done for some reason other than the deadline passing.
+		if cOld.Err() != context.DeadlineExceeded {
+			cancel()
+		}
+	}()
+
+	return cNew, cancel
 }
 
 func noOpAnyChar(re *syntax.Regexp) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -431,10 +431,13 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 func contextWithoutDeadline(cOld context.Context) (context.Context, context.CancelFunc) {
 	cNew, cancel := context.WithCancel(context.Background())
 	go func() {
-		<-cOld.Done()
-		// cancel the new context if the old one is done for some reason other than the deadline passing.
-		if cOld.Err() != context.DeadlineExceeded {
-			cancel()
+		select {
+		case <-cOld.Done():
+			// cancel the new context if the old one is done for some reason other than the deadline passing.
+			if cOld.Err() != context.DeadlineExceeded {
+				cancel()
+			}
+		case <-cNew.Done():
 		}
 	}()
 


### PR DESCRIPTION
I noticed we sometimes didn't get zoekt spans in Jaeger traces. Turns
out it's due to the "no context deadline" logic we use when count or
timeout fields are specified. This is because we use a new context. We
now set the trace on the new context.
