### PR TITLE
graphqlbackend: audit uses of context.Background

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -71,9 +71,6 @@ type SearchImplementer interface {
 
 // NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
 func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplementer, error) {
-	tr, _ := trace.New(context.Background(), "graphql.schemaResolver", "Search")
-	defer tr.Finish()
-
 	settings, err := decodedViewerFinalSettings(ctx)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -150,15 +150,8 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		// We'll create a new context that gets cancelled if the other context is cancelled for any
 		// reason other than the deadline being exceeded. This essentially means the deadline for the new context
 		// will be `deadline + time for zoekt to cancel + network latency`.
-		cNew, cancel := context.WithCancel(context.Background())
-		go func(cOld context.Context) {
-			<-cOld.Done()
-			// cancel the new context if the old one is done for some reason other than the deadline passing.
-			if cOld.Err() != context.DeadlineExceeded {
-				cancel()
-			}
-		}(ctx)
-		ctx = cNew
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithoutDeadline(ctx)
 		defer cancel()
 	}
 

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -54,13 +54,13 @@ func limitOrDefault(first *int32) int {
 // indexedSymbols checks to see if Zoekt has indexed symbols information for a
 // repository at a specific commit. If it has it returns the branch name (for
 // use when querying zoekt). Otherwise an empty string is returned.
-func indexedSymbolsBranch(repository, commit string) string {
+func indexedSymbolsBranch(ctx context.Context, repository, commit string) string {
 	z := search.Indexed()
 	if !z.Enabled() {
 		return ""
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	set, err := z.ListAll(ctx)
 	if err != nil {
@@ -165,7 +165,9 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 }
 
 func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
-	if branch := indexedSymbolsBranch(string(commit.repoResolver.repo.Name), string(commit.oid)); branch != "" {
+	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
+	// and remove indexedSymbolsBranch.
+	if branch := indexedSymbolsBranch(ctx, string(commit.repoResolver.repo.Name), string(commit.oid)); branch != "" {
 		return searchZoektSymbols(ctx, commit, branch, query, first, includePatterns)
 	}
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -431,6 +431,12 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 // canceled.
 func contextWithoutDeadline(cOld context.Context) (context.Context, context.CancelFunc) {
 	cNew, cancel := context.WithCancel(context.Background())
+
+	// Set trace context so we still get spans propagated
+	if tr := trace.TraceFromContext(cOld); tr != nil {
+		cNew = trace.ContextWithTrace(cNew, tr)
+	}
+
 	go func() {
 		select {
 		case <-cOld.Done():
@@ -441,11 +447,6 @@ func contextWithoutDeadline(cOld context.Context) (context.Context, context.Canc
 		case <-cNew.Done():
 		}
 	}()
-
-	// Set trace context so we still get spans propagated
-	if tr := trace.TraceFromContext(cOld); tr != nil {
-		cNew = trace.ContextWithTrace(cNew, tr)
-	}
 
 	return cNew, cancel
 }


### PR DESCRIPTION
Looked at the places we used context.Background in graphqlbackend. Pretty much all are invalid.