### PR TITLE
docker-compose: fix permissions in LSIF data migration

### DIFF
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -42,7 +42,12 @@ If your users have uploaded LSIF precise code intelligence data, you may keep it
 docker run --rm -it -v /var/lib/docker:/docker alpine:latest sh -c 'cp -R /docker/volumes/docker-compose_lsif-server/_data/* /docker/volumes/docker-compose_precise-code-intel-bundle-manager/_data/'
 ```
 
-(No restart is required after running the above command.)
+Followed by:
+
+```sh
+docker run --rm -it -v /var/lib/docker:/docker alpine:latest sh -c 'chown -R 100:101 /docker/volumes/docker-compose_precise-code-intel-bundle-manager'
+docker restart precise-code-intel-bundle-manager
+```
 
 ## v3.14.2 -> v3.14.4
 


### PR DESCRIPTION
Fixes an issue reported by a customer with @efritz in https://sourcegraph.atlassian.net/jira/servicedesk/projects/SG/queues/custom/1/SG-295

When following this migration:

- Bundle-manager is started, which creates the volume directory with `100:101` as expected
- lsif-server's data was missing the USER directive _before_ and thus was owned by root (if you missed the 3.13 -> 3.14 migration, https://docs.sourcegraph.com/admin/updates/docker_compose#v3-13-3-14)
-In this migration, you copy the data over, so the volume has OK permissions but the data is still owned by root

This corrects that case.