### PR TITLE
monitoring: remove no_results__suggest_quotes from alert

### DIFF
--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -281,7 +281,7 @@ func Frontend() *Container {
 						{
 							Name:            "search_api_alert_user_suggestions",
 							Description:     "search API alert user suggestions shown every 5m",
-							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="other"}[5m]))`,
+							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="other"}[5m]))`,
 							DataMayNotExist: true,
 							Warning:         Alert{GreaterOrEqual: 50},
 							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}"),


### PR DESCRIPTION
Filters out quote suggestions from the search suggestions alert query - from @rvantonder:

> We wrongly suggest this alert sometimes (False positive), since a query like content:"quoted value" is legitimate query (no user error) but will still come up if quoted value does not exist. This suggestion was added back in the day of literal vs regex search when the error of quotes was common. We can and should be smarter about it now. But either way it's low value/prone to FP and not worth showing/monitoring.

[comparison](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-7d%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22sum%20by%20(alert_type)(increase(src_graphql_search_response%7Bstatus%3D%5C%22alert%5C%22,alert_type!~%5C%22timed_out%7Cno_results__suggest_quotes%5C%22,source%3D%5C%22other%5C%22%7D%5B5m%5D))%22%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D&right=%5B%22now-7d%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22sum%20by%20(alert_type)(increase(src_graphql_search_response%7Bstatus%3D%5C%22alert%5C%22,alert_type!~%5C%22timed_out%5C%22,source%3D%5C%22other%5C%22%7D%5B5m%5D))%22%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

[thread](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1596507176198700)
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
