### PR TITLE
web: highlight search operators and/or/not

### DIFF
--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -609,8 +609,7 @@ describe('parseSearchQuery()', () => {
                             start: 15,
                         },
                         token: {
-                            type: 'literal',
-                            value: 'and',
+                            type: 'operator',
                         },
                     },
                     {
@@ -690,8 +689,7 @@ describe('parseSearchQuery()', () => {
                             start: 3,
                         },
                         token: {
-                            type: 'literal',
-                            value: 'and',
+                            type: 'operator',
                         },
                     },
                     {
@@ -737,8 +735,7 @@ describe('parseSearchQuery()', () => {
                             start: 10,
                         },
                         token: {
-                            type: 'literal',
-                            value: 'or',
+                            type: 'operator',
                         },
                     },
                     {
@@ -784,8 +781,7 @@ describe('parseSearchQuery()', () => {
                             start: 16,
                         },
                         token: {
-                            type: 'literal',
-                            value: 'and',
+                            type: 'operator',
                         },
                     },
                     {

--- a/shared/src/search/parser/parser.test.ts
+++ b/shared/src/search/parser/parser.test.ts
@@ -610,6 +610,7 @@ describe('parseSearchQuery()', () => {
                         },
                         token: {
                             type: 'operator',
+                            value: 'and',
                         },
                     },
                     {

--- a/shared/src/search/parser/parser.ts
+++ b/shared/src/search/parser/parser.ts
@@ -42,6 +42,16 @@ export interface Filter {
 }
 
 /**
+ * Represents an operator in a search query.
+ *
+ * Example: AND, OR, NOT.
+ */
+export interface Operator {
+    type: 'operator'
+    value: string
+}
+
+/**
  * Represents a sequence of tokens in a search query.
  */
 export interface Sequence {
@@ -63,6 +73,7 @@ export type Token =
     | { type: 'whitespace' }
     | { type: 'openingParen' }
     | { type: 'closingParen' }
+    | { type: 'operator' }
     | Literal
     | Filter
     | Sequence
@@ -226,6 +237,8 @@ const whitespace = pattern(/\s+/, { type: 'whitespace' as const }, 'whitespace')
 
 const literal = pattern(/[^\s)]+/)
 
+const operator = pattern(/(and|AND|or|OR|not|NOT)/, { type: 'operator' as const })
+
 const filterKeyword = pattern(/-?[A-Za-z]+(?=:)/)
 
 const filterDelimiter = character(':')
@@ -304,7 +317,7 @@ const searchQuery = zeroOrMore(
         whitespace,
         openingParen,
         closingParen,
-        ...[filter, quoted, literal].map(token =>
+        ...[operator, filter, quoted, literal].map(token =>
             followedBy(token, oneOf<{ type: 'whitespace' } | { type: 'closingParen' }>(whitespace, closingParen))
         )
     )

--- a/shared/src/search/parser/tokens.test.ts
+++ b/shared/src/search/parser/tokens.test.ts
@@ -71,7 +71,7 @@ describe('getMonacoTokens()', () => {
                 startIndex: 8,
             },
             {
-                scopes: 'identifier',
+                scopes: 'operator',
                 startIndex: 9,
             },
             {

--- a/shared/src/search/parser/tokens.ts
+++ b/shared/src/search/parser/tokens.ts
@@ -28,6 +28,12 @@ export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.
                     }
                 }
                 break
+            case 'operator':
+                tokens.push({
+                    startIndex: range.start,
+                    scopes: 'operator',
+                })
+                break
             default:
                 tokens.push({
                     startIndex: range.start,

--- a/web/src/components/MonacoEditor.tsx
+++ b/web/src/components/MonacoEditor.tsx
@@ -33,6 +33,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
     rules: [
         { token: 'identifier', foreground: '#f2f4f8' },
         { token: 'keyword', foreground: '#569cd6' },
+        { token: 'operator', foreground: '#c586c0' },
     ],
 })
 
@@ -57,6 +58,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
     rules: [
         { token: 'identifier', foreground: '#2b3750' },
         { token: 'keyword', foreground: '#268bd2' },
+        { token: 'operator', foreground: '#a367c1' },
     ],
 })
 

--- a/web/src/components/MonacoEditor.tsx
+++ b/web/src/components/MonacoEditor.tsx
@@ -33,7 +33,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
     rules: [
         { token: 'identifier', foreground: '#f2f4f8' },
         { token: 'keyword', foreground: '#569cd6' },
-        { token: 'operator', foreground: '#c586c0' },
+        { token: 'operator', foreground: '#da77f2' },
     ],
 })
 
@@ -58,7 +58,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
     rules: [
         { token: 'identifier', foreground: '#2b3750' },
         { token: 'keyword', foreground: '#268bd2' },
-        { token: 'operator', foreground: '#a367c1' },
+        { token: 'operator', foreground: '#ae3ec9' },
     ],
 })
 


### PR DESCRIPTION
Adds highlighting for and/or/not. It does _not_ have to be these colors. @rrhyne @felixfbecker please weigh in your thoughts on a color choice for operators and I will update it. I picked the dark mode purple-ish color based on the VScode rendering of the `return` keyword in vscode, (which I think uses our theme?). For light mode I just picked something reasonably close.

Here is what it currently looks like:


<img width="941" alt="Screen Shot 2020-08-03 at 11 29 42 PM" src="https://user-images.githubusercontent.com/888624/89261604-36172380-d5e3-11ea-8ef1-01d047be1625.png">

<img width="928" alt="Screen Shot 2020-08-03 at 11 37 54 PM" src="https://user-images.githubusercontent.com/888624/89261613-38797d80-d5e3-11ea-8b3b-2982334dbcc6.png">

Since I didn't find tests that would specifically break the color highlighting, I didn't add any for that. ~Though, I'll add some tests to make sure we lex the right ranges for these operators~ I did some exhaustive manual testing, and also updated our existing tests that already have test inputs for parsing operators. 
