### PR TITLE
Fix: trailing parens get removed from interactive mode queries

### DIFF
--- a/shared/src/search/parser/parser.ts
+++ b/shared/src/search/parser/parser.ts
@@ -224,7 +224,7 @@ const pattern = <T = Literal>(regexp: RegExp, output?: T, expected?: string): Pa
 
 const whitespace = pattern(/\s+/, { type: 'whitespace' as const }, 'whitespace')
 
-const literal = pattern(/\S+/)
+const literal = pattern(/[^\s)]+/)
 
 const filterKeyword = pattern(/-?[A-Za-z]+(?=:)/)
 

--- a/shared/src/search/parser/parser.ts
+++ b/shared/src/search/parser/parser.ts
@@ -224,7 +224,7 @@ const pattern = <T = Literal>(regexp: RegExp, output?: T, expected?: string): Pa
 
 const whitespace = pattern(/\s+/, { type: 'whitespace' as const }, 'whitespace')
 
-const literal = pattern(/[^\s)]+/)
+const literal = pattern(/\S+/)
 
 const filterKeyword = pattern(/-?[A-Za-z]+(?=:)/)
 

--- a/web/src/search/input/helpers.test.ts
+++ b/web/src/search/input/helpers.test.ts
@@ -64,5 +64,19 @@ describe('Search input helpers', () => {
                         }
             )
         })
+        test('converts query with parentheses', () => {
+            const newQuery = convertPlainTextToInteractiveQuery('function()')
+            expect(newQuery.navbarQuery === 'function' && newQuery.filtersInQuery === {})
+        })
+
+        test('converts query with parentheses', () => {
+            const newQuery = convertPlainTextToInteractiveQuery('0) {')
+            expect(newQuery.navbarQuery === '0) {' && newQuery.filtersInQuery === {})
+        })
+
+        test('converts query with closing parentheses', () => {
+            const newQuery = convertPlainTextToInteractiveQuery('\\)')
+            expect(newQuery.navbarQuery === '\\)' && newQuery.filtersInQuery === {})
+        })
     })
 })

--- a/web/src/search/input/helpers.ts
+++ b/web/src/search/input/helpers.ts
@@ -50,5 +50,5 @@ export function convertPlainTextToInteractiveQuery(
         }
     }
 
-    return { filtersInQuery: newFiltersInQuery, navbarQuery: newNavbarQuery }
+    return { filtersInQuery: newFiltersInQuery, navbarQuery: newNavbarQuery.trim() }
 }

--- a/web/src/search/input/helpers.ts
+++ b/web/src/search/input/helpers.ts
@@ -39,14 +39,13 @@ export function convertPlainTextToInteractiveQuery(
                     negated: isNegatedFilter(filterType),
                 }
             } else if (
-                member.token.type === 'literal' ||
-                member.token.type === 'quoted' ||
+                member.token.type !== 'filter' ||
                 (member.token.type === 'filter' &&
                     !validateFilter(member.token.filterType.token.value, member.token.filterValue).valid)
             ) {
                 newNavbarQuery = [newNavbarQuery, query.slice(member.range.start, member.range.end)]
                     .filter(query => query.length > 0)
-                    .join(' ')
+                    .join('')
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/12506 and fixes https://github.com/sourcegraph/sourcegraph/issues/12690.

The closing paren character seems to be mistakenly excluded from literal values, hence it will always be excluded when parsing queries. Can you confirm this is the correct fix @lguychard?
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
