### PR TITLE
search: treat * at pattern borders properly

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -134,10 +134,18 @@ func globToRegex(value string) (string, error) {
 	for i = 0; i < l; i++ {
 		switch r[i] {
 		case '*':
+			// **
 			if i < l-1 && r[i+1] == '*' {
 				sb.WriteString(".*?")
 			} else {
+				// *
+				if i == 0 {
+					sb.WriteRune('^')
+				}
 				sb.WriteString("[^/]*?")
+				if i == l-1 {
+					sb.WriteRune('$')
+				}
 			}
 			// Skip repeated '*'.
 			for i < l-1 && r[i+1] == '*' {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -126,26 +126,17 @@ func globToRegex(value string) (string, error) {
 	l := len(r)
 	sb := strings.Builder{}
 
-	i := 0
-	// Add regex anchor "^" if glob does not start with *.
-	if r[i] != '*' {
-		sb.WriteRune('^')
-	}
-	for i = 0; i < l; i++ {
+	// Add regex anchor "^" as prefix to all patterns
+	sb.WriteRune('^')
+
+	for i := 0; i < l; i++ {
 		switch r[i] {
 		case '*':
 			// **
 			if i < l-1 && r[i+1] == '*' {
 				sb.WriteString(".*?")
 			} else {
-				// *
-				if i == 0 {
-					sb.WriteRune('^')
-				}
 				sb.WriteString("[^/]*?")
-				if i == l-1 {
-					sb.WriteRune('$')
-				}
 			}
 			// Skip repeated '*'.
 			for i < l-1 && r[i+1] == '*' {
@@ -187,11 +178,8 @@ func globToRegex(value string) (string, error) {
 			sb.WriteString(regexp.QuoteMeta(string(r[i])))
 		}
 	}
-
-	// add regex anchor "$" if glob doesn't end with *
-	if r[l-1] != '*' {
-		sb.WriteRune('$')
-	}
+	// add regex anchor '$' as suffix to all patterns
+	sb.WriteRune('$')
 	return sb.String(), nil
 }
 

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -377,11 +377,11 @@ func TestTranslateGlobToRegex(t *testing.T) {
 	}{
 		{
 			input: "*",
-			want:  "[^/]*?",
+			want:  "^[^/]*?",
 		},
 		{
 			input: "*repo",
-			want:  "[^/]*?repo$",
+			want:  "^[^/]*?repo$",
 		},
 		{
 			input: "re*o",
@@ -389,7 +389,7 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "repo*",
-			want:  "^repo[^/]*?",
+			want:  "^repo[^/]*?$",
 		},
 		{
 			input: "?",
@@ -417,7 +417,7 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "*.go",
-			want:  "[^/]*?\\.go$",
+			want:  "^[^/]*?\\.go$",
 		},
 		{
 			input: "h[a-z]llo",

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -377,7 +377,7 @@ func TestTranslateGlobToRegex(t *testing.T) {
 	}{
 		{
 			input: "*",
-			want:  "^[^/]*?",
+			want:  "^[^/]*?$",
 		},
 		{
 			input: "*repo",

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -385,11 +385,11 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "**.go",
-			want:  ".*?\\.go$",
+			want:  "^.*?\\.go$",
 		},
 		{
 			input: "foo**",
-			want:  "^foo.*?",
+			want:  "^foo.*?$",
 		},
 		{
 			input: "re*o",
@@ -461,7 +461,7 @@ func TestTranslateGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "foo/**",
-			want:  "^foo/.*?",
+			want:  "^foo/.*?$",
 		},
 		{
 			input: "[a-z0-9]",
@@ -510,7 +510,7 @@ func TestTranslateGlobToRegex(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.want, func(t *testing.T) {
+		t.Run(c.input, func(t *testing.T) {
 			got, err := globToRegex(c.input)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -384,6 +384,14 @@ func TestTranslateGlobToRegex(t *testing.T) {
 			want:  "^[^/]*?repo$",
 		},
 		{
+			input: "**.go",
+			want:  ".*?\\.go$",
+		},
+		{
+			input: "foo**",
+			want:  "^foo.*?",
+		},
+		{
 			input: "re*o",
 			want:  "^re[^/]*?o$",
 		},


### PR DESCRIPTION
Currently, a `*` at the beginning or end of a pattern does not respect path separators, because we do not add regex anchors if a pattern begins or ends with `*`. With this PR the difference between`*` and `**` becomes much more consistent: `*` is a universal matcher within the same path, `**` matches everything.

glob|before PR (translated regex) |after PR (translated regex)|
|---|---|---|
`file:*.go`| matches any go file in the repo (`file:[^/]*?\.go$` ) |matches any go file in the root directory (`file:^[^/]*?\.go$`)
`file:**.go`|matches any go file in the repo (`file:.*?\.go$` ) |matches any go file in the repo (`file:^.*?\.go$`)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
