### PR TITLE
Fix patternType addition in SearchResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed site admins are getting errors when visiting user settings page in OSS version. [#12313](https://github.com/sourcegraph/sourcegraph/pull/12313)
 - `github-proxy` now respects the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` (or the lowercase versions thereof). Other services already respect these variables, but this was missed. If you need a proxy to access github.com set the environment variable for the github-proxy container. [#12377](https://github.com/sourcegraph/sourcegraph/issues/12377)
+- Fixed a bug that would sometimes cause trailing parentheses to be removed from search queries upon page load. [#12960](https://github.com/sourcegraph/sourcegraph/issues/12690)
 
 ### Removed
 

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -30,7 +30,6 @@ import { SearchResultsFilterBars, SearchScopeWithOptionalName } from './SearchRe
 import { SearchResultsList } from './SearchResultsList'
 import { SearchResultTypeTabs } from './SearchResultTypeTabs'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
-import { convertPlainTextToInteractiveQuery } from '../input/helpers'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { VersionContext } from '../../schema/site.schema'
 import AlertOutlineIcon from 'mdi-react/AlertOutlineIcon'
@@ -114,17 +113,14 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         if (!patternType) {
             // If the patternType query parameter does not exist in the URL or is invalid, redirect to a URL which
             // has patternType=regexp appended. This is to ensure old URLs before requiring patternType still work.
-
-            const query = parseSearchURLQuery(this.props.location.search) || ''
-            const { navbarQuery, filtersInQuery } = convertPlainTextToInteractiveQuery(query)
+            const query = parseSearchURLQuery(this.props.location.search) ?? ''
             const newLocation =
                 '/search?' +
                 buildSearchURLQuery(
-                    navbarQuery,
+                    query,
                     GQL.SearchPatternType.regexp,
                     this.props.caseSensitive,
-                    this.props.versionContext,
-                    filtersInQuery
+                    this.props.versionContext
                 )
             this.props.history.replace(newLocation)
         }


### PR DESCRIPTION
By calling `convertPlainTextToInteractiveQuery()`, SearchResults did quite a bit more than simply setting `patternType` in the URL if it didn't exist, mutating the query content needlessly.

There's more that needs to happen for a fully correct fix to #12506 and #12690, but this is a start.
