### PR TITLE
Fix 'template inlines' CI check

### DIFF
--- a/dev/check/template-inlines.sh
+++ b/dev/check/template-inlines.sh
@@ -16,7 +16,7 @@ main() {
     exit 1
   fi
   local found
-  found=$(grep -EHnr '(<script|<style|style=)' "${template_dir}" | grep -v '<script src=' | grep -v '<script ignore-csp' | grep -v '<div ignore-csp' | grep -v '<style ignore-csp' | 'grep -v <iframe ignore-csp' || echo -n)
+  found=$(grep -EHnr '(<script|<style|style=)' "${template_dir}" | grep -v '<script src=' | grep -v '<script ignore-csp' | grep -v '<div ignore-csp' | grep -v '<style ignore-csp' | grep -v '<iframe ignore-csp' || echo -n)
 
   if [[ ! "$found" == "" ]]; then
     echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'


### PR DESCRIPTION
Looks like this has been broken for a while. Found this by accident with @keegancsmith while looking at our CI checks:

<img width="1205" alt="screenshot_2020-08-04_13 54 00@2x" src="https://user-images.githubusercontent.com/1185253/89291026-14a54e80-d65a-11ea-9b66-08ac4f470fe0.png">


Funnily enough: **CI didn't break.**