### PR TITLE
Check for publicationState/reconcilerState in permission tests

### DIFF
--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -138,18 +138,19 @@ type Repository struct {
 }
 
 type Changeset struct {
-	Typename      string `json:"__typename"`
-	ID            string
-	Repository    Repository
-	Campaigns     CampaignConnection
-	CreatedAt     string
-	UpdatedAt     string
-	NextSyncAt    string
-	Title         string
-	Body          string
-	State         string
-	ExternalState string
-	ExternalURL   struct {
+	Typename         string `json:"__typename"`
+	ID               string
+	Repository       Repository
+	Campaigns        CampaignConnection
+	CreatedAt        string
+	UpdatedAt        string
+	NextSyncAt       string
+	Title            string
+	Body             string
+	PublicationState string
+	ReconcilerState  string
+	ExternalState    string
+	ExternalURL      struct {
 		URL         string
 		ServiceType string
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -746,8 +746,16 @@ func testChangesetResponse(t *testing.T, s *graphql.Schema, ctx context.Context,
 		t.Fatalf("changeset has wrong typename. want=%q, have=%q", want, have)
 	}
 
+	if have, want := res.Node.PublicationState, string(campaigns.ChangesetPublicationStatePublished); have != want {
+		t.Fatalf("changeset has wrong publication state. want=%q, have=%q", want, have)
+	}
+
+	if have, want := res.Node.ReconcilerState, string(campaigns.ReconcilerStateCompleted); have != want {
+		t.Fatalf("changeset has wrong reconciler state. want=%q, have=%q", want, have)
+	}
+
 	if have, want := res.Node.ExternalState, string(campaigns.ChangesetExternalStateOpen); have != want {
-		t.Fatalf("changeset has wrong state. want=%q, have=%q", want, have)
+		t.Fatalf("changeset has wrong external state. want=%q, have=%q", want, have)
 	}
 
 	if have, want := res.Node.Campaigns.TotalCount, 1; have != want {
@@ -775,6 +783,8 @@ query {
     ... on HiddenExternalChangeset {
       id
 
+	  publicationState
+	  reconcilerState
 	  externalState
 	  createdAt
 	  updatedAt
@@ -786,6 +796,8 @@ query {
     ... on ExternalChangeset {
       id
 
+	  publicationState
+	  reconcilerState
 	  externalState
 	  createdAt
 	  updatedAt


### PR DESCRIPTION
This fixes #12647 by extending the tests to make sure that both of these fields are visible for `HiddenExternalChangesets` and for `ExternalChangesets`.