### PR TITLE
Set env var for reviewdog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,6 +9,8 @@ jobs:
         uses: actions/checkout@v2
       - name: golangci-lint
         uses: docker://reviewdog/action-golangci-lint:latest
+        env:
+          GITHUB_ACTION: reviewdog
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: file


### PR DESCRIPTION
This fixes golangci-lint for CI by setting this env var

https://github.com/reviewdog/reviewdog/blob/c9d205fb4143e6c35c77f8885a27e71d666f90fb/cienv/github_actions.go#L95  

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->