### PR TITLE
search: clicking a search suggestion no longer appends filters

### DIFF
--- a/web/src/integration/search.test.ts
+++ b/web/src/integration/search.test.ts
@@ -270,6 +270,57 @@ describe('Search', () => {
             await driver.page.click('.test-confirm-filter-button')
             await driver.assertWindowLocation('/search?q=fork:%22no%22+test&patternType=literal')
         })
+
+        test.only('Clicking on alert proposed query navigates to the right filter', async () => {
+            const searchResultsWithAlert = searchResults()
+            if (searchResultsWithAlert.search) {
+                searchResultsWithAlert.search.results.results = []
+                searchResultsWithAlert.search.results.alert = {
+                    title: 'Test title',
+                    description: 'Test description',
+                    proposedQueries: [
+                        {
+                            description: 'test',
+                            query: 'repo:test1|test2',
+                        },
+                    ],
+                }
+            }
+
+            testContext.overrideGraphQL({
+                ...commonWebGraphQlResults,
+                Search: () => searchResultsWithAlert,
+            })
+
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+            await driver.page.waitForSelector('.test-search-mode-toggle', { visible: true })
+            await driver.page.click('.test-search-mode-toggle')
+            await driver.page.click('.test-search-mode-toggle__interactive-mode')
+
+            // Wait for the input component to appear
+            await driver.page.waitForSelector('.test-interactive-mode-input', { visible: true })
+            // Wait for the add filter row to appear.
+            await driver.page.waitForSelector('.test-add-filter-row', { visible: true })
+            // Wait for the default add filter buttons appear
+            await driver.page.waitForSelector('.test-add-filter-button-repo', { visible: true })
+            await driver.page.waitForSelector('.test-add-filter-button-file', { visible: true })
+
+            // Add a repo filter
+            await driver.page.waitForSelector('.test-add-filter-button-repo')
+            await driver.page.click('.test-add-filter-button-repo')
+
+            // FilterInput is autofocused
+            await driver.page.waitForSelector('.filter-input')
+            // Search for repo:gorilla in the repo filter chip input
+            await driver.page.keyboard.type('gorilla')
+            await driver.page.keyboard.press('Enter')
+            await driver.assertWindowLocation('/search?q=repo:%22gorilla%22&patternType=literal')
+
+            // Click on proposed query from GraphQL and verify existing filters aren't added
+            await driver.page.waitForSelector('[data-testid="proposed-query-link"]')
+            await driver.page.click('[data-testid="proposed-query-link"]')
+            await driver.assertWindowLocation('/search?q=repo:test1%7Ctest2&patternType=literal')
+        })
     })
 
     describe('Case sensitivity toggle', () => {

--- a/web/src/search/helpers.test.tsx
+++ b/web/src/search/helpers.test.tsx
@@ -7,6 +7,7 @@ import {
     isFuzzyWordSearch,
     formatQueryForFuzzySearch,
     filterAliasForSearch,
+    toggleSearchFilter,
 } from './helpers'
 import { SearchType } from './results/SearchResults'
 import { searchFilterSuggestions } from './searchFilterSuggestions'
@@ -241,6 +242,20 @@ describe('search/helpers', () => {
                     cursorPosition: 27,
                 })
             ).toBe('l:javascript file:index.js archived:No')
+        })
+    })
+
+    describe('toggleSearchFilter', () => {
+        it('adds filter if it is not already in query', () => {
+            expect(toggleSearchFilter('repo:test ', 'lang:c++')).toStrictEqual('repo:test lang:c++ ')
+        })
+
+        it('adds filter if it is not already in query, even if it matches substring for an existing filter', () => {
+            expect(toggleSearchFilter('repo:test lang:c++ ', 'lang:c')).toStrictEqual('repo:test lang:c++ lang:c ')
+        })
+
+        it('removes filter from query it it exists', () => {
+            expect(toggleSearchFilter('repo:test lang:c++ lang:c ', 'lang:c')).toStrictEqual('repo:test lang:c++')
         })
     })
 })

--- a/web/src/search/helpers.tsx
+++ b/web/src/search/helpers.tsx
@@ -76,8 +76,11 @@ export function queryIndexOfScope(query: string, scope: string): number {
             break
         }
 
+        const boundAtStart = index === 0 || query[index - 1] === ' '
+        const boundAtEnd = index + scope.length === query.length || query[index + scope.length] === ' '
+
         // prevent matching scopes that are substrings of other scopes
-        if (index > 0 && query[index - 1] !== ' ') {
+        if (!boundAtStart || !boundAtEnd) {
             index = index + 1
         } else {
             break

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../../shared/src/util/searchTestHelpers'
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
 import { NEVER } from 'rxjs'
+import { FiltersToTypeAndValue, FilterType } from '../../../../shared/src/search/interactive/util'
 
 let VISIBILITY_CHANGED_CALLBACKS: ((isVisible: boolean) => void)[] = []
 
@@ -266,5 +267,50 @@ describe('SearchResultsList', () => {
         )
         scrollToBottom()
         expect(getByTestId(container, 'search-show-more-button')).toBeTruthy()
+    })
+
+    it('does not add filters to query in search suggestions link', () => {
+        const resultsOrError = mockResults({ resultCount: 0, limitHit: false })
+        resultsOrError.alert = {
+            __typename: 'SearchAlert',
+            title: 'Test title',
+            description: 'Test description',
+            proposedQueries: [
+                {
+                    __typename: 'SearchQueryDescription',
+                    description: 'test',
+                    query: 'repo:test1|test2',
+                },
+            ],
+        }
+
+        const filtersInQuery: FiltersToTypeAndValue = {
+            a: {
+                type: FilterType.repo,
+                value: 'test1',
+                editable: true,
+            },
+            b: {
+                type: FilterType.repo,
+                value: 'test2',
+                editable: true,
+            },
+        }
+
+        const props = {
+            ...defaultProps,
+            resultsOrError,
+            filtersInQuery,
+        }
+
+        const { container } = render(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+
+        const link = getByTestId(container, 'search-suggestions-link') as HTMLAnchorElement
+        expect(link).toBeTruthy()
+        expect(link.href).toStrictEqual('http://localhost/search?q=repo:test1%7Ctest2&patternType=regexp')
     })
 })

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -309,7 +309,7 @@ describe('SearchResultsList', () => {
             </BrowserRouter>
         )
 
-        const link = getByTestId(container, 'search-suggestions-link') as HTMLAnchorElement
+        const link = getByTestId(container, 'proposed-query-link') as HTMLAnchorElement
         expect(link).toBeTruthy()
         expect(link.href).toStrictEqual('http://localhost/search?q=repo:test1%7Ctest2&patternType=regexp')
     })

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -425,6 +425,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                             <li key={proposedQuery.query}>
                                                                 <Link
                                                                     className="btn btn-secondary btn-sm"
+                                                                    data-testid="search-suggestions-link"
                                                                     to={
                                                                         '/search?' +
                                                                         buildSearchURLQuery(

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -432,7 +432,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                                             this.props.patternType,
                                                                             this.props.caseSensitive,
                                                                             this.props.versionContext,
-                                                                            this.props.filtersInQuery
+                                                                            {}
                                                                         )
                                                                     }
                                                                 >

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -425,7 +425,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                             <li key={proposedQuery.query}>
                                                                 <Link
                                                                     className="btn btn-secondary btn-sm"
-                                                                    data-testid="search-suggestions-link"
+                                                                    data-testid="proposed-query-link"
                                                                     to={
                                                                         '/search?' +
                                                                         buildSearchURLQuery(


### PR DESCRIPTION
Search suggestions already come with all the existing filters added, so there is no need to add them to the URL when generating the link.

Also fixes a small bug that caused filters to not be toggled properly (eg. after clicking on "lang:c++" and then on "lang:c", the result would be "++" instead of "lang:c++ lang:c". Gif of this bug:

![Screen Recording 2020-08-05 at 8 41 28 AM 2](https://user-images.githubusercontent.com/206864/89434345-4b31a680-d6f8-11ea-80e4-1ec25fffe072.gif)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
