### PR TITLE
monitoring: set long-term provisioning alerts to 14d

### DIFF
--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -192,7 +192,7 @@ var sharedProvisioningMemoryUsage7d sharedObservable = func(containerName string
 		Description:     "container memory usage (7d maximum) by instance",
 		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_memory_usage_percentage_total{%s}[7d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
-		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80, For: 7 * 24 * time.Hour},
+		Warning:         Alert{LessOrEqual: 30, GreaterOrEqual: 80, For: 14 * 24 * time.Hour},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Max(100).Min(0),
 		Owner:           ObservableOwnerDistribution,
 		PossibleSolutions: strings.Replace(`


### PR DESCRIPTION
Part of efforts to reduce noise of these alerts

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
