### PR TITLE
search: filter out noisy inputs used in diff testing

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"math/rand"
 	"regexp"
 	regexpsyntax "regexp/syntax"
 	"sort"
@@ -42,6 +41,8 @@ import (
 // This file contains the root resolver for search. It currently has a lot of
 // logic that spans out into all the other search_* files.
 var mockResolveRepositories func(effectiveRepoFieldValues []string) (repoRevs, missingRepoRevs []*search.RepositoryRevisions, excludedRepos *excludedRepos, overLimit bool, err error)
+
+var disallowLogQuery = lazyregexp.New(`(type:symbol|type:commit|type:diff)`)
 
 func maxReposToSearch() int {
 	switch max := conf.Get().MaxReposToSearch; {
@@ -89,8 +90,8 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 	}
 
 	if envvar.SourcegraphDotComMode() {
-		// Instrumentation to log 1 in 10 search inputs for differential testing, see #12477.
-		if rand.Intn(10) == 0 {
+		// Instrumentation to log search inputs for differential testing, see #12477.
+		if !disallowLogQuery.MatchString(args.Query) {
 			log15.Info("search input", "type", searchType, "magic-887c6d4c", args.Query)
 		}
 	}


### PR DESCRIPTION
So there's a lot of noisy searches logged (saved searches and symbol stuff), so now I'm acting on ["maybe exclude type:symbol and log everything?"](https://github.com/sourcegraph/sourcegraph/pull/12479#pullrequestreview-455267853). The previous inputs have been useful, but would now like more diversity that I can collect over a short time frame (so no throttling to 1 in 10 queries, there has not been that much in coming in a short time frame).