### PR TITLE
RFC211: list external services allow filtering by user

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -174,6 +174,8 @@ type ExternalServicesArgs struct {
 	graphqlutil.ConnectionArgs
 }
 
+var errMustBeSiteAdminOrSameUser = errors.New("must be site admin or the namespace is same as the authenticated user")
+
 func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalServicesArgs) (*externalServiceConnectionResolver, error) {
 	var namespaceUserID int32
 	if args.Namespace != nil {
@@ -196,7 +198,7 @@ func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalSer
 		// NOTE: We do not directly return the err here because it contains the desired username,
 		// which then allows attacker to brute force over our database ID and get corresponding
 		// username.
-		return nil, backend.ErrMustBeSiteAdmin
+		return nil, errMustBeSiteAdminOrSameUser
 	}
 
 	opt := db.ExternalServicesListOptions{

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -167,14 +169,39 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-func (r *schemaResolver) ExternalServices(ctx context.Context, args *struct {
+type ExternalServicesArgs struct {
+	Namespace *graphql.ID
 	graphqlutil.ConnectionArgs
-}) (*externalServiceConnectionResolver, error) {
-	// 🚨 SECURITY: Only site admins may read external services (they have secrets).
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
+}
+
+func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalServicesArgs) (*externalServiceConnectionResolver, error) {
+	var namespaceUserID int32
+	if args.Namespace != nil {
+		var err error
+		switch relay.UnmarshalKind(*args.Namespace) {
+		case "User":
+			err = relay.UnmarshalSpec(*args.Namespace, &namespaceUserID)
+		default:
+			err = errors.Errorf("invalid namespace %q", *args.Namespace)
+		}
+
+		if err != nil {
+			return nil, err
+		}
 	}
-	var opt db.ExternalServicesListOptions
+
+	// 🚨 SECURITY: Only site admins may read all or a user's external services.
+	// Otherwise, the authenticated user can only read external services under the same namespace.
+	if backend.CheckSiteAdminOrSameUser(ctx, namespaceUserID) != nil {
+		// NOTE: We do not directly return the err here because it contains the desired username,
+		// which then allows attacker to brute force over our database ID and get corresponding
+		// username.
+		return nil, backend.ErrMustBeSiteAdmin
+	}
+
+	opt := db.ExternalServicesListOptions{
+		NamespaceUserID: namespaceUserID,
+	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &externalServiceConnectionResolver{opt: opt}, nil
 }

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -215,6 +216,93 @@ func TestDeleteExternalService(t *testing.T) {
 			{
 				"deleteExternalService": {
 					"alwaysNil": null
+				}
+			}
+		`,
+		},
+	})
+}
+
+func TestExternalServices(t *testing.T) {
+	t.Run("authenticated as non-admin", func(t *testing.T) {
+		t.Run("read someone else's external services", func(t *testing.T) {
+			db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+				return &types.User{ID: 1}, nil
+			}
+			db.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+				return &types.User{ID: id}, nil
+			}
+			defer func() {
+				db.Mocks.Users = db.MockUsers{}
+			}()
+
+			id := MarshalUserID(2)
+			result, err := (&schemaResolver{}).ExternalServices(context.Background(), &ExternalServicesArgs{
+				Namespace: &id,
+			})
+			if want := backend.ErrMustBeSiteAdmin; err != want {
+				t.Errorf("err: want %q but got %v", want, err)
+			}
+			if result != nil {
+				t.Errorf("result: want nil but got %v", result)
+			}
+		})
+	})
+
+	db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+		return &types.User{SiteAdmin: true}, nil
+	}
+	db.Mocks.ExternalServices.List = func(opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+		if opt.NamespaceUserID > 0 {
+			return []*types.ExternalService{
+				{ID: 1},
+			}, nil
+		}
+		return []*types.ExternalService{
+			{ID: 1},
+			{ID: 2},
+		}, nil
+	}
+	defer func() {
+		db.Mocks.Users = db.MockUsers{}
+		db.Mocks.ExternalServices = db.MockExternalServices{}
+	}()
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+			{
+				externalServices() {
+					nodes {
+						id
+					}
+				}
+			}
+		`,
+			ExpectedResult: `
+			{
+				"externalServices": {
+					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE="}, {"id":"RXh0ZXJuYWxTZXJ2aWNlOjI="}]
+				}
+			}
+		`,
+		},
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+			{
+				externalServices(namespace: "VXNlcjoy") {
+					nodes {
+						id
+					}
+				}
+			}
+		`,
+			ExpectedResult: `
+			{
+				"externalServices": {
+					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE="}]
 				}
 			}
 		`,

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -240,7 +240,7 @@ func TestExternalServices(t *testing.T) {
 			result, err := (&schemaResolver{}).ExternalServices(context.Background(), &ExternalServicesArgs{
 				Namespace: &id,
 			})
-			if want := backend.ErrMustBeSiteAdmin; err != want {
+			if want := errMustBeSiteAdminOrSameUser; err != want {
 				t.Errorf("err: want %q but got %v", want, err)
 			}
 			if result != nil {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1236,8 +1236,12 @@ type Query {
         # Will not actually check the code host to see if the repository actually exists.
         cloneURL: String
     ): RepositoryRedirect
-    # Lists all external services.
+    # Lists external services under given namespace.
+    # If no namespace is given, it returns all external services.
     externalServices(
+        # The namespace to scope returned external services.
+        # Currently, this can only be used for a user.
+        namespace: ID
         # Returns the first n external services from the list.
         first: Int
     ): ExternalServiceConnection!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1243,8 +1243,12 @@ type Query {
         # Will not actually check the code host to see if the repository actually exists.
         cloneURL: String
     ): RepositoryRedirect
-    # Lists all external services.
+    # Lists external services under given namespace.
+    # If no namespace is given, it returns all external services.
     externalServices(
+        # The namespace to scope returned external services.
+        # Currently, this can only be used for a user.
+        namespace: ID
         # Returns the first n external services from the list.
         first: Int
     ): ExternalServiceConnection!

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -404,7 +404,8 @@ func (e *ExternalServicesStore) GetByID(ctx context.Context, id int64) (*types.E
 	return ess[0], nil
 }
 
-// List returns all or a user's external services.
+// List returns external services under given namespace.
+// If no namespace is given, it returns all external services.
 //
 // 🚨 SECURITY: The caller must ensure one of the following:
 // 	- The actor is a site admin


### PR DESCRIPTION
Modified our GraphQL query to accept an optional `namespace` argument to filter external services by user. Besides, site admin is able to list all or arbitrary user's external services.

The `namespace` argument is used instead of always relying on authenticated user because then we couldn't distinguish if a site admin wants to list all external services or is just viewing his/her user settings (i.e. external services owned by the particular site admin). 

Example usage:
```graphql
{
  externalServices(namespace: "VXNlcjoy") {
    nodes {
      id
      kind
      config
    }
  }
}
```

Fixes #12704