### PR TITLE
Have separate coverage tracking for campaigns

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -10,6 +10,14 @@ coverage:
           - cmd/symbols
           - enterprise/cmd/precise-code-intel-*
           - enterprise/internal/codeintel
+      campaigns:
+        informational: true
+        paths:
+          - cmd/frontend/graphqlbackend/campaigns.go
+          - enterprise/cmd/frontend/internal/campaigns
+          - internal/campaigns
+          - enterprise/internal/campaigns
+          - web/src/enterprise/campaigns
       typescript:
         informational: true
         flags:


### PR DESCRIPTION
As discussed in todays sync, we would like to track coverage for campaigns code in an additional category, so we have insight how far we got in catching up with what remained untested during the big refactor of the campaigns workflow.
This isn't very noisy, since it just adds one additional check to the PR, like the one for codeintel does.