### PR TITLE
search: facilitate simple searches if globbing is active

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1928,7 +1928,7 @@ func (r *searchResolver) getExactFilePatterns() map[string]struct{} {
 		query.FieldFile,
 		func(value string, negated bool, annotation query.Annotation) {
 			originalValue := r.originalQuery[annotation.Range.Start.Column+len(query.FieldFile)+1 : annotation.Range.End.Column]
-			if !negated && query.ContainsNoGlobSymbols(originalValue) {
+			if !negated && query.ContainsNoGlobSyntax(originalValue) {
 				m[originalValue] = struct{}{}
 			}
 		})

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1913,12 +1913,12 @@ func compareSearchResults(a, b searchResultURIGetter, exactFilePatterns map[stri
 	return arepo < brepo
 }
 
-func (r *searchResolver) sortResults(ctx context.Context, rr []SearchResultResolver) {
+func (r *searchResolver) sortResults(ctx context.Context, results []SearchResultResolver) {
 	var exactPatterns map[string]struct{}
 	if settings, err := decodedViewerFinalSettings(ctx); err != nil || getBoolPtr(settings.SearchGlobbing, false) {
 		exactPatterns = r.getExactFilePatterns()
 	}
-	sort.Slice(rr, func(i, j int) bool { return compareSearchResults(rr[i], rr[j], exactPatterns) })
+	sort.Slice(results, func(i, j int) bool { return compareSearchResults(results[i], results[j], exactPatterns) })
 }
 
 // getExactFilePatterns returns the set of file patterns without glob syntax.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1907,7 +1907,8 @@ func sortResults(r []SearchResultResolver) {
 }
 
 // compareSearchResultsAndOr is like compareSearchResults, but overrides sorting in alphabetical order if
-// one of the filenames is contained in exactFilePatterns.
+// one of the filenames is contained in exactFilePatterns, in which case exact matches are sorted by
+// length of their file path and then alphabetically.
 func compareSearchResultsAndOr(a, b searchResultURIGetter, exactFilePatterns map[string]struct{}) bool {
 	arepo, afile := a.searchResultURIs()
 	brepo, bfile := b.searchResultURIs()

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1899,6 +1899,7 @@ func compareSearchResults(a, b searchResultURIGetter, exactFilePatterns map[stri
 		_, bMatch := exactFilePatterns[path.Base(bfile)]
 		if aMatch || bMatch {
 			if aMatch && bMatch {
+				// Prefer shorter file names (ie root files come first)
 				if len(afile) != len(bfile) {
 					return len(afile) < len(bfile)
 				}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1920,6 +1920,12 @@ func compareSearchResultsAndOr(a, b searchResultURIGetter, exactFilePatterns map
 		_, bMatch := exactFilePatterns[filepath.Base(bfile)]
 		if aMatch || bMatch {
 			if aMatch && bMatch {
+				if len(afile) < len(bfile) {
+					return true
+				}
+				if len(bfile) < len(afile) {
+					return false
+				}
 				return afile < bfile
 			}
 			if aMatch {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1426,6 +1426,18 @@ func TestCompareSearchResultsAndOr(t *testing.T) {
 			want:              true,
 		},
 		{
+			a:                 mockSearchResultURIGetter{repo: "arepo", file: "dir1/file"},
+			b:                 mockSearchResultURIGetter{repo: "arepo", file: "adir1/file"},
+			exactFilePatterns: map[string]struct{}{"file": {}},
+			want:              true,
+		},
+		{
+			a:                 mockSearchResultURIGetter{repo: "arepo", file: "adir1/file"},
+			b:                 mockSearchResultURIGetter{repo: "arepo", file: "dir1/file"},
+			exactFilePatterns: map[string]struct{}{"file": {}},
+			want:              false,
+		},
+		{
 			a:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
 			b:                 mockSearchResultURIGetter{repo: "arepo", file: "bfile"},
 			exactFilePatterns: nil,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1452,8 +1452,8 @@ func TestCompareSearchResultsAndOr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if got := compareSearchResultsAndOr(tt.a, tt.b, tt.exactFilePatterns); got != tt.want {
-				t.Errorf("compareSearchResultsAndOr() = %v, want %v", got, tt.want)
+			if got := searchResultIsLess(tt.a, tt.b, tt.exactFilePatterns); got != tt.want {
+				t.Errorf("searchResultIsLess() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -849,69 +849,6 @@ func TestSearchRevspecs(t *testing.T) {
 	}
 }
 
-func TestCompareSearchResultsREMOVEME(t *testing.T) {
-	type testCase struct {
-		a       SearchResultResolver
-		b       SearchResultResolver
-		aIsLess bool
-	}
-
-	tests := []testCase{{
-		// Different repo matches
-		a: &RepositoryResolver{
-			repo: &types.Repo{Name: api.RepoName("a")},
-		},
-		b: &RepositoryResolver{
-			repo: &types.Repo{Name: api.RepoName("b")},
-		},
-		aIsLess: true,
-	}, {
-		// Repo match vs file match in same repo
-		a: &FileMatchResolver{
-			Repo: &RepositoryResolver{repo: &types.Repo{Name: "a"}},
-
-			JPath: "a",
-		},
-		b: &RepositoryResolver{
-			repo: &types.Repo{Name: api.RepoName("a")},
-		},
-		aIsLess: false,
-	}, {
-		// Same repo, different files
-		a: &FileMatchResolver{
-			Repo: &RepositoryResolver{repo: &types.Repo{Name: "a"}},
-
-			JPath: "a",
-		},
-		b: &FileMatchResolver{
-			Repo: &RepositoryResolver{repo: &types.Repo{Name: "a"}},
-
-			JPath: "b",
-		},
-		aIsLess: true,
-	}, {
-		// different repo, same file name
-		a: &FileMatchResolver{
-			Repo: &RepositoryResolver{repo: &types.Repo{Name: "a"}},
-
-			JPath: "a",
-		},
-		b: &FileMatchResolver{
-			Repo: &RepositoryResolver{repo: &types.Repo{Name: "b"}},
-
-			JPath: "a",
-		},
-		aIsLess: true,
-	}}
-
-	for i, test := range tests {
-		got := compareSearchResults(test.a, test.b, nil)
-		if got != test.aIsLess {
-			t.Errorf("[%d] incorrect comparison. got %t, expected %t", i, got, test.aIsLess)
-		}
-	}
-}
-
 func TestLonger(t *testing.T) {
 	N := 2
 	noise := time.Nanosecond

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -849,7 +849,7 @@ func TestSearchRevspecs(t *testing.T) {
 	}
 }
 
-func TestCompareSearchResults(t *testing.T) {
+func TestCompareSearchResultsREMOVEME(t *testing.T) {
 	type testCase struct {
 		a       SearchResultResolver
 		b       SearchResultResolver
@@ -905,7 +905,7 @@ func TestCompareSearchResults(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		got := compareSearchResults(test.a, test.b)
+		got := compareSearchResults(test.a, test.b, nil)
 		if got != test.aIsLess {
 			t.Errorf("[%d] incorrect comparison. got %t, expected %t", i, got, test.aIsLess)
 		}
@@ -1364,7 +1364,7 @@ func (m mockSearchResultURIGetter) searchResultURIs() (string, string) {
 	return m.repo, m.file
 }
 
-func TestCompareSearchResultsAndOr(t *testing.T) {
+func TestCompareSearchResults(t *testing.T) {
 	tests := []struct {
 		a                 searchResultURIGetter
 		b                 searchResultURIGetter
@@ -1452,8 +1452,8 @@ func TestCompareSearchResultsAndOr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if got := searchResultIsLess(tt.a, tt.b, tt.exactFilePatterns); got != tt.want {
-				t.Errorf("searchResultIsLess() = %v, want %v", got, tt.want)
+			if got := compareSearchResults(tt.a, tt.b, tt.exactFilePatterns); got != tt.want {
+				t.Errorf("compareSearchResults() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1365,7 +1365,6 @@ func TestCompareSearchResults(t *testing.T) {
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           true,
 		},
-		// file matches (different repos)
 		{
 			name:              "different repo, 1 exact match",
 			a:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -27,6 +27,8 @@ const (
 	FieldContent            = "content"
 	FieldVisibility         = "visibility"
 
+	FieldFileOffset = len(FieldFile) + 1
+
 	// For diff and commit search only:
 	FieldBefore    = "before"
 	FieldAfter     = "after"

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -27,8 +27,6 @@ const (
 	FieldContent            = "content"
 	FieldVisibility         = "visibility"
 
-	FieldFileOffset = len(FieldFile) + 1
-
 	// For diff and commit search only:
 	FieldBefore    = "before"
 	FieldAfter     = "after"

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -242,9 +242,6 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 			if ContainsNoGlobSymbols(value) {
 				value = fuzzifyGlobPattern(value)
 			}
-			if len(value) > 0 && value[0] == '/' {
-				value = value[1:]
-			}
 			value, err = globToRegex(value)
 		}
 		if err != nil {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -216,10 +216,10 @@ func reporevToRegex(value string) (string, error) {
 	return value, nil
 }
 
-var globSymbols = lazyregexp.New(`[][*?/]`)
+var globSyntax = lazyregexp.New(`[][*?/]`)
 
 func ContainsNoGlobSymbols(value string) bool {
-	return !globSymbols.MatchString(value)
+	return !globSyntax.MatchString(value)
 }
 
 func fuzzifyGlobPattern(value string) string {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -246,7 +246,6 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 				value = value[1:]
 			}
 			value, err = globToRegex(value)
-
 		}
 		if err != nil {
 			globErrors = append(globErrors, globError{field: field, err: err})

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -202,7 +202,7 @@ func (g globError) Error() string {
 func reporevToRegex(value string) (string, error) {
 	reporev := strings.SplitN(value, "@", 2)
 	repo := reporev[0]
-	if ContainsNoGlobSymbols(repo) {
+	if ContainsNoGlobSyntax(repo) {
 		repo = fuzzifyGlobPattern(repo)
 	}
 	repo, err := globToRegex(repo)
@@ -218,7 +218,7 @@ func reporevToRegex(value string) (string, error) {
 
 var globSyntax = lazyregexp.New(`[][*?/]`)
 
-func ContainsNoGlobSymbols(value string) bool {
+func ContainsNoGlobSyntax(value string) bool {
 	return !globSyntax.MatchString(value)
 }
 
@@ -239,7 +239,7 @@ func mapGlobToRegex(nodes []Node) ([]Node, error) {
 		case FieldRepo:
 			value, err = reporevToRegex(value)
 		case FieldFile, FieldRepoHasFile:
-			if ContainsNoGlobSymbols(value) {
+			if ContainsNoGlobSyntax(value) {
 				value = fuzzifyGlobPattern(value)
 			}
 			value, err = globToRegex(value)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -728,6 +728,10 @@ func TestMapGlobToRegex(t *testing.T) {
 			input: "file:afile file:bfile file:**cfile",
 			want:  `(and "file:^.*?afile.*?$" "file:^.*?bfile.*?$" "file:^.*?cfile$")`,
 		},
+		{
+			input: "file:afile file:/bfile",
+			want:  `(and "file:^.*?afile.*?$" "file:^bfile$")`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -729,8 +729,8 @@ func TestMapGlobToRegex(t *testing.T) {
 			want:  `(and "file:^.*?afile.*?$" "file:^.*?bfile.*?$" "file:^.*?cfile$")`,
 		},
 		{
-			input: "file:afile file:/bfile",
-			want:  `(and "file:^.*?afile.*?$" "file:^bfile$")`,
+			input: "file:afile file:dir1/bfile",
+			want:  `(and "file:^.*?afile.*?$" "file:^dir1/bfile$")`,
 		},
 	}
 	for _, c := range cases {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -572,12 +572,17 @@ func TestReporevToRegex(t *testing.T) {
 		{
 			name: "many @",
 			arg:  "foo@bar@bas",
-			want: "^foo$@bar@bas",
+			want: "^.*?foo.*?$@bar@bas",
 		},
 		{
 			name: "just @",
 			arg:  "@",
 			want: "@",
+		},
+		{
+			name: "fuzzy repo",
+			arg:  "sourcegraph",
+			want: "^.*?sourcegraph.*?$",
 		},
 	}
 	for _, tt := range tests {
@@ -611,6 +616,126 @@ func TestFuzzifyRegexPatterns(t *testing.T) {
 			got := prettyPrint(FuzzifyRegexPatterns(query))
 			if got != tt.want {
 				t.Fatalf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsNoGlobSyntax(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{
+			in:   "foo",
+			want: true,
+		},
+		{
+			in:   "foo.bar",
+			want: true,
+		},
+		{
+			in:   "/foo.bar",
+			want: false,
+		},
+		{
+			in:   "path/to/file/foo.bar",
+			want: false,
+		},
+		{
+			in:   "github.com/org/repo",
+			want: false,
+		},
+		{
+			in:   "foo**",
+			want: false,
+		},
+		{
+			in:   "**foo",
+			want: false,
+		},
+		{
+			in:   "**foo**",
+			want: false,
+		},
+		{
+			in:   "*foo*",
+			want: false,
+		},
+		{
+			in:   "foo?",
+			want: false,
+		},
+		{
+			in:   "fo?o",
+			want: false,
+		},
+		{
+			in:   "fo[o]bar",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := ContainsNoGlobSymbols(tt.in); got != tt.want {
+				t.Errorf("ContainsNoGlobSymbols() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFuzzifyGlobPattern(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{
+			in:   "foo",
+			want: "**foo**",
+		},
+		{
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := fuzzifyGlobPattern(tt.in); got != tt.want {
+				t.Errorf("fuzzifyGlobPattern() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapGlobToRegex(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "repo:sourcegraph",
+			want:  `"repo:^.*?sourcegraph.*?$"`,
+		},
+		{
+			input: "repo:**sourcegraph",
+			want:  `"repo:^.*?sourcegraph$"`,
+		},
+		{
+			input: "file:**foo.bar",
+			want:  `"file:^.*?foo\\.bar$"`,
+		},
+		{
+			input: "file:afile file:bfile file:**cfile",
+			want:  `(and "file:^.*?afile.*?$" "file:^.*?bfile.*?$" "file:^.*?cfile$")`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			regexQuery, _ := mapGlobToRegex(query)
+			got := prettyPrint(regexQuery)
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -677,8 +677,8 @@ func TestContainsNoGlobSyntax(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			if got := ContainsNoGlobSymbols(tt.in); got != tt.want {
-				t.Errorf("ContainsNoGlobSymbols() = %v, want %v", got, tt.want)
+			if got := ContainsNoGlobSyntax(tt.in); got != tt.want {
+				t.Errorf("ContainsNoGlobSyntax() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/issues/12476

With this PR we slightly modify the interpretation of filter values if globbing is active.

Users can now enter queries like

```
repo:sourcegraph file:search.go 
```

which will be interpreted as

```
repo:**sourcegraph** file:**search.go** 
```

in the backend. 

Filter values containing glob symbols or path separators will be interpreted as glob-pattern without further modification. Results that match the file: filter value exactly (e.g. files named search.go in any directory) will be listed first. Multiple exact matches are sorted by length of the file path, and then alphabetically.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
