### PR TITLE
Fix default host for SRC_HTTP_ADDR_INTERNAL

### DIFF
--- a/cmd/frontend/envvar/envvar.go
+++ b/cmd/frontend/envvar/envvar.go
@@ -9,7 +9,7 @@ import (
 
 var HTTPAddrInternal = env.Get(
 	"SRC_HTTP_ADDR_INTERNAL",
-	"localhost:3090", // CI:LOCALHOST_OK
+	"0.0.0.0:3090",
 	"HTTP listen address for internal HTTP API. This should never be exposed externally, as it lacks certain authz checks.",
 )
 


### PR DESCRIPTION
`localhost` makes the container inaccessible outside of a container, which makes the frontends unreachable from other services in the cloud instance.

This makes it accessible everywhere serving from the current host. See https://github.com/sourcegraph/sourcegraph/pull/12758 and the chain of discussion ending there.