### PR TITLE
Properly return null for empty descriptions on labels

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -554,5 +554,8 @@ func (r *changesetLabelResolver) Color() string {
 }
 
 func (r *changesetLabelResolver) Description() *string {
+	if r.label.Description == "" {
+		return nil
+	}
 	return &r.label.Description
 }


### PR DESCRIPTION
Before, an empty description would always have been returned as `""`, rather than `null`.