### PR TITLE
Don't load twice if changeset is not scheduled for syncing

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -49,6 +49,7 @@ type changesetResolver struct {
 	events     ee.ChangesetEvents
 	eventsErr  error
 
+	attemptedPreloadNextSyncAt bool
 	// When the next sync is scheduled
 	preloadedNextSyncAt *time.Time
 	nextSyncAtOnce      sync.Once
@@ -160,8 +161,10 @@ func (r *changesetResolver) computeEvents(ctx context.Context) ([]*campaigns.Cha
 
 func (r *changesetResolver) computeNextSyncAt(ctx context.Context) (time.Time, error) {
 	r.nextSyncAtOnce.Do(func() {
-		if r.preloadedNextSyncAt != nil {
-			r.nextSyncAt = *r.preloadedNextSyncAt
+		if r.attemptedPreloadNextSyncAt {
+			if r.preloadedNextSyncAt != nil {
+				r.nextSyncAt = *r.preloadedNextSyncAt
+			}
 		} else {
 			syncData, err := r.store.ListChangesetSyncData(ctx, ee.ListChangesetSyncDataOpts{ChangesetIDs: []int64{r.changeset.ID}})
 			if err != nil {

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -70,12 +70,13 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 		}
 
 		resolvers = append(resolvers, &changesetResolver{
-			store:                r.store,
-			httpFactory:          r.httpFactory,
-			changeset:            c,
-			preloadedRepo:        repo,
-			attemptedPreloadRepo: true,
-			preloadedNextSyncAt:  preloadedNextSyncAt,
+			store:                      r.store,
+			httpFactory:                r.httpFactory,
+			changeset:                  c,
+			preloadedRepo:              repo,
+			attemptedPreloadRepo:       true,
+			attemptedPreloadNextSyncAt: true,
+			preloadedNextSyncAt:        preloadedNextSyncAt,
 		})
 	}
 

--- a/enterprise/internal/campaigns/resolvers/testing.go
+++ b/enterprise/internal/campaigns/resolvers/testing.go
@@ -105,7 +105,8 @@ func marshalDateTime(t testing.TB, ts time.Time) string {
 		t.Fatal(err)
 	}
 
-	return string(bs)
+	// Unquote the date time.
+	return strings.ReplaceAll(string(bs), "\"", "")
 }
 
 func parseJSONTime(t testing.TB, ts string) time.Time {
@@ -233,6 +234,7 @@ type testChangesetOpts struct {
 	externalCheckState  campaigns.ChangesetCheckState
 
 	publicationState campaigns.ChangesetPublicationState
+	reconcilerState  campaigns.ReconcilerState
 	failureMessage   string
 
 	createdByCampaign bool
@@ -265,6 +267,7 @@ func createChangeset(
 		ExternalCheckState:  opts.externalCheckState,
 
 		PublicationState: opts.publicationState,
+		ReconcilerState:  opts.reconcilerState,
 
 		CreatedByCampaign: opts.createdByCampaign,
 		OwnedByCampaignID: opts.ownedByCampaign,


### PR DESCRIPTION
Before, an empty `preloadedNextSyncAt` was not distinguished from not preloaded, and hence we loaded the sync state twice.
This fixes it by explicitly passing that a preload was performed.