### PR TITLE
Perform same trailing paren heuristic as old parser in new parser

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -548,11 +548,7 @@ func (p *parser) ParsePattern() Pattern {
 	value, advance, sawDanglingParen := ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
 	var labels labels
 	if sawDanglingParen {
-		// If we saw a dangling parenthesis, this is not a well-formed
-		// regular expression and we will interpret it as a literal.
-		// TODO(rvantonder): Try to still support a trailing parentheses
-		// combined with regex, like "foo.*bar(".
-		labels = HeuristicDanglingParens | Literal
+		labels = HeuristicDanglingParens | Regexp
 	} else {
 		labels = Regexp
 	}
@@ -965,7 +961,7 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		}
 		query = substituteConcat(query, " ")
 	case SearchTypeRegex:
-		query = EmptyGroupsToLiteral(query)
+		query = Map(query, EmptyGroupsToLiteral, TrailingParensToLiteral)
 	}
 
 	if options.Globbing {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -128,10 +128,16 @@ func TestParseParameterList(t *testing.T) {
 			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":4}}`,
 			WantLabels: Literal | Quoted,
 		},
+		{
+			Input:      `foo.*bar(`,
+			Want:       `{"value":"foo.*bar(","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":9}}`,
+			WantLabels: Regexp | HeuristicDanglingParens,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			parser := &parser{buf: []byte(tt.Input)}
+			parser := &parser{buf: []byte(tt.Input), heuristics: parensAsPatterns | allowDanglingParens}
 			result, err := parser.parseLeavesRegexp()
 			if err != nil {
 				t.Fatal(fmt.Sprintf("Unexpected error: %s", err))

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -483,6 +483,26 @@ func substituteConcat(nodes []Node, separator string) []Node {
 	return new
 }
 
+// TrailingParensToLiteral is a heuristic used in the context of regular
+// expression search. It checks whether any pattern is annotated with a label
+// HeusticDanglingParens. This label implies that the regular expression is not
+// well-formed, for example, "foo.*bar(" or "foo(.*bar". As a special case for
+// usability we escape a trailing parenthesis and treat it literally. Any other
+// forms are ignored, and will likely not pass validation.
+func TrailingParensToLiteral(nodes []Node) []Node {
+	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
+		if annotation.Labels.isSet(HeuristicDanglingParens) && strings.HasSuffix(value, "(") {
+			value = strings.TrimSuffix(value, "(")
+			value += `\(`
+		}
+		return Pattern{
+			Value:      value,
+			Negated:    negated,
+			Annotation: annotation,
+		}
+	})
+}
+
 // EmptyGroupsToLiteral is a heuristic used in the context of regular expression
 // search. It labels any pattern containing "()" as a literal pattern since in
 // regex it implies the empty string, which is meaningless as a search query and


### PR DESCRIPTION
Fixes #12733 (see description there). Apparently I left a TODO for myself about this.

We can inline the heuristic logic in the parser, and that would be more efficient. But as a matter of organizing this code, I prefer to apply any heuristics as passes after parsing, where possible. Even though that means doing another pass on the query. So, I've implemented this as an additional transformer function.