### PR TITLE
external_services: use SQL to get distinct kinds

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -277,18 +277,10 @@ func authProviderTypes() []string {
 	return types
 }
 
-func externalServiceKinds(ctx context.Context) (_ []string, err error) {
+func externalServiceKinds(ctx context.Context) (kinds []string, err error) {
 	defer recordOperation("externalServiceKinds")(&err)
-
-	services, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	kinds := make([]string, len(services))
-	for i, s := range services {
-		kinds[i] = s.Kind
-	}
-	return kinds, nil
+	kinds, err = db.ExternalServices.DistinctKinds(ctx)
+	return kinds, err
 }
 
 // check performs an update check. It returns the result and updates the global state

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -421,9 +421,10 @@ func (e *ExternalServicesStore) List(ctx context.Context, opt ExternalServicesLi
 // DistinctKinds returns the distinct list of external services kinds that are stored in the database.
 func (e *ExternalServicesStore) DistinctKinds(ctx context.Context) ([]string, error) {
 	q := sqlf.Sprintf(`
-SELECT ARRAY(
-	SELECT DISTINCT(kind)::TEXT FROM external_services
-)`)
+SELECT ARRAY_AGG(DISTINCT(kind)::TEXT)
+FROM external_services
+WHERE deleted_at IS NULL
+`)
 
 	rows, err := dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -406,7 +406,12 @@ func TestExternalServicesStore_DistinctKinds(t *testing.T) {
 		{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GITLAB #1",
-			Config:      `{"url": "https://github.com", "projectQuery": ["none"], "token": "def"}`,
+			Config:      `{"url": "https://github.com", "projectQuery": ["none"], "token": "abc"}`,
+		},
+		{
+			Kind:        extsvc.KindOther,
+			DisplayName: "OTHER #1",
+			Config:      `{"repos": []}`,
 		},
 	}
 	for _, es := range ess {
@@ -414,6 +419,12 @@ func TestExternalServicesStore_DistinctKinds(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	// Delete the last external service which should be excluded from the result
+	err := ExternalServices.Delete(ctx, ess[3].ID)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	kinds, err := ExternalServices.DistinctKinds(ctx)


### PR DESCRIPTION
Instead of listing all external services then get distinct kinds, we do it in SQL.

Part of #12760.