### PR TITLE
Fix deletion of expired ChangesetSpecs

### DIFF
--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -60,11 +60,14 @@ func enterpriseInit(
 	// Set up expired spec deletion
 	go func() {
 		for {
-			if err := campaignsStore.DeleteExpiredCampaignSpecs(ctx); err != nil {
-				log15.Error("DeleteExpiredCampaignSpecs", "error", err)
-			}
+			// We first need to delete expired ChangesetSpecs...
 			if err := campaignsStore.DeleteExpiredChangesetSpecs(ctx); err != nil {
 				log15.Error("DeleteExpiredChangesetSpecs", "error", err)
+			}
+			// ... and then the CampaignSpecs, due to the campaign_spec_id
+			// foreign key on changeset_specs.
+			if err := campaignsStore.DeleteExpiredCampaignSpecs(ctx); err != nil {
+				log15.Error("DeleteExpiredCampaignSpecs", "error", err)
 			}
 
 			time.Sleep(2 * time.Minute)

--- a/enterprise/internal/campaigns/store_campaign_specs.go
+++ b/enterprise/internal/campaigns/store_campaign_specs.go
@@ -284,7 +284,10 @@ WHERE
   created_at < %s
 AND
 NOT EXISTS (
-  SELECT 1 FROM campaigns WHERE campaigns.campaign_spec_id = campaign_specs.id
+  SELECT 1 FROM campaigns WHERE campaign_spec_id = campaign_specs.id
+)
+AND NOT EXISTS (
+  SELECT 1 FROM changeset_specs WHERE campaign_spec_id = campaign_specs.id
 );
 `
 


### PR DESCRIPTION
The comments in the code explain what was wrong before:

* We tried to delete `CampaignSpecs` before the `ChangesetSpecs`, which would lead to a foreign key constraint violation.
* We expired `ChangesetSpecs` that were still attached to a `Changeset`, either as the `PreviousSpec` or the `CurrentSpec`.

This commit fixes both issues and fixes #12763.
