### PR TITLE
external_services: add NoNamespace option to the List method

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -119,7 +119,11 @@ func handleConfigOverrides() error {
 				log15.Warn("EXTSVC_CONFIG_FILE contains zero external service configurations")
 			}
 
-			existing, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{})
+			existing, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{
+				// NOTE: External services loaded from config file do not have namespace specified.
+				// Therefore, we only need to load those from database.
+				NoNamespace: true,
+			})
 			if err != nil {
 				return errors.Wrap(err, "ExternalServices.List")
 			}

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -57,14 +57,21 @@ type ExternalServiceKind struct {
 
 // ExternalServicesListOptions contains options for listing external services.
 type ExternalServicesListOptions struct {
+	// When true, only include external services not under any namespace (i.e. owned by all site admins),
+	// and value of NamespaceUserID is ignored.
+	NoNamespace bool
+	// When specified, only include external services under given user namespace.
 	NamespaceUserID int32
-	Kinds           []string
+	// When specified, only include external services with given list of kinds.
+	Kinds []string
 	*LimitOffset
 }
 
 func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	conds := []*sqlf.Query{sqlf.Sprintf("deleted_at IS NULL")}
-	if o.NamespaceUserID > 0 {
+	if o.NoNamespace {
+		conds = append(conds, sqlf.Sprintf(`namespace_user_id IS NULL`))
+	} else if o.NamespaceUserID > 0 {
 		conds = append(conds, sqlf.Sprintf(`namespace_user_id = %d`, o.NamespaceUserID))
 	}
 	if len(o.Kinds) > 0 {

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -272,24 +272,24 @@ func (e *ExternalServicesStore) validateDuplicateRateLimits(ctx context.Context,
 // determines a deadlock occurred.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error {
+func (e *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, es *types.ExternalService) error {
 	if Mocks.ExternalServices.Create != nil {
-		return Mocks.ExternalServices.Create(ctx, confGet, externalService)
+		return Mocks.ExternalServices.Create(ctx, confGet, es)
 	}
 
 	ps := confGet().AuthProviders
-	if err := e.ValidateConfig(ctx, 0, externalService.Kind, externalService.Config, ps); err != nil {
+	if err := e.ValidateConfig(ctx, 0, es.Kind, es.Config, ps); err != nil {
 		return err
 	}
 
-	externalService.CreatedAt = time.Now().UTC().Truncate(time.Microsecond)
-	externalService.UpdatedAt = externalService.CreatedAt
+	es.CreatedAt = time.Now().UTC().Truncate(time.Microsecond)
+	es.UpdatedAt = es.CreatedAt
 
 	return dbconn.Global.QueryRowContext(
 		ctx,
 		"INSERT INTO external_services(kind, display_name, config, created_at, updated_at, namespace_user_id) VALUES($1, $2, $3, $4, $5, $6) RETURNING id",
-		externalService.Kind, externalService.DisplayName, externalService.Config, externalService.CreatedAt, externalService.UpdatedAt, externalService.NamespaceUserID,
-	).Scan(&externalService.ID)
+		es.Kind, es.DisplayName, es.Config, es.CreatedAt, es.UpdatedAt, es.NamespaceUserID,
+	).Scan(&es.ID)
 }
 
 // ExternalServiceUpdate contains optional fields to update.

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -18,6 +19,7 @@ import (
 func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 	tests := []struct {
 		name            string
+		noNamespace     bool
 		namespaceUserID int32
 		kinds           []string
 		wantQuery       string
@@ -45,10 +47,17 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 			wantQuery:       "deleted_at IS NULL AND namespace_user_id = $1",
 			wantArgs:        []interface{}{int32(1)},
 		},
+		{
+			name:            "want no namespace",
+			noNamespace:     true,
+			namespaceUserID: 1,
+			wantQuery:       "deleted_at IS NULL AND namespace_user_id IS NULL",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			opts := ExternalServicesListOptions{
+				NoNamespace:     test.noNamespace,
 				NamespaceUserID: test.namespaceUserID,
 				Kinds:           test.kinds,
 			}
@@ -313,46 +322,69 @@ func TestExternalServicesStore_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a new external service
+	// Create new external services
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
 	}
-	es := &types.ExternalService{
-		Kind:            extsvc.KindGitHub,
-		DisplayName:     "GITHUB #1",
-		Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-		NamespaceUserID: &user.ID,
+	ess := []*types.ExternalService{
+		{
+			Kind:            extsvc.KindGitHub,
+			DisplayName:     "GITHUB #1",
+			Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			NamespaceUserID: &user.ID,
+		},
+		{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "GITHUB #2",
+			Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "def"}`,
+		},
 	}
-	err = (&ExternalServicesStore{}).Create(ctx, confGet, es)
-	if err != nil {
-		t.Fatal(err)
+	for _, es := range ess {
+		err := ExternalServices.Create(ctx, confGet, es)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	t.Run("list all external services", func(t *testing.T) {
-		ess, err := (&ExternalServicesStore{}).List(ctx, ExternalServicesListOptions{})
+		got, err := (&ExternalServicesStore{}).List(ctx, ExternalServicesListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Slice(got, func(i, j int) bool { return got[i].ID < got[j].ID })
+
+		if diff := cmp.Diff(ess, got); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("list external services with no namespace", func(t *testing.T) {
+		got, err := (&ExternalServicesStore{}).List(ctx, ExternalServicesListOptions{
+			NoNamespace: true,
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(ess) != 1 {
+		if len(got) != 1 {
 			t.Fatalf("Want 1 external service but got %d", len(ess))
-		} else if diff := cmp.Diff(es, ess[0]); diff != "" {
-			t.Fatalf("(-want +got):\n%s", diff)
+		} else if diff := cmp.Diff(ess[1], got[0]); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
 	})
 
 	t.Run("list only test user's external services", func(t *testing.T) {
-		ess, err := (&ExternalServicesStore{}).List(ctx, ExternalServicesListOptions{
+		got, err := (&ExternalServicesStore{}).List(ctx, ExternalServicesListOptions{
 			NamespaceUserID: user.ID,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(ess) != 1 {
+		if len(got) != 1 {
 			t.Fatalf("Want 1 external service but got %d", len(ess))
-		} else if diff := cmp.Diff(es, ess[0]); diff != "" {
-			t.Fatalf("(-want +got):\n%s", diff)
+		} else if diff := cmp.Diff(ess[0], got[0]); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
 	})
 


### PR DESCRIPTION
The new `NoNamespace` option allow listing external services under no particular namespace (i.e. site-level external services owned by all site admins). 

This option is then used in handling config overrides of external services from config file. This approach has the minimal change without listing any user-added external services (which are not used in the process of config overrides).

Easier to review by commit.

Part of #12760.