### PR TITLE
Fix "changesets processing?" checks in CloseCampaign/DeleteCampaign methods

### DIFF
--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -217,25 +217,69 @@ func TestService(t *testing.T) {
 			t.Fatalf("campaign not deleted: %s", err)
 		}
 
-		_, err = store.GetCampaign(ctx, GetCampaignOpts{ID: campaign.ID})
+		_, err := store.GetCampaign(ctx, GetCampaignOpts{ID: campaign.ID})
 		if err != nil && err != ErrNoResults {
 			t.Fatalf("want campaign to be deleted, but was not: %e", err)
 		}
 	})
 
 	t.Run("CloseCampaign", func(t *testing.T) {
-		campaign := testCampaign(admin.ID)
-		if err := svc.CreateCampaign(ctx, campaign); err != nil {
-			t.Fatal(err)
+		createCampaign := func(t *testing.T) *campaigns.Campaign {
+			t.Helper()
+			campaign := testCampaign(admin.ID)
+			if err := store.CreateCampaign(ctx, campaign); err != nil {
+				t.Fatal(err)
+			}
+			return campaign
 		}
 
-		campaign, err := svc.CloseCampaign(ctx, campaign.ID, true)
-		if err != nil {
-			t.Fatalf("campaign not closed: %s", err)
+		closeConfirm := func(t *testing.T, c *campaigns.Campaign, closeChangesets bool) {
+			t.Helper()
+
+			closedCampaign, err := svc.CloseCampaign(ctx, c.ID, closeChangesets)
+			if err != nil {
+				t.Fatalf("campaign not closed: %s", err)
+			}
+			if closedCampaign.ClosedAt.IsZero() {
+				t.Fatalf("campaign ClosedAt is zero")
+			}
 		}
-		if campaign.ClosedAt.IsZero() {
-			t.Fatalf("campaign ClosedAt is zero")
-		}
+
+		t.Run("no changesets", func(t *testing.T) {
+			campaign := createCampaign(t)
+			closeConfirm(t, campaign, false)
+		})
+
+		t.Run("processing changesets", func(t *testing.T) {
+			campaign := createCampaign(t)
+
+			changeset := testChangeset(rs[0].ID, campaign.ID, campaigns.ChangesetExternalStateOpen)
+			changeset.ReconcilerState = campaigns.ReconcilerStateProcessing
+			if err := store.CreateChangeset(ctx, changeset); err != nil {
+				t.Fatal(err)
+			}
+
+			// should fail
+			_, err := svc.CloseCampaign(ctx, campaign.ID, true)
+			if err != ErrCloseProcessingCampaign {
+				t.Fatalf("CloseCampaign returned unexpected error: %s", err)
+			}
+
+			// without trying to close changesets, it should succeed:
+			closeConfirm(t, campaign, false)
+		})
+
+		t.Run("non-processing changesets", func(t *testing.T) {
+			campaign := createCampaign(t)
+
+			changeset := testChangeset(rs[0].ID, campaign.ID, campaigns.ChangesetExternalStateOpen)
+			changeset.ReconcilerState = campaigns.ReconcilerStateCompleted
+			if err := store.CreateChangeset(ctx, changeset); err != nil {
+				t.Fatal(err)
+			}
+
+			closeConfirm(t, campaign, true)
+		})
 	})
 
 	t.Run("EnqueueChangesetSync", func(t *testing.T) {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -216,6 +216,11 @@ func TestService(t *testing.T) {
 		if err := svc.DeleteCampaign(ctx, campaign.ID); err != nil {
 			t.Fatalf("campaign not deleted: %s", err)
 		}
+
+		_, err = store.GetCampaign(ctx, GetCampaignOpts{ID: campaign.ID})
+		if err != nil && err != ErrNoResults {
+			t.Fatalf("want campaign to be deleted, but was not: %e", err)
+		}
 	})
 
 	t.Run("CloseCampaign", func(t *testing.T) {

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -185,6 +185,7 @@ type CountChangesetsOpts struct {
 	ExternalState       *campaigns.ChangesetExternalState
 	ExternalReviewState *campaigns.ChangesetReviewState
 	ExternalCheckState  *campaigns.ChangesetCheckState
+	ReconcilerState     *campaigns.ReconcilerState
 }
 
 // CountChangesets returns the number of changesets in the database.
@@ -216,6 +217,11 @@ func countChangesetsQuery(opts *CountChangesetsOpts) *sqlf.Query {
 	}
 	if opts.ExternalCheckState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.external_check_state = %s", *opts.ExternalCheckState))
+	}
+
+	if opts.ReconcilerState != nil {
+		state := (*opts.ReconcilerState).ToDB()
+		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state = %s", state))
 	}
 
 	return sqlf.Sprintf(countChangesetsQueryFmtstr, sqlf.Join(preds, "\n AND "))

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -235,23 +236,50 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 	})
 
 	t.Run("Count", func(t *testing.T) {
-		count, err := s.CountChangesets(ctx, CountChangesetsOpts{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run("No options", func(t *testing.T) {
+			count, err := s.CountChangesets(ctx, CountChangesetsOpts{})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if have, want := count, len(changesets); have != want {
-			t.Fatalf("have count: %d, want: %d", have, want)
-		}
+			if have, want := count, len(changesets); have != want {
+				t.Fatalf("have count: %d, want: %d", have, want)
+			}
 
-		count, err = s.CountChangesets(ctx, CountChangesetsOpts{CampaignID: 1})
-		if err != nil {
-			t.Fatal(err)
-		}
+		})
 
-		if have, want := count, 1; have != want {
-			t.Fatalf("have count: %d, want: %d", have, want)
-		}
+		t.Run("CampaignID", func(t *testing.T) {
+			count, err := s.CountChangesets(ctx, CountChangesetsOpts{CampaignID: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := count, 1; have != want {
+				t.Fatalf("have count: %d, want: %d", have, want)
+			}
+		})
+
+		t.Run("ReconcilerState", func(t *testing.T) {
+			completed := campaigns.ReconcilerStateCompleted
+			countCompleted, err := s.CountChangesets(ctx, CountChangesetsOpts{ReconcilerState: &completed})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countCompleted, len(changesets); have != want {
+				t.Fatalf("have countCompleted: %d, want: %d", have, want)
+			}
+
+			processing := campaigns.ReconcilerStateProcessing
+			countProcessing, err := s.CountChangesets(ctx, CountChangesetsOpts{ReconcilerState: &processing})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countProcessing, 0; have != want {
+				t.Fatalf("have countProcessing: %d, want: %d", have, want)
+			}
+		})
 	})
 
 	t.Run("List", func(t *testing.T) {


### PR DESCRIPTION
This fixes #12643 by fixing the checks and updating the methods to the new workflow model.

1. `DeleteCampaign` won't have a check anymore, since it also doesn't accept the `closeChangesets: bool` parameter anymore. That's documented in the GraphQL API and we should make that visible in the UI.
2. `CloseCampaign` now only returns an error if the user _wants to close the open changesets_ and the _changesets are processing_.

Why do we return an error? Because if the user wants to close the open changesets, we can't guarantee that we close all of them if they're currently processing.

In the future, when we move the closing of changesets to the reconciler, we can revisit this. But even then it'll be hard to mark a changeset as closed *and* enqueue it for the reconciler while the reconciler is working on it. Since the reconciler would overwrite the the `reconciler_state` field. But that can be worked around by, say, introducing a `to_be_closed` field and a cron-like job enqueuing these changesets again and again until the field is `false` and the `external_state` is closed.