### PR TITLE
Allow listing a user's and org's campaigns

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -29,6 +29,8 @@ type ListCampaignArgs struct {
 	First               *int32
 	State               *string
 	ViewerCanAdminister *bool
+
+	Namespace *graphql.ID
 }
 
 type CloseCampaignArgs struct {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -335,11 +335,12 @@ func prometheusGraphQLRequestName(requestName string) string {
 
 func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz AuthzResolver) (*graphql.Schema, error) {
 	resolver := &schemaResolver{
-		// CampaignsResolver: defaultCampaignsResolver{},
+		CampaignsResolver: defaultCampaignsResolver{},
 		AuthzResolver:     defaultAuthzResolver{},
 		CodeIntelResolver: defaultCodeIntelResolver{},
 	}
 	if campaigns != nil {
+		EnterpriseResolvers.campaignsResolver = campaigns
 		resolver.CampaignsResolver = campaigns
 	}
 	if codeIntel != nil {
@@ -524,9 +525,11 @@ type schemaResolver struct {
 var EnterpriseResolvers = struct {
 	codeIntelResolver CodeIntelResolver
 	authzResolver     AuthzResolver
+	campaignsResolver CampaignsResolver
 }{
 	codeIntelResolver: defaultCodeIntelResolver{},
 	authzResolver:     defaultAuthzResolver{},
+	campaignsResolver: defaultCampaignsResolver{},
 }
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -171,6 +171,12 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 
 func (o *OrgResolver) NamespaceName() string { return o.org.Name }
 
+func (o *OrgResolver) Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error) {
+	id := o.ID()
+	args.Namespace = &id
+	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)
+}
+
 func (*schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	Name        string
 	DisplayName *string

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3334,6 +3334,15 @@ type User implements Node & SettingsSubject & Namespace {
     # The permissions information of the user over repositories.
     # It is null when there is no permissions data stored for the user.
     permissionsInfo: PermissionsInfo
+
+    # A list of campaigns applied under this user's namespace.
+    campaigns(
+        # Returns the first n campaigns from the list.
+        first: Int
+        state: CampaignState
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
 }
 
 # An access token that grants to the holder the privileges of the user who created it.
@@ -3526,6 +3535,15 @@ type Org implements Node & SettingsSubject & Namespace {
 
     # The name of this user namespace's component. For organizations, this is the organization's name.
     namespaceName: String!
+
+    # A list of campaigns initially applied in this organization.
+    campaigns(
+        # Returns the first n campaigns from the list.
+        first: Int
+        state: CampaignState
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
 }
 
 # The result of Mutation.inviteUserToOrganization.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3341,6 +3341,15 @@ type User implements Node & SettingsSubject & Namespace {
     # The permissions information of the user over repositories.
     # It is null when there is no permissions data stored for the user.
     permissionsInfo: PermissionsInfo
+
+    # A list of campaigns applied under this user's namespace.
+    campaigns(
+        # Returns the first n campaigns from the list.
+        first: Int
+        state: CampaignState
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
 }
 
 # An access token that grants to the holder the privileges of the user who created it.
@@ -3533,6 +3542,15 @@ type Org implements Node & SettingsSubject & Namespace {
 
     # The name of this user namespace's component. For organizations, this is the organization's name.
     namespaceName: String!
+
+    # A list of campaigns initially applied in this organization.
+    campaigns(
+        # Returns the first n campaigns from the list.
+        first: Int
+        state: CampaignState
+        # Only include campaigns that the viewer can administer.
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
 }
 
 # The result of Mutation.inviteUserToOrganization.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -317,6 +317,12 @@ func (r *UserResolver) ViewerCanChangeUsername(ctx context.Context) bool {
 	return viewerCanChangeUsername(ctx, r.user.ID)
 }
 
+func (r *UserResolver) Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error) {
+	id := r.ID()
+	args.Namespace = &id
+	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)
+}
+
 func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		return false

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -63,11 +63,15 @@ type User struct {
 	ID         string
 	DatabaseID int32
 	SiteAdmin  bool
+
+	Campaigns CampaignConnection
 }
 
 type Org struct {
 	ID   string
 	Name string
+
+	Campaigns CampaignConnection
 }
 
 type UserOrg struct {

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -41,7 +41,13 @@ func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacke
 }
 
 func (r *campaignsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	opts := ee.CountCampaignsOpts{ChangesetID: r.opts.ChangesetID, State: r.opts.State, OnlyForAuthor: r.opts.OnlyForAuthor}
+	opts := ee.CountCampaignsOpts{
+		ChangesetID:     r.opts.ChangesetID,
+		State:           r.opts.State,
+		OnlyForAuthor:   r.opts.OnlyForAuthor,
+		NamespaceUserID: r.opts.NamespaceUserID,
+		NamespaceOrgID:  r.opts.NamespaceOrgID,
+	}
 	count, err := r.store.CountCampaigns(ctx, opts)
 	return int32(count), err
 }

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -412,12 +412,14 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 		case "Org":
 			err = relay.UnmarshalSpec(*args.Namespace, &opts.NamespaceOrgID)
 		default:
-			err = errors.Errorf("Invalid namespace %q", args.Namespace)
+			err = errors.Errorf("Invalid namespace %q", *args.Namespace)
 		}
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	fmt.Printf("opts=%+v\n", opts)
 
 	return &campaignsConnectionResolver{
 		store:       r.store,

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -395,7 +395,7 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 
 	authErr := backend.CheckCurrentUserIsSiteAdmin(ctx)
 	if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
-		return nil, err
+		return nil, authErr
 	}
 	isSiteAdmin := authErr != backend.ErrMustBeSiteAdmin
 	if !isSiteAdmin {
@@ -414,7 +414,11 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 		default:
 			err = errors.Errorf("Invalid namespace %q", args.Namespace)
 		}
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	return &campaignsConnectionResolver{
 		store:       r.store,
 		httpFactory: r.httpFactory,

--- a/enterprise/internal/campaigns/store_campaigns.go
+++ b/enterprise/internal/campaigns/store_campaigns.go
@@ -273,6 +273,9 @@ type ListCampaignsOpts struct {
 	State       campaigns.CampaignState
 	// Only return campaigns where author_id is the given.
 	OnlyForAuthor int32
+
+	NamespaceUserID int32
+	NamespaceOrgID  int32
 }
 
 // ListCampaigns lists Campaigns with the given filters.
@@ -328,6 +331,14 @@ func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
 
 	if opts.OnlyForAuthor != 0 {
 		preds = append(preds, sqlf.Sprintf("author_id = %d", opts.OnlyForAuthor))
+	}
+
+	if opts.NamespaceUserID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaigns.namespace_user_id = %s", opts.NamespaceUserID))
+	}
+
+	if opts.NamespaceOrgID != 0 {
+		preds = append(preds, sqlf.Sprintf("campaigns.namespace_org_id = %s", opts.NamespaceOrgID))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store_campaigns.go
+++ b/enterprise/internal/campaigns/store_campaigns.go
@@ -155,6 +155,9 @@ type CountCampaignsOpts struct {
 	State       campaigns.CampaignState
 	// Only return campaigns where author_id is the given.
 	OnlyForAuthor int32
+
+	NamespaceUserID int32
+	NamespaceOrgID  int32
 }
 
 // CountCampaigns returns the number of campaigns in the database.
@@ -184,6 +187,14 @@ func countCampaignsQuery(opts *CountCampaignsOpts) *sqlf.Query {
 
 	if opts.OnlyForAuthor != 0 {
 		preds = append(preds, sqlf.Sprintf("author_id = %d", opts.OnlyForAuthor))
+	}
+
+	if opts.NamespaceUserID != 0 {
+		preds = append(preds, sqlf.Sprintf("namespace_user_id = %s", opts.NamespaceUserID))
+	}
+
+	if opts.NamespaceOrgID != 0 {
+		preds = append(preds, sqlf.Sprintf("namespace_org_id = %s", opts.NamespaceOrgID))
 	}
 
 	if len(preds) == 0 {

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -216,6 +216,44 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				}
 			}
 		})
+
+		t.Run("ListCampaigns by NamespaceUserID", func(t *testing.T) {
+			for _, c := range campaigns {
+				if c.NamespaceUserID == 0 {
+					continue
+				}
+				opts := ListCampaignsOpts{NamespaceUserID: c.NamespaceUserID}
+				have, _, err := s.ListCampaigns(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				for _, haveCampaign := range have {
+					if have, want := haveCampaign.NamespaceUserID, opts.NamespaceUserID; have != want {
+						t.Fatalf("campaign has wrong NamespaceUserID. want=%d, have=%d", want, have)
+					}
+				}
+			}
+		})
+
+		t.Run("ListCampaigns by NamespaceOrgID", func(t *testing.T) {
+			for _, c := range campaigns {
+				if c.NamespaceOrgID == 0 {
+					continue
+				}
+				opts := ListCampaignsOpts{NamespaceOrgID: c.NamespaceOrgID}
+				have, _, err := s.ListCampaigns(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				for _, haveCampaign := range have {
+					if have, want := haveCampaign.NamespaceOrgID, opts.NamespaceOrgID; have != want {
+						t.Fatalf("campaign has wrong NamespaceOrgID. want=%d, have=%d", want, have)
+					}
+				}
+			}
+		})
 	})
 
 	t.Run("Update", func(t *testing.T) {

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -93,6 +93,54 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 				}
 			}
 		})
+
+		t.Run("NamespaceUserID", func(t *testing.T) {
+			wantCounts := map[int32]int{}
+			for _, c := range campaigns {
+				if c.NamespaceUserID == 0 {
+					continue
+				}
+				wantCounts[c.NamespaceUserID] += 1
+			}
+			if len(wantCounts) == 0 {
+				t.Fatalf("No campaigns with NamespaceUserID")
+			}
+
+			for userID, want := range wantCounts {
+				have, err := s.CountCampaigns(ctx, CountCampaignsOpts{NamespaceUserID: userID})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have != want {
+					t.Fatalf("campaigns count for NamespaceUserID=%d wrong. want=%d, have=%d", userID, want, have)
+				}
+			}
+		})
+
+		t.Run("NamespaceOrgID", func(t *testing.T) {
+			wantCounts := map[int32]int{}
+			for _, c := range campaigns {
+				if c.NamespaceOrgID == 0 {
+					continue
+				}
+				wantCounts[c.NamespaceOrgID] += 1
+			}
+			if len(wantCounts) == 0 {
+				t.Fatalf("No campaigns with NamespaceOrgID")
+			}
+
+			for orgID, want := range wantCounts {
+				have, err := s.CountCampaigns(ctx, CountCampaignsOpts{NamespaceOrgID: orgID})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have != want {
+					t.Fatalf("campaigns count for NamespaceOrgID=%d wrong. want=%d, have=%d", orgID, want, have)
+				}
+			}
+		})
 	})
 
 	t.Run("List", func(t *testing.T) {

--- a/web/src/repogroups/RepogroupPage.story.tsx
+++ b/web/src/repogroups/RepogroupPage.story.tsx
@@ -116,6 +116,12 @@ const authUser = {
     databaseID: 0,
     namespaceName: '',
     permissionsInfo: null,
+    campaigns: {
+        __typename: 'CampaignConnection',
+        totalCount: 0,
+        pageInfo: { __typename: 'PageInfo', endCursor: null, hasNextPage: false },
+        nodes: [] as GQL.ICampaign[],
+    },
 } as GQL.IUser
 
 const commonProps: RepogroupPageProps = {


### PR DESCRIPTION
This fixes #12563.

@eseliger does it make sense to make the `Namespace: graphql.ID` parameter on `campaigns()` public? It would allow filtering campaigns by namespace on the main page. But I'm not sure whether we have a need for that right now.

@efritz @unknwon I saw that you two use this pattern of using `EnterpriseResolvers` to talk to them from the normal graphqlbackend — can you both take a look and see whether I did it correctly?