### PR TITLE
dev: add DEV_NO_CONFIG to prevent overwriting config

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -101,10 +101,12 @@ export SOURCEGRAPH_HTTPS_PORT="${SOURCEGRAPH_HTTPS_PORT:-"3443"}"
 export SRC_HTTP_ADDR=":3082"
 export WEBPACK_DEV_SERVER=1
 
-export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-./dev/site-config.json}
-export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-./dev/global-settings.json}
-export SITE_CONFIG_ALLOW_EDITS=true
-export GLOBAL_SETTINGS_ALLOW_EDITS=true
+if [ -z "${DEV_NO_CONFIG-}" ]; then
+  export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-./dev/site-config.json}
+  export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-./dev/global-settings.json}
+  export SITE_CONFIG_ALLOW_EDITS=true
+  export GLOBAL_SETTINGS_ALLOW_EDITS=true
+fi
 
 # WebApp
 export NODE_ENV=development

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -57,6 +57,8 @@ You'll need to clone [`sourcegraph/dev-private`](https://github.com/sourcegraph/
 
 After the initial setup you can run `enterprise/dev/start.sh` instead of `dev/start.sh`.
 
+The environment variables `SITE_CONFIG_FILE`, `EXTSVC_CONFIG_FILE` and `GLOBAL_SETTINGS_FILE` are paths that are read at startup. The content of the files will overwrite the respective setting. `start.sh` will set these files to point into `dev-private`. To avoid overwriting configuration changes done in Sourcegraph, you can set the environment variable `DEV_NO_CONFIG=1`.
+
 ## Step 1: Install dependencies
 
 

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -25,12 +25,14 @@ fi
 # shellcheck disable=SC1090
 source "$DEV_PRIVATE_PATH/enterprise/dev/env"
 
-export SITE_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/site-config.json
-export EXTSVC_CONFIG_FILE=$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json
-export GLOBAL_SETTINGS_FILE=$PWD/../dev/global-settings.json
-export SITE_CONFIG_ALLOW_EDITS=true
-export GLOBAL_SETTINGS_ALLOW_EDITS=true
-export EXTSVC_CONFIG_ALLOW_EDITS=true
+if [ -z "${DEV_NO_CONFIG-}" ]; then
+  export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-$DEV_PRIVATE_PATH/enterprise/dev/site-config.json}
+  export EXTSVC_CONFIG_FILE=${EXTSVC_CONFIG_FILE:-$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json}
+  export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-$PWD/../dev/global-settings.json}
+  export SITE_CONFIG_ALLOW_EDITS=true
+  export GLOBAL_SETTINGS_ALLOW_EDITS=true
+  export EXTSVC_CONFIG_ALLOW_EDITS=true
+fi
 
 SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat "$DEV_PRIVATE_PATH"/enterprise/dev/test-license-generation-key.pem)
 export SOURCEGRAPH_LICENSE_GENERATION_KEY


### PR DESCRIPTION
When developing and restarting the sourcegraph frontend, it will
overwrite the configuration stored in the database. This setting
prevents loading configuration from files, which in turn will prevent
the overwriting behaviour.