### PR TITLE
Add test for label resolver with empty description

### DIFF
--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -149,7 +149,7 @@ type Comparison struct {
 type Label struct {
 	Text        string
 	Color       string
-	Description string
+	Description *string
 }
 
 type ChangesetConnection struct {

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -117,7 +117,7 @@ func TestChangesetResolver(t *testing.T) {
 			},
 			Labels: struct{ Nodes []github.Label }{
 				Nodes: []github.Label{
-					{ID: "label-no-description", Name: "Bug", Color: "121212"},
+					{ID: "label-no-description", Name: "no-description", Color: "121212"},
 				},
 			},
 			CreatedAt: now,
@@ -184,8 +184,8 @@ func TestChangesetResolver(t *testing.T) {
 					TotalCount: 2,
 				},
 				Labels: []apitest.Label{
-					{Text: "Bug", Color: "121212", Description: nil},
 					{Text: "cool-label", Color: "blue", Description: &labelEventDescriptionText},
+					{Text: "no-description", Color: "121212", Description: nil},
 				},
 				Head: apitest.GitRef{
 					Name:        "refs/heads/open-pr",

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -70,6 +70,8 @@ func TestChangesetResolver(t *testing.T) {
 		createdByCampaign:   false,
 	})
 
+	labelEventDescriptionText := "the best label in town"
+
 	syncedGitHubChangeset := createChangeset(t, ctx, store, testChangesetOpts{
 		repo: repo.ID,
 		// We don't need a spec, because the resolver should take all the data
@@ -106,11 +108,17 @@ func TestChangesetResolver(t *testing.T) {
 				{Type: "LabeledEvent", Item: &github.LabelEvent{
 					CreatedAt: now.Add(5 * time.Second),
 					Label: github.Label{
+						ID:          "label-event",
 						Name:        "cool-label",
 						Color:       "blue",
-						Description: "the best label in town",
+						Description: labelEventDescriptionText,
 					},
 				}},
+			},
+			Labels: struct{ Nodes []github.Label }{
+				Nodes: []github.Label{
+					{ID: "label-no-description", Name: "Bug", Color: "121212"},
+				},
 			},
 			CreatedAt: now,
 			UpdatedAt: now,
@@ -176,7 +184,8 @@ func TestChangesetResolver(t *testing.T) {
 					TotalCount: 2,
 				},
 				Labels: []apitest.Label{
-					{Text: "cool-label", Color: "blue", Description: "the best label in town"},
+					{Text: "Bug", Color: "121212", Description: nil},
+					{Text: "cool-label", Color: "blue", Description: &labelEventDescriptionText},
 				},
 				Head: apitest.GitRef{
 					Name:        "refs/heads/open-pr",


### PR DESCRIPTION
I figured we should have a test for that as well, to prevent a regression.