### PR TITLE
Fix pagination for changesets

### DIFF
--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -155,10 +155,8 @@ type Label struct {
 type ChangesetConnection struct {
 	Nodes      []Changeset
 	TotalCount int
-	PageInfo   struct {
-		HasNextPage bool
-	}
-	Stats ChangesetConnectionStats
+	PageInfo   PageInfo
+	Stats      ChangesetConnectionStats
 }
 
 type ChangesetConnectionStats struct {
@@ -243,4 +241,8 @@ type ChangesetSpecDescription struct {
 type GitCommitDescription struct {
 	Message string
 	Diff    string
+}
+
+type PageInfo struct {
+	HasNextPage bool
 }

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -165,20 +165,18 @@ func (r *changesetResolver) computeNextSyncAt(ctx context.Context) (time.Time, e
 			if r.preloadedNextSyncAt != nil {
 				r.nextSyncAt = *r.preloadedNextSyncAt
 			}
-		} else {
-			syncData, err := r.store.ListChangesetSyncData(ctx, ee.ListChangesetSyncDataOpts{ChangesetIDs: []int64{r.changeset.ID}})
-			if err != nil {
-				r.nextSyncAtErr = err
+			return
+		}
+		syncData, err := r.store.ListChangesetSyncData(ctx, ee.ListChangesetSyncDataOpts{ChangesetIDs: []int64{r.changeset.ID}})
+		if err != nil {
+			r.nextSyncAtErr = err
+			return
+		}
+		for _, d := range syncData {
+			if d.ChangesetID == r.changeset.ID {
+				r.nextSyncAt = ee.NextSync(time.Now, d)
 				return
 			}
-			for _, d := range syncData {
-				if d.ChangesetID == r.changeset.ID {
-					r.nextSyncAt = ee.NextSync(time.Now, d)
-					return
-				}
-			}
-			// Return zero time if not found in the sync data.
-			return
 		}
 	})
 	return r.nextSyncAt, r.nextSyncAtErr

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,6 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
@@ -30,9 +33,11 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 
 	repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)
-	if err := rstore.UpsertRepos(ctx, repo); err != nil {
+	inaccessibleRepo := newGitHubTestRepo("github.com/sourcegraph/private", 2)
+	if err := rstore.UpsertRepos(ctx, repo, inaccessibleRepo); err != nil {
 		t.Fatal(err)
 	}
+	ct.AuthzFilterRepos(t, inaccessibleRepo.ID)
 
 	campaign := &campaigns.Campaign{
 		Name:            "my-unique-name",
@@ -50,6 +55,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		currentSpec:         0,
 		externalServiceType: "github",
 		publicationState:    campaigns.ChangesetPublicationStateUnpublished,
+		externalReviewState: campaigns.ChangesetReviewStatePending,
 		ownedByCampaign:     campaign.ID,
 		campaign:            campaign.ID,
 	})
@@ -61,6 +67,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		externalBranch:      "open-pr",
 		externalState:       campaigns.ChangesetExternalStateOpen,
 		publicationState:    campaigns.ChangesetPublicationStatePublished,
+		externalReviewState: campaigns.ChangesetReviewStatePending,
 		ownedByCampaign:     campaign.ID,
 		campaign:            campaign.ID,
 	})
@@ -72,6 +79,18 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		externalBranch:      "merged-pr",
 		externalState:       campaigns.ChangesetExternalStateMerged,
 		publicationState:    campaigns.ChangesetPublicationStatePublished,
+		externalReviewState: campaigns.ChangesetReviewStatePending,
+		ownedByCampaign:     campaign.ID,
+		campaign:            campaign.ID,
+	})
+	changeset4 := createChangeset(t, ctx, store, testChangesetOpts{
+		repo:                inaccessibleRepo.ID,
+		externalServiceType: "github",
+		externalID:          "987651",
+		externalBranch:      "open-hidden-pr",
+		externalState:       campaigns.ChangesetExternalStateOpen,
+		publicationState:    campaigns.ChangesetPublicationStatePublished,
+		externalReviewState: campaigns.ChangesetReviewStatePending,
 		ownedByCampaign:     campaign.ID,
 		campaign:            campaign.ID,
 	})
@@ -79,6 +98,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	addChangeset(t, ctx, store, campaign, changeset1.ID)
 	addChangeset(t, ctx, store, campaign, changeset2.ID)
 	addChangeset(t, ctx, store, campaign, changeset3.ID)
+	addChangeset(t, ctx, store, campaign, changeset4.ID)
 
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
 	if err != nil {
@@ -86,49 +106,130 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	}
 
 	campaignApiID := string(campaigns.MarshalCampaignID(campaign.ID))
-
-	input := map[string]interface{}{"campaign": campaignApiID}
-	var response struct{ Node apitest.Campaign }
-	apitest.MustExec(ctx, t, s, input, &response, queryChangesetConnection)
-
-	wantChangesets := apitest.ChangesetConnection{
-		Stats: apitest.ChangesetConnectionStats{
-			Unpublished: 1,
-			Open:        1,
-			Merged:      1,
-			Closed:      0,
-			Total:       3,
+	nodes := []apitest.Changeset{
+		{
+			Typename:   "ExternalChangeset",
+			ID:         string(marshalChangesetID(changeset1.ID)),
+			Repository: apitest.Repository{Name: repo.Name},
 		},
-		TotalCount: 3,
-		Nodes: []apitest.Changeset{
-			{
-				Typename:   "ExternalChangeset",
-				ID:         string(marshalChangesetID(changeset1.ID)),
-				Repository: apitest.Repository{Name: repo.Name},
-			},
-			{
-				Typename:   "ExternalChangeset",
-				ID:         string(marshalChangesetID(changeset2.ID)),
-				Repository: apitest.Repository{Name: repo.Name},
-			},
-			{
-				Typename:   "ExternalChangeset",
-				ID:         string(marshalChangesetID(changeset3.ID)),
-				Repository: apitest.Repository{Name: repo.Name},
-			},
+		{
+			Typename:   "ExternalChangeset",
+			ID:         string(marshalChangesetID(changeset2.ID)),
+			Repository: apitest.Repository{Name: repo.Name},
+		},
+		{
+			Typename:   "ExternalChangeset",
+			ID:         string(marshalChangesetID(changeset3.ID)),
+			Repository: apitest.Repository{Name: repo.Name},
+		},
+		{
+			Typename: "HiddenExternalChangeset",
+			ID:       string(marshalChangesetID(changeset4.ID)),
 		},
 	}
 
-	if diff := cmp.Diff(wantChangesets, response.Node.Changesets); diff != "" {
-		t.Fatalf("wrong changesets response (-want +got):\n%s", diff)
+	tests := []struct {
+		First           int
+		unsafeOpts      bool
+		wantHasNextPage bool
+		wantTotalCount  int
+		wantOpen        int
+		wantNodes       []apitest.Changeset
+	}{
+		{
+			First:           1,
+			wantHasNextPage: true,
+			wantTotalCount:  4,
+			wantOpen:        2,
+			wantNodes:       nodes[:1],
+		},
+		{
+			First:           2,
+			wantHasNextPage: true,
+			wantTotalCount:  4,
+			wantOpen:        2,
+			wantNodes:       nodes[:2],
+		},
+		{
+			First:           3,
+			wantHasNextPage: true,
+			wantTotalCount:  4,
+			wantOpen:        2,
+			wantNodes:       nodes[:3],
+		},
+		{
+			First:           4,
+			wantHasNextPage: false,
+			wantTotalCount:  4,
+			wantOpen:        2,
+			wantNodes:       nodes[:4],
+		},
+		{
+			First:           1,
+			unsafeOpts:      true,
+			wantHasNextPage: true,
+			// Expect only 3 changesets to be returned when an unsafe filter is applied.
+			wantTotalCount: 3,
+			wantOpen:       1,
+			wantNodes:      nodes[:1],
+		},
+		{
+			First:           2,
+			unsafeOpts:      true,
+			wantHasNextPage: true,
+			wantTotalCount:  3,
+			wantOpen:        1,
+			wantNodes:       nodes[:2],
+		},
+		{
+			First:           3,
+			unsafeOpts:      true,
+			wantHasNextPage: false,
+			wantTotalCount:  3,
+			wantOpen:        1,
+			wantNodes:       nodes[:3],
+		},
+	}
+
+	reviewStatePending := campaigns.ChangesetReviewStatePending
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("Unsafe opts %t, first %d", tc.unsafeOpts, tc.First), func(t *testing.T) {
+			var reviewState *campaigns.ChangesetReviewState
+			if tc.unsafeOpts {
+				reviewState = &reviewStatePending
+			}
+			input := map[string]interface{}{"campaign": campaignApiID, "first": int64(tc.First), "reviewState": reviewState}
+			var response struct{ Node apitest.Campaign }
+			apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryChangesetConnection)
+
+			wantChangesets := apitest.ChangesetConnection{
+				Stats: apitest.ChangesetConnectionStats{
+					Unpublished: 1,
+					Open:        tc.wantOpen,
+					Merged:      1,
+					Closed:      0,
+					Total:       tc.wantTotalCount,
+				},
+				TotalCount: tc.wantTotalCount,
+				PageInfo: apitest.PageInfo{
+					HasNextPage: tc.wantHasNextPage,
+				},
+				Nodes: tc.wantNodes,
+			}
+
+			if diff := cmp.Diff(wantChangesets, response.Node.Changesets); diff != "" {
+				t.Fatalf("wrong changesets response (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
 const queryChangesetConnection = `
-query($campaign: ID!){
+query($campaign: ID!, $first: Int, $reviewState: ChangesetReviewState){
   node(id: $campaign) {
     ... on Campaign {
-      changesets {
+      changesets(first: $first, reviewState: $reviewState) {
         totalCount
         stats { unpublished, open, merged, closed, total }
         nodes {
@@ -139,7 +240,14 @@ query($campaign: ID!){
 			repository { name }
 			nextSyncAt
           }
-        }
+          ... on HiddenExternalChangeset {
+            id
+			nextSyncAt
+          }
+		}
+		pageInfo {
+		  hasNextPage
+		}
       }
     }
   }

--- a/enterprise/internal/campaigns/testing/mock_authzfilter.go
+++ b/enterprise/internal/campaigns/testing/mock_authzfilter.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AuthzFilterRepos sets up a mock for the authzFilter in the db package that
-// filters out the repositories with the given IDs IDs.
+// filters out the repositories with the given IDs.
 func AuthzFilterRepos(t *test.T, ids ...api.RepoID) {
 	toFilter := map[api.RepoID]struct{}{}
 	for _, id := range ids {

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -492,7 +492,7 @@ func (cs Changesets) RepoIDs() []api.RepoID {
 	for _, c := range cs {
 		repoIDMap[c.RepoID] = struct{}{}
 	}
-	repoIDs := make([]api.RepoID, 0)
+	repoIDs := make([]api.RepoID, len(repoIDMap))
 	for id := range repoIDMap {
 		repoIDs = append(repoIDs, id)
 	}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -486,11 +486,15 @@ func (cs Changesets) IDs() []int64 {
 	return ids
 }
 
-// IDs returns the RepoIDs of all changesets in the slice.
+// IDs returns the unique RepoIDs of all changesets in the slice.
 func (cs Changesets) RepoIDs() []api.RepoID {
-	repoIDs := make([]api.RepoID, len(cs))
-	for i, c := range cs {
-		repoIDs[i] = c.RepoID
+	repoIDMap := make(map[api.RepoID]struct{})
+	for _, c := range cs {
+		repoIDMap[c.RepoID] = struct{}{}
+	}
+	repoIDs := make([]api.RepoID, 0)
+	for id := range repoIDMap {
+		repoIDs = append(repoIDs, id)
 	}
 	return repoIDs
 }


### PR DESCRIPTION
Also moves the calculation of the sync state to the nodes resolver because it's not needed for PageInfo.

Closes https://github.com/sourcegraph/sourcegraph/issues/12764