### PR TITLE
Make breadcrumbs props less leaky and more tree/linked-list-like

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -60,6 +60,7 @@ import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import { Settings } from './schema/settings.schema'
 import { Remote } from 'comlink'
 import { FlatExtHostAPI } from '../../shared/src/api/contract'
+import { useRootBreadcrumb } from './components/Breadcrumbs'
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,
@@ -144,6 +145,8 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const hideGlobalSearchInput: boolean =
         props.location.pathname === '/stats' || props.location.pathname === '/search/query-builder'
 
+    const breadcrumb = useRootBreadcrumb()
+
     useScrollToLocationHash(props.location)
     // Remove trailing slash (which is never valid in any of our URLs).
     if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
@@ -188,14 +191,23 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                         {/* eslint-disable react/jsx-no-bind */}
                         {props.routes.map(
                             ({ render, condition = () => true, ...route }) =>
-                                condition(props) && (
+                                condition({
+                                    ...props,
+                                    parentBreadcrumb: breadcrumb,
+                                    rootBreadcrumb: breadcrumb.breadcrumb,
+                                }) && (
                                     <Route
                                         {...route}
                                         key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                         component={undefined}
                                         render={routeComponentProps => (
                                             <div className="layout__app-router-container">
-                                                {render({ ...props, ...routeComponentProps })}
+                                                {render({
+                                                    ...props,
+                                                    ...routeComponentProps,
+                                                    parentBreadcrumb: breadcrumb,
+                                                    rootBreadcrumb: breadcrumb.breadcrumb,
+                                                })}
                                             </div>
                                         )}
                                     />

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -16,7 +16,7 @@ import { EventLoggerProps } from '../tracking/eventLogger'
 import { ActionButtonDescriptor } from '../util/contributions'
 import { ResolvedRevision } from './backend'
 import { RepositoriesPopover } from './RepositoriesPopover'
-import { Breadcrumbs, UpdateBreadcrumbsProps, BreadcrumbsProps } from '../components/Breadcrumbs'
+import { Breadcrumbs, ParentBreadcrumbProps, RootBreadcrumbProps } from '../components/Breadcrumbs'
 /**
  * Stores the list of RepoHeaderContributions, manages addition/deletion, and ensures they are sorted.
  *
@@ -124,12 +124,7 @@ export interface RepoHeaderContext {
 
 export interface RepoHeaderActionButton extends ActionButtonDescriptor<RepoHeaderContext> {}
 
-interface Props
-    extends PlatformContextProps,
-        ExtensionsControllerProps,
-        EventLoggerProps,
-        UpdateBreadcrumbsProps,
-        BreadcrumbsProps {
+interface Props extends PlatformContextProps, ExtensionsControllerProps, EventLoggerProps, RootBreadcrumbProps {
     /**
      * An array of render functions for action buttons that can be configured *in addition* to action buttons
      * contributed through {@link RepoHeaderContributionsLifecycleProps} and through extensions.
@@ -174,7 +169,7 @@ interface Props
  */
 export const RepoHeader: React.FunctionComponent<Props> = ({
     onLifecyclePropsChange,
-    setBreadcrumb,
+    rootBreadcrumb,
     resolvedRev,
     repo,
     ...props
@@ -187,30 +182,7 @@ export const RepoHeader: React.FunctionComponent<Props> = ({
     useEffect(() => {
         onLifecyclePropsChange(repoHeaderContributionStore.props)
     }, [onLifecyclePropsChange, repoHeaderContributionStore])
-    const [repoDirectory, repoBase] = splitPath(displayRepoName(repo.name))
-    const { history, location } = props
-    useEffect(
-        () =>
-            setBreadcrumb(
-                'repo',
-                <>
-                    <Link
-                        to={resolvedRev && !isErrorLike(resolvedRev) ? resolvedRev.rootTreeURL : repo.url}
-                        className="repo-header__repo"
-                    >
-                        {repoDirectory ? `${repoDirectory}/` : ''}
-                        <span className="repo-header__repo-basename">{repoBase}</span>
-                    </Link>
-                    <button type="button" id="repo-popover" className="btn btn-link px-0">
-                        <MenuDownIcon className="icon-inline" />
-                    </button>
-                    <UncontrolledPopover placement="bottom-start" target="repo-popover" trigger="legacy">
-                        <RepositoriesPopover currentRepo={repo.id} history={history} location={location} />
-                    </UncontrolledPopover>
-                </>
-            ),
-        [history, location, setBreadcrumb, repo.id, repo.url, repoBase, repoDirectory, resolvedRev]
-    )
+
     const context: RepoHeaderContext = {
         repoName: repo.name,
         encodedRev: props.revision,
@@ -221,7 +193,7 @@ export const RepoHeader: React.FunctionComponent<Props> = ({
         <nav className="repo-header navbar navbar-expand">
             <div className="d-flex align-items-center">
                 {/* Breadcrump for the nav elements */}
-                <Breadcrumbs breadcrumbs={props.breadcrumbs} />
+                <Breadcrumbs root={rootBreadcrumb} />
             </div>
             <ul className="navbar-nav">
                 {leftActions.map((a, index) => (

--- a/web/src/repo/RepoRevisionContainer.tsx
+++ b/web/src/repo/RepoRevisionContainer.tsx
@@ -37,7 +37,7 @@ import * as H from 'history'
 import { VersionContextProps } from '../../../shared/src/search/util'
 import { RevisionSpec } from '../../../shared/src/util/url'
 import { RepoSettingsSideBarGroup } from './settings/RepoSettingsSidebar'
-import { UpdateBreadcrumbsProps } from '../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../components/Breadcrumbs'
 
 /** Props passed to sub-routes of {@link RepoRevisionContainer}. */
 export interface RepoRevisionContainerContext
@@ -57,7 +57,7 @@ export interface RepoRevisionContainerContext
         CopyQueryButtonProps,
         VersionContextProps,
         RevisionSpec,
-        UpdateBreadcrumbsProps {
+        ParentBreadcrumbProps {
     repo: GQL.IRepository
     resolvedRev: ResolvedRevision
 
@@ -84,7 +84,7 @@ interface RepoRevisionContainerProps
         CopyQueryButtonProps,
         VersionContextProps,
         RevisionSpec,
-        UpdateBreadcrumbsProps {
+        ParentBreadcrumbProps {
     routes: readonly RepoRevisionContainerRoute[]
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
@@ -108,14 +108,14 @@ interface RepoRevisionContainerProps
  * blob and tree pages are revisioned, but the repository settings page is not.)
  */
 export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContainerProps> = ({
-    setBreadcrumb,
+    parentBreadcrumb,
     ...props
 }) => {
-    useEffect(() => {
+    const breadcrumb = useMemo(() => {
         if (!props.resolvedRevisionOrError || isErrorLike(props.resolvedRevisionOrError)) {
             return
         }
-        return setBreadcrumb(
+        return parentBreadcrumb.setChildBreadcrumb(
             'revision',
             <div className="d-flex align-items-center" key="repo-revision">
                 <span className="test-revision">
@@ -142,16 +142,16 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
             </div>
         )
     }, [
-        props.revision,
         props.resolvedRevisionOrError,
+        props.revision,
         props.repo.id,
         props.repo.name,
-        setBreadcrumb,
         props.history,
         props.location,
+        parentBreadcrumb,
     ])
 
-    if (!props.resolvedRevisionOrError) {
+    if (!props.resolvedRevisionOrError || !breadcrumb) {
         // Render nothing while loading
         return null
     }
@@ -198,7 +198,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
 
     const context: RepoRevisionContainerContext = {
         ...props,
-        setBreadcrumb,
+        parentBreadcrumb: breadcrumb,
         resolvedRev: props.resolvedRevisionOrError,
     }
 

--- a/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -7,7 +7,7 @@ import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepositoryBranchesAllPage } from './RepositoryBranchesAllPage'
 import { RepositoryBranchesNavbar } from './RepositoryBranchesNavbar'
 import { RepositoryBranchesOverviewPage } from './RepositoryBranchesOverviewPage'
-import { UpdateBreadcrumbsProps } from '../../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -17,7 +17,7 @@ const NotFoundPage: React.FunctionComponent = () => (
     />
 )
 
-interface Props extends RouteComponentProps<{}>, UpdateBreadcrumbsProps {
+interface Props extends RouteComponentProps<{}>, ParentBreadcrumbProps {
     repo: GQL.IRepository
 }
 
@@ -34,19 +34,22 @@ export interface RepositoryBranchesAreaPageProps {
 /**
  * Renders pages related to repository branches.
  */
-export const RepositoryBranchesArea: React.FunctionComponent<Props> = ({ setBreadcrumb, repo, match }) => {
+export const RepositoryBranchesArea: React.FunctionComponent<Props> = ({
+    setChildBreadcrumb,
+    removeChildBreadcrumb,
+    repo,
+    match,
+}) => {
     const transferProps: { repo: GQL.IRepository } = {
         repo,
     }
 
-    useEffect(
-        () =>
-            setBreadcrumb(
-                'branches',
-                <RepoHeaderBreadcrumbNavItem key="branches">Branches</RepoHeaderBreadcrumbNavItem>
-            ),
-        [setBreadcrumb]
+    const breadcrumb = setChildBreadcrumb(
+        'branches',
+        <RepoHeaderBreadcrumbNavItem key="branches">Branches</RepoHeaderBreadcrumbNavItem>
     )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => removeChildBreadcrumb, [])
 
     return (
         <div className="repository-branches-area container">

--- a/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -12,7 +12,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 import { GitCommitNode, GitCommitNodeProps } from './GitCommitNode'
 import { RevisionSpec, ResolvedRevisionSpec } from '../../../../shared/src/util/url'
-import { UpdateBreadcrumbsProps } from '../../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
 export const gitCommitFragment = gql`
     fragment GitCommitFields on GitCommit {
@@ -104,7 +104,7 @@ interface Props
     extends RepoHeaderContributionsLifecycleProps,
         Partial<RevisionSpec>,
         ResolvedRevisionSpec,
-        UpdateBreadcrumbsProps {
+        ParentBreadcrumbProps {
     repo: GQL.IRepository
 
     history: H.History

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -34,7 +34,7 @@ import { RepositoryCompareOverviewPage } from './RepositoryCompareOverviewPage'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorMessage } from '../../components/alerts'
 import * as H from 'history'
-import { UpdateBreadcrumbsProps } from '../../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -51,7 +51,7 @@ interface RepositoryCompareAreaProps
         EventLoggerProps,
         ExtensionsControllerProps,
         ThemeProps,
-        UpdateBreadcrumbsProps {
+        ParentBreadcrumbProps {
     repo: GQL.IRepository
     history: H.History
 }

--- a/web/src/repo/releases/RepositoryReleasesArea.tsx
+++ b/web/src/repo/releases/RepositoryReleasesArea.tsx
@@ -7,7 +7,7 @@ import { RepoContainerContext } from '../RepoContainer'
 import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
 import * as H from 'history'
-import { UpdateBreadcrumbsProps } from '../../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -20,7 +20,7 @@ const NotFoundPage: React.FunctionComponent = () => (
 interface Props
     extends RouteComponentProps<{}>,
         Pick<RepoContainerContext, 'repo' | 'routePrefix' | 'repoHeaderContributionsLifecycleProps'>,
-        UpdateBreadcrumbsProps {
+        ParentBreadcrumbProps {
     repo: GQL.IRepository
     history: H.History
 }

--- a/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -18,6 +18,7 @@ import { ActionContainer, BaseActionContainer } from './components/ActionContain
 import { ErrorAlert } from '../../components/alerts'
 import { asError } from '../../../../shared/src/util/errors'
 import * as H from 'history'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
 interface UpdateMirrorRepositoryActionContainerProps {
     repo: GQL.IRepository
@@ -238,7 +239,7 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
     private checkMirrorRepositoryConnection = (): void => this.checkRequests.next()
 }
 
-interface Props extends RouteComponentProps<{}> {
+interface Props extends RouteComponentProps<{}>, ParentBreadcrumbProps {
     repo: GQL.IRepository
     onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
     history: H.History
@@ -277,6 +278,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<Props, State> {
 
     public componentDidMount(): void {
         eventLogger.logViewEvent('RepoSettingsMirror')
+        this.props.parentBreadcrumb.setChildBreadcrumb('repo-settings-mirror', <>Mirror settings</>)
 
         this.subscriptions.add(
             this.repoUpdates.pipe(switchMap(() => fetchRepository(this.props.repo.name))).subscribe(

--- a/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -13,8 +13,9 @@ import { ErrorAlert } from '../../components/alerts'
 import { defaultExternalServices } from '../../site-admin/externalServices'
 import { asError } from '../../../../shared/src/util/errors'
 import * as H from 'history'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
-interface Props extends RouteComponentProps<{}> {
+interface Props extends RouteComponentProps<{}>, ParentBreadcrumbProps {
     repo: GQL.IRepository
     onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
     history: H.History
@@ -48,7 +49,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
 
     public componentDidMount(): void {
         eventLogger.logViewEvent('RepoSettings')
-
+        this.props.parentBreadcrumb.setChildBreadcrumb('repoSettings', <>Options</>)
         this.subscriptions.add(
             this.repoUpdates.pipe(switchMap(() => fetchRepository(this.props.repo.name))).subscribe(
                 repo => this.setState({ repo }),

--- a/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -6,7 +6,7 @@ import { HeroPage } from '../../components/HeroPage'
 import { RepositoryStatsContributorsPage } from './RepositoryStatsContributorsPage'
 import { RepositoryStatsNavbar } from './RepositoryStatsNavbar'
 import { PatternTypeProps } from '../../search'
-import { UpdateBreadcrumbsProps } from '../../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -16,7 +16,7 @@ const NotFoundPage: React.FunctionComponent = () => (
     />
 )
 
-interface Props extends RouteComponentProps<{}>, UpdateBreadcrumbsProps, Omit<PatternTypeProps, 'setPatternType'> {
+interface Props extends RouteComponentProps<{}>, ParentBreadcrumbProps, Omit<PatternTypeProps, 'setPatternType'> {
     repo: GQL.IRepository
     globbing: boolean
 }

--- a/web/src/repo/tree/TreePage.tsx
+++ b/web/src/repo/tree/TreePage.tsx
@@ -43,7 +43,7 @@ import { getViewsForContainer } from '../../../../shared/src/api/client/services
 import { Settings } from '../../schema/settings.schema'
 import { ViewGrid } from './ViewGrid'
 import { VersionContextProps } from '../../../../shared/src/search/util'
-import { UpdateBreadcrumbsProps } from '../../components/Breadcrumbs'
+import { ParentBreadcrumbProps } from '../../components/Breadcrumbs'
 import { FilePathBreadcrumb } from '../FilePathBreadcrumb'
 
 const TreeEntry: React.FunctionComponent<{
@@ -156,7 +156,7 @@ interface Props
         CaseSensitivityProps,
         CopyQueryButtonProps,
         VersionContextProps,
-        UpdateBreadcrumbsProps {
+        ParentBreadcrumbProps {
     repoName: string
     repoID: GQL.ID
     repoDescription: string
@@ -179,7 +179,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
     patternType,
     caseSensitive,
     settingsCascade,
-    setBreadcrumb,
+    parentBreadcrumb,
     ...props
 }) => {
     useEffect(() => {
@@ -190,10 +190,10 @@ export const TreePage: React.FunctionComponent<Props> = ({
         }
     }, [filePath])
 
-    useEffect(
+    const breadcrumb = useMemo(
         () =>
             filePath &&
-            setBreadcrumb(
+            parentBreadcrumb.setChildBreadcrumb(
                 'treePath',
                 <FilePathBreadcrumb
                     key="path"
@@ -203,8 +203,10 @@ export const TreePage: React.FunctionComponent<Props> = ({
                     isDir={true}
                 />
             ),
-        [repoName, revision, filePath, setBreadcrumb]
+        [filePath, parentBreadcrumb, repoName, revision]
     )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => parentBreadcrumb.removeChildBreadcrumb, [])
 
     const [showOlderCommits, setShowOlderCommits] = useState(false)
 

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -10,6 +10,7 @@ import { kubernetes } from './repogroups/Kubernetes'
 import { golang } from './repogroups/Golang'
 import { reactHooks } from './repogroups/ReactHooks'
 import { android } from './repogroups/Android'
+import { ParentBreadcrumbProps, RootBreadcrumbProps } from './components/Breadcrumbs'
 
 const SearchPage = lazyComponent(() => import('./search/input/SearchPage'), 'SearchPage')
 const SearchResults = lazyComponent(() => import('./search/results/SearchResults'), 'SearchResults')
@@ -18,7 +19,9 @@ const ExtensionsArea = lazyComponent(() => import('./extensions/ExtensionsArea')
 
 interface LayoutRouteComponentProps<Params extends { [K in keyof Params]?: string }>
     extends RouteComponentProps<Params>,
-        Omit<LayoutProps, 'match'> {}
+        Omit<LayoutProps, 'match'>,
+        ParentBreadcrumbProps,
+        RootBreadcrumbProps {}
 
 export interface LayoutRouteProps<Params extends { [K in keyof Params]?: string }> {
     path: string


### PR DESCRIPTION
This is an attempt at https://github.com/sourcegraph/sourcegraph/pull/12536#issuecomment-667259404

Unfortunately I am running into these errors:

```
Warning: Cannot update a component from inside the function body of a different component.
```
```
Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
```

I'm not sure how to prevent them (if this approach is inherently flawed, or whether I overlooked something and made a mistake somewhere)