### PR TITLE
Deduplicate logic for determining map of accessible repos

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -129,6 +129,8 @@ func (r *changesetsConnectionResolver) computeAllAccessibleChangesets(ctx contex
 			return
 		}
 
+		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
+		// filters out repositories that the user doesn't have access to.
 		accessibleRepos, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
 		if err != nil {
 			r.allAccessibleChangesetsErr = err
@@ -169,6 +171,8 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) (campaigns.C
 			return
 		}
 
+		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
+		// filters out repositories that the user doesn't have access to.
 		r.reposByID, r.err = db.Repos.GetRepoIDsSet(ctx, r.changesets.RepoIDs()...)
 	})
 

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -11,6 +11,7 @@ import (
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
@@ -128,7 +129,7 @@ func (r *changesetsConnectionResolver) computeAllAccessibleChangesets(ctx contex
 			return
 		}
 
-		accessibleRepos, err := cs.RepoIDs().AccessibleRepos(ctx)
+		accessibleRepos, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
 		if err != nil {
 			r.allAccessibleChangesetsErr = err
 			return
@@ -168,7 +169,7 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) (campaigns.C
 			return
 		}
 
-		r.reposByID, r.err = r.changesets.RepoIDs().AccessibleRepos(ctx)
+		r.reposByID, r.err = db.Repos.GetRepoIDsSet(ctx, r.changesets.RepoIDs()...)
 	})
 
 	return r.changesets, r.reposByID, r.err

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -131,7 +131,7 @@ func (r *changesetsConnectionResolver) computeAllAccessibleChangesets(ctx contex
 
 		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		accessibleRepos, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
+		accessibleRepos, err := db.Repos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
 		if err != nil {
 			r.allAccessibleChangesetsErr = err
 			return
@@ -173,7 +173,7 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) (campaigns.C
 
 		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, r.err = db.Repos.GetRepoIDsSet(ctx, r.changesets.RepoIDs()...)
+		r.reposByID, r.err = db.Repos.GetReposSetByIDs(ctx, r.changesets.RepoIDs()...)
 	})
 
 	return r.changesets, r.reposByID, r.err

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -11,6 +11,7 @@ import (
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
@@ -90,9 +91,9 @@ func (r *changesetSpecConnectionResolver) compute(ctx context.Context) (campaign
 			return
 		}
 
-		// 🚨 SECURITY: RepoIDs.AccessibleRepos uses the authzFilter under the hood and
+		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, r.err = r.changesetSpecs.RepoIDs().AccessibleRepos(ctx)
+		r.reposByID, r.err = db.Repos.GetRepoIDsSet(ctx, r.changesetSpecs.RepoIDs()...)
 	})
 
 	return r.changesetSpecs, r.reposByID, r.next, r.err

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -93,7 +93,7 @@ func (r *changesetSpecConnectionResolver) compute(ctx context.Context) (campaign
 
 		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, r.err = db.Repos.GetRepoIDsSet(ctx, r.changesetSpecs.RepoIDs()...)
+		r.reposByID, r.err = db.Repos.GetReposSetByIDs(ctx, r.changesetSpecs.RepoIDs()...)
 	})
 
 	return r.changesetSpecs, r.reposByID, r.next, r.err

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -119,7 +119,7 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 		return nil, err
 	}
 
-	accessibleReposByID, err := cs.RepoIDs().AccessibleRepos(ctx)
+	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	// under the hood.
 	repoIDs := newChangesetSpecs.RepoIDs()
 	repoIDs = append(repoIDs, changesets.RepoIDs()...)
-	accessibleReposByID, err := repoIDs.AccessibleRepos(ctx)
+	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, repoIDs...)
 	if err != nil {
 		return nil, err
 	}
@@ -818,7 +818,7 @@ func (s *Service) CloseOpenChangesets(ctx context.Context, cs campaigns.Changese
 		return nil
 	}
 
-	accessibleReposByID, err := cs.RepoIDs().AccessibleRepos(ctx)
+	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -119,6 +119,8 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 		return nil, err
 	}
 
+	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
+	// filters out repositories that the user doesn't have access to.
 	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return nil, err
@@ -344,6 +346,8 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	// under the hood.
 	repoIDs := newChangesetSpecs.RepoIDs()
 	repoIDs = append(repoIDs, changesets.RepoIDs()...)
+	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
+	// filters out repositories that the user doesn't have access to.
 	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, repoIDs...)
 	if err != nil {
 		return nil, err
@@ -818,6 +822,8 @@ func (s *Service) CloseOpenChangesets(ctx context.Context, cs campaigns.Changese
 		return nil
 	}
 
+	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
+	// filters out repositories that the user doesn't have access to.
 	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return err

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -121,7 +121,7 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 
 	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
+	accessibleReposByID, err := db.Repos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return nil, err
 	}
@@ -344,11 +344,10 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 
 	// We load all the repositories involved, checking for repository permissions
 	// under the hood.
-	repoIDs := newChangesetSpecs.RepoIDs()
-	repoIDs = append(repoIDs, changesets.RepoIDs()...)
+	repoIDs := append(newChangesetSpecs.RepoIDs(), changesets.RepoIDs()...)
 	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, repoIDs...)
+	accessibleReposByID, err := db.Repos.GetReposSetByIDs(ctx, repoIDs...)
 	if err != nil {
 		return nil, err
 	}
@@ -824,7 +823,7 @@ func (s *Service) CloseOpenChangesets(ctx context.Context, cs campaigns.Changese
 
 	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	accessibleReposByID, err := db.Repos.GetRepoIDsSet(ctx, cs.RepoIDs()...)
+	accessibleReposByID, err := db.Repos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -265,10 +265,10 @@ type ListChangesetSpecsOpts struct {
 }
 
 // ListChangesetSpecs lists ChangesetSpecs with the given filters.
-func (s *Store) ListChangesetSpecs(ctx context.Context, opts ListChangesetSpecsOpts) (cs []*campaigns.ChangesetSpec, next int64, err error) {
+func (s *Store) ListChangesetSpecs(ctx context.Context, opts ListChangesetSpecsOpts) (cs campaigns.ChangesetSpecs, next int64, err error) {
 	q := listChangesetSpecsQuery(&opts)
 
-	cs = make([]*campaigns.ChangesetSpec, 0, opts.Limit)
+	cs = make(campaigns.ChangesetSpecs, 0, opts.Limit)
 	err = s.query(ctx, q, func(sc scanner) error {
 		var c campaigns.ChangesetSpec
 		if err := scanChangesetSpec(&c, sc); err != nil {

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -20,7 +20,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 		t.Fatal(err)
 	}
 
-	changesetSpecs := make([]*cmpgn.ChangesetSpec, 0, 3)
+	changesetSpecs := make(cmpgn.ChangesetSpecs, 0, 3)
 	for i := 0; i < cap(changesetSpecs); i++ {
 		c := &cmpgn.ChangesetSpec{
 			RawSpec: `{"externalID":"12345"}`,
@@ -54,7 +54,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 	}
 
 	t.Run("Create", func(t *testing.T) {
-		toCreate := make([]*cmpgn.ChangesetSpec, 0, len(changesetSpecs)+1)
+		toCreate := make(cmpgn.ChangesetSpecs, 0, len(changesetSpecs)+1)
 		toCreate = append(toCreate, changesetSpecDeletedRepo)
 		toCreate = append(toCreate, changesetSpecs...)
 
@@ -209,7 +209,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 					t.Fatal(err)
 				}
 
-				want := []*cmpgn.ChangesetSpec{c}
+				want := cmpgn.ChangesetSpecs{c}
 				if diff := cmp.Diff(have, want); diff != "" {
 					t.Fatalf("opts: %+v, diff: %s", opts, diff)
 				}
@@ -224,7 +224,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 					t.Fatal(err)
 				}
 
-				want := []*cmpgn.ChangesetSpec{c}
+				want := cmpgn.ChangesetSpecs{c}
 				if diff := cmp.Diff(have, want); diff != "" {
 					t.Fatalf("opts: %+v, diff: %s", opts, diff)
 				}

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -1,6 +1,7 @@
 package campaigns
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +17,9 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -474,6 +477,43 @@ func (c *Changeset) URL() (s string, err error) {
 	}
 }
 
+// RepoIDs is a slice of RepoIDs.
+type RepoIDs []api.RepoID
+
+// AccessibleRepos returns the subset of repositories for which the actor in
+// ctx has read permissions.
+func (rs RepoIDs) AccessibleRepos(ctx context.Context) (map[api.RepoID]*types.Repo, error) {
+	// 🚨 SECURITY: We use db.Repos.GetByIDs to filter out repositories the
+	// user doesn't have access to.
+	accessibleRepos, err := db.Repos.GetByIDs(ctx, rs...)
+	if err != nil {
+		return nil, err
+	}
+
+	accessibleRepoIDs := make(map[api.RepoID]*types.Repo, len(accessibleRepos))
+	for _, r := range accessibleRepos {
+		accessibleRepoIDs[r.ID] = r
+	}
+
+	return accessibleRepoIDs, nil
+}
+
+// ChangesetSpecs is a slice of *ChangesetSpecs.
+type ChangesetSpecs []*ChangesetSpec
+
+// IDs returns the unique RepoIDs of all changeset specs in the slice.
+func (cs ChangesetSpecs) RepoIDs() RepoIDs {
+	repoIDMap := make(map[api.RepoID]struct{})
+	for _, c := range cs {
+		repoIDMap[c.RepoID] = struct{}{}
+	}
+	repoIDs := make(RepoIDs, 0)
+	for id := range repoIDMap {
+		repoIDs = append(repoIDs, id)
+	}
+	return repoIDs
+}
+
 // Changesets is a slice of *Changesets.
 type Changesets []*Changeset
 
@@ -487,12 +527,12 @@ func (cs Changesets) IDs() []int64 {
 }
 
 // IDs returns the unique RepoIDs of all changesets in the slice.
-func (cs Changesets) RepoIDs() []api.RepoID {
+func (cs Changesets) RepoIDs() RepoIDs {
 	repoIDMap := make(map[api.RepoID]struct{})
 	for _, c := range cs {
 		repoIDMap[c.RepoID] = struct{}{}
 	}
-	repoIDs := make([]api.RepoID, len(repoIDMap))
+	repoIDs := make(RepoIDs, len(repoIDMap))
 	for id := range repoIDMap {
 		repoIDs = append(repoIDs, id)
 	}

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -117,7 +117,9 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 	return s.getReposBySQL(ctx, true, q)
 }
 
-func (s *repos) GetRepoIDsSet(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
+// GetReposSetByIDs returns a map of repositories with the given IDs, indexed by their IDs. The number of results
+// entries could be less than the candidate list due to no repository is associated with some IDs.
+func (s *repos) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
 	repos, err := s.GetByIDs(ctx, ids...)
 	if err != nil {
 		return nil, err

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -117,6 +117,20 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 	return s.getReposBySQL(ctx, true, q)
 }
 
+func (s *repos) GetRepoIDsSet(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
+	repos, err := s.GetByIDs(ctx, ids...)
+	if err != nil {
+		return nil, err
+	}
+
+	repoMap := make(map[api.RepoID]*types.Repo, len(repos))
+	for _, r := range repos {
+		repoMap[r.ID] = r
+	}
+
+	return repoMap, nil
+}
+
 func (s *repos) Count(ctx context.Context, opt ReposListOptions) (int, error) {
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)


### PR DESCRIPTION
I found this logic has been sitting at many different places, so I figured we can extract it into a single place. Also, the deduplication of repo IDs will bring us some performance benefits when a campaign has lot's of changesets in the same repository.

Stacked on top of #12794 