### PR TITLE
codeintel: Add disable indexer flag

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer/env.go
@@ -21,6 +21,7 @@ var (
 	rawIndexMinimumSearchCount          = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_COUNT", "50", "Minimum number of search events to trigger indexing for a repo.")
 	rawIndexMinimumSearchRatio          = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_RATIO", "50", "Minimum ratio of search events to total events to trigger indexing for a repo.")
 	rawIndexMinimumPreciseCount         = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_PRECISE_COUNT", "1", "Minimum number of precise events to trigger indexing for a repo.")
+	rawDisableIndexer                   = env.Get("PRECISE_CODE_INTEL_DISABLE_INDEXER", "false", "Set to true to disable the indexer that runs in the cluster.")
 	rawDisableJanitor                   = env.Get("PRECISE_CODE_INTEL_DISABLE_JANITOR", "false", "Set to true to disable the janitor process during system migrations.")
 	rawMaxTransactions                  = env.Get("PRECISE_CODE_INTEL_MAXIMUM_TRANSACTIONS", "10", "Number of index jobs that can be active at once.")
 	rawRequeueDelay                     = env.Get("PRECISE_CODE_INTEL_REQUEUE_DELAY", "1m", "The requeue delay of index jobs assigned to an unreachable indexer.")

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -44,6 +44,7 @@ func main() {
 		indexMinimumSearchCount          = mustParseInt(rawIndexMinimumSearchCount, "PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_COUNT")
 		indexMinimumSearchRatio          = mustParsePercent(rawIndexMinimumSearchRatio, "PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_RATIO")
 		indexMinimumPreciseCount         = mustParseInt(rawIndexMinimumPreciseCount, "PRECISE_CODE_INTEL_INDEX_MINIMUM_PRECISE_COUNT")
+		disableIndexer                   = mustParseBool(rawDisableIndexer, "PRECISE_CODE_INTEL_DISABLE_INDEXER")
 		disableJanitor                   = mustParseBool(rawDisableJanitor, "PRECISE_CODE_INTEL_DISABLE_JANITOR")
 		maximumTransactions              = mustParseInt(rawMaxTransactions, "PRECISE_CODE_INTEL_MAXIMUM_TRANSACTIONS")
 		requeueDelay                     = mustParseInterval(rawRequeueDelay, "PRECISE_CODE_INTEL_REQUEUE_DELAY")
@@ -107,8 +108,13 @@ func main() {
 	go indexResetter.Start()
 	go indexabilityUpdater.Start()
 	go scheduler.Start()
-	go indexer.Start()
 	go debugserver.Start()
+
+	if !disableIndexer {
+		go indexer.Start()
+	} else {
+		log15.Warn("Indexer process is disabled.")
+	}
 
 	if !disableJanitor {
 		go janitor.Run()


### PR DESCRIPTION
Once we deploy the VM-based indexer, we'll need to ensure that we're not continuing to process indexes inside the cluster. This flag will help us in this transition:

- Process all indexes within cluster
- Deploy new VM-based service
- Disable indexing within cluster
- Start new VM-based service
- Check health; reset flag on issues, continue if the new service works well
- Remove in-cluster index code