### PR TITLE
Fix logic for To(Hidden)Changeset and remove fetch repo workaround

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -263,7 +263,7 @@ type ExternalChangesetResolver interface {
 	ExternalURL() (*externallink.Resolver, error)
 	ReviewState(context.Context) *campaigns.ChangesetReviewState
 	CheckState() *campaigns.ChangesetCheckState
-	Repository(ctx context.Context) (*RepositoryResolver, error)
+	Repository(ctx context.Context) *RepositoryResolver
 
 	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)
 	Diff(ctx context.Context) (RepositoryComparisonInterface, error)

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -163,7 +163,7 @@ func (r *changesetResolver) ExternalID() *string {
 }
 
 func (r *changesetResolver) Repository(ctx context.Context) *graphqlbackend.RepositoryResolver {
-	return graphqlbackend.NewRepositoryResolver(r.repo)
+	return r.repoResolver
 }
 
 func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignArgs) (graphqlbackend.CampaignsConnectionResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -30,6 +30,7 @@ type changesetResolver struct {
 
 	changeset *campaigns.Changeset
 
+	// When repo is nil, this resolver resolves to a `HiddenExternalChangeset` in the API.
 	repo         *types.Repo
 	repoResolver *graphqlbackend.RepositoryResolver
 
@@ -51,10 +52,10 @@ type changesetResolver struct {
 	specErr  error
 }
 
-func NewChangesetResolverWithPreloadedNextSync(store *ee.Store, httpFactory *httpcli.Factory, changeset *campaigns.Changeset, repo *types.Repo, preloadedNextSyncAt *time.Time) *changesetResolver {
+func NewChangesetResolverWithNextSync(store *ee.Store, httpFactory *httpcli.Factory, changeset *campaigns.Changeset, repo *types.Repo, nextSyncAt *time.Time) *changesetResolver {
 	r := NewChangesetResolver(store, httpFactory, changeset, repo)
 	r.attemptedPreloadNextSyncAt = true
-	r.preloadedNextSyncAt = preloadedNextSyncAt
+	r.preloadedNextSyncAt = nextSyncAt
 	return r
 }
 

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -76,15 +76,7 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 			continue
 		}
 
-		resolvers = append(resolvers, &changesetResolver{
-			store:                      r.store,
-			httpFactory:                r.httpFactory,
-			changeset:                  c,
-			preloadedRepo:              repo,
-			attemptedPreloadRepo:       true,
-			attemptedPreloadNextSyncAt: true,
-			preloadedNextSyncAt:        preloadedNextSyncAt,
-		})
+		resolvers = append(resolvers, NewChangesetResolverWithPreloadedNextSync(r.store, r.httpFactory, c, repo, preloadedNextSyncAt))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -76,7 +76,7 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 			continue
 		}
 
-		resolvers = append(resolvers, NewChangesetResolverWithPreloadedNextSync(r.store, r.httpFactory, c, repo, preloadedNextSyncAt))
+		resolvers = append(resolvers, NewChangesetResolverWithNextSync(r.store, r.httpFactory, c, repo, preloadedNextSyncAt))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -76,13 +76,7 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 		return nil, err
 	}
 
-	return &changesetResolver{
-		store:                r.store,
-		httpFactory:          r.httpFactory,
-		changeset:            changeset,
-		attemptedPreloadRepo: true,
-		preloadedRepo:        repo,
-	}, nil
+	return NewChangesetResolver(r.store, r.httpFactory, changeset, repo), nil
 }
 
 func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignResolver, error) {


### PR DESCRIPTION
We needed to pass in a `repoCtx` and if not passed in, it would error, because it's not possible to get a context in the `ToXX` interface resolution functions of our graphql library. Since we passed in repos almost everywhere anyways, it was easy to get rid of that additional overhead and it fixes wrong boolean logic in the `ToXX` handlers (was true on error before), and reduces complexity.