### PR TITLE
addition to local dev docs for fish shell users

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -131,7 +131,6 @@ The following are two recommendations for installing these dependencies:
         set -x NVM_DIR ~/.nvm
         ```
 
-
 5.  Install the current recommended version of Node JS by running the following
     from the working directory of a sourcegraph repository clone:
 

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -114,6 +114,24 @@ The following are two recommendations for installing these dependencies:
     There is also a Homebrew package for `nvm`, but it is unsupported by the
     `nvm` maintainers.
 
+    * For fish shell users, you will want to install `bass` which you can get via `omf`:
+
+        ```
+        curl -L https://get.oh-my.fish | fish
+        omf install bass
+        ```
+
+    * Then add the following to your `config.fish`:
+
+        ```
+        function nvm
+          bass source ~/.nvm/nvm.sh --no-use ';' nvm $argv
+        end
+
+        set -x NVM_DIR ~/.nvm
+        ```
+
+
 5.  Install the current recommended version of Node JS by running the following
     from the working directory of a sourcegraph repository clone:
 
@@ -476,7 +494,7 @@ yarn
 Validating package.json...
 error @: The engine "node" is incompatible with this module. Expected version "^v14.7.0". Got "14.5.0"
 ```
-If you see an error like this you need to upgrade the version of node installed. You can do this with `nvm use` and then following the prompts to install or update to the correct Node.js version. 
+If you see an error like this you need to upgrade the version of node installed. You can do this with `nvm use` and then following the prompts to install or update to the correct Node.js version.
 
 #### dial tcp 127.0.0.1:3090: connect: connection refused
 


### PR DESCRIPTION
Adds instructions to the local development docs for setting up `nvm` for fish shell users.