### PR TITLE
search: fix panic calling getExactFilePatterns for unguarded glob flag

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1915,7 +1915,7 @@ func compareSearchResults(a, b searchResultURIGetter, exactFilePatterns map[stri
 
 func (r *searchResolver) sortResults(ctx context.Context, results []SearchResultResolver) {
 	var exactPatterns map[string]struct{}
-	if settings, err := decodedViewerFinalSettings(ctx); err != nil || getBoolPtr(settings.SearchGlobbing, false) {
+	if settings, err := decodedViewerFinalSettings(ctx); err != nil && getBoolPtr(settings.SearchGlobbing, false) {
 		exactPatterns = r.getExactFilePatterns()
 	}
 	sort.Slice(results, func(i, j int) bool { return compareSearchResults(results[i], results[j], exactPatterns) })


### PR DESCRIPTION
The `getExactFilePatterns` function should be guarded by the  `getBoolPtr(settings.SearchGlobbing, false)` flag (not `or` clause). Prior to this fix, the suggestions code can trigger a type assertion error on this path.
