### PR TITLE
campaigns: Remove all references to old graphql types

### DIFF
--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -3,6 +3,7 @@ import { catchError, map, mergeMap, tap } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '../../shared/src/graphql/graphql'
 import * as GQL from '../../shared/src/graphql/schema'
 import { queryGraphQL } from './backend/graphql'
+import { CurrentAuthStateResult } from './graphql-operations'
 
 /**
  * Always represents the latest state of the currently authenticated user.
@@ -11,6 +12,8 @@ import { queryGraphQL } from './backend/graphql'
  * in, sign out, and account changes all require a full-page reload in the browser to take effect.
  */
 export const authenticatedUser = new ReplaySubject<GQL.IUser | null>(1)
+
+export type AuthenticatedUser = NonNullable<CurrentAuthStateResult['currentUser']>
 
 /**
  * Fetches the current user, orgs, and config state from the remote. Emits no items, completes when done.

--- a/web/src/auth/withAuthenticatedUser.tsx
+++ b/web/src/auth/withAuthenticatedUser.tsx
@@ -1,17 +1,16 @@
 import React from 'react'
 import { Redirect } from 'react-router'
-import * as GQL from '../../../shared/src/graphql/schema'
+import { AuthenticatedUser } from '../auth'
 
 /**
  * Wraps a React component and requires an authenticated user. If the viewer is not authenticated, it redirects to
  * the sign-in flow.
  */
-export const withAuthenticatedUser = <P extends object & { authenticatedUser: GQL.IUser }>(
+export const withAuthenticatedUser = <P extends object & { authenticatedUser: AuthenticatedUser }>(
     Component: React.ComponentType<P>
-): React.ComponentType<Pick<P, Exclude<keyof P, 'authenticatedUser'>> & { authenticatedUser: GQL.IUser | null }> => ({
-    authenticatedUser,
-    ...props
-}) => {
+): React.ComponentType<
+    Pick<P, Exclude<keyof P, 'authenticatedUser'>> & { authenticatedUser: AuthenticatedUser | null }
+> => ({ authenticatedUser, ...props }) => {
     // If not logged in, redirect to sign in.
     if (!authenticatedUser) {
         const newUrl = new URL(window.location.href)

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import * as GQL from '../../../../../shared/src/graphql/schema'
 import { CampaignsIcon } from '../icons'
 import { Link } from '../../../../../shared/src/components/Link'
+import { CampaignFields } from '../../../graphql-operations'
 
 interface Props {
-    campaign: Pick<GQL.ICampaign, 'name' | 'closedAt' | 'viewerCanAdminister'> & {
+    campaign: Pick<CampaignFields, 'name' | 'closedAt' | 'viewerCanAdminister'> & {
         changesets: {
-            totalCount: GQL.ICampaign['changesets']['totalCount']
-            stats: Pick<GQL.ICampaign['changesets']['stats'], 'total' | 'closed' | 'merged'>
+            totalCount: CampaignFields['changesets']['totalCount']
+            stats: Pick<CampaignFields['changesets']['stats'], 'total' | 'closed' | 'merged'>
         }
     }
 }

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -1,54 +1,20 @@
 import React from 'react'
-import * as GQL from '../../../../../shared/src/graphql/schema'
 import { CampaignDetails } from './CampaignDetails'
 import * as H from 'history'
 import { of } from 'rxjs'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
 import { PageTitle } from '../../../components/PageTitle'
 import { registerHighlightContributions } from '../../../../../shared/src/highlight/contributions'
-import { shallow, mount } from 'enzyme'
+import { mount } from 'enzyme'
 
 // This is idempotent, so calling it in multiple tests is not a problem.
 registerHighlightContributions()
-
-jest.mock('./changesets/CampaignChangesets', () => ({ CampaignChangesets: 'CampaignChangesets' }))
-jest.mock('../icons', () => ({ CampaignsIcon: 'CampaignsIcon' }))
 
 const history = H.createMemoryHistory()
 
 describe('CampaignDetails', () => {
     afterEach(() => {
         PageTitle.titleSet = false
-    })
-
-    test('creation form for empty manual campaign', () =>
-        expect(
-            shallow(
-                <CampaignDetails
-                    campaignID={undefined}
-                    history={history}
-                    location={history.location}
-                    isLightTheme={true}
-                    extensionsController={undefined as any}
-                    platformContext={undefined as any}
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                />
-            )
-        ).toMatchSnapshot())
-
-    test('creation form given existing patch set', () => {
-        const component = mount(
-            <CampaignDetails
-                campaignID={undefined}
-                history={history}
-                location={{ ...history.location, search: 'patchSet=p' }}
-                isLightTheme={true}
-                extensionsController={undefined as any}
-                platformContext={undefined as any}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
-        )
-        expect(component).toMatchSnapshot()
     })
 
     const renderCampaignDetails = ({ viewerCanAdminister }: { viewerCanAdminister: boolean }) => (
@@ -61,28 +27,28 @@ describe('CampaignDetails', () => {
             platformContext={undefined as any}
             telemetryService={NOOP_TELEMETRY_SERVICE}
             _fetchCampaignById={() =>
-                of(({
-                    __typename: 'Campaign' as const,
+                of({
+                    __typename: 'Campaign',
                     id: 'c',
                     name: 'n',
                     description: 'd',
-                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                    author: { username: 'alice' } as GQL.IUser,
-                    changesets: { totalCount: 2, stats: { total: 10, closed: 0, merged: 0 } },
-                    changesetCountsOverTime: [] as GQL.IChangesetCounts[],
+                    author: { username: 'alice', avatarURL: 'http://test.test/avatar' },
+                    changesets: { totalCount: 0, stats: { total: 10, closed: 0, merged: 0, open: 8, unpublished: 2 } },
+                    changesetCountsOverTime: [],
                     viewerCanAdminister,
-                    hasUnpublishedPatches: false,
                     branch: 'awesome-branch',
                     createdAt: '2020-01-01',
                     updatedAt: '2020-01-01',
                     closedAt: null,
                     diffStat: {
-                        __typename: 'IDiffStat' as const,
                         added: 5,
                         changed: 3,
                         deleted: 2,
                     },
-                } as any) as GQL.ICampaign)
+                    namespace: {
+                        namespaceName: 'alice',
+                    },
+                })
             }
         />
     )
@@ -90,7 +56,8 @@ describe('CampaignDetails', () => {
     for (const viewerCanAdminister of [true, false]) {
         describe(`viewerCanAdminister: ${String(viewerCanAdminister)}`, () => {
             test('viewing existing', () => {
-                expect(mount(renderCampaignDetails({ viewerCanAdminister }))).toMatchSnapshot()
+                const rendered = mount(renderCampaignDetails({ viewerCanAdminister }))
+                expect(rendered).toMatchSnapshot()
             })
         })
     }

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -17,14 +17,14 @@ import { pluralize } from '../../../../../shared/src/util/strings'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
-import { CampaignFields } from '../../../graphql-operations'
+import { CampaignFields, Scalars } from '../../../graphql-operations'
 import { CampaignInfoCard } from './CampaignInfoCard'
 
 interface Props extends ThemeProps, ExtensionsControllerProps, PlatformContextProps, TelemetryProps {
     /**
      * The campaign ID.
      */
-    campaignID: string
+    campaignID: Scalars['ID']
     history: H.History
     location: H.Location
 

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.tsx
@@ -1,10 +1,9 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import React, { useState, useEffect, useRef, useMemo } from 'react'
-import * as GQL from '../../../../../shared/src/graphql/schema'
+import React, { useState, useEffect, useMemo } from 'react'
 import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
-import { noop, isEqual } from 'lodash'
+import { isEqual } from 'lodash'
 import { fetchCampaignById } from './backend'
 import { useError } from '../../../../../shared/src/util/useObservable'
 import * as H from 'history'
@@ -24,9 +23,8 @@ import { CampaignInfoCard } from './CampaignInfoCard'
 interface Props extends ThemeProps, ExtensionsControllerProps, PlatformContextProps, TelemetryProps {
     /**
      * The campaign ID.
-     * If not given, will display a creation form.
      */
-    campaignID?: GQL.ID
+    campaignID: string
     history: H.History
     location: H.Location
 
@@ -89,20 +87,8 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         return () => subscription.unsubscribe()
     }, [campaignID, triggerError, changesetUpdates, campaignUpdates, _fetchCampaignById])
 
-    // To unblock the history after leaving edit mode
-    const unblockHistoryReference = useRef<H.UnregisterCallback>(noop)
-    useEffect(() => {
-        if (!campaignID) {
-            unblockHistoryReference.current()
-            unblockHistoryReference.current = history.block('Do you want to discard this campaign?')
-        }
-        // Note: the current() method gets dynamically reassigned,
-        // therefor we can't return it directly.
-        return () => unblockHistoryReference.current()
-    }, [campaignID, history])
-
     // Is loading.
-    if (campaignID && campaign === undefined) {
+    if (campaign === undefined) {
         return (
             <div className="text-center">
                 <LoadingSpinner className="icon-inline mx-auto my-4" />
@@ -110,8 +96,7 @@ export const CampaignDetails: React.FunctionComponent<Props> = ({
         )
     }
     // Campaign was not found
-    // TODO: remove campaign === undefined.
-    if (campaign === undefined || campaign === null) {
+    if (campaign === null) {
         return <HeroPage icon={AlertCircleIcon} title="Campaign not found" />
     }
 

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -1,70 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CampaignDetails creation form for empty manual campaign 1`] = `
-<HeroPage
-  icon={
-    Object {
-      "$$typeof": Symbol(react.memo),
-      "compare": null,
-      "type": [Function],
-    }
-  }
-  title="Campaign not found"
-/>
-`;
-
-exports[`CampaignDetails creation form given existing patch set 1`] = `
-<CampaignDetails
-  history="[History]"
-  isLightTheme={true}
-  location="[Location path=/?patchSet=p]"
-  telemetryService={
-    Object {
-      "log": [Function],
-      "logViewEvent": [Function],
-    }
-  }
->
-  <HeroPage
-    icon={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "compare": null,
-        "type": [Function],
-      }
-    }
-    title="Campaign not found"
-  >
-    <div
-      className="hero-page "
-    >
-      <div
-        className="hero-page__icon"
-      >
-        <Memo(AlertCircleIcon)>
-          <svg
-            className="mdi-icon "
-            fill="currentColor"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-          >
-            <path
-              d="M13,13H11V7H13M13,17H11V15H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-            />
-          </svg>
-        </Memo(AlertCircleIcon)>
-      </div>
-      <div
-        className="hero-page__title"
-      >
-        Campaign not found
-      </div>
-    </div>
-  </HeroPage>
-</CampaignDetails>
-`;
-
 exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
 <CampaignDetails
   _fetchCampaignById={[Function]}
@@ -87,6 +22,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
       Object {
         "__typename": "Campaign",
         "author": Object {
+          "avatarURL": "http://test.test/avatar",
           "username": "alice",
         },
         "branch": "awesome-branch",
@@ -95,22 +31,25 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
           "stats": Object {
             "closed": 0,
             "merged": 0,
+            "open": 8,
             "total": 10,
+            "unpublished": 2,
           },
-          "totalCount": 2,
+          "totalCount": 0,
         },
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
         "diffStat": Object {
-          "__typename": "IDiffStat",
           "added": 5,
           "changed": 3,
           "deleted": 2,
         },
-        "hasUnpublishedPatches": false,
         "id": "c",
         "name": "n",
+        "namespace": Object {
+          "namespaceName": "alice",
+        },
         "updatedAt": "2020-01-01",
         "viewerCanAdminister": false,
       }
@@ -155,9 +94,21 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
             <span
               className="badge badge-success text-uppercase mr-2"
             >
-              <CampaignsIcon
+              <Memo(ImageAutoAdjustIcon)
                 className="icon-inline campaign-actions-bar__campaign-icon"
-              />
+              >
+                <svg
+                  className="mdi-icon icon-inline campaign-actions-bar__campaign-icon"
+                  fill="currentColor"
+                  height={24}
+                  viewBox="0 0 24 24"
+                  width={24}
+                >
+                  <path
+                    d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z"
+                  />
+                </svg>
+              </Memo(ImageAutoAdjustIcon)>
                Open
             </span>
           </CampaignStateBadge>
@@ -166,7 +117,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
           >
             0
             % complete. 
-            2
+            0
              changesets total
           </small>
         </div>
@@ -176,6 +127,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
   <CampaignInfoCard
     author={
       Object {
+        "avatarURL": "http://test.test/avatar",
         "username": "alice",
       }
     }
@@ -194,10 +146,16 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
             className="icon-inline"
             user={
               Object {
+                "avatarURL": "http://test.test/avatar",
                 "username": "alice",
               }
             }
-          />
+          >
+            <img
+              className="user-avatar icon-inline"
+              src="http://test.test/avatar"
+            />
+          </UserAvatar>
            
           alice
         </strong>
@@ -236,43 +194,6 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
       </div>
     </div>
   </CampaignInfoCard>
-  <h3
-    className="mt-4 mb-2"
-  >
-    Progress
-  </h3>
-  <CampaignBurndownChart
-    changesetCountsOverTime={Array []}
-    history="[History]"
-  >
-    <p>
-      <em>
-        Burndown chart will be shown when there is more than 1 day of data.
-      </em>
-    </p>
-  </CampaignBurndownChart>
-  <h3
-    className="mt-4 d-flex align-items-end mb-0"
-  >
-    2
-     
-    Changesets
-  </h3>
-  <CampaignChangesets
-    campaignID="c"
-    campaignUpdates="[Subject]"
-    changesetUpdates="[Subject]"
-    history="[History]"
-    isLightTheme={true}
-    location="[Location path=/]"
-    telemetryService={
-      Object {
-        "log": [Function],
-        "logViewEvent": [Function],
-      }
-    }
-    viewerCanAdminister={false}
-  />
 </CampaignDetails>
 `;
 
@@ -298,6 +219,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
       Object {
         "__typename": "Campaign",
         "author": Object {
+          "avatarURL": "http://test.test/avatar",
           "username": "alice",
         },
         "branch": "awesome-branch",
@@ -306,22 +228,25 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
           "stats": Object {
             "closed": 0,
             "merged": 0,
+            "open": 8,
             "total": 10,
+            "unpublished": 2,
           },
-          "totalCount": 2,
+          "totalCount": 0,
         },
         "closedAt": null,
         "createdAt": "2020-01-01",
         "description": "d",
         "diffStat": Object {
-          "__typename": "IDiffStat",
           "added": 5,
           "changed": 3,
           "deleted": 2,
         },
-        "hasUnpublishedPatches": false,
         "id": "c",
         "name": "n",
+        "namespace": Object {
+          "namespaceName": "alice",
+        },
         "updatedAt": "2020-01-01",
         "viewerCanAdminister": true,
       }
@@ -366,9 +291,21 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
             <span
               className="badge badge-success text-uppercase mr-2"
             >
-              <CampaignsIcon
+              <Memo(ImageAutoAdjustIcon)
                 className="icon-inline campaign-actions-bar__campaign-icon"
-              />
+              >
+                <svg
+                  className="mdi-icon icon-inline campaign-actions-bar__campaign-icon"
+                  fill="currentColor"
+                  height={24}
+                  viewBox="0 0 24 24"
+                  width={24}
+                >
+                  <path
+                    d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z"
+                  />
+                </svg>
+              </Memo(ImageAutoAdjustIcon)>
                Open
             </span>
           </CampaignStateBadge>
@@ -377,7 +314,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
           >
             0
             % complete. 
-            2
+            0
              changesets total
           </small>
         </div>
@@ -387,6 +324,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
   <CampaignInfoCard
     author={
       Object {
+        "avatarURL": "http://test.test/avatar",
         "username": "alice",
       }
     }
@@ -405,10 +343,16 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
             className="icon-inline"
             user={
               Object {
+                "avatarURL": "http://test.test/avatar",
                 "username": "alice",
               }
             }
-          />
+          >
+            <img
+              className="user-avatar icon-inline"
+              src="http://test.test/avatar"
+            />
+          </UserAvatar>
            
           alice
         </strong>
@@ -447,42 +391,5 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
       </div>
     </div>
   </CampaignInfoCard>
-  <h3
-    className="mt-4 mb-2"
-  >
-    Progress
-  </h3>
-  <CampaignBurndownChart
-    changesetCountsOverTime={Array []}
-    history="[History]"
-  >
-    <p>
-      <em>
-        Burndown chart will be shown when there is more than 1 day of data.
-      </em>
-    </p>
-  </CampaignBurndownChart>
-  <h3
-    className="mt-4 d-flex align-items-end mb-0"
-  >
-    2
-     
-    Changesets
-  </h3>
-  <CampaignChangesets
-    campaignID="c"
-    campaignUpdates="[Subject]"
-    changesetUpdates="[Subject]"
-    history="[History]"
-    isLightTheme={true}
-    location="[Location path=/]"
-    telemetryService={
-      Object {
-        "log": [Function],
-        "logViewEvent": [Function],
-      }
-    }
-    viewerCanAdminister={true}
-  />
 </CampaignDetails>
 `;

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -1,7 +1,6 @@
 import { map } from 'rxjs/operators'
 import { dataOrThrowErrors, gql, requestGraphQL } from '../../../../../shared/src/graphql/graphql'
 import { Observable } from 'rxjs'
-import { ID } from '../../../../../shared/src/graphql/schema'
 import { diffStatFields, fileDiffFields } from '../../../backend/diff'
 import {
     CampaignFields,
@@ -81,7 +80,7 @@ const changesetLabelFragment = gql`
     }
 `
 
-export const fetchCampaignById = (campaign: ID): Observable<CampaignFields | null> =>
+export const fetchCampaignById = (campaign: string): Observable<CampaignFields | null> =>
     requestGraphQL<CampaignByIDResult, CampaignByIDVariables>({
         request: gql`
             query CampaignByID($campaign: ID!) {
@@ -202,7 +201,7 @@ export const queryChangesets = ({
         })
     )
 
-export async function syncChangeset(changeset: ID): Promise<void> {
+export async function syncChangeset(changeset: string): Promise<void> {
     const result = await requestGraphQL<SyncChangesetResult, SyncChangesetVariables>({
         request: gql`
             mutation SyncChangeset($changeset: ID!) {

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -13,6 +13,7 @@ import {
     ExternalChangesetFileDiffsFields,
     SyncChangesetResult,
     SyncChangesetVariables,
+    Scalars,
 } from '../../../graphql-operations'
 
 const changesetCountsOverTimeFragment = gql`
@@ -80,7 +81,7 @@ const changesetLabelFragment = gql`
     }
 `
 
-export const fetchCampaignById = (campaign: string): Observable<CampaignFields | null> =>
+export const fetchCampaignById = (campaign: Scalars['ID']): Observable<CampaignFields | null> =>
     requestGraphQL<CampaignByIDResult, CampaignByIDVariables>({
         request: gql`
             query CampaignByID($campaign: ID!) {
@@ -201,7 +202,7 @@ export const queryChangesets = ({
         })
     )
 
-export async function syncChangeset(changeset: string): Promise<void> {
+export async function syncChangeset(changeset: Scalars['ID']): Promise<void> {
     const result = await requestGraphQL<SyncChangesetResult, SyncChangesetVariables>({
         request: gql`
             mutation SyncChangeset($changeset: ID!) {

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.story.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.story.tsx
@@ -6,16 +6,16 @@ import webStyles from '../../../../enterprise.scss'
 import { Tooltip } from '../../../../components/tooltip/Tooltip'
 import { CampaignChangesets } from './CampaignChangesets'
 import { addHours } from 'date-fns'
-import {
-    ChangesetExternalState,
-    ChangesetReconcilerState,
-    ChangesetCheckState,
-    ChangesetReviewState,
-    ChangesetPublicationState,
-} from '../../../../../../shared/src/graphql/schema'
 import { of, Subject } from 'rxjs'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../../shared/src/telemetry/telemetryService'
-import { ChangesetFields } from '../../../../graphql-operations'
+import {
+    ChangesetFields,
+    ChangesetExternalState,
+    ChangesetReconcilerState,
+    ChangesetPublicationState,
+    ChangesetCheckState,
+    ChangesetReviewState,
+} from '../../../../graphql-operations'
 
 let isLightTheme = true
 

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -32,11 +32,12 @@ import {
     ChangesetExternalState,
     ChangesetReviewState,
     ChangesetCheckState,
+    Scalars,
 } from '../../../../graphql-operations'
 import { isValidChangesetExternalState, isValidChangesetReviewState, isValidChangesetCheckState } from '../../utils'
 
 interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
-    campaignID: string
+    campaignID: Scalars['ID']
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react'
 import * as H from 'history'
-import * as GQL from '../../../../../../shared/src/graphql/schema'
 import { ChangesetNodeProps, ChangesetNode } from './ChangesetNode'
 import { ThemeProps } from '../../../../../../shared/src/theme'
 import { FilteredConnection, FilteredConnectionQueryArgs } from '../../../../components/FilteredConnection'
@@ -28,11 +27,16 @@ import { PlatformContextProps } from '../../../../../../shared/src/platform/cont
 import { TelemetryProps } from '../../../../../../shared/src/telemetry/telemetryService'
 import { property, isDefined } from '../../../../../../shared/src/util/types'
 import { useObservable } from '../../../../../../shared/src/util/useObservable'
-import { ChangesetFields } from '../../../../graphql-operations'
+import {
+    ChangesetFields,
+    ChangesetExternalState,
+    ChangesetReviewState,
+    ChangesetCheckState,
+} from '../../../../graphql-operations'
 import { isValidChangesetExternalState, isValidChangesetReviewState, isValidChangesetCheckState } from '../../utils'
 
 interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
-    campaignID: GQL.ID
+    campaignID: string
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
@@ -47,9 +51,9 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
 }
 
 interface ChangesetFilters {
-    externalState: GQL.ChangesetExternalState | null
-    reviewState: GQL.ChangesetReviewState | null
-    checkState: GQL.ChangesetCheckState | null
+    externalState: ChangesetExternalState | null
+    reviewState: ChangesetReviewState | null
+    checkState: ChangesetCheckState | null
 }
 
 /**
@@ -83,7 +87,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                         externalState: changesetFilters.externalState,
                         reviewState: changesetFilters.reviewState,
                         checkState: changesetFilters.checkState,
-                        ...(onlyOpen ? { externalState: GQL.ChangesetExternalState.OPEN } : {}),
+                        ...(onlyOpen ? { externalState: ChangesetExternalState.OPEN } : {}),
                         first: args.first ?? null,
                         campaign: campaignID,
                     }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000))))
@@ -209,15 +213,15 @@ const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
     onFiltersChange,
 }) => {
     const searchParameters = new URLSearchParams(location.search)
-    const [externalState, setExternalState] = useState<GQL.ChangesetExternalState | undefined>(() => {
+    const [externalState, setExternalState] = useState<ChangesetExternalState | undefined>(() => {
         const value = searchParameters.get('external_state')
         return value && isValidChangesetExternalState(value) ? value : undefined
     })
-    const [reviewState, setReviewState] = useState<GQL.ChangesetReviewState | undefined>(() => {
+    const [reviewState, setReviewState] = useState<ChangesetReviewState | undefined>(() => {
         const value = searchParameters.get('review_state')
         return value && isValidChangesetReviewState(value) ? value : undefined
     })
-    const [checkState, setCheckState] = useState<GQL.ChangesetCheckState | undefined>(() => {
+    const [checkState, setCheckState] = useState<ChangesetCheckState | undefined>(() => {
         const value = searchParameters.get('check_state')
         return value && isValidChangesetCheckState(value) ? value : undefined
     })
@@ -250,22 +254,22 @@ const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
     }, [externalState, reviewState, checkState])
     return (
         <div className="form-inline mb-0 mt-2">
-            <ChangesetFilter<GQL.ChangesetExternalState>
-                values={Object.values(GQL.ChangesetExternalState)}
+            <ChangesetFilter<ChangesetExternalState>
+                values={Object.values(ChangesetExternalState)}
                 label="State"
                 htmlID="changeset-state-filter"
                 selected={externalState}
                 onChange={setExternalState}
             />
-            <ChangesetFilter<GQL.ChangesetReviewState>
-                values={Object.values(GQL.ChangesetReviewState)}
+            <ChangesetFilter<ChangesetReviewState>
+                values={Object.values(ChangesetReviewState)}
                 label="Review state"
                 htmlID="changeset-review-state-filter"
                 selected={reviewState}
                 onChange={setReviewState}
             />
-            <ChangesetFilter<GQL.ChangesetCheckState>
-                values={Object.values(GQL.ChangesetCheckState)}
+            <ChangesetFilter<ChangesetCheckState>
+                values={Object.values(ChangesetCheckState)}
                 label="Check state"
                 htmlID="changeset-check-state-filter"
                 selected={checkState}

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import { IExternalChangeset } from '../../../../../../shared/src/graphql/schema'
 import classNames from 'classnames'
 import { formatDistance, parseISO } from 'date-fns'
 import { syncChangeset } from '../backend'
@@ -9,9 +8,10 @@ import { Observer } from 'rxjs'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import { isErrorLike } from '../../../../../../shared/src/util/errors'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
+import { ChangesetFields } from '../../../../graphql-operations'
 
 interface Props {
-    changeset: Pick<IExternalChangeset, 'id' | 'nextSyncAt' | 'updatedAt'>
+    changeset: Pick<ChangesetFields, 'id' | 'nextSyncAt' | 'updatedAt'>
     viewerCanAdminister: boolean
     campaignUpdates?: Pick<Observer<void>, 'next'>
     /** For testing purposes only */

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetStateIcon.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetStateIcon.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ChangesetStateIcon } from './ChangesetStateIcon'
-import { ChangesetExternalState } from '../../../../../../shared/src/graphql/schema'
 import { mount } from 'enzyme'
+import { ChangesetExternalState } from '../../../../graphql-operations'
 
 describe('ChangesetStateIcon', () => {
     for (const state of Object.values(ChangesetExternalState)) {

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetStateIcon.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetStateIcon.tsx
@@ -1,7 +1,7 @@
 import { changesetExternalStateIcons, changesetExternalStateColorClasses, changesetStateLabels } from './presentation'
-import { ChangesetExternalState } from '../../../../../../shared/src/graphql/schema'
 import React from 'react'
 import classNames from 'classnames'
+import { ChangesetExternalState } from '../../../../graphql-operations'
 
 export interface ChangesetStateIconProps {
     externalState: ChangesetExternalState

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
@@ -8,11 +8,11 @@ import { ExternalChangesetNode } from './ExternalChangesetNode'
 import { addHours } from 'date-fns'
 import {
     ChangesetExternalState,
-    ChangesetCheckState,
-    ChangesetReviewState,
     ChangesetReconcilerState,
     ChangesetPublicationState,
-} from '../../../../../../shared/src/graphql/schema'
+    ChangesetCheckState,
+    ChangesetReviewState,
+} from '../../../../graphql-operations'
 
 let isLightTheme = true
 

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.test.tsx
@@ -1,22 +1,15 @@
 import * as H from 'history'
 import React from 'react'
 import { ExternalChangesetNode } from './ExternalChangesetNode'
-import {
-    ChangesetReviewState,
-    ChangesetCheckState,
-    ChangesetExternalState,
-    ChangesetReconcilerState,
-    ChangesetPublicationState,
-} from '../../../../../../shared/src/graphql/schema'
 import { Subject } from 'rxjs'
 import { shallow } from 'enzyme'
-
-jest.mock('mdi-react/AccountCheckIcon', () => 'AccountCheckIcon')
-jest.mock('mdi-react/AccountAlertIcon', () => 'AccountAlertIcon')
-jest.mock('mdi-react/AccountQuestionIcon', () => 'AccountQuestionIcon')
-jest.mock('mdi-react/SourceMergeIcon', () => 'SourceMergeIcon')
-jest.mock('mdi-react/SourcePullIcon', () => 'SourcePullIcon')
-jest.mock('mdi-react/DeleteIcon', () => 'DeleteIcon')
+import {
+    ChangesetReviewState,
+    ChangesetPublicationState,
+    ChangesetReconcilerState,
+    ChangesetExternalState,
+    ChangesetCheckState,
+} from '../../../../graphql-operations'
 
 describe('ExternalChangesetNode', () => {
     const history = H.createMemoryHistory({ keyLength: 0 })

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -1,5 +1,4 @@
 import { ThemeProps } from '../../../../../../shared/src/theme'
-import { ChangesetCheckState, ChangesetExternalState } from '../../../../../../shared/src/graphql/schema'
 import { Observer } from 'rxjs'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '../../../../../../shared/src/util/url'
@@ -30,7 +29,13 @@ import { FileDiffConnection } from '../../../../components/diff/FileDiffConnecti
 import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { tap, map } from 'rxjs/operators'
 import { ChangesetStateIcon } from './ChangesetStateIcon'
-import { ChangesetFields, GitRefSpecFields, ExternalChangesetFileDiffsFields } from '../../../../graphql-operations'
+import {
+    ChangesetFields,
+    GitRefSpecFields,
+    ExternalChangesetFileDiffsFields,
+    ChangesetCheckState,
+    ChangesetExternalState,
+} from '../../../../graphql-operations'
 
 export interface ExternalChangesetNodeProps extends ThemeProps {
     node: ChangesetFields & { __typename: 'ExternalChangeset' }

--- a/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.story.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.story.tsx
@@ -5,7 +5,7 @@ import webStyles from '../../../../enterprise.scss'
 import { Tooltip } from '../../../../components/tooltip/Tooltip'
 import { HiddenExternalChangesetNode } from './HiddenExternalChangesetNode'
 import { addHours } from 'date-fns'
-import { ChangesetExternalState } from '../../../../../../shared/src/graphql/schema'
+import { ChangesetExternalState } from '../../../../graphql-operations'
 
 const { add } = storiesOf('web/campaigns/HiddenExternalChangesetNode', module).addDecorator(story => {
     const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')

--- a/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { HiddenExternalChangesetNode } from './HiddenExternalChangesetNode'
 import { addDays } from 'date-fns'
-import { ChangesetExternalState } from '../../../../../../shared/src/graphql/schema'
 import { mount } from 'enzyme'
+import { ChangesetExternalState } from '../../../../graphql-operations'
 
 describe('HiddenExternalChangesetNode', () => {
     test('renders', () => {

--- a/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.tsx
@@ -1,10 +1,10 @@
-import { IHiddenExternalChangeset } from '../../../../../../shared/src/graphql/schema'
 import React from 'react'
 import { ChangesetStateIcon } from './ChangesetStateIcon'
 import { ChangesetLastSynced } from './ChangesetLastSynced'
+import { ChangesetFields } from '../../../../graphql-operations'
 
 export interface HiddenExternalChangesetNodeProps {
-    node: Pick<IHiddenExternalChangeset, 'id' | 'nextSyncAt' | 'updatedAt' | 'externalState'>
+    node: Pick<ChangesetFields, 'id' | 'nextSyncAt' | 'updatedAt' | 'externalState'>
 }
 
 export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternalChangesetNodeProps> = ({ node }) => (

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`ExternalChangesetNode renders an externalchangeset 1`] = `
         <div
           className="flex-shrink-0 flex-grow-0 ml-1 align-items-end"
         >
-          <AccountQuestionIcon
+          <Memo(AccountQuestionIcon)
             className="text-warning"
             data-tooltip="pending review"
           />

--- a/web/src/enterprise/campaigns/detail/changesets/presentation.ts
+++ b/web/src/enterprise/campaigns/detail/changesets/presentation.ts
@@ -1,8 +1,3 @@
-import {
-    ChangesetExternalState,
-    ChangesetReviewState,
-    ChangesetCheckState,
-} from '../../../../../../shared/src/graphql/schema'
 import { MdiReactIconComponentType } from 'mdi-react'
 import AccountCheckIcon from 'mdi-react/AccountCheckIcon'
 import AccountAlertIcon from 'mdi-react/AccountAlertIcon'
@@ -13,6 +8,7 @@ import DeleteIcon from 'mdi-react/DeleteIcon'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import CheckboxBlankCircleIcon from 'mdi-react/CheckboxBlankCircleIcon'
+import { ChangesetExternalState, ChangesetReviewState, ChangesetCheckState } from '../../../../graphql-operations'
 
 export const changesetExternalStateColorClasses: Record<ChangesetExternalState, string> = {
     [ChangesetExternalState.OPEN]: 'success',

--- a/web/src/enterprise/campaigns/global/GlobalCampaignsArea.story.tsx
+++ b/web/src/enterprise/campaigns/global/GlobalCampaignsArea.story.tsx
@@ -6,7 +6,7 @@ import { createMemoryHistory } from 'history'
 import webStyles from '../../../SourcegraphWebApp.scss'
 import { MemoryRouter } from 'react-router'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
-import { IUser } from '../../../../../shared/src/graphql/schema'
+import { AuthenticatedUser } from '../../../auth'
 
 const { add } = storiesOf('web/campaigns/GlobalCampaignsArea', module).addDecorator(story => {
     const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')
@@ -29,7 +29,7 @@ add('Dotcom', () => (
         telemetryService={NOOP_TELEMETRY_SERVICE}
         platformContext={undefined as any}
         extensionsController={undefined as any}
-        authenticatedUser={boolean('isAuthenticated', false) ? ({ username: 'alice' } as IUser) : null}
+        authenticatedUser={boolean('isAuthenticated', false) ? ({ username: 'alice' } as AuthenticatedUser) : null}
         match={{ isExact: true, path: '/campaigns', url: 'http://test.test/campaigns', params: {} }}
     />
 ))
@@ -43,7 +43,7 @@ add('Private instance', () => (
         telemetryService={NOOP_TELEMETRY_SERVICE}
         platformContext={undefined as any}
         extensionsController={undefined as any}
-        authenticatedUser={{ username: 'alice', siteAdmin: boolean('Site admin', false) } as IUser}
+        authenticatedUser={{ username: 'alice', siteAdmin: boolean('Site admin', false) } as AuthenticatedUser}
         match={{ isExact: true, path: '/campaigns', url: 'http://test.test/campaigns', params: {} }}
     />
 ))

--- a/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
+++ b/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { RouteComponentProps, Switch, Route } from 'react-router'
 import { GlobalCampaignListPage } from './list/GlobalCampaignListPage'
 import { CampaignDetails } from '../detail/CampaignDetails'
-import { IUser } from '../../../../../shared/src/graphql/schema'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { CreateCampaign } from './create/CreateCampaign'
@@ -14,6 +13,7 @@ import { CampaignsDotComPage } from './marketing/CampaignsDotComPage'
 import { CampaignsSiteAdminMarketingPage } from './marketing/CampaignsSiteAdminMarketingPage'
 import { CampaignsUserMarketingPage } from './marketing/CampaignsUserMarketingPage'
 import { CampaignsBetaFeedbackAlert } from './CampaignsBetaFeedbackAlert'
+import { AuthenticatedUser } from '../../../auth'
 
 interface Props
     extends RouteComponentProps<{}>,
@@ -21,7 +21,7 @@ interface Props
         ExtensionsControllerProps,
         TelemetryProps,
         PlatformContextProps {
-    authenticatedUser: IUser | null
+    authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }
 
@@ -40,7 +40,7 @@ export const GlobalCampaignsArea: React.FunctionComponent<Props> = props => {
 }
 
 interface AuthenticatedProps extends Props {
-    authenticatedUser: IUser
+    authenticatedUser: AuthenticatedUser
 }
 
 export const AuthenticatedCampaignsArea = withAuthenticatedUser<AuthenticatedProps>(({ match, ...outerProps }) => {

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.tsx
@@ -6,13 +6,13 @@ import {
     FilteredConnectionFilter,
     FilteredConnectionQueryArgs,
 } from '../../../../components/FilteredConnection'
-import { CampaignState, IUser } from '../../../../../../shared/src/graphql/schema'
 import { CampaignNode, CampaignNodeProps } from '../../list/CampaignNode'
 import { TelemetryProps } from '../../../../../../shared/src/telemetry/telemetryService'
-import { ListCampaign } from '../../../../graphql-operations'
+import { ListCampaign, CampaignState } from '../../../../graphql-operations'
+import { AuthenticatedUser } from '../../../../auth'
 
 interface Props extends TelemetryProps, Pick<RouteComponentProps, 'history' | 'location'> {
-    authenticatedUser: Pick<IUser, 'siteAdmin'>
+    authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'>
     queryCampaigns?: typeof _queryCampaigns
 }
 

--- a/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -7,8 +7,6 @@ import { ListCampaign } from '../../../graphql-operations'
 
 const now = parseISO('2019-01-01T23:15:01Z')
 
-jest.mock('../icons', () => ({ CampaignsIcon: 'CampaignsIcon' }))
-
 describe('CampaignNode', () => {
     const node: ListCampaign = {
         id: '123',

--- a/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Markdown } from '../../../../../shared/src/components/Markdown'
-import * as GQL from '../../../../../shared/src/graphql/schema'
 import { renderMarkdown } from '../../../../../shared/src/util/markdown'
 import { CampaignsIcon } from '../icons'
 import { Link } from '../../../../../shared/src/components/Link'
@@ -10,7 +9,7 @@ import parseISO from 'date-fns/parseISO'
 import * as H from 'history'
 import { changesetExternalStateIcons, changesetExternalStateColorClasses } from '../detail/changesets/presentation'
 import { Timestamp } from '../../../components/time/Timestamp'
-import { ListCampaign } from '../../../graphql-operations'
+import { ListCampaign, ChangesetExternalState } from '../../../graphql-operations'
 
 export interface CampaignNodeProps {
     node: ListCampaign
@@ -24,9 +23,9 @@ export interface CampaignNodeProps {
  */
 export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node, history, now = new Date() }) => {
     const campaignIconClass = node.closedAt ? 'text-danger' : 'text-success'
-    const OpenChangesetIcon = changesetExternalStateIcons[GQL.ChangesetExternalState.OPEN]
-    const ClosedChangesetIcon = changesetExternalStateIcons[GQL.ChangesetExternalState.CLOSED]
-    const MergedChangesetIcon = changesetExternalStateIcons[GQL.ChangesetExternalState.MERGED]
+    const OpenChangesetIcon = changesetExternalStateIcons[ChangesetExternalState.OPEN]
+    const ClosedChangesetIcon = changesetExternalStateIcons[ChangesetExternalState.CLOSED]
+    const MergedChangesetIcon = changesetExternalStateIcons[ChangesetExternalState.MERGED]
     return (
         <li className="list-group-item">
             <div className="d-flex align-items-center p-2">

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -30,10 +30,23 @@ exports[`CampaignNode campaign without description 1`] = `
     <div
       className="d-flex align-items-center p-2"
     >
-      <CampaignsIcon
+      <Memo(ImageAutoAdjustIcon)
         className="icon-inline mr-2 flex-shrink-0 align-self-stretch text-success"
         data-tooltip="Open"
-      />
+      >
+        <svg
+          className="mdi-icon icon-inline mr-2 flex-shrink-0 align-self-stretch text-success"
+          data-tooltip="Open"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z"
+          />
+        </svg>
+      </Memo(ImageAutoAdjustIcon)>
       <div
         className="flex-grow-1 campaign-node__content"
       >
@@ -196,10 +209,23 @@ exports[`CampaignNode closed campaign 1`] = `
     <div
       className="d-flex align-items-center p-2"
     >
-      <CampaignsIcon
+      <Memo(ImageAutoAdjustIcon)
         className="icon-inline mr-2 flex-shrink-0 align-self-stretch text-danger"
         data-tooltip="Closed"
-      />
+      >
+        <svg
+          className="mdi-icon icon-inline mr-2 flex-shrink-0 align-self-stretch text-danger"
+          data-tooltip="Closed"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z"
+          />
+        </svg>
+      </Memo(ImageAutoAdjustIcon)>
       <div
         className="flex-grow-1 campaign-node__content"
       >
@@ -370,10 +396,23 @@ exports[`CampaignNode open campaign 1`] = `
     <div
       className="d-flex align-items-center p-2"
     >
-      <CampaignsIcon
+      <Memo(ImageAutoAdjustIcon)
         className="icon-inline mr-2 flex-shrink-0 align-self-stretch text-success"
         data-tooltip="Open"
-      />
+      >
+        <svg
+          className="mdi-icon icon-inline mr-2 flex-shrink-0 align-self-stretch text-success"
+          data-tooltip="Open"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z"
+          />
+        </svg>
+      </Memo(ImageAutoAdjustIcon)>
       <div
         className="flex-grow-1 campaign-node__content"
       >


### PR DESCRIPTION
Since the new type system was introduced, we had two different ways to describe things in our codebase.
This streamlines the usage of the types to just use the new ones from `graphql-operations`.