### PR TITLE
monitoring(syntec-server): ratios for timeouts, errors

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3810,7 +3810,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _syntect-server: 5+ syntax highlighting errors every 5m_
+- _syntect-server: 5%+ syntax highlighting errors every 5m_
 
 **Possible solutions:**
 
@@ -3819,6 +3819,22 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 ```json
 "observability.silenceAlerts": [
   "warning_syntect-server_syntax_highlighting_errors"
+]
+```
+
+## syntect-server: syntax_highlighting_timeouts
+
+**Descriptions:**
+
+- _syntect-server: 5%+ syntax highlighting timeouts every 5m_
+
+**Possible solutions:**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_syntect-server_syntax_highlighting_timeouts"
 ]
 ```
 
@@ -3835,22 +3851,6 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 ```json
 "observability.silenceAlerts": [
   "warning_syntect-server_syntax_highlighting_panics"
-]
-```
-
-## syntect-server: syntax_highlighting_timeouts
-
-**Descriptions:**
-
-- _syntect-server: 5+ syntax highlighting timeouts every 5m_
-
-**Possible solutions:**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_syntect-server_syntax_highlighting_timeouts"
 ]
 ```
 

--- a/monitoring/syntect_server.go
+++ b/monitoring/syntect_server.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 func SyntectServer() *Container {
 	return &Container{
 		Name:        "syntect-server",
@@ -13,13 +15,25 @@ func SyntectServer() *Container {
 						{
 							Name:              "syntax_highlighting_errors",
 							Description:       "syntax highlighting errors every 5m",
-							Query:             `sum(increase(src_syntax_highlighting_requests{status="error"}[5m]))`,
+							Query:             `sum(increase(src_syntax_highlighting_requests{status="error"}[5m])) / sum(increase(src_syntax_highlighting_requests[5m])) * 100`,
 							DataMayNotExist:   true,
-							Warning:           Alert{GreaterOrEqual: 5},
-							PanelOptions:      PanelOptions().LegendFormat("error"),
+							Warning:           Alert{GreaterOrEqual: 5, For: 5 * time.Minute},
+							PanelOptions:      PanelOptions().LegendFormat("error").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
 							PossibleSolutions: "none",
 						},
+						{
+							Name:              "syntax_highlighting_timeouts",
+							Description:       "syntax highlighting timeouts every 5m",
+							Query:             `sum(increase(src_syntax_highlighting_requests{status="timeout"}[5m])) / sum(increase(src_syntax_highlighting_requests[5m])) * 100`,
+							DataMayNotExist:   true,
+							Warning:           Alert{GreaterOrEqual: 5, For: 5 * time.Minute},
+							PanelOptions:      PanelOptions().LegendFormat("timeout").Unit(Percentage),
+							Owner:             ObservableOwnerCodeIntel,
+							PossibleSolutions: "none",
+						},
+					},
+					{
 						{
 							Name:              "syntax_highlighting_panics",
 							Description:       "syntax highlighting panics every 5m",
@@ -27,18 +41,6 @@ func SyntectServer() *Container {
 							DataMayNotExist:   true,
 							Warning:           Alert{GreaterOrEqual: 5},
 							PanelOptions:      PanelOptions().LegendFormat("panic"),
-							Owner:             ObservableOwnerCodeIntel,
-							PossibleSolutions: "none",
-						},
-					},
-					{
-						{
-							Name:              "syntax_highlighting_timeouts",
-							Description:       "syntax highlighting timeouts every 5m",
-							Query:             `sum(increase(src_syntax_highlighting_requests{status="timeout"}[5m]))`,
-							DataMayNotExist:   true,
-							Warning:           Alert{GreaterOrEqual: 5},
-							PanelOptions:      PanelOptions().LegendFormat("timeout"),
 							Owner:             ObservableOwnerCodeIntel,
 							PossibleSolutions: "none",
 						},


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/issues/12816

I've kept panics, worker deaths as hard thresholds because to my understanding they shouldn't happen at all (?) - I've grouped these together on a row

[query](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-2d%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22sum(increase(src_syntax_highlighting_requests%7Bstatus%3D%5C%22timeout%5C%22%7D%5B5m%5D))%20%2F%20sum(increase(src_syntax_highlighting_requests%5B5m%5D))%20*%20100%22%7D,%7B%22expr%22:%22sum(increase(src_syntax_highlighting_requests%7Bstatus%3D%5C%22error%5C%22%7D%5B5m%5D))%20%2F%20sum(increase(src_syntax_highlighting_requests%5B5m%5D))%20*%20100%22%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D) - with `for: 5m` this will resolve the current frequently firing alerts about timeouts and errors

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
