### PR TITLE
linux requires running `watchman watch` on sourcegraph directory

### DIFF
--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -191,6 +191,8 @@ The following are two recommendations for installing these dependencies:
     sudo cp lib/* /usr/local/lib
     sudo chmod 755 /usr/local/bin/watchman
     sudo chmod 2777 /usr/local/var/run/watchman
+    # On Linux, you'll need to run the following in addition:
+    watchman watch <path to sourcegraph repository>
 
     # nvm (to manage Node.js)
     NVM_VERSION="$(curl https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r .name)"

--- a/doc/dev/local_development.md
+++ b/doc/dev/local_development.md
@@ -191,7 +191,7 @@ The following are two recommendations for installing these dependencies:
     sudo cp lib/* /usr/local/lib
     sudo chmod 755 /usr/local/bin/watchman
     sudo chmod 2777 /usr/local/var/run/watchman
-    # On Linux, you'll need to run the following in addition:
+    # On Linux, you may need to run the following in addition:
     watchman watch <path to sourcegraph repository>
 
     # nvm (to manage Node.js)


### PR DESCRIPTION
Any other Linux users find they have to run `watchman watch path/to/sourcegraph` for watchman to work properly? Otherwise, the `subscribe` invocation results in a "unable to resolve root" error (presumably because the root has to be watched first).

Based on my (limited) understanding of watchman behavior, this ought to be required on macOS, too, but maybe it's obvious to others that they need to run `watchman watch` separately first?