### PR TITLE
search: update integration tests for parser migration

### DIFF
--- a/internal/cmd/search-integration-tester/search_tests.go
+++ b/internal/cmd/search-integration-tester/search_tests.go
@@ -22,7 +22,7 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, repo search by name, case yes, nonzero result`,
-		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ String case:yes count:1 stable:yes`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ String case:yes count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `True is an alias for yes when fork is set`,
@@ -31,15 +31,15 @@ var tests = []test{
 	// Text search, focused to repo.
 	{
 		Name:  `Repo search, non-master branch, nonzero result`,
-		Query: `repo:^github.com/facebook/react$@0.3-stable var ExecutionEnvironment = require('ExecutionEnvironment'); patterntype:literal count:1 stable:yes`,
+		Query: `repo:^github.com/facebook/react$@0.3-stable var ExecutionEnvironment = require('ExecutionEnvironment'); patterntype:literal count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Repo search, indexed multiline search, nonzero result`,
-		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \nimport index:only count:1 stable:yes`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \nimport index:only count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Repo search, unindexed multiline search, nonzero result`,
-		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \nimport index:no count:1 stable:yes`,
+		Query: `repo:^github\.com/rvantonderp/adjust-go-wrk$ \nimport index:no count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Repo search, zero results`,
@@ -67,21 +67,21 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, double-quoted pattern, nonzero result`,
-		Query: `"error type:\n" patterntype:regexp count:1 stable:yes`,
+		Query: `"error type:\n" patterntype:regexp count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Global search, exclude repo, nonzero result`,
-		Query: `"error type:\n" -repo:DirectXMan12 patterntype:regexp count:1 stable:yes`,
+		Query: `"error type:\n" -repo:DirectXMan12 patterntype:regexp count:1 stable:yes type:file`,
 	},
 	// Repohascommitafter.
 	{
 		Name:  `Global search, repohascommitafter, nonzero result`,
-		Query: `repohascommitafter:"5 months ago" test patterntype:literal count:1 stable:yes`,
+		Query: `repohascommitafter:"5 months ago" test patterntype:literal count:1`,
 	},
 	// Global regex text search.
 	{
 		Name:  `Global search, regex, unindexed, nonzero result`,
-		Query: `^func.*$ patterntype:regexp index:only count:1 stable:yes`,
+		Query: `^func.*$ patterntype:regexp index:only count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Global search, fork only, nonzero result`,
@@ -89,7 +89,7 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, filter by language`,
-		Query: `\bfunc\b lang:go count:1 stable:yes`,
+		Query: `\bfunc\b lang:go count:1 stable:yes type:file`,
 	},
 	{
 		Name:  `Global search, filename, zero results`,
@@ -97,12 +97,12 @@ var tests = []test{
 	},
 	{
 		Name:  `Global search, filename, nonzero result`,
-		Query: `file:router.go count:1 stable:yes`,
+		Query: `file:router.go count:1`,
 	},
 	// Symbol search.
 	{
 		Name:  `Global search, symbols, nonzero result`,
-		Query: `type:symbol test count:1 stable:yes`,
+		Query: `type:symbol test count:1`,
 	},
 	// Structural search.
 	{


### PR DESCRIPTION
Happy to say that the parser migration passes all of the existing search integration tests. The new parser is stricter about enforcing that `type:file` is specified with `stable:yes` (addresses https://github.com/sourcegraph/sourcegraph/issues/9715), so the relevant tests are updated here. There are also some queries that have `stable:yes`, that we don't technically support yet, so I have updated those tests as well.

 The assumption from here on out is that these tests work consistently with the new parser, until I/we put @unknwon's testing work into CI.

There is one discrepancy for a test that returns a slightly different suggested query for a particular alert (ordering is different). This is too low value to try and make consistent, but just noting it.

Old:

<img width="911" alt="Screen Shot 2020-08-06 at 8 12 06 PM" src="https://user-images.githubusercontent.com/888624/89604928-1ec57980-d821-11ea-92c4-44ba075faefc.png">

New:

<img width="915" alt="Screen Shot 2020-08-06 at 8 12 46 PM" src="https://user-images.githubusercontent.com/888624/89604957-36046700-d821-11ea-96a4-b5fe67c27937.png">


