### PR TITLE
search: fuzzify glob patterns if users enter paths

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -216,7 +216,7 @@ func reporevToRegex(value string) (string, error) {
 	return value, nil
 }
 
-var globSyntax = lazyregexp.New(`[][*?/]`)
+var globSyntax = lazyregexp.New(`[][*?]`)
 
 func ContainsNoGlobSyntax(value string) bool {
 	return !globSyntax.MatchString(value)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -557,12 +557,12 @@ func TestReporevToRegex(t *testing.T) {
 		{
 			name: "no revision",
 			arg:  "github.com/foo",
-			want: "^github\\.com/foo$",
+			want: "^.*?github\\.com/foo.*?$",
 		},
 		{
 			name: "with revision",
 			arg:  "github.com/foo@bar",
-			want: "^github\\.com/foo$@bar",
+			want: "^.*?github\\.com/foo.*?$@bar",
 		},
 		{
 			name: "empty string",
@@ -636,15 +636,15 @@ func TestContainsNoGlobSyntax(t *testing.T) {
 		},
 		{
 			in:   "/foo.bar",
-			want: false,
+			want: true,
 		},
 		{
 			in:   "path/to/file/foo.bar",
-			want: false,
+			want: true,
 		},
 		{
 			in:   "github.com/org/repo",
-			want: false,
+			want: true,
 		},
 		{
 			in:   "foo**",
@@ -717,6 +717,10 @@ func TestMapGlobToRegex(t *testing.T) {
 			want:  `"repo:^.*?sourcegraph.*?$"`,
 		},
 		{
+			input: "repo:github.com/sourcegraph",
+			want:  `"repo:^.*?github\\.com/sourcegraph.*?$"`,
+		},
+		{
 			input: "repo:**sourcegraph",
 			want:  `"repo:^.*?sourcegraph$"`,
 		},
@@ -730,7 +734,7 @@ func TestMapGlobToRegex(t *testing.T) {
 		},
 		{
 			input: "file:afile file:dir1/bfile",
-			want:  `(and "file:^.*?afile.*?$" "file:^dir1/bfile$")`,
+			want:  `(and "file:^.*?afile.*?$" "file:^.*?dir1/bfile.*?$")`,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
relates to #12476 

After dogfooding fuzzy globbing for a while, treating `/` as glob syntax turns out to be inconvenient. For example, `repo:github.com/sourcegraph` does not return any results because we treat `/` as a marker not to fuzzify the filter value. This PR removes `/` from the list of markers.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
