### PR TITLE
Return error when applying a campaign spec to a closed campaign

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -128,7 +128,7 @@ func (r *campaignResolver) UpdatedAt() graphqlbackend.DateTime {
 }
 
 func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
-	if r.Campaign.ClosedAt.IsZero() {
+	if !r.Campaign.Closed() {
 		return nil
 	}
 	return &graphqlbackend.DateTime{Time: r.Campaign.ClosedAt}

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -210,6 +210,10 @@ func (e *changesetSpecNotFoundErr) Error() string {
 
 func (e *changesetSpecNotFoundErr) NotFound() bool { return true }
 
+// ErrApplyClosedCampaign is returned by ApplyCampaign when the campaign
+// matched by the campaign spec is already closed.
+var ErrApplyClosedCampaign = errors.New("existing campaign matched by campaign spec is closed")
+
 type ApplyCampaignOpts struct {
 	CampaignSpecRandID string
 	EnsureCampaignID   int64
@@ -302,6 +306,10 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 
 	if opts.EnsureCampaignID != 0 && campaign.ID != opts.EnsureCampaignID {
 		return nil, ErrEnsureCampaignFailed
+	}
+
+	if !campaign.ClosedAt.IsZero() {
+		return nil, ErrApplyClosedCampaign
 	}
 
 	if campaign.CampaignSpecID == campaignSpec.ID {

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -308,7 +308,7 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 		return nil, ErrEnsureCampaignFailed
 	}
 
-	if !campaign.ClosedAt.IsZero() {
+	if campaign.Closed() {
 		return nil, ErrApplyClosedCampaign
 	}
 
@@ -744,6 +744,10 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 			return errors.Wrap(err, "getting campaign")
 		}
 
+		if campaign.Closed() {
+			return nil
+		}
+
 		if err := backend.CheckSiteAdminOrSameUser(ctx, campaign.AuthorID); err != nil {
 			return err
 		}
@@ -762,10 +766,6 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 				err = ErrCloseProcessingCampaign
 				return err
 			}
-		}
-
-		if !campaign.ClosedAt.IsZero() {
-			return nil
 		}
 
 		campaign.ClosedAt = time.Now().UTC()

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -86,6 +86,9 @@ func (c *Campaign) RemoveChangesetID(id int64) {
 	}
 }
 
+// Closed returns true when the ClosedAt timestamp has been set.
+func (c *Campaign) Closed() bool { return !c.ClosedAt.IsZero() }
+
 // GenChangesetBody creates the markdown to be used as the body of a changeset.
 // It includes a URL back to the campaign on the Sourcegraph instance.
 func (c *Campaign) GenChangesetBody(externalURL string) string {


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/pull/12782#issuecomment-669908171 for more context.

Short version: it doesn't make sense to allow applying a new spec to a closed campaign.