### PR TITLE
search: don't propose regex queries if globbing is active

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -282,7 +282,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			return &searchAlert{
 				prometheusType: "no_resolved_repos__suggest_add_remove_repos",
 				title:          "No repositories satisfied all of your repo: filters.",
-				description:    "remove repo: filters",
+				description:    "remove repo: filters to see results",
 			}
 		}
 		proposedQueries := []*searchQueryDescription{}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -137,8 +137,8 @@ func reposExist(ctx context.Context, options resolveRepoOp) bool {
 
 func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAlert {
 	globbing := false
-	if settings, err := decodedViewerFinalSettings(ctx); err != nil || getBoolPtr(settings.SearchGlobbing, false) {
-		globbing = true
+	if settings, err := decodedViewerFinalSettings(ctx); err == nil {
+		globbing = getBoolPtr(settings.SearchGlobbing, false)
 	}
 
 	repoFilters, minusRepoFilters := r.query.RegexpPatterns(query.FieldRepo)

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -282,7 +282,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			return &searchAlert{
 				prometheusType: "no_resolved_repos__suggest_add_remove_repos",
 				title:          "No repositories satisfied all of your repo: filters.",
-				description:    "remove repo: filters to see results",
+				description:    "Remove repo: filters to see results",
 			}
 		}
 		proposedQueries := []*searchQueryDescription{}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -218,7 +218,6 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			onlyForks:        onlyForks,
 			noForks:          noForks,
 		}
-
 		if reposExist(ctx, tryAnyRepo) {
 			proposedQueries = append(proposedQueries, &searchQueryDescription{
 				description: "include repositories satisfying any (not all) of your repo: filters",
@@ -295,7 +294,6 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			onlyForks:        onlyForks,
 			noForks:          noForks,
 		}
-
 		if reposExist(ctx, tryAnyRepo) {
 			proposedQueries = append(proposedQueries, &searchQueryDescription{
 				description: "include repositories satisfying any (not all) of your repo: filters",
@@ -308,7 +306,6 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			description: "remove repo: filters",
 			query:       withoutRepoFields,
 		})
-
 		return &searchAlert{
 			prometheusType:  "no_resolved_repos__suggest_add_remove_repos",
 			title:           "No repositories satisfied all of your repo: filters.",


### PR DESCRIPTION
Relates to #12476 

This PR updates `alertForNoResolvedRepos` to not propose regex queries if globbing is active. The alert messages are still helpful.

#### Background:

`alertForNoResolvedRepos` contains a lot of logic to propose queries, most of which is based on regex syntax. For example, if `repo:a repo:b` does not return results, the alert proposes to try `repo:a|b`. For now, we neither support AND/OR operators for filters nor `|` as part of an extended glob syntax. Until then we cannot propose similar queries when globbing is active.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
