### PR TITLE
Try to fix typescript coverage on Go only branches

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -33,11 +33,6 @@ coverage:
 comment:
   require_changes: yes
   layout: 'diff, flags, files'
-  # We upload at least 6 times in CI (to confirm: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%22https://codecov.io/bash%22&patternType=regexp)
-  # Exceptions:
-  # - PRs that only update docs, we don't need Codecov there.
-  # - e2e tests, which don't run on most PRs.
-  after_n_builds: 6
 ignore:
   - '**/bindata.go'
 flags:

--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -40,3 +40,6 @@ comment:
   after_n_builds: 6
 ignore:
   - '**/bindata.go'
+flags:
+  typescript:
+    carryforward: true


### PR DESCRIPTION
Since we introduced smaller builds for PRs that only affect Go code, the coverage for TypeScript varies a lot since no reports are uploaded. Also, no reports would be posted ever, since we don't reach the number of 6 builds.
Should we give this a try and revert if it doesn't help?