### PR TITLE
Fix test.only in integration test

### DIFF
--- a/web/src/integration/search.test.ts
+++ b/web/src/integration/search.test.ts
@@ -271,7 +271,7 @@ describe('Search', () => {
             await driver.assertWindowLocation('/search?q=fork:%22no%22+test&patternType=literal')
         })
 
-        test.only('Clicking on alert proposed query navigates to the right filter', async () => {
+        test('Clicking on alert proposed query navigates to the right filter', async () => {
             const searchResultsWithAlert = searchResults()
             if (searchResultsWithAlert.search) {
                 searchResultsWithAlert.search.results.results = []


### PR DESCRIPTION
@felixfbecker also added a config to our linter to prevent this from happening again.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
