### PR TITLE
Try to fix carryforward code coverage

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -35,6 +35,9 @@ comment:
   layout: 'diff, flags, files'
 ignore:
   - '**/bindata.go'
+
 flags:
   typescript:
     carryforward: true
+
+show_carryforward_flags: true

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -148,7 +148,7 @@ func addPostgresBackcompat(pipeline *bk.Pipeline) {
 func addGoTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go:",
 		bk.Cmd("./dev/ci/go-test.sh"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go -F unit"))
+		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go"))
 }
 
 // Builds the OSS and Enterprise Go commands.

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -503,7 +504,7 @@ func (r *changesetLabelResolver) Text() string {
 }
 
 func (r *changesetLabelResolver) Color() string {
-	return r.label.Color
+	return fmt.Sprintf("%s", r.label.Color)
 }
 
 func (r *changesetLabelResolver) Description() *string {

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -504,7 +503,7 @@ func (r *changesetLabelResolver) Text() string {
 }
 
 func (r *changesetLabelResolver) Color() string {
-	return fmt.Sprintf("%s", r.label.Color)
+	return r.label.Color
 }
 
 func (r *changesetLabelResolver) Description() *string {


### PR DESCRIPTION
It could be that the unit report isn't carried forward because go also defines it. Since go has only a single report, I think it's fine to leave the label out (?)