### PR TITLE
Implement user and org campaigns page

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.story.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.story.tsx
@@ -21,7 +21,11 @@ const { add } = storiesOf('web/campaigns/CampaignActionsBar', module).addDecorat
 add('Bar', () => (
     <CampaignActionsBar
         campaign={{
-            name: 'Awesome campaign',
+            name: 'sourcegraph-prettier',
+            namespace: {
+                namespaceName: 'alice',
+                url: '/users/alice',
+            },
             closedAt: boolean('Closed', false) ? new Date().toISOString() : null,
             viewerCanAdminister: boolean('viewerCanAdminister', false),
             changesets: {

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.story.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.story.tsx
@@ -34,6 +34,8 @@ add('Bar', () => (
                     total: 107,
                     closed: 10,
                     merged: 20,
+                    open: 60,
+                    unpublished: 17,
                 },
             },
         }}

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -5,6 +5,7 @@ import { CampaignFields } from '../../../graphql-operations'
 
 interface Props {
     campaign: Pick<CampaignFields, 'name' | 'closedAt' | 'viewerCanAdminister'> & {
+        namespace: CampaignFields['namespace']
         changesets: {
             totalCount: CampaignFields['changesets']['totalCount']
             stats: Pick<CampaignFields['changesets']['stats'], 'total' | 'closed' | 'merged'>
@@ -26,6 +27,10 @@ export const CampaignActionsBar: React.FunctionComponent<Props> = ({ campaign })
             <div className="mb-2">
                 <span>
                     <Link to="/campaigns">Campaigns</Link>
+                </span>
+                <span className="text-muted d-inline-block mx-1">/</span>
+                <span>
+                    <Link to={campaign.namespace.url}>{campaign.namespace.namespaceName}</Link>
                 </span>
                 <span className="text-muted d-inline-block mx-1">/</span>
                 <span>{campaign.name}</span>

--- a/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignActionsBar.tsx
@@ -4,13 +4,7 @@ import { Link } from '../../../../../shared/src/components/Link'
 import { CampaignFields } from '../../../graphql-operations'
 
 interface Props {
-    campaign: Pick<CampaignFields, 'name' | 'closedAt' | 'viewerCanAdminister'> & {
-        namespace: CampaignFields['namespace']
-        changesets: {
-            totalCount: CampaignFields['changesets']['totalCount']
-            stats: Pick<CampaignFields['changesets']['stats'], 'total' | 'closed' | 'merged'>
-        }
-    }
+    campaign: Pick<CampaignFields, 'name' | 'closedAt' | 'viewerCanAdminister' | 'namespace' | 'changesets'>
 }
 
 export const CampaignActionsBar: React.FunctionComponent<Props> = ({ campaign }) => {

--- a/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetails.test.tsx
@@ -47,6 +47,7 @@ describe('CampaignDetails', () => {
                     },
                     namespace: {
                         namespaceName: 'alice',
+                        url: '/users/alice',
                     },
                 })
             }

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
         "name": "n",
         "namespace": Object {
           "namespaceName": "alice",
+          "url": "/users/alice",
         },
         "updatedAt": "2020-01-01",
         "viewerCanAdminister": false,
@@ -66,6 +67,22 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
             href="/campaigns"
           >
             Campaigns
+          </a>
+        </AnchorLink>
+      </span>
+      <span
+        className="text-muted d-inline-block mx-1"
+      >
+        /
+      </span>
+      <span>
+        <AnchorLink
+          to="/users/alice"
+        >
+          <a
+            href="/users/alice"
+          >
+            alice
           </a>
         </AnchorLink>
       </span>
@@ -246,6 +263,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
         "name": "n",
         "namespace": Object {
           "namespaceName": "alice",
+          "url": "/users/alice",
         },
         "updatedAt": "2020-01-01",
         "viewerCanAdminister": true,
@@ -263,6 +281,22 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
             href="/campaigns"
           >
             Campaigns
+          </a>
+        </AnchorLink>
+      </span>
+      <span
+        className="text-muted d-inline-block mx-1"
+      >
+        /
+      </span>
+      <span>
+        <AnchorLink
+          to="/users/alice"
+        >
+          <a
+            href="/users/alice"
+          >
+            alice
           </a>
         </AnchorLink>
       </span>

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -35,6 +35,7 @@ const campaignFragment = gql`
         name
         namespace {
             namespaceName
+            url
         }
         description
         initialApplier {

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.story.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.story.tsx
@@ -26,7 +26,6 @@ add('List of campaigns', () => {
     const history = createMemoryHistory()
     return (
         <GlobalCampaignListPage
-            authenticatedUser={{ siteAdmin: true }}
             queryCampaigns={() => of({ totalCount: Object.values(nodes).length, nodes: Object.values(nodes) })}
             telemetryService={NOOP_TELEMETRY_SERVICE}
             history={history}

--- a/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.test.tsx
+++ b/web/src/enterprise/campaigns/global/list/GlobalCampaignListPage.test.tsx
@@ -16,7 +16,6 @@ describe('GlobalCampaignListPage', () => {
                     <GlobalCampaignListPage
                         history={history}
                         location={history.location}
-                        authenticatedUser={{ siteAdmin: true }}
                         queryCampaigns={() =>
                             of({ totalCount: Object.values(nodes).length, nodes: Object.values(nodes) })
                         }
@@ -31,7 +30,6 @@ describe('GlobalCampaignListPage', () => {
                     <GlobalCampaignListPage
                         history={history}
                         location={history.location}
-                        authenticatedUser={{ siteAdmin: false }}
                         queryCampaigns={() =>
                             of({ totalCount: Object.values(nodes).length, nodes: Object.values(nodes) })
                         }

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
     nodeComponent={[Function]}
     nodeComponentProps={
       Object {
+        "displayNamespace": true,
         "history": "[History]",
       }
     }
@@ -219,6 +220,7 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
     nodeComponent={[Function]}
     nodeComponentProps={
       Object {
+        "displayNamespace": true,
         "history": "[History]",
       }
     }
@@ -337,6 +339,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
     nodeComponent={[Function]}
     nodeComponentProps={
       Object {
+        "displayNamespace": true,
         "history": "[History]",
       }
     }
@@ -455,6 +458,7 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
     nodeComponent={[Function]}
     nodeComponentProps={
       Object {
+        "displayNamespace": true,
         "history": "[History]",
       }
     }

--- a/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/list/__snapshots__/GlobalCampaignListPage.test.tsx.snap
@@ -62,11 +62,6 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 0 1`] 
     </div>
   </div>
   <FilteredConnection
-    authenticatedUser={
-      Object {
-        "siteAdmin": false,
-      }
-    }
     className="mb-3"
     defaultFirst={20}
     filters={
@@ -181,11 +176,6 @@ exports[`GlobalCampaignListPage renders for non-siteadmin and totalCount: 1 1`] 
     </div>
   </div>
   <FilteredConnection
-    authenticatedUser={
-      Object {
-        "siteAdmin": false,
-      }
-    }
     className="mb-3"
     defaultFirst={20}
     filters={
@@ -300,11 +290,6 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 0 1`] = `
     </div>
   </div>
   <FilteredConnection
-    authenticatedUser={
-      Object {
-        "siteAdmin": true,
-      }
-    }
     className="mb-3"
     defaultFirst={20}
     filters={
@@ -419,11 +404,6 @@ exports[`GlobalCampaignListPage renders for siteadmin and totalCount: 1 1`] = `
     </div>
   </div>
   <FilteredConnection
-    authenticatedUser={
-      Object {
-        "siteAdmin": true,
-      }
-    }
     className="mb-3"
     defaultFirst={20}
     filters={

--- a/web/src/enterprise/campaigns/global/list/backend.ts
+++ b/web/src/enterprise/campaigns/global/list/backend.ts
@@ -1,18 +1,26 @@
 import { map } from 'rxjs/operators'
 import { dataOrThrowErrors, gql, requestGraphQL } from '../../../../../../shared/src/graphql/graphql'
 import { Observable } from 'rxjs'
-import { CampaignsVariables, CampaignsResult } from '../../../../graphql-operations'
+import {
+    CampaignsVariables,
+    CampaignsResult,
+    CampaignsByUserResult,
+    CampaignsByUserVariables,
+    CampaignsByOrgResult,
+    CampaignsByOrgVariables,
+} from '../../../../graphql-operations'
 
 const ListCampaignFragment = gql`
     fragment ListCampaign on Campaign {
         id
         name
+        namespace {
+            namespaceName
+            url
+        }
         description
         createdAt
         closedAt
-        initialApplier {
-            username
-        }
         changesets {
             stats {
                 open
@@ -27,7 +35,7 @@ export const queryCampaigns = ({
     first,
     state,
     viewerCanAdminister,
-}: CampaignsVariables): Observable<CampaignsResult['campaigns']> =>
+}: Partial<CampaignsVariables>): Observable<CampaignsResult['campaigns']> =>
     requestGraphQL<CampaignsResult, CampaignsVariables>({
         request: gql`
             query Campaigns($first: Int, $state: CampaignState, $viewerCanAdminister: Boolean) {
@@ -41,8 +49,84 @@ export const queryCampaigns = ({
 
             ${ListCampaignFragment}
         `,
-        variables: { first, state, viewerCanAdminister },
+        variables: { first: first ?? null, state: state ?? null, viewerCanAdminister: viewerCanAdminister ?? null },
     }).pipe(
         map(dataOrThrowErrors),
         map(data => data.campaigns)
+    )
+
+export const queryCampaignsByUser = ({
+    userID,
+    first,
+    state,
+    viewerCanAdminister,
+}: CampaignsByUserVariables): Observable<CampaignsResult['campaigns']> =>
+    requestGraphQL<CampaignsByUserResult, CampaignsByUserVariables>({
+        request: gql`
+            query CampaignsByUser($userID: ID!, $first: Int, $state: CampaignState, $viewerCanAdminister: Boolean) {
+                node(id: $userID) {
+                    __typename
+                    ... on User {
+                        campaigns(first: $first, state: $state, viewerCanAdminister: $viewerCanAdminister) {
+                            nodes {
+                                ...ListCampaign
+                            }
+                            totalCount
+                        }
+                    }
+                }
+            }
+
+            ${ListCampaignFragment}
+        `,
+        variables: { first, state, viewerCanAdminister, userID },
+    }).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.node) {
+                throw new Error('User not found')
+            }
+            if (data.node.__typename !== 'User') {
+                throw new Error(`Requested node is a ${data.node.__typename}, not a User`)
+            }
+            return data.node.campaigns
+        })
+    )
+
+export const queryCampaignsByOrg = ({
+    orgID,
+    first,
+    state,
+    viewerCanAdminister,
+}: CampaignsByOrgVariables): Observable<CampaignsResult['campaigns']> =>
+    requestGraphQL<CampaignsByOrgResult, CampaignsByOrgVariables>({
+        request: gql`
+            query CampaignsByOrg($orgID: ID!, $first: Int, $state: CampaignState, $viewerCanAdminister: Boolean) {
+                node(id: $orgID) {
+                    __typename
+                    ... on Org {
+                        campaigns(first: $first, state: $state, viewerCanAdminister: $viewerCanAdminister) {
+                            nodes {
+                                ...ListCampaign
+                            }
+                            totalCount
+                        }
+                    }
+                }
+            }
+
+            ${ListCampaignFragment}
+        `,
+        variables: { first, state, viewerCanAdminister, orgID },
+    }).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.node) {
+                throw new Error('Org not found')
+            }
+            if (data.node.__typename !== 'Org') {
+                throw new Error(`Requested node is a ${data.node.__typename}, not an Org`)
+            }
+            return data.node.campaigns
+        })
     )

--- a/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
@@ -28,9 +28,6 @@ This is my thorough explanation. And it can also get very long, in that case the
             namespaceName: 'alice',
             url: '/users/alice',
         },
-        initialApplier: {
-            username: 'alice',
-        },
     },
     'No description': {
         id: 'test2',
@@ -48,9 +45,6 @@ This is my thorough explanation. And it can also get very long, in that case the
         namespace: {
             namespaceName: 'alice',
             url: '/users/alice',
-        },
-        initialApplier: {
-            username: 'alice',
         },
     },
     'Closed campaign': {
@@ -71,9 +65,6 @@ This is my thorough explanation. And it can also get very long, in that case the
         namespace: {
             namespaceName: 'alice',
             url: '/users/alice',
-        },
-        initialApplier: {
-            username: 'alice',
         },
     },
 }

--- a/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react'
-import { radios } from '@storybook/addon-knobs'
+import { radios, boolean } from '@storybook/addon-knobs'
 import React from 'react'
 import { CampaignNode } from './CampaignNode'
 import { createMemoryHistory } from 'history'
@@ -12,7 +12,7 @@ export const nodes: Record<string, ListCampaign> = {
     'Open campaign': {
         id: 'test',
         name: 'Awesome campaign',
-        description: `# Description
+        description: `# What this does
 
 This is my thorough explanation. And it can also get very long, in that case the UI doesn't break though, which is good. And one more line to finally be longer than the viewport.`,
         createdAt: new Date('2020-05-05').toISOString(),
@@ -23,6 +23,10 @@ This is my thorough explanation. And it can also get very long, in that case the
                 closed: 0,
                 merged: 5,
             },
+        },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
         },
         initialApplier: {
             username: 'alice',
@@ -41,6 +45,10 @@ This is my thorough explanation. And it can also get very long, in that case the
                 merged: 5,
             },
         },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
+        },
         initialApplier: {
             username: 'alice',
         },
@@ -48,7 +56,7 @@ This is my thorough explanation. And it can also get very long, in that case the
     'Closed campaign': {
         id: 'test3',
         name: 'Awesome campaign',
-        description: `# Description
+        description: `# My campaign
 
         This is my thorough explanation.`,
         createdAt: new Date('2020-05-05').toISOString(),
@@ -59,6 +67,10 @@ This is my thorough explanation. And it can also get very long, in that case the
                 closed: 10,
                 merged: 5,
             },
+        },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
         },
         initialApplier: {
             username: 'alice',
@@ -83,6 +95,7 @@ for (const key of Object.keys(nodes)) {
     add(key, () => (
         <CampaignNode
             node={nodes[key]}
+            displayNamespace={boolean('Display namespace', true)}
             now={isChromatic() ? new Date('2020-05-05') : undefined}
             history={createMemoryHistory()}
         />

--- a/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -23,9 +23,6 @@ describe('CampaignNode', () => {
             namespaceName: 'alice',
             url: '/users/alice',
         },
-        initialApplier: {
-            username: 'alice',
-        },
     }
 
     test('open campaign', () => {

--- a/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -19,19 +19,31 @@ describe('CampaignNode', () => {
         changesets: { stats: { merged: 0, open: 1, closed: 3 } },
         createdAt: '2019-12-04T23:15:01Z',
         closedAt: null,
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
+        },
         initialApplier: {
             username: 'alice',
         },
     }
 
     test('open campaign', () => {
-        expect(mount(<CampaignNode node={node} now={now} history={createMemoryHistory()} />)).toMatchSnapshot()
+        expect(
+            mount(<CampaignNode displayNamespace={true} node={node} now={now} history={createMemoryHistory()} />)
+        ).toMatchSnapshot()
+    })
+    test('open campaign on user page', () => {
+        expect(
+            mount(<CampaignNode displayNamespace={false} node={node} now={now} history={createMemoryHistory()} />)
+        ).toMatchSnapshot()
     })
     test('closed campaign', () => {
         expect(
             mount(
                 <CampaignNode
                     node={{ ...node, closedAt: '2019-12-04T23:19:01Z' }}
+                    displayNamespace={true}
                     now={now}
                     history={createMemoryHistory()}
                 />
@@ -46,6 +58,7 @@ describe('CampaignNode', () => {
                         ...node,
                         description: null,
                     }}
+                    displayNamespace={true}
                     now={now}
                     history={createMemoryHistory()}
                 />

--- a/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -16,12 +16,18 @@ export interface CampaignNodeProps {
     /** Used for testing purposes. Sets the current date */
     now?: Date
     history: H.History
+    displayNamespace: boolean
 }
 
 /**
  * An item in the list of campaigns.
  */
-export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node, history, now = new Date() }) => {
+export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({
+    node,
+    history,
+    now = new Date(),
+    displayNamespace,
+}) => {
     const campaignIconClass = node.closedAt ? 'text-danger' : 'text-success'
     const OpenChangesetIcon = changesetExternalStateIcons[ChangesetExternalState.OPEN]
     const ClosedChangesetIcon = changesetExternalStateIcons[ChangesetExternalState.CLOSED]
@@ -36,14 +42,21 @@ export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({ node,
                 <div className="flex-grow-1 campaign-node__content">
                     <div className="m-0 d-flex align-items-baseline">
                         <h3 className="m-0 d-inline-block">
+                            {displayNamespace && (
+                                <>
+                                    <Link className="text-muted" to={`${node.namespace.url}/campaigns`}>
+                                        {node.namespace.namespaceName}
+                                    </Link>
+                                    <span className="text-muted d-inline-block mx-1">/</span>
+                                </>
+                            )}
                             <Link to={`/campaigns/${node.id}`}>{node.name}</Link>
                         </h3>
                         <small className="ml-2 text-muted">
                             created{' '}
                             <span data-tooltip={<Timestamp date={node.createdAt} />}>
                                 {formatDistance(parseISO(node.createdAt), now)} ago
-                            </span>{' '}
-                            by <strong>{node.initialApplier.username}</strong>
+                            </span>
                         </small>
                     </div>
                     <Markdown

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -17,9 +17,6 @@ exports[`CampaignNode campaign without description 1`] = `
       "createdAt": "2019-12-04T23:15:01Z",
       "description": null,
       "id": "123",
-      "initialApplier": Object {
-        "username": "alice",
-      },
       "name": "Upgrade lodash to v4",
       "namespace": Object {
         "namespaceName": "alice",
@@ -212,9 +209,6 @@ exports[`CampaignNode closed campaign 1`] = `
 - and renders in markdown
         ",
       "id": "123",
-      "initialApplier": Object {
-        "username": "alice",
-      },
       "name": "Upgrade lodash to v4",
       "namespace": Object {
         "namespaceName": "alice",
@@ -415,9 +409,6 @@ exports[`CampaignNode open campaign 1`] = `
 - and renders in markdown
         ",
       "id": "123",
-      "initialApplier": Object {
-        "username": "alice",
-      },
       "name": "Upgrade lodash to v4",
       "namespace": Object {
         "namespaceName": "alice",
@@ -618,9 +609,6 @@ exports[`CampaignNode open campaign on user page 1`] = `
 - and renders in markdown
         ",
       "id": "123",
-      "initialApplier": Object {
-        "username": "alice",
-      },
       "name": "Upgrade lodash to v4",
       "namespace": Object {
         "namespaceName": "alice",

--- a/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`CampaignNode campaign without description 1`] = `
 <CampaignNode
+  displayNamespace={true}
   history="[History]"
   node={
     Object {
@@ -20,6 +21,10 @@ exports[`CampaignNode campaign without description 1`] = `
         "username": "alice",
       },
       "name": "Upgrade lodash to v4",
+      "namespace": Object {
+        "namespaceName": "alice",
+        "url": "/users/alice",
+      },
     }
   }
   now={2019-01-01T23:15:01.000Z}
@@ -57,6 +62,22 @@ exports[`CampaignNode campaign without description 1`] = `
             className="m-0 d-inline-block"
           >
             <AnchorLink
+              className="text-muted"
+              to="/users/alice/campaigns"
+            >
+              <a
+                className="text-muted"
+                href="/users/alice/campaigns"
+              >
+                alice
+              </a>
+            </AnchorLink>
+            <span
+              className="text-muted d-inline-block mx-1"
+            >
+              /
+            </span>
+            <AnchorLink
               to="/campaigns/123"
             >
               <a
@@ -81,11 +102,6 @@ exports[`CampaignNode campaign without description 1`] = `
               11 months
                ago
             </span>
-             
-            by 
-            <strong>
-              alice
-            </strong>
           </small>
         </div>
         <Markdown
@@ -177,6 +193,7 @@ exports[`CampaignNode campaign without description 1`] = `
 
 exports[`CampaignNode closed campaign 1`] = `
 <CampaignNode
+  displayNamespace={true}
   history="[History]"
   node={
     Object {
@@ -199,6 +216,10 @@ exports[`CampaignNode closed campaign 1`] = `
         "username": "alice",
       },
       "name": "Upgrade lodash to v4",
+      "namespace": Object {
+        "namespaceName": "alice",
+        "url": "/users/alice",
+      },
     }
   }
   now={2019-01-01T23:15:01.000Z}
@@ -236,6 +257,22 @@ exports[`CampaignNode closed campaign 1`] = `
             className="m-0 d-inline-block"
           >
             <AnchorLink
+              className="text-muted"
+              to="/users/alice/campaigns"
+            >
+              <a
+                className="text-muted"
+                href="/users/alice/campaigns"
+              >
+                alice
+              </a>
+            </AnchorLink>
+            <span
+              className="text-muted d-inline-block mx-1"
+            >
+              /
+            </span>
+            <AnchorLink
               to="/campaigns/123"
             >
               <a
@@ -260,11 +297,6 @@ exports[`CampaignNode closed campaign 1`] = `
               11 months
                ago
             </span>
-             
-            by 
-            <strong>
-              alice
-            </strong>
           </small>
         </div>
         <Markdown
@@ -364,6 +396,7 @@ and renders in markdown
 
 exports[`CampaignNode open campaign 1`] = `
 <CampaignNode
+  displayNamespace={true}
   history="[History]"
   node={
     Object {
@@ -386,6 +419,213 @@ exports[`CampaignNode open campaign 1`] = `
         "username": "alice",
       },
       "name": "Upgrade lodash to v4",
+      "namespace": Object {
+        "namespaceName": "alice",
+        "url": "/users/alice",
+      },
+    }
+  }
+  now={2019-01-01T23:15:01.000Z}
+>
+  <li
+    className="list-group-item"
+  >
+    <div
+      className="d-flex align-items-center p-2"
+    >
+      <Memo(ImageAutoAdjustIcon)
+        className="icon-inline mr-2 flex-shrink-0 align-self-stretch text-success"
+        data-tooltip="Open"
+      >
+        <svg
+          className="mdi-icon icon-inline mr-2 flex-shrink-0 align-self-stretch text-success"
+          data-tooltip="Open"
+          fill="currentColor"
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M19 10V19H5V5H14V3H5C3.92 3 3 3.9 3 5V19C3 20.1 3.92 21 5 21H19C20.12 21 21 20.1 21 19V10H19M17 10L17.94 7.94L20 7L17.94 6.06L17 4L16.06 6.06L14 7L16.06 7.94L17 10M13.25 10.75L12 8L10.75 10.75L8 12L10.75 13.25L12 16L13.25 13.25L16 12L13.25 10.75Z"
+          />
+        </svg>
+      </Memo(ImageAutoAdjustIcon)>
+      <div
+        className="flex-grow-1 campaign-node__content"
+      >
+        <div
+          className="m-0 d-flex align-items-baseline"
+        >
+          <h3
+            className="m-0 d-inline-block"
+          >
+            <AnchorLink
+              className="text-muted"
+              to="/users/alice/campaigns"
+            >
+              <a
+                className="text-muted"
+                href="/users/alice/campaigns"
+              >
+                alice
+              </a>
+            </AnchorLink>
+            <span
+              className="text-muted d-inline-block mx-1"
+            >
+              /
+            </span>
+            <AnchorLink
+              to="/campaigns/123"
+            >
+              <a
+                href="/campaigns/123"
+              >
+                Upgrade lodash to v4
+              </a>
+            </AnchorLink>
+          </h3>
+          <small
+            className="ml-2 text-muted"
+          >
+            created
+             
+            <span
+              data-tooltip={
+                <Timestamp
+                  date="2019-12-04T23:15:01Z"
+                />
+              }
+            >
+              11 months
+               ago
+            </span>
+          </small>
+        </div>
+        <Markdown
+          className="text-truncate"
+          dangerousInnerHTML="Removes lodash
+
+and renders in markdown
+
+"
+          history="[History]"
+        >
+          <div
+            className="text-truncate markdown"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "Removes lodash
+
+and renders in markdown
+
+",
+              }
+            }
+            onClick={[Function]}
+          />
+        </Markdown>
+      </div>
+      <div
+        className="flex-shrink-0"
+        data-tooltip="Open changesets"
+      >
+        1
+         
+        <Memo(SourcePullIcon)
+          className="text-success ml-1 mr-2"
+        >
+          <svg
+            className="mdi-icon text-success ml-1 mr-2"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M6,3A3,3 0 0,1 9,6C9,7.31 8.17,8.42 7,8.83V15.17C8.17,15.58 9,16.69 9,18A3,3 0 0,1 6,21A3,3 0 0,1 3,18C3,16.69 3.83,15.58 5,15.17V8.83C3.83,8.42 3,7.31 3,6A3,3 0 0,1 6,3M6,5A1,1 0 0,0 5,6A1,1 0 0,0 6,7A1,1 0 0,0 7,6A1,1 0 0,0 6,5M6,17A1,1 0 0,0 5,18A1,1 0 0,0 6,19A1,1 0 0,0 7,18A1,1 0 0,0 6,17M21,18A3,3 0 0,1 18,21A3,3 0 0,1 15,18C15,16.69 15.83,15.58 17,15.17V7H15V10.25L10.75,6L15,1.75V5H17A2,2 0 0,1 19,7V15.17C20.17,15.58 21,16.69 21,18M18,17A1,1 0 0,0 17,18A1,1 0 0,0 18,19A1,1 0 0,0 19,18A1,1 0 0,0 18,17Z"
+            />
+          </svg>
+        </Memo(SourcePullIcon)>
+      </div>
+      <div
+        className="flex-shrink-0"
+        data-tooltip="Closed changesets"
+      >
+        3
+         
+        <Memo(SourcePullIcon)
+          className="text-danger ml-1 mr-2"
+        >
+          <svg
+            className="mdi-icon text-danger ml-1 mr-2"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M6,3A3,3 0 0,1 9,6C9,7.31 8.17,8.42 7,8.83V15.17C8.17,15.58 9,16.69 9,18A3,3 0 0,1 6,21A3,3 0 0,1 3,18C3,16.69 3.83,15.58 5,15.17V8.83C3.83,8.42 3,7.31 3,6A3,3 0 0,1 6,3M6,5A1,1 0 0,0 5,6A1,1 0 0,0 6,7A1,1 0 0,0 7,6A1,1 0 0,0 6,5M6,17A1,1 0 0,0 5,18A1,1 0 0,0 6,19A1,1 0 0,0 7,18A1,1 0 0,0 6,17M21,18A3,3 0 0,1 18,21A3,3 0 0,1 15,18C15,16.69 15.83,15.58 17,15.17V7H15V10.25L10.75,6L15,1.75V5H17A2,2 0 0,1 19,7V15.17C20.17,15.58 21,16.69 21,18M18,17A1,1 0 0,0 17,18A1,1 0 0,0 18,19A1,1 0 0,0 19,18A1,1 0 0,0 18,17Z"
+            />
+          </svg>
+        </Memo(SourcePullIcon)>
+      </div>
+      <div
+        className="flex-shrink-0"
+        data-tooltip="Merged changesets"
+      >
+        0
+         
+        <Memo(SourceMergeIcon)
+          className="text-merged ml-1"
+        >
+          <svg
+            className="mdi-icon text-merged ml-1"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M7,3A3,3 0 0,1 10,6C10,7.29 9.19,8.39 8.04,8.81C8.58,13.81 13.08,14.77 15.19,14.96C15.61,13.81 16.71,13 18,13A3,3 0 0,1 21,16A3,3 0 0,1 18,19C16.69,19 15.57,18.16 15.16,17C10.91,16.8 9.44,15.19 8,13.39V15.17C9.17,15.58 10,16.69 10,18A3,3 0 0,1 7,21A3,3 0 0,1 4,18C4,16.69 4.83,15.58 6,15.17V8.83C4.83,8.42 4,7.31 4,6A3,3 0 0,1 7,3M7,5A1,1 0 0,0 6,6A1,1 0 0,0 7,7A1,1 0 0,0 8,6A1,1 0 0,0 7,5M7,17A1,1 0 0,0 6,18A1,1 0 0,0 7,19A1,1 0 0,0 8,18A1,1 0 0,0 7,17M18,15A1,1 0 0,0 17,16A1,1 0 0,0 18,17A1,1 0 0,0 19,16A1,1 0 0,0 18,15Z"
+            />
+          </svg>
+        </Memo(SourceMergeIcon)>
+      </div>
+    </div>
+  </li>
+</CampaignNode>
+`;
+
+exports[`CampaignNode open campaign on user page 1`] = `
+<CampaignNode
+  displayNamespace={false}
+  history="[History]"
+  node={
+    Object {
+      "changesets": Object {
+        "stats": Object {
+          "closed": 3,
+          "merged": 0,
+          "open": 1,
+        },
+      },
+      "closedAt": null,
+      "createdAt": "2019-12-04T23:15:01Z",
+      "description": "
+# Removes lodash
+
+- and renders in markdown
+        ",
+      "id": "123",
+      "initialApplier": Object {
+        "username": "alice",
+      },
+      "name": "Upgrade lodash to v4",
+      "namespace": Object {
+        "namespaceName": "alice",
+        "url": "/users/alice",
+      },
     }
   }
   now={2019-01-01T23:15:01.000Z}
@@ -447,11 +687,6 @@ exports[`CampaignNode open campaign 1`] = `
               11 months
                ago
             </span>
-             
-            by 
-            <strong>
-              alice
-            </strong>
           </small>
         </div>
         <Markdown

--- a/web/src/enterprise/namespaces/navitems.ts
+++ b/web/src/enterprise/namespaces/navitems.ts
@@ -1,6 +1,13 @@
 import { NavItemWithIconDescriptor } from '../../util/contributions'
+import { CampaignsIcon } from '../campaigns/icons'
 
-export const enterpriseNamespaceAreaHeaderNavItems: readonly Pick<
-    NavItemWithIconDescriptor,
-    Exclude<keyof NavItemWithIconDescriptor, 'condition'>
->[] = []
+export const enterpriseNamespaceAreaHeaderNavItems: readonly NavItemWithIconDescriptor<{
+    isSourcegraphDotCom: boolean
+}>[] = [
+    {
+        to: '/campaigns',
+        label: 'Campaigns',
+        icon: CampaignsIcon,
+        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
+    },
+]

--- a/web/src/enterprise/namespaces/navitems.ts
+++ b/web/src/enterprise/namespaces/navitems.ts
@@ -1,9 +1,7 @@
-import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { CampaignsIcon } from '../campaigns/icons'
+import { OrgAreaHeaderNavItem } from '../../org/area/OrgHeader'
 
-export const enterpriseNamespaceAreaHeaderNavItems: readonly NavItemWithIconDescriptor<{
-    isSourcegraphDotCom: boolean
-}>[] = [
+export const enterpriseNamespaceAreaHeaderNavItems: OrgAreaHeaderNavItem[] = [
     {
         to: '/campaigns',
         label: 'Campaigns',

--- a/web/src/enterprise/namespaces/navitems.ts
+++ b/web/src/enterprise/namespaces/navitems.ts
@@ -1,11 +1,6 @@
-import { CampaignsIcon } from '../campaigns/icons'
-import { OrgAreaHeaderNavItem } from '../../org/area/OrgHeader'
+import { NavItemWithIconDescriptor } from '../../util/contributions'
 
-export const enterpriseNamespaceAreaHeaderNavItems: OrgAreaHeaderNavItem[] = [
-    {
-        to: '/campaigns',
-        label: 'Campaigns',
-        icon: CampaignsIcon,
-        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
-    },
-]
+export const enterpriseNamespaceAreaHeaderNavItems: readonly Pick<
+    NavItemWithIconDescriptor,
+    Exclude<keyof NavItemWithIconDescriptor, 'condition'>
+>[] = []

--- a/web/src/enterprise/organizations/navitems.ts
+++ b/web/src/enterprise/organizations/navitems.ts
@@ -11,6 +11,6 @@ export const enterpriseOrgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[] = 
         label: 'Campaigns',
         icon: CampaignsIcon,
         condition: ({ isSourcegraphDotCom }) =>
-            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
+            !isSourcegraphDotCom && window.context.experimentalFeatures?.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/organizations/navitems.ts
+++ b/web/src/enterprise/organizations/navitems.ts
@@ -1,6 +1,7 @@
 import { orgAreaHeaderNavItems } from '../../org/area/navitems'
 import { OrgAreaHeaderNavItem } from '../../org/area/OrgHeader'
 import { enterpriseNamespaceAreaHeaderNavItems } from '../namespaces/navitems'
+import { CampaignsIcon } from '../campaigns/icons'
 
 export const enterpriseOrgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[] = [
     ...orgAreaHeaderNavItems,
@@ -9,6 +10,7 @@ export const enterpriseOrgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[] = 
         to: '/campaigns',
         label: 'Campaigns',
         icon: CampaignsIcon,
-        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
+        condition: ({ isSourcegraphDotCom }) =>
+            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/organizations/navitems.ts
+++ b/web/src/enterprise/organizations/navitems.ts
@@ -5,4 +5,10 @@ import { enterpriseNamespaceAreaHeaderNavItems } from '../namespaces/navitems'
 export const enterpriseOrgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[] = [
     ...orgAreaHeaderNavItems,
     ...enterpriseNamespaceAreaHeaderNavItems,
+    {
+        to: '/campaigns',
+        label: 'Campaigns',
+        icon: CampaignsIcon,
+        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
+    },
 ]

--- a/web/src/enterprise/organizations/routes.ts
+++ b/web/src/enterprise/organizations/routes.ts
@@ -1,8 +1,0 @@
-import { OrgAreaRoute } from '../../org/area/OrgArea'
-import { orgAreaRoutes } from '../../org/area/routes'
-import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
-
-export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
-    ...orgAreaRoutes,
-    ...enterpriseNamespaceAreaRoutes,
-]

--- a/web/src/enterprise/organizations/routes.tsx
+++ b/web/src/enterprise/organizations/routes.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { OrgAreaRoute } from '../../org/area/OrgArea'
+import { orgAreaRoutes } from '../../org/area/routes'
+import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
+import { lazyComponent } from '../../util/lazyComponent'
+import { OrgCampaignListPageProps } from '../campaigns/global/list/GlobalCampaignListPage'
+
+const OrgCampaignListPage = lazyComponent<OrgCampaignListPageProps, 'OrgCampaignListPage'>(
+    () => import('../campaigns/global/list/GlobalCampaignListPage'),
+    'OrgCampaignListPage'
+)
+
+export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
+    ...orgAreaRoutes,
+    ...enterpriseNamespaceAreaRoutes,
+    {
+        path: '/campaigns',
+        render: props => <OrgCampaignListPage {...props} orgID={props.org.id} />,
+    },
+]

--- a/web/src/enterprise/organizations/routes.tsx
+++ b/web/src/enterprise/organizations/routes.tsx
@@ -17,6 +17,6 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
         path: '/campaigns',
         render: props => <OrgCampaignListPage {...props} orgID={props.org.id} />,
         condition: ({ isSourcegraphDotCom }) =>
-            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
+            !isSourcegraphDotCom && window.context.experimentalFeatures?.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/organizations/routes.tsx
+++ b/web/src/enterprise/organizations/routes.tsx
@@ -16,5 +16,6 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
     {
         path: '/campaigns',
         render: props => <OrgCampaignListPage {...props} orgID={props.org.id} />,
+        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
     },
 ]

--- a/web/src/enterprise/organizations/routes.tsx
+++ b/web/src/enterprise/organizations/routes.tsx
@@ -16,6 +16,7 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
     {
         path: '/campaigns',
         render: props => <OrgCampaignListPage {...props} orgID={props.org.id} />,
-        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
+        condition: ({ isSourcegraphDotCom }) =>
+            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/user/navitems.ts
+++ b/web/src/enterprise/user/navitems.ts
@@ -8,6 +8,7 @@ export const enterpriseUserAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] 
         to: '/campaigns',
         label: 'Campaigns',
         icon: CampaignsIcon,
-        condition: ({ isSourcegraphDotCom }): boolean => !isSourcegraphDotCom,
+        condition: ({ isSourcegraphDotCom }): boolean =>
+            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/user/navitems.ts
+++ b/web/src/enterprise/user/navitems.ts
@@ -9,6 +9,6 @@ export const enterpriseUserAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] 
         label: 'Campaigns',
         icon: CampaignsIcon,
         condition: ({ isSourcegraphDotCom }): boolean =>
-            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
+            !isSourcegraphDotCom && window.context.experimentalFeatures?.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/user/navitems.ts
+++ b/web/src/enterprise/user/navitems.ts
@@ -1,4 +1,13 @@
 import { userAreaHeaderNavItems } from '../../user/area/navitems'
 import { UserAreaHeaderNavItem } from '../../user/area/UserAreaHeader'
+import { CampaignsIcon } from '../campaigns/icons'
 
-export const enterpriseUserAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [...userAreaHeaderNavItems]
+export const enterpriseUserAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
+    ...userAreaHeaderNavItems,
+    {
+        to: '/campaigns',
+        label: 'Campaigns',
+        icon: CampaignsIcon,
+        condition: ({ isSourcegraphDotCom }): boolean => !isSourcegraphDotCom,
+    },
+]

--- a/web/src/enterprise/user/routes.tsx
+++ b/web/src/enterprise/user/routes.tsx
@@ -29,6 +29,7 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
     {
         path: '/campaigns',
         render: props => <UserCampaignListPage {...props} userID={props.user.id} />,
-        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
+        condition: ({ isSourcegraphDotCom }) =>
+            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/user/routes.tsx
+++ b/web/src/enterprise/user/routes.tsx
@@ -30,6 +30,6 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
         path: '/campaigns',
         render: props => <UserCampaignListPage {...props} userID={props.user.id} />,
         condition: ({ isSourcegraphDotCom }) =>
-            !isSourcegraphDotCom && window.context.experimentalFeatures.automation === 'enabled',
+            !isSourcegraphDotCom && window.context.experimentalFeatures?.automation === 'enabled',
     },
 ]

--- a/web/src/enterprise/user/routes.tsx
+++ b/web/src/enterprise/user/routes.tsx
@@ -3,6 +3,13 @@ import { Redirect, RouteComponentProps } from 'react-router'
 import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute, UserAreaRouteContext } from '../../user/area/UserArea'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
+import { UserCampaignListPageProps } from '../campaigns/global/list/GlobalCampaignListPage'
+import { lazyComponent } from '../../util/lazyComponent'
+
+const UserCampaignListPage = lazyComponent<UserCampaignListPageProps, 'UserCampaignListPage'>(
+    () => import('../campaigns/global/list/GlobalCampaignListPage'),
+    'UserCampaignListPage'
+)
 
 export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
     ...userAreaRoutes,
@@ -18,5 +25,9 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
                 }`}
             />
         ),
+    },
+    {
+        path: '/campaigns',
+        render: props => <UserCampaignListPage {...props} userID={props.user.id} />,
     },
 ]

--- a/web/src/enterprise/user/routes.tsx
+++ b/web/src/enterprise/user/routes.tsx
@@ -29,5 +29,6 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
     {
         path: '/campaigns',
         render: props => <UserCampaignListPage {...props} userID={props.user.id} />,
+        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
     },
 ]

--- a/web/src/org/OrgsArea.tsx
+++ b/web/src/org/OrgsArea.tsx
@@ -33,6 +33,7 @@ interface Props
     orgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[]
 
     authenticatedUser: GQL.IUser | null
+    isSourcegraphDotCom: boolean
 }
 
 /**

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -114,6 +114,8 @@ export interface OrgAreaPageProps
 
     /** The currently authenticated user. */
     authenticatedUser: GQL.IUser | null
+
+    isSourcegraphDotCom: boolean
 }
 
 /**
@@ -191,6 +193,7 @@ export class OrgArea extends React.Component<Props> {
             namespace: this.state.orgOrError,
             patternType: this.props.patternType,
             telemetryService: this.props.telemetryService,
+            isSourcegraphDotCom: this.props.isSourcegraphDotCom,
         }
 
         if (this.props.location.pathname === `${this.props.match.url}/invitation`) {

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -85,6 +85,7 @@ interface Props
      */
     authenticatedUser: GQL.IUser | null
     history: H.History
+    isSourcegraphDotCom: boolean
 }
 
 interface State {

--- a/web/src/org/area/OrgHeader.tsx
+++ b/web/src/org/area/OrgHeader.tsx
@@ -5,18 +5,25 @@ import { OrgAvatar } from '../OrgAvatar'
 import { OrgAreaPageProps } from './OrgArea'
 
 interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
+    isSourcegraphDotCom: boolean
     navItems: readonly OrgAreaHeaderNavItem[]
     className?: string
 }
 
-export type OrgAreaHeaderContext = Pick<Props, 'org'>
+export type OrgAreaHeaderContext = Pick<Props, 'org'> & { isSourcegraphDotCom: boolean }
 
 export interface OrgAreaHeaderNavItem extends NavItemWithIconDescriptor<OrgAreaHeaderContext> {}
 
 /**
  * Header for the organization area.
  */
-export const OrgHeader: React.FunctionComponent<Props> = ({ org, navItems, match, className = '' }) => (
+export const OrgHeader: React.FunctionComponent<Props> = ({
+    org,
+    navItems,
+    match,
+    className = '',
+    isSourcegraphDotCom,
+}) => (
     <div className={`org-header ${className}`}>
         <div className="container">
             {org && (
@@ -29,7 +36,7 @@ export const OrgHeader: React.FunctionComponent<Props> = ({ org, navItems, match
                         <ul className="nav nav-tabs border-bottom-0">
                             {navItems.map(
                                 ({ to, label, exact, icon: Icon, condition = () => true }) =>
-                                    condition({ org }) && (
+                                    condition({ org, isSourcegraphDotCom }) && (
                                         <li key={label} className="nav-item">
                                             <NavLink
                                                 to={match.url + to}

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -96,6 +96,8 @@ interface UserAreaProps
      * parameter.
      */
     authenticatedUser: GQL.IUser | null
+
+    isSourcegraphDotCom: boolean
 }
 
 interface UserAreaState {

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -140,6 +140,8 @@ export interface UserAreaRouteContext
     authenticatedUser: GQL.IUser | null
     userSettingsSideBarItems: UserSettingsSidebarItems
     userSettingsAreaRoutes: readonly UserSettingsAreaRoute[]
+
+    isSourcegraphDotCom: boolean
 }
 
 /**

--- a/web/src/user/area/UserAreaHeader.tsx
+++ b/web/src/user/area/UserAreaHeader.tsx
@@ -8,10 +8,11 @@ import { UserAreaRouteContext } from './UserArea'
 
 interface Props extends UserAreaRouteContext, RouteComponentProps<{}> {
     navItems: readonly UserAreaHeaderNavItem[]
+    isSourcegraphDotCom: boolean
     className?: string
 }
 
-export type UserAreaHeaderContext = Pick<Props, 'user'>
+export type UserAreaHeaderContext = Pick<Props, 'user'> & { isSourcegraphDotCom: boolean }
 
 export interface UserAreaHeaderNavItem extends NavItemWithIconDescriptor<UserAreaHeaderContext> {}
 

--- a/web/src/user/area/UserAreaHeader.tsx
+++ b/web/src/user/area/UserAreaHeader.tsx
@@ -8,11 +8,12 @@ import { UserAreaRouteContext } from './UserArea'
 
 interface Props extends UserAreaRouteContext, RouteComponentProps<{}> {
     navItems: readonly UserAreaHeaderNavItem[]
-    isSourcegraphDotCom: boolean
     className?: string
 }
 
-export type UserAreaHeaderContext = Pick<Props, 'user'> & { isSourcegraphDotCom: boolean }
+export interface UserAreaHeaderContext extends Pick<Props, 'user'> {
+    isSourcegraphDotCom: boolean
+}
 
 export interface UserAreaHeaderNavItem extends NavItemWithIconDescriptor<UserAreaHeaderContext> {}
 


### PR DESCRIPTION
This PR:
- Adds namespaces on the global campaigns page
- Adds the list of owned campaigns to the user and org pages

@sourcegraph/web Could you take a look and see if I did everything correct to use enterprise components in within the non-enterprise user and org pages?