### PR TITLE
Don't use jest --verbose in CI

### DIFF
--- a/dev/ci/yarn-test-separate.sh
+++ b/dev/ci/yarn-test-separate.sh
@@ -16,4 +16,4 @@ echo "--- test"
 # Limit the number of workers to prevent the default of 1 worker per core from
 # causing OOM on the buildkite nodes that have 96 CPUs. 4 matches the CPU limits
 # in infrastructure/kubernetes/ci/buildkite/buildkite-agent/buildkite-agent.Deployment.yaml
-yarn -s run test --maxWorkers 4 --verbose
+yarn -s run test --maxWorkers 4


### PR DESCRIPTION
The log output of Jest in CI is so huge that it is hard to debug and find the errors. Making it non-verbose means only output from failing tests is shown.