### PR TITLE
monitoring: add DataMayBeNaN to ratio alerts, fix wording

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -431,7 +431,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _frontend: 5+ precise code intel database errors every 5m for 15m0s_
+- _frontend: 5%+ precise code intel database errors every 5m for 15m0s_
 
 **Possible solutions:**
 
@@ -780,7 +780,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _frontend: 10000+ maximum active goroutines for 10m for 10m0s_
+- _frontend: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -812,7 +812,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _frontend: less than 90% percentage pods available for 10m for 10m0s_
+- _frontend: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -1086,7 +1086,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _gitserver: 10000+ maximum active goroutines for 10m for 10m0s_
+- _gitserver: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -1118,7 +1118,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _gitserver: less than 90% percentage pods available for 10m for 10m0s_
+- _gitserver: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -1320,7 +1320,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _github-proxy: 10000+ maximum active goroutines for 10m for 10m0s_
+- _github-proxy: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -1352,7 +1352,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _github-proxy: less than 90% percentage pods available for 10m for 10m0s_
+- _github-proxy: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -1723,7 +1723,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 10000+ maximum active goroutines for 10m for 10m0s_
+- _precise-code-intel-bundle-manager: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -1755,7 +1755,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: less than 90% percentage pods available for 10m for 10m0s_
+- _precise-code-intel-bundle-manager: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -2138,7 +2138,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 10000+ maximum active goroutines for 10m for 10m0s_
+- _precise-code-intel-worker: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -2170,7 +2170,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-worker: less than 90% percentage pods available for 10m for 10m0s_
+- _precise-code-intel-worker: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -2585,7 +2585,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 10000+ maximum active goroutines for 10m for 10m0s_
+- _precise-code-intel-indexer: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -2617,7 +2617,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: less than 90% percentage pods available for 10m for 10m0s_
+- _precise-code-intel-indexer: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -2808,7 +2808,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _query-runner: 10000+ maximum active goroutines for 10m for 10m0s_
+- _query-runner: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -2840,7 +2840,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _query-runner: less than 90% percentage pods available for 10m for 10m0s_
+- _query-runner: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -3031,7 +3031,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _repo-updater: 10000+ maximum active goroutines for 10m for 10m0s_
+- _repo-updater: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -3063,7 +3063,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _repo-updater: less than 90% percentage pods available for 10m for 10m0s_
+- _repo-updater: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -3286,7 +3286,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _searcher: 10000+ maximum active goroutines for 10m for 10m0s_
+- _searcher: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -3318,7 +3318,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _searcher: less than 90% percentage pods available for 10m for 10m0s_
+- _searcher: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -3541,7 +3541,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _symbols: 10000+ maximum active goroutines for 10m for 10m0s_
+- _symbols: 10000+ maximum active goroutines for 10m0s_
 
 **Possible solutions:**
 
@@ -3573,7 +3573,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _symbols: less than 90% percentage pods available for 10m for 10m0s_
+- _symbols: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -3805,7 +3805,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _syntect-server: less than 90% percentage pods available for 10m for 10m0s_
+- _syntect-server: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -3992,7 +3992,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _zoekt-indexserver: less than 90% percentage pods available for 10m for 10m0s_
+- _zoekt-indexserver: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 
@@ -4361,7 +4361,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _prometheus: less than 90% percentage pods available for 10m for 10m0s_
+- _prometheus: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 

--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -342,7 +342,7 @@ func Frontend() *Container {
 							Query:             `sum(increase(src_code_intel_store_errors_total{job="frontend"}[5m])) / sum(increase(src_code_intel_store_total{job="frontend"}[5m])) * 100`,
 							DataMayNotExist:   true,
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
-							PanelOptions:      PanelOptions().LegendFormat("store operations"),
+							PanelOptions:      PanelOptions().LegendFormat("store operations").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
 							PossibleSolutions: "none",
 						},

--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -51,6 +51,7 @@ func Frontend() *Container {
 							Description:       "hard timeout search responses every 5m",
 							Query:             `(sum(increase(src_graphql_search_response{status="timeout",source="browser",name!="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",name!="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard timeout").Unit(Percentage),
@@ -62,6 +63,7 @@ func Frontend() *Container {
 							Description:       "hard error search responses every 5m",
 							Query:             `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{status}}").Unit(Percentage),
@@ -73,6 +75,7 @@ func Frontend() *Container {
 							Description:       "partial timeout search responses every 5m",
 							Query:             `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{status}}").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,
@@ -83,6 +86,7 @@ func Frontend() *Container {
 							Description:     "search alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -165,6 +169,7 @@ func Frontend() *Container {
 							Description:       "hard timeout search code-intel responses every 5m",
 							Query:             `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard timeout").Unit(Percentage),
@@ -176,6 +181,7 @@ func Frontend() *Container {
 							Description:       "hard error search code-intel responses every 5m",
 							Query:             `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard error").Unit(Percentage),
@@ -187,6 +193,7 @@ func Frontend() *Container {
 							Description:       "partial timeout search code-intel responses every 5m",
 							Query:             `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("partial timeout").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -197,6 +204,7 @@ func Frontend() *Container {
 							Description:     "search code-intel alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
 							Owner:           ObservableOwnerCodeIntel,
@@ -253,6 +261,7 @@ func Frontend() *Container {
 							Description:       "hard timeout search API responses every 5m",
 							Query:             `(sum(increase(src_graphql_search_response{status="timeout",source="other"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="other"}[5m]))) / sum(increase(src_graphql_search_response{source="other"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard timeout").Unit(Percentage),
@@ -264,6 +273,7 @@ func Frontend() *Container {
 							Description:       "hard error search API responses every 5m",
 							Query:             `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{status}}").Unit(Percentage),
@@ -275,6 +285,7 @@ func Frontend() *Container {
 							Description:       "partial timeout search API responses every 5m",
 							Query:             `sum(increase(src_graphql_search_response{status="partial_timeout",source="other"}[5m])) / sum(increase(src_graphql_search_response{source="other"}[5m]))`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("partial timeout").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,
@@ -285,6 +296,7 @@ func Frontend() *Container {
 							Description:     "search API alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="other"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{status="alert",source="other"}[5m]))`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5},
 							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -317,6 +329,7 @@ func Frontend() *Container {
 							Description:       "precise code intel api errors every 5m",
 							Query:             `sum(increase(src_code_intel_api_errors_total[5m])) / sum(increase(src_code_intel_api_total[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("api operations").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -341,6 +354,7 @@ func Frontend() *Container {
 							Description:       "precise code intel database errors every 5m",
 							Query:             `sum(increase(src_code_intel_store_errors_total{job="frontend"}[5m])) / sum(increase(src_code_intel_store_total{job="frontend"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("store operations").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -359,6 +373,7 @@ func Frontend() *Container {
 							Description:     "internal indexed search error responses every 5m",
 							Query:           `sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{code}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -371,6 +386,7 @@ func Frontend() *Container {
 							Description:     "internal unindexed search error responses every 5m",
 							Query:           `sum by(code) (increase(searcher_service_request_total{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total[5m])) * 100`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{code}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -383,6 +399,7 @@ func Frontend() *Container {
 							Description:     "internal API error responses every 5m by route",
 							Query:           `sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_frontend_internal_request_duration_seconds_count[5m])) * 100`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -419,6 +436,7 @@ func Frontend() *Container {
 							Description:       "precise-code-intel-bundle-manager error responses every 5m",
 							Query:             `sum by(category) (increase(src_precise_code_intel_bundle_manager_request_duration_seconds_count{job="frontend",code!~"2.."}[5m]))  / ignoring(code) group_left sum by(category) (increase(src_precise_code_intel_bundle_manager_request_duration_seconds_count{job="frontend"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -442,6 +460,7 @@ func Frontend() *Container {
 							Description:       "gitserver error responses every 5m",
 							Query:             `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="frontend",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="frontend"}[5m])) * 100`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,

--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -720,6 +720,7 @@ func (c *Container) promAlertsFile() *promRulesFile {
 							fireOnNan = "0"
 						}
 						alertQuery = fmt.Sprintf("((%s) >= 0) OR on() vector(%v)", alertQuery, fireOnNan)
+
 						// Wrap the query in max() so that if there are multiple series (e.g. per-container) they
 						// get flattened into a single one (we only support per-service alerts,
 						// not per-container/replica).
@@ -747,6 +748,7 @@ func (c *Container) promAlertsFile() *promRulesFile {
 							fireOnNan = "0"
 						}
 						alertQuery = fmt.Sprintf("((%s) >= 0) OR on() vector(%v)", alertQuery, fireOnNan)
+
 						// Wrap the query in min() so that if there are multiple series (e.g. per-container) they
 						// get flattened into a single one (we only support per-service alerts,
 						// not per-container/replica).

--- a/monitoring/precise_code_intel_indexer.go
+++ b/monitoring/precise_code_intel_indexer.go
@@ -25,6 +25,7 @@ func PreciseCodeIntelIndexer() *Container {
 							Description:       "index queue growth rate every 5m",
 							Query:             `sum(increase(src_index_queue_indexes_total[30m])) / sum(increase(src_index_queue_processor_total[30m]))`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // numerator and denominator could both be 0
 							Warning:           Alert{GreaterOrEqual: 5},
 							PanelOptions:      PanelOptions().LegendFormat("index queue growth rate"),
 							Owner:             ObservableOwnerCodeIntel,

--- a/monitoring/precise_code_intel_worker.go
+++ b/monitoring/precise_code_intel_worker.go
@@ -25,6 +25,7 @@ func PreciseCodeIntelWorker() *Container {
 							Description:       "upload queue growth rate every 5m",
 							Query:             `sum(increase(src_upload_queue_uploads_total[30m])) / sum(increase(src_upload_queue_processor_total[30m]))`,
 							DataMayNotExist:   true,
+							DataMayBeNaN:      true, // numerator and denominator could both be 0
 							Warning:           Alert{GreaterOrEqual: 5},
 							PanelOptions:      PanelOptions().LegendFormat("upload queue growth rate"),
 							Owner:             ObservableOwnerCodeIntel,

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -208,7 +208,7 @@ var sharedProvisioningMemoryUsageLongTerm sharedObservable = func(containerName 
 var sharedGoGoroutines sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:              "go_goroutines",
-		Description:       "maximum active goroutines for 10m",
+		Description:       "maximum active goroutines",
 		Query:             fmt.Sprintf(`max by(instance) (go_goroutines{job=~".*%s"})`, containerName),
 		DataMayNotExist:   true,
 		Warning:           Alert{GreaterOrEqual: 10000, For: 10 * time.Minute},
@@ -236,7 +236,7 @@ var sharedGoGcDuration sharedObservable = func(containerName string) Observable 
 var sharedKubernetesPodsAvailable sharedObservable = func(containerName string) Observable {
 	return Observable{
 		Name:              "pods_available_percentage",
-		Description:       "percentage pods available for 10m",
+		Description:       "percentage pods available",
 		Query:             fmt.Sprintf(`sum by(app) (up{app=~".*%[1]s"}) / count by (app) (up{app=~".*%[1]s"}) * 100`, containerName),
 		Critical:          Alert{LessOrEqual: 90, For: 10 * time.Minute},
 		DataMayNotExist:   true,


### PR DESCRIPTION
Add DataMayBeNaN to ratio alerts, since the denominator of these queries (typically some form of "total requests") can be 0. For example, [`index_queue_growth_rate` has been firing frequently due to `sum(increase(src_index_queue_processor_total[30m])) == 0`](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-2d%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22sum(increase(src_index_queue_indexes_total%5B30m%5D))%20%2F%20sum(increase(src_index_queue_processor_total%5B30m%5D))%22,%22datasource%22:%22Prometheus%22%7D,%7B%22expr%22:%22max(((((sum(increase(src_index_queue_indexes_total%5B30m%5D))%20%2F%20sum(increase(src_index_queue_processor_total%5B30m%5D)))%20%2F%205)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%20%3E%3D%201%22%7D,%7B%22expr%22:%22sum(increase(src_index_queue_processor_total%5B30m%5D))%20%3D%3D%200%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D). This issue happens most frequently with `*_queue_growth_rate` alerts it seems

[frequency comparison for `index_queue_growth_rate`](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-2d%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(((((sum(increase(src_index_queue_indexes_total%5B30m%5D))%20%2F%20sum(increase(src_index_queue_processor_total%5B30m%5D)))%20%2F%205)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(1))%20%3E%3D%201%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D&right=%5B%22now-2d%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(((((sum(increase(src_index_queue_indexes_total%5B30m%5D))%20%2F%20sum(increase(src_index_queue_processor_total%5B30m%5D)))%20%2F%205)%20OR%20on()%20vector(0))%20%3E%3D%200)%20OR%20on()%20vector(0))%20%3E%3D%201%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D):

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/23356519/89961672-10d68500-dc75-11ea-927a-c42091e5c1be.png">

Also removes some redundant `"for ..."` from metric descriptions, since this is appended by the generator already.

closes https://github.com/sourcegraph/sourcegraph/issues/12868

follows up https://github.com/sourcegraph/sourcegraph/pull/12756

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
