### PR TITLE
Implement CreateCampaign mutation and add CampaignSpec.AppliesToCampaign field

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -102,6 +102,8 @@ type CampaignSpecResolver interface {
 	ViewerCanAdminister(context.Context) (bool, error)
 
 	DiffStat(ctx context.Context) (*DiffStat, error)
+
+	AppliesToCampaign(ctx context.Context) (CampaignResolver, error)
 }
 
 type CampaignDescriptionResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -666,6 +666,10 @@ type CampaignSpec implements Node {
 
     # The diff stat for all the changeset specs in the campaign spec.
     diffStat: DiffStat!
+
+    # The campaign this spec will update when applied. If it's null, the
+    # campaign doesn't yet exist.
+    appliesToCampaign: Campaign
 }
 
 # A user (identified either by username or email address) with its repository permission.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -673,6 +673,10 @@ type CampaignSpec implements Node {
 
     # The diff stat for all the changeset specs in the campaign spec.
     diffStat: DiffStat!
+
+    # The campaign this spec will update when applied. If it's null, the
+    # campaign doesn't yet exist.
+    appliesToCampaign: Campaign
 }
 
 # A user (identified either by username or email address) with its repository permission.

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -206,6 +206,8 @@ type CampaignSpec struct {
 
 	DiffStat DiffStat
 
+	AppliesToCampaign Campaign
+
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -158,3 +158,20 @@ func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.Di
 
 	return totalStat, nil
 }
+
+func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlbackend.CampaignResolver, error) {
+	svc := ee.NewService(r.store, r.httpFactory)
+	campaign, err := svc.GetCampaignMatchingCampaignSpec(ctx, r.store, r.campaignSpec)
+	if err != nil {
+		return nil, err
+	}
+	if campaign == nil {
+		return nil, nil
+	}
+
+	return &campaignResolver{
+		store:       r.store,
+		httpFactory: r.httpFactory,
+		Campaign:    campaign,
+	}, nil
+}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -61,6 +61,15 @@ func TestCampaignSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	matchingCampaign := &campaigns.Campaign{
+		Name:            spec.Spec.Name,
+		NamespaceUserID: userID,
+		AuthorID:        userID,
+	}
+	if err := store.CreateCampaign(ctx, matchingCampaign); err != nil {
+		t.Fatal(err)
+	}
+
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -116,6 +125,10 @@ func TestCampaignSpecResolver(t *testing.T) {
 			Changed: changesetSpec.DiffStatChanged,
 			Deleted: changesetSpec.DiffStatDeleted,
 		},
+
+		AppliesToCampaign: apitest.Campaign{
+			ID: string(campaigns.MarshalCampaignID(matchingCampaign.ID)),
+		},
 	}
 
 	if diff := cmp.Diff(want, response.Node); diff != "" {
@@ -149,6 +162,8 @@ query($campaignSpec: ID!) {
       expiresAt
 
       diffStat { added, deleted, changed }
+
+      appliesToCampaign { id }
 
       changesetSpecs(first: 100) {
         totalCount

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -692,6 +692,41 @@ func TestService(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("GetCampaignMatchingCampaignSpec", func(t *testing.T) {
+		campaignSpec := createCampaignSpec(t, ctx, store, "matching-campaign-spec", admin.ID)
+
+		haveCampaign, err := svc.GetCampaignMatchingCampaignSpec(ctx, store, campaignSpec)
+		if err != nil {
+			t.Fatalf("unexpected error: %s\n", err)
+		}
+		if haveCampaign != nil {
+			t.Fatalf("expected campaign to be nil, but is not: %+v\n", haveCampaign)
+		}
+
+		matchingCampaign := &campaigns.Campaign{
+			Name:            campaignSpec.Spec.Name,
+			Description:     campaignSpec.Spec.Description,
+			AuthorID:        admin.ID,
+			NamespaceOrgID:  campaignSpec.NamespaceOrgID,
+			NamespaceUserID: campaignSpec.NamespaceUserID,
+		}
+		if err := store.CreateCampaign(ctx, matchingCampaign); err != nil {
+			t.Fatalf("failed to create campaign: %s\n", err)
+		}
+
+		haveCampaign, err = svc.GetCampaignMatchingCampaignSpec(ctx, store, campaignSpec)
+		if err != nil {
+			t.Fatalf("unexpected error: %s\n", err)
+		}
+		if haveCampaign == nil {
+			t.Fatalf("expected to have matching campaign, but got nil")
+		}
+
+		if diff := cmp.Diff(matchingCampaign, haveCampaign); diff != "" {
+			t.Fatalf("wrong campaign was matched (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestServiceApplyCampaign(t *testing.T) {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -196,22 +196,9 @@ func TestService(t *testing.T) {
 
 	svc := NewService(store, nil)
 
-	t.Run("CreateCampaign", func(t *testing.T) {
-		campaign := testCampaign(admin.ID)
-		err := svc.CreateCampaign(ctx, campaign)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = store.GetCampaign(ctx, GetCampaignOpts{ID: campaign.ID})
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
 	t.Run("DeleteCampaign", func(t *testing.T) {
 		campaign := testCampaign(admin.ID)
-		if err := svc.CreateCampaign(ctx, campaign); err != nil {
+		if err := store.CreateCampaign(ctx, campaign); err != nil {
 			t.Fatal(err)
 		}
 		if err := svc.DeleteCampaign(ctx, campaign.ID); err != nil {
@@ -800,6 +787,16 @@ func TestServiceApplyCampaign(t *testing.T) {
 
 				if have, want := campaign2.ID, campaign.ID; have != want {
 					t.Fatalf("campaign ID is wrong. want=%d, have=%d", want, have)
+				}
+			})
+
+			t.Run("apply same campaignSpec with FailIfExists", func(t *testing.T) {
+				_, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
+					CampaignSpecRandID:   campaignSpec.RandID,
+					FailIfCampaignExists: true,
+				})
+				if err != ErrMatchingCampaignExists {
+					t.Fatalf("unexpected error. want=%s, got=%s", ErrMatchingCampaignExists, err)
 				}
 			})
 


### PR DESCRIPTION
This fixes #12469 by implementing the `createCampaign` mutation (as a thin wrapper around `ApplyCampaign`) and by implementing the `AppliesToCampaign` field on `CampaignSpec`.

