### PR TITLE
Include namespace in Campaign/CampaignSpec URLs

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -97,7 +97,7 @@ type CampaignSpecResolver interface {
 
 	ExpiresAt() *DateTime
 
-	PreviewURL() (string, error)
+	ApplyURL(ctx context.Context) (string, error)
 
 	ViewerCanAdminister(context.Context) (bool, error)
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -658,8 +658,9 @@ type CampaignSpec implements Node {
     # never expires if it has been applied.
     expiresAt: DateTime
 
-    # The URL of a web page that displays a preview of creating a campaign from this spec.
-    previewURL: String!
+    # The URL of a web page that allows applying this campaign spec and
+    # displays a preview of which changesets will be created by applying it.
+    applyURL: String!
 
     # When true, the viewing user can apply this spec.
     viewerCanAdminister: Boolean!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -665,8 +665,9 @@ type CampaignSpec implements Node {
     # never expires if it has been applied.
     expiresAt: DateTime
 
-    # The URL of a web page that displays a preview of creating a campaign from this spec.
-    previewURL: String!
+    # The URL of a web page that allows applying this campaign spec and
+    # displays a preview of which changesets will be created by applying it.
+    applyURL: String!
 
     # When true, the viewing user can apply this spec.
     viewerCanAdminister: Boolean!

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -195,7 +195,7 @@ type CampaignSpec struct {
 	OriginalInput string
 	ParsedInput   graphqlbackend.JSONValue
 
-	PreviewURL string
+	ApplyURL string
 
 	Namespace UserOrg
 	Creator   User

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -107,7 +107,6 @@ func (r *campaignSpecResolver) computeNamespace(ctx context.Context) (*graphqlba
 
 		r.namespace = n
 		r.namespaceErr = err
-		return
 	})
 	return r.namespace, r.namespaceErr
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"strconv"
+	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -29,6 +30,11 @@ type campaignSpecResolver struct {
 	httpFactory *httpcli.Factory
 
 	campaignSpec *campaigns.CampaignSpec
+
+	// We cache the namespace on the resolver, since it's accessed more than once.
+	namespaceOnce sync.Once
+	namespace     *graphqlbackend.NamespaceResolver
+	namespaceErr  error
 }
 
 func (r *campaignSpecResolver) ID() graphql.ID {
@@ -77,26 +83,41 @@ func (r *campaignSpecResolver) Creator(ctx context.Context) (*graphqlbackend.Use
 }
 
 func (r *campaignSpecResolver) Namespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
-	var (
-		err error
-		n   = &graphqlbackend.NamespaceResolver{}
-	)
-
-	if r.campaignSpec.NamespaceUserID != 0 {
-		n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, r.campaignSpec.NamespaceUserID)
-	} else {
-		n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, r.campaignSpec.NamespaceOrgID)
-	}
-
-	if errcode.IsNotFound(err) {
-		return nil, nil
-	}
-
-	return n, err
+	return r.computeNamespace(ctx)
 }
 
-func (r *campaignSpecResolver) PreviewURL() (string, error) {
-	return "/campaigns/new?spec=" + string(r.ID()), nil
+func (r *campaignSpecResolver) computeNamespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
+	r.namespaceOnce.Do(func() {
+		var (
+			err error
+			n   = &graphqlbackend.NamespaceResolver{}
+		)
+
+		if r.campaignSpec.NamespaceUserID != 0 {
+			n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, r.campaignSpec.NamespaceUserID)
+		} else {
+			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, r.campaignSpec.NamespaceOrgID)
+		}
+
+		if errcode.IsNotFound(err) {
+			r.namespace = nil
+			r.namespaceErr = nil
+			return
+		}
+
+		r.namespace = n
+		r.namespaceErr = err
+		return
+	})
+	return r.namespace, r.namespaceErr
+}
+
+func (r *campaignSpecResolver) ApplyURL(ctx context.Context) (string, error) {
+	n, err := r.computeNamespace(ctx)
+	if err != nil {
+		return "", err
+	}
+	return campaignsApplyURL(n, r), nil
 }
 
 func (r *campaignSpecResolver) CreatedAt() graphqlbackend.DateTime {

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -37,7 +38,8 @@ func TestCampaignSpecResolver(t *testing.T) {
 	}
 	repoID := graphqlbackend.MarshalRepositoryID(repo.ID)
 
-	userID := insertTestUser(t, dbconn.Global, "campaign-spec-by-id", false)
+	username := "campaign-spec-by-id-user-name"
+	userID := insertTestUser(t, dbconn.Global, username, false)
 
 	spec, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawCampaignSpec)
 	if err != nil {
@@ -87,7 +89,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		OriginalInput: spec.RawSpec,
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 
-		PreviewURL:          "/campaigns/new?spec=" + apiID,
+		ApplyURL:            fmt.Sprintf("/users/%s/campaigns/apply?spec=%s", username, apiID),
 		Namespace:           apitest.UserOrg{ID: userApiID, DatabaseID: userID},
 		Creator:             apitest.User{ID: userApiID, DatabaseID: userID},
 		ViewerCanAdminister: true,
@@ -142,7 +144,7 @@ query($campaignSpec: ID!) {
         ... on Org  { ...o }
       }
 
-      previewURL
+      applyURL
       viewerCanAdminister
 
       createdAt

--- a/enterprise/internal/campaigns/resolvers/campaigns_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns_test.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -22,7 +23,8 @@ func TestCampaignResolver(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
 
-	userID := insertTestUser(t, dbconn.Global, "campaign-resolver", true)
+	username := "campaign-resolver-username"
+	userID := insertTestUser(t, dbconn.Global, username, true)
 
 	store := ee.NewStore(dbconn.Global)
 
@@ -53,7 +55,7 @@ func TestCampaignResolver(t *testing.T) {
 		Description: campaign.Description,
 		Namespace:   apitest.UserOrg{DatabaseID: userID, SiteAdmin: true},
 		Author:      apitest.User{DatabaseID: userID, SiteAdmin: true},
-		URL:         "/campaigns/" + campaignApiID,
+		URL:         fmt.Sprintf("/users/%s/campaigns/%s", username, campaignApiID),
 	}
 	if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
 		t.Fatalf("wrong campaign response (-want +got):\n%s", diff)

--- a/enterprise/internal/campaigns/resolvers/urls.go
+++ b/enterprise/internal/campaigns/resolvers/urls.go
@@ -1,0 +1,13 @@
+package resolvers
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignSpecResolver) string {
+	return n.URL() + "/campaigns/apply?spec=" + string(c.ID())
+}
+
+func campaignURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignResolver) string {
+	return n.URL() + "/campaigns/" + string(c.ID())
+}


### PR DESCRIPTION
This fixes #12473 by including the namespace path in the URL of Campaigns and CampaignSpecs.