### PR TITLE
frontend: disallow non-admins from using TriggerObservabilityTestAlert

### DIFF
--- a/cmd/frontend/graphqlbackend/observability.go
+++ b/cmd/frontend/graphqlbackend/observability.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 )
 
 var testMetricWarning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -26,6 +27,11 @@ func init() {
 func (r *schemaResolver) TriggerObservabilityTestAlert(ctx context.Context, args *struct {
 	Level string
 }) (*EmptyResponse, error) {
+	// 🚨 SECURITY: Do not allow arbitrary users to set off alerts.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	var metric *prometheus.GaugeVec
 	switch args.Level {
 	case "warning":


### PR DESCRIPTION
I suspect that somebody set off https://sourcegraph.app.opsgenie.com/alert/detail/7921f57e-fae0-4f21-99bc-fa3060409339-1597066049210/details , since I just realized I did not set a guard on this endpoint (https://github.com/sourcegraph/sourcegraph/pull/12532)

Looking into logs now to see if I can confirm if the last person to use this endpoint is in our org

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
