### PR TITLE
Use stable clock for nextSyncAt to fix flaky test

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -144,7 +144,7 @@ func (r *changesetResolver) computeNextSyncAt(ctx context.Context) (time.Time, e
 		}
 		for _, d := range syncData {
 			if d.ChangesetID == r.changeset.ID {
-				r.nextSyncAt = ee.NextSync(time.Now, d)
+				r.nextSyncAt = ee.NextSync(r.store.Clock(), d)
 				return
 			}
 		}

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -31,7 +31,8 @@ func TestChangesetResolver(t *testing.T) {
 	userID := insertTestUser(t, dbconn.Global, "campaign-resolver", true)
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	store := ee.NewStore(dbconn.Global)
+	clock := func() time.Time { return now.UTC().Truncate(time.Microsecond) }
+	store := ee.NewStoreWithClock(dbconn.Global, clock)
 	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 
 	repo := newGitHubTestRepo("github.com/sourcegraph/sourcegraph", 1)


### PR DESCRIPTION
Before `now` in the test could run out of sync with the `time.Now` passed into `ee.NextSync`, causing flaky test results.