### PR TITLE
repo-updater: Add /healthz endpoint

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -66,6 +66,7 @@ type Server struct {
 // Handler returns the http.Handler that should be used to serve requests.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/repo-update-scheduler-info", s.handleRepoUpdateSchedulerInfo)
 	mux.HandleFunc("/repo-lookup", s.handleRepoLookup)
 	mux.HandleFunc("/repo-external-services", s.handleRepoExternalServices)
@@ -76,6 +77,15 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/enqueue-changeset-sync", s.handleEnqueueChangesetSync)
 	mux.HandleFunc("/schedule-perms-sync", s.handleSchedulePermsSync)
 	return mux
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	_, err := w.Write([]byte("ok"))
+	if err != nil {
+		log15.Info("Error checking /healthz: " + err.Error())
+	}
+	return
 }
 
 func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Request) {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -80,7 +80,7 @@ func (s *Server) Handler() http.Handler {
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte("ok"))
 	if err != nil {
 		log15.Info("Error checking /healthz: " + err.Error())

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -85,7 +85,6 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log15.Info("Error checking /healthz: " + err.Error())
 	}
-	return
 }
 
 func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Request) {

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -66,7 +66,9 @@ type Server struct {
 // Handler returns the http.Handler that should be used to serve requests.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 	mux.HandleFunc("/repo-update-scheduler-info", s.handleRepoUpdateSchedulerInfo)
 	mux.HandleFunc("/repo-lookup", s.handleRepoLookup)
 	mux.HandleFunc("/repo-external-services", s.handleRepoExternalServices)
@@ -77,14 +79,6 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/enqueue-changeset-sync", s.handleEnqueueChangesetSync)
 	mux.HandleFunc("/schedule-perms-sync", s.handleSchedulePermsSync)
 	return mux
-}
-
-func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, err := w.Write([]byte("ok"))
-	if err != nil {
-		log15.Info("Error checking /healthz: " + err.Error())
-	}
 }
 
 func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Currently the `healthz` endpoint does not check for anything, but it will help ensure the http service is up before rolling new images. Ill make another change to `deploy-sourcegraph` to add the K8s probe.


### Notes
`handleHealthz` does not need to be a method of Server, but it seems all handlers are part of that class, so I assumed we attach them there by convention.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->