### PR TITLE
external_services: add pagination options for List method

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1252,6 +1252,8 @@ type Query {
         namespace: ID
         # Returns the first n external services from the list.
         first: Int
+        # Opaque pagination cursor.
+        after: String
     ): ExternalServiceConnection!
     # List all repositories.
     repositories(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1259,6 +1259,8 @@ type Query {
         namespace: ID
         # Returns the first n external services from the list.
         first: Int
+        # Opaque pagination cursor.
+        after: String
     ): ExternalServiceConnection!
     # List all repositories.
     repositories(

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -65,6 +65,9 @@ type ExternalServicesListOptions struct {
 	NamespaceUserID int32
 	// When specified, only include external services with given list of kinds.
 	Kinds []string
+	// When specified, only include external services with ID below this number
+	// (because we're sorting results by ID in descending order).
+	AfterID int64
 	*LimitOffset
 }
 
@@ -81,6 +84,9 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 			kinds = append(kinds, sqlf.Sprintf("%s", kind))
 		}
 		conds = append(conds, sqlf.Sprintf("kind IN (%s)", sqlf.Join(kinds, ",")))
+	}
+	if o.AfterID > 0 {
+		conds = append(conds, sqlf.Sprintf(`id < %d`, o.AfterID))
 	}
 	return conds
 }

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -22,11 +22,12 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 		noNamespace     bool
 		namespaceUserID int32
 		kinds           []string
+		afterID         int64
 		wantQuery       string
 		wantArgs        []interface{}
 	}{
 		{
-			name:      "no kind",
+			name:      "no condition",
 			wantQuery: "deleted_at IS NULL",
 		},
 		{
@@ -53,6 +54,12 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 			namespaceUserID: 1,
 			wantQuery:       "deleted_at IS NULL AND namespace_user_id IS NULL",
 		},
+		{
+			name:      "has after ID",
+			afterID:   10,
+			wantQuery: "deleted_at IS NULL AND id < $1",
+			wantArgs:  []interface{}{int64(10)},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -60,6 +67,7 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 				NoNamespace:     test.noNamespace,
 				NamespaceUserID: test.namespaceUserID,
 				Kinds:           test.kinds,
+				AfterID:         test.afterID,
 			}
 			q := sqlf.Join(opts.sqlConditions(), "AND")
 			if diff := cmp.Diff(test.wantQuery, q.Query(sqlf.PostgresBindVar)); diff != "" {


### PR DESCRIPTION
Adds pagination option `AfterID` as the opaque cursor for listing external services, and enriched the response data of `PageInfo` for `ExternalServiceConnection`.

Added unit tests and tested end-to-end.

Part of #12822.