### PR TITLE
doc: use 'main' branch in UI elements

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -9,12 +9,12 @@
 {{define "versionSelector"}}
     <div id="version-selector" class="dropdown version-dropdown ml-2">
         <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            {{.ContentVersion}}{{/* If no version is specified we are on the master branch */}}{{if eq .ContentVersion ""}}master{{end}}
+            {{.ContentVersion}}{{/* If no version is specified we are on the main branch */}}{{if eq .ContentVersion ""}}main{{end}}
         </button>
         <details-menu aria-label="Sourcegraph version" class="dropdown-menu m-0 p-0" aria-labelledby="Version Dropdown">
 
-            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.17.3"}} {{$previousReleaseVersion := "3.17"}} {{$currentReleaseRevspec := "v3.18.0"}} {{$currentReleaseVersion := "3.18"}} {{$nextReleaseVersion := "master"}}
-            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">master</a>
+            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.17.3"}} {{$previousReleaseVersion := "3.17"}} {{$currentReleaseRevspec := "v3.18.0"}} {{$currentReleaseVersion := "3.18"}} {{$nextReleaseVersion := "main"}}
+            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">main</a>
             <a rel="nofollow" class=" dropdown-item {{if eq $currentReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
             <a rel="nofollow" class=" dropdown-item {{if eq $previousReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$previousReleaseVersion}}/{{.ContentPagePath}}">{{$previousReleaseVersion}}</a>
         </details-menu>
@@ -403,7 +403,7 @@
             <ul>{{template "doc_nav_nested" .}}</ul>
         {{end}}
     {{end}}
-    <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/master/doc/{{.FilePath}}">Edit this page on GitHub</a>
+    <a class="nav-edit-button btn btn-outline-secondary btn-sm" target="blank" href="https://github.com/sourcegraph/sourcegraph/edit/main/doc/{{.FilePath}}">Edit this page on GitHub</a>
 {{end}}
 
 {{define "doc_nav"}}


### PR DESCRIPTION
Docsite is now correctly serving stuff on the `main` branch it seems: https://docs.sourcegraph.com/admin/observability/alert_solutions

however, UI elements still show `master` - this PR updates it

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
