### PR TITLE
Remove Campaign.Branch field #12735

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -189,7 +189,6 @@ type CampaignResolver interface {
 	ID() graphql.ID
 	Name() string
 	Description() *string
-	Branch() *string
 	Author(ctx context.Context) (*UserResolver, error)
 	ViewerCanAdminister(ctx context.Context) (bool, error)
 	URL(ctx context.Context) (string, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -697,9 +697,6 @@ type Campaign implements Node {
     # The description (as Markdown).
     description: String
 
-    # The branch of the changesets.
-    branch: String
-
     # The user who authored the campaign.
     author: User!
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -704,9 +704,6 @@ type Campaign implements Node {
     # The description (as Markdown).
     description: String
 
-    # The branch of the changesets.
-    branch: String
-
     # The user who authored the campaign.
     author: User!
 

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -85,7 +85,6 @@ type Campaign struct {
 	ID                      string
 	Name                    string
 	Description             string
-	Branch                  string
 	Author                  User
 	ViewerCanAdminister     bool
 	Namespace               UserOrg

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -95,13 +95,6 @@ func (r *campaignResolver) Description() *string {
 	return &r.Campaign.Description
 }
 
-func (r *campaignResolver) Branch() *string {
-	if r.Campaign.Branch == "" {
-		return nil
-	}
-	return &r.Campaign.Branch
-}
-
 func (r *campaignResolver) Author(ctx context.Context) (*graphqlbackend.UserResolver, error) {
 	return graphqlbackend.UserByIDInt32(ctx, r.AuthorID)
 }

--- a/enterprise/internal/campaigns/resolvers/campaigns_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns_test.go
@@ -69,7 +69,7 @@ fragment o on Org  { name }
 query($campaign: ID!){
   node(id: $campaign) {
     ... on Campaign {
-      id, name, description, branch
+      id, name, description
       author    { ...u }
       namespace {
         ... on User { ...u }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -334,7 +334,6 @@ func TestApplyCampaign(t *testing.T) {
 		ID:          have.ID,
 		Name:        campaignSpec.Spec.Name,
 		Description: campaignSpec.Spec.Description,
-		Branch:      campaignSpec.Spec.ChangesetTemplate.Branch,
 		Namespace: apitest.UserOrg{
 			ID:         userApiID,
 			DatabaseID: userID,
@@ -390,7 +389,7 @@ fragment o on Org  { id, name }
 
 mutation($campaignSpec: ID!, $ensureCampaign: ID){
   applyCampaign(campaignSpec: $campaignSpec, ensureCampaign: $ensureCampaign) {
-    id, name, description, branch
+    id, name, description
     author    { ...u }
     namespace {
         ... on User { ...u }
@@ -566,7 +565,7 @@ fragment o on Org  { id, name }
 
 mutation($campaign: ID!, $newName: String, $newNamespace: ID){
   moveCampaign(campaign: $campaign, newName: $newName, newNamespace: $newNamespace) {
-	id, name, description, branch
+	id, name, description
 	author    { ...u }
 	namespace {
 		... on User { ...u }

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -285,9 +285,6 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	campaign.Name = campaignSpec.Spec.Name
 
 	campaign.Description = campaignSpec.Spec.Description
-	// TODO(mrnugget): This doesn't need to be populated, since the branch is
-	// now ChangesetSpec.Spec.HeadRef.
-	campaign.Branch = campaignSpec.Spec.ChangesetTemplate.Branch
 
 	if campaign.ID == 0 {
 		err := tx.CreateCampaign(ctx, campaign)
@@ -912,24 +909,6 @@ func (s *Service) EnqueueChangesetSync(ctx context.Context, id int64) (err error
 // ErrCampaignNameBlank is returned by CreateCampaign or UpdateCampaign if the
 // specified Campaign name is blank.
 var ErrCampaignNameBlank = errors.New("Campaign title cannot be blank")
-
-// ErrCampaignBranchBlank is returned by CreateCampaign or UpdateCampaign if the specified Campaign's
-// branch is blank.
-var ErrCampaignBranchBlank = errors.New("Campaign branch cannot be blank")
-
-// ErrCampaignBranchInvalid is returned by CreateCampaign or UpdateCampaign if the specified Campaign's
-// branch is invalid.
-var ErrCampaignBranchInvalid = errors.New("Campaign branch is invalid")
-
-func validateCampaignBranch(branch string) error {
-	if branch == "" {
-		return ErrCampaignBranchBlank
-	}
-	if !git.ValidateBranchName(branch) {
-		return ErrCampaignBranchInvalid
-	}
-	return nil
-}
 
 // checkNamespaceAccess checks whether the current user in the ctx has access
 // to either the user ID or the org ID as a namespace.

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -756,7 +756,6 @@ func TestServiceApplyCampaign(t *testing.T) {
 			want := &campaigns.Campaign{
 				Name:            campaignSpec.Spec.Name,
 				Description:     campaignSpec.Spec.Description,
-				Branch:          campaignSpec.Spec.ChangesetTemplate.Branch,
 				AuthorID:        campaignSpec.UserID,
 				ChangesetIDs:    []int64{},
 				NamespaceUserID: campaignSpec.NamespaceUserID,

--- a/enterprise/internal/campaigns/store_campaigns.go
+++ b/enterprise/internal/campaigns/store_campaigns.go
@@ -14,7 +14,6 @@ var campaignColumns = []*sqlf.Query{
 	sqlf.Sprintf("campaigns.id"),
 	sqlf.Sprintf("campaigns.name"),
 	sqlf.Sprintf("campaigns.description"),
-	sqlf.Sprintf("campaigns.branch"),
 	sqlf.Sprintf("campaigns.author_id"),
 	sqlf.Sprintf("campaigns.namespace_user_id"),
 	sqlf.Sprintf("campaigns.namespace_org_id"),
@@ -31,7 +30,6 @@ var campaignColumns = []*sqlf.Query{
 var campaignInsertColumns = []*sqlf.Query{
 	sqlf.Sprintf("name"),
 	sqlf.Sprintf("description"),
-	sqlf.Sprintf("branch"),
 	sqlf.Sprintf("author_id"),
 	sqlf.Sprintf("namespace_user_id"),
 	sqlf.Sprintf("namespace_org_id"),
@@ -57,7 +55,7 @@ func (s *Store) CreateCampaign(ctx context.Context, c *campaigns.Campaign) error
 var createCampaignQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store.go:CreateCampaign
 INSERT INTO campaigns (%s)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING %s
 `
 
@@ -80,7 +78,6 @@ func (s *Store) createCampaignQuery(c *campaigns.Campaign) (*sqlf.Query, error) 
 		sqlf.Join(campaignInsertColumns, ", "),
 		c.Name,
 		c.Description,
-		c.Branch,
 		c.AuthorID,
 		nullInt32Column(c.NamespaceUserID),
 		nullInt32Column(c.NamespaceOrgID),
@@ -106,7 +103,7 @@ func (s *Store) UpdateCampaign(ctx context.Context, c *campaigns.Campaign) error
 var updateCampaignQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store.go:UpdateCampaign
 UPDATE campaigns
-SET (%s) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+SET (%s) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING %s
 `
@@ -124,7 +121,6 @@ func (s *Store) updateCampaignQuery(c *campaigns.Campaign) (*sqlf.Query, error) 
 		sqlf.Join(campaignInsertColumns, ", "),
 		c.Name,
 		c.Description,
-		c.Branch,
 		c.AuthorID,
 		nullInt32Column(c.NamespaceUserID),
 		nullInt32Column(c.NamespaceOrgID),
@@ -365,7 +361,6 @@ func scanCampaign(c *campaigns.Campaign, s scanner) error {
 		&c.ID,
 		&c.Name,
 		&dbutil.NullString{S: &c.Description},
-		&dbutil.NullString{S: &c.Branch},
 		&c.AuthorID,
 		&dbutil.NullInt32{N: &c.NamespaceUserID},
 		&dbutil.NullInt32{N: &c.NamespaceOrgID},

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -20,7 +20,6 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 			c := &cmpgn.Campaign{
 				Name:           fmt.Sprintf("test-campaign-%d", i),
 				Description:    "All the Javascripts are belong to us",
-				Branch:         "upgrade-es-lint",
 				AuthorID:       int32(i) + 50,
 				ChangesetIDs:   []int64{int64(i) + 1},
 				CampaignSpecID: 1742 + int64(i),

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -58,7 +58,6 @@ type Campaign struct {
 	ID              int64
 	Name            string
 	Description     string
-	Branch          string
 	AuthorID        int32
 	NamespaceUserID int32
 	NamespaceOrgID  int32

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -61,7 +61,6 @@ Referenced by:
  updated_at        | timestamp with time zone | not null default now()
  changeset_ids     | jsonb                    | not null default '{}'::jsonb
  closed_at         | timestamp with time zone | 
- branch            | text                     | 
  campaign_spec_id  | bigint                   | 
 Indexes:
     "campaigns_pkey" PRIMARY KEY, btree (id)

--- a/migrations/1528395699_campaign_remove_branch.down.sql
+++ b/migrations/1528395699_campaign_remove_branch.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaigns ADD COLUMN branch text;
+
+COMMIT;

--- a/migrations/1528395699_campaign_remove_branch.up.sql
+++ b/migrations/1528395699_campaign_remove_branch.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE campaigns DROP COLUMN IF EXISTS branch;
+
+COMMIT;

--- a/migrations/bindata.go
+++ b/migrations/bindata.go
@@ -98,6 +98,8 @@
 // 1528395697_add_changeset_state_machine.up.sql (2.213kB)
 // 1528395698_add_sync_time_and_user_id_to_external_services.down.sql (335B)
 // 1528395698_add_sync_time_and_user_id_to_external_services.up.sql (425B)
+// 1528395699_campaign_remove_branch.down.sql (63B)
+// 1528395699_campaign_remove_branch.up.sql (69B)
 
 package migrations
 
@@ -2126,6 +2128,46 @@ func _1528395698_add_sync_time_and_user_id_to_external_servicesUpSql() (*asset, 
 	return a, nil
 }
 
+var __1528395699_campaign_remove_branchDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x2b\x56\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x2a\x4a\xcc\x4b\xce\x50\x28\x49\xad\x28\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x1c\x0a\x98\x4f\x3f\x00\x00\x00")
+
+func _1528395699_campaign_remove_branchDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395699_campaign_remove_branchDownSql,
+		"1528395699_campaign_remove_branch.down.sql",
+	)
+}
+
+func _1528395699_campaign_remove_branchDownSql() (*asset, error) {
+	bytes, err := _1528395699_campaign_remove_branchDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395699_campaign_remove_branch.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x84, 0x36, 0x5b, 0xa7, 0x8e, 0x31, 0x18, 0xc6, 0x73, 0x75, 0x61, 0xd9, 0xa9, 0x74, 0xab, 0x5b, 0x3d, 0x8d, 0x27, 0x76, 0x6a, 0x58, 0xc5, 0xe, 0x8e, 0x84, 0xf8, 0xe6, 0x7d, 0xb6, 0xf0, 0xed}}
+	return a, nil
+}
+
+var __1528395699_campaign_remove_branchUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x2b\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\x2a\x4a\xcc\x4b\xce\xb0\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xfa\x6b\xa5\x74\x45\x00\x00\x00")
+
+func _1528395699_campaign_remove_branchUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395699_campaign_remove_branchUpSql,
+		"1528395699_campaign_remove_branch.up.sql",
+	)
+}
+
+func _1528395699_campaign_remove_branchUpSql() (*asset, error) {
+	bytes, err := _1528395699_campaign_remove_branchUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395699_campaign_remove_branch.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x58, 0x8a, 0x6, 0x46, 0xc2, 0x7, 0xf6, 0x66, 0xa1, 0xe1, 0x26, 0x6c, 0x87, 0x30, 0x7c, 0xd1, 0x9, 0x3e, 0x54, 0xe5, 0xdc, 0x75, 0x93, 0x41, 0xbf, 0xcc, 0x7f, 0x83, 0x53, 0x51, 0xbf, 0xa0}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2315,6 +2357,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395697_add_changeset_state_machine.up.sql":                           _1528395697_add_changeset_state_machineUpSql,
 	"1528395698_add_sync_time_and_user_id_to_external_services.down.sql":      _1528395698_add_sync_time_and_user_id_to_external_servicesDownSql,
 	"1528395698_add_sync_time_and_user_id_to_external_services.up.sql":        _1528395698_add_sync_time_and_user_id_to_external_servicesUpSql,
+	"1528395699_campaign_remove_branch.down.sql":                              _1528395699_campaign_remove_branchDownSql,
+	"1528395699_campaign_remove_branch.up.sql":                                _1528395699_campaign_remove_branchUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2459,6 +2503,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395697_add_changeset_state_machine.up.sql":                           {_1528395697_add_changeset_state_machineUpSql, map[string]*bintree{}},
 	"1528395698_add_sync_time_and_user_id_to_external_services.down.sql":      {_1528395698_add_sync_time_and_user_id_to_external_servicesDownSql, map[string]*bintree{}},
 	"1528395698_add_sync_time_and_user_id_to_external_services.up.sql":        {_1528395698_add_sync_time_and_user_id_to_external_servicesUpSql, map[string]*bintree{}},
+	"1528395699_campaign_remove_branch.down.sql":                              {_1528395699_campaign_remove_branchDownSql, map[string]*bintree{}},
+	"1528395699_campaign_remove_branch.up.sql":                                {_1528395699_campaign_remove_branchUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -44,7 +44,6 @@ const campaignFragment = gql`
         namespace {
             namespaceName
         }
-        branch
         createdAt
         updatedAt
         closedAt


### PR DESCRIPTION
Remove Campaign.Branch field, which fixes #12735. The branch is no longer needed, since the branch name is now part of the spec.