### PR TITLE
search: add github.com start anchor for literal patterns on dotcom

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -996,7 +996,7 @@ func filterRepoHasCommitAfter(ctx context.Context, revisions []*search.Repositor
 }
 
 func optimizeRepoPatternWithHeuristics(repoPattern string) string {
-	if envvar.SourcegraphDotComMode() && strings.HasPrefix(string(repoPattern), "github.com") {
+	if envvar.SourcegraphDotComMode() && (strings.HasPrefix(string(repoPattern), "github.com") || strings.HasPrefix(string(repoPattern), `github\.com`)) {
 		repoPattern = "^" + repoPattern
 	}
 	// Optimization: make the "." in "github.com" a literal dot


### PR DESCRIPTION
An existing heuristic makes `github.com/...` patterns faster by prepending a start anchor `^` for sourcegraph.com. This heuristic assumes the `github.com` is a regex. However, a user (or query transformer) may escape the `.` before it gets to this function called in the resolve repos code, yielding `github\.com/...`. Because this string doesn't match the heuristic conditions, no `^` is prepended and so slow search behavior happens #12889. 

This PR expands the heuristic conditions to also prepend a `^` when the `.` is escaped (we must still assume the input is regex until this logic is moved out of the resolve repo function, and into a query transformer, for which I've filed https://github.com/sourcegraph/sourcegraph/issues/12890)

No test since this is `SourcegraphDotComMode` specific, and straightforward enough.