### PR TITLE
reduce a few common kinds of linter warnings

### DIFF
--- a/enterprise/internal/campaigns/counts.go
+++ b/enterprise/internal/campaigns/counts.go
@@ -82,7 +82,7 @@ func CalcCounts(start, end time.Time, cs []*campaigns.Changeset, es ...*campaign
 			c.Total++
 			switch states.externalState {
 			case campaigns.ChangesetExternalStateOpen:
-				c.Open += 1
+				c.Open++
 				switch states.reviewState {
 				case campaigns.ChangesetReviewStatePending:
 					c.OpenPending++
@@ -93,9 +93,9 @@ func CalcCounts(start, end time.Time, cs []*campaigns.Changeset, es ...*campaign
 				}
 
 			case campaigns.ChangesetExternalStateMerged:
-				c.Merged += 1
+				c.Merged++
 			case campaigns.ChangesetExternalStateClosed:
-				c.Closed += 1
+				c.Closed++
 			}
 
 		}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -435,12 +435,6 @@ func TestReconcilerProcess(t *testing.T) {
 	}
 }
 
-var (
-	diffStatOne   int32 = 1
-	diffStatTwo   int32 = 2
-	diffStatThree int32 = 3
-)
-
 func buildGithubPR(now time.Time, externalID, title, body, headRef string) interface{} {
 	return &github.PullRequest{
 		ID:          externalID,

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -75,11 +75,10 @@ func TestCampaignSpecResolver(t *testing.T) {
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
-
 	}
 
 	apiID := string(marshalCampaignSpecRandID(spec.RandID))
-	userApiID := string(graphqlbackend.MarshalUserID(userID))
+	userAPIID := string(graphqlbackend.MarshalUserID(userID))
 
 	input := map[string]interface{}{"campaignSpec": apiID}
 	var response struct{ Node apitest.CampaignSpec }
@@ -99,8 +98,8 @@ func TestCampaignSpecResolver(t *testing.T) {
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 
 		ApplyURL:            fmt.Sprintf("/users/%s/campaigns/apply?spec=%s", username, apiID),
-		Namespace:           apitest.UserOrg{ID: userApiID, DatabaseID: userID},
-		Creator:             apitest.User{ID: userApiID, DatabaseID: userID},
+		Namespace:           apitest.UserOrg{ID: userAPIID, DatabaseID: userID},
+		Creator:             apitest.User{ID: userAPIID, DatabaseID: userID},
 		ViewerCanAdminister: true,
 
 		CreatedAt: graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},

--- a/enterprise/internal/campaigns/resolvers/campaigns.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns.go
@@ -150,12 +150,9 @@ func (r *campaignResolver) computeNamespace(ctx context.Context) (graphqlbackend
 		if errcode.IsNotFound(r.namespaceErr) {
 			r.namespaceErr = nil
 		}
-
-		return
 	})
 
 	return r.namespace, r.namespaceErr
-
 }
 
 func (r *campaignResolver) CreatedAt() graphqlbackend.DateTime {

--- a/enterprise/internal/campaigns/resolvers/campaigns_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns_test.go
@@ -60,21 +60,21 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignApiID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
 
-	input := map[string]interface{}{"campaign": campaignApiID}
+	input := map[string]interface{}{"campaign": campaignAPIID}
 	var response struct{ Node apitest.Campaign }
 	apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
 
 	wantCampaign := apitest.Campaign{
-		ID:             campaignApiID,
+		ID:             campaignAPIID,
 		Name:           campaign.Name,
 		Description:    campaign.Description,
 		Namespace:      apitest.UserOrg{DatabaseID: userID, SiteAdmin: true},
 		InitialApplier: apitest.User{DatabaseID: userID, SiteAdmin: true},
 		LastApplier:    apitest.User{DatabaseID: userID, SiteAdmin: true},
 		LastAppliedAt:  marshalDateTime(t, now),
-		URL:            fmt.Sprintf("/users/%s/campaigns/%s", username, campaignApiID),
+		URL:            fmt.Sprintf("/users/%s/campaigns/%s", username, campaignAPIID),
 	}
 	if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
 		t.Fatalf("wrong campaign response (-want +got):\n%s", diff)

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -102,7 +102,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignApiID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
 	nodes := []apitest.Changeset{
 		{
 			Typename:   "ExternalChangeset",
@@ -145,7 +145,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("Unsafe opts %t, first %d", tc.useUnsafeOpts, tc.firstParam), func(t *testing.T) {
-			input := map[string]interface{}{"campaign": campaignApiID, "first": int64(tc.firstParam)}
+			input := map[string]interface{}{"campaign": campaignAPIID, "first": int64(tc.firstParam)}
 			if tc.useUnsafeOpts {
 				input["reviewState"] = campaigns.ChangesetReviewStatePending
 			}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -71,7 +71,6 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
-
 	}
 
 	apiID := string(marshalCampaignSpecRandID(campaignSpec.RandID))

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -44,7 +44,6 @@ func TestChangesetSpecResolver(t *testing.T) {
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
-
 	}
 
 	tests := []struct {
@@ -113,7 +112,6 @@ func TestChangesetSpecResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			spec, err := campaigns.NewChangesetSpecFromRaw(tc.rawSpec)
 			if err != nil {
 				t.Fatal(err)

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -51,7 +51,7 @@ func TestChangesetResolver(t *testing.T) {
 	defer func() { git.Mocks.ResolveRevision = nil }()
 	// These are needed in addition for preview repository comparisons.
 	mockBackendCommits(t, api.CommitID(baseRev))
-	mockRepoComparison(t, baseRev, headRev, testDiff)
+	mockRepoComparison(t, baseRev, headRev)
 
 	unpublishedSpec := createChangesetSpec(t, ctx, store, testSpecOpts{
 		user:          userID,

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -51,7 +51,7 @@ func TestChangesetResolver(t *testing.T) {
 	defer func() { git.Mocks.ResolveRevision = nil }()
 	// These are needed in addition for preview repository comparisons.
 	mockBackendCommits(t, api.CommitID(baseRev))
-	mockRepoComparison(t, baseRev, headRev)
+	mockRepoComparison(t, baseRev, headRev, testDiff)
 
 	unpublishedSpec := createChangesetSpec(t, ctx, store, testSpecOpts{
 		user:          userID,

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -192,7 +192,7 @@ func mockBackendCommits(t *testing.T, revs ...api.CommitID) {
 	t.Cleanup(func() { backend.Mocks.Repos.GetCommit = nil })
 }
 
-func mockRepoComparison(t *testing.T, baseRev, headRev, _ string) {
+func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 	t.Helper()
 
 	spec := fmt.Sprintf("%s...%s", baseRev, headRev)
@@ -213,7 +213,7 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, _ string) {
 		if have, want := args[len(args)-2], spec; have != want {
 			t.Fatalf("gitserver.ExecReader received wrong spec: %q, want %q", have, want)
 		}
-		return ioutil.NopCloser(strings.NewReader(testDiff)), nil
+		return ioutil.NopCloser(strings.NewReader(diff)), nil
 	}
 	t.Cleanup(func() { git.Mocks.ExecReader = nil })
 

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -192,7 +192,7 @@ func mockBackendCommits(t *testing.T, revs ...api.CommitID) {
 	t.Cleanup(func() { backend.Mocks.Repos.GetCommit = nil })
 }
 
-func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
+func mockRepoComparison(t *testing.T, baseRev, headRev, _ string) {
 	t.Helper()
 
 	spec := fmt.Sprintf("%s...%s", baseRev, headRev)
@@ -201,7 +201,7 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 		if string(id) != baseRev && string(id) != headRev {
 			t.Fatalf("git.Mocks.GetCommit received unknown commit id: %s", id)
 		}
-		return &git.Commit{ID: api.CommitID(id)}, nil
+		return &git.Commit{ID: id}, nil
 	}
 	t.Cleanup(func() { git.Mocks.GetCommit = nil })
 

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -192,7 +192,7 @@ func mockBackendCommits(t *testing.T, revs ...api.CommitID) {
 	t.Cleanup(func() { backend.Mocks.Repos.GetCommit = nil })
 }
 
-func mockRepoComparison(t *testing.T, baseRev, headRev string) {
+func mockRepoComparison(t *testing.T, baseRev, headRev, _ string) {
 	t.Helper()
 
 	spec := fmt.Sprintf("%s...%s", baseRev, headRev)

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -192,7 +192,7 @@ func mockBackendCommits(t *testing.T, revs ...api.CommitID) {
 	t.Cleanup(func() { backend.Mocks.Repos.GetCommit = nil })
 }
 
-func mockRepoComparison(t *testing.T, baseRev, headRev, _ string) {
+func mockRepoComparison(t *testing.T, baseRev, headRev string) {
 	t.Helper()
 
 	spec := fmt.Sprintf("%s...%s", baseRev, headRev)

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -491,7 +491,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Create 2 changesets for 2 repositories
 		changesetBaseRefOid := "f00b4r"
 		changesetHeadRefOid := "b4rf00"
-		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid)
+		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid, testDiff)
 		changesetDiffStat := apitest.DiffStat{Added: 0, Changed: 2, Deleted: 0}
 
 		changesets := make([]*campaigns.Changeset, 0, len(repos))

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -491,7 +491,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Create 2 changesets for 2 repositories
 		changesetBaseRefOid := "f00b4r"
 		changesetHeadRefOid := "b4rf00"
-		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid, testDiff)
+		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid)
 		changesetDiffStat := apitest.DiffStat{Added: 0, Changed: 2, Deleted: 0}
 
 		changesets := make([]*campaigns.Changeset, 0, len(repos))

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -100,7 +100,7 @@ func TestPermissionLevels(t *testing.T) {
 		return cs.RandID
 	}
 
-	cleanUpCampaigns := func(t *testing.T, s *ee.Store) {
+	cleanUpCampaigns := func(t *testing.T, _ *ee.Store) {
 		t.Helper()
 
 		campaigns, next, err := store.ListCampaigns(ctx, ee.ListCampaignsOpts{Limit: 1000})
@@ -910,7 +910,7 @@ query($campaignSpec: ID!) {
 }
 `
 
-func testChangesetSpecResponse(t *testing.T, s *graphql.Schema, ctx context.Context, randID string, wantType string) {
+func testChangesetSpecResponse(t *testing.T, s *graphql.Schema, ctx context.Context, randID, wantType string) {
 	t.Helper()
 
 	var res struct{ Node apitest.ChangesetSpec }

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -100,10 +100,10 @@ func TestPermissionLevels(t *testing.T) {
 		return cs.RandID
 	}
 
-	cleanUpCampaigns := func(t *testing.T, _ *ee.Store) {
+	cleanUpCampaigns := func(t *testing.T, s *ee.Store) {
 		t.Helper()
 
-		campaigns, next, err := store.ListCampaigns(ctx, ee.ListCampaignsOpts{Limit: 1000})
+		campaigns, next, err := s.ListCampaigns(ctx, ee.ListCampaignsOpts{Limit: 1000})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -112,7 +112,7 @@ func TestPermissionLevels(t *testing.T) {
 		}
 
 		for _, c := range campaigns {
-			if err := store.DeleteCampaign(ctx, c.ID); err != nil {
+			if err := s.DeleteCampaign(ctx, c.ID); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -106,15 +106,14 @@ func TestCreateCampaignSpec(t *testing.T) {
 	s, err := graphqlbackend.NewSchema(r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
-
 	}
 
-	userApiID := string(graphqlbackend.MarshalUserID(userID))
+	userAPIID := string(graphqlbackend.MarshalUserID(userID))
 	changesetSpecID := marshalChangesetSpecRandID(changesetSpec.RandID)
 	rawSpec := ct.TestRawCampaignSpec
 
 	input := map[string]interface{}{
-		"namespace":      userApiID,
+		"namespace":      userAPIID,
 		"campaignSpec":   rawSpec,
 		"changesetSpecs": []graphql.ID{changesetSpecID},
 	}
@@ -138,8 +137,8 @@ func TestCreateCampaignSpec(t *testing.T) {
 		OriginalInput: rawSpec,
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 		ApplyURL:      fmt.Sprintf("/users/%s/campaigns/apply?spec=%s", username, have.ID),
-		Namespace:     apitest.UserOrg{ID: userApiID, DatabaseID: userID, SiteAdmin: true},
-		Creator:       apitest.User{ID: userApiID, DatabaseID: userID, SiteAdmin: true},
+		Namespace:     apitest.UserOrg{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
+		Creator:       apitest.User{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
 		ChangesetSpecs: apitest.ChangesetSpecConnection{
 			Nodes: []apitest.ChangesetSpec{
 				{
@@ -210,7 +209,6 @@ func TestCreateChangesetSpec(t *testing.T) {
 	s, err := graphqlbackend.NewSchema(r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
-
 	}
 
 	input := map[string]interface{}{
@@ -283,7 +281,7 @@ func TestApplyCampaign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoApiID := graphqlbackend.MarshalRepositoryID(repo.ID)
+	repoAPIID := graphqlbackend.MarshalRepositoryID(repo.ID)
 
 	campaignSpec := &campaigns.CampaignSpec{
 		RawSpec: ct.TestRawCampaignSpec,
@@ -310,7 +308,7 @@ func TestApplyCampaign(t *testing.T) {
 	changesetSpec := &campaigns.ChangesetSpec{
 		CampaignSpecID: campaignSpec.ID,
 		Spec: &campaigns.ChangesetSpecDescription{
-			BaseRepository: repoApiID,
+			BaseRepository: repoAPIID,
 		},
 		RepoID: repo.ID,
 		UserID: userID,
@@ -325,7 +323,7 @@ func TestApplyCampaign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	userApiID := string(graphqlbackend.MarshalUserID(userID))
+	userAPIID := string(graphqlbackend.MarshalUserID(userID))
 	input := map[string]interface{}{
 		"campaignSpec": string(marshalCampaignSpecRandID(campaignSpec.RandID)),
 	}
@@ -340,17 +338,17 @@ func TestApplyCampaign(t *testing.T) {
 		Name:        campaignSpec.Spec.Name,
 		Description: campaignSpec.Spec.Description,
 		Namespace: apitest.UserOrg{
-			ID:         userApiID,
+			ID:         userAPIID,
 			DatabaseID: userID,
 			SiteAdmin:  true,
 		},
 		InitialApplier: apitest.User{
-			ID:         userApiID,
+			ID:         userAPIID,
 			DatabaseID: userID,
 			SiteAdmin:  true,
 		},
 		LastApplier: apitest.User{
-			ID:         userApiID,
+			ID:         userAPIID,
 			DatabaseID: userID,
 			SiteAdmin:  true,
 		},
@@ -533,9 +531,9 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	// Move to a new name
-	campaignApiID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
 	input := map[string]interface{}{
-		"campaign": campaignApiID,
+		"campaign": campaignAPIID,
 		"newName":  "new-name",
 	}
 
@@ -548,25 +546,25 @@ func TestMoveCampaign(t *testing.T) {
 		t.Fatalf("unexpected name (-want +got):\n%s", diff)
 	}
 
-	wantURL := fmt.Sprintf("/users/%s/campaigns/%s", username, campaignApiID)
+	wantURL := fmt.Sprintf("/users/%s/campaigns/%s", username, campaignAPIID)
 	if diff := cmp.Diff(wantURL, haveCampaign.URL); diff != "" {
 		t.Fatalf("unexpected URL (-want +got):\n%s", diff)
 	}
 
 	// Move to a new namespace
-	orgApiID := graphqlbackend.MarshalOrgID(org.ID)
+	orgAPIID := graphqlbackend.MarshalOrgID(org.ID)
 	input = map[string]interface{}{
 		"campaign":     string(campaigns.MarshalCampaignID(campaign.ID)),
-		"newNamespace": orgApiID,
+		"newNamespace": orgAPIID,
 	}
 
 	apitest.MustExec(actorCtx, t, s, input, &response, mutationMoveCampaign)
 
 	haveCampaign = response.MoveCampaign
-	if diff := cmp.Diff(string(orgApiID), haveCampaign.Namespace.ID); diff != "" {
+	if diff := cmp.Diff(string(orgAPIID), haveCampaign.Namespace.ID); diff != "" {
 		t.Fatalf("unexpected namespace (-want +got):\n%s", diff)
 	}
-	wantURL = fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaignApiID)
+	wantURL = fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaignAPIID)
 	if diff := cmp.Diff(wantURL, haveCampaign.URL); diff != "" {
 		t.Fatalf("unexpected URL (-want +got):\n%s", diff)
 	}
@@ -764,14 +762,14 @@ func TestCampaignsListing(t *testing.T) {
 		campaign := &campaigns.Campaign{NamespaceUserID: userID}
 		createCampaign(t, campaign)
 
-		userApiID := string(graphqlbackend.MarshalUserID(userID))
-		input := map[string]interface{}{"node": userApiID}
+		userAPIID := string(graphqlbackend.MarshalUserID(userID))
+		input := map[string]interface{}{"node": userAPIID}
 
 		var response struct{ Node apitest.User }
 		apitest.MustExec(actorCtx, t, s, input, &response, listNamespacesCampaigns)
 
 		want := apitest.User{
-			ID: userApiID,
+			ID: userAPIID,
 			Campaigns: apitest.CampaignConnection{
 				TotalCount: 1,
 				Nodes: []apitest.Campaign{
@@ -789,14 +787,14 @@ func TestCampaignsListing(t *testing.T) {
 		campaign := &campaigns.Campaign{NamespaceOrgID: org.ID}
 		createCampaign(t, campaign)
 
-		orgApiID := string(graphqlbackend.MarshalOrgID(org.ID))
-		input := map[string]interface{}{"node": orgApiID}
+		orgAPIID := string(graphqlbackend.MarshalOrgID(org.ID))
+		input := map[string]interface{}{"node": orgAPIID}
 
 		var response struct{ Node apitest.Org }
 		apitest.MustExec(actorCtx, t, s, input, &response, listNamespacesCampaigns)
 
 		want := apitest.Org{
-			ID: orgApiID,
+			ID: orgAPIID,
 			Campaigns: apitest.CampaignConnection{
 				TotalCount: 1,
 				Nodes: []apitest.Campaign{


### PR DESCRIPTION
Now that I can run the campaigns tests in reasonable amount of time, I thought I'd chip away at a bit of the linter noise.