### PR TITLE
Reduce logspam and don't try to talk to external services from tests

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -49,6 +49,8 @@ func TestChangesetResolver(t *testing.T) {
 		return api.CommitID(spec), nil
 	}
 	defer func() { git.Mocks.ResolveRevision = nil }()
+	// These are needed in addition for preview repository comparisons.
+	mockBackendCommits(t, api.CommitID(baseRev))
 	mockRepoComparison(t, baseRev, headRev, testDiff)
 
 	unpublishedSpec := createChangesetSpec(t, ctx, store, testSpecOpts{

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -38,6 +39,12 @@ func TestPermissionLevels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// SyncChangeset uses EnqueueChangesetSync and tries to talk to repo-updater, hence we need to mock it.
+	repoupdater.MockEnqueueChangesetSync = func(ctx context.Context, ids []int64) error {
+		return nil
+	}
+	t.Cleanup(func() { repoupdater.MockEnqueueChangesetSync = nil })
 
 	ctx := context.Background()
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -519,7 +519,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 
 	svc := ee.NewService(r.store, r.httpFactory)
 	// 🚨 SECURITY: CloseCampaign checks whether current user is authorized.
-	campaign, err := svc.CloseCampaign(ctx, campaignID, args.CloseChangesets)
+	campaign, err := svc.CloseCampaign(ctx, campaignID, args.CloseChangesets, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "closing campaign")
 	}

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -703,7 +703,7 @@ var ErrEnsureCampaignFailed = errors.New("a campaign in the given namespace and 
 var ErrCloseProcessingCampaign = errors.New("cannot close a campaign while changesets are being processed")
 
 // CloseCampaign closes the Campaign with the given ID if it has not been closed yet.
-func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets bool) (campaign *campaigns.Campaign, err error) {
+func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets, closeAsync bool) (campaign *campaigns.Campaign, err error) {
 	traceTitle := fmt.Sprintf("campaign: %d, closeChangesets: %t", id, closeChangesets)
 	tr, ctx := trace.New(ctx, "service.CloseCampaign", traceTitle)
 	defer func() {
@@ -758,7 +758,7 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 	}
 
 	if closeChangesets {
-		go func() {
+		closer := func() {
 			ctx := trace.ContextWithTrace(context.Background(), tr)
 
 			open := campaigns.ChangesetExternalStateOpen
@@ -777,7 +777,12 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 			if err != nil {
 				log15.Error("CloseCampaignChangesets", "err", err)
 			}
-		}()
+		}
+		if closeAsync {
+			go closer()
+		} else {
+			closer()
+		}
 	}
 
 	return campaign, nil

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -203,7 +203,7 @@ func TestService(t *testing.T) {
 	store := NewStore(dbconn.Global)
 	rs, _ := createTestRepos(t, ctx, dbconn.Global, 4)
 
-	fakeSource := &ct.FakeChangesetSource{Err: nil}
+	fakeSource := &ct.FakeChangesetSource{}
 	sourcer := repos.NewFakeSourcer(nil, fakeSource)
 
 	svc := NewService(store, nil)

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -333,6 +333,13 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("CloseOpenChangesets", func(t *testing.T) {
+		// After close, the changesets will be synced, so we need to mock that operation.
+		state := ct.MockChangesetSyncState(&protocol.RepoInfo{
+			Name: api.RepoName(rs[0].Name),
+			VCS:  protocol.VCSInfo{URL: rs[0].URI},
+		})
+		defer state.Unmock()
+
 		changeset1 := testChangeset(rs[0].ID, 0, campaigns.ChangesetExternalStateOpen)
 		if err := store.CreateChangeset(ctx, changeset1); err != nil {
 			t.Fatal(err)
@@ -350,13 +357,6 @@ func TestService(t *testing.T) {
 
 		svc := NewService(store, nil)
 		svc.sourcer = sourcer
-
-		// After close, the changesets will be synced, so we need to mock that operation.
-		state := ct.MockChangesetSyncState(&protocol.RepoInfo{
-			Name: api.RepoName(rs[0].Name),
-			VCS:  protocol.VCSInfo{URL: rs[0].URI},
-		})
-		defer state.Unmock()
 
 		// Try to close open changesets
 		err := svc.CloseOpenChangesets(ctx, []*campaigns.Changeset{changeset1, changeset2})

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -126,11 +126,6 @@ func computeExternalState(c *campaigns.Changeset, history []changesetStatesAtTim
 // associated events. The events should be presorted.
 func computeReviewState(c *campaigns.Changeset, history []changesetStatesAtTime) (campaigns.ChangesetReviewState, error) {
 	if len(history) == 0 {
-		// GitHub doesn't keep the review state on a changeset, so a GitHub Changeset
-		// will always return ChangesetReviewStatePending.
-		if c.ExternalServiceType == extsvc.TypeGitHub {
-			return campaigns.ChangesetReviewStatePending, nil
-		}
 		return computeSingleChangesetReviewState(c)
 	}
 
@@ -467,8 +462,7 @@ func computeSingleChangesetReviewState(c *campaigns.Changeset) (s campaigns.Chan
 
 	switch m := c.Metadata.(type) {
 	case *github.PullRequest:
-		// For GitHub we need to use `ChangesetEvents.ReviewState`
-		log15.Warn("Changeset.ReviewState() called, but GitHub review state is calculated through ChangesetEvents.ReviewState", "changeset", c)
+		// For GitHub we need to use `ChangesetEvents.ReviewState`.
 		return campaigns.ChangesetReviewStatePending, nil
 
 	case *bitbucketserver.PullRequest:

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -126,6 +126,11 @@ func computeExternalState(c *campaigns.Changeset, history []changesetStatesAtTim
 // associated events. The events should be presorted.
 func computeReviewState(c *campaigns.Changeset, history []changesetStatesAtTime) (campaigns.ChangesetReviewState, error) {
 	if len(history) == 0 {
+		// GitHub doesn't keep the review state on a changeset, so a GitHub Changeset
+		// will always return ChangesetReviewStatePending.
+		if c.ExternalServiceType == extsvc.TypeGitHub {
+			return campaigns.ChangesetReviewStatePending, nil
+		}
 		return computeSingleChangesetReviewState(c)
 	}
 

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -80,7 +80,7 @@ func (s *FakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Chan
 	return c.SetMetadata(s.FakeMetadata)
 }
 
-var fakeNotImplemented = errors.New("not implement in FakeChangesetSource")
+var fakeNotImplemented = errors.New("not implemented in FakeChangesetSource")
 
 func (s *FakeChangesetSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
 	s.ListReposCalled = true

--- a/enterprise/internal/campaigns/webhooks_gitlab_test.go
+++ b/enterprise/internal/campaigns/webhooks_gitlab_test.go
@@ -616,13 +616,6 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					MergeRequest: &gitlab.MergeRequest{IID: gitlab.ID(cid)},
 				}
 
-				t.Logf("event: %+v", event)
-				rs, err := rstore.ListRepos(ctx, repos.StoreListReposArgs{})
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Logf("all repos: %+v", rs)
-
 				want := errors.New("foo")
 				repoupdater.MockEnqueueChangesetSync = func(ctx context.Context, ids []int64) error {
 					return want


### PR DESCRIPTION
Inspired by the issue @chrispine had today, it turns out some of our tests try to talk to external services (and fail). I've tried to catch them all and added the missing mocks here.