### PR TITLE
search: don't fuzzy search repos if rev is specified

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -201,8 +201,9 @@ func (g globError) Error() string {
 // from glob to regex.
 func reporevToRegex(value string) (string, error) {
 	reporev := strings.SplitN(value, "@", 2)
+	containsRev := len(reporev) == 2
 	repo := reporev[0]
-	if ContainsNoGlobSyntax(repo) {
+	if !containsRev && ContainsNoGlobSyntax(repo) {
 		repo = fuzzifyGlobPattern(repo)
 	}
 	repo, err := globToRegex(repo)
@@ -225,6 +226,9 @@ func ContainsNoGlobSyntax(value string) bool {
 func fuzzifyGlobPattern(value string) string {
 	if value == "" {
 		return value
+	}
+	if strings.HasPrefix(value, "github.com") {
+		return value + "**"
 	}
 	return "**" + value + "**"
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -201,9 +201,9 @@ func (g globError) Error() string {
 // from glob to regex.
 func reporevToRegex(value string) (string, error) {
 	reporev := strings.SplitN(value, "@", 2)
-	containsRev := len(reporev) == 2
+	containsNoRev := len(reporev) == 1
 	repo := reporev[0]
-	if !containsRev && ContainsNoGlobSyntax(repo) {
+	if containsNoRev && ContainsNoGlobSyntax(repo) {
 		repo = fuzzifyGlobPattern(repo)
 	}
 	repo, err := globToRegex(repo)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -555,14 +555,19 @@ func TestReporevToRegex(t *testing.T) {
 		want string
 	}{
 		{
-			name: "no revision",
+			name: "starting with github.com, no revision",
 			arg:  "github.com/foo",
-			want: "^.*?github\\.com/foo.*?$",
+			want: "^github\\.com/foo.*?$",
 		},
 		{
-			name: "with revision",
+			name: "starting with github.com, with revision",
 			arg:  "github.com/foo@bar",
-			want: "^.*?github\\.com/foo.*?$@bar",
+			want: "^github\\.com/foo$@bar",
+		},
+		{
+			name: "starting with foo.com, no revision",
+			arg:  "foo.com/bar",
+			want: "^.*?foo\\.com/bar.*?$",
 		},
 		{
 			name: "empty string",
@@ -572,7 +577,7 @@ func TestReporevToRegex(t *testing.T) {
 		{
 			name: "many @",
 			arg:  "foo@bar@bas",
-			want: "^.*?foo.*?$@bar@bas",
+			want: "^foo$@bar@bas",
 		},
 		{
 			name: "just @",
@@ -694,6 +699,10 @@ func TestFuzzifyGlobPattern(t *testing.T) {
 			want: "**foo**",
 		},
 		{
+			in:   "github.com/foo/bar",
+			want: "github.com/foo/bar**",
+		},
+		{
 			in:   "",
 			want: "",
 		},
@@ -717,8 +726,16 @@ func TestMapGlobToRegex(t *testing.T) {
 			want:  `"repo:^.*?sourcegraph.*?$"`,
 		},
 		{
+			input: "repo:sourcegraph@commit-id",
+			want:  `"repo:^sourcegraph$@commit-id"`,
+		},
+		{
 			input: "repo:github.com/sourcegraph",
-			want:  `"repo:^.*?github\\.com/sourcegraph.*?$"`,
+			want:  `"repo:^github\\.com/sourcegraph.*?$"`,
+		},
+		{
+			input: "repo:github.com/sourcegraph/sourcegraph@v3.18.0",
+			want:  `"repo:^github\\.com/sourcegraph/sourcegraph$@v3.18.0"`,
 		},
 		{
 			input: "repo:**sourcegraph",


### PR DESCRIPTION
Fixes #12892 
Relates to #12476 

This PR optimizes how we translate glob patterns of repo: filters

1. If a revision is specified we don't fuzzify. Example: `repo:foo@bar` is mapped to `repo:foo@bar`, while `repo:foo` is mapped to `repo:**foo**`
2. Heuristic for github.com because #12891 does not work for globbing if rev is not specified: `repo:github.com/repo` is mapped to `repo:github.com/repo**` instead of `repo:**github.com/repo**`.  
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
