### PR TITLE
Only restart services with goreman if they're running

### DIFF
--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -79,7 +79,7 @@ if [ ${#rebuilt[@]} -gt 0 ]; then
   if [ -n "$GOREMAN" ]; then
     for cmd in "${rebuilt[@]}"; do
       if $GOREMAN run list | grep -Ee "^${cmd}$"; then
-        $GOREMAN run restart ${cmd}
+        $GOREMAN run restart "${cmd}"
       fi
     done
   fi

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -77,8 +77,7 @@ if [ ${#rebuilt[@]} -gt 0 ]; then
   echo >&2 "Rebuilt: ${rebuilt[*]}"
 
   if [ -n "$GOREMAN" ]; then
-    for cmd in "${rebuilt[@]}";
-    do
+    for cmd in "${rebuilt[@]}"; do
       if $GOREMAN run list | grep -Ee "^${cmd}$"; then
         $GOREMAN run restart ${cmd}
       fi

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -77,7 +77,12 @@ if [ ${#rebuilt[@]} -gt 0 ]; then
   echo >&2 "Rebuilt: ${rebuilt[*]}"
 
   if [ -n "$GOREMAN" ]; then
-    $GOREMAN run restart "${rebuilt[@]}"
+    for cmd in "${rebuilt[@]}";
+    do
+      if $GOREMAN run list | grep -Ee "^${cmd}$"; then
+        $GOREMAN run restart ${cmd}
+      fi
+    done
   fi
 
 else


### PR DESCRIPTION
When running `./dev/start.sh` with a modified `Procfile`, or passing the
`--only`/`--except` options to it, the list of running services doesn't
match the list of binaries the `watch` command rebuilds.

So what happens is that you modify code, `watch` re-compiles the binaries
and runs into an error:

```
08:54:27  watch | Building with optimizations disabled (for debugging). Make sure you have at least go1.10 installed.
08:54:32  watch | Rebuilt: symbols precise-code-intel-bundle-manager precise-code-intel-worker
08:54:32  watch | goreman: unknown proc: symbols
```

Because `symbols` wasn't running now all three services aren't
restarted.

That cost me a lot of time and caused a ton of facepalms... so here's
the fix.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
