### PR TITLE
Handle creation of CampaignSpecs without ChangesetSpecs correctly

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -77,6 +77,10 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 	spec.NamespaceUserID = opts.NamespaceUserID
 	spec.UserID = actor.UID
 
+	if len(opts.ChangesetSpecRandIDs) == 0 {
+		return spec, s.store.CreateCampaignSpec(ctx, spec)
+	}
+
 	listOpts := ListChangesetSpecsOpts{Limit: -1, RandIDs: opts.ChangesetSpecRandIDs}
 	cs, _, err := s.store.ListChangesetSpecs(ctx, listOpts)
 	if err != nil {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -517,6 +517,31 @@ func TestService(t *testing.T) {
 				t.Fatalf("expected no error but got %s", err)
 			}
 		})
+
+		t.Run("no side-effects if no changeset spec IDs are given", func(t *testing.T) {
+			// We already have ChangesetSpecs in the database. Here we
+			// want to make sure that the new CampaignSpec is created,
+			// without accidently attaching the existing ChangesetSpecs.
+			opts := CreateCampaignSpecOpts{
+				NamespaceUserID:      admin.ID,
+				RawSpec:              ct.TestRawCampaignSpec,
+				ChangesetSpecRandIDs: []string{},
+			}
+
+			spec, err := svc.CreateCampaignSpec(adminCtx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			countOpts := CountChangesetSpecsOpts{CampaignSpecID: spec.ID}
+			count, err := store.CountChangesetSpecs(adminCtx, countOpts)
+			if err != nil {
+				return
+			}
+			if count != 0 {
+				t.Fatalf("want no changeset specs attached to campaign spec, but have %d", count)
+			}
+		})
 	})
 
 	t.Run("CreateChangesetSpec", func(t *testing.T) {


### PR DESCRIPTION
I ran into this while testing the reconciler: when you create a
CampaignSpec with 0 ChangesetSpecs and apply it, you should end up with
a Campaign that has 0 Changesets.

What you instead get is a Campaign with all the ChangesetSpecs that were
lying around in your database, because the `ListChangesetSpecs` call returns
all ChangesetSpecs if `RandIDs` is empty.

This fixes that.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
