### PR TITLE
repo-updater: No private repos on sourcegraph.com

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -523,6 +523,12 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 		}
 	}
 
+	if repo.Private {
+		return &protocol.RepoLookupResult{
+			ErrorNotFound: true,
+		}, nil
+	}
+
 	err = s.Syncer.SyncSubset(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -1071,6 +1071,19 @@ func TestRepoLookup(t *testing.T) {
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
 			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("git-codecommit.us-west-1.amazonaws.com/stripe-go"), true),
 		},
+		{
+			name: "Private repos are not supported on sourcegraph.com",
+			args: protocol.RepoLookupArgs{
+				Repo: api.RepoName(githubRepository.Name),
+			},
+			githubDotComSource: &fakeRepoSource{
+				repo: githubRepository.With(func(r *repos.Repo) {
+					r.Private = true
+				}),
+			},
+			result: &protocol.RepoLookupResult{ErrorNotFound: true},
+			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName(githubRepository.Name), true),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This commit makes it so that repo-updater's repo lookup endpoint returns
a "not found" for any private repo in either github.com or gitlab.com.

This is better than only relying on the access token in the external
service not having access to private repos and failing to clone those
repos in gitserver.

This change does not affect the normal syncer code paths, so we'll have
to consider how to not support private code (for now) there, before we
roll out everything from #12699.

Additional context: https://sourcegraph.slack.com/archives/C07KZF47K/p1597091562260500
