### PR TITLE
repo-updater: Add PerPage to StoreListExternalServicesArgs

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -69,8 +69,8 @@ type StoreListExternalServicesArgs struct {
 	RepoIDs []api.RepoID
 	// Kinds of external services to list. When zero-valued, this is omitted from the predicate set.
 	Kinds []string
-	// PerPage defines how many external services to fetch per page. If zero, DefaultListExternalServicePageSize
-	// will be used
+	// PerPage defines how many external services to fetch per page. When zero-valued,
+	// DefaultListExternalServicePageSize will be used.
 	PerPage int64
 }
 


### PR DESCRIPTION
To make it clear that pagination is used.

Also renamed a parameter from page to perPage as page wasn't clear. It
could also mean "which page to return".
