### PR TITLE
Avoid possible disaster by loading *all* changesets in campaign

### DIFF
--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -317,7 +317,10 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	}
 
 	// Load all Changesets attached to this Campaign.
-	changesets, _, err := tx.ListChangesets(ctx, ListChangesetsOpts{CampaignID: campaign.ID})
+	changesets, _, err := tx.ListChangesets(ctx, ListChangesetsOpts{
+		Limit:      -1,
+		CampaignID: campaign.ID,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Clickbaity title, yes. But is this deliciously subtle bug worth it? Maybe.