### PR TITLE
docker-images: Add ignite-ubuntu

### DIFF
--- a/docker-images/ignite-ubuntu/Dockerfile
+++ b/docker-images/ignite-ubuntu/Dockerfile
@@ -1,0 +1,8 @@
+FROM weaveworks/ignite-ubuntu:20.04-amd64@sha256:4f5f5ed56fae650ae122daa28a785192dda081be4f0b37dca2eb25ea57840500
+
+# hadolint ignore=DL3008,DL3009
+RUN set -ex && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    docker.io

--- a/docker-images/ignite-ubuntu/README.md
+++ b/docker-images/ignite-ubuntu/README.md
@@ -1,0 +1,5 @@
+# sourcegraph/ignite-ubuntu
+
+We produce a version of Ubuntu 20.04 (Focal Fossa) based on [weaveworks/ignite-ubuntu:20.04-amd64](https://github.com/weaveworks/ignite/blob/46bdd5d48425c4245fbe895e7da3621f491c3660/images/ubuntu/Dockerfile) that also contains the Docker distribution.
+
+This image serves as the base image for precise-code-intel-indexer [Firecracker](https://github.com/firecracker-microvm/firecracker) virtual machines in which we run user configured containers and code.

--- a/docker-images/ignite-ubuntu/build.sh
+++ b/docker-images/ignite-ubuntu/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+docker build -t "${IMAGE:-sourcegraph/ignite-ubuntu}" .

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -34,6 +34,7 @@ var allDockerImages = []string{
 	"syntax-highlighter",
 	"jaeger-agent",
 	"jaeger-all-in-one",
+	"ignite-ubuntu",
 }
 
 // Verifies the docs formatting and builds the `docsite` command.


### PR DESCRIPTION
Verified to work when the image is created locally on the compute node containing firecracker.

```
docker build -t ignite-ubuntu-local .
sudo ignite create ignite-ubuntu-local --name test --cpus 1 --memory 1GB --size 4GB --ssh --runtime docker
sudo ignite test
sudo ignite exec test "docker run sourcegraph/lsif-go lsif-go -h"
```
