### PR TITLE
debug: expose version in /-/debug/proxies/<instance>/vars pages

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"math"
 	"os"
@@ -17,6 +18,11 @@ var devTimestamp = strconv.FormatInt(time.Now().Unix(), 10) // build timestamp f
 //
 // The version may not be semver-compatible, e.g. `insiders` or `65769_2020-06-05_9bd91a3`.
 var version = devVersion
+
+func init() {
+	exportedVersion := expvar.NewString("sourcegraph.version")
+	exportedVersion.Set(version)
+}
 
 // Version returns the version string configured at build time.
 func Version() string {


### PR DESCRIPTION
wanted a quick way to find the exact version one of our processes is running

this exposes it in the debug proxy. you would see it for each process in 

```
https://<your SG instance>/-/debug/proxies/gitserver-0/vars
```

we can also add commit sha to this.
