### PR TITLE
codeintel: Remove tracer.Init from indexer-vm service

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/main.go
@@ -19,13 +19,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
-	tracer.Init()
+	// TODO(efritz) - disabled as it requires internal API access
+	// tracer.Init()
 
 	var (
 		frontendURL              = mustGet(rawFrontendURL, "PRECISE_CODE_INTEL_EXTERNAL_URL")


### PR DESCRIPTION
This currently reads config from the frontend which requires reading from the frontend's internal API. I left a note to figure out how to do this effectively from a separated deployment.