### PR TITLE
store: remove SetMaxConcurrentFetchTar

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -56,7 +56,6 @@ func main() {
 		},
 		Log: log15.Root(),
 	}
-	service.Store.SetMaxConcurrentFetchTar(10)
 	service.Store.Start()
 	handler := ot.Middleware(service)
 


### PR DESCRIPTION
This would immediately be overriden by 10 * gitserver
count. Additionally we move watching gitservers into its own goroutine,
instead of being shoe horned into the eviction goroutine.