### PR TITLE
tracer: prevent race when updating SpanURL

### DIFF
--- a/internal/trace/traceutil_test.go
+++ b/internal/trace/traceutil_test.go
@@ -1,0 +1,22 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+func TestSpanURL(t *testing.T) {
+	want := func(want string) {
+		t.Helper()
+		got := SpanURL(nil)
+		if got != want {
+			t.Fatalf("want %s, got %s", want, got)
+		}
+	}
+	want("#tracer-not-enabled")
+	SetSpanURLFunc(func(span opentracing.Span) string { return "test" })
+	want("test")
+	SetSpanURLFunc(nil)
+	want("#tracer-not-enabled")
+}

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -199,14 +199,14 @@ func initTracer(serviceName string) {
 		}
 
 		globalTracer.set(tracer, closer, opts.Debug)
-		trace.SpanURL = urlFunc
+		trace.SetSpanURLFunc(urlFunc)
 	})
 }
 
 func newTracer(opts *jaegerOpts) (opentracing.Tracer, func(span opentracing.Span) string, io.Closer, error) {
 	if !opts.Enabled {
 		log15.Info("opentracing: Jaeger disabled")
-		return opentracing.NoopTracer{}, trace.NoopSpanURL, nil, nil
+		return opentracing.NoopTracer{}, nil, nil, nil
 	}
 
 	log15.Info("opentracing: Jaeger enabled")


### PR DESCRIPTION
If someone adjusts the external URL or jaeger configuration, we will
update the "SpanURL" function. Previously this caused a race condition.
We add synchronisation around it.