### PR TITLE
tracer: watch configuration in background

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -150,13 +150,12 @@ func initTracer(serviceName string) {
 	// Initially everything is disabled since we haven't read conf yet.
 	oldOpts := jaegerOpts{
 		ServiceName: serviceName,
-		ExternalURL: conf.Get().ExternalURL,
 		Enabled:     false,
 		Debug:       false,
 	}
 
 	// Watch loop
-	conf.Watch(func() {
+	go conf.Watch(func() {
 		siteConfig := conf.Get()
 
 		// Set sampling strategy


### PR DESCRIPTION
This allows services to get started before they are able to reach the
frontend. This is useful when a service could be making progress without
frontend. Additionally it makes it easier to test services in
isolation (without frontend).

Depends on https://github.com/sourcegraph/sourcegraph/pull/12928
