### PR TITLE
Refactor `SourcegraphWebApp` for performance improvement

### DIFF
--- a/web/src/util/globbing.ts
+++ b/web/src/util/globbing.ts
@@ -5,4 +5,4 @@ import { isErrorLike } from '../../../shared/src/util/errors'
  * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise
  */
 export const globbingEnabledFromSettings = (settings: SettingsCascadeOrError): boolean =>
-    Boolean(settings.final && !isErrorLike(settings.final) && settings.final['search.globbing'])
+    !!(settings.final && !isErrorLike(settings.final) && settings.final['search.globbing'])

--- a/web/src/util/globbing.ts
+++ b/web/src/util/globbing.ts
@@ -5,4 +5,4 @@ import { isErrorLike } from '../../../shared/src/util/errors'
  * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise
  */
 export const globbingEnabledFromSettings = (settings: SettingsCascadeOrError): boolean =>
-    settings.final && !isErrorLike(settings.final) && settings.final['search.globbing']
+    Boolean(settings.final && !isErrorLike(settings.final) && settings.final['search.globbing'])

--- a/web/src/util/settings.ts
+++ b/web/src/util/settings.ts
@@ -1,0 +1,67 @@
+import * as GQL from '../../../shared/src/graphql/schema'
+import { SettingsCascadeOrError } from '../../../shared/src/settings/settings'
+import { isErrorLike } from '../../../shared/src/util/errors'
+import { LayoutProps } from '../Layout'
+import { parseSearchURLPatternType } from '../search'
+import { SettingsExperimentalFeatures } from '../schema/settings.schema'
+
+/** A fallback settings subject that can be constructed synchronously at initialization time. */
+export const SITE_SUBJECT_NO_ADMIN: Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdminister'> = {
+    id: window.context.siteGQLID,
+    viewerCanAdminister: false,
+}
+
+export function viewerSubjectFromSettings(
+    cascade: SettingsCascadeOrError,
+    authenticatedUser: GQL.IUser | null
+): LayoutProps['viewerSubject'] {
+    if (authenticatedUser) {
+        return authenticatedUser
+    }
+    if (cascade && !isErrorLike(cascade) && cascade.subjects && cascade.subjects.length > 0) {
+        return cascade.subjects[0].subject
+    }
+    return SITE_SUBJECT_NO_ADMIN
+}
+
+export function defaultPatternTypeFromSettings(
+    settingsCascade: SettingsCascadeOrError
+): GQL.SearchPatternType | undefined {
+    // When the web app mounts, if the current page does not have a patternType URL
+    // parameter, set the search pattern type to the defaultPatternType from settings
+    // (if it is set), otherwise default to literal.
+    //
+    // For search result URLs that have no patternType= query parameter,
+    // the `SearchResults` component will append &patternType=regexp
+    // to the URL to ensure legacy search links continue to work.
+    if (!parseSearchURLPatternType(window.location.search)) {
+        const defaultPatternType =
+            settingsCascade.final &&
+            !isErrorLike(settingsCascade.final) &&
+            settingsCascade.final['search.defaultPatternType']
+        return defaultPatternType || 'literal'
+    }
+    return
+}
+
+export function experimentalFeaturesFromSettings(
+    settingsCascade: SettingsCascadeOrError
+): {
+    splitSearchModes: boolean
+    smartSearchField: boolean
+    copyQueryButton: boolean
+    showRepogroupHomepage: boolean
+} {
+    const experimentalFeatures: SettingsExperimentalFeatures =
+        (settingsCascade.final && !isErrorLike(settingsCascade.final) && settingsCascade.final.experimentalFeatures) ||
+        {}
+
+    const {
+        splitSearchModes = true,
+        smartSearchField = true,
+        copyQueryButton = false,
+        showRepogroupHomepage = false,
+    } = experimentalFeatures
+
+    return { splitSearchModes, smartSearchField, copyQueryButton, showRepogroupHomepage }
+}


### PR DESCRIPTION
Implement medium-term proposal from #12637. 

I combined 6 state-setting subscriptions into 1. Logic for turning settings into state now lives in util functions. Result: only one render when toggling extensions or updating settings.

