### PR TITLE
Add telemetry opt-in to the Firefox add-on

### DIFF
--- a/browser/src/browser-extension/options-page/OptionsContainer.test.tsx
+++ b/browser/src/browser-extension/options-page/OptionsContainer.test.tsx
@@ -12,8 +12,8 @@ describe('OptionsContainer', () => {
         | 'fetchCurrentTabStatus'
         | 'ensureValidSite'
         | 'toggleExtensionDisabled'
-        | 'toggleFeatureFlag'
-        | 'featureFlags'
+        | 'onChangeOptionFlag'
+        | 'optionFlags'
         | 'hasPermissions'
         | 'requestPermissions'
     > = {
@@ -23,8 +23,8 @@ describe('OptionsContainer', () => {
         fetchCurrentTabStatus: () => Promise.resolve(undefined),
         ensureValidSite: (url: string) => new Observable<void>(),
         toggleExtensionDisabled: (isActivated: boolean) => Promise.resolve(undefined),
-        toggleFeatureFlag: noop,
-        featureFlags: [],
+        onChangeOptionFlag: noop,
+        optionFlags: [],
     }
 
     test('checks the connection status when it mounts', () => {

--- a/browser/src/browser-extension/options-page/OptionsContainer.tsx
+++ b/browser/src/browser-extension/options-page/OptionsContainer.tsx
@@ -8,7 +8,7 @@ import { getExtensionVersion } from '../../shared/util/context'
 import { OptionsMenu, OptionsMenuProps } from './OptionsMenu'
 import { ConnectionErrors } from './ServerUrlForm'
 import { isHTTPAuthError } from '../../../../shared/src/backend/fetch'
-import { OptionFlagWithValue, OptionFlagKey } from '../../shared/util/optionFlags'
+import { OptionFlagWithValue } from '../../shared/util/optionFlags'
 
 export interface OptionsContainerProps {
     sourcegraphURL: string
@@ -19,7 +19,7 @@ export interface OptionsContainerProps {
     requestPermissions: (url: string) => void
     setSourcegraphURL: (url: string) => Promise<void>
     toggleExtensionDisabled: (isActivated: boolean) => Promise<void>
-    onChangeOptionFlag: (key: OptionFlagKey, value: boolean) => void
+    onChangeOptionFlag: (key: string, value: boolean) => void
     optionFlags: OptionFlagWithValue[]
 }
 

--- a/browser/src/browser-extension/options-page/OptionsContainer.tsx
+++ b/browser/src/browser-extension/options-page/OptionsContainer.tsx
@@ -29,7 +29,7 @@ interface OptionsContainerState
         | 'status'
         | 'sourcegraphURL'
         | 'connectionError'
-        | 'isOptionsMenuExpanded'
+        | 'showOptionFlags'
         | 'isActivated'
         | 'urlHasPermissions'
         | 'currentTabStatus'
@@ -53,7 +53,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
             isActivated: props.isActivated,
             urlHasPermissions: false,
             connectionError: undefined,
-            isOptionsMenuExpanded: false,
+            showOptionFlags: false,
         }
 
         const fetchingSite: Observable<string | ErrorLike> = this.urlUpdates.pipe(
@@ -156,7 +156,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
 
     private handleClickExpandOptionsMenu = (): void => {
         this.setState(state => ({
-            isOptionsMenuExpanded: !state.isOptionsMenuExpanded,
+            showOptionFlags: !state.showOptionFlags,
         }))
     }
 

--- a/browser/src/browser-extension/options-page/OptionsContainer.tsx
+++ b/browser/src/browser-extension/options-page/OptionsContainer.tsx
@@ -8,6 +8,7 @@ import { getExtensionVersion } from '../../shared/util/context'
 import { OptionsMenu, OptionsMenuProps } from './OptionsMenu'
 import { ConnectionErrors } from './ServerUrlForm'
 import { isHTTPAuthError } from '../../../../shared/src/backend/fetch'
+import { OptionFlagWithValue, OptionFlagKey } from '../../shared/util/optionFlags'
 
 export interface OptionsContainerProps {
     sourcegraphURL: string
@@ -18,8 +19,8 @@ export interface OptionsContainerProps {
     requestPermissions: (url: string) => void
     setSourcegraphURL: (url: string) => Promise<void>
     toggleExtensionDisabled: (isActivated: boolean) => Promise<void>
-    toggleFeatureFlag: (key: string) => void
-    featureFlags: { key: string; value: boolean }[]
+    onChangeOptionFlag: (key: OptionFlagKey, value: boolean) => void
+    optionFlags: OptionFlagWithValue[]
 }
 
 interface OptionsContainerState
@@ -28,7 +29,7 @@ interface OptionsContainerState
         | 'status'
         | 'sourcegraphURL'
         | 'connectionError'
-        | 'isSettingsOpen'
+        | 'isOptionsMenuExpanded'
         | 'isActivated'
         | 'urlHasPermissions'
         | 'currentTabStatus'
@@ -52,7 +53,7 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
             isActivated: props.isActivated,
             urlHasPermissions: false,
             connectionError: undefined,
-            isSettingsOpen: false,
+            isOptionsMenuExpanded: false,
         }
 
         const fetchingSite: Observable<string | ErrorLike> = this.urlUpdates.pipe(
@@ -136,9 +137,9 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
                 onURLChange={this.handleURLChange}
                 onURLSubmit={this.handleURLSubmit}
                 isActivated={this.props.isActivated}
-                toggleFeatureFlag={this.props.toggleFeatureFlag}
-                featureFlags={this.props.featureFlags}
-                onSettingsClick={this.handleSettingsClick}
+                onChangeOptionFlag={this.props.onChangeOptionFlag}
+                optionFlags={this.props.optionFlags}
+                onClickExpandOptionsMenu={this.handleClickExpandOptionsMenu}
                 onToggleActivationClick={this.handleToggleActivationClick}
                 requestPermissions={this.props.requestPermissions}
             />
@@ -153,9 +154,9 @@ export class OptionsContainer extends React.Component<OptionsContainerProps, Opt
         await this.props.setSourcegraphURL(this.state.sourcegraphURL)
     }
 
-    private handleSettingsClick = (): void => {
+    private handleClickExpandOptionsMenu = (): void => {
         this.setState(state => ({
-            isSettingsOpen: !state.isSettingsOpen,
+            isOptionsMenuExpanded: !state.isOptionsMenuExpanded,
         }))
     }
 

--- a/browser/src/browser-extension/options-page/OptionsHeader.tsx
+++ b/browser/src/browser-extension/options-page/OptionsHeader.tsx
@@ -7,7 +7,7 @@ export interface OptionsHeaderProps {
     version: string
     assetsDir?: string
     isActivated: boolean
-    onSettingsClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+    onClickExpandOptionsMenu: (event: React.MouseEvent<HTMLButtonElement>) => void
     onToggleActivationClick: (value: boolean) => void
 }
 
@@ -16,7 +16,7 @@ export const OptionsHeader: React.FunctionComponent<OptionsHeaderProps> = ({
     version,
     assetsDir,
     isActivated,
-    onSettingsClick,
+    onClickExpandOptionsMenu,
     onToggleActivationClick,
 }: OptionsHeaderProps) => (
     <div className={`options-header ${className || ''}`}>
@@ -25,7 +25,7 @@ export const OptionsHeader: React.FunctionComponent<OptionsHeaderProps> = ({
             <div className="options-header__version">v{version}</div>
         </div>
         <div className="options-header__right">
-            <button type="button" className="options-header__settings btn btn-icon" onClick={onSettingsClick}>
+            <button type="button" className="options-header__settings btn btn-icon" onClick={onClickExpandOptionsMenu}>
                 <SettingsOutlineIcon className="icon-inline" />
             </button>
             <Toggle

--- a/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
@@ -18,7 +18,7 @@ storiesOf('browser/Options/OptionsMenu', module)
             sourcegraphURL="https://sourcegraph.com"
             onURLChange={action('Sourcegraph URL changed')}
             onURLSubmit={action('New Sourcegraph URL submitted')}
-            onSettingsClick={action('Settings clicked')}
+            onClickExpandOptionsMenu={action('Expand clicked')}
             onToggleActivationClick={action('Toggle activation clicked')}
             optionFlags={[]}
             isOptionsMenuExpanded={false}

--- a/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
@@ -21,9 +21,9 @@ storiesOf('browser/Options/OptionsMenu', module)
             onClickExpandOptionsMenu={action('Expand clicked')}
             onToggleActivationClick={action('Toggle activation clicked')}
             optionFlags={[]}
-            isOptionsMenuExpanded={false}
+            showOptionFlags={false}
             isActivated={true}
-            onChangeOptionFlag={action('Feature flag changed')}
+            onChangeOptionFlag={action('Option flag changed')}
             requestPermissions={() => undefined}
             urlHasPermissions={true}
         />
@@ -35,11 +35,11 @@ storiesOf('browser/Options/OptionsMenu', module)
             sourcegraphURL="https://sourcegraph.com"
             onURLChange={action('Sourcegraph URL changed')}
             onURLSubmit={action('New Sourcegraph URL submitted')}
-            onClickExpandOptionsMenu={action('Settings clicked')}
+            onClickExpandOptionsMenu={action('Expand clicked')}
             onToggleActivationClick={action('Toggle activation clicked')}
-            isOptionsMenuExpanded={true}
+            showOptionFlags={true}
             isActivated={true}
-            onChangeOptionFlag={action('Feature flag changed')}
+            onChangeOptionFlag={action('Option flag changed')}
             optionFlags={[
                 { label: 'Test setting 1', key: 'testSetting1', value: true },
                 { label: 'Test setting 2', key: 'testSetting2', value: false },

--- a/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
@@ -20,10 +20,10 @@ storiesOf('browser/Options/OptionsMenu', module)
             onURLSubmit={action('New Sourcegraph URL submitted')}
             onSettingsClick={action('Settings clicked')}
             onToggleActivationClick={action('Toggle activation clicked')}
-            featureFlags={[]}
-            isSettingsOpen={false}
+            optionFlags={[]}
+            isOptionsMenuExpanded={false}
             isActivated={true}
-            toggleFeatureFlag={action('Feature flag toggled')}
+            onChangeOptionFlag={action('Feature flag changed')}
             requestPermissions={() => undefined}
             urlHasPermissions={true}
         />
@@ -37,12 +37,12 @@ storiesOf('browser/Options/OptionsMenu', module)
             onURLSubmit={action('New Sourcegraph URL submitted')}
             onSettingsClick={action('Settings clicked')}
             onToggleActivationClick={action('Toggle activation clicked')}
-            isSettingsOpen={true}
+            isOptionsMenuExpanded={true}
             isActivated={true}
-            toggleFeatureFlag={action('Feature flag toggled')}
-            featureFlags={[
-                { key: 'Test setting 1', value: true },
-                { key: 'Test setting 2', value: false },
+            onChangeOptionFlag={action('Feature flag changed')}
+            optionFlags={[
+                { label: 'Test setting 1', key: 'testSetting1', value: true },
+                { label: 'Test setting 2', key: 'testSetting2', value: false },
             ]}
             requestPermissions={() => undefined}
             urlHasPermissions={true}

--- a/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.story.tsx
@@ -35,7 +35,7 @@ storiesOf('browser/Options/OptionsMenu', module)
             sourcegraphURL="https://sourcegraph.com"
             onURLChange={action('Sourcegraph URL changed')}
             onURLSubmit={action('New Sourcegraph URL submitted')}
-            onSettingsClick={action('Settings clicked')}
+            onClickExpandOptionsMenu={action('Settings clicked')}
             onToggleActivationClick={action('Toggle activation clicked')}
             isOptionsMenuExpanded={true}
             isActivated={true}

--- a/browser/src/browser-extension/options-page/OptionsMenu.test.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.test.tsx
@@ -95,8 +95,8 @@ describe('OptionsMenu', () => {
                     {...stubs}
                     isOptionsMenuExpanded={true}
                     optionFlags={[
-                        { key: 'foo', value: true },
-                        { key: 'bar', value: false },
+                        { label: 'Foo', key: 'foo', value: true },
+                        { label: 'Bar', key: 'bar', value: false },
                     ]}
                 />
             )
@@ -110,8 +110,8 @@ describe('OptionsMenu', () => {
                 {...stubs}
                 isOptionsMenuExpanded={true}
                 optionFlags={[
-                    { key: 'foo', value: true },
-                    { key: 'bar', value: false },
+                    { label: 'Foo', key: 'foo', value: true },
+                    { label: 'Bar', key: 'bar', value: false },
                 ]}
                 onChangeOptionFlag={toggleFeatureFlag}
             />

--- a/browser/src/browser-extension/options-page/OptionsMenu.test.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.test.tsx
@@ -93,7 +93,7 @@ describe('OptionsMenu', () => {
             renderer.create(
                 <OptionsMenu
                     {...stubs}
-                    isOptionsMenuExpanded={true}
+                    showOptionFlags={true}
                     optionFlags={[
                         { label: 'Foo', key: 'foo', value: true },
                         { label: 'Bar', key: 'bar', value: false },
@@ -108,7 +108,7 @@ describe('OptionsMenu', () => {
         const { container } = render(
             <OptionsMenu
                 {...stubs}
-                isOptionsMenuExpanded={true}
+                showOptionFlags={true}
                 optionFlags={[
                     { label: 'Foo', key: 'foo', value: true },
                     { label: 'Bar', key: 'bar', value: false },

--- a/browser/src/browser-extension/options-page/OptionsMenu.test.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.test.tsx
@@ -21,9 +21,9 @@ describe('OptionsMenu', () => {
         onURLChange: noop,
         onURLSubmit: noop,
         isActivated: true,
-        toggleFeatureFlag: noop,
+        onChangeOptionFlag: noop,
         onToggleActivationClick: noop,
-        onSettingsClick: noop,
+        onClickExpandOptionsMenu: noop,
     }
 
     test('renders a default state', () => {
@@ -93,8 +93,8 @@ describe('OptionsMenu', () => {
             renderer.create(
                 <OptionsMenu
                     {...stubs}
-                    isSettingsOpen={true}
-                    featureFlags={[
+                    isOptionsMenuExpanded={true}
+                    optionFlags={[
                         { key: 'foo', value: true },
                         { key: 'bar', value: false },
                     ]}
@@ -108,12 +108,12 @@ describe('OptionsMenu', () => {
         const { container } = render(
             <OptionsMenu
                 {...stubs}
-                isSettingsOpen={true}
-                featureFlags={[
+                isOptionsMenuExpanded={true}
+                optionFlags={[
                     { key: 'foo', value: true },
                     { key: 'bar', value: false },
                 ]}
-                toggleFeatureFlag={toggleFeatureFlag}
+                onChangeOptionFlag={toggleFeatureFlag}
             />
         )
         const fooCheckbox = container.querySelector('#foo')!

--- a/browser/src/browser-extension/options-page/OptionsMenu.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { OptionsHeader, OptionsHeaderProps } from './OptionsHeader'
 import { ServerUrlForm, ServerUrlFormProps } from './ServerUrlForm'
-import { OptionFlagWithValue } from '../../shared/util/optionFlags'
+import { OptionFlagWithValue, OptionFlagKey } from '../../shared/util/optionFlags'
 
 export interface OptionsMenuProps
     extends OptionsHeaderProps,
@@ -12,7 +12,7 @@ export interface OptionsMenuProps
 
     isOptionsMenuExpanded?: boolean
     isActivated: boolean
-    onChangeOptionFlag: (key: string, value: boolean) => void
+    onChangeOptionFlag: (key: OptionFlagKey, value: boolean) => void
     optionFlags?: OptionFlagWithValue[]
     currentTabStatus?: {
         host: string

--- a/browser/src/browser-extension/options-page/OptionsMenu.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { OptionsHeader, OptionsHeaderProps } from './OptionsHeader'
 import { ServerUrlForm, ServerUrlFormProps } from './ServerUrlForm'
-import { OptionFlagWithValue, OptionFlagKey } from '../../shared/util/optionFlags'
 
 export interface OptionsMenuProps
     extends OptionsHeaderProps,
@@ -12,8 +11,8 @@ export interface OptionsMenuProps
 
     isOptionsMenuExpanded?: boolean
     isActivated: boolean
-    onChangeOptionFlag: (key: OptionFlagKey, value: boolean) => void
-    optionFlags?: OptionFlagWithValue[]
+    onChangeOptionFlag: (key: string, value: boolean) => void
+    optionFlags?: { key: string; label: string; value: boolean }[]
     currentTabStatus?: {
         host: string
         protocol: string
@@ -109,23 +108,20 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
             <div className="options-menu__section">
                 <label>Configuration</label>
                 <div>
-                    {options.map(
-                        ({ label, key, value, hidden }) =>
-                            !hidden && (
-                                <div className="form-check" key={key}>
-                                    <label className="form-check-label">
-                                        <input
-                                            id={key}
-                                            onChange={event => onChangeOptionFlag(key, event.target.checked)}
-                                            className="form-check-input"
-                                            type="checkbox"
-                                            checked={value}
-                                        />{' '}
-                                        {label}
-                                    </label>
-                                </div>
-                            )
-                    )}
+                    {options.map(({ label, key, value }) => (
+                        <div className="form-check" key={key}>
+                            <label className="form-check-label">
+                                <input
+                                    id={key}
+                                    onChange={event => onChangeOptionFlag(key, event.target.checked)}
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    checked={value}
+                                />{' '}
+                                {label}
+                            </label>
+                        </div>
+                    ))}
                 </div>
             </div>
         )}

--- a/browser/src/browser-extension/options-page/OptionsMenu.tsx
+++ b/browser/src/browser-extension/options-page/OptionsMenu.tsx
@@ -9,7 +9,7 @@ export interface OptionsMenuProps
     onURLChange: ServerUrlFormProps['onChange']
     onURLSubmit: ServerUrlFormProps['onSubmit']
 
-    isOptionsMenuExpanded?: boolean
+    showOptionFlags?: boolean
     isActivated: boolean
     onChangeOptionFlag: (key: string, value: boolean) => void
     optionFlags?: { key: string; label: string; value: boolean }[]
@@ -23,7 +23,7 @@ export interface OptionsMenuProps
 /**
  * Determine if the options menu is being showed as a popup panel (opened via
  * the toolbar icon) or as a full page (opened via the options URL on a page of
- * its owen)
+ * its own)
  */
 const isFullPage = (): boolean => !new URLSearchParams(window.location.search).get('popup')
 
@@ -44,7 +44,7 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
     sourcegraphURL,
     onURLChange,
     onURLSubmit,
-    isOptionsMenuExpanded,
+    showOptionFlags,
     isActivated,
     onChangeOptionFlag,
     optionFlags: options,
@@ -104,7 +104,7 @@ export const OptionsMenu: React.FunctionComponent<OptionsMenuProps> = ({
                 .
             </p>
         </div>
-        {isOptionsMenuExpanded && options && (
+        {showOptionFlags && options && (
             <div className="options-menu__section">
                 <label>Configuration</label>
                 <div>

--- a/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -25,7 +25,7 @@ const IS_EXTENSION = true
 
 type State = Pick<
     FeatureFlags,
-    'allowErrorReporting' | 'experimentalLinkPreviews' | 'experimentalTextFieldCompletion'
+    'allowErrorReporting' | 'experimentalLinkPreviews' | 'experimentalTextFieldCompletion' | 'sendTelemetry'
 > & { sourcegraphURL: string | null; isActivated: boolean }
 
 const keyIsFeatureFlag = (key: string): key is keyof FeatureFlags =>
@@ -64,7 +64,10 @@ class Options extends React.Component<{}, State> {
     public state: State = {
         sourcegraphURL: null,
         isActivated: true,
+
+        // Feature flags
         allowErrorReporting: false,
+        sendTelemetry: false,
         experimentalLinkPreviews: false,
         experimentalTextFieldCompletion: false,
     }
@@ -74,7 +77,12 @@ class Options extends React.Component<{}, State> {
     public componentDidMount(): void {
         this.subscriptions.add(
             observeStorageKey('sync', 'featureFlags').subscribe(featureFlags => {
-                const { allowErrorReporting, experimentalLinkPreviews, experimentalTextFieldCompletion } = {
+                const {
+                    allowErrorReporting,
+                    experimentalLinkPreviews,
+                    experimentalTextFieldCompletion,
+                    sendTelemetry,
+                } = {
                     ...featureFlagDefaults,
                     ...featureFlags,
                 }
@@ -82,6 +90,7 @@ class Options extends React.Component<{}, State> {
                     allowErrorReporting,
                     experimentalLinkPreviews,
                     experimentalTextFieldCompletion,
+                    sendTelemetry,
                 })
             })
         )
@@ -129,6 +138,7 @@ class Options extends React.Component<{}, State> {
             toggleExtensionDisabled: (isActivated: boolean) => storage.sync.set({ disableExtension: !isActivated }),
             toggleFeatureFlag,
             featureFlags: [
+                { key: 'sendTelemetry', value: this.state.sendTelemetry },
                 { key: 'allowErrorReporting', value: this.state.allowErrorReporting },
                 { key: 'experimentalLinkPreviews', value: this.state.experimentalLinkPreviews },
                 { key: 'experimentalTextFieldCompletion', value: this.state.experimentalTextFieldCompletion },

--- a/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -8,7 +8,6 @@ import { GraphQLResult } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { background } from '../web-extension-api/runtime'
 import { observeStorageKey, storage } from '../web-extension-api/storage'
-import { featureFlagDefaults, FeatureFlags } from '../web-extension-api/types'
 import { OptionsContainer, OptionsContainerProps } from '../options-page/OptionsContainer'
 import { OptionsMenuProps } from '../options-page/OptionsMenu'
 import { initSentry } from '../../shared/sentry'
@@ -20,6 +19,7 @@ import {
     assignOptionFlagValues,
     observeOptionFlags,
     shouldOverrideSendTelemetry,
+    optionFlagDefinitions,
 } from '../../shared/util/optionFlags'
 import { assertEnvironment } from '../environmentAssertion'
 import { observeSourcegraphURL, isFirefox } from '../../shared/util/context'
@@ -38,8 +38,8 @@ interface State {
     optionFlags: OptionFlagWithValue[]
 }
 
-const keyIsFeatureFlag = (key: string): key is keyof FeatureFlags =>
-    !!Object.keys(featureFlagDefaults).find(featureFlag => key === featureFlag)
+const isOptionFlagKey = (key: string): key is OptionFlagKey =>
+    !!optionFlagDefinitions.find(definition => definition.key === key)
 
 const fetchCurrentTabStatus = async (): Promise<OptionsMenuProps['currentTabStatus']> => {
     const tabs = await browser.tabs.query({ active: true, currentWindow: true })
@@ -137,8 +137,8 @@ class Options extends React.Component<{}, State> {
 
             setSourcegraphURL: (sourcegraphURL: string) => storage.sync.set({ sourcegraphURL }),
             toggleExtensionDisabled: (isActivated: boolean) => storage.sync.set({ disableExtension: !isActivated }),
-            onChangeOptionFlag: (key: OptionFlagKey, value: boolean) => {
-                if (keyIsFeatureFlag(key)) {
+            onChangeOptionFlag: (key: string, value: boolean) => {
+                if (isOptionFlagKey(key)) {
                     featureFlags.set(key, value).then(noop, noop)
                 }
             },

--- a/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -3,7 +3,7 @@ import '../../shared/polyfills'
 
 import * as React from 'react'
 import { render } from 'react-dom'
-import { from, noop, Observable, Subscription } from 'rxjs'
+import { from, noop, Observable, Subscription, combineLatest } from 'rxjs'
 import { GraphQLResult } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { background } from '../web-extension-api/runtime'
@@ -14,9 +14,17 @@ import { OptionsMenuProps } from '../options-page/OptionsMenu'
 import { initSentry } from '../../shared/sentry'
 import { fetchSite } from '../../shared/backend/server'
 import { featureFlags } from '../../shared/util/featureFlags'
-import { OptionFlagKey } from '../../shared/util/optionFlags'
+import {
+    OptionFlagKey,
+    OptionFlagWithValue,
+    assignOptionFlagValues,
+    observeOptionFlags,
+    shouldOverrideSendTelemetry,
+} from '../../shared/util/optionFlags'
 import { assertEnvironment } from '../environmentAssertion'
-import { observeSourcegraphURL } from '../../shared/util/context'
+import { observeSourcegraphURL, isFirefox } from '../../shared/util/context'
+import { map } from 'rxjs/operators'
+import { isExtension } from '../../shared/context'
 
 assertEnvironment('OPTIONS')
 
@@ -24,10 +32,11 @@ initSentry('options')
 
 const IS_EXTENSION = true
 
-type State = Pick<
-    FeatureFlags,
-    'allowErrorReporting' | 'experimentalLinkPreviews' | 'experimentalTextFieldCompletion' | 'sendTelemetry'
-> & { sourcegraphURL: string | null; isActivated: boolean }
+interface State {
+    sourcegraphURL: string | null
+    isActivated: boolean
+    optionFlags: OptionFlagWithValue[]
+}
 
 const keyIsFeatureFlag = (key: string): key is keyof FeatureFlags =>
     !!Object.keys(featureFlagDefaults).find(featureFlag => key === featureFlag)
@@ -53,8 +62,21 @@ function requestGraphQL<T, V = object>(options: { request: string; variables: V 
     return from(background.requestGraphQL<T, V>(options))
 }
 
-const observeOptionFlags = (): Observable<Partial<FeatureFlags> | undefined> =>
-    observeStorageKey('sync', 'featureFlags')
+const observeOptionFlagsWithValues = (): Observable<OptionFlagWithValue[]> => {
+    const overrideSendTelemetry: Observable<boolean> = observeSourcegraphURL(IS_EXTENSION).pipe(
+        map(sourcegraphUrl => shouldOverrideSendTelemetry(isFirefox(), isExtension, sourcegraphUrl))
+    )
+
+    return combineLatest([observeOptionFlags(), overrideSendTelemetry]).pipe(
+        map(([flags, override]) => {
+            const definitions = assignOptionFlagValues(flags)
+            if (override) {
+                return definitions.filter(flag => flag.key !== 'sendTelemetry')
+            }
+            return definitions
+        })
+    )
+}
 
 const ensureValidSite = (): Observable<GQL.ISite> => fetchSite(requestGraphQL)
 
@@ -62,34 +84,15 @@ class Options extends React.Component<{}, State> {
     public state: State = {
         sourcegraphURL: null,
         isActivated: true,
-
-        // Feature flags
-        allowErrorReporting: false,
-        sendTelemetry: false,
-        experimentalLinkPreviews: false,
-        experimentalTextFieldCompletion: false,
+        optionFlags: [],
     }
 
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            observeOptionFlags().subscribe(optionFlags => {
-                const {
-                    allowErrorReporting,
-                    experimentalLinkPreviews,
-                    experimentalTextFieldCompletion,
-                    sendTelemetry,
-                } = {
-                    ...featureFlagDefaults,
-                    ...optionFlags,
-                }
-                this.setState({
-                    allowErrorReporting,
-                    experimentalLinkPreviews,
-                    experimentalTextFieldCompletion,
-                    sendTelemetry,
-                })
+            observeOptionFlagsWithValues().subscribe(optionFlags => {
+                this.setState({ optionFlags })
             })
         )
 
@@ -139,28 +142,7 @@ class Options extends React.Component<{}, State> {
                     featureFlags.set(key, value).then(noop, noop)
                 }
             },
-            optionFlags: [
-                {
-                    key: 'sendTelemetry',
-                    label: 'Send telemetry',
-                    value: this.state.sendTelemetry,
-                },
-                {
-                    key: 'allowErrorReporting',
-                    label: 'Allow error reporting',
-                    value: this.state.allowErrorReporting,
-                },
-                {
-                    key: 'experimentalLinkPreviews',
-                    label: 'Experimental link previews',
-                    value: this.state.experimentalLinkPreviews,
-                },
-                {
-                    key: 'experimentalTextFieldCompletion',
-                    label: 'Experimental text field completion',
-                    value: this.state.experimentalTextFieldCompletion,
-                },
-            ],
+            optionFlags: this.state.optionFlags,
         }
 
         return <OptionsContainer {...props} />

--- a/browser/src/browser-extension/web-extension-api/types.ts
+++ b/browser/src/browser-extension/web-extension-api/types.ts
@@ -17,6 +17,11 @@ export interface FeatureFlags {
     allowErrorReporting: boolean
 
     /**
+     * Send telemetry
+     */
+    sendTelemetry: boolean
+
+    /**
      * Support link previews from extensions in content views (such as GitHub issues).
      */
     experimentalLinkPreviews: boolean
@@ -29,6 +34,7 @@ export interface FeatureFlags {
 
 export const featureFlagDefaults: FeatureFlags = {
     allowErrorReporting: false,
+    sendTelemetry: true,
     experimentalLinkPreviews: false,
     experimentalTextFieldCompletion: false,
 }

--- a/browser/src/browser-extension/web-extension-api/types.ts
+++ b/browser/src/browser-extension/web-extension-api/types.ts
@@ -1,4 +1,5 @@
 import { GraphQLResult } from '../../../../shared/src/graphql/graphql'
+import { OptionFlagValues } from '../../shared/util/optionFlags'
 
 export interface PhabricatorMapping {
     callsign: string
@@ -52,7 +53,7 @@ export interface SyncStorageItems extends SourcegraphURL {
     /**
      * Storage for feature flags.
      */
-    featureFlags: Partial<FeatureFlags>
+    featureFlags: Partial<OptionFlagValues>
     /**
      * Overrides settings from Sourcegraph.
      */

--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -1066,24 +1066,17 @@ export function injectCodeIntelligenceToCodeHost(
     )
     const { requestGraphQL } = platformContext
 
-    const sendTelemetryOptionFlagObserverable = observeStorageKey('sync', 'featureFlags').pipe(
+    const sendTelemetryOptionFlagObservable = observeStorageKey('sync', 'featureFlags').pipe(
         tap(value => console.log('Feature flags changed', value)),
-        distinct(value => !!value?.sendTelemetry),
-        pluck('sendTelemetry'),
+        map(value => !!value?.sendTelemetry),
+        distinctUntilChanged(),
         tap(value => {
             console.log('sendTelemetry changed', value)
         })
     )
 
-    // Debug message TODO(marek) remove debug message
-    subscriptions.add(
-        sendTelemetryOptionFlagObserverable.subscribe(value => {
-            console.log('Observed a change in sendTelemetry', value)
-        })
-    )
-
     const innerTelemetryService = new EventLogger(isExtension, requestGraphQL)
-    const telemetryService = new ConditionalTelemetryService(innerTelemetryService, sendTelemetryOptionFlagObserverable)
+    const telemetryService = new ConditionalTelemetryService(innerTelemetryService, sendTelemetryOptionFlagObservable)
 
     subscriptions.add(extensionsController)
 

--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -1062,7 +1062,13 @@ export function injectCodeIntelligenceToCodeHost(
         isExtension
     )
     const { requestGraphQL } = platformContext
+    const sendTelemetry = featureFlags.isEnabled('sendTelemetry').then(value => {
+        console.log('Value of feature flag sendTelemetry in injectCodeIntelligenceToCodeHost:', value)
+    })
+
+    console.log('Creating telemetry service')
     const telemetryService = new EventLogger(isExtension, requestGraphQL)
+
     subscriptions.add(extensionsController)
 
     let codeHostSubscription: Subscription

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash'
-import { Observable, ReplaySubject, Subscribable, Subscription } from 'rxjs'
+import { Observable, ReplaySubject, Subscription } from 'rxjs'
 import { take } from 'rxjs/operators'
 import * as uuid from 'uuid'
 import * as GQL from '../../../../shared/src/graphql/schema'
@@ -43,13 +43,11 @@ export class ConditionalTelemetryService implements TelemetryService {
 
     public log(eventName: string, eventProperties?: any): void {
         if (this.isEnabled) {
-            console.log(`ConditionalTelemetryService log ${eventName}`)
             this.innerTelemetryService.log(eventName, eventProperties)
         }
     }
     public logViewEvent(eventName: string): void {
         if (this.isEnabled) {
-            console.log(`ConditionalTelemetryService log ${eventName}`)
             this.innerTelemetryService.logViewEvent(eventName)
         }
     }

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -12,6 +12,44 @@ import { observeSourcegraphURL, getPlatformName } from '../util/context'
 
 const uidKey = 'sourcegraphAnonymousUid'
 
+/**
+ * Telemetry Service which only logs when the enable condition is set. Accepts a
+ * promise as the enabled value, to allow to instantiate the logger and use it
+ * before the enablement state is determined.
+ *
+ * TODO: Potential to be improved by accepting an observable of the enabled state
+ * and updating accordingly.
+ */
+export class ConditionalTelemetryService implements TelemetryService {
+    private innerTelemetryService: TelemetryService
+
+    /**
+     * The enabled state is a promise so that we can start logging events before
+     * the result of the enabled setting is available
+     */
+    private isEnabledPromise: Promise<boolean>
+
+    constructor(innerTelemetryService: TelemetryService, isEnabled: boolean | Promise<boolean>) {
+        this.innerTelemetryService = innerTelemetryService
+        this.isEnabledPromise = Promise.resolve(isEnabled)
+    }
+
+    public setEnabled(isEnabled: boolean | Promise<boolean>): void {
+        this.isEnabledPromise = Promise.resolve(isEnabled)
+    }
+
+    public async log(eventName: string, eventProperties?: any): Promise<void> {
+        if (await this.isEnabledPromise) {
+            this.innerTelemetryService.log(eventName, eventProperties)
+        }
+    }
+    public async logViewEvent(eventName: string): Promise<void> {
+        if (await this.isEnabledPromise) {
+            this.innerTelemetryService.logViewEvent(eventName)
+        }
+    }
+}
+
 export class EventLogger implements TelemetryService {
     private uid: string | null = null
 

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -16,6 +16,9 @@ const uidKey = 'sourcegraphAnonymousUid'
  * Telemetry Service which only logs when the enable flag is set. Accepts an
  * observable that emits the enabled value.
  *
+ * This was implemented as a wrapper around TelemetryService in order to avoid
+ * modifying EventLogger, but the enabled flag could be rolled into EventLogger.
+ *
  * TODO: Potential to be improved by buffering log events until the first emit
  * of the enabled value.
  */
@@ -30,7 +33,11 @@ export class ConditionalTelemetryService implements TelemetryService {
     private isEnabled = false
 
     constructor(innerTelemetryService: TelemetryService, isEnabled: Observable<boolean>) {
-        this.subscription.add(isEnabled.subscribe(value => (this.isEnabled = value)))
+        this.subscription.add(
+            isEnabled.subscribe(value => {
+                this.isEnabled = value
+            })
+        )
         this.innerTelemetryService = innerTelemetryService
     }
 

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -40,11 +40,13 @@ export class ConditionalTelemetryService implements TelemetryService {
 
     public async log(eventName: string, eventProperties?: any): Promise<void> {
         if (await this.isEnabledPromise) {
+            console.log(`ConditionalTelemetryService log ${eventName}`)
             this.innerTelemetryService.log(eventName, eventProperties)
         }
     }
     public async logViewEvent(eventName: string): Promise<void> {
         if (await this.isEnabledPromise) {
+            console.log(`ConditionalTelemetryService log ${eventName}`)
             this.innerTelemetryService.logViewEvent(eventName)
         }
     }

--- a/browser/src/shared/util/context.tsx
+++ b/browser/src/shared/util/context.tsx
@@ -55,3 +55,8 @@ export function getExtensionVersion(): string {
 export function isFirefox(): boolean {
     return window.navigator.userAgent.includes('Firefox')
 }
+
+export function isDefaultSourcegraphUrl(url: string): boolean {
+    // TODO: Can this be improved by normalizing the url first?
+    return url === DEFAULT_SOURCEGRAPH_URL
+}

--- a/browser/src/shared/util/optionFlags.ts
+++ b/browser/src/shared/util/optionFlags.ts
@@ -1,0 +1,12 @@
+export type OptionFlagKey =
+    | 'sendTelemetry'
+    | 'allowErrorReporting'
+    | 'experimentalLinkPreviews'
+    | 'experimentalTextFieldCompletion'
+
+export interface OptionFlagWithValue {
+    label: string
+    key: OptionFlagKey
+    value: boolean
+    hidden?: boolean
+}

--- a/browser/src/shared/util/optionFlags.ts
+++ b/browser/src/shared/util/optionFlags.ts
@@ -1,12 +1,66 @@
+import { observeStorageKey } from '../../browser-extension/web-extension-api/storage'
+import { map, distinctUntilChanged } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+
+const OPTION_FLAGS_SYNC_STORAGE_KEY = 'featureFlags'
+
 export type OptionFlagKey =
     | 'sendTelemetry'
     | 'allowErrorReporting'
     | 'experimentalLinkPreviews'
     | 'experimentalTextFieldCompletion'
 
-export interface OptionFlagWithValue {
+export interface OptionFlagDefinition {
     label: string
     key: OptionFlagKey
-    value: boolean
     hidden?: boolean
+}
+
+export interface OptionFlagWithValue<T = boolean> extends OptionFlagDefinition {
+    value: T
+}
+
+export type OptionFlagValues<T = boolean> = Record<OptionFlagKey, T>
+
+export const optionFlagDefinitions: OptionFlagDefinition[] = [
+    {
+        key: 'sendTelemetry',
+        label: 'Send telemetry',
+    },
+    {
+        key: 'allowErrorReporting',
+        label: 'Allow error reporting',
+    },
+    {
+        key: 'experimentalLinkPreviews',
+        label: 'Experimental link previews',
+    },
+    {
+        key: 'experimentalTextFieldCompletion',
+        label: 'Experimental text field completion',
+    },
+]
+
+const optionFlagDefaults: OptionFlagValues = {
+    sendTelemetry: false,
+    allowErrorReporting: false,
+    experimentalLinkPreviews: false,
+    experimentalTextFieldCompletion: false,
+}
+
+export function assignOptionFlagValues(values: OptionFlagValues): OptionFlagWithValue[] {
+    return optionFlagDefinitions.map(flag => ({ ...flag, value: values[flag.key] }))
+}
+
+export function applyOptionFlagDefaults(values: Partial<OptionFlagValues> | undefined): OptionFlagValues {
+    return { ...optionFlagDefaults, ...values }
+}
+export const observeOptionFlags = (): Observable<OptionFlagValues> =>
+    observeStorageKey('sync', OPTION_FLAGS_SYNC_STORAGE_KEY).pipe(map(applyOptionFlagDefaults))
+
+export function observeOptionFlag(key: OptionFlagKey): Observable<boolean | undefined> {
+    return observeOptionFlags().pipe(
+        map(value => value?.[key]),
+        distinctUntilChanged()
+    )
 }


### PR DESCRIPTION
Closes #13377 

## Background

For policy compliance, the *Sourcegraph for Firefox* add-on must provide a control mechanism for the user to control data collection. Our current interpretation of the add-on policy is that we can make data collection (telemetry) an opt-in feature on Firefox, and this will bring us into compliance. Our collection of data falls under the "User interactions & technical data" category in the policies.

Another possible method for compliance, not addressed in this PR, would be to show UI to the user upon first run of the add-on that gives them the option of opting out of data collection.

Source: https://extensionworkshop.com/documentation/publish/add-on-policies/

## Implementation

### Adding a new setting in the Options Page UI

The browser extension shows a list of boolean options in the add-on Options Page. Internally we call these options feature flags.

Part of this PR introduces a renaming to call these "option flags" instead of feature flags. This does not change the internal string key used for saving the option values in extension `sync` storage, so the change is backwards-compatible.

This PR adds a new boolean option, represented as a checkbox, to the option flags, tentatively called "Send telemetry".

### Added to the scope of this PR

- The feature flags in the browser extension aren't strictly speaking feature flags anymore, although they started out that way. They are renamed to `Option Flags`
- The feature flags have labels in the UI which are derived directly from their internal names. For example `allowErrorReporting` become `Allow error reporting` in the UI, using a string conversion function. This makes it compact but it also makes it difficult to change flag names in the future, because changing the UI label will require changing the internal name, and making such a change will have the side-effect of resetting the user's saved value to default. The `Option Flags` now have a separate label field instead of deriving the label from the key.

### Telemetry service implementation

The telemetry service in the browser extension is implemented with an `EventLogger` which is instantiated in `injectCodeIntelligenceToCodeHost`.

This telemetry service is then passed to several places that use it:

- `initCodeIntelligence`
- `handleCodeHost`
- `renderCommandPalette`
- `<CodeViewToolbar/>`
- `<HoverOverlay/>`

To make the telemetry service depend on the flag:

- Instantiate a telemetry service which itself will observe the setting, and will pass events along while telemetry is enabled, and will swallow events otherwise.

## Different behavior based on the environment

The opt-in setting behavior should be present on Firefox and in particular when the Sourcegraph URL is set to `sourcegraph.com`.

In other cases the flag is not applicable (it is overriden) and the checkbox is not shown in the interface.

## Alternatives considered

An alternative to the opt-in mechanism is to make it an opt-out flag while making sure that the user is shown the options page at first installation to make sure that they've seen it and have given consent. In order to avoid introducing a new step in the installation process, we didn't pursue this solution.

