### PR TITLE
RFC 196: Secrets package

### DIFF
--- a/internal/secrets/crypt.go
+++ b/internal/secrets/crypt.go
@@ -1,0 +1,212 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/inconshreveable/log15"
+)
+
+const (
+	validKeyLength = 32
+	hmacSize       = sha256.Size
+	primaryKey     = 0
+	secondaryKey   = 1
+)
+
+type EncryptionError struct {
+	Message string
+}
+
+// NotEncodedError means we can test for whether or not a string is encoded, prior to attempting decryption
+var NotEncodedError = errors.New("object is not encoded")
+
+// Generate a valid key for AES-256 encryption
+func GenerateRandomAESKey() ([]byte, error) {
+	b := make([]byte, validKeyLength)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (err *EncryptionError) Error() string {
+	return err.Message
+}
+
+// Encryptor contains the encryption key used in encryption and decryption.
+type Encryptor struct {
+	// the first key is always used to encrypt, attempt to decrypt with every key
+	EncryptionKeys [][]byte
+}
+
+// Returns an encrypted string.
+func (e *Encryptor) encrypt(b []byte) (string, error) {
+	// create a one time nonce of standard length, without repetitions
+	// ONLY use the primary key to encrypt
+	block, err := aes.NewCipher(e.EncryptionKeys[primaryKey])
+	if err != nil {
+		return "", err
+	}
+
+	encrypted := make([]byte, aes.BlockSize+len(b))
+	nonce := encrypted[:aes.BlockSize]
+
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return "", err
+	}
+
+	stream := cipher.NewCFBEncrypter(block, nonce)
+	stream.XORKeyStream(encrypted[aes.BlockSize:], b)
+
+	// encrypt-then-MAC
+	// TODO(Dax): We should stretch the key above rather than try to reuse this
+	mac := hmac.New(sha256.New, e.EncryptionKeys[primaryKey])
+	n, err := mac.Write(encrypted)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println("bytes written: ", n)
+	macSum := mac.Sum(nil)
+	encrypted = append(encrypted, macSum...)
+
+	return base64.StdEncoding.EncodeToString(encrypted), nil
+}
+
+// Encrypts the string, returning the encrypted value.
+func (e *Encryptor) EncryptBytes(b []byte) (string, error) {
+	return e.encrypt(b)
+}
+
+// Encrypts the string, returning the encrypted value.
+func (e *Encryptor) Encrypt(value string) (string, error) {
+	return e.encrypt([]byte(value))
+}
+
+func (e *Encryptor) EncryptBytesIfPossible(b []byte) (string, error) {
+	if configuredToEncrypt {
+		return e.EncryptBytes(b)
+	}
+	return string(b), nil
+}
+
+func EncryptBytesIfPossible(b []byte) (string, error) {
+	if configuredToEncrypt {
+		return CryptObject.encrypt(b)
+	}
+	return string(b), nil
+}
+
+// EncryptIfPossible encrypts the string if encryption is configured.
+// Returns an error only when encryption is enabled, and encryption fails.
+func EncryptIfPossible(value string) (string, error) {
+	if configuredToEncrypt {
+		return CryptObject.Encrypt(value)
+	}
+	return value, nil
+}
+
+// EncryptIfPossible encrypts  the string if encryption is configured.
+// Returns an error only when encryption is enabled, and encryption fails.
+func (e *Encryptor) EncryptIfPossible(value string) (string, error) {
+	if configuredToEncrypt {
+		return e.Encrypt(value)
+	}
+	return value, nil
+}
+
+func (e *Encryptor) Decrypt(value string) (string, error) {
+	return e.decrypt(value)
+}
+
+func (e *Encryptor) DecryptBytes(b []byte) (string, error) {
+	return e.decrypt(string(b))
+}
+
+// Decrypts the string, returning the decrypted value.
+func (e *Encryptor) decrypt(encodedValue string) (string, error) {
+
+	// handle plaintext use case
+	if len(e.EncryptionKeys) == 0 {
+		return encodedValue, nil
+	}
+
+	for _, key := range e.EncryptionKeys {
+		encrypted, err := base64.StdEncoding.DecodeString(encodedValue)
+		if err != nil {
+			return "", NotEncodedError
+		}
+
+		//remove hmac
+		extractedMac := encrypted[len(encrypted)-hmacSize:]
+		encrypted = encrypted[:len(encrypted)-hmacSize]
+
+		// validate hmac
+		// TODO(Dax): We should stretch the key above rather than try to reuse
+		mac := hmac.New(sha256.New, key)
+		n, err := mac.Write(encrypted)
+		if err != nil {
+			return "", err
+		}
+		fmt.Printf("wrote %d bytes \n", n)
+		expectedMac := mac.Sum(nil)
+		if !hmac.Equal(extractedMac, expectedMac) {
+			log15.Warn("mac doesn't match, may retry")
+			continue
+		}
+
+		if len(encrypted) < aes.BlockSize {
+			return "", &EncryptionError{Message: "Invalid block size."}
+		}
+
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return "", nil
+		}
+
+		nonce := encrypted[:aes.BlockSize]
+		value := encrypted[aes.BlockSize:]
+		stream := cipher.NewCFBDecrypter(block, nonce)
+		stream.XORKeyStream(value, value)
+		return string(value), nil
+	}
+	return "", fmt.Errorf("unable to decrypt")
+
+}
+
+// DecryptIfPossible decrypts the string if encryption is configured.
+// It returns an error only if encryption is enabled and it cannot decrypt the string
+func (e *Encryptor) DecryptIfPossible(value string) (string, error) {
+	if configuredToEncrypt {
+		return e.Decrypt(value)
+	}
+	return value, nil
+}
+
+func (e *Encryptor) DecryptBytesIfPossible(b []byte) (string, error) {
+	if configuredToEncrypt {
+		return e.DecryptBytes(b)
+	}
+	return string(b), nil
+}
+
+// This function rotates the encryption used on an item by decrypting and then re-encrypting.
+// Rotating keys updates the EncryptionKey within the Encryptor object
+//func (e *Encryptor) RotateKey(newKey []byte, encryptedValue string) (string, error) {
+//	decrypted, err := e.Decrypt(encryptedValue)
+//	if err != nil {
+//		return "", err
+//	}
+//
+//	e.EncryptionKey = newKey
+//	return e.encrypt([]byte(decrypted))
+//}

--- a/internal/secrets/crypt_test.go
+++ b/internal/secrets/crypt_test.go
@@ -1,0 +1,321 @@
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+const (
+	messageToEncrypt = "I Madam. I made radio, So I dard. Am I mad? Am I?"
+)
+
+func TestRandomAESKey(t *testing.T) {
+	key, err := GenerateRandomAESKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(key) != validKeyLength {
+		t.Fatalf("Exepected key length of %d received %d", validKeyLength, len(key))
+	}
+}
+
+// Test that encrypting and decryption the message yields the same value
+func TestEncryptingAndDecrypting(t *testing.T) {
+	// 32 bytes means an AES-256 cipher
+	key, _ := GenerateRandomAESKey()
+	e := Encryptor{EncryptionKeys: [][]byte{primaryKey: key}}
+
+	encrypted, err := e.Encrypt(messageToEncrypt)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// better way to compare byte arrays
+	if encrypted == messageToEncrypt {
+		t.Fatal(err)
+	}
+
+	decrypted, err := e.Decrypt(encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if decrypted != messageToEncrypt {
+		t.Fatalf("failed to decrypt")
+	}
+}
+
+// Test the negative result - we should fail to decrypt with bad keys
+func TestBadKeysFailToDecrypt(t *testing.T) {
+	key, _ := GenerateRandomAESKey()
+	e := Encryptor{EncryptionKeys: [][]byte{primaryKey: key}}
+
+	message := "The secret is to bang the rocks together guys."
+	encrypted, err := e.Encrypt(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decrypted, err := e.Decrypt(encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	notTheSameKey, _ := GenerateRandomAESKey()
+	e.EncryptionKeys = [][]byte{primaryKey: notTheSameKey}
+	decryptAgain, err := e.Decrypt(encrypted)
+
+	if err == nil {
+		t.Fatal("Should not have been able to decrypt string with a second set of secrets.")
+	}
+
+	if decrypted == decryptAgain {
+		t.Fatal("Should not have been able to decrypt string with a second set of secrets.")
+	}
+}
+
+// Test that different strings encrypt to different outputs
+func TestDifferentOutputs(t *testing.T) {
+	key, _ := GenerateRandomAESKey()
+	e := Encryptor{EncryptionKeys: [][]byte{primaryKey: key}}
+	messages := []string{
+		"This may or may",
+		"This is not the same as that",
+		"The end of that",
+		"Plants and animals",
+		"Snow, igloos, sunshine, unicords",
+	}
+
+	var crypts []string
+	for _, m := range messages {
+		encrypted, _ := e.Encrypt(m)
+		crypts = append(crypts, encrypted)
+	}
+
+	for _, c := range crypts {
+		if !isInSliceOnce(c, crypts) {
+			t.Fatalf("Duplicate encryption string: %v.", c)
+		}
+	}
+}
+
+func isInSliceOnce(item string, slice []string) bool {
+	found := 0
+	for _, s := range slice {
+		if item == s {
+			found++
+		}
+	}
+
+	return found == 1
+}
+
+func TestSampleNoRepeats(t *testing.T) {
+	key, _ := GenerateRandomAESKey()
+	e := Encryptor{EncryptionKeys: [][]byte{primaryKey: key}}
+
+	var crypts []string
+	for i := 0; i < 10000; i++ {
+		encrypted, _ := e.Encrypt(messageToEncrypt)
+		crypts = append(crypts, encrypted)
+	}
+
+	for _, item := range crypts {
+		if isInSliceOnce(item, crypts) == false {
+			t.Fatalf("Duplicate encrypted string found.")
+		}
+	}
+}
+
+// Test that rotating keys returns different encrypted strings
+//func TestKeyRotation(t *testing.T) {
+//	initialKey, _ := GenerateRandomAESKey()
+//	secondKey, _ := GenerateRandomAESKey()
+//
+//	e := Encryptor{EncryptionKeys: [][]byte{primaryKey:initialKey,secondaryKey:secondKey}}
+//	encrypted, _ := e.Encrypt(messageToEncrypt) // another test validates
+//
+//	reEncrypted, _ := e.RotateKey(secondKey, encrypted)
+//
+//	if reEncrypted == encrypted {
+//		t.Fatalf("Failed to re-encrypt the string.")
+//	}
+//
+//	// validate decrypting the message works with the new key
+//	anotherES := Encryptor{EncryptionKey: secondKey}
+//	decrypted, err := anotherES.Decrypt(reEncrypted)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	if decrypted != messageToEncrypt {
+//		t.Fatal("failed to decrypt")
+//	}
+//
+//	if !bytes.Equal(e.EncryptionKey, secondKey) {
+//		// if !reflect.DeepEqual(e.EncryptionKey, secondKey) {
+//		t.Fatalf("Expected key to be %s, got %s.", secondKey, e.EncryptionKey)
+//	}
+//}
+
+func TestKeyMigration(t *testing.T) {
+	keyA, err := GenerateRandomAESKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyB, err := GenerateRandomAESKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encryptorA := Encryptor{EncryptionKeys: [][]byte{primaryKey: keyA}}
+
+	message := "encrypted with Key A"
+	encryptedMessage, err := encryptorA.Encrypt(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now rotate keys to use Key B
+	encryptorB := Encryptor{EncryptionKeys: [][]byte{primaryKey: keyB, secondaryKey: keyA}}
+
+	decryptedMessage, err := encryptorB.Decrypt(encryptedMessage)
+	if err != nil {
+		t.Fatalf("unable to decrypt string: %v", err)
+	}
+
+	if decryptedMessage != message {
+		t.Fatalf("messages do not match")
+	}
+
+}
+func TestEncryptAndDecryptIfPossible(t *testing.T) {
+	initialKey, _ := GenerateRandomAESKey()
+	configuredToEncrypt = true
+	e := Encryptor{EncryptionKeys: [][]byte{primaryKey: initialKey}}
+
+	encString, err := e.EncryptIfPossible(messageToEncrypt)
+	if err != nil {
+		t.Fatalf("Failed to encrypt")
+	}
+	if encString == messageToEncrypt {
+		t.Fatalf("Encryption failed.")
+	}
+
+	decString, err := e.DecryptIfPossible(encString)
+	if err != nil {
+		t.Fatalf("Failed to decrypt")
+	}
+	if decString != messageToEncrypt {
+		t.Fatalf("Decryption failed.")
+	}
+
+	// now test when we cannot encrypt
+
+	e = Encryptor{}
+	configuredToEncrypt = false // setting this false means that EncryptIfPossible will not return an err
+	encString, err = e.EncryptIfPossible(messageToEncrypt)
+	if err != nil {
+		t.Fatalf("Received error when no err expected %v", err)
+	}
+	if encString != messageToEncrypt {
+		t.Fatalf("Received encrypted string, expected unencrypted.")
+	}
+	configuredToEncrypt = true
+	/* TODO(Dax): Need input here, if we enable encryption when our encryption object does not have an encryption key
+	then should we get an error?
+	*/
+	decString, err = e.DecryptIfPossible(encString)
+	if err != nil {
+		t.Fatalf("Received error when code path should be nil. %v", err)
+	}
+	if decString != messageToEncrypt {
+		t.Fatalf("Received encrypted string, expected unencrypted.")
+	}
+}
+
+func TestEncryptAndDecryptBytesIfPossible(t *testing.T) {
+	initialKey, _ := GenerateRandomAESKey()
+	configuredToEncrypt = true
+	e := Encryptor{EncryptionKeys: [][]byte{primaryKey: initialKey}}
+
+	encString, err := e.EncryptBytesIfPossible([]byte(messageToEncrypt))
+	if err != nil {
+		t.Fatalf("Failed to encrypt")
+	}
+	if encString == messageToEncrypt {
+		t.Fatalf("Encryption failed.")
+	}
+
+	decString, err := e.DecryptBytesIfPossible([]byte(encString))
+	if err != nil {
+		t.Fatalf("Failed to decrypt")
+	}
+	if decString != messageToEncrypt {
+		t.Fatalf("Decryption failed.")
+	}
+
+	// now test when we cannot encrypt
+
+	e = Encryptor{}
+	configuredToEncrypt = false // setting this false means that EncryptBytesIfPossible will not return an err
+	encString, err = e.EncryptBytesIfPossible([]byte(messageToEncrypt))
+	if err != nil {
+		t.Fatalf("Received error when code path should be nil. %v", err)
+	}
+	if encString != messageToEncrypt {
+		t.Fatalf("Received encrypted string, expected unencrypted.")
+	}
+	configuredToEncrypt = true
+	decString, err = e.DecryptBytesIfPossible([]byte(encString))
+	if err != nil {
+		t.Fatalf("Received error when code path should be nil. %v", err)
+	}
+	if decString != messageToEncrypt {
+		t.Fatalf("Received encrypted string, expected unencrypted.")
+	}
+}
+
+func Test_gatherKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       []byte
+		wantOldKey []byte
+		wantNewKey []byte
+	}{
+		{
+			"base-case",
+			[]byte("key123,key345"),
+			[]byte("key345"),
+			[]byte("key123"),
+		},
+		{
+			"no key set",
+			[]byte("key123"),
+			nil,
+			[]byte("key123"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOldKey, gotNewKey := gatherKeys(tt.data)
+			if bytes.Equal(gotOldKey, tt.wantOldKey) {
+				t.Errorf("gatherKeys() oOldKey = %v, want %v", gotOldKey, tt.wantOldKey)
+			}
+			if bytes.Equal(gotNewKey, tt.wantNewKey) {
+				t.Errorf("gathrKeys() gotNewKey = %v, want %v", gotNewKey, tt.wantNewKey)
+			}
+		})
+	}
+
+	data := []byte("look mom, I am a key, me too")
+	defer func() {
+		p := recover()
+		if p == nil {
+			fmt.Println("t.Fail: should have panicked")
+		}
+	}()
+	gatherKeys(data)
+
+}

--- a/internal/secrets/init.go
+++ b/internal/secrets/init.go
@@ -1,0 +1,110 @@
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+// TODO: Make private, access via functions
+var CryptObject Encryptor
+var configuredToEncrypt bool
+
+const (
+	// #nosec G101
+	sourcegraphSecretfileEnvvar = "SOURCEGRAPH_SECRET_FILE"
+	sourcegraphCryptEnvvar      = "SOURCEGRAPH_CRYPT_KEY"
+)
+
+// gatherKeys splits the encryption string into its potential two components
+func gatherKeys(data []byte) (oldKey, newKey []byte) {
+	parts := bytes.Split(data, []byte(","))
+	if len(parts) > 2 {
+		panic("no more than two encryption keys should be specified.")
+	}
+	if len(parts) == 1 {
+		return parts[0], nil
+	}
+
+	return parts[0], parts[1]
+}
+
+func init() {
+	configuredToEncrypt = false
+
+	envCryptKey, cryptOK := os.LookupEnv(sourcegraphCryptEnvvar)
+	var encryptionKey []byte
+
+	// set the default location if none exists
+	secretFile := os.Getenv(sourcegraphSecretfileEnvvar)
+	if secretFile == "" {
+		// #nosec G101
+		secretFile = "/var/lib/sourcegraph/token"
+	}
+
+	_, err := os.Stat(secretFile)
+
+	// reading from a file is first order
+	if err == nil {
+		contents, readErr := ioutil.ReadFile(secretFile)
+		if readErr != nil {
+			panic(fmt.Sprintf("couldn't read file %s", sourcegraphSecretfileEnvvar))
+		}
+		if len(contents) < validKeyLength {
+			panic(fmt.Sprintf("key length of %d characters is required.", validKeyLength))
+		}
+		encryptionKey = contents
+		err = os.Chmod(secretFile, 0400)
+		if err != nil {
+			panic("failed to make secrets file read only.")
+		}
+
+		newKey, oldKey := gatherKeys(encryptionKey)
+
+		CryptObject.EncryptionKeys = [][]byte{primaryKey: newKey, secondaryKey: oldKey}
+		return
+	}
+
+	// environment is second order
+	if cryptOK {
+		if len(envCryptKey) != validKeyLength {
+			panic(fmt.Sprintf("encryption key must be %d characters", validKeyLength))
+		}
+		newKey, oldKey := gatherKeys(encryptionKey)
+		CryptObject.EncryptionKeys = [][]byte{primaryKey: newKey, secondaryKey: oldKey}
+		return
+	}
+
+	// for the single docker case, we generate the secret
+	deployType := conf.DeployType()
+	if conf.IsDeployTypeSingleDockerContainer(deployType) {
+		b, err := GenerateRandomAESKey()
+		if err != nil {
+			panic(fmt.Sprintf("unable to read from random source: %v", err))
+		}
+		err = ioutil.WriteFile(secretFile, b, 0600)
+		if err != nil {
+			panic(err)
+		}
+
+		err = os.Chmod(secretFile, 0400)
+		if err != nil {
+			panic("failed to make secrets file read only.")
+		}
+		newKey, oldkey := gatherKeys(b)
+		CryptObject.EncryptionKeys = [][]byte{primaryKey: newKey, secondaryKey: oldkey}
+	}
+
+	// wrapping in deploytype check so that we can still compile and test locally
+	if !(conf.IsDev(deployType) || os.Getenv("CI") == "") {
+		// for k8s & docker compose, expect a secret to be provided
+		panic(fmt.Sprintf("Either specify environment variable %s or provide the secrets file %s.",
+			sourcegraphCryptEnvvar,
+			sourcegraphSecretfileEnvvar))
+	}
+
+	configuredToEncrypt = true
+}

--- a/internal/secrets/secret.go
+++ b/internal/secrets/secret.go
@@ -1,0 +1,22 @@
+package secrets
+
+import (
+	"fmt"
+)
+
+func (e *Encryptor) Raw(crypt string) (string, error) {
+	plaintext, err := e.Decrypt(crypt)
+	if err != nil {
+		return "", err
+	}
+	return plaintext, nil
+}
+
+// Return a masked version of the decrypted secret, for when a token-like string needs to be displayed in the UI
+func (e *Encryptor) Mask(crypt string) (string, error) {
+	plaintext, err := e.Decrypt(crypt)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s***********", plaintext[0:0]), nil
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/12269 

This is the first PR of RFC 196 to enter into the codebase. This is the secrets package which will ultimately be used by developers to encrypt & decrypt secrets. Therefore ergonomics are important. 

Is this package discoverable? 
Are the methods it exposes reasonable? 

@chayim The key rotation code was non-trivial to implement since we need to support usage before and after the ciphertext is rotated to use the new key. The only way I saw was to use HMAC to verify data integrity and ensure that we were using the right key to encrypt or decrypt the data. 

TODO: 

- [ ] Verify that HMAC is the right solution here
- [ ] Update HMAC code to use a derived key

