### PR TITLE
monitoring: relax blob_load_latency, github_core_rate_limit_remaining

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -141,7 +141,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _frontend: 2s+ 90th percentile blob load latency over 10m_
+- _frontend: 5s+ 90th percentile blob load latency over 10m_
 
 **Possible solutions:**
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1134,7 +1134,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _github-proxy: less than 1000 remaining calls to GitHub before hitting the rate limit_
+- _github-proxy: less than 500 remaining calls to GitHub before hitting the rate limit for 5m0s_
 
 **Possible solutions:**
 

--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -114,7 +114,7 @@ func Frontend() *Container {
 							Description:     "90th percentile blob load latency over 10m",
 							Query:           `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`,
 							DataMayNotExist: true,
-							Critical:        Alert{GreaterOrEqual: 2},
+							Critical:        Alert{GreaterOrEqual: 5},
 							PanelOptions:    PanelOptions().LegendFormat("latency").Unit(Seconds),
 							Owner:           ObservableOwnerSearch,
 							PossibleSolutions: `

--- a/monitoring/github_proxy.go
+++ b/monitoring/github_proxy.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 func GitHubProxy() *Container {
 	return &Container{
 		Name:        "github-proxy",
@@ -15,7 +17,7 @@ func GitHubProxy() *Container {
 							Description:       "remaining calls to GitHub before hitting the rate limit",
 							Query:             `src_github_rate_limit_remaining{resource="core"}`,
 							DataMayNotExist:   true,
-							Critical:          Alert{LessOrEqual: 1000},
+							Critical:          Alert{LessOrEqual: 500, For: 5 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("calls remaining"),
 							Owner:             ObservableOwnerSearch,
 							PossibleSolutions: `Try restarting the pod to get a different public IP.`,


### PR DESCRIPTION
* increase blob_load_latency threshold - the previous threshold has been causing it to fire very frequently lately. i think it makes sense that this threshold be more relaxed than page_load_latency. that said, this might indicate a real problem, since it seems to have a tendency to spike occasionally while being pretty low the rest of the time. [Dashboard](https://sourcegraph.com/-/debug/grafana/d/frontend/frontend)
* decrease github_core_rate_limit_remaining threshold and duration - the last time this fired was when it dipped to 999 for an instant. the new limit seems like a generous limit still, and if rate limit does not recover for a period of time, then it indicates a real problem. [Dashboard](https://sourcegraph.com/-/debug/grafana/d/github-proxy/github-proxy?viewPanel=5&orgId=1&from=now-24h&to=now)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
