### PR TITLE
Separate the initialization of logger and tracer

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/processrestart"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -130,7 +131,8 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 
 	// Filter trace logs
 	d, _ := time.ParseDuration(traceThreshold)
-	tracer.Init(tracer.Filter(loghandlers.Trace(strings.Fields(trace), d)))
+	logging.Init(logging.Filter(loghandlers.Trace(strings.Fields(trace), d)))
+	tracer.Init()
 
 	// Run enterprise setup hook
 	enterprise := enterpriseSetupHook()

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
@@ -60,6 +61,7 @@ var hopHeaders = map[string]struct{}{
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
+	logging.Init()
 	tracer.Init()
 
 	go func() {

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -33,6 +34,7 @@ var (
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
+	logging.Init()
 	tracer.Init()
 
 	if reposDir == "" {

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
@@ -33,7 +34,7 @@ const port = "3183"
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
-
+	logging.Init()
 	tracer.Init()
 
 	go func() {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -43,6 +44,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	ctx := context.Background()
 	env.Lock()
 	env.HandleHelpFlag()
+	logging.Init()
 	tracer.Init()
 
 	clock := func() time.Time { return time.Now().UTC() }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -35,6 +36,7 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	log.SetFlags(0)
+	logging.Init()
 	tracer.Init()
 
 	go debugserver.Start()

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -39,6 +40,7 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	log.SetFlags(0)
+	logging.Init()
 	tracer.Init()
 
 	sqliteutil.MustRegisterSqlite3WithPcre()

--- a/enterprise/cmd/precise-code-intel-bundle-manager/main.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
@@ -28,6 +29,7 @@ import (
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
+	logging.Init()
 	tracer.Init()
 
 	sqliteutil.MustRegisterSqlite3WithPcre()

--- a/enterprise/cmd/precise-code-intel-indexer-vm/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/main.go
@@ -17,6 +17,7 @@ import (
 	queue "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/queue/client"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -24,8 +25,8 @@ import (
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
-	// TODO(efritz) - disabled as it requires internal API access
-	// tracer.Init()
+	logging.Init()
+	//	tracer.Init() // TODO(efritz) - disabled as it requires internal API access
 
 	var (
 		frontendURL              = mustGet(rawFrontendURL, "PRECISE_CODE_INTEL_EXTERNAL_URL")

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -30,6 +31,7 @@ import (
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
+	logging.Init()
 	tracer.Init()
 
 	var (

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -32,6 +33,7 @@ import (
 func main() {
 	env.Lock()
 	env.HandleHelpFlag()
+	logging.Init()
 	tracer.Init()
 
 	sqliteutil.MustRegisterSqlite3WithPcre()

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -1,0 +1,103 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var (
+	logColors = map[log15.Lvl]color.Attribute{
+		log15.LvlCrit:  color.FgRed,
+		log15.LvlError: color.FgRed,
+		log15.LvlWarn:  color.FgYellow,
+		log15.LvlInfo:  color.FgCyan,
+		log15.LvlDebug: color.Faint,
+	}
+	// We'd prefer these in caps, not lowercase, and don't need the 4-character alignment
+	logLabels = map[log15.Lvl]string{
+		log15.LvlCrit:  "CRITICAL",
+		log15.LvlError: "ERROR",
+		log15.LvlWarn:  "WARN",
+		log15.LvlInfo:  "INFO",
+		log15.LvlDebug: "DEBUG",
+	}
+)
+
+func condensedFormat(r *log15.Record) []byte {
+	colorAttr := logColors[r.Lvl]
+	text := logLabels[r.Lvl]
+	var msg bytes.Buffer
+	if colorAttr != 0 {
+		fmt.Print(color.New(colorAttr).Sprint(text) + " " + r.Msg)
+	} else {
+		fmt.Print(&msg, r.Msg)
+	}
+	if len(r.Ctx) > 0 {
+		for i := 0; i < len(r.Ctx); i += 2 {
+			// not as smart about printing things as log15's internal magic
+			fmt.Fprintf(&msg, ", %s: %v", r.Ctx[i].(string), r.Ctx[i+1])
+		}
+	}
+	msg.WriteByte('\n')
+	return msg.Bytes()
+}
+
+// Options control the behavior of a tracer.
+type Options struct {
+	filters     []func(*log15.Record) bool
+	serviceName string
+}
+
+// If this idiom seems strange:
+// https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md
+type Option func(*Options)
+
+func ServiceName(s string) Option {
+	return func(o *Options) {
+		o.serviceName = s
+	}
+}
+
+func Filter(f func(*log15.Record) bool) Option {
+	return func(o *Options) {
+		o.filters = append(o.filters, f)
+	}
+}
+
+func init() {
+	// Enable colors by default but support https://no-color.org/
+	color.NoColor = env.Get("NO_COLOR", "", "Disable colored output") != ""
+}
+
+func Init(options ...Option) {
+	opts := &Options{}
+	for _, setter := range options {
+		setter(opts)
+	}
+	if opts.serviceName == "" {
+		opts.serviceName = env.MyName
+	}
+	var handler log15.Handler
+	switch env.LogFormat {
+	case "condensed":
+		handler = log15.StreamHandler(os.Stderr, log15.FormatFunc(condensedFormat))
+	case "logfmt":
+		fallthrough
+	default:
+		handler = log15.StreamHandler(os.Stderr, log15.LogfmtFormat())
+	}
+	for _, filter := range opts.filters {
+		handler = log15.FilterHandler(filter, handler)
+	}
+	// Filter log output by level.
+	lvl, err := log15.LvlFromString(env.LogLevel)
+	if err == nil {
+		handler = log15.LvlFilterHandler(lvl, handler)
+	}
+	log15.Root().SetHandler(log15.LvlFilterHandler(lvl, handler))
+}


### PR DESCRIPTION
The tracer package initialized logging, which isn't obvious from the call of `trace.Init()`. I've moved the logging setup into the internal/logging package and added a call where tracer was initialized previously.

This is necessary for precise-code-intel-indexer-vm, which does not need to set up tracing (it runs external to k8s and has no access to the internal network/APIs), but does need to set up logging as the rest of the apps do.