### PR TITLE
search: update comby dependecies for 0.18.1

### DIFF
--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -6,7 +6,7 @@
 FROM sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
 
 # hadolint ignore=DL3018
-RUN apk --no-cache add pcre
+RUN apk --no-cache add pcre sqlite-libs
 
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -37,7 +37,7 @@ RUN apk update && apk add --no-cache \
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
     bind-tools ca-certificates git@edge \
-    mailcap 'nginx=1.16.1-r2' openssh-client pcre su-exec tini nodejs-current=12.4.0-r0 curl
+    mailcap 'nginx=1.16.1-r2' openssh-client pcre sqlite-libs su-exec tini nodejs-current=12.4.0-r0 curl
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)

--- a/dev/comby-install-or-upgrade.sh
+++ b/dev/comby-install-or-upgrade.sh
@@ -3,7 +3,7 @@
 # This function installs the comby dependency for cmd/searcher.
 # The CI pipeline calls this script to install or upgrade comby
 # for tests or development environments.
-REQUIRE_VERSION="0.14.1"
+REQUIRE_VERSION="0.18.1"
 
 RELEASE_VERSION=$REQUIRE_VERSION
 RELEASE_TAG=$REQUIRE_VERSION


### PR DESCRIPTION
I want to release a new version of comby in #13003. It requires the alpine [`sqlite-dev`](https://pkgs.alpinelinux.org/package/edge/main/x86/sqlite-dev) dependency, which will need to be added to the server and searcher images. This adds the following sizes to the images but overall it's quite small:

Size | 154.29 kB
-- | --
Installed size | 628 kB

