### PR TITLE
graphqlbackend: update reposourceCloneURLToRepoName to use pagination

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -18,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -205,69 +207,71 @@ func reposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 		return repoName, nil
 	}
 
-	var repoSources []reposource.RepoSource
+	opt := db.ExternalServicesListOptions{
+		Kinds: []string{
+			extsvc.KindGitHub,
+			extsvc.KindGitLab,
+			extsvc.KindBitbucketServer,
+			extsvc.KindAWSCodeCommit,
+			extsvc.KindGitolite,
+		},
+		LimitOffset: &db.LimitOffset{
+			Limit: 500, // The number is randomly chosen
+		},
+	}
+	for {
+		svcs, err := db.ExternalServices.List(ctx, opt)
+		if err != nil {
+			return "", errors.Wrap(err, "list")
+		}
+		if len(svcs) == 0 {
+			break // No more results, exiting
+		}
+		opt.AfterID = svcs[len(svcs)-1].ID // Advance the cursor
 
-	// The following code makes serial database calls.
-	// Ideally these could be done in parallel, but the table is small
-	// and I don't think real world perf is going to be bad.
-	// It is also unclear to me if deterministic order is important here (it seems like it might be),
-	// so if this is parallelized in the future, consider whether order is important.
+		for _, svc := range svcs {
+			cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
+			if err != nil {
+				return "", errors.Wrap(err, "parse config")
+			}
 
-	githubs, err := db.ExternalServices.ListGitHubConnections(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, c := range githubs {
-		repoSources = append(repoSources, reposource.GitHub{GitHubConnection: c.GitHubConnection})
-	}
+			var rs reposource.RepoSource
+			switch c := cfg.(type) {
+			case *schema.GitHubConnection:
+				rs = reposource.GitHub{GitHubConnection: c}
+			case *schema.GitLabConnection:
+				rs = reposource.GitLab{GitLabConnection: c}
+			case *schema.BitbucketServerConnection:
+				rs = reposource.BitbucketServer{BitbucketServerConnection: c}
+			case *schema.AWSCodeCommitConnection:
+				rs = reposource.AWS{AWSCodeCommitConnection: c}
+			case *schema.GitoliteConnection:
+				rs = reposource.Gitolite{GitoliteConnection: c}
+			default:
+				return "", errors.Errorf("unexpected connection type: %T", cfg)
+			}
 
-	gitlabs, err := db.ExternalServices.ListGitLabConnections(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, c := range gitlabs {
-		repoSources = append(repoSources, reposource.GitLab{GitLabConnection: c.GitLabConnection})
-	}
+			repoName, err := rs.CloneURLToRepoName(cloneURL)
+			if err != nil {
+				return "", err
+			}
+			if repoName != "" {
+				return repoName, nil
+			}
+		}
 
-	bitbuckets, err := db.ExternalServices.ListBitbucketServerConnections(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, c := range bitbuckets {
-		repoSources = append(repoSources, reposource.BitbucketServer{BitbucketServerConnection: c.BitbucketServerConnection})
-	}
-
-	awscodecommits, err := db.ExternalServices.ListAWSCodeCommitConnections(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, c := range awscodecommits {
-		repoSources = append(repoSources, reposource.AWS{AWSCodeCommitConnection: c.AWSCodeCommitConnection})
-	}
-
-	gitolites, err := db.ExternalServices.ListGitoliteConnections(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, c := range gitolites {
-		repoSources = append(repoSources, reposource.Gitolite{GitoliteConnection: c.GitoliteConnection})
+		if len(svcs) < opt.Limit {
+			break // Less results than limit means we've reached end
+		}
 	}
 
 	// Fallback for github.com
-	repoSources = append(repoSources, reposource.GitHub{
-		GitHubConnection: &schema.GitHubConnection{Url: "https://github.com"},
-	})
-	for _, ch := range repoSources {
-		repoName, err := ch.CloneURLToRepoName(cloneURL)
-		if err != nil {
-			return "", err
-		}
-		if repoName != "" {
-			return repoName, nil
-		}
+	rs := reposource.GitHub{
+		GitHubConnection: &schema.GitHubConnection{
+			Url: "https://github.com",
+		},
 	}
-
-	return "", nil
+	return rs.CloneURLToRepoName(cloneURL)
 }
 
 func CreateFileInfo(path string, isDir bool) os.FileInfo {

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -62,5 +64,54 @@ func TestGitTreeEntry_Content(t *testing.T) {
 
 	if have, want := newByteSize, int32(len([]byte(wantContent))); have != want {
 		t.Fatalf("wrong file size, want=%d have=%d", want, have)
+	}
+}
+
+func TestReposourceCloneURLToRepoName(t *testing.T) {
+	ctx := context.Background()
+
+	db.Mocks.ExternalServices.List = func(db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+		return []*types.ExternalService{
+			{
+				ID:          1,
+				Kind:        extsvc.KindGitHub,
+				DisplayName: "GITHUB #1",
+				Config:      `{"url": "https://github.example.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			},
+		}, nil
+	}
+	defer func() { db.Mocks.ExternalServices = db.MockExternalServices{} }()
+
+	tests := []struct {
+		name         string
+		cloneURL     string
+		wantRepoName api.RepoName
+	}{
+		{
+			name:     "no match",
+			cloneURL: "https://gitlab.com/user/repo",
+		},
+		{
+			name:         "match existing external service",
+			cloneURL:     "https://github.example.com/user/repo.git",
+			wantRepoName: api.RepoName("github.example.com/user/repo"),
+		},
+		{
+			name:         "fallback for github.com",
+			cloneURL:     "https://github.com/user/repo",
+			wantRepoName: api.RepoName("github.com/user/repo"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repoName, err := reposourceCloneURLToRepoName(ctx, test.cloneURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(test.wantRepoName, repoName); diff != "" {
+				t.Fatalf("RepoName mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Updates `reposourceCloneURLToRepoName` to do paginated queries via `db.ExternalServices.List` method.

Fixes #12944