### PR TITLE
search: support /.../ regexp delimiters in new parser

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -304,8 +304,10 @@ func (p *parser) parseNegatedLeafNode() (Node, error) {
 // delimiter, returning the undelimited value, and the end position of the
 // original delimited value (i.e., including quotes). `\` is treated as an
 // escape character for the delimiter and traditional string escape sequences.
+// The `strict` input parameter sets whether this delimiter may contain only
+// recognized escaped characters (strict), or arbitrary ones.
 // The input buffer must start with the chosen delimiter.
-func ScanDelimited(buf []byte, delimiter rune) (string, int, error) {
+func ScanDelimited(buf []byte, strict bool, delimiter rune) (string, int, error) {
 	var count, advance int
 	var r rune
 	var result []rune
@@ -344,7 +346,12 @@ loop:
 				case '\\', delimiter:
 					result = append(result, r)
 				default:
-					return "", count, errors.New("unrecognized escape sequence")
+					if strict {
+						return "", count, errors.New("unrecognized escape sequence")
+					} else {
+						// Accept anything else literally.
+						result = append(result, '\\', r)
+					}
 				}
 				if len(buf) == 0 {
 					return "", count, errors.New("unterminated literal: expected " + string(delimiter))
@@ -476,11 +483,18 @@ func ScanValue(buf []byte, allowDanglingParens bool) (string, int, bool) {
 // succeeded, and the interpreted (i.e., unquoted) value if it succeeds.
 func (p *parser) TryParseDelimiter() (string, bool) {
 	delimited := func(delimiter rune) (string, error) {
-		value, advance, err := ScanDelimited(p.buf[p.pos:], delimiter)
+		start := p.pos
+		value, advance, err := ScanDelimited(p.buf[p.pos:], false, delimiter)
 		if err != nil {
 			return "", err
 		}
 		p.pos += advance
+		if !p.done() {
+			if r, _ := utf8.DecodeRune([]byte{p.buf[p.pos]}); !unicode.IsSpace(r) {
+				p.pos = start // backtrack
+				return "", errors.New("delimited value should be followed by whitespace")
+			}
+		}
 		return value, nil
 	}
 	tryScanDelimiter := func() (string, error) {
@@ -489,6 +503,9 @@ func (p *parser) TryParseDelimiter() (string, bool) {
 		}
 		if p.match(DQUOTE) {
 			return delimited('"')
+		}
+		if p.match("/") {
+			return delimited('/')
 		}
 		return "", errors.New("failed to scan delimiter")
 	}
@@ -503,7 +520,7 @@ func (p *parser) TryParseDelimiter() (string, bool) {
 // returned.
 func (p *parser) ParseFieldValue() (string, error) {
 	delimited := func(delimiter rune) (string, error) {
-		value, advance, err := ScanDelimited(p.buf[p.pos:], delimiter)
+		value, advance, err := ScanDelimited(p.buf[p.pos:], true, delimiter)
 		if err != nil {
 			return "", err
 		}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -713,7 +713,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			Input:         `repo:foo /b\/ar/`,
-			WantGrammar:   `(and "repo:foo" "/b\\/ar/")`,
+			WantGrammar:   `(and "repo:foo" "b/ar")`,
 			WantHeuristic: Same,
 		},
 		{
@@ -728,7 +728,17 @@ func TestParse(t *testing.T) {
 		},
 		{
 			Input:         `repo:foo /a/ /another/path/`,
-			WantGrammar:   `(and "repo:foo" (concat "/a/" "/another/path/"))`,
+			WantGrammar:   `(and "repo:foo" (concat "a" "/another/path/"))`,
+			WantHeuristic: Same,
+		},
+		{
+			Input:         `repo:foo /\s+b\d+ar/ `,
+			WantGrammar:   `(and "repo:foo" "\\s+b\\d+ar")`,
+			WantHeuristic: Same,
+		},
+		{
+			Input:         `repo:foo /bar/ `,
+			WantGrammar:   `(and "repo:foo" "bar")`,
 			WantHeuristic: Same,
 		},
 		{
@@ -869,11 +879,11 @@ func TestScanDelimited(t *testing.T) {
 					t.Errorf("expected panic for ScanDelimited")
 				}
 			}()
-			_, _, _ = ScanDelimited([]byte(tt.input), tt.delimiter)
+			_, _, _ = ScanDelimited([]byte(tt.input), true, tt.delimiter)
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			value, count, err := ScanDelimited([]byte(tt.input), tt.delimiter)
+			value, count, err := ScanDelimited([]byte(tt.input), true, tt.delimiter)
 			var errMsg string
 			if err != nil {
 				errMsg = err.Error()


### PR DESCRIPTION
Our [search docs](https://docs.sourcegraph.com/user/search/queries#regular-expression-search) describe support for `/.../` syntax, but prior to this PR it wasn't supported in the new parser. This syntax has caused some trouble for users before, e.g., when they search for paths, and we throw an error. _However_, in that context, the previous scanner was a bit too strict, and would think that a search pattern like `/foo/bar/baz/` also means a `/`-delimited string (but this would actually not be well-formed, since a `/` inside `/.../` should be escaped). The scanner in the new parser is a bit smarter (so less opportunity for foot-shooting).

So, before:

`/foo bar/` -> OK
`/foo/bar/` -> Error "Got TokenLiteral, want separator or EOF". To search for the string `/foo/bar/`, you needed to escape all of the slashes: `\/foo\/bar\/`
`/foo\/bar` -> OK, searches literally for `foo/bar`

Now:

`/foo bar/` -> OK
`/foo/bar/` -> key difference: this is interpreted literally, since it is not a well-formed `/.../` string, no need to escape anything
`/foo\/bar/` -> As above, it's a well-formed `/.../` string, interpreted literally as `foo/bar`

---

There is a case to be made for deprecating this syntax, but because it is currently officially documented, we should support continue to support it and and then deprecate it officially if/when needed. With the improvement that it is now not so strict, and _if we can highlight these delimiters in future so it's clear something is happening_, I think it's still worth keeping.