### PR TITLE
store: adjust hardcoded timeout from 2m to 10m

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -87,7 +87,7 @@ func (s *Store) Start() {
 		s.cache = &diskcache.Store{
 			Dir:               s.Path,
 			Component:         "store",
-			BackgroundTimeout: 2 * time.Minute,
+			BackgroundTimeout: 10 * time.Minute,
 			BeforeEvict:       s.ZipCache.delete,
 		}
 		_ = os.MkdirAll(s.Path, 0700)


### PR DESCRIPTION
We currently timeout out fetching of archives for searcher at 2m. In
very large monorepos this isn't enough time to fetch. We increase the
timeout to 10m.

Fixes https://github.com/sourcegraph/sourcegraph/issues/12443