### PR TITLE
httpapi: External service api supports pagination

### DIFF
--- a/cmd/frontend/graphqlbackend/client_configuration.go
+++ b/cmd/frontend/graphqlbackend/client_configuration.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"context"
+	"net/url"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
@@ -86,4 +88,20 @@ func (r *schemaResolver) ClientConfiguration(ctx context.Context) (*clientConfig
 		contentScriptUrls: contentScriptUrls,
 		parentSourcegraph: &parentSourcegraph,
 	}, nil
+}
+
+// stripPassword strips the password from u if it can be parsed as a URL.
+// If not, it is left unchanged
+// This is a modified version of stringPassword from the standard lib
+// in net/http/client.go
+func stripPassword(s string) string {
+	u, err := url.Parse(s)
+	if err != nil {
+		return s
+	}
+	_, passSet := u.User.Password()
+	if passSet {
+		return strings.Replace(u.String(), u.User.String()+"@", u.User.Username()+":***@", 1)
+	}
+	return s
 }

--- a/cmd/frontend/graphqlbackend/client_configuration.go
+++ b/cmd/frontend/graphqlbackend/client_configuration.go
@@ -34,6 +34,9 @@ func (r *schemaResolver) ClientConfiguration(ctx context.Context) (*clientConfig
 	// Ideally these could be done in parallel, but the table is small
 	// and I don't think real world perf is going to be bad.
 
+	// TODO: This could become an issue once we have a large number of external services. At that point
+	// we can update the code below to instead extract the URL's in one SQL query.
+
 	// We could have multiple services with the same URL so we dedupe them
 	urlMap := make(map[string]struct{})
 

--- a/cmd/frontend/graphqlbackend/client_configuration_test.go
+++ b/cmd/frontend/graphqlbackend/client_configuration_test.go
@@ -1,0 +1,32 @@
+package graphqlbackend
+
+import "testing"
+
+func TestStripPassword(t *testing.T) {
+	tests := []struct {
+		u    string
+		want string
+	}{
+		{
+			u:    "http://example.com/",
+			want: "http://example.com/",
+		},
+		{
+			u:    "a string",
+			want: "a string",
+		},
+		{
+			u:    "http://user:pass@example.com/",
+			want: "http://user:***@example.com/",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			have := stripPassword(test.u)
+			if have != test.want {
+				t.Fatalf("Have %q, want %q", have, test.want)
+			}
+		})
+	}
+}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -70,9 +70,18 @@ func serveExternalServiceConfigs(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	services, err := db.ExternalServices.List(r.Context(), db.ExternalServicesListOptions{
-		Kinds: []string{req.Kind},
-	})
+
+	options := db.ExternalServicesListOptions{
+		Kinds:   []string{req.Kind},
+		AfterID: int64(req.AfterID),
+	}
+	if req.Limit > 0 {
+		options.LimitOffset = &db.LimitOffset{
+			Limit: req.Limit,
+		}
+	}
+
+	services, err := db.ExternalServices.List(r.Context(), options)
 	if err != nil {
 		return err
 	}
@@ -114,9 +123,17 @@ func serveExternalServicesList(w http.ResponseWriter, r *http.Request) error {
 		req.Kinds = append(req.Kinds, req.Kind)
 	}
 
-	services, err := db.ExternalServices.List(r.Context(), db.ExternalServicesListOptions{
-		Kinds: req.Kinds,
-	})
+	options := db.ExternalServicesListOptions{
+		Kinds:   []string{req.Kind},
+		AfterID: int64(req.AfterID),
+	}
+	if req.Limit > 0 {
+		options.LimitOffset = &db.LimitOffset{
+			Limit: req.Limit,
+		}
+	}
+
+	services, err := db.ExternalServices.List(r.Context(), options)
 	if err != nil {
 		return err
 	}

--- a/internal/api/httpapi_schema.go
+++ b/internal/api/httpapi_schema.go
@@ -40,7 +40,9 @@ type PhabricatorRepoCreateRequest struct {
 }
 
 type ExternalServiceConfigsRequest struct {
-	Kind string `json:"kind"`
+	Kind    string `json:"kind"`
+	Limit   int    `json:"limit"`
+	AfterID int    `json:"after_id"`
 }
 
 type ExternalServicesListRequest struct {

--- a/internal/api/httpapi_schema.go
+++ b/internal/api/httpapi_schema.go
@@ -48,6 +48,8 @@ type ExternalServiceConfigsRequest struct {
 type ExternalServicesListRequest struct {
 	// NOTE(tsenart): We must keep this field in addition to the
 	// Kinds field until after we roll-out this change, for backwards compatibility.
-	Kind  string   `json:"kind"`
-	Kinds []string `json:"kinds"`
+	Kind    string   `json:"kind"`
+	Kinds   []string `json:"kinds"`
+	Limit   int      `json:"limit"`
+	AfterID int      `json:"after_id"`
 }


### PR DESCRIPTION
This just adds support for including AfterID and Limit in api requests for external services.

The callers themselves have not been updated as it's not an issue yet. 

There appear to only be two internal callers:
internalClient.ExternalServicesList which isn't used anywhere.
internalClient.ExternalServiceConfigs which is only used from out GraphQL layer and actually only ends up extracting the code host URLs. If that code path becomes an issue we can write a custom SQL query.