### PR TITLE
monitoring: sync gitserver_error_responses for code-intel with frontend

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1947,7 +1947,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 5+ gitserver error responses every 5m_
+- _precise-code-intel-worker: 5%+ gitserver error responses every 5m for 15m0s_
 
 **Possible solutions:**
 
@@ -2394,7 +2394,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 5+ gitserver error responses every 5m_
+- _precise-code-intel-indexer: 5%+ gitserver error responses every 5m for 15m0s_
 
 **Possible solutions:**
 

--- a/monitoring/precise_code_intel_indexer.go
+++ b/monitoring/precise_code_intel_indexer.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 func PreciseCodeIntelIndexer() *Container {
 	return &Container{
 		Name:        "precise-code-intel-indexer",
@@ -182,10 +184,11 @@ func PreciseCodeIntelIndexer() *Container {
 						{
 							Name:              "gitserver_error_responses",
 							Description:       "gitserver error responses every 5m",
-							Query:             `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-indexer",code!~"2.."}[5m]))`,
+							Query:             `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-indexer",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-indexer"}[5m])) * 100`,
 							DataMayNotExist:   true,
-							Warning:           Alert{GreaterOrEqual: 5},
-							PanelOptions:      PanelOptions().LegendFormat("{{category}}"),
+							DataMayBeNaN:      true, // ratio denominator could be 0
+							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
+							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,
 							PossibleSolutions: "none",
 						},

--- a/monitoring/precise_code_intel_worker.go
+++ b/monitoring/precise_code_intel_worker.go
@@ -145,7 +145,7 @@ func PreciseCodeIntelWorker() *Container {
 							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
-							Owner:             ObservableOwnerCodeIntel,
+							Owner:             ObservableOwnerSearch,
 							PossibleSolutions: "none",
 						},
 						{


### PR DESCRIPTION
Frontend's gitserver_error_responses was converted to a ratio, this PR applies the same change to the precise-code-intel versions of this panel


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
