### PR TITLE
repo-updater: Add Cursor and Limit options to StoreListExternalServiceArgs

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -516,6 +516,8 @@ func (s DBStore) paginate(ctx context.Context, limit, perPage int64, cursor int6
 		next, count int64
 	)
 
+	// We need this so that we enter the loop below for the first iteration
+	// since cursor will be < next
 	next = cursor
 	cursor--
 

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -273,18 +273,45 @@ func testStoreListExternalServices(store repos.Store) func(*testing.T) {
 			},
 			assert: repos.Assert.ExternalServicesEqual(&phabricatorService),
 		},
-	)
-
-	testCases = append(testCases, testCase{
-		name:   "returns svcs by their ids",
-		stored: svcs,
-		args: func(stored repos.ExternalServices) repos.StoreListExternalServicesArgs {
-			return repos.StoreListExternalServicesArgs{
-				IDs: []int64{stored[0].ID, stored[1].ID},
-			}
+		testCase{
+			name:   "returns svcs by their ids",
+			stored: svcs,
+			args: func(stored repos.ExternalServices) repos.StoreListExternalServicesArgs {
+				return repos.StoreListExternalServicesArgs{
+					IDs: []int64{stored[0].ID, stored[1].ID},
+				}
+			},
+			assert: repos.Assert.ExternalServicesEqual(svcs[:2].Clone()...),
 		},
-		assert: repos.Assert.ExternalServicesEqual(svcs[:2].Clone()...),
-	})
+		testCase{
+			name:   "limit and zero cursor",
+			stored: svcs,
+			args: func(repos.ExternalServices) (args repos.StoreListExternalServicesArgs) {
+				args.Cursor = 0
+				args.Limit = 1
+				return args
+			},
+			assert: repos.Assert.ExternalServicesEqual(func() (es repos.ExternalServices) {
+				return repos.ExternalServices{
+					svcs[0],
+				}
+			}()...),
+		},
+		testCase{
+			name:   "limit and non-zero cursor",
+			stored: svcs,
+			args: func(repos repos.ExternalServices) (args repos.StoreListExternalServicesArgs) {
+				args.Cursor = repos[0].ID
+				args.Limit = 1
+				return args
+			},
+			assert: repos.Assert.ExternalServicesEqual(func() (es repos.ExternalServices) {
+				return repos.ExternalServices{
+					svcs[1],
+				}
+			}()...),
+		},
+	)
 
 	return func(t *testing.T) {
 		t.Helper()

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -160,12 +160,24 @@ func (s FakeStore) ListExternalServices(ctx context.Context, args StoreListExter
 
 			svcs = append(svcs, svc)
 			set[svc] = true
+
 		}
 	}
 
 	sort.Sort(svcs)
 
-	return svcs, nil
+	paginated := make(ExternalServices, 0, len(svcs))
+	for _, svc := range svcs {
+		if svc.ID > args.Cursor {
+			paginated = append(paginated, svc)
+		}
+
+		if args.Limit > 0 && int64(len(paginated)) >= args.Limit {
+			break
+		}
+	}
+
+	return paginated, nil
 }
 
 // UpsertExternalServices updates or inserts the given ExternalServices.


### PR DESCRIPTION
This will allow us to paginate rather than return all external services.

By default we continue to fetch all services in batches. Another PR will update clients to use pagination.

