### PR TITLE
repo-updater: Use pagination when syncing rate limiters

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -49,6 +49,7 @@ func TestIntegration(t *testing.T) {
 	}{
 		{"DBStore/Transact", testDBStoreTransact(dbstore)},
 		{"DBStore/ListExternalServices", testStoreListExternalServices(store)},
+		{"DBStore/SyncRateLimiters", testSyncRateLimiters(store)},
 		{"DBStore/ListExternalServices/ByRepo", testStoreListExternalServicesByRepos(store)},
 		{"DBStore/UpsertExternalServices", testStoreUpsertExternalServices(store)},
 		{"DBStore/UpsertRepos", testStoreUpsertRepos(store)},

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-	"github.com/sourcegraph/sourcegraph/schema"
 	"reflect"
 	"sort"
 	"strconv"
@@ -13,9 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -26,7 +23,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestFakeStore(t *testing.T) {

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -988,12 +988,10 @@ func NewRateLimitSyncer(registry *ratelimit.Registry, serviceLister externalServ
 // and rate limits can be defined in multiple external services for the same host.
 func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context) error {
 	var cursor int64
-	var err error
-	services := make([]*ExternalService, 0, int(r.limit))
 	byURL := make(map[string]extsvc.RateLimitConfig)
 
 	for {
-		services, err = r.serviceLister.ListExternalServices(ctx, StoreListExternalServicesArgs{
+		services, err := r.serviceLister.ListExternalServices(ctx, StoreListExternalServicesArgs{
 			Cursor: cursor,
 			Limit:  r.limit,
 		})

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -969,7 +969,7 @@ type externalServiceLister interface {
 type RateLimitSyncer struct {
 	registry      *ratelimit.Registry
 	serviceLister externalServiceLister
-	// How many services to fetch one each DB call
+	// How many services to fetch in each DB call
 	limit int64
 }
 

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -965,53 +965,71 @@ type externalServiceLister interface {
 	ListExternalServices(context.Context, StoreListExternalServicesArgs) ([]*ExternalService, error)
 }
 
+// RateLimitSyncer syncs rate limits based on external service configuration
+type RateLimitSyncer struct {
+	registry      *ratelimit.Registry
+	serviceLister externalServiceLister
+	// How many services to fetch one each DB call
+	limit int64
+}
+
 // NewRateLimitSyncer returns a new syncer
 func NewRateLimitSyncer(registry *ratelimit.Registry, serviceLister externalServiceLister) *RateLimitSyncer {
 	r := &RateLimitSyncer{
 		registry:      registry,
 		serviceLister: serviceLister,
+		limit:         500,
 	}
 	return r
-}
-
-// RateLimitSyncer syncs rate limits based on external service configuration
-type RateLimitSyncer struct {
-	registry      *ratelimit.Registry
-	serviceLister externalServiceLister
 }
 
 // SyncRateLimiters syncs all rate limiters using current config.
 // We sync them all as we need to pick the most restrictive configured limit per code host
 // and rate limits can be defined in multiple external services for the same host.
 func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context) error {
-	services, err := r.serviceLister.ListExternalServices(ctx, StoreListExternalServicesArgs{})
-	if err != nil {
-		return errors.Wrap(err, "listing external services")
-	}
+	var cursor int64
+	var err error
+	services := make([]*ExternalService, 0, int(r.limit))
+	byURL := make(map[string]extsvc.RateLimitConfig)
 
-	var limits []extsvc.RateLimitConfig
-	for _, svc := range services {
-		rlc, err := extsvc.ExtractRateLimitConfig(svc.Config, svc.Kind, svc.DisplayName)
+	for {
+		services, err = r.serviceLister.ListExternalServices(ctx, StoreListExternalServicesArgs{
+			Cursor: cursor,
+			Limit:  r.limit,
+		})
 		if err != nil {
-			if _, ok := err.(extsvc.ErrRateLimitUnsupported); ok {
+			return errors.Wrap(err, "listing external services")
+		}
+
+		if len(services) == 0 {
+			break
+		}
+
+		cursor = services[len(services)-1].ID
+
+		for _, svc := range services {
+			rlc, err := extsvc.ExtractRateLimitConfig(svc.Config, svc.Kind, svc.DisplayName)
+			if err != nil {
+				if _, ok := err.(extsvc.ErrRateLimitUnsupported); ok {
+					continue
+				}
+				return errors.Wrap(err, "getting rate limit configuration")
+			}
+
+			current, ok := byURL[rlc.BaseURL]
+			if !ok || (ok && current.IsDefault) {
+				byURL[rlc.BaseURL] = rlc
 				continue
 			}
-			return errors.Wrap(err, "getting rate limit configuration")
+			// Use the lower limit, but a default value should not override
+			// a limit that has been configured
+			if rlc.Limit < current.Limit && !rlc.IsDefault {
+				byURL[rlc.BaseURL] = rlc
+			}
 		}
-		limits = append(limits, rlc)
-	}
 
-	byURL := make(map[string]extsvc.RateLimitConfig)
-	for _, rlc := range limits {
-		current, ok := byURL[rlc.BaseURL]
-		if !ok || (ok && current.IsDefault) {
-			byURL[rlc.BaseURL] = rlc
-			continue
-		}
-		// Use the lower limit, but a default value should not override
-		// a limit that has been configured
-		if rlc.Limit < current.Limit && !rlc.IsDefault {
-			byURL[rlc.BaseURL] = rlc
+		if len(services) < int(r.limit) {
+			break
 		}
 	}
 

--- a/cmd/repo-updater/repos/types_test.go
+++ b/cmd/repo-updater/repos/types_test.go
@@ -672,6 +672,7 @@ func TestSyncRateLimiters(t *testing.T) {
 			r := &RateLimitSyncer{
 				registry:      reg,
 				serviceLister: makeLister(tc.options...),
+				limit:         10,
 			}
 
 			err := r.SyncRateLimiters(ctx)

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -206,3 +206,10 @@ func (r *Registry) GetOrSet(baseURL string, fallback *rate.Limiter) *rate.Limite
 	}
 	return l
 }
+
+// Count returns the total number of rate limiters in the registry
+func (r *Registry) Count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rateLimiters)
+}


### PR DESCRIPTION
This change now fetches external services in batches of 500 when syncing the rate limiters.
