### PR TITLE
Don't break campaign resolver when a related user is deleted

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -697,15 +697,15 @@ type Campaign implements Node {
     # The description (as Markdown).
     description: String
 
-    # The user that created the initial spec. In an org, this will be different from the namespace.
-    specCreator: User!
+    # The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
+    specCreator: User
 
-    # The user who created the campaign initially by applying the spec for the first time.
-    initialApplier: User!
+    # The user who created the campaign initially by applying the spec for the first time, or null if the user was deleted.
+    initialApplier: User
 
     # The user who last updated the campaign by applying a spec to this campaign.
-    # If the campaign hasn't been updated, the lastApplier is the initialApplier.
-    lastApplier: User!
+    # If the campaign hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
+    lastApplier: User
 
     # Whether the current user can edit or delete this campaign.
     viewerCanAdminister: Boolean!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -704,15 +704,15 @@ type Campaign implements Node {
     # The description (as Markdown).
     description: String
 
-    # The user that created the initial spec. In an org, this will be different from the namespace.
-    specCreator: User!
+    # The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
+    specCreator: User
 
-    # The user who created the campaign initially by applying the spec for the first time.
-    initialApplier: User!
+    # The user who created the campaign initially by applying the spec for the first time, or null if the user was deleted.
+    initialApplier: User
 
     # The user who last updated the campaign by applying a spec to this campaign.
-    # If the campaign hasn't been updated, the lastApplier is the initialApplier.
-    lastApplier: User!
+    # If the campaign hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
+    lastApplier: User
 
     # Whether the current user can edit or delete this campaign.
     viewerCanAdminister: Boolean!

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -200,7 +200,7 @@ type CampaignSpec struct {
 	ApplyURL string
 
 	Namespace UserOrg
-	Creator   User
+	Creator   *User
 
 	ChangesetSpecs ChangesetSpecConnection
 

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -85,8 +85,9 @@ type Campaign struct {
 	ID                      string
 	Name                    string
 	Description             string
-	InitialApplier          User
-	LastApplier             User
+	SpecCreator             *User
+	InitialApplier          *User
+	LastApplier             *User
 	LastAppliedAt           string
 	ViewerCanAdminister     bool
 	Namespace               UserOrg

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -80,7 +80,11 @@ func (r *campaignSpecResolver) Description() graphqlbackend.CampaignDescriptionR
 }
 
 func (r *campaignSpecResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return graphqlbackend.UserByIDInt32(ctx, r.campaignSpec.UserID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, r.campaignSpec.UserID)
+	if errcode.IsNotFound(err) {
+		return nil, nil
+	}
+	return user, err
 }
 
 func (r *campaignSpecResolver) Namespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
@@ -39,14 +40,20 @@ func TestCampaignSpecResolver(t *testing.T) {
 	repoID := graphqlbackend.MarshalRepositoryID(repo.ID)
 
 	username := "campaign-spec-by-id-user-name"
+	orgname := "test-org"
 	userID := insertTestUser(t, dbconn.Global, username, false)
+	org, err := db.Orgs.Create(ctx, orgname, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := org.ID
 
 	spec, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawCampaignSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
 	spec.UserID = userID
-	spec.NamespaceUserID = userID
+	spec.NamespaceOrgID = orgID
 	if err := store.CreateCampaignSpec(ctx, spec); err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +72,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 
 	matchingCampaign := &campaigns.Campaign{
 		Name:             spec.Spec.Name,
-		NamespaceUserID:  userID,
+		NamespaceOrgID:   orgID,
 		InitialApplierID: userID,
 		LastApplierID:    userID,
 		LastAppliedAt:    time.Now(),
@@ -82,10 +89,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 
 	apiID := string(marshalCampaignSpecRandID(spec.RandID))
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
-
-	input := map[string]interface{}{"campaignSpec": apiID}
-	var response struct{ Node apitest.CampaignSpec }
-	apitest.MustExec(ctx, t, s, input, &response, queryCampaignSpecNode)
+	orgAPIID := string(graphqlbackend.MarshalOrgID(orgID))
 
 	var unmarshaled interface{}
 	err = json.Unmarshal([]byte(spec.RawSpec), &unmarshaled)
@@ -100,9 +104,9 @@ func TestCampaignSpecResolver(t *testing.T) {
 		OriginalInput: spec.RawSpec,
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 
-		ApplyURL:            fmt.Sprintf("/users/%s/campaigns/apply/%s", username, apiID),
-		Namespace:           apitest.UserOrg{ID: userAPIID, DatabaseID: userID},
-		Creator:             apitest.User{ID: userAPIID, DatabaseID: userID},
+		ApplyURL:            fmt.Sprintf("/organizations/%s/campaigns/apply/%s", orgname, apiID),
+		Namespace:           apitest.UserOrg{ID: orgAPIID, Name: orgname},
+		Creator:             &apitest.User{ID: userAPIID, DatabaseID: userID},
 		ViewerCanAdminister: true,
 
 		CreatedAt: graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
@@ -135,8 +139,31 @@ func TestCampaignSpecResolver(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(want, response.Node); diff != "" {
-		t.Fatalf("unexpected response (-want +got):\n%s", diff)
+	input := map[string]interface{}{"campaignSpec": apiID}
+	{
+		var response struct{ Node apitest.CampaignSpec }
+		apitest.MustExec(ctx, t, s, input, &response, queryCampaignSpecNode)
+
+		if diff := cmp.Diff(want, response.Node); diff != "" {
+			t.Fatalf("unexpected response (-want +got):\n%s", diff)
+		}
+	}
+
+	// Now delete the creator and check that the campaign spec is still retrievable.
+	err = db.Users.Delete(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	{
+		var response struct{ Node apitest.CampaignSpec }
+		apitest.MustExec(ctx, t, s, input, &response, queryCampaignSpecNode)
+
+		// Expect creator to not be returned anymore.
+		want.Creator = nil
+
+		if diff := cmp.Diff(want, response.Node); diff != "" {
+			t.Fatalf("unexpected response (-want +got):\n%s", diff)
+		}
 	}
 }
 

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -149,8 +149,25 @@ func TestCampaignSpecResolver(t *testing.T) {
 		}
 	}
 
-	// Now delete the creator and check that the campaign spec is still retrievable.
+	// Now soft-delete the creator and check that the campaign spec is still retrievable.
 	err = db.Users.Delete(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	{
+		var response struct{ Node apitest.CampaignSpec }
+		apitest.MustExec(ctx, t, s, input, &response, queryCampaignSpecNode)
+
+		// Expect creator to not be returned anymore.
+		want.Creator = nil
+
+		if diff := cmp.Diff(want, response.Node); diff != "" {
+			t.Fatalf("unexpected response (-want +got):\n%s", diff)
+		}
+	}
+
+	// Now hard-delete the creator and check that the campaign spec is still retrievable.
+	err = db.Users.HardDelete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaigns_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaigns_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
@@ -27,15 +28,19 @@ func TestCampaignResolver(t *testing.T) {
 
 	username := "campaign-resolver-username"
 	userID := insertTestUser(t, dbconn.Global, username, true)
+	org, err := db.Orgs.Create(ctx, "test-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	store := ee.NewStore(dbconn.Global)
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
 	campaignSpec := &campaigns.CampaignSpec{
-		RawSpec:         ct.TestRawCampaignSpec,
-		UserID:          userID,
-		NamespaceUserID: userID,
+		RawSpec:        ct.TestRawCampaignSpec,
+		UserID:         userID,
+		NamespaceOrgID: org.ID,
 	}
 	if err := store.CreateCampaignSpec(ctx, campaignSpec); err != nil {
 		t.Fatal(err)
@@ -44,7 +49,7 @@ func TestCampaignResolver(t *testing.T) {
 	campaign := &campaigns.Campaign{
 		Name:             "my-unique-name",
 		Description:      "The campaign description",
-		NamespaceUserID:  userID,
+		NamespaceOrgID:   org.ID,
 		InitialApplierID: userID,
 		LastApplierID:    userID,
 		LastAppliedAt:    now,
@@ -53,7 +58,6 @@ func TestCampaignResolver(t *testing.T) {
 	if err := store.CreateCampaign(ctx, campaign); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("campaign=%+v\n", campaign)
 
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
 	if err != nil {
@@ -63,27 +67,57 @@ func TestCampaignResolver(t *testing.T) {
 	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
 
 	input := map[string]interface{}{"campaign": campaignAPIID}
-	var response struct{ Node apitest.Campaign }
-	apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
+	{
+		var response struct{ Node apitest.Campaign }
+		apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
 
-	wantCampaign := apitest.Campaign{
-		ID:             campaignAPIID,
-		Name:           campaign.Name,
-		Description:    campaign.Description,
-		Namespace:      apitest.UserOrg{DatabaseID: userID, SiteAdmin: true},
-		InitialApplier: apitest.User{DatabaseID: userID, SiteAdmin: true},
-		LastApplier:    apitest.User{DatabaseID: userID, SiteAdmin: true},
-		LastAppliedAt:  marshalDateTime(t, now),
-		URL:            fmt.Sprintf("/users/%s/campaigns/%s", username, campaignAPIID),
+		apiUser := &apitest.User{DatabaseID: userID, SiteAdmin: true}
+
+		wantCampaign := apitest.Campaign{
+			ID:             campaignAPIID,
+			Name:           campaign.Name,
+			Description:    campaign.Description,
+			Namespace:      apitest.UserOrg{ID: string(graphqlbackend.MarshalOrgID(org.ID)), Name: org.Name},
+			InitialApplier: apiUser,
+			LastApplier:    apiUser,
+			SpecCreator:    apiUser,
+			LastAppliedAt:  marshalDateTime(t, now),
+			URL:            fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaignAPIID),
+		}
+		if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
+			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+		}
 	}
-	if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
-		t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+
+	// Now delete the user and check we can still access the campaign in the org namespace.
+	err = db.Users.Delete(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	{
+		var response struct{ Node apitest.Campaign }
+		apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
+
+		wantCampaign := apitest.Campaign{
+			ID:             campaignAPIID,
+			Name:           campaign.Name,
+			Description:    campaign.Description,
+			Namespace:      apitest.UserOrg{ID: string(graphqlbackend.MarshalOrgID(org.ID)), Name: org.Name},
+			InitialApplier: nil,
+			LastApplier:    nil,
+			SpecCreator:    nil,
+			LastAppliedAt:  marshalDateTime(t, now),
+			URL:            fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaignAPIID),
+		}
+		if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
+			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+		}
 	}
 }
 
 const queryCampaign = `
 fragment u on User { databaseID, siteAdmin }
-fragment o on Org  { name }
+fragment o on Org  { id, name }
 
 query($campaign: ID!){
   node(id: $campaign) {
@@ -91,6 +125,7 @@ query($campaign: ID!){
       id, name, description
       initialApplier { ...u }
       lastApplier    { ...u }
+      specCreator    { ...u }
       lastAppliedAt
       namespace {
         ... on User { ...u }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -138,7 +138,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 		ApplyURL:      fmt.Sprintf("/users/%s/campaigns/apply/%s", username, have.ID),
 		Namespace:     apitest.UserOrg{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
-		Creator:       apitest.User{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
+		Creator:       &apitest.User{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
 		ChangesetSpecs: apitest.ChangesetSpecConnection{
 			Nodes: []apitest.ChangesetSpec{
 				{

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -332,6 +332,12 @@ func TestApplyCampaign(t *testing.T) {
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 	apitest.MustExec(actorCtx, t, s, input, &response, mutationApplyCampaign)
 
+	apiUser := &apitest.User{
+		ID:         userAPIID,
+		DatabaseID: userID,
+		SiteAdmin:  true,
+	}
+
 	have := response.ApplyCampaign
 	want := apitest.Campaign{
 		ID:          have.ID,
@@ -342,17 +348,9 @@ func TestApplyCampaign(t *testing.T) {
 			DatabaseID: userID,
 			SiteAdmin:  true,
 		},
-		InitialApplier: apitest.User{
-			ID:         userAPIID,
-			DatabaseID: userID,
-			SiteAdmin:  true,
-		},
-		LastApplier: apitest.User{
-			ID:         userAPIID,
-			DatabaseID: userID,
-			SiteAdmin:  true,
-		},
-		LastAppliedAt: marshalDateTime(t, now),
+		InitialApplier: apiUser,
+		LastApplier:    apiUser,
+		LastAppliedAt:  marshalDateTime(t, now),
 		Changesets: apitest.ChangesetConnection{
 			Nodes: []apitest.Changeset{
 				{Typename: "ExternalChangeset", ReconcilerState: "QUEUED"},


### PR DESCRIPTION
We allow related users to be deleted, so we should allow to still return without error. This adds the check on the err and adds tests.

Also, I've removed the "reset error when namespace is not found", because `namespace` is not nullable (and shouldn't be, because it's unreachable when no namespace exists anymore). Hence, the API failed with an ambiguous error message "unexpected null returned for namespace", instead of "cannot find user ...".