### PR TITLE
web: add a stray 'is' to a message

### DIFF
--- a/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -96,7 +96,7 @@ export class SiteAdminCreateUserPage extends React.Component<Props, State> {
                 <p>
                     Create a new user account
                     {window.context.resetPasswordEnabled
-                        ? ' and generate a password reset link. If sending emails not configured, you must manually send the link to the new user.'
+                        ? ' and generate a password reset link. If sending emails is not configured, you must manually send the link to the new user.'
                         : '. New users must authenticate using a configured authentication provider.'}
                 </p>
                 <p className="mb-4">


### PR DESCRIPTION
I noticed this while looking at #13010, so we might as well fix this before release cut.