### PR TITLE
e2e test: search visibility test refs wrong repo

### DIFF
--- a/web/src/end-to-end/end-to-end.test.ts
+++ b/web/src/end-to-end/end-to-end.test.ts
@@ -356,7 +356,7 @@ describe('e2e test suite', () => {
         })
 
         test('Search visibility:private|public', async () => {
-            const privateRepos = ['github.com/sourcegraph/test-test-private-repository']
+            const privateRepos = ['github.com/sourcegraph/e2e-test-private-repository']
 
             await driver.page.goto(sourcegraphBaseUrl + '/search?q=type:repo+visibility:private')
             await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length >= 1)


### PR DESCRIPTION
left-over from rename from `e2e` to `test`