### PR TITLE
Add test for reconciler state variables

### DIFF
--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -139,6 +139,7 @@ type Changeset struct {
 	Body             string
 	PublicationState string
 	ReconcilerState  string
+	Error            string
 	ExternalState    string
 	ExternalID       string
 	ExternalURL      ExternalURL


### PR DESCRIPTION
Especially important for error, as that path wasn't tested at all.
Since we now rely on those three variables heavily in the frontend, I figured it's .... **testing time 🎊**