### PR TITLE
Solve todos in graphql schema

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -592,8 +592,6 @@ type GitBranchChangesetDescription {
 }
 
 # A description of a Git commit.
-#
-# TODO: Support specifying committer/author.
 type GitCommitDescription {
     # The Git commit message.
     message: String!
@@ -629,7 +627,10 @@ type CampaignDescription {
 type CampaignSpec implements Node {
     # The unique ID for a campaign spec.
     #
-    # TODO(sqs): document permissions and ID guessability
+    # The ID is unguessable (i.e., long and randomly generated, not sequential).
+    # Consider a campaign to fix a security vulnerability: the campaign author may prefer
+    # to prepare the campaign, including the description in private so that the window
+    # between revealing the problem and merging the fixes is as short as possible.
     id: ID!
 
     # The original YAML or JSON input that was used to create this campaign spec.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -599,8 +599,6 @@ type GitBranchChangesetDescription {
 }
 
 # A description of a Git commit.
-#
-# TODO: Support specifying committer/author.
 type GitCommitDescription {
     # The Git commit message.
     message: String!
@@ -636,7 +634,10 @@ type CampaignDescription {
 type CampaignSpec implements Node {
     # The unique ID for a campaign spec.
     #
-    # TODO(sqs): document permissions and ID guessability
+    # The ID is unguessable (i.e., long and randomly generated, not sequential).
+    # Consider a campaign to fix a security vulnerability: the campaign author may prefer
+    # to prepare the campaign, including the description in private so that the window
+    # between revealing the problem and merging the fixes is as short as possible.
     id: ID!
 
     # The original YAML or JSON input that was used to create this campaign spec.


### PR DESCRIPTION
There shouldn't be TODOs in our public API description, so I've

- solved one, by adding the missing documentation
- opened https://github.com/sourcegraph/sourcegraph/issues/13036 to track work on the other one. It's not an API limitation, just a feature request, so I think it should live in a ticket rather than the API spec.