### PR TITLE
clean up PrivateCodeCta

### DIFF
--- a/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
@@ -242,26 +242,16 @@ exports[`CampaignsDotComPage renders 1`] = `
                 Search your private code
               </h3>
               <p>
-                Set up a private Sourcegraph instance to search your private repositories on GitHub, GitLab, Bitbucket and local installations of git, perforce, svn and other code repositories.
+                Set up a self-hosted Sourcegraph instance to search your private repositories on GitHub, GitLab, Bitbucket and local installations of Git, Perforce, Subversion and other code repositories.
               </p>
-              <AnchorLink
+              <a
+                className="btn btn-primary ga-cta-install-now"
+                href="https://docs.sourcegraph.com/"
                 rel="noreferrer"
                 target="_blank"
-                to="https://docs.sourcegraph.com/"
               >
-                <a
-                  href="https://docs.sourcegraph.com/"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  <button
-                    className="btn btn-primary ga-cta-install-now"
-                    type="button"
-                  >
-                    Install now
-                  </button>
-                </a>
-              </AnchorLink>
+                Install now
+              </a>
             </div>
           </div>
         </PrivateCodeCta>

--- a/web/src/search/input/PrivateCodeCta.tsx
+++ b/web/src/search/input/PrivateCodeCta.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { Link } from '../../../../shared/src/components/Link'
 import classNames from 'classnames'
 
 interface Props {
@@ -16,14 +15,17 @@ export const PrivateCodeCta: React.FunctionComponent<Props> = props => {
             <div>
                 <h3>Search your private code</h3>
                 <p>
-                    Set up a private Sourcegraph instance to search your private repositories on GitHub, GitLab,
-                    Bitbucket and local installations of git, perforce, svn and other code repositories.
+                    Set up a self-hosted Sourcegraph instance to search your private repositories on GitHub, GitLab,
+                    Bitbucket and local installations of Git, Perforce, Subversion and other code repositories.
                 </p>
-                <Link to="https://docs.sourcegraph.com/" target="_blank" rel="noreferrer">
-                    <button type="button" className="btn btn-primary ga-cta-install-now">
-                        Install now
-                    </button>
-                </Link>
+                <a
+                    href="https://docs.sourcegraph.com/"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="btn btn-primary ga-cta-install-now"
+                >
+                    Install now
+                </a>
             </div>
         </div>
     )


### PR DESCRIPTION
- Use `<a>` not `<Link>` for external links (if there were no `target="_blank"` I believe this would not have worked; it would have treated the `to` prop value as a relative path)
- To style a link as a button, use the Bootstrap classes directly, instead of embedding a button in a link (which is unnecessary and could have unintended consequences if this element is inside a form element)
- Use consistent language: self-hosted not private, capitalize/spell Git/Perforce/Subversion in the standard way