### PR TITLE
external_serivces: remove List methods for individual kind

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -11,16 +11,19 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type RepositoryResolverCache map[api.RepoName]*RepositoryResolver
@@ -481,21 +484,51 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 }
 
 func makePhabClientForOrigin(ctx context.Context, origin string) (*phabricator.Client, error) {
-	phabs, err := db.ExternalServices.ListPhabricatorConnections(ctx)
-	if err != nil {
-		return nil, err
+	opt := db.ExternalServicesListOptions{
+		Kinds: []string{extsvc.KindPhabricator},
+		LimitOffset: &db.LimitOffset{
+			Limit: 500, // The number is randomly chosen
+		},
 	}
+	for {
+		svcs, err := db.ExternalServices.List(ctx, opt)
+		if err != nil {
+			return nil, errors.Wrap(err, "list")
+		}
+		if len(svcs) == 0 {
+			break // No more results, exiting
+		}
+		opt.AfterID = svcs[len(svcs)-1].ID // Advance the cursor
 
-	for _, phab := range phabs {
-		if phab.Url != origin {
-			continue
+		for _, svc := range svcs {
+			cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
+			if err != nil {
+				return nil, errors.Wrap(err, "parse config")
+			}
+
+			var conn *schema.PhabricatorConnection
+			switch c := cfg.(type) {
+			case *schema.PhabricatorConnection:
+				conn = c
+			default:
+				log15.Error("makePhabClientForOrigin", "error", errors.Errorf("want *schema.PhabricatorConnection but got %T", cfg))
+				continue
+			}
+
+			if conn.Url != origin {
+				continue
+			}
+
+			if conn.Token == "" {
+				return nil, errors.Errorf("no phabricator token was given for: %s", origin)
+			}
+
+			return phabricator.NewClient(ctx, conn.Url, conn.Token, nil)
 		}
 
-		if phab.Token == "" {
-			return nil, errors.Errorf("no phabricator token was given for: %s", origin)
+		if len(svcs) < opt.Limit {
+			break // Less results than limit means we've reached end
 		}
-
-		return phabricator.NewClient(ctx, phab.Url, phab.Token, nil)
 	}
 
 	return nil, errors.Errorf("no phabricator was configured for: %s", origin)

--- a/cmd/frontend/types/external_services.go
+++ b/cmd/frontend/types/external_services.go
@@ -4,48 +4,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-type CodeHostConnection interface {
-	// SetURN updates the URN field of the underlying connection.
-	SetURN(string)
-}
-
-var _ CodeHostConnection = (*AWSCodeCommitConnection)(nil)
-
-type AWSCodeCommitConnection struct {
-	// The unique resource identifier of the external service.
-	URN string
-	*schema.AWSCodeCommitConnection
-}
-
-func (c *AWSCodeCommitConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*BitbucketCloudConnection)(nil)
-
-type BitbucketCloudConnection struct {
-	// The unique resource identifier of the external service.
-	URN string
-	*schema.BitbucketCloudConnection
-}
-
-func (c *BitbucketCloudConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*BitbucketServerConnection)(nil)
-
 type BitbucketServerConnection struct {
 	// The unique resource identifier of the external service.
 	URN string
 	*schema.BitbucketServerConnection
 }
-
-func (c *BitbucketServerConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*GitHubConnection)(nil)
 
 type GitHubConnection struct {
 	// The unique resource identifier of the external service.
@@ -53,54 +16,8 @@ type GitHubConnection struct {
 	*schema.GitHubConnection
 }
 
-func (c *GitHubConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*GitLabConnection)(nil)
-
 type GitLabConnection struct {
 	// The unique resource identifier of the external service.
 	URN string
 	*schema.GitLabConnection
-}
-
-func (c *GitLabConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*GitoliteConnection)(nil)
-
-type GitoliteConnection struct {
-	// The unique resource identifier of the external service.
-	URN string
-	*schema.GitoliteConnection
-}
-
-func (c *GitoliteConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*OtherExternalServiceConnection)(nil)
-
-type OtherExternalServiceConnection struct {
-	// The unique resource identifier of the external service.
-	URN string
-	*schema.OtherExternalServiceConnection
-}
-
-func (c *OtherExternalServiceConnection) SetURN(urn string) {
-	c.URN = urn
-}
-
-var _ CodeHostConnection = (*PhabricatorConnection)(nil)
-
-type PhabricatorConnection struct {
-	// The unique resource identifier of the external service.
-	URN string
-	*schema.PhabricatorConnection
-}
-
-func (c *PhabricatorConnection) SetURN(urn string) {
-	c.URN = urn
 }

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -14,12 +15,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz/github"
 	"github.com/sourcegraph/sourcegraph/internal/authz/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type ExternalServicesStore interface {
-	ListGitLabConnections(context.Context) ([]*types.GitLabConnection, error)
-	ListGitHubConnections(context.Context) ([]*types.GitHubConnection, error)
-	ListBitbucketServerConnections(context.Context) ([]*types.BitbucketServerConnection, error)
+	List(context.Context, db.ExternalServicesListOptions) ([]*types.ExternalService, error)
 }
 
 // ProvidersFromConfig returns the set of permission-related providers derived from the site config.
@@ -29,7 +31,7 @@ type ExternalServicesStore interface {
 func ProvidersFromConfig(
 	ctx context.Context,
 	cfg *conf.Unified,
-	s ExternalServicesStore,
+	store ExternalServicesStore,
 ) (
 	allowAccessByDefault bool,
 	providers []authz.Provider,
@@ -44,28 +46,84 @@ func ProvidersFromConfig(
 		}
 	}()
 
-	if ghConns, err := s.ListGitHubConnections(ctx); err != nil {
-		seriousProblems = append(seriousProblems, fmt.Sprintf("Could not load GitHub external service configs: %s", err))
-	} else {
-		ghProviders, ghProblems, ghWarnings := github.NewAuthzProviders(ghConns)
+	opt := db.ExternalServicesListOptions{
+		Kinds: []string{
+			extsvc.KindGitHub,
+			extsvc.KindGitLab,
+			extsvc.KindBitbucketServer,
+		},
+		LimitOffset: &db.LimitOffset{
+			Limit: 500, // The number is randomly chosen
+		},
+	}
+
+	var (
+		gitHubConns          []*types.GitHubConnection
+		gitLabConns          []*types.GitLabConnection
+		bitbucketServerConns []*types.BitbucketServerConnection
+	)
+	for {
+		svcs, err := store.List(ctx, opt)
+		if err != nil {
+			seriousProblems = append(seriousProblems, fmt.Sprintf("Could not list external services: %v", err))
+			break
+		}
+		if len(svcs) == 0 {
+			break // No more results, exiting
+		}
+		opt.AfterID = svcs[len(svcs)-1].ID // Advance the cursor
+
+		for _, svc := range svcs {
+			cfg, err := extsvc.ParseConfig(svc.Kind, svc.Config)
+			if err != nil {
+				seriousProblems = append(seriousProblems, fmt.Sprintf("Could not parse config of external service %d: %v", svc.ID, err))
+				continue
+			}
+
+			switch c := cfg.(type) {
+			case *schema.GitHubConnection:
+				gitHubConns = append(gitHubConns, &types.GitHubConnection{
+					URN:              svc.URN(),
+					GitHubConnection: c,
+				})
+			case *schema.GitLabConnection:
+				gitLabConns = append(gitLabConns, &types.GitLabConnection{
+					URN:              svc.URN(),
+					GitLabConnection: c,
+				})
+			case *schema.BitbucketServerConnection:
+				bitbucketServerConns = append(bitbucketServerConns, &types.BitbucketServerConnection{
+					URN:                       svc.URN(),
+					BitbucketServerConnection: c,
+				})
+			default:
+				log15.Error("ProvidersFromConfig", "error", errors.Errorf("unexpected connection type: %T", cfg))
+				continue
+			}
+
+		}
+
+		if len(svcs) < opt.Limit {
+			break // Less results than limit means we've reached end
+		}
+	}
+
+	if len(gitHubConns) > 0 {
+		ghProviders, ghProblems, ghWarnings := github.NewAuthzProviders(gitHubConns)
 		providers = append(providers, ghProviders...)
 		seriousProblems = append(seriousProblems, ghProblems...)
 		warnings = append(warnings, ghWarnings...)
 	}
 
-	if glConns, err := s.ListGitLabConnections(ctx); err != nil {
-		seriousProblems = append(seriousProblems, fmt.Sprintf("Could not load GitLab external service configs: %s", err))
-	} else {
-		glProviders, glProblems, glWarnings := gitlab.NewAuthzProviders(cfg, glConns)
+	if len(gitLabConns) > 0 {
+		glProviders, glProblems, glWarnings := gitlab.NewAuthzProviders(cfg, gitLabConns)
 		providers = append(providers, glProviders...)
 		seriousProblems = append(seriousProblems, glProblems...)
 		warnings = append(warnings, glWarnings...)
 	}
 
-	if bbsConns, err := s.ListBitbucketServerConnections(ctx); err != nil {
-		seriousProblems = append(seriousProblems, fmt.Sprintf("Could not load Bitbucket Server external service configs: %s", err))
-	} else {
-		bbsProviders, bbsProblems, bbsWarnings := bitbucketserver.NewAuthzProviders(bbsConns)
+	if len(bitbucketServerConns) > 0 {
+		bbsProviders, bbsProblems, bbsWarnings := bitbucketserver.NewAuthzProviders(bitbucketServerConns)
 		providers = append(providers, bbsProviders...)
 		seriousProblems = append(seriousProblems, bbsProblems...)
 		warnings = append(warnings, bbsWarnings...)

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -7,11 +7,16 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -61,8 +66,8 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 
 	providersEqual := func(want ...authz.Provider) func(*testing.T, []authz.Provider) {
 		return func(t *testing.T, have []authz.Provider) {
-			if !reflect.DeepEqual(have, want) {
-				t.Errorf("authzProviders: (actual) %+v != (expected) %+v", asJSON(t, have), asJSON(t, want))
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Errorf("authzProviders mismatch (-want +got):\n%s", diff)
 			}
 		}
 	}
@@ -107,6 +112,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthProviderOp{
+						URN:     "extsvc:gitlab:0",
 						BaseURL: mustURLParse(t, "https://gitlab.mine"),
 						Token:   "asdf",
 					},
@@ -208,12 +214,14 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthProviderOp{
+						URN:     "extsvc:gitlab:0",
 						BaseURL: mustURLParse(t, "https://gitlab.mine"),
 						Token:   "asdf",
 					},
 				},
 				gitlabAuthzProviderParams{
 					OAuthOp: gitlab.OAuthProviderOp{
+						URN:     "extsvc:gitlab:0",
 						BaseURL: mustURLParse(t, "https://gitlab.com"),
 						Token:   "asdf",
 					},
@@ -275,6 +283,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
 					SudoOp: gitlab.SudoProviderOp{
+						URN:     "extsvc:gitlab:0",
 						BaseURL: mustURLParse(t, "https://gitlab.mine"),
 						AuthnConfigID: providers.ConfigID{
 							Type: "saml",
@@ -307,6 +316,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 			expAuthzProviders: providersEqual(
 				gitlabAuthzProviderParams{
 					SudoOp: gitlab.SudoProviderOp{
+						URN:               "extsvc:gitlab:0",
 						BaseURL:           mustURLParse(t, "https://gitlab.mine"),
 						SudoToken:         "asdf",
 						UseNativeUsername: true,
@@ -497,26 +507,43 @@ type fakeStore struct {
 	bitbucketServers []*schema.BitbucketServerConnection
 }
 
-func (s fakeStore) ListGitHubConnections(context.Context) ([]*types.GitHubConnection, error) {
-	conns := make([]*types.GitHubConnection, 0, len(s.githubs))
-	for _, github := range s.githubs {
-		conns = append(conns, &types.GitHubConnection{GitHubConnection: github})
+func (s fakeStore) List(ctx context.Context, opt db.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+	mustMarshalJSONString := func(v interface{}) string {
+		str, err := jsoniter.MarshalToString(v)
+		if err != nil {
+			panic(err)
+		}
+		return str
 	}
-	return conns, nil
-}
 
-func (s fakeStore) ListGitLabConnections(context.Context) ([]*types.GitLabConnection, error) {
-	conns := make([]*types.GitLabConnection, 0, len(s.gitlabs))
-	for _, gitlab := range s.gitlabs {
-		conns = append(conns, &types.GitLabConnection{GitLabConnection: gitlab})
+	var svcs []*types.ExternalService
+	for _, kind := range opt.Kinds {
+		switch kind {
+		case extsvc.KindGitHub:
+			for _, github := range s.githubs {
+				svcs = append(svcs, &types.ExternalService{
+					Kind:   kind,
+					Config: mustMarshalJSONString(github),
+				})
+			}
+		case extsvc.KindGitLab:
+			for _, gitlab := range s.gitlabs {
+				svcs = append(svcs, &types.ExternalService{
+					Kind:   kind,
+					Config: mustMarshalJSONString(gitlab),
+				})
+			}
+		case extsvc.KindBitbucketServer:
+			for _, bbs := range s.bitbucketServers {
+				svcs = append(svcs, &types.ExternalService{
+					Kind:   kind,
+					Config: mustMarshalJSONString(bbs),
+				})
+			}
+		default:
+			return nil, errors.Errorf("unexpected kind: %s", kind)
+		}
 	}
-	return conns, nil
-}
 
-func (s fakeStore) ListBitbucketServerConnections(context.Context) ([]*types.BitbucketServerConnection, error) {
-	conns := make([]*types.BitbucketServerConnection, 0, len(s.bitbucketServers))
-	for _, bbs := range s.bitbucketServers {
-		conns = append(conns, &types.BitbucketServerConnection{BitbucketServerConnection: bbs})
-	}
-	return conns, nil
+	return svcs, nil
 }

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -513,39 +513,6 @@ func (e *ExternalServicesStore) listConfigs(ctx context.Context, kind string, re
 	return nil
 }
 
-// ListBitbucketServerConnections returns a list of BitbucketServer configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListBitbucketServerConnections(ctx context.Context) ([]*types.BitbucketServerConnection, error) {
-	var connections []*types.BitbucketServerConnection
-	if err := e.listConfigs(ctx, extsvc.KindBitbucketServer, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListGitHubConnections returns a list of GitHubConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListGitHubConnections(ctx context.Context) ([]*types.GitHubConnection, error) {
-	var connections []*types.GitHubConnection
-	if err := e.listConfigs(ctx, extsvc.KindGitHub, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListGitLabConnections returns a list of GitLabConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*types.GitLabConnection, error) {
-	var connections []*types.GitLabConnection
-	if err := e.listConfigs(ctx, extsvc.KindGitLab, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
 // ListPhabricatorConnections returns a list of PhabricatorConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -513,17 +513,6 @@ func (e *ExternalServicesStore) listConfigs(ctx context.Context, kind string, re
 	return nil
 }
 
-// ListPhabricatorConnections returns a list of PhabricatorConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) ([]*types.PhabricatorConnection, error) {
-	var connections []*types.PhabricatorConnection
-	if err := e.listConfigs(ctx, extsvc.KindPhabricator, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
 func (*ExternalServicesStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*types.ExternalService, error) {
 	q := sqlf.Sprintf(`
 		SELECT id, kind, display_name, config, created_at, updated_at, deleted_at, last_sync_at, next_sync_at, namespace_user_id

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -513,28 +513,6 @@ func (e *ExternalServicesStore) listConfigs(ctx context.Context, kind string, re
 	return nil
 }
 
-// ListAWSCodeCommitConnections returns a list of AWSCodeCommit configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListAWSCodeCommitConnections(ctx context.Context) ([]*types.AWSCodeCommitConnection, error) {
-	var connections []*types.AWSCodeCommitConnection
-	if err := e.listConfigs(ctx, extsvc.KindAWSCodeCommit, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListBitbucketCloudConnections returns a list of BitbucketCloud configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListBitbucketCloudConnections(ctx context.Context) ([]*types.BitbucketCloudConnection, error) {
-	var connections []*types.BitbucketCloudConnection
-	if err := e.listConfigs(ctx, extsvc.KindBitbucketCloud, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
 // ListBitbucketServerConnections returns a list of BitbucketServer configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
@@ -568,34 +546,12 @@ func (e *ExternalServicesStore) ListGitLabConnections(ctx context.Context) ([]*t
 	return connections, nil
 }
 
-// ListGitoliteConnections returns a list of GitoliteConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListGitoliteConnections(ctx context.Context) ([]*types.GitoliteConnection, error) {
-	var connections []*types.GitoliteConnection
-	if err := e.listConfigs(ctx, extsvc.KindGitolite, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
 // ListPhabricatorConnections returns a list of PhabricatorConnection configs.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
 func (e *ExternalServicesStore) ListPhabricatorConnections(ctx context.Context) ([]*types.PhabricatorConnection, error) {
 	var connections []*types.PhabricatorConnection
 	if err := e.listConfigs(ctx, extsvc.KindPhabricator, &connections); err != nil {
-		return nil, err
-	}
-	return connections, nil
-}
-
-// ListOtherExternalServicesConnections returns a list of OtherExternalServiceConnection configs.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
-func (e *ExternalServicesStore) ListOtherExternalServicesConnections(ctx context.Context) ([]*types.OtherExternalServiceConnection, error) {
-	var connections []*types.OtherExternalServiceConnection
-	if err := e.listConfigs(ctx, extsvc.KindOther, &connections); err != nil {
 		return nil, err
 	}
 	return connections, nil

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
@@ -506,56 +505,4 @@ func TestExternalServicesStore_Count(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("Want 1 external service but got %d", count)
 	}
-}
-
-func TestListConfigs(t *testing.T) {
-	t.Run("call SetURN method", func(t *testing.T) {
-		Mocks.ExternalServices.List = func(opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-			return []*types.ExternalService{
-				{
-					ID:          1,
-					Kind:        extsvc.KindGitHub,
-					DisplayName: "GITHUB #1",
-					Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-				},
-			}, nil
-		}
-		defer func() { Mocks.ExternalServices = MockExternalServices{} }()
-
-		var connections []*types.GitHubConnection
-		err := ExternalServices.listConfigs(context.Background(), extsvc.KindGitHub, &connections)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		urns := make([]string, 0, len(connections))
-		for _, conn := range connections {
-			urns = append(urns, conn.URN)
-		}
-
-		wantURNs := []string{"extsvc:github:1"}
-		if diff := cmp.Diff(wantURNs, urns); diff != "" {
-			t.Fatalf("URNs mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("should not fail when no SetURN method", func(t *testing.T) {
-		Mocks.ExternalServices.List = func(opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-			return []*types.ExternalService{
-				{
-					ID:          1,
-					Kind:        extsvc.KindGitHub,
-					DisplayName: "GITHUB #1",
-					Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-				},
-			}, nil
-		}
-		defer func() { Mocks.ExternalServices = MockExternalServices{} }()
-
-		var connections []*schema.GitHubConnection
-		err := ExternalServices.listConfigs(context.Background(), extsvc.KindGitHub, &connections)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
 }


### PR DESCRIPTION
Removes `List*Connections` methods to make `List` as the single entry point of our paginated queries of external services.

It turns out many of the methods aren't used anywhere.

Easier to review by commit.