### PR TITLE
gqltest: migrate repohascommitafter, global regex text search and repo search part 2

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -323,6 +323,28 @@ func TestSearch(t *testing.T) {
 				name:  `Repohascommitafter, nonzero result`,
 				query: `repo:^github\.com/sgtest/go-diff$ repohascommitafter:"8 months ago" test patterntype:literal count:1`,
 			},
+			// Regex text search
+			{
+				name:  `regex, unindexed, nonzero result`,
+				query: `^func.*$ patterntype:regexp index:only count:1 stable:yes type:file`,
+			},
+			{
+				name:  `regex, fork only, nonzero result`,
+				query: `fork:only patterntype:regexp FORK_SENTINEL`,
+			},
+			{
+				name:  `regex, filter by language`,
+				query: `\bfunc\b lang:go count:1 stable:yes type:file patterntype:regexp`,
+			},
+			{
+				name:       `regex, filename, zero results`,
+				query:      `file:asdfasdf.go patterntype:regexp`,
+				zeroResult: true,
+			},
+			{
+				name:  `regexp, filename, nonzero result`,
+				query: `file:doc.go patterntype:regexp count:1`,
+			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -242,11 +242,11 @@ func TestSearch(t *testing.T) {
 			},
 			{
 				name:  "double-quoted pattern, nonzero result",
-				query: `"func main() {\n" patterntype:regexp count:1 stable:yes`,
+				query: `"func main() {\n" patterntype:regexp count:1 stable:yes type:file`,
 			},
 			{
 				name:  "exclude repo, nonzero result",
-				query: `"func main() {\n" -repo:go-diff patterntype:regexp count:1 stable:yes`,
+				query: `"func main() {\n" -repo:go-diff patterntype:regexp count:1 stable:yes type:file`,
 			},
 			{
 				name:       "fork:no",
@@ -265,7 +265,7 @@ func TestSearch(t *testing.T) {
 			},
 			{
 				name:  "repo search by name, case yes, nonzero result",
-				query: `repo:^github\.com/sgtest/go-diff$ String case:yes count:1 stable:yes`,
+				query: `repo:^github\.com/sgtest/go-diff$ String case:yes count:1 stable:yes type:file`,
 			},
 			{
 				name:  "true is an alias for yes when fork is set",
@@ -273,15 +273,15 @@ func TestSearch(t *testing.T) {
 			},
 			{
 				name:  "non-master branch, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 stable:yes`,
+				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 stable:yes type:file`,
 			},
 			{
 				name:  "indexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp count:1 stable:yes`,
+				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp count:1 stable:yes type:file`,
 			},
 			{
 				name:  "unindexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:no patterntype:regexp count:1 stable:yes`,
+				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:no patterntype:regexp count:1 stable:yes type:file`,
 			},
 			{
 				name:       "random characters, zero result",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -64,6 +64,13 @@ func TestSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	err = client.WaitForReposToBeIndex(
+		"github.com/sgtest/java-langserver",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("visibility", func(t *testing.T) {
 		tests := []struct {
 			query       string

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -326,6 +326,10 @@ func TestSearch(t *testing.T) {
 					t.Fatal(err)
 				}
 
+				if results.Alert != nil {
+					t.Fatalf("Unexpected alert: %v", results.Alert)
+				}
+
 				if test.zeroResult {
 					if len(results.Results) > 0 {
 						t.Fatalf("Want zero result but got %d", len(results.Results))
@@ -344,12 +348,12 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("timeout search options", func(t *testing.T) {
-		alert, err := client.SearchAlert(`router index:no timeout:1ns`)
+		results, err := client.SearchFiles(`router index:no timeout:1ns`)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if alert == nil {
+		if results.Alert == nil {
 			t.Fatal("Want search alert but got nil")
 		}
 	})

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -318,6 +318,11 @@ func TestSearch(t *testing.T) {
 				name:  "diff search, nonzero result",
 				query: `repo:^github\.com/sgtest/go-diff$ type:diff main count:1`,
 			},
+			// Repohascommitafter
+			{
+				name:  `Repohascommitafter, nonzero result`,
+				query: `repo:^github\.com/sgtest/go-diff$ repohascommitafter:"8 months ago" test patterntype:literal count:1`,
+			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -21,31 +21,54 @@ query Repositories {
 	}
 }
 `
-		var resp struct {
-			Data struct {
-				Repositories struct {
-					Nodes []struct {
-						Name string `json:"name"`
-					} `json:"nodes"`
-				} `json:"repositories"`
-			} `json:"data"`
-		}
-		err := c.GraphQL("", query, nil, &resp)
-		if err != nil {
-			return errors.Wrap(err, "request GraphQL")
-		}
-
-		repoSet := make(map[string]struct{}, len(repos))
-		for _, repo := range repos {
-			repoSet[repo] = struct{}{}
-		}
-		for _, node := range resp.Data.Repositories.Nodes {
-			delete(repoSet, node.Name)
-		}
-		if len(repoSet) > 0 {
-			return ErrContinueRetry
-		}
-
-		return nil
+		return c.waitForReposByQuery(query, repos...)
 	})
+}
+
+// WaitForReposToBeIndex waits (up to 30 seconds) for all repositories
+// in the list to be indexed.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) WaitForReposToBeIndex(repos ...string) error {
+	return Retry(300*time.Second, func() error {
+		const query = `
+query Repositories {
+	repositories(first: 1000, notIndexed: false, notCloned: false) {
+		nodes {
+			name
+		}
+	}
+}
+`
+		return c.waitForReposByQuery(query, repos...)
+	})
+}
+
+func (c *Client) waitForReposByQuery(query string, repos ...string) error {
+	var resp struct {
+		Data struct {
+			Repositories struct {
+				Nodes []struct {
+					Name string `json:"name"`
+				} `json:"nodes"`
+			} `json:"repositories"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, nil, &resp)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+
+	repoSet := make(map[string]struct{}, len(repos))
+	for _, repo := range repos {
+		repoSet[repo] = struct{}{}
+	}
+	for _, node := range resp.Data.Repositories.Nodes {
+		delete(repoSet, node.Name)
+	}
+	if len(repoSet) > 0 {
+		return ErrContinueRetry
+	}
+
+	return nil
 }

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -64,7 +64,8 @@ query Search($query: String!) {
 }
 
 type SearchFileResults struct {
-	MatchCount int64 `json:"matchCount"`
+	MatchCount int64        `json:"matchCount"`
+	Alert      *SearchAlert `json:"alert"`
 	Results    []*struct {
 		File struct {
 			Name string `json:"name"`
@@ -78,14 +79,32 @@ type SearchFileResults struct {
 	} `json:"results"`
 }
 
+// SearchAlert is an alert specific to searches (i.e. not site alert).
+type SearchAlert struct {
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	ProposedQueries []struct {
+		Description string `json:"description"`
+		Query       string `json:"query"`
+	} `json:"proposedQueries"`
+}
+
 // SearchFiles searches files with given query. It returns the match count and
-// corresponding file matches.
+// corresponding file matches. Search alert is also included if any.
 func (c *Client) SearchFiles(query string) (*SearchFileResults, error) {
 	const gqlQuery = `
 query Search($query: String!) {
 	search(query: $query) {
 		results {
 			matchCount
+			alert {
+				title
+				description
+				proposedQueries {
+					description
+					query
+				}
+			}
 			results {
 				... on FileMatch {
 					file {
@@ -167,55 +186,6 @@ query Search($query: String!) {
 	}
 
 	return resp.Data.Search.Results.SearchCommitResults, nil
-}
-
-// SearchAlert is an alert specific to searches (i.e. not site alert).
-type SearchAlert struct {
-	Title           string `json:"title"`
-	Description     string `json:"description"`
-	ProposedQueries []struct {
-		Description string `json:"description"`
-		Query       string `json:"query"`
-	} `json:"proposedQueries"`
-}
-
-// SearchAlert returns the alert returned by searching for given query.
-// It returns both nil values if no alert raised and no error occurred.
-func (c *Client) SearchAlert(query string) (*SearchAlert, error) {
-	const gqlQuery = `
-query Search($query: String!) {
-	search(query: $query) {
-		results {
-			alert {
-				title
-				description
-				proposedQueries {
-					description
-					query
-				}
-			}
-		}
-	}
-}
-`
-	variables := map[string]interface{}{
-		"query": query,
-	}
-	var resp struct {
-		Data struct {
-			Search struct {
-				Results struct {
-					*SearchAlert `json:"alert"`
-				} `json:"results"`
-			} `json:"search"`
-		} `json:"data"`
-	}
-	err := c.GraphQL("", gqlQuery, variables, &resp)
-	if err != nil {
-		return nil, errors.Wrap(err, "request GraphQL")
-	}
-
-	return resp.Data.Search.Results.SearchAlert, nil
 }
 
 type SearchStatsResult struct {


### PR DESCRIPTION
Migrated all remaining tests except _structural and AND/OR queries_ to `dev/gqltest`:

Easier to review by commit.

Part of #12143.