### PR TITLE
graphqlbackend: add site config to allow users add external services

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -81,6 +82,14 @@ func (r *externalServiceResolver) CreatedAt() DateTime {
 
 func (r *externalServiceResolver) UpdatedAt() DateTime {
 	return DateTime{Time: r.externalService.UpdatedAt}
+}
+
+func (r *externalServiceResolver) Namespace() *graphql.ID {
+	if r.externalService.NamespaceUserID == nil {
+		return nil
+	}
+	userID := MarshalUserID(*r.externalService.NamespaceUserID)
+	return &userID
 }
 
 func (r *externalServiceResolver) WebhookURL() (*string, error) {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -25,25 +25,65 @@ import (
 
 var extsvcConfigAllowEdits, _ = strconv.ParseBool(env.Get("EXTSVC_CONFIG_ALLOW_EDITS", "false", "When EXTSVC_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
 
-func (r *schemaResolver) AddExternalService(ctx context.Context, args *struct {
-	Input struct {
-		Kind        string
-		DisplayName string
-		Config      string
-	}
-}) (*externalServiceResolver, error) {
-	// 🚨 SECURITY: Only site admins may add external services.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
-	}
+type addExternalServiceArgs struct {
+	Input addExternalServiceInput
+}
+
+type addExternalServiceInput struct {
+	Kind        string
+	DisplayName string
+	Config      string
+	Namespace   *graphql.ID
+}
+
+func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExternalServiceArgs) (*externalServiceResolver, error) {
 	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !extsvcConfigAllowEdits {
 		return nil, errors.New("adding external service not allowed when using EXTSVC_CONFIG_FILE")
+	}
+
+	// 🚨 SECURITY: Only site admins may add external services if user mode is not enabled.
+	namespaceUserID := int32(0)
+	isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
+	enabled := conf.ExternalServiceUserMode()
+	if args.Input.Namespace != nil {
+		if !enabled {
+			return nil, errors.New("allow users to add external services is not enabled")
+		}
+
+		var err error
+		switch relay.UnmarshalKind(*args.Input.Namespace) {
+		case "User":
+			err = relay.UnmarshalSpec(*args.Input.Namespace, &namespaceUserID)
+		default:
+			err = errors.Errorf("invalid namespace %q", *args.Input.Namespace)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		authUser, err := backend.CurrentUser(ctx)
+		if err != nil {
+			return nil, err
+		} else if authUser == nil {
+			return nil, backend.ErrNotAuthenticated
+		}
+
+		if namespaceUserID != authUser.ID {
+			return nil, errors.New("the namespace is not same as the authenticated user")
+		}
+
+	} else if !isSiteAdmin {
+		return nil, backend.ErrMustBeSiteAdmin
 	}
 
 	externalService := &types.ExternalService{
 		Kind:        args.Input.Kind,
 		DisplayName: args.Input.DisplayName,
 		Config:      args.Input.Config,
+	}
+	if namespaceUserID > 0 {
+		externalService.NamespaceUserID = &namespaceUserID
 	}
 
 	if err := db.ExternalServices.Create(ctx, conf.Get, externalService); err != nil {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -62,14 +63,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 			return nil, err
 		}
 
-		authUser, err := backend.CurrentUser(ctx)
-		if err != nil {
-			return nil, err
-		} else if authUser == nil {
-			return nil, backend.ErrNotAuthenticated
-		}
-
-		if namespaceUserID != authUser.ID {
+		if namespaceUserID != actor.FromContext(ctx).UID {
 			return nil, errors.New("the namespace is not same as the authenticated user")
 		}
 

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -42,7 +42,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		return nil, errors.New("adding external service not allowed when using EXTSVC_CONFIG_FILE")
 	}
 
-	// 🚨 SECURITY: Only site admins may add external services if user mode is not enabled.
+	// 🚨 SECURITY: Only site admins may add external services if user mode is disabled.
 	namespaceUserID := int32(0)
 	isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
 	enabled := conf.ExternalServiceUserMode()

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1844,6 +1844,8 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
+    # The namespace this external service belongs to.
+    namespace: ID
     # An optional URL that will be populated when webhooks have been configured for the external service.
     webhookURL: String
     # This is an optional field that's populated when we ran into errors on the

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1070,6 +1070,9 @@ input AddExternalServiceInput {
     displayName: String!
     # The JSON configuration of the external service.
     config: String!
+    # The namespace this external service belongs to.
+    # Currently, this can only be used for a user.
+    namespace: ID
 }
 
 # Fields to update for an existing external service.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1851,6 +1851,8 @@ type ExternalService implements Node {
     createdAt: DateTime!
     # When the external service was last updated.
     updatedAt: DateTime!
+    # The namespace this external service belongs to.
+    namespace: ID
     # An optional URL that will be populated when webhooks have been configured for the external service.
     webhookURL: String
     # This is an optional field that's populated when we ran into errors on the

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1077,6 +1077,9 @@ input AddExternalServiceInput {
     displayName: String!
     # The JSON configuration of the external service.
     config: String!
+    # The namespace this external service belongs to.
+    # Currently, this can only be used for a user.
+    namespace: ID
 }
 
 # Fields to update for an existing external service.

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -337,3 +337,10 @@ func AuthMinPasswordLength() int {
 	}
 	return val
 }
+
+// ExternalServiceUserMode returns true if users are allowed to add external services
+// for public repositories.
+func ExternalServiceUserMode() bool {
+	val := Get().ExternalServiceUserMode
+	return val == "public"
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1179,6 +1179,8 @@ type SiteConfiguration struct {
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: Configures Sourcegraph extensions.
 	Extensions *Extensions `json:"extensions,omitempty"`
+	// ExternalServiceUserMode description: Enable to allow users to add external services for public reposirories to the Sourcegraph instance.
+	ExternalServiceUserMode string `json:"externalService.userMode,omitempty"`
 	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
 	ExternalURL string `json:"externalURL,omitempty"`
 	// GitCloneURLToRepositoryName description: JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -376,6 +376,12 @@
       ],
       "group": "Security"
     },
+    "externalService.userMode": {
+      "description": "Enable to allow users to add external services for public reposirories to the Sourcegraph instance.",
+      "type": "string",
+      "enum": ["public", "disabled"],
+      "default": "disabled"
+    },
     "permissions.userMapping": {
       "description": "Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).",
       "type": "object",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -381,6 +381,12 @@ const SiteSchemaJSON = `{
       ],
       "group": "Security"
     },
+    "externalService.userMode": {
+      "description": "Enable to allow users to add external services for public reposirories to the Sourcegraph instance.",
+      "type": "string",
+      "enum": ["public", "disabled"],
+      "default": "disabled"
+    },
     "permissions.userMapping": {
       "description": "Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's ` + "`" + `authorization` + "`" + ` field is set).",
       "type": "object",

--- a/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -65,6 +65,7 @@ describe('StatusMessagesNavItem', () => {
                 displayName: 'GitHub.com',
                 kind: GQL.ExternalServiceKind.GITHUB,
                 config: '{}',
+                namespace: null,
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString(),
                 webhookURL: null,


### PR DESCRIPTION
Adds a new feature flag `externalService.userMode` in site config to control if users are allowed to add external services.

Easier to review by commit.

Part of #12699