### PR TITLE
regression e2e: in password reset helper wait for page buildup

### DIFF
--- a/web/src/regression/util/helpers.ts
+++ b/web/src/regression/util/helpers.ts
@@ -111,6 +111,7 @@ async function createTestUser(
     }
 
     await driver.page.goto(passwordResetURL)
+    await driver.page.waitForSelector('.reset-password-page__form')
     await driver.page.keyboard.type(testUserPassword)
     await driver.page.keyboard.down(Key.Enter)
 


### PR DESCRIPTION
don't start typing password until form is ready.

with special thanks to @slimsag who spotted the weak point