### PR TITLE
external_services: disallow users to use repositoryPathPattern

### DIFF
--- a/enterprise/internal/db/external_services_test.go
+++ b/enterprise/internal/db/external_services_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -1257,7 +1258,11 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			}
 
 			s := NewExternalServicesStore()
-			err := s.ValidateConfig(context.Background(), 0, tc.kind, tc.config, tc.ps)
+			err := s.ValidateConfig(context.Background(), db.ValidateExternalServiceConfigOptions{
+				Kind:          tc.kind,
+				Config:        tc.config,
+				AuthProviders: tc.ps,
+			})
 			switch e := err.(type) {
 			case nil:
 				have = append(have, "<nil>")

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775
 	github.com/temoto/robotstxt v1.1.1
+	github.com/tidwall/gjson v1.6.0
 	github.com/tinylib/msgp v1.1.2 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/uber/gonduit v0.6.1
@@ -163,7 +164,6 @@ require (
 	go.uber.org/atomic v1.6.0
 	go.uber.org/automaxprocs v1.3.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -1267,6 +1267,10 @@ github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775 h1:BLNsFR8l/hj/o
 github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775/go.mod h1:XUZ4x3oGhWfiOnUvTslnKKs39AWUct3g3yJvXTQSJOQ=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -1672,8 +1676,6 @@ golang.org/x/tools v0.0.0-20200409170454-77362c5149f0/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200420001825-978e26b7c37c h1:JzwTM5XxGxiCwZEIZQPG46csyhWQxQlu2uSi3bEza34=
 golang.org/x/tools v0.0.0-20200420001825-978e26b7c37c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200626032829-bcbc01e07a20 h1:q+ysxVHVQNTVHgzwjuk4ApAILRbfOLARfnEaqCIBR6A=
-golang.org/x/tools v0.0.0-20200626032829-bcbc01e07a20/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6 h1:qKpj8TpV+LEhel7H/fR788J+KvhWZ3o3V6N2fU/iuLU=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -90,12 +90,25 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	return conds
 }
 
+type ValidateExternalServiceConfigOptions struct {
+	// The ID of the external service, 0 is a valid value for not-yet-created external service.
+	ID int64
+	// The kind of external service.
+	Kind string
+	// The actual config of the external service.
+	Config string
+	// The list of authN providers configured on the instance.
+	AuthProviders []schema.AuthProviders
+	// When true, indicates this is a user-added the external service.
+	HasNamespace bool
+}
+
 // ValidateConfig validates the given external service configuration.
 // A non zero id indicates we are updating an existing service, 0 indicates we are adding a new one.
-func (e *ExternalServicesStore) ValidateConfig(ctx context.Context, id int64, kind, config string, ps []schema.AuthProviders) error {
-	ext, ok := ExternalServiceKinds[kind]
+func (e *ExternalServicesStore) ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) error {
+	ext, ok := ExternalServiceKinds[opt.Kind]
 	if !ok {
-		return fmt.Errorf("invalid external service kind: %s", kind)
+		return fmt.Errorf("invalid external service kind: %s", opt.Kind)
 	}
 
 	// All configs must be valid JSON.
@@ -105,17 +118,17 @@ func (e *ExternalServicesStore) ValidateConfig(ctx context.Context, id int64, ki
 	sl := gojsonschema.NewSchemaLoader()
 	sc, err := sl.Compile(gojsonschema.NewStringLoader(ext.JSONSchema))
 	if err != nil {
-		return errors.Wrapf(err, "failed to compile schema for external service of kind %q", kind)
+		return errors.Wrapf(err, "unable to compile schema for external service of kind %q", opt.Kind)
 	}
 
-	normalized, err := jsonc.Parse(config)
+	normalized, err := jsonc.Parse(opt.Config)
 	if err != nil {
-		return errors.Wrapf(err, "failed to normalize JSON")
+		return errors.Wrapf(err, "unable to normalize JSON")
 	}
 
 	res, err := sc.Validate(gojsonschema.NewBytesLoader(normalized))
 	if err != nil {
-		return errors.Wrap(err, "failed to validate config against schema")
+		return errors.Wrap(err, "unable to validate config against schema")
 	}
 
 	var errs *multierror.Error
@@ -128,34 +141,34 @@ func (e *ExternalServicesStore) ValidateConfig(ctx context.Context, id int64, ki
 	}
 
 	// Extra validation not based on JSON Schema.
-	switch kind {
+	switch opt.Kind {
 	case extsvc.KindGitHub:
 		var c schema.GitHubConnection
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = e.validateGitHubConnection(ctx, id, &c)
+		err = e.validateGitHubConnection(ctx, opt.ID, &c)
 
 	case extsvc.KindGitLab:
 		var c schema.GitLabConnection
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = e.validateGitLabConnection(ctx, id, &c, ps)
+		err = e.validateGitLabConnection(ctx, opt.ID, &c, opt.AuthProviders)
 
 	case extsvc.KindBitbucketServer:
 		var c schema.BitbucketServerConnection
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = e.validateBitbucketServerConnection(ctx, id, &c)
+		err = e.validateBitbucketServerConnection(ctx, opt.ID, &c)
 
 	case extsvc.KindBitbucketCloud:
 		var c schema.BitbucketCloudConnection
 		if err = json.Unmarshal(normalized, &c); err != nil {
 			return err
 		}
-		err = e.validateBitbucketCloudConnection(ctx, id, &c)
+		err = e.validateBitbucketCloudConnection(ctx, opt.ID, &c)
 
 	case extsvc.KindOther:
 		var c schema.OtherExternalServiceConnection
@@ -290,7 +303,7 @@ func (e *ExternalServicesStore) validateDuplicateRateLimits(ctx context.Context,
 	return nil
 }
 
-// Create creates a external service.
+// Create creates an external service.
 //
 // Since this method is used before the configuration server has started
 // (search for "EXTSVC_CONFIG_FILE") you must pass the conf.Get function in so
@@ -299,13 +312,20 @@ func (e *ExternalServicesStore) validateDuplicateRateLimits(ctx context.Context,
 // determines a deadlock occurred.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin.
+// Otherwise, `es.NamespaceUserID` must be specified (i.e. non-nil) for
+// a user-added external service.
 func (e *ExternalServicesStore) Create(ctx context.Context, confGet func() *conf.Unified, es *types.ExternalService) error {
 	if Mocks.ExternalServices.Create != nil {
 		return Mocks.ExternalServices.Create(ctx, confGet, es)
 	}
 
 	ps := confGet().AuthProviders
-	if err := e.ValidateConfig(ctx, 0, es.Kind, es.Config, ps); err != nil {
+	if err := e.ValidateConfig(ctx, ValidateExternalServiceConfigOptions{
+		Kind:          es.Kind,
+		Config:        es.Config,
+		AuthProviders: ps,
+		HasNamespace:  es.NamespaceUserID != nil,
+	}); err != nil {
 		return err
 	}
 
@@ -340,7 +360,13 @@ func (e *ExternalServicesStore) Update(ctx context.Context, ps []schema.AuthProv
 			return err
 		}
 
-		if err := e.ValidateConfig(ctx, id, externalService.Kind, *update.Config, ps); err != nil {
+		if err := e.ValidateConfig(ctx, ValidateExternalServiceConfigOptions{
+			ID:            id,
+			Kind:          externalService.Kind,
+			Config:        *update.Config,
+			AuthProviders: ps,
+			HasNamespace:  externalService.NamespaceUserID != nil,
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -146,7 +146,10 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 				test.setup(t)
 			}
 
-			err := (&ExternalServicesStore{}).ValidateConfig(context.Background(), 0, test.kind, test.config, nil)
+			err := ExternalServices.ValidateConfig(context.Background(), ValidateExternalServiceConfigOptions{
+				Kind:   test.kind,
+				Config: test.config,
+			})
 			gotErr := fmt.Sprintf("%v", err)
 			if gotErr != test.wantErr {
 				t.Errorf("error: want %q but got %q", test.wantErr, gotErr)

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -145,7 +145,7 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			kind:         extsvc.KindGitHub,
 			config:       `{"url": "https://github.com", "repositoryPathPattern": "github/{nameWithOwner}" // comments}`,
 			hasNamespace: true,
-			wantErr:      `field "repositoryPathPattern" is not allowed to be used by users`,
+			wantErr:      `field "repositoryPathPattern" is not allowed in a user-added external service`,
 		},
 	}
 	for _, test := range tests {

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -80,11 +80,12 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 
 func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 	tests := []struct {
-		name    string
-		kind    string
-		config  string
-		setup   func(t *testing.T)
-		wantErr string
+		name         string
+		kind         string
+		config       string
+		hasNamespace bool
+		setup        func(t *testing.T)
+		wantErr      string
 	}{
 		{
 			name:    "0 errors",
@@ -139,6 +140,13 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			},
 			wantErr: "1 error occurred:\n\t* existing external service, \"GITHUB 1\", already has a rate limit set\n\n",
 		},
+		{
+			name:         "prevent disallowed fields",
+			kind:         extsvc.KindGitHub,
+			config:       `{"url": "https://github.com", "repositoryPathPattern": "github/{nameWithOwner}" // comments}`,
+			hasNamespace: true,
+			wantErr:      `field "repositoryPathPattern" is not allowed to be used by users`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -147,8 +155,9 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			}
 
 			err := ExternalServices.ValidateConfig(context.Background(), ValidateExternalServiceConfigOptions{
-				Kind:   test.kind,
-				Config: test.config,
+				Kind:         test.kind,
+				Config:       test.config,
+				HasNamespace: test.hasNamespace,
 			})
 			gotErr := fmt.Sprintf("%v", err)
 			if gotErr != test.wantErr {


### PR DESCRIPTION
Allowing `repositoryPathPattern` is known to be able to cause problems so we should disallow it in user-added external services until further justification.

Uses a new package https://github.com/tidwall/gjson because its API and path syntax are very nature, and works with JSON with comments.

_Easier to review by commit._