### PR TITLE
frontend: Allow tagged users to add external services

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,6 +15,7 @@ const config = {
   webpackFinal: config => {
     // Include sourcemaps
     config.mode = 'development'
+    config.devtool = 'cheap-module-eval-source-map'
     const definePlugin = config.plugins.find(plugin => plugin instanceof DefinePlugin)
     // @ts-ignore
     definePlugin.definitions.NODE_ENV = JSON.stringify('development')

--- a/cmd/frontend/backend/users.go
+++ b/cmd/frontend/backend/users.go
@@ -16,7 +16,6 @@ func MakeRandomHardToGuessPassword() string {
 }
 
 var MockMakePasswordResetURL func(ctx context.Context, userID int32) (*url.URL, error)
-var MockCheckActorHasTag func(ctx context.Context, tag string) error
 
 func MakePasswordResetURL(ctx context.Context, userID int32) (*url.URL, error) {
 	if MockMakePasswordResetURL != nil {
@@ -35,10 +34,6 @@ func MakePasswordResetURL(ctx context.Context, userID int32) (*url.URL, error) {
 // CheckActorHasTag reports whether the context actor has the given tag. If not, or if an error
 // occurs, a non-nil error is returned.
 func CheckActorHasTag(ctx context.Context, tag string) error {
-	if MockCheckActorHasTag != nil {
-		return MockCheckActorHasTag(ctx, tag)
-	}
-
 	actor := actor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return ErrNotAuthenticated

--- a/cmd/frontend/backend/users.go
+++ b/cmd/frontend/backend/users.go
@@ -16,6 +16,7 @@ func MakeRandomHardToGuessPassword() string {
 }
 
 var MockMakePasswordResetURL func(ctx context.Context, userID int32) (*url.URL, error)
+var MockCheckActorHasTag func(ctx context.Context, tag string) error
 
 func MakePasswordResetURL(ctx context.Context, userID int32) (*url.URL, error) {
 	if MockMakePasswordResetURL != nil {
@@ -34,6 +35,10 @@ func MakePasswordResetURL(ctx context.Context, userID int32) (*url.URL, error) {
 // CheckActorHasTag reports whether the context actor has the given tag. If not, or if an error
 // occurs, a non-nil error is returned.
 func CheckActorHasTag(ctx context.Context, tag string) error {
+	if MockCheckActorHasTag != nil {
+		return MockCheckActorHasTag(ctx, tag)
+	}
+
 	actor := actor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return ErrNotAuthenticated
@@ -52,3 +57,7 @@ func CheckActorHasTag(ctx context.Context, tag string) error {
 	}
 	return fmt.Errorf("actor lacks required tag %q", tag)
 }
+
+const (
+	TagAllowUserExternalServicePublic = "AllowUserExternalServicePublic"
+)

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -45,9 +45,14 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 	// 🚨 SECURITY: Only site admins may add external services if user mode is disabled.
 	namespaceUserID := int32(0)
 	isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
-	enabled := conf.ExternalServiceUserMode()
+	allowUserExternalServices := conf.ExternalServiceUserMode()
+	if !allowUserExternalServices {
+		// The user may have a tag that opts them in
+		err := backend.CheckActorHasTag(ctx, backend.TagAllowUserExternalServicePublic)
+		allowUserExternalServices = err == nil
+	}
 	if args.Input.Namespace != nil {
-		if !enabled {
+		if !allowUserExternalServices {
 			return nil, errors.New("allow users to add external services is not enabled")
 		}
 


### PR DESCRIPTION
This allows us to allow specific users to add external services. It could also be used to opt in a random percentage of users by running a once off query.