### PR TITLE
Fix reconciler failing for duplicate headref changesets

### DIFF
--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -440,6 +441,72 @@ func TestReconcilerProcess(t *testing.T) {
 				t.Fatalf("wrong UpdateChangeset call. wantCalled=%t, wasCalled=%t", want, have)
 			}
 		})
+	}
+}
+
+func TestReconcilerProcess_PublishedChangesetDuplicateBranch(t *testing.T) {
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	store := NewStore(dbconn.Global)
+
+	admin := createTestUser(ctx, t)
+	if !admin.SiteAdmin {
+		t.Fatalf("admin is not site admin")
+	}
+
+	rs, _ := createTestRepos(t, ctx, dbconn.Global, 1)
+
+	state := ct.MockChangesetSyncState(&protocol.RepoInfo{
+		Name: api.RepoName(rs[0].Name),
+		VCS:  protocol.VCSInfo{URL: rs[0].URI},
+	})
+	defer state.Unmock()
+
+	commonHeadRef := "refs/heads/collision"
+
+	// Create a published changeset.
+	campaignSpec := createCampaignSpec(t, ctx, store, "reconciler-test-campaign", admin.ID)
+	campaign := createCampaign(t, ctx, store, "reconciler-test-campaign", admin.ID, campaignSpec.ID)
+	changesetSpec := createChangesetSpec(t, ctx, store, testSpecOpts{
+		user:         admin.ID,
+		repo:         rs[0].ID,
+		campaignSpec: campaignSpec.ID,
+		headRef:      commonHeadRef,
+	})
+	createChangeset(t, ctx, store, testChangesetOpts{
+		repo:             rs[0].ID,
+		publicationState: campaigns.ChangesetPublicationStatePublished,
+		campaign:         campaign.ID,
+		ownedByCampaign:  campaign.ID,
+		currentSpec:      changesetSpec.ID,
+		externalBranch:   git.AbbreviateRef(commonHeadRef),
+		externalID:       "123",
+	})
+
+	// Try to publish a changeset on the same HeadRef/ExternalBranch.
+	otherCampaignSpec := createCampaignSpec(t, ctx, store, "other-test-campaign", admin.ID)
+	otherCampaign := createCampaign(t, ctx, store, "other-test-campaign", admin.ID, otherCampaignSpec.ID)
+	otherChangesetSpec := createChangesetSpec(t, ctx, store, testSpecOpts{
+		user:         admin.ID,
+		repo:         rs[0].ID,
+		campaignSpec: otherCampaignSpec.ID,
+		headRef:      commonHeadRef,
+		published:    true,
+	})
+	otherChangeset := createChangeset(t, ctx, store, testChangesetOpts{
+		repo:             rs[0].ID,
+		publicationState: campaigns.ChangesetPublicationStateUnpublished,
+		campaign:         otherCampaign.ID,
+		ownedByCampaign:  otherCampaign.ID,
+		currentSpec:      otherChangesetSpec.ID,
+	})
+
+	// Run the reconciler
+	rec := reconciler{store: store}
+	haveErr := rec.process(ctx, store, otherChangeset)
+	if !errors.Is(haveErr, ErrPublishSameBranch) {
+		t.Fatalf("reconciler process failed with wrong error: %s", haveErr)
 	}
 }
 

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -233,6 +233,7 @@ type GetChangesetOpts struct {
 	RepoID              api.RepoID
 	ExternalID          string
 	ExternalServiceType string
+	ExternalBranch      string
 }
 
 // GetChangeset gets a changeset matching the given options.
@@ -277,6 +278,9 @@ func getChangesetQuery(opts *GetChangesetOpts) *sqlf.Query {
 			sqlf.Sprintf("changesets.external_id = %s", opts.ExternalID),
 			sqlf.Sprintf("changesets.external_service_type = %s", opts.ExternalServiceType),
 		)
+	}
+	if opts.ExternalBranch != "" {
+		preds = append(preds, sqlf.Sprintf("changesets.external_branch = %s", opts.ExternalBranch))
 	}
 
 	return sqlf.Sprintf(


### PR DESCRIPTION
When creating a changeset on the same branch as an existing changeset in the database, we need to fail creating the changeset.
Before, The reconciler would fail and the changeset stays in "processing" state.


Closes https://github.com/sourcegraph/sourcegraph/issues/13087