### PR TITLE
Implement filters like they are displayed in the UI

### DIFF
--- a/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
@@ -66,6 +66,7 @@ export const CampaignCloseChangesetsList: React.FunctionComponent<Props> = ({
             queryChangesets({
                 externalState: ChangesetExternalState.OPEN,
                 publicationState: ChangesetPublicationState.PUBLISHED,
+                reconcilerState: null,
                 checkState: null,
                 reviewState: null,
                 first: args.first ?? null,

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -551,10 +551,13 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
           >
             <ChangesetFilter
               className="mr-2"
-              label="State"
+              label="Status"
               onChange={[Function]}
               values={
                 Array [
+                  "UNPUBLISHED",
+                  "ERRORED",
+                  "PROCESSING",
                   "OPEN",
                   "CLOSED",
                   "MERGED",
@@ -569,7 +572,25 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
                 <option
                   value=""
                 >
-                  State
+                  Status
+                </option>
+                <option
+                  key="UNPUBLISHED"
+                  value="UNPUBLISHED"
+                >
+                  Unpublished
+                </option>
+                <option
+                  key="ERRORED"
+                  value="ERRORED"
+                >
+                  Errored
+                </option>
+                <option
+                  key="PROCESSING"
+                  value="PROCESSING"
+                >
+                  Processing
                 </option>
                 <option
                   key="OPEN"
@@ -599,6 +620,46 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
             </ChangesetFilter>
             <ChangesetFilter
               className="mr-2"
+              label="Check state"
+              onChange={[Function]}
+              values={
+                Array [
+                  "PENDING",
+                  "PASSED",
+                  "FAILED",
+                ]
+              }
+            >
+              <select
+                className="form-control mr-2"
+                onChange={[Function]}
+              >
+                <option
+                  value=""
+                >
+                  Check state
+                </option>
+                <option
+                  key="PENDING"
+                  value="PENDING"
+                >
+                  Pending
+                </option>
+                <option
+                  key="PASSED"
+                  value="PASSED"
+                >
+                  Passed
+                </option>
+                <option
+                  key="FAILED"
+                  value="FAILED"
+                >
+                  Failed
+                </option>
+              </select>
+            </ChangesetFilter>
+            <ChangesetFilter
               label="Review state"
               onChange={[Function]}
               values={
@@ -612,7 +673,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
               }
             >
               <select
-                className="form-control mr-2"
+                className="form-control"
                 onChange={[Function]}
               >
                 <option
@@ -649,46 +710,6 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
                   value="DISMISSED"
                 >
                   Dismissed
-                </option>
-              </select>
-            </ChangesetFilter>
-            <ChangesetFilter
-              label="Check state"
-              onChange={[Function]}
-              values={
-                Array [
-                  "PENDING",
-                  "PASSED",
-                  "FAILED",
-                ]
-              }
-            >
-              <select
-                className="form-control"
-                onChange={[Function]}
-              >
-                <option
-                  value=""
-                >
-                  Check state
-                </option>
-                <option
-                  key="PENDING"
-                  value="PENDING"
-                >
-                  Pending
-                </option>
-                <option
-                  key="PASSED"
-                  value="PASSED"
-                >
-                  Passed
-                </option>
-                <option
-                  key="FAILED"
-                  value="FAILED"
-                >
-                  Failed
                 </option>
               </select>
             </ChangesetFilter>
@@ -1311,10 +1332,13 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
           >
             <ChangesetFilter
               className="mr-2"
-              label="State"
+              label="Status"
               onChange={[Function]}
               values={
                 Array [
+                  "UNPUBLISHED",
+                  "ERRORED",
+                  "PROCESSING",
                   "OPEN",
                   "CLOSED",
                   "MERGED",
@@ -1329,7 +1353,25 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
                 <option
                   value=""
                 >
-                  State
+                  Status
+                </option>
+                <option
+                  key="UNPUBLISHED"
+                  value="UNPUBLISHED"
+                >
+                  Unpublished
+                </option>
+                <option
+                  key="ERRORED"
+                  value="ERRORED"
+                >
+                  Errored
+                </option>
+                <option
+                  key="PROCESSING"
+                  value="PROCESSING"
+                >
+                  Processing
                 </option>
                 <option
                   key="OPEN"
@@ -1359,6 +1401,46 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
             </ChangesetFilter>
             <ChangesetFilter
               className="mr-2"
+              label="Check state"
+              onChange={[Function]}
+              values={
+                Array [
+                  "PENDING",
+                  "PASSED",
+                  "FAILED",
+                ]
+              }
+            >
+              <select
+                className="form-control mr-2"
+                onChange={[Function]}
+              >
+                <option
+                  value=""
+                >
+                  Check state
+                </option>
+                <option
+                  key="PENDING"
+                  value="PENDING"
+                >
+                  Pending
+                </option>
+                <option
+                  key="PASSED"
+                  value="PASSED"
+                >
+                  Passed
+                </option>
+                <option
+                  key="FAILED"
+                  value="FAILED"
+                >
+                  Failed
+                </option>
+              </select>
+            </ChangesetFilter>
+            <ChangesetFilter
               label="Review state"
               onChange={[Function]}
               values={
@@ -1372,7 +1454,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
               }
             >
               <select
-                className="form-control mr-2"
+                className="form-control"
                 onChange={[Function]}
               >
                 <option
@@ -1409,46 +1491,6 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
                   value="DISMISSED"
                 >
                   Dismissed
-                </option>
-              </select>
-            </ChangesetFilter>
-            <ChangesetFilter
-              label="Check state"
-              onChange={[Function]}
-              values={
-                Array [
-                  "PENDING",
-                  "PASSED",
-                  "FAILED",
-                ]
-              }
-            >
-              <select
-                className="form-control"
-                onChange={[Function]}
-              >
-                <option
-                  value=""
-                >
-                  Check state
-                </option>
-                <option
-                  key="PENDING"
-                  value="PENDING"
-                >
-                  Pending
-                </option>
-                <option
-                  key="PASSED"
-                  value="PASSED"
-                >
-                  Passed
-                </option>
-                <option
-                  key="FAILED"
-                  value="FAILED"
-                >
-                  Failed
                 </option>
               </select>
             </ChangesetFilter>

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -164,6 +164,7 @@ export const queryChangesets = ({
     reviewState,
     checkState,
     publicationState,
+    reconcilerState,
     onlyPublishedByThisCampaign,
 }: CampaignChangesetsVariables): Observable<
     (CampaignChangesetsResult['node'] & { __typename: 'Campaign' })['changesets']
@@ -177,6 +178,7 @@ export const queryChangesets = ({
                 $reviewState: ChangesetReviewState
                 $checkState: ChangesetCheckState
                 $publicationState: ChangesetPublicationState
+                $reconcilerState: ChangesetReconcilerState
                 $onlyPublishedByThisCampaign: Boolean
             ) {
                 node(id: $campaign) {
@@ -186,6 +188,7 @@ export const queryChangesets = ({
                             first: $first
                             externalState: $externalState
                             publicationState: $publicationState
+                            reconcilerState: $reconcilerState
                             reviewState: $reviewState
                             checkState: $checkState
                             onlyPublishedByThisCampaign: $onlyPublishedByThisCampaign
@@ -212,6 +215,7 @@ export const queryChangesets = ({
             reviewState,
             checkState,
             publicationState,
+            reconcilerState,
             onlyPublishedByThisCampaign,
         },
     }).pipe(

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -4,7 +4,6 @@ import { ChangesetNodeProps, ChangesetNode } from './ChangesetNode'
 import { ThemeProps } from '../../../../../../shared/src/theme'
 import { FilteredConnection, FilteredConnectionQueryArgs } from '../../../../components/FilteredConnection'
 import { Subject, merge, of } from 'rxjs'
-import { upperFirst, lowerCase } from 'lodash'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
@@ -22,21 +21,10 @@ import { PlatformContextProps } from '../../../../../../shared/src/platform/cont
 import { TelemetryProps } from '../../../../../../shared/src/telemetry/telemetryService'
 import { property, isDefined } from '../../../../../../shared/src/util/types'
 import { useObservable } from '../../../../../../shared/src/util/useObservable'
-import {
-    ChangesetFields,
-    ChangesetExternalState,
-    ChangesetReviewState,
-    ChangesetCheckState,
-    Scalars,
-} from '../../../../graphql-operations'
-import {
-    isValidChangesetExternalState,
-    isValidChangesetReviewState,
-    isValidChangesetCheckState,
-    getLSPTextDocumentPositionParameters,
-} from '../../utils'
-import classNames from 'classnames'
+import { ChangesetFields, Scalars } from '../../../../graphql-operations'
+import { getLSPTextDocumentPositionParameters } from '../../utils'
 import { CampaignChangesetsHeader } from './CampaignChangesetsHeader'
+import { ChangesetFilters, ChangesetFilterRow } from './ChangesetFilterRow'
 
 interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
     campaignID: Scalars['ID']
@@ -45,20 +33,13 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     location: H.Location
     campaignUpdates: Subject<void>
     changesetUpdates: Subject<void>
-    /** When true, only open changesets will be listed. */
-    onlyOpen?: boolean
+
     hideFilters?: boolean
 
     /** For testing only. */
     queryChangesets?: typeof _queryChangesets
     /** For testing only. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
-}
-
-interface ChangesetFilters {
-    externalState: ChangesetExternalState | null
-    reviewState: ChangesetReviewState | null
-    checkState: ChangesetCheckState | null
 }
 
 /**
@@ -75,7 +56,6 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
     extensionsController,
     platformContext,
     telemetryService,
-    onlyOpen = false,
     hideFilters = false,
     queryChangesets = _queryChangesets,
     queryExternalChangesetWithFileDiffs,
@@ -84,6 +64,8 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
         checkState: null,
         externalState: null,
         reviewState: null,
+        publicationState: null,
+        reconcilerState: null,
     })
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArgs) =>
@@ -93,8 +75,8 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                         externalState: changesetFilters.externalState,
                         reviewState: changesetFilters.reviewState,
                         checkState: changesetFilters.checkState,
-                        publicationState: null,
-                        ...(onlyOpen ? { externalState: ChangesetExternalState.OPEN } : {}),
+                        publicationState: changesetFilters.publicationState,
+                        reconcilerState: changesetFilters.reconcilerState,
                         first: args.first ?? null,
                         campaign: campaignID,
                         onlyPublishedByThisCampaign: null,
@@ -106,9 +88,10 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
             changesetFilters.externalState,
             changesetFilters.reviewState,
             changesetFilters.checkState,
+            changesetFilters.reconcilerState,
+            changesetFilters.publicationState,
             queryChangesets,
             changesetUpdates,
-            onlyOpen,
         ]
     )
 
@@ -214,111 +197,3 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
         </>
     )
 }
-
-interface ChangesetFilterRowProps {
-    history: H.History
-    location: H.Location
-    onFiltersChange: (newFilters: ChangesetFilters) => void
-}
-
-const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
-    history,
-    location,
-    onFiltersChange,
-}) => {
-    const searchParameters = new URLSearchParams(location.search)
-    const [externalState, setExternalState] = useState<ChangesetExternalState | undefined>(() => {
-        const value = searchParameters.get('external_state')
-        return value && isValidChangesetExternalState(value) ? value : undefined
-    })
-    const [reviewState, setReviewState] = useState<ChangesetReviewState | undefined>(() => {
-        const value = searchParameters.get('review_state')
-        return value && isValidChangesetReviewState(value) ? value : undefined
-    })
-    const [checkState, setCheckState] = useState<ChangesetCheckState | undefined>(() => {
-        const value = searchParameters.get('check_state')
-        return value && isValidChangesetCheckState(value) ? value : undefined
-    })
-    useEffect(() => {
-        const searchParameters = new URLSearchParams(location.search)
-        if (externalState) {
-            searchParameters.set('external_state', externalState)
-        } else {
-            searchParameters.delete('external_state')
-        }
-        if (reviewState) {
-            searchParameters.set('review_state', reviewState)
-        } else {
-            searchParameters.delete('review_state')
-        }
-        if (checkState) {
-            searchParameters.set('check_state', checkState)
-        } else {
-            searchParameters.delete('check_state')
-        }
-        history.replace({ ...location, search: searchParameters.toString() })
-        // Update the filters in the parent component.
-        onFiltersChange({
-            externalState: externalState || null,
-            reviewState: reviewState || null,
-            checkState: checkState || null,
-        })
-        // We cannot depend on the history, since it's modified by this hook and that would cause an infinite render loop.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [externalState, reviewState, checkState])
-    return (
-        <div className="form-inline m-0">
-            <ChangesetFilter<ChangesetExternalState>
-                values={Object.values(ChangesetExternalState)}
-                label="State"
-                selected={externalState}
-                onChange={setExternalState}
-                className="mr-2"
-            />
-            <ChangesetFilter<ChangesetReviewState>
-                values={Object.values(ChangesetReviewState)}
-                label="Review state"
-                selected={reviewState}
-                onChange={setReviewState}
-                className="mr-2"
-            />
-            <ChangesetFilter<ChangesetCheckState>
-                values={Object.values(ChangesetCheckState)}
-                label="Check state"
-                selected={checkState}
-                onChange={setCheckState}
-            />
-        </div>
-    )
-}
-
-interface ChangesetFilterProps<T extends string> {
-    label: string
-    values: T[]
-    selected: T | undefined
-    onChange: (value: T | undefined) => void
-    className?: string
-}
-
-export const ChangesetFilter = <T extends string>({
-    label,
-    values,
-    selected,
-    onChange,
-    className,
-}: ChangesetFilterProps<T>): React.ReactElement<ChangesetFilterProps<T>> => (
-    <>
-        <select
-            className={classNames('form-control', className)}
-            value={selected}
-            onChange={event => onChange((event.target.value ?? undefined) as T | undefined)}
-        >
-            <option value="">{label}</option>
-            {values.map(state => (
-                <option value={state} key={state}>
-                    {upperFirst(lowerCase(state))}
-                </option>
-            ))}
-        </select>
-    </>
-)

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
@@ -90,18 +90,18 @@ export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps
                 onChange={setUIState}
                 className="mr-2"
             />
-            <ChangesetFilter<ChangesetReviewState>
-                values={Object.values(ChangesetReviewState)}
-                label="Review state"
-                selected={reviewState}
-                onChange={setReviewState}
-                className="mr-2"
-            />
             <ChangesetFilter<ChangesetCheckState>
                 values={Object.values(ChangesetCheckState)}
                 label="Check state"
                 selected={checkState}
                 onChange={setCheckState}
+                className="mr-2"
+            />
+            <ChangesetFilter<ChangesetReviewState>
+                values={Object.values(ChangesetReviewState)}
+                label="Review state"
+                selected={reviewState}
+                onChange={setReviewState}
             />
         </div>
     )

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
@@ -1,0 +1,189 @@
+import React, { useState, useEffect } from 'react'
+import * as H from 'history'
+import {
+    ChangesetExternalState,
+    ChangesetReviewState,
+    ChangesetCheckState,
+    ChangesetReconcilerState,
+    ChangesetPublicationState,
+} from '../../../../graphql-operations'
+import {
+    ChangesetUIState,
+    isValidChangesetUIState,
+    isValidChangesetReviewState,
+    isValidChangesetCheckState,
+} from '../../utils'
+import classNames from 'classnames'
+import { upperFirst, lowerCase } from 'lodash'
+
+export interface ChangesetFilters {
+    externalState: ChangesetExternalState | null
+    reviewState: ChangesetReviewState | null
+    checkState: ChangesetCheckState | null
+    reconcilerState: ChangesetReconcilerState | null
+    publicationState: ChangesetPublicationState | null
+}
+
+export interface ChangesetFilterRowProps {
+    history: H.History
+    location: H.Location
+    onFiltersChange: (newFilters: ChangesetFilters) => void
+}
+
+export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps> = ({
+    history,
+    location,
+    onFiltersChange,
+}) => {
+    const searchParameters = new URLSearchParams(location.search)
+    const [uiState, setUIState] = useState<ChangesetUIState | undefined>(() => {
+        const value = searchParameters.get('status')
+        return value && isValidChangesetUIState(value) ? value : undefined
+    })
+    const [reviewState, setReviewState] = useState<ChangesetReviewState | undefined>(() => {
+        const value = searchParameters.get('review_state')
+        return value && isValidChangesetReviewState(value) ? value : undefined
+    })
+    const [checkState, setCheckState] = useState<ChangesetCheckState | undefined>(() => {
+        const value = searchParameters.get('check_state')
+        return value && isValidChangesetCheckState(value) ? value : undefined
+    })
+    useEffect(() => {
+        const searchParameters = new URLSearchParams(location.search)
+        if (uiState) {
+            searchParameters.set('status', uiState)
+        } else {
+            searchParameters.delete('status')
+        }
+        if (reviewState) {
+            searchParameters.set('review_state', reviewState)
+        } else {
+            searchParameters.delete('review_state')
+        }
+        if (checkState) {
+            searchParameters.set('check_state', checkState)
+        } else {
+            searchParameters.delete('check_state')
+        }
+        history.replace({ ...location, search: searchParameters.toString() })
+        // Update the filters in the parent component.
+        onFiltersChange({
+            ...(uiState
+                ? changesetUIStateToChangesetFilters(uiState)
+                : {
+                      reconcilerState: null,
+                      publicationState: null,
+                      externalState: null,
+                  }),
+            reviewState: reviewState || null,
+            checkState: checkState || null,
+        })
+        // We cannot depend on the history, since it's modified by this hook and that would cause an infinite render loop.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [uiState, reviewState, checkState])
+    return (
+        <div className="form-inline m-0">
+            <ChangesetFilter<ChangesetUIState>
+                values={Object.values(ChangesetUIState)}
+                label="Status"
+                selected={uiState}
+                onChange={setUIState}
+                className="mr-2"
+            />
+            <ChangesetFilter<ChangesetReviewState>
+                values={Object.values(ChangesetReviewState)}
+                label="Review state"
+                selected={reviewState}
+                onChange={setReviewState}
+                className="mr-2"
+            />
+            <ChangesetFilter<ChangesetCheckState>
+                values={Object.values(ChangesetCheckState)}
+                label="Check state"
+                selected={checkState}
+                onChange={setCheckState}
+            />
+        </div>
+    )
+}
+
+export interface ChangesetFilterProps<T extends string> {
+    label: string
+    values: T[]
+    selected: T | undefined
+    onChange: (value: T | undefined) => void
+    className?: string
+}
+
+export const ChangesetFilter = <T extends string>({
+    label,
+    values,
+    selected,
+    onChange,
+    className,
+}: ChangesetFilterProps<T>): React.ReactElement<ChangesetFilterProps<T>> => (
+    <>
+        <select
+            className={classNames('form-control', className)}
+            value={selected}
+            onChange={event => onChange((event.target.value ?? undefined) as T | undefined)}
+        >
+            <option value="">{label}</option>
+            {values.map(state => (
+                <option value={state} key={state}>
+                    {upperFirst(lowerCase(state))}
+                </option>
+            ))}
+        </select>
+    </>
+)
+
+function changesetUIStateToChangesetFilters(
+    state: ChangesetUIState
+): Omit<ChangesetFilters, 'checkState' | 'reviewState'> {
+    switch (state) {
+        case ChangesetUIState.OPEN:
+            return {
+                externalState: ChangesetExternalState.OPEN,
+                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                publicationState: ChangesetPublicationState.PUBLISHED,
+            }
+        case ChangesetUIState.CLOSED:
+            return {
+                externalState: ChangesetExternalState.CLOSED,
+                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                publicationState: ChangesetPublicationState.PUBLISHED,
+            }
+        case ChangesetUIState.MERGED:
+            return {
+                externalState: ChangesetExternalState.MERGED,
+                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                publicationState: ChangesetPublicationState.PUBLISHED,
+            }
+        case ChangesetUIState.DELETED:
+            return {
+                externalState: ChangesetExternalState.DELETED,
+                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                publicationState: ChangesetPublicationState.PUBLISHED,
+            }
+        case ChangesetUIState.UNPUBLISHED:
+            return {
+                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                externalState: null,
+                publicationState: ChangesetPublicationState.UNPUBLISHED,
+            }
+        case ChangesetUIState.PROCESSING:
+            return {
+                reconcilerState: ChangesetReconcilerState.PROCESSING,
+                // TODO: reconcilerState: [ChangesetReconcilerState.QUEUED, ChangesetReconcilerState.PROCESSING],
+                externalState: null,
+                publicationState: null,
+            }
+        case ChangesetUIState.ERRORED:
+            return {
+                reconcilerState: ChangesetReconcilerState.ERRORED,
+                publicationState: null,
+                externalState: null,
+            }
+    }
+}

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetStatusCell.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetStatusCell.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-    ChangesetFields,
-    ChangesetPublicationState,
-    ChangesetReconcilerState,
-    ChangesetExternalState,
-} from '../../../../graphql-operations'
+import { ChangesetFields } from '../../../../graphql-operations'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import SourcePullIcon from 'mdi-react/SourcePullIcon'
 import SourceMergeIcon from 'mdi-react/SourceMergeIcon'
@@ -12,6 +7,7 @@ import DeleteIcon from 'mdi-react/DeleteIcon'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import classNames from 'classnames'
+import { computeChangesetUIState, ChangesetUIState } from '../../utils'
 
 export interface ChangesetStatusCellProps {
     className?: string
@@ -19,25 +15,20 @@ export interface ChangesetStatusCellProps {
 }
 
 export const ChangesetStatusCell: React.FunctionComponent<ChangesetStatusCellProps> = ({ changeset }) => {
-    if (changeset.reconcilerState === ChangesetReconcilerState.ERRORED) {
-        return <ChangesetStatusError />
-    }
-    if (changeset.reconcilerState !== ChangesetReconcilerState.COMPLETED) {
-        return <ChangesetStatusProcessing />
-    }
-    if (changeset.publicationState === ChangesetPublicationState.UNPUBLISHED) {
-        return <ChangesetStatusUnpublished />
-    }
-    // Must be set, because changesetPublicationState !== UNPUBLISHED.
-    const externalState = changeset.externalState!
-    switch (externalState) {
-        case ChangesetExternalState.OPEN:
+    switch (computeChangesetUIState(changeset)) {
+        case ChangesetUIState.ERRORED:
+            return <ChangesetStatusError />
+        case ChangesetUIState.PROCESSING:
+            return <ChangesetStatusProcessing />
+        case ChangesetUIState.UNPUBLISHED:
+            return <ChangesetStatusUnpublished />
+        case ChangesetUIState.OPEN:
             return <ChangesetStatusOpen />
-        case ChangesetExternalState.CLOSED:
+        case ChangesetUIState.CLOSED:
             return <ChangesetStatusClosed />
-        case ChangesetExternalState.MERGED:
+        case ChangesetUIState.MERGED:
             return <ChangesetStatusMerged />
-        case ChangesetExternalState.DELETED:
+        case ChangesetUIState.DELETED:
             return <ChangesetStatusDeleted />
     }
 }

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/CampaignChangesets.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/CampaignChangesets.test.tsx.snap
@@ -30,10 +30,13 @@ exports[`CampaignChangesets renders 1`] = `
       >
         <ChangesetFilter
           className="mr-2"
-          label="State"
+          label="Status"
           onChange={[Function]}
           values={
             Array [
+              "UNPUBLISHED",
+              "ERRORED",
+              "PROCESSING",
               "OPEN",
               "CLOSED",
               "MERGED",
@@ -48,7 +51,25 @@ exports[`CampaignChangesets renders 1`] = `
             <option
               value=""
             >
-              State
+              Status
+            </option>
+            <option
+              key="UNPUBLISHED"
+              value="UNPUBLISHED"
+            >
+              Unpublished
+            </option>
+            <option
+              key="ERRORED"
+              value="ERRORED"
+            >
+              Errored
+            </option>
+            <option
+              key="PROCESSING"
+              value="PROCESSING"
+            >
+              Processing
             </option>
             <option
               key="OPEN"
@@ -78,6 +99,46 @@ exports[`CampaignChangesets renders 1`] = `
         </ChangesetFilter>
         <ChangesetFilter
           className="mr-2"
+          label="Check state"
+          onChange={[Function]}
+          values={
+            Array [
+              "PENDING",
+              "PASSED",
+              "FAILED",
+            ]
+          }
+        >
+          <select
+            className="form-control mr-2"
+            onChange={[Function]}
+          >
+            <option
+              value=""
+            >
+              Check state
+            </option>
+            <option
+              key="PENDING"
+              value="PENDING"
+            >
+              Pending
+            </option>
+            <option
+              key="PASSED"
+              value="PASSED"
+            >
+              Passed
+            </option>
+            <option
+              key="FAILED"
+              value="FAILED"
+            >
+              Failed
+            </option>
+          </select>
+        </ChangesetFilter>
+        <ChangesetFilter
           label="Review state"
           onChange={[Function]}
           values={
@@ -91,7 +152,7 @@ exports[`CampaignChangesets renders 1`] = `
           }
         >
           <select
-            className="form-control mr-2"
+            className="form-control"
             onChange={[Function]}
           >
             <option
@@ -128,46 +189,6 @@ exports[`CampaignChangesets renders 1`] = `
               value="DISMISSED"
             >
               Dismissed
-            </option>
-          </select>
-        </ChangesetFilter>
-        <ChangesetFilter
-          label="Check state"
-          onChange={[Function]}
-          values={
-            Array [
-              "PENDING",
-              "PASSED",
-              "FAILED",
-            ]
-          }
-        >
-          <select
-            className="form-control"
-            onChange={[Function]}
-          >
-            <option
-              value=""
-            >
-              Check state
-            </option>
-            <option
-              key="PENDING"
-              value="PENDING"
-            >
-              Pending
-            </option>
-            <option
-              key="PASSED"
-              value="PASSED"
-            >
-              Passed
-            </option>
-            <option
-              key="FAILED"
-              value="FAILED"
-            >
-              Failed
             </option>
           </select>
         </ChangesetFilter>


### PR DESCRIPTION
Currently, the changeset filters only allowed to filter by externalState, now they (almost) reflect what's in the UI.

### almost
/ˈɔːlməʊst/
All states but `reconcilerState: QUEUED` are correctly reflected. We need to think about a better API first to be able to query the "processing" changesets, because it's the joined set of queued and processing changesets.

Closes https://github.com/sourcegraph/sourcegraph/issues/13057