### PR TITLE
single server docker image: pick your poison

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,3 +1,80 @@
+FROM alpine:3.12 as redis-builder
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis
+# alpine already has a gid 999, so we'll use the next id
+
+RUN apk add --no-cache \
+# grab su-exec for easy step-down from root
+		'su-exec>=0.2' \
+# add tzdata for https://github.com/docker-library/redis/issues/138
+		tzdata
+
+ENV REDIS_VERSION 5.0.9
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-5.0.9.tar.gz
+ENV REDIS_DOWNLOAD_SHA 53d0ae164cd33536c3d4b720ae9a128ea6166ebf04ff1add3b85f1242090cb85
+
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		gcc \
+		linux-headers \
+		make \
+		musl-dev \
+		openssl-dev \
+# install real "wget" to avoid:
+#   + wget -O redis.tar.gz http://download.redis.io/releases/redis-6.0.6.tar.gz
+#   Connecting to download.redis.io (45.60.121.1:80)
+#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
+		wget \
+	; \
+	\
+	wget -O redis.tar.gz "$REDIS_DOWNLOAD_URL"; \
+	echo "$REDIS_DOWNLOAD_SHA *redis.tar.gz" | sha256sum -c -; \
+	mkdir -p /usr/src/redis; \
+	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
+	rm redis.tar.gz; \
+	\
+# disable Redis protected mode [1] as it is unnecessary in context of Docker
+# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
+# [1]: https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	grep -q '^#define CONFIG_DEFAULT_PROTECTED_MODE 1$' /usr/src/redis/src/server.h; \
+	sed -ri 's!^(#define CONFIG_DEFAULT_PROTECTED_MODE) 1$!\1 0!' /usr/src/redis/src/server.h; \
+	grep -q '^#define CONFIG_DEFAULT_PROTECTED_MODE 0$' /usr/src/redis/src/server.h; \
+# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
+# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
+# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	\
+	make CFLAGS="-static" EXEEXT="-static" LDFLAGS="-I/usr/local/include/" -C /usr/src/redis -j "$(nproc)" all; \
+	make CFLAGS="-static" EXEEXT="-static" LDFLAGS="-I/usr/local/include/" -C /usr/src/redis install; \
+	\
+# TODO https://github.com/antirez/redis/pull/3494 (deduplicate "redis-server" copies)
+	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
+	find /usr/local/bin/redis* -maxdepth 0 \
+		-type f -not -name redis-server \
+		-exec sh -eux -c ' \
+			md5="$(md5sum "$1" | cut -d" " -f1)"; \
+			test "$md5" = "$serverMd5"; \
+		' -- '{}' ';' \
+		-exec ln -svfT 'redis-server' '{}' ';' \
+	; \
+	\
+	rm -r /usr/src/redis; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .redis-rundeps $runDeps; \
+	apk del --no-network .build-deps; \
+	\
+	redis-cli --version; \
+	redis-server --version
+
+
 FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a as libsqlite3-pcre
 
 COPY libsqlite3-pcre-install-alpine.sh /libsqlite3-pcre-install-alpine.sh
@@ -42,7 +119,7 @@ COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e41
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 # hadolint ignore=DL3022
-COPY --from=redis:5-alpine@sha256:abd9d0fc18e163747253aae8d69be344c7e90d6b6d6027fa7f2f2c0e6c20b2b8 /usr/local/bin/redis-* /usr/local/bin/
+COPY --from=redis-builder /usr/local/bin/redis-* /usr/local/bin/
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/prometheus:server /bin/prom-wrapper /bin

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,80 +1,3 @@
-FROM alpine:3.12 as redis-builder
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis
-# alpine already has a gid 999, so we'll use the next id
-
-RUN apk add --no-cache \
-# grab su-exec for easy step-down from root
-		'su-exec>=0.2' \
-# add tzdata for https://github.com/docker-library/redis/issues/138
-		tzdata
-
-ENV REDIS_VERSION 5.0.9
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-5.0.9.tar.gz
-ENV REDIS_DOWNLOAD_SHA 53d0ae164cd33536c3d4b720ae9a128ea6166ebf04ff1add3b85f1242090cb85
-
-RUN set -eux; \
-	\
-	apk add --no-cache --virtual .build-deps \
-		coreutils \
-		gcc \
-		linux-headers \
-		make \
-		musl-dev \
-		openssl-dev \
-# install real "wget" to avoid:
-#   + wget -O redis.tar.gz http://download.redis.io/releases/redis-6.0.6.tar.gz
-#   Connecting to download.redis.io (45.60.121.1:80)
-#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
-		wget \
-	; \
-	\
-	wget -O redis.tar.gz "$REDIS_DOWNLOAD_URL"; \
-	echo "$REDIS_DOWNLOAD_SHA *redis.tar.gz" | sha256sum -c -; \
-	mkdir -p /usr/src/redis; \
-	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
-	rm redis.tar.gz; \
-	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -q '^#define CONFIG_DEFAULT_PROTECTED_MODE 1$' /usr/src/redis/src/server.h; \
-	sed -ri 's!^(#define CONFIG_DEFAULT_PROTECTED_MODE) 1$!\1 0!' /usr/src/redis/src/server.h; \
-	grep -q '^#define CONFIG_DEFAULT_PROTECTED_MODE 0$' /usr/src/redis/src/server.h; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
-	make CFLAGS="-static" EXEEXT="-static" LDFLAGS="-I/usr/local/include/" -C /usr/src/redis -j "$(nproc)" all; \
-	make CFLAGS="-static" EXEEXT="-static" LDFLAGS="-I/usr/local/include/" -C /usr/src/redis install; \
-	\
-# TODO https://github.com/antirez/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
-	rm -r /usr/src/redis; \
-	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .redis-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	\
-	redis-cli --version; \
-	redis-server --version
-
-
 FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a as libsqlite3-pcre
 
 COPY libsqlite3-pcre-install-alpine.sh /libsqlite3-pcre-install-alpine.sh
@@ -98,7 +21,9 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+  echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+  echo "@3.10 http://dl-cdn.alpinelinux.org/alpine/v3.10/main" >> /etc/apk/repositories && \
+  echo "@3.10 http://dl-cdn.alpinelinux.org/alpine/v3.10/community" >> /etc/apk/repositories
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
@@ -106,8 +31,8 @@ RUN apk update && apk add --no-cache \
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
-    'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
-    bind-tools ca-certificates git@edge \
+    musl@3.10 'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
+    bind-tools ca-certificates git@edge musl@3.10 \
     mailcap 'nginx=1.16.1-r2' openssh-client pcre sqlite-libs su-exec tini nodejs-current=12.4.0-r0 curl
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
@@ -119,7 +44,7 @@ COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e41
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 # hadolint ignore=DL3022
-COPY --from=redis-builder /usr/local/bin/redis-* /usr/local/bin/
+COPY --from=redis:5-alpine@sha256:abd9d0fc18e163747253aae8d69be344c7e90d6b6d6027fa7f2f2c0e6c20b2b8 /usr/local/bin/redis-* /usr/local/bin/
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/prometheus:server /bin/prom-wrapper /bin

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e41
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 
 # install postgres 11
-# hadolint ignore=DL3022,DL3003,DL3018,DL3019
+# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
 RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
     tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
     cd target/main/x86_64/ && \
@@ -43,7 +43,7 @@ RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc
     rm -rf target/
 
 # install git edge
-# hadolint ignore=DL3022,DL3003,DL3018,DL3019
+# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
 RUN wget https://storage.googleapis.com/apktmp/git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz  && \
     tar -xzf git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz && \
     cd target/main/x86_64/ && \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,23 +1,3 @@
-# Build Git
-FROM ubuntu:18.04@sha256:767eea1efb29ab7e215e1d97c8d758df5d587ca86e769a2dfb254c6b022895c3 as git-builder
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    gettext \
-    libcurl4-gnutls-dev \
-    libexpat1-dev \
-    libghc-zlib-dev \
-    libssl-dev \
-    make \
-    tar
-WORKDIR /git
-ENV GIT_VERSION=2.28.0
-ENV CFLAGS="${CFLAGS} -static"
-RUN curl -Lfs https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz | tar xz --strip-components 1 && \
-    make prefix=/usr/local all && \
-    make prefix=/usr/local install
-
 FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321 as libsqlite3-pcre
 
 COPY libsqlite3-pcre-install-alpine.sh /libsqlite3-pcre-install-alpine.sh
@@ -52,12 +32,19 @@ RUN apk update && apk add --no-cache \
 COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
-# hadolint ignore=DL3022
-COPY --from=git-builder /usr/local/bin /usr/local/bin/
 
 # install postgres 11
 RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
     tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
+    cd target/main/x86_64/ && \
+    apk add --allow-untrusted *.apk && \
+    cd ../../../ && \
+    rm -rf target/
+
+# install git edge
+
+RUN wget https://storage.googleapis.com/apktmp/git-edge-for-alpine-3-12-.tar.gz  && \
+    tar -xzf git-edge-for-alpine-3-12-.tar.gz && \
     cd target/main/x86_64/ && \
     apk add --allow-untrusted *.apk && \
     cd ../../../ && \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e41
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 
 # install postgres 11
+# hadolint ignore=DL3022,DL3003,DL3018,DL3019
 RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
     tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
     cd target/main/x86_64/ && \
@@ -42,9 +43,9 @@ RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc
     rm -rf target/
 
 # install git edge
-
-RUN wget https://storage.googleapis.com/apktmp/git-edge-for-alpine-3-12-.tar.gz  && \
-    tar -xzf git-edge-for-alpine-3-12-.tar.gz && \
+# hadolint ignore=DL3022,DL3003,DL3018,DL3019
+RUN wget https://storage.googleapis.com/apktmp/git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz  && \
+    tar -xzf git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz && \
     cd target/main/x86_64/ && \
     apk add --allow-untrusted *.apk && \
     cd ../../../ && \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,15 +1,30 @@
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a as libsqlite3-pcre
+# Build Git
+FROM ubuntu:18.04@sha256:767eea1efb29ab7e215e1d97c8d758df5d587ca86e769a2dfb254c6b022895c3 as git-builder
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gettext \
+    libcurl4-gnutls-dev \
+    libexpat1-dev \
+    libghc-zlib-dev \
+    libssl-dev \
+    make \
+    tar
+WORKDIR /git
+ENV GIT_VERSION=2.28.0
+ENV CFLAGS="${CFLAGS} -static"
+RUN curl -Lfs https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz | tar xz --strip-components 1 && \
+    make prefix=/usr/local all && \
+    make prefix=/usr/local install
+
+FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321 as libsqlite3-pcre
 
 COPY libsqlite3-pcre-install-alpine.sh /libsqlite3-pcre-install-alpine.sh
 RUN /libsqlite3-pcre-install-alpine.sh
 
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a AS ctags
-
-COPY ctags-install-alpine.sh /ctags-install-alpine.sh
-RUN /ctags-install-alpine.sh
-
-# TODO: Make this image use our sourcegraph/alpine:3.10 base image
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a
+# TODO: Make this image use our sourcegraph/alpine:3.12 base image
+FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -20,20 +35,15 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-  echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-  echo "@3.10 http://dl-cdn.alpinelinux.org/alpine/v3.10/main" >> /etc/apk/repositories && \
-  echo "@3.10 http://dl-cdn.alpinelinux.org/alpine/v3.10/community" >> /etc/apk/repositories
-
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
-    musl@3.10 'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
-    bind-tools ca-certificates git@edge musl@3.10 \
-    mailcap 'nginx=1.16.1-r2' openssh-client pcre sqlite-libs su-exec tini nodejs-current=12.4.0-r0 curl
+   'bash=5.0.17-r0' \
+   'redis=5.0.9-r0' bind-tools ca-certificates \
+    mailcap 'nginx=1.18.0-r0' openssh-client pcre sqlite-libs su-exec tini 'nodejs-current=14.5.0-r0' curl
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
@@ -42,9 +52,19 @@ RUN apk update && apk add --no-cache \
 COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
-COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
 # hadolint ignore=DL3022
-COPY --from=redis:5-alpine@sha256:abd9d0fc18e163747253aae8d69be344c7e90d6b6d6027fa7f2f2c0e6c20b2b8 /usr/local/bin/redis-* /usr/local/bin/
+COPY --from=git-builder /usr/local/bin /usr/local/bin/
+
+# install postgres 11
+RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
+    tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
+    cd target/main/x86_64/ && \
+    apk add --allow-untrusted *.apk && \
+    cd ../../../ && \
+    rm -rf target/
+
+COPY ctags-install-alpine.sh /ctags-install-alpine.sh
+RUN /ctags-install-alpine.sh
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/prometheus:server /bin/prom-wrapper /bin

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -8,7 +8,6 @@ set -eux
 CTAGS_VERSION=03f933a96d3ef87adbf9d167462d45ce69577edb
 
 apk --no-cache add \
-  --virtual build-deps \
   autoconf \
   automake \
   binutils \
@@ -17,6 +16,8 @@ apk --no-cache add \
   gcc \
   jansson-dev \
   libseccomp-dev \
+  jansson \
+  libseccomp \
   linux-headers \
   make \
   pkgconfig
@@ -25,11 +26,10 @@ apk --no-cache add \
 curl "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/ctags-$CTAGS_VERSION
 ./autogen.sh
-LDFLAGS=-static ./configure --program-prefix=universal- --enable-json --enable-seccomp
+./configure --program-prefix=universal- --enable-json --enable-seccomp
 make -j8
 make install
 
 # Cleanup
 cd /
 rm -rf /tmp/ctags-$CTAGS_VERSION
-apk --no-cache --purge del build-deps


### PR DESCRIPTION
addresses the single server issues (a fragile system with a lot of butterfly effects)

this didn't work https://github.com/sourcegraph/sourcegraph/pull/13107

also see
https://github.com/sourcegraph/postgres-apk-builder
https://github.com/sourcegraph/git-apk-builder

this upgrades the lot to alpine 3.12