### PR TITLE
codeintel: Install docker inside precise-code-intel-indexer-vm docker image

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/Dockerfile
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/Dockerfile
@@ -12,7 +12,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     git \
-    tini
+    tini \
+    docker
 
 USER sourcegraph
 EXPOSE 3190


### PR DESCRIPTION
We're use docker until we transition to firecracker on the google compute node. Doing this will allow it to function outside of k8s so we can continue the transition described in [RFC 199](https://docs.google.com/document/d/1rCduWqaLAbMu2s43RwJTBbRlhL6qS3oqq4iawiGdoVE/edit).