### PR TITLE
doc(alerting): provide reference for webhook bodies

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -4,8 +4,7 @@ This document contains possible solutions for when you find alerts are firing in
 If your alert isn't mentioned here, or if the solution doesn't help, [contact us](mailto:support@sourcegraph.com)
 for assistance.
 
-To learn more about Sourcegraph's alerting, see [our alerting documentation](https://docs.sourcegraph.com/admin/observability/alerting)
-and learn more about alert labels and metrics in our [metrics guide](metrics_guide).
+To learn more about Sourcegraph's alerting, see [our alerting documentation](https://docs.sourcegraph.com/admin/observability/alerting).
 
 <!-- DO NOT EDIT: generated via: go generate ./monitoring -->
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -4,7 +4,8 @@ This document contains possible solutions for when you find alerts are firing in
 If your alert isn't mentioned here, or if the solution doesn't help, [contact us](mailto:support@sourcegraph.com)
 for assistance.
 
-To learn more about Sourcegraph's alerting, see [our alerting documentation](https://docs.sourcegraph.com/admin/observability/alerting).
+To learn more about Sourcegraph's alerting, see [our alerting documentation](https://docs.sourcegraph.com/admin/observability/alerting)
+and learn more about alert labels and metrics in our [metrics guide](metrics_guide).
 
 <!-- DO NOT EDIT: generated via: go generate ./monitoring -->
 

--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -59,6 +59,24 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
 ]
 ```
 
+Webhook events provide the following fields relevant for Sourcegraph alerts that we recommend you leverage:
+
+<!-- Refer to `commonLabels` on receivers.go for labels we can guarantee will be provided in commonLabels -->
+
+```json
+{
+  "status": "<resolved|firing>",
+  "commonLabels": {
+    "level": "<critical|warning>",
+    "service_name": "<string>",
+    "name": "<string>",
+    "owner": "<string>"
+  },
+}
+```
+
+For the complete set of fields, please refer to the [Alertmanager webhook documentation](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config).
+
 #### Email
 
 Note that to receive email notifications, the [`email.address`](../config/site_config.md#email-address) and [`email.smtp`](../config/site_config.md#email-smtp) fields must be configured in site configuration.

--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -71,6 +71,7 @@ Webhook events provide the following fields relevant for Sourcegraph alerts that
     // Use the service name and alert name to find solutions in https://docs.sourcegraph.com/admin/observability/alert_solutions
     "service_name": "<string>",
     "name": "<string>",
+    "description": "<string>",
     // This field can be provided to Sourcegraph to help direct support.
     "owner": "<string>"
   },

--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -4,7 +4,7 @@ Alerts can be configured to notify site admins when there is something wrong or 
 
 ## Understanding alerts
 
-See [alert solutions](alert_solutions.md) for possible solutions when alerts are firing, and learn more about alert labels and metrics in our [metrics guide](metrics_guide).
+See [alert solutions](alert_solutions.md) for possible solutions when alerts are firing, and learn more about alert labels and metrics in our [metrics guide](metrics_guide.md).
 
 ## Setting up alerting
 

--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -4,7 +4,7 @@ Alerts can be configured to notify site admins when there is something wrong or 
 
 ## Understanding alerts
 
-See [alert solutions](alert_solutions.md) for possible solutions when alerts are firing.
+See [alert solutions](alert_solutions.md) for possible solutions when alerts are firing, and learn more about alert labels and metrics in our [metrics guide](metrics_guide).
 
 ## Setting up alerting
 
@@ -68,8 +68,10 @@ Webhook events provide the following fields relevant for Sourcegraph alerts that
   "status": "<resolved|firing>",
   "commonLabels": {
     "level": "<critical|warning>",
+    // Use the service name and alert name to find solutions in https://docs.sourcegraph.com/admin/observability/alert_solutions
     "service_name": "<string>",
     "name": "<string>",
+    // This field can be provided to Sourcegraph to help direct support.
     "owner": "<string>"
   },
 }

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -44,10 +44,7 @@ func changeReceivers(ctx context.Context, log log15.Logger, change ChangeContext
 		Name: alertmanagerNoopReceiver,
 	})
 	change.AMConfig.Route = &amconfig.Route{
-		// include `alertname` for now to accommodate non-generator alerts - in the long run, we want to remove grouping on `alertname`
-		// because all alerts should have some predefined labels
-		// https://github.com/sourcegraph/sourcegraph/issues/5370
-		GroupByStr: []string{"alertname", "level", "service_name", "name", "owner"},
+		GroupByStr: commonLabels,
 
 		// How long to initially wait to send a notification for a group - each group matches exactly one alert, so fire immediately
 		GroupWait: duration(1 * time.Second),

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -29,7 +29,7 @@ const (
 // for alerts provided by the Sourcegraph generator.
 //
 // When changing this, make sure to update the webhook body documentation in /doc/admin/observability/alerting.md
-var commonLabels = []string{"alertname", "level", "service_name", "name", "owner"}
+var commonLabels = []string{"alertname", "level", "service_name", "name", "owner", "description"}
 
 // Static alertmanager templates
 var (

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -22,6 +22,13 @@ const (
 	colorGood     = "#00FF00" // green
 )
 
+// commonLabels defines the set of labels we group alerts by, such that each alert falls in a unique group.
+// These labels are available in Alertmanager templates as fields of `.CommonLabels`
+//
+// Note that `alertname` is provided as a fallback grouping only - combinations of the other labels should be unique
+// for alerts provided by the Sourcegraph generator.
+var commonLabels = []string{"alertname", "level", "service_name", "name", "owner"}
+
 // Static alertmanager templates
 var (
 	// Alertmanager notification template reference: https://prometheus.io/docs/alerting/latest/notifications

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -23,10 +23,12 @@ const (
 )
 
 // commonLabels defines the set of labels we group alerts by, such that each alert falls in a unique group.
-// These labels are available in Alertmanager templates as fields of `.CommonLabels`
+// These labels are available in Alertmanager templates as fields of `.CommonLabels`.
 //
 // Note that `alertname` is provided as a fallback grouping only - combinations of the other labels should be unique
 // for alerts provided by the Sourcegraph generator.
+//
+// When changing this, make sure to update the webhook body documentation in /doc/admin/observability/alerting.md
 var commonLabels = []string{"alertname", "level", "service_name", "name", "owner"}
 
 // Static alertmanager templates


### PR DESCRIPTION
Documents a subset of Alertmanager's webhook events that site admins can leverage for Sourcegraph alerts, [as requested by a customer](https://sourcegraph.slack.com/archives/CJX299FGE/p1597716972141400) via @dadlerj 

We exclude many fields because there are certain assumptions we can make about the grouping of alerts (for example, a guaranteed set of `commonLabels`, and that a group will only ever have one alert). I've moved the definition of these common labels to a separate variable to enable clearer documentation.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
