### PR TITLE
Release pure-docker v3.18.0 & fix announced Docker Compose version

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -44,7 +44,7 @@ var (
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newBuild("3.18.0-1")
+	latestReleaseDockerComposeOrPureDocker = newBuild("3.18.0")
 )
 
 func getLatestRelease(deployType string) build {

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -4,6 +4,14 @@ This document describes the exact changes needed to update a [pure-Docker Source
 
 Each section comprehensively describes the changes needed in Docker images, environment variables, and added/removed services.
 
+## 3.17.2 -> 3.18.0 changes
+
+To upgrade, please perform the changes in the following diff:
+
+https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/7e6b23cdfead3be639048c5fa7fffe07441610f2
+
+Note: `deploy-grafana.sh` and `deploy-prometheus.sh` had environment variables changed, otherwise only image tags have changed.
+
 ## v3.16.0 -> v3.17.2 changes
 
 To upgrade, please perform the changes in the following diff:


### PR DESCRIPTION
`3.18.0-1` is the tag in the repo but NOT the tag of the Docker images, so it should be `3.18.0`. All instances currently without this change are seeing "an upgrade is available v3.18.0-1` even if they are on that (because the images are `3.18.0`)