### PR TITLE
Revert "single server docker image: pick your poison (#13113)"

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,10 +1,15 @@
-FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321 as libsqlite3-pcre
+FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a as libsqlite3-pcre
 
 COPY libsqlite3-pcre-install-alpine.sh /libsqlite3-pcre-install-alpine.sh
 RUN /libsqlite3-pcre-install-alpine.sh
 
-# TODO: Make this image use our sourcegraph/alpine:3.12 base image
-FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
+FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a AS ctags
+
+COPY ctags-install-alpine.sh /ctags-install-alpine.sh
+RUN /ctags-install-alpine.sh
+
+# TODO: Make this image use our sourcegraph/alpine:3.10 base image
+FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -15,15 +20,18 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
-   'bash=5.0.17-r0' \
-   'redis=5.0.9-r0' bind-tools ca-certificates \
-    mailcap 'nginx=1.18.0-r0' openssh-client pcre sqlite-libs su-exec tini 'nodejs-current=14.5.0-r0' curl
+    'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
+    bind-tools ca-certificates git@edge \
+    mailcap 'nginx=1.16.1-r2' openssh-client pcre sqlite-libs su-exec tini nodejs-current=12.4.0-r0 curl
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
@@ -32,27 +40,9 @@ RUN apk update && apk add --no-cache \
 COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
-
-# install postgres 11
-# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
-RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
-    tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
-    cd target/main/x86_64/ && \
-    apk add --allow-untrusted *.apk && \
-    cd ../../../ && \
-    rm -rf target/
-
-# install git edge
-# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
-RUN wget https://storage.googleapis.com/apktmp/git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz  && \
-    tar -xzf git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz && \
-    cd target/main/x86_64/ && \
-    apk add --allow-untrusted *.apk && \
-    cd ../../../ && \
-    rm -rf target/
-
-COPY ctags-install-alpine.sh /ctags-install-alpine.sh
-RUN /ctags-install-alpine.sh
+COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
+# hadolint ignore=DL3022
+COPY --from=redis:5-alpine@sha256:abd9d0fc18e163747253aae8d69be344c7e90d6b6d6027fa7f2f2c0e6c20b2b8 /usr/local/bin/redis-* /usr/local/bin/
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/prometheus:server /bin/prom-wrapper /bin

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -8,6 +8,7 @@ set -eux
 CTAGS_VERSION=03f933a96d3ef87adbf9d167462d45ce69577edb
 
 apk --no-cache add \
+  --virtual build-deps \
   autoconf \
   automake \
   binutils \
@@ -16,8 +17,6 @@ apk --no-cache add \
   gcc \
   jansson-dev \
   libseccomp-dev \
-  jansson \
-  libseccomp \
   linux-headers \
   make \
   pkgconfig
@@ -26,10 +25,11 @@ apk --no-cache add \
 curl "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/ctags-$CTAGS_VERSION
 ./autogen.sh
-./configure --program-prefix=universal- --enable-json --enable-seccomp
+LDFLAGS=-static ./configure --program-prefix=universal- --enable-json --enable-seccomp
 make -j8
 make install
 
 # Cleanup
 cd /
 rm -rf /tmp/ctags-$CTAGS_VERSION
+apk --no-cache --purge del build-deps


### PR DESCRIPTION
This reverts commit da580674467e75074566a54b94f99c803d6dceec.

It appears to be causing the following error when symbols starts up on Sourceraph.com:

```
Start: NewParser: unexpected EOF from ctags.
```