### PR TITLE
searcher: factor client out of graphlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -2,23 +2,17 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 
-	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/inconshreveable/log15"
@@ -30,30 +24,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	querytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 const maxUnindexedRepoRevSearchesPerQuery = 200
 
-var (
-	// A global limiter on number of concurrent searcher searches.
-	textSearchLimiter = mutablelimiter.New(32)
-
-	requestCounter = metrics.NewRequestMeter("textsearch", "Total number of requests sent to the textsearch API.")
-
-	searchHTTPClient = &http.Client{
-		// ot.Transport will propagate opentracing spans
-		Transport: &ot.Transport{
-			RoundTripper: requestCounter.Transport(&http.Transport{
-				// Default is 2, but we can send many concurrent requests
-				MaxIdleConnsPerHost: 500,
-			}, func(u *url.URL) string {
-				return "search"
-			}),
-		},
-	}
-)
+// A global limiter on number of concurrent searcher searches.
+var textSearchLimiter = mutablelimiter.New(32)
 
 // A light wrapper around the search service. We implement the service here so
 // that we can unmarshal the result directly into graphql resolvers.
@@ -175,183 +153,9 @@ func (lm *lineMatch) LimitHit() bool {
 	return lm.JLimitHit
 }
 
-var mockTextSearch func(ctx context.Context, repo gitserver.Repo, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
-
-// textSearch searches repo@commit with p.
-// Note: the returned matches do not set fileMatch.uri
-func textSearch(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.Repo, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
-	if mockTextSearch != nil {
-		return mockTextSearch(ctx, repo, commit, p, fetchTimeout)
-	}
-
-	tr, ctx := trace.New(ctx, "searcher.client", fmt.Sprintf("%s@%s", repo.Name, commit))
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
-
-	q := url.Values{
-		"Repo":            []string{string(repo.Name)},
-		"URL":             []string{repo.URL},
-		"Commit":          []string{string(commit)},
-		"Pattern":         []string{p.Pattern},
-		"ExcludePattern":  []string{p.ExcludePattern},
-		"IncludePatterns": p.IncludePatterns,
-		"FetchTimeout":    []string{fetchTimeout.String()},
-		"Languages":       p.Languages,
-		"CombyRule":       []string{p.CombyRule},
-
-		"PathPatternsAreRegExps": []string{"true"},
-	}
-	if deadline, ok := ctx.Deadline(); ok {
-		t, err := deadline.MarshalText()
-		if err != nil {
-			return nil, false, err
-		}
-		q.Set("Deadline", string(t))
-	}
-	q.Set("FileMatchLimit", strconv.FormatInt(int64(p.FileMatchLimit), 10))
-	if p.IsRegExp {
-		q.Set("IsRegExp", "true")
-	}
-	if p.IsStructuralPat {
-		q.Set("IsStructuralPat", "true")
-	}
-	if p.IsWordMatch {
-		q.Set("IsWordMatch", "true")
-	}
-	if p.IsCaseSensitive {
-		q.Set("IsCaseSensitive", "true")
-	}
-	if p.PathPatternsAreCaseSensitive {
-		q.Set("PathPatternsAreCaseSensitive", "true")
-	}
-	// TEMP BACKCOMPAT: always set even if false so that searcher can distinguish new frontends that send
-	// these fields from old frontends that do not (and provide a default in the latter case).
-	q.Set("PatternMatchesContent", strconv.FormatBool(p.PatternMatchesContent))
-	q.Set("PatternMatchesPath", strconv.FormatBool(p.PatternMatchesPath))
-	rawQuery := q.Encode()
-
-	// Searcher caches the file contents for repo@commit since it is
-	// relatively expensive to fetch from gitserver. So we use consistent
-	// hashing to increase cache hits.
-	consistentHashKey := string(repo.Name) + "@" + string(commit)
-	tr.LazyPrintf("%s", consistentHashKey)
-
-	var (
-		// When we retry do not use a host we already tried.
-		excludedSearchURLs = map[string]bool{}
-		attempt            = 0
-		maxAttempts        = 2
-	)
-	for {
-		attempt++
-
-		searcherURL, err := searcherURLs.Get(consistentHashKey, excludedSearchURLs)
-		if err != nil {
-			return nil, false, err
-		}
-
-		// Fallback to a bad host if nothing is left
-		if searcherURL == "" {
-			tr.LazyPrintf("failed to find endpoint, trying again without excludes")
-			searcherURL, err = searcherURLs.Get(consistentHashKey, nil)
-			if err != nil {
-				return nil, false, err
-			}
-		}
-
-		url := searcherURL + "?" + rawQuery
-		tr.LazyPrintf("attempt %d: %s", attempt, url)
-		matches, limitHit, err = textSearchURL(ctx, url)
-		if err == nil || errcode.IsTimeout(err) {
-			return matches, limitHit, err
-		}
-
-		// If we are canceled, return that error.
-		if err := ctx.Err(); err != nil {
-			return nil, false, err
-		}
-
-		// If not temporary or our last attempt then don't try again.
-		if !errcode.IsTemporary(err) || attempt == maxAttempts {
-			return nil, false, err
-		}
-
-		tr.LazyPrintf("transient error %s", err.Error())
-		// Retry search on another searcher instance (if possible)
-		excludedSearchURLs[searcherURL] = true
-	}
-}
-
-func textSearchURL(ctx context.Context, url string) ([]*FileMatchResolver, bool, error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, false, err
-	}
-	req = req.WithContext(ctx)
-
-	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req,
-		nethttp.OperationName("Searcher Client"),
-		nethttp.ClientTrace(false))
-	defer ht.Finish()
-
-	// Do not lose the context returned by TraceRequest
-	ctx = req.Context()
-
-	resp, err := searchHTTPClient.Do(req)
-	if err != nil {
-		// If we failed due to cancellation or timeout (with no partial results in the response
-		// body), return just that.
-		if ctx.Err() != nil {
-			err = ctx.Err()
-		}
-		return nil, false, errors.Wrap(err, "searcher request failed")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, false, err
-		}
-		return nil, false, errors.WithStack(&searcherError{StatusCode: resp.StatusCode, Message: string(body)})
-	}
-
-	r := struct {
-		Matches     []*FileMatchResolver
-		LimitHit    bool
-		DeadlineHit bool
-	}{}
-	err = json.NewDecoder(resp.Body).Decode(&r)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "searcher response invalid")
-	}
-	if r.DeadlineHit {
-		err = context.DeadlineExceeded
-	}
-	return r.Matches, r.LimitHit, err
-}
-
-type searcherError struct {
-	StatusCode int
-	Message    string
-}
-
-func (e *searcherError) BadRequest() bool {
-	return e.StatusCode == http.StatusBadRequest
-}
-
-func (e *searcherError) Temporary() bool {
-	return e.StatusCode == http.StatusServiceUnavailable
-}
-
-func (e *searcherError) Error() string {
-	return e.Message
-}
-
 var mockSearchFilesInRepo func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
 
-func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]*FileMatchResolver, bool, error) {
 	if mockSearchFilesInRepo != nil {
 		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout)
 	}
@@ -373,21 +177,43 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 		return nil, false, err
 	}
 
-	matches, limitHit, err = textSearch(ctx, searcherURLs, gitserverRepo, commit, info, fetchTimeout)
+	matches, limitHit, err := searcher.Search(ctx, searcherURLs, gitserverRepo, commit, info, fetchTimeout)
 	if err != nil {
 		return nil, false, err
 	}
 
 	workspace := fileMatchURI(repo.Name, rev, "")
 	repoResolver := &RepositoryResolver{repo: repo}
+	resolvers := make([]*FileMatchResolver, 0, len(matches))
 	for _, fm := range matches {
-		fm.uri = workspace + fm.JPath
-		fm.Repo = repoResolver
-		fm.CommitID = commit
-		fm.InputRev = &rev
+		lineMatches := make([]*lineMatch, 0, len(fm.LineMatches))
+		for _, lm := range fm.LineMatches {
+			ranges := make([][2]int32, 0, len(lm.OffsetAndLengths))
+			for _, ol := range lm.OffsetAndLengths {
+				ranges = append(ranges, [2]int32{int32(ol[0]), int32(ol[1])})
+			}
+			lineMatches = append(lineMatches, &lineMatch{
+				JPreview:          lm.Preview,
+				JOffsetAndLengths: ranges,
+				JLineNumber:       int32(lm.LineNumber),
+				JLimitHit:         lm.LimitHit,
+			})
+		}
+
+		resolvers = append(resolvers, &FileMatchResolver{
+			JPath:        fm.Path,
+			JLineMatches: lineMatches,
+			JLimitHit:    fm.LimitHit,
+			MatchCount:   fm.MatchCount,
+
+			uri:      workspace + fm.Path,
+			Repo:     repoResolver,
+			CommitID: commit,
+			InputRev: &rev,
+		})
 	}
 
-	return matches, limitHit, err
+	return resolvers, limitHit, err
 }
 
 // repoShouldBeSearched determines whether a repository should be searched in, based on whether the repository
@@ -416,7 +242,7 @@ func repoShouldBeSearched(ctx context.Context, searcherURLs *endpoint.Map, searc
 func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.Map, include bool, repoHasFileFlag []string, gitserverRepo gitserver.Repo, commit api.CommitID, fetchTimeout time.Duration) (bool, error) {
 	for _, pattern := range repoHasFileFlag {
 		p := search.TextPatternInfo{IsRegExp: true, FileMatchLimit: 1, IncludePatterns: []string{pattern}, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
-		matches, _, err := textSearch(ctx, searcherURLs, gitserverRepo, commit, &p, fetchTimeout)
+		matches, _, err := searcher.Search(ctx, searcherURLs, gitserverRepo, commit, &p, fetchTimeout)
 		if err != nil {
 			return false, err
 		}

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -1,0 +1,215 @@
+// Packager searcher provides a client for our just in time text searching
+// service "searcher".
+package searcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/endpoint"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+)
+
+var (
+	requestCounter = metrics.NewRequestMeter("textsearch", "Total number of requests sent to the textsearch API.")
+
+	searchHTTPClient = &http.Client{
+		// ot.Transport will propagate opentracing spans
+		Transport: &ot.Transport{
+			RoundTripper: requestCounter.Transport(&http.Transport{
+				// Default is 2, but we can send many concurrent requests
+				MaxIdleConnsPerHost: 500,
+			}, func(u *url.URL) string {
+				return "search"
+			}),
+		},
+	}
+)
+
+var MockSearch func(ctx context.Context, repo gitserver.Repo, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*protocol.FileMatch, limitHit bool, err error)
+
+// Search searches repo@commit with p.
+func Search(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.Repo, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*protocol.FileMatch, limitHit bool, err error) {
+	if MockSearch != nil {
+		return MockSearch(ctx, repo, commit, p, fetchTimeout)
+	}
+
+	tr, ctx := trace.New(ctx, "searcher.client", fmt.Sprintf("%s@%s", repo.Name, commit))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	q := url.Values{
+		"Repo":            []string{string(repo.Name)},
+		"URL":             []string{repo.URL},
+		"Commit":          []string{string(commit)},
+		"Pattern":         []string{p.Pattern},
+		"ExcludePattern":  []string{p.ExcludePattern},
+		"IncludePatterns": p.IncludePatterns,
+		"FetchTimeout":    []string{fetchTimeout.String()},
+		"Languages":       p.Languages,
+		"CombyRule":       []string{p.CombyRule},
+
+		"PathPatternsAreRegExps": []string{"true"},
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		t, err := deadline.MarshalText()
+		if err != nil {
+			return nil, false, err
+		}
+		q.Set("Deadline", string(t))
+	}
+	q.Set("FileMatchLimit", strconv.FormatInt(int64(p.FileMatchLimit), 10))
+	if p.IsRegExp {
+		q.Set("IsRegExp", "true")
+	}
+	if p.IsStructuralPat {
+		q.Set("IsStructuralPat", "true")
+	}
+	if p.IsWordMatch {
+		q.Set("IsWordMatch", "true")
+	}
+	if p.IsCaseSensitive {
+		q.Set("IsCaseSensitive", "true")
+	}
+	if p.PathPatternsAreCaseSensitive {
+		q.Set("PathPatternsAreCaseSensitive", "true")
+	}
+	// TEMP BACKCOMPAT: always set even if false so that searcher can distinguish new frontends that send
+	// these fields from old frontends that do not (and provide a default in the latter case).
+	q.Set("PatternMatchesContent", strconv.FormatBool(p.PatternMatchesContent))
+	q.Set("PatternMatchesPath", strconv.FormatBool(p.PatternMatchesPath))
+	rawQuery := q.Encode()
+
+	// Searcher caches the file contents for repo@commit since it is
+	// relatively expensive to fetch from gitserver. So we use consistent
+	// hashing to increase cache hits.
+	consistentHashKey := string(repo.Name) + "@" + string(commit)
+	tr.LazyPrintf("%s", consistentHashKey)
+
+	var (
+		// When we retry do not use a host we already tried.
+		excludedSearchURLs = map[string]bool{}
+		attempt            = 0
+		maxAttempts        = 2
+	)
+	for {
+		attempt++
+
+		searcherURL, err := searcherURLs.Get(consistentHashKey, excludedSearchURLs)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// Fallback to a bad host if nothing is left
+		if searcherURL == "" {
+			tr.LazyPrintf("failed to find endpoint, trying again without excludes")
+			searcherURL, err = searcherURLs.Get(consistentHashKey, nil)
+			if err != nil {
+				return nil, false, err
+			}
+		}
+
+		url := searcherURL + "?" + rawQuery
+		tr.LazyPrintf("attempt %d: %s", attempt, url)
+		matches, limitHit, err = textSearchURL(ctx, url)
+		if err == nil || errcode.IsTimeout(err) {
+			return matches, limitHit, err
+		}
+
+		// If we are canceled, return that error.
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+
+		// If not temporary or our last attempt then don't try again.
+		if !errcode.IsTemporary(err) || attempt == maxAttempts {
+			return nil, false, err
+		}
+
+		tr.LazyPrintf("transient error %s", err.Error())
+		// Retry search on another searcher instance (if possible)
+		excludedSearchURLs[searcherURL] = true
+	}
+}
+
+func textSearchURL(ctx context.Context, url string) ([]*protocol.FileMatch, bool, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	req = req.WithContext(ctx)
+
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req,
+		nethttp.OperationName("Searcher Client"),
+		nethttp.ClientTrace(false))
+	defer ht.Finish()
+
+	// Do not lose the context returned by TraceRequest
+	ctx = req.Context()
+
+	resp, err := searchHTTPClient.Do(req)
+	if err != nil {
+		// If we failed due to cancellation or timeout (with no partial results in the response
+		// body), return just that.
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		return nil, false, errors.Wrap(err, "searcher request failed")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, false, err
+		}
+		return nil, false, errors.WithStack(&searcherError{StatusCode: resp.StatusCode, Message: string(body)})
+	}
+
+	r := struct {
+		Matches     []*protocol.FileMatch
+		LimitHit    bool
+		DeadlineHit bool
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&r)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "searcher response invalid")
+	}
+	if r.DeadlineHit {
+		err = context.DeadlineExceeded
+	}
+	return r.Matches, r.LimitHit, err
+}
+
+type searcherError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *searcherError) BadRequest() bool {
+	return e.StatusCode == http.StatusBadRequest
+}
+
+func (e *searcherError) Temporary() bool {
+	return e.StatusCode == http.StatusServiceUnavailable
+}
+
+func (e *searcherError) Error() string {
+	return e.Message
+}

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -1,4 +1,4 @@
-// Packager searcher provides a client for our just in time text searching
+// Package searcher provides a client for our just in time text searching
 // service "searcher".
 package searcher
 


### PR DESCRIPTION
This doesn't improve the client or change it at all. It just cuts and
pastes it into its own package.

We now will "copy" the data. Previously we intentionally unmarshalled
straight into the resolvers to be more efficient. However, we never
do large searches with searcher anymore. Additionally Zoekt does large
scale searches and also does a copy.

This change moves us towards a potentially more general interface that
all search clients could implement.