### PR TITLE
search: support new rev: filter

### DIFF
--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -36,4 +36,5 @@ var allFields = map[string]struct{}{
 	FieldMax:                empty,
 	FieldTimeout:            empty,
 	FieldCombyRule:          empty,
+	FieldRev:                empty,
 }

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -981,7 +981,7 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		query = Map(query, EmptyGroupsToLiteral, TrailingParensToLiteral)
 	}
 
-	query, err = mapRevFilters(query)
+	query, err = concatRevFilters(query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -981,6 +981,11 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		query = Map(query, EmptyGroupsToLiteral, TrailingParensToLiteral)
 	}
 
+	query, err = mapRevFilters(query)
+	if err != nil {
+		return nil, err
+	}
+
 	if options.Globbing {
 		query, err = mapGlobToRegex(query)
 		if err != nil {

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -26,6 +26,7 @@ const (
 	FieldPatternType        = "patterntype"
 	FieldContent            = "content"
 	FieldVisibility         = "visibility"
+	FieldRev                = "rev"
 
 	// For diff and commit search only:
 	FieldBefore    = "before"

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -572,7 +572,6 @@ func mapRevFilters(nodes []Node) ([]Node, error) {
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
-
 	// top-level And
 	if op, isOperator := nodes[0].(Operator); len(nodes) == 1 && isOperator && op.Kind == And {
 		nodes, err := mapRevFiltersFlat(op.Operands)
@@ -580,9 +579,8 @@ func mapRevFilters(nodes []Node) ([]Node, error) {
 			return nil, err
 		}
 		return newOperator(nodes, And), nil
-	} else {
-		return mapRevFiltersFlat(nodes)
 	}
+	return mapRevFiltersFlat(nodes)
 }
 
 func mapRevFiltersFlat(nodes []Node) ([]Node, error) {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -565,9 +565,8 @@ func FuzzifyRegexPatterns(nodes []Node) []Node {
 }
 
 // concatRevFilters removes rev: filters from []Node and attaches their value as @rev to the repo: filters.
-// All rev: filters are assumed to be on the top-level, i.e. mapRevFilter will not traverse the tree.
-// To be compatible with the output of the parser with and without DNF we handle both, []Node with
-// an explicit top-level And operator and []Node with an implicit And.
+// Invariant: we assume that all rev: filters are at the top-level of []Node, or in one of it's direct children.
+// This invariant is ensured when the query is normalized to DNF.
 func concatRevFilters(nodes []Node) ([]Node, error) {
 	if len(nodes) == 0 {
 		return nodes, nil

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -585,8 +585,8 @@ func mapRevFilters(nodes []Node) ([]Node, error) {
 
 func mapRevFiltersFlat(nodes []Node) ([]Node, error) {
 	var revs []string
-	for _, o := range nodes {
-		if param, ok := o.(Parameter); !ok || param.Field != FieldRev {
+	for _, n := range nodes {
+		if param, ok := n.(Parameter); !ok || param.Field != FieldRev {
 			continue
 		} else {
 			revs = append(revs, param.Value)
@@ -602,27 +602,26 @@ func mapRevFiltersFlat(nodes []Node) ([]Node, error) {
 	}
 	operands := make([]Node, len(nodes))
 	i := 0
-	for _, o := range nodes {
-		switch o.(type) {
+	for _, n := range nodes {
+		switch p := n.(type) {
 		case Parameter:
-			param := o.(Parameter)
-			switch param.Field {
+			switch p.Field {
 			case FieldRepo:
-				if strings.ContainsRune(param.Value, '@') {
+				if strings.ContainsRune(p.Value, '@') {
 					return nil, fmt.Errorf("invalid syntax. You have specified @ and rev: for the same" +
 						" repo: filter and I don't know how to interpret this. Remove either @ or rev: and try again")
 				}
-				param.Value += "@" + revs[0]
-				operands[i] = param
+				p.Value += "@" + revs[0]
+				operands[i] = p
 				i++
 			case FieldRev:
 				continue
 			default:
-				operands[i] = o
+				operands[i] = n
 				i++
 			}
 		default:
-			operands[i] = o
+			operands[i] = n
 			i++
 		}
 	}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -596,7 +596,7 @@ func concatRevFiltersFlat(nodes []Node) ([]Node, error) {
 		return nodes, nil
 	}
 	if len(revs) > 1 {
-		return nil, fmt.Errorf("invalid syntax. You have specified multiple revisions (%s) and "+
+		return nil, fmt.Errorf("invalid syntax. You have specified multiple revisions (%s) and"+
 			" I don't know how to interpret this. Remove all but one rev: keywords"+
 			" and try again", strings.Join(revs, ", "))
 	}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -564,26 +564,26 @@ func FuzzifyRegexPatterns(nodes []Node) []Node {
 	})
 }
 
-// mapRevFilters removes rev: filters from []Node and attaches their value as @rev to the repo: filters.
+// concatRevFilters removes rev: filters from []Node and attaches their value as @rev to the repo: filters.
 // All rev: filters are assumed to be on the top-level, i.e. mapRevFilter will not traverse the tree.
 // To be compatible with the output of the parser with and without DNF we handle both, []Node with
 // an explicit top-level And operator and []Node with an implicit And.
-func mapRevFilters(nodes []Node) ([]Node, error) {
+func concatRevFilters(nodes []Node) ([]Node, error) {
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
 	// top-level And
 	if op, isOperator := nodes[0].(Operator); len(nodes) == 1 && isOperator && op.Kind == And {
-		nodes, err := mapRevFiltersFlat(op.Operands)
+		nodes, err := concatRevFiltersFlat(op.Operands)
 		if err != nil {
 			return nil, err
 		}
 		return newOperator(nodes, And), nil
 	}
-	return mapRevFiltersFlat(nodes)
+	return concatRevFiltersFlat(nodes)
 }
 
-func mapRevFiltersFlat(nodes []Node) ([]Node, error) {
+func concatRevFiltersFlat(nodes []Node) ([]Node, error) {
 	var revs []string
 	for _, n := range nodes {
 		if param, ok := n.(Parameter); !ok || param.Field != FieldRev {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -766,7 +766,7 @@ func TestMapGlobToRegex(t *testing.T) {
 	}
 }
 
-func TestMapRevFilters(t *testing.T) {
+func TestConcatRevFilters(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
@@ -803,11 +803,11 @@ func TestMapRevFilters(t *testing.T) {
 
 			var queriesStr []string
 			for _, q := range queries {
-				qMapped, err := mapRevFilters(q)
+				qConcat, err := concatRevFilters(q)
 				if err != nil {
 					t.Fatal(err)
 				}
-				queriesStr = append(queriesStr, prettyPrint(qMapped))
+				queriesStr = append(queriesStr, prettyPrint(qConcat))
 			}
 			got := "(" + strings.Join(queriesStr, ") OR (") + ")"
 			if diff := cmp.Diff(c.want, got); diff != "" {
@@ -817,7 +817,7 @@ func TestMapRevFilters(t *testing.T) {
 	}
 }
 
-func TestMapRevFiltersTopLevelAnd(t *testing.T) {
+func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
@@ -838,18 +838,18 @@ func TestMapRevFiltersTopLevelAnd(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			qMapped, err := mapRevFilters(query)
+			qConcat, err := concatRevFilters(query)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(c.want, prettyPrint(qMapped)); diff != "" {
+			if diff := cmp.Diff(c.want, prettyPrint(qConcat)); diff != "" {
 				t.Error(diff)
 			}
 		})
 	}
 }
 
-func TestMapRevFiltersForInvalidSyntax(t *testing.T) {
+func TestConcatRevFiltersForInvalidSyntax(t *testing.T) {
 	cases := []string{
 		"repo:foo rev:a rev:b",
 		"repo:foo@a rev:b",
@@ -859,7 +859,7 @@ func TestMapRevFiltersForInvalidSyntax(t *testing.T) {
 			query, _ := ParseAndOr(c, SearchTypeRegex)
 			queries := dnf(query)
 			for _, q := range queries {
-				_, err := mapRevFilters(q)
+				_, err := concatRevFilters(q)
 				if err == nil {
 					t.Fatal("Expected err, but got nil")
 				}


### PR DESCRIPTION
Relates to #13091 

This PR adds `rev:` to our query syntax. For now `rev:` is equivalent to `@`.

Example: 
`repo:foo rev:bar` is equivalent to `repo:foo@bar`

However, once we support expressions for filters we will be able to write queries like this `repo:foo (rev:bar or rev:bas)`.

We only support one `rev:` filter per operator-level.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
