### PR TITLE
graphlbackend: introduce mkFileMatch test helper

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -42,9 +42,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	result := func(repo *types.Repo, path string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, Repo: &RepositoryResolver{repo: repo}}
-	}
+	result := mkFileMatch
 	format := func(r slicedSearchResults) string {
 		var b bytes.Buffer
 		fmt.Fprintln(&b, "results:")
@@ -273,7 +271,9 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
 	result := func(repo *types.Repo, path, rev string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, Repo: &RepositoryResolver{repo: repo}, InputRev: &rev}
+		fm := mkFileMatch(repo, path)
+		fm.InputRev = &rev
+		return fm
 	}
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
@@ -296,11 +296,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			for _, rev := range repoRev.Revs {
 				rev := rev.RevSpec
 				for i := 0; i < 3; i++ {
-					results = append(results, &FileMatchResolver{
-						JPath:    fmt.Sprintf("some/file%d.go", i),
-						Repo:     &RepositoryResolver{repo: repoRev.Repo},
-						InputRev: &rev,
-					})
+					results = append(results, result(repoRev.Repo, fmt.Sprintf("some/file%d.go", i), rev))
 				}
 			}
 			common.repos = append(common.repos, repoRev.Repo)
@@ -490,9 +486,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	result := func(repo *types.Repo, path string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, Repo: &RepositoryResolver{repo: repo}}
-	}
+	result := mkFileMatch
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
 			Repo: repo(name),
@@ -608,9 +602,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	result := func(repo *types.Repo, path string) *FileMatchResolver {
-		return &FileMatchResolver{JPath: path, Repo: &RepositoryResolver{repo: repo}}
-	}
+	result := mkFileMatch
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
 			Repo: repo(name),

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -54,6 +54,19 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
+	fileMatch := func(path string, lineNumbers ...int32) *FileMatchResolver {
+		var lines []*lineMatch
+		for _, n := range lineNumbers {
+			lines = append(lines, &lineMatch{JLineNumber: n})
+		}
+		return &FileMatchResolver{
+			JPath:        path,
+			JLineMatches: lines,
+			Repo:         &RepositoryResolver{repo: &types.Repo{Name: "r"}},
+			CommitID:     wantCommitID,
+		}
+	}
+
 	tests := map[string]struct {
 		results  []SearchResultResolver
 		getFiles []os.FileInfo
@@ -65,39 +78,20 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		},
 		"1 entire file": {
 			results: []SearchResultResolver{
-				&FileMatchResolver{
-					JPath:    "three.go",
-					Repo:     &RepositoryResolver{repo: &types.Repo{Name: "r"}},
-					CommitID: wantCommitID,
-				},
+				fileMatch("three.go"),
 			},
 			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 3}},
 		},
 		"line matches in 1 file": {
 			results: []SearchResultResolver{
-				&FileMatchResolver{
-					JPath:        "three.go",
-					Repo:         &RepositoryResolver{repo: &types.Repo{Name: "r"}},
-					CommitID:     wantCommitID,
-					JLineMatches: []*lineMatch{{JLineNumber: 1}},
-				},
+				fileMatch("three.go", 1),
 			},
 			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 1}},
 		},
 		"line matches in 2 files": {
 			results: []SearchResultResolver{
-				&FileMatchResolver{
-					JPath:        "two.go",
-					Repo:         &RepositoryResolver{repo: &types.Repo{Name: "r"}},
-					CommitID:     wantCommitID,
-					JLineMatches: []*lineMatch{{JLineNumber: 1}, {JLineNumber: 2}},
-				},
-				&FileMatchResolver{
-					JPath:        "three.go",
-					Repo:         &RepositoryResolver{repo: &types.Repo{Name: "r"}},
-					CommitID:     wantCommitID,
-					JLineMatches: []*lineMatch{{JLineNumber: 1}},
-				},
+				fileMatch("two.go", 1, 2),
+				fileMatch("three.go", 1),
 			},
 			want: []inventory.Lang{{Name: "Go", TotalBytes: 10, TotalLines: 3}},
 		},

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -51,9 +51,9 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "indexed/one":
-			return []*FileMatchResolver{{JPath: indexedFileName}}, false, nil
+			return []*FileMatchResolver{mkFileMatch(nil, indexedFileName)}, false, nil
 		case "unindexed/one":
-			return []*FileMatchResolver{{JPath: "unindexed.go"}}, false, nil
+			return []*FileMatchResolver{mkFileMatch(nil, "unindexed.go")}, false, nil
 		default:
 			return nil, false, errors.New("Unexpected repo")
 		}
@@ -104,8 +104,8 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 	}
 
 	fm, _ := results.Results()[0].ToFileMatch()
-	if fm.JPath != indexedFileName {
-		t.Fatalf("wrong indexed filename. want=%s, have=%s\n", indexedFileName, fm.JPath)
+	if got, want := fm.JPath, indexedFileName; got != want {
+		t.Fatalf("wrong indexed filename. want=%s, have=%s\n", want, got)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -107,9 +107,10 @@ func TestSearchSuggestions(t *testing.T) {
 			if want := "foo"; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
-			return []*FileMatchResolver{
-				{uri: "git://repo?rev#dir/file", JPath: "dir/file", Repo: &RepositoryResolver{repo: &types.Repo{Name: "repo"}}, CommitID: "rev"},
-			}, &searchResultsCommon{}, nil
+			fm := mkFileMatch(&types.Repo{Name: "repo"}, "dir/file")
+			fm.uri = "git://repo?rev#dir/file"
+			fm.CommitID = "rev"
+			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 		for _, v := range searchVersions {
@@ -183,10 +184,16 @@ func TestSearchSuggestions(t *testing.T) {
 			if args.PatternInfo.Pattern != "." && args.PatternInfo.Pattern != "foo" {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, `"foo" or "."`)
 			}
+			mk := func(name api.RepoName, path string) *FileMatchResolver {
+				fm := mkFileMatch(&types.Repo{Name: name}, path)
+				fm.uri = fileMatchURI(name, "rev", path)
+				fm.CommitID = "rev"
+				return fm
+			}
 			return []*FileMatchResolver{
-				{uri: "git://repo?rev#dir/foo-repo3-file-name-match", JPath: "dir/foo-repo3-file-name-match", Repo: &RepositoryResolver{repo: &types.Repo{Name: "repo3"}}, CommitID: "rev"},
-				{uri: "git://repo?rev#dir/foo-repo1-file-name-match", JPath: "dir/foo-repo1-file-name-match", Repo: &RepositoryResolver{repo: &types.Repo{Name: "repo1"}}, CommitID: "rev"},
-				{uri: "git://repo?rev#dir/file-content-match", JPath: "dir/file-content-match", Repo: &RepositoryResolver{repo: &types.Repo{Name: "repo"}}, CommitID: "rev"},
+				mk("repo3", "dir/foo-repo3-file-name-match"),
+				mk("repo1", "dir/foo-repo1-file-name-match"),
+				mk("repo", "dir/file-content-match"),
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -259,7 +266,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
 			return []*FileMatchResolver{
-				{uri: "git://foo-repo?rev#dir/file", JPath: "dir/file", Repo: &RepositoryResolver{repo: &types.Repo{Name: "foo-repo"}}, CommitID: ""},
+				mkFileMatch(&types.Repo{Name: "foo-repo"}, "dir/file"),
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -361,7 +368,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.Repos, want)
 			}
 			return []*FileMatchResolver{
-				{uri: "git://foo-repo?rev#dir/bar-file", JPath: "dir/bar-file", Repo: &RepositoryResolver{repo: &types.Repo{Name: "foo-repo"}}, CommitID: ""},
+				mkFileMatch(&types.Repo{Name: "foo-repo"}, "dir/bar-file"),
 			}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -760,3 +760,22 @@ func TestComputeExcludedRepositories(t *testing.T) {
 		})
 	}
 }
+
+func mkFileMatch(repo *types.Repo, path string, lineNumbers ...int32) *FileMatchResolver {
+	if repo == nil {
+		repo = &types.Repo{
+			ID:   1,
+			Name: "repo",
+		}
+	}
+	var lines []*lineMatch
+	for _, n := range lineNumbers {
+		lines = append(lines, &lineMatch{JLineNumber: n})
+	}
+	return &FileMatchResolver{
+		uri:          fileMatchURI(repo.Name, "", path),
+		JPath:        path,
+		JLineMatches: lines,
+		Repo:         &RepositoryResolver{repo: repo},
+	}
+}


### PR DESCRIPTION
This cleans up quite a verbose pattern we have in our test code for
search. This was motivated by me changing fields like JPath and having
to fix a _lot_ of test code.