### PR TITLE
Tour: add structural search step using query param

### DIFF
--- a/web/src/nav/GlobalNavbar.test.tsx
+++ b/web/src/nav/GlobalNavbar.test.tsx
@@ -41,6 +41,7 @@ const PROPS: GlobalNavbar['props'] = {
     availableVersionContexts: [],
     variant: 'default',
     globbing: false,
+    showOnboardingTour: false,
 }
 
 describe('GlobalNavbar', () => {

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -14,6 +14,7 @@ import {
     CaseSensitivityProps,
     SmartSearchFieldProps,
     CopyQueryButtonProps,
+    OnboardingTourProps,
 } from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { EventLoggerProps } from '../tracking/eventLogger'
@@ -46,7 +47,8 @@ interface Props
         InteractiveSearchProps,
         SmartSearchFieldProps,
         CopyQueryButtonProps,
-        VersionContextProps {
+        VersionContextProps,
+        OnboardingTourProps {
     history: H.History
     location: H.Location<{ query: string }>
     authenticatedUser: GQL.IUser | null

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -10,6 +10,7 @@ import {
     SmartSearchFieldProps,
     CopyQueryButtonProps,
     OnboardingTourProps,
+    parseSearchURLPatternType,
 } from '..'
 import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 import { QueryInput } from './QueryInput'
@@ -25,6 +26,7 @@ import {
     HAS_CANCELLED_TOUR_KEY,
 } from './SearchOnboardingTour'
 import { useLocalStorage } from '../../util/useLocalStorage'
+import { SearchPatternType } from '../../graphql-operations'
 
 interface Props
     extends ActivationProps,
@@ -97,7 +99,8 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
 
     useEffect(() => {
         const url = new URLSearchParams(props.location.search)
-        if (url.has('onboardingTour') && props.showOnboardingTour) {
+        const isStructuralSearch = parseSearchURLPatternType(props.location.search) === SearchPatternType.structural
+        if (url.has('onboardingTour') && isStructuralSearch && props.showOnboardingTour) {
             tour.start()
         }
     }, [tour, props.showOnboardingTour, props.location.search])

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -88,7 +88,8 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
                 but simple with structural search. Tip: 'my_match' is a name for the\n
                 code we matched between code boundries. This is similar to a named capture\n
                 group in regex.`,
-                createStructuralSearchTourTooltip()
+                createStructuralSearchTourTooltip(),
+                true
             ),
             attachTo: {
                 element: '.test-structural-search-toggle',

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -19,13 +19,7 @@ import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import Shepherd from 'shepherd.js'
-import {
-    defaultTourOptions,
-    generateStepTooltip,
-    HAS_SEEN_TOUR_KEY,
-    HAS_CANCELLED_TOUR_KEY,
-} from './SearchOnboardingTour'
-import { useLocalStorage } from '../../util/useLocalStorage'
+import { defaultTourOptions, generateStepTooltip } from './SearchOnboardingTour'
 import { SearchPatternType } from '../../graphql-operations'
 
 interface Props

--- a/web/src/search/input/SearchNavbarItem.tsx
+++ b/web/src/search/input/SearchNavbarItem.tsx
@@ -1,16 +1,30 @@
 import * as H from 'history'
-import React from 'react'
+import React, { useCallback, useMemo, useEffect } from 'react'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 import { Form } from '../../components/Form'
 import { submitSearch, QueryState } from '../helpers'
 import { SearchButton } from './SearchButton'
-import { PatternTypeProps, CaseSensitivityProps, SmartSearchFieldProps, CopyQueryButtonProps } from '..'
+import {
+    PatternTypeProps,
+    CaseSensitivityProps,
+    SmartSearchFieldProps,
+    CopyQueryButtonProps,
+    OnboardingTourProps,
+} from '..'
 import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 import { QueryInput } from './QueryInput'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
+import Shepherd from 'shepherd.js'
+import {
+    defaultTourOptions,
+    generateStepTooltip,
+    HAS_SEEN_TOUR_KEY,
+    HAS_CANCELLED_TOUR_KEY,
+} from './SearchOnboardingTour'
+import { useLocalStorage } from '../../util/useLocalStorage'
 
 interface Props
     extends ActivationProps,
@@ -20,7 +34,8 @@ interface Props
         SettingsCascadeProps,
         ThemeProps,
         CopyQueryButtonProps,
-        VersionContextProps {
+        VersionContextProps,
+        OnboardingTourProps {
     location: H.Location
     history: H.History
     navbarSearchState: QueryState
@@ -28,44 +43,98 @@ interface Props
     globbing: boolean
 }
 
+function createStructuralSearchTourTooltip(): HTMLElement {
+    const listItem = document.createElement('li')
+    listItem.className = 'list-group-item p-0 border-0 my-4'
+    listItem.textContent = '>'
+    const exampleButton = document.createElement('a')
+    exampleButton.href = 'https://docs.sourcegraph.com/user/search/structural'
+    exampleButton.target = '_blank'
+    exampleButton.className = 'btn btn-link test-tour-language-example'
+    exampleButton.textContent = 'Structural search documentation'
+    listItem.append(exampleButton)
+    return listItem
+}
+
 /**
  * The search item in the navbar
  */
-export class SearchNavbarItem extends React.PureComponent<Props> {
-    private onSubmit = (): void => {
-        submitSearch({ ...this.props, query: this.props.navbarSearchState.query, source: 'nav' })
-    }
+export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) => {
+    const onSubmit = useCallback((): void => {
+        submitSearch({ ...props, query: props.navbarSearchState.query, source: 'nav' })
+    }, [props])
 
-    private onFormSubmit = (event: React.FormEvent): void => {
-        event.preventDefault()
-        this.onSubmit()
-    }
+    const onFormSubmit = useCallback(
+        () => (event: React.FormEvent): void => {
+            event.preventDefault()
+            onSubmit()
+        },
+        [onSubmit]
+    )
 
-    public render(): React.ReactNode {
-        return (
-            <Form
-                className="search--navbar-item d-flex align-items-flex-start flex-grow-1 flex-shrink-past-contents"
-                onSubmit={this.onFormSubmit}
-            >
-                {this.props.smartSearchField ? (
-                    <LazyMonacoQueryInput
-                        {...this.props}
-                        hasGlobalQueryBehavior={true}
-                        queryState={this.props.navbarSearchState}
-                        onSubmit={this.onSubmit}
-                        autoFocus={true}
-                    />
-                ) : (
-                    <QueryInput
-                        {...this.props}
-                        value={this.props.navbarSearchState}
-                        autoFocus={this.props.location.pathname === '/search' ? 'cursor-at-end' : undefined}
-                        keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
-                        hasGlobalQueryBehavior={true}
-                    />
-                )}
-                <SearchButton />
-            </Form>
-        )
-    }
+    const tour = useMemo(() => new Shepherd.Tour(defaultTourOptions), [])
+
+    useEffect(() => {
+        tour.addStep({
+            id: 'structural-search-tip',
+            text: generateStepTooltip(
+                tour,
+                'You ran a structural search',
+                6,
+                `Note that it properly matches the entire code block within the braces.\n
+                It is hard to match blocks of code or multiline expressions with regex,\n
+                but simple with structural search. Tip: 'my_match' is a name for the\n
+                code we matched between code boundries. This is similar to a named capture\n
+                group in regex.`,
+                createStructuralSearchTourTooltip()
+            ),
+            attachTo: {
+                element: '.test-structural-search-toggle',
+                on: 'bottom',
+            },
+        })
+    }, [tour])
+
+    useEffect(() => {
+        const url = new URLSearchParams(props.location.search)
+        if (url.has('onboardingTour') && props.showOnboardingTour) {
+            tour.start()
+        }
+    }, [tour, props.showOnboardingTour, props.location.search])
+
+    useEffect(
+        () => () => {
+            // End tour on unmount.
+            if (tour.isActive()) {
+                tour.complete()
+            }
+        },
+        [tour]
+    )
+
+    return (
+        <Form
+            className="search--navbar-item d-flex align-items-flex-start flex-grow-1 flex-shrink-past-contents"
+            onSubmit={onFormSubmit}
+        >
+            {props.smartSearchField ? (
+                <LazyMonacoQueryInput
+                    {...props}
+                    hasGlobalQueryBehavior={true}
+                    queryState={props.navbarSearchState}
+                    onSubmit={onSubmit}
+                    autoFocus={true}
+                />
+            ) : (
+                <QueryInput
+                    {...props}
+                    value={props.navbarSearchState}
+                    autoFocus={props.location.pathname === '/search' ? 'cursor-at-end' : undefined}
+                    keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
+                    hasGlobalQueryBehavior={true}
+                />
+            )}
+            <SearchButton />
+        </Form>
+    )
 }

--- a/web/src/search/input/SearchOnboardingTour.scss
+++ b/web/src/search/input/SearchOnboardingTour.scss
@@ -1,10 +1,14 @@
-.shepherd-element {
-    background: #1d2535;
-}
-
 .tour-card {
     box-shadow: 0 4px 36px rgba(0, 0, 0, 0.4);
     border-radius: 10px;
+
+    &__description {
+        max-width: 24rem;
+    }
+}
+
+.shepherd-element {
+    background: #1d2535;
 }
 
 .shepherd-arrow::after {

--- a/web/src/search/input/SearchOnboardingTour.ts
+++ b/web/src/search/input/SearchOnboardingTour.ts
@@ -7,6 +7,25 @@ import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 export const HAS_CANCELLED_TOUR_KEY = 'has-cancelled-onboarding-tour'
 export const HAS_SEEN_TOUR_KEY = 'has-seen-onboarding-tour'
 
+export const defaultTourOptions: Shepherd.Tour.TourOptions = {
+    useModalOverlay: true,
+    defaultStepOptions: {
+        arrow: true,
+        classes: 'web-content tour-card card py-4 px-3',
+        popperOptions: {
+            // Removes default behavior of autofocusing steps
+            modifiers: [
+                {
+                    name: 'focusAfterRender',
+                    enabled: false,
+                },
+                { name: 'offset', options: { offset: [0, 8] } },
+            ],
+        },
+        attachTo: { on: 'bottom' },
+        scrollTo: false,
+    },
+}
 /**
  * generateStep creates the content for tooltips for the search tour. All steps that just contain
  * simple text should use this function to populate the step's `text` field.
@@ -25,8 +44,9 @@ export function generateStepTooltip(
     titleElement.className = 'font-weight-bold'
     element.append(titleElement)
     if (description) {
-        const descriptionElement = document.createElement('h4')
+        const descriptionElement = document.createElement('p')
         descriptionElement.textContent = description
+        descriptionElement.className = 'tour-card__description mb-0'
         element.append(descriptionElement)
     }
     if (additionalContent) {
@@ -48,7 +68,7 @@ export function generateStepTooltip(
 export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number): HTMLElement {
     const stepNumberLabel = document.createElement('span')
     stepNumberLabel.className = 'font-weight-light font-italic'
-    stepNumberLabel.textContent = `${stepNumber} of 5`
+    stepNumberLabel.textContent = `${stepNumber} of 6`
 
     const closeTourButton = document.createElement('button')
     closeTourButton.className = 'btn btn-link p-0'

--- a/web/src/search/input/SearchOnboardingTour.ts
+++ b/web/src/search/input/SearchOnboardingTour.ts
@@ -35,7 +35,8 @@ export function generateStepTooltip(
     title: string,
     stepNumber: number,
     description?: string,
-    additionalContent?: HTMLElement
+    additionalContent?: HTMLElement,
+    dontShowStepCount?: boolean
 ): HTMLElement {
     const element = document.createElement('div')
     element.className = `d-flex flex-column test-tour-step-${stepNumber}`
@@ -54,7 +55,7 @@ export function generateStepTooltip(
         additionalContentContainer.append(additionalContent)
         element.append(additionalContent)
     }
-    const bottomRow = generateBottomRow(tour, stepNumber)
+    const bottomRow = generateBottomRow(tour, stepNumber, dontShowStepCount)
     element.append(bottomRow)
     return element
 }
@@ -65,11 +66,7 @@ export function generateStepTooltip(
  * @param tour the tour instance.
  * @param stepNumber the step number.
  */
-export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number): HTMLElement {
-    const stepNumberLabel = document.createElement('span')
-    stepNumberLabel.className = 'font-weight-light font-italic'
-    stepNumberLabel.textContent = `${stepNumber} of 6`
-
+export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number, dontShowStepCount?: boolean): HTMLElement {
     const closeTourButton = document.createElement('button')
     closeTourButton.className = 'btn btn-link p-0'
     closeTourButton.textContent = 'Close tour'
@@ -80,7 +77,14 @@ export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number): HTML
 
     const bottomRow = document.createElement('div')
     bottomRow.className = 'd-flex justify-content-between'
-    bottomRow.append(stepNumberLabel)
+
+    if (!dontShowStepCount) {
+        const stepNumberLabel = document.createElement('span')
+        stepNumberLabel.className = 'font-weight-light font-italic'
+        stepNumberLabel.textContent = `${stepNumber} of 5`
+        bottomRow.append(stepNumberLabel)
+    }
+
     bottomRow.append(closeTourButton)
     return bottomRow
 }

--- a/web/src/search/input/SearchPageInput.tsx
+++ b/web/src/search/input/SearchPageInput.tsx
@@ -39,6 +39,7 @@ import {
     stepCallbacks,
     HAS_SEEN_TOUR_KEY,
     HAS_CANCELLED_TOUR_KEY,
+    defaultTourOptions,
 } from './SearchOnboardingTour'
 import { useLocalStorage } from '../../util/useLocalStorage'
 import Shepherd from 'shepherd.js'
@@ -107,29 +108,7 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
 
     const showOnboardingTour = props.showOnboardingTour && isHomepage
 
-    const tour = useMemo(
-        () =>
-            new Shepherd.Tour({
-                useModalOverlay: true,
-                defaultStepOptions: {
-                    arrow: true,
-                    classes: 'web-content tour-card card py-4 px-3',
-                    popperOptions: {
-                        // Removes default behavior of autofocusing steps
-                        modifiers: [
-                            {
-                                name: 'focusAfterRender',
-                                enabled: false,
-                            },
-                            { name: 'offset', options: { offset: [0, 8] } },
-                        ],
-                    },
-                    attachTo: { on: 'bottom' },
-                    scrollTo: false,
-                },
-            }),
-        []
-    )
+    const tour = useMemo(() => new Shepherd.Tour(defaultTourOptions), [])
 
     useEffect(() => {
         if (showOnboardingTour) {


### PR DESCRIPTION
Adds an additional step to the tour that explains structural search. This gets displayed if the search results page URL has an `onboardingTour` query param appended to it, and the search conducted was a structural search. 

The query param gets appended to the results page URL whenever the tour is active. If users click our structural search example in the tour, we will enable the structural search toggle. Therefore, when users click our structural search example in the tour, we'll display this additional tour tooltip.

This PR is based off of the existing PR https://github.com/sourcegraph/sourcegraph/pull/12972.

![image](https://user-images.githubusercontent.com/16265452/90653450-c73bfa80-e271-11ea-86d5-3d2f279a787d.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
