### PR TITLE
single server: fix redis-cache segfault and DNS issues

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,15 +1,10 @@
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a as libsqlite3-pcre
+FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321 as libsqlite3-pcre
 
 COPY libsqlite3-pcre-install-alpine.sh /libsqlite3-pcre-install-alpine.sh
 RUN /libsqlite3-pcre-install-alpine.sh
 
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a AS ctags
-
-COPY ctags-install-alpine.sh /ctags-install-alpine.sh
-RUN /ctags-install-alpine.sh
-
-# TODO: Make this image use our sourcegraph/alpine:3.10 base image
-FROM alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a
+# TODO: Make this image use our sourcegraph/alpine:3.12 base image
+FROM alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -20,18 +15,15 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
-    'bash=5.0.0-r0' 'postgresql-contrib=11.7-r0' 'postgresql=11.7-r0' \
-    bind-tools ca-certificates git@edge \
-    mailcap 'nginx=1.16.1-r2' openssh-client pcre sqlite-libs su-exec tini nodejs-current=12.4.0-r0 curl
+   'bash=5.0.17-r0' \
+   'redis=5.0.9-r0' bind-tools ca-certificates \
+    mailcap 'nginx=1.18.0-r0' openssh-client pcre sqlite-libs su-exec tini 'nodejs-current=14.5.0-r0' curl
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
@@ -40,9 +32,27 @@ RUN apk update && apk add --no-cache \
 COPY --from=comby/comby:0.15.0@sha256:b3b57ed810be1489ccd1ef8fa42210d87d2d396e416c62cee345f615a0dcb09b /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
-COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
-# hadolint ignore=DL3022
-COPY --from=redis:5-alpine@sha256:abd9d0fc18e163747253aae8d69be344c7e90d6b6d6027fa7f2f2c0e6c20b2b8 /usr/local/bin/redis-* /usr/local/bin/
+
+# install postgres 11
+# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
+RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
+    tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
+    cd target/main/x86_64/ && \
+    apk add --allow-untrusted *.apk && \
+    cd ../../../ && \
+    rm -rf target/
+
+# install git edge
+# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
+RUN wget https://storage.googleapis.com/apktmp/git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz  && \
+    tar -xzf git-edge-for-alpine-3-12-0bd5f13f2f.tar.gz && \
+    cd target/main/x86_64/ && \
+    apk add --allow-untrusted *.apk && \
+    cd ../../../ && \
+    rm -rf target/
+
+COPY ctags-install-alpine.sh /ctags-install-alpine.sh
+RUN /ctags-install-alpine.sh
 
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/prometheus:server /bin/prom-wrapper /bin

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -27,8 +27,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache bind-tools ca-certificates mailcap tini
 
-# hadolint ignore=DL3022
-COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
+COPY ctags-install-alpine.sh /ctags-install-alpine.sh
+RUN /ctags-install-alpine.sh
 
 # hadolint ignore=DL3022
 COPY --from=libsqlite3-pcre /sqlite3-pcre/pcre.so /libsqlite3-pcre.so

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -8,7 +8,6 @@ set -eux
 CTAGS_VERSION=03f933a96d3ef87adbf9d167462d45ce69577edb
 
 apk --no-cache add \
-  --virtual build-deps \
   autoconf \
   automake \
   binutils \
@@ -17,6 +16,8 @@ apk --no-cache add \
   gcc \
   jansson-dev \
   libseccomp-dev \
+  jansson \
+  libseccomp \
   linux-headers \
   make \
   pkgconfig
@@ -25,11 +26,10 @@ apk --no-cache add \
 curl "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/ctags-$CTAGS_VERSION
 ./autogen.sh
-LDFLAGS=-static ./configure --program-prefix=universal- --enable-json --enable-seccomp
+./configure --program-prefix=universal- --enable-json --enable-seccomp
 make -j8
 make install
 
 # Cleanup
 cd /
 rm -rf /tmp/ctags-$CTAGS_VERSION
-apk --no-cache --purge del build-deps


### PR DESCRIPTION
re-applies https://github.com/sourcegraph/sourcegraph/pull/13113, but now with fix for symbols pod malfunction. the reason is: we switched to shared lib from static lib and i forgot to do that for the symbols docker image itself, not just the single server docker image.

this reverses https://github.com/sourcegraph/sourcegraph/pull/13127 with the additional symbols pod fix.

reason we switched to shared library for ctags: it was failing in single-server as a static library. well, sort of a cascading effect:

- we pull in edge because we want git@edge
- this resulted in something being pulled in which caused redis-cache segfaults (https://github.com/sourcegraph/sourcegraph/issues/12772)
- we tried several ways to avoid that (https://github.com/sourcegraph/sourcegraph/pull/13107), but some ways resulted in DNS failures (ping github.com wouldn't work, https://github.com/sourcegraph/sourcegraph/issues/13046) and some resulted in ctags either not being compiled or failing on startup

this is an attempt to fix all this for 3.19. for 3.20 we will clean up our docker images. 

NOTE: if this lands it means single-server runs in alpine 3.12 whereas rest of the bunch runs in alpine 3.10

NOTE: for the symbols pod i kept the builder layer because apparently it's used in local dev. so effectively this is being built twice as specified in this PR (a little hacky). i will clean it up for 3.20

here are the two extra builders that make artifacts for single server (git edge for alpine 3.12 and postgres 11 for alpine 3.12)
https://github.com/sourcegraph/postgres-apk-builder
https://github.com/sourcegraph/git-apk-builder
