### PR TITLE
codeintel: Install and use the LSIF upload route on the codeintel internal API

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -61,11 +61,13 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		hunkCache,
 	))
 
-	enterpriseServices.NewCodeIntelUploadHandler = func(internal bool) http.Handler {
+	newCodeIntelUploadHandler := func(internal bool) http.Handler {
 		return codeintelhttpapi.NewUploadHandler(store, bundleManagerClient, internal)
 	}
 
-	h, err := newInternalProxyHandler()
+	enterpriseServices.NewCodeIntelUploadHandler = newCodeIntelUploadHandler
+
+	h, err := newInternalProxyHandler(newCodeIntelUploadHandler(false))
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/internal_proxy_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/internal_proxy_handler.go
@@ -62,7 +62,7 @@ func newInternalProxyHandler(uploadHandler http.Handler) (func() http.Handler, e
 		base.Path("/index-queue/{rest:(?:dequeue|complete|heartbeat)}").Handler(reverseProxy(indexerOrigin))
 
 		// Upload LSIF indexes without a sudo access token or github tokens
-		base.Path("/lsif/upload").Handler(uploadHandler)
+		base.Path("/lsif/upload").Methods("POST").Handler(uploadHandler)
 
 		return internalProxyAuthTokenMiddleware(base)
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/internal_proxy_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/internal_proxy_handler.go
@@ -20,7 +20,7 @@ import (
 var indexerURL = env.Get("PRECISE_CODE_INTEL_INDEX_MANAGER_URL", "", "HTTP address for the internal precise-code-intel-indexer-manager.")
 var internalProxyAuthToken = env.Get("PRECISE_CODE_INTEL_INTERNAL_PROXY_AUTH_TOKEN", "", "The auth token used to secure communication between the precise-code-intel-indexer service and the internal API provided by this proxy.")
 
-func newInternalProxyHandler() (func() http.Handler, error) {
+func newInternalProxyHandler(uploadHandler http.Handler) (func() http.Handler, error) {
 	if indexerURL == "" {
 		factory := func() http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +60,9 @@ func newInternalProxyHandler() (func() http.Handler, error) {
 
 		// Proxy only the known routes in the index queue API
 		base.Path("/index-queue/{rest:(?:dequeue|complete|heartbeat)}").Handler(reverseProxy(indexerOrigin))
+
+		// Upload LSIF indexes without a sudo access token or github tokens
+		base.Path("/lsif/upload").Handler(uploadHandler)
 
 		return internalProxyAuthTokenMiddleware(base)
 	}

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -50,7 +50,11 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 	indexAndUploadCommand := []string{
 		"lsif-go",
 		"&&",
-		"src", "-endpoint", fmt.Sprintf(h.options.FrontendURLFromDocker), "lsif", "upload", "-repo", index.RepositoryName, "-commit", index.Commit,
+		fmt.Sprintf("SRC_ENDPOINT=%s", h.options.FrontendURLFromDocker),
+		"src", "lsif", "upload",
+		"-repo", index.RepositoryName,
+		"-commit", index.Commit,
+		"-upload-route", "/.internal-code-intel/lsif/upload",
 	}
 
 	if err := h.commander.Run(

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -51,7 +51,7 @@ func TestHandle(t *testing.T) {
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
-			"docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest bash -c lsif-go && src -endpoint https://sourcegraph.test:5432 lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+			"docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest bash -c lsif-go && SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 src lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
 		}
 
 		calls := commander.RunFunc.History()


### PR DESCRIPTION
The precise-code-intel-indexer-vm goes through the public API, but this requires that a sudo sourcegraph access token be given to the indexer. Instead, we can use the same token-based auth we have for the other routes hit by this service and install the same handler to a second route.