### PR TITLE
docker-images: bump syntect_server image

### DIFF
--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff
-docker tag index.docker.io/sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff "$IMAGE"
+docker pull index.docker.io/sourcegraph/syntect_server:33dc1ba@sha256:625c556f5cf456144e51e3fe55e6312398b7714994165b4f605711e6f7d862a0
+docker tag index.docker.io/sourcegraph/syntect_server:33dc1ba@sha256:625c556f5cf456144e51e3fe55e6312398b7714994165b4f605711e6f7d862a0 "$IMAGE"


### PR DESCRIPTION
Includes (likely) fixes for https://github.com/sourcegraph/sourcegraph/issues/12999