### PR TITLE
Surveys should go from 0–10, not 0–9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- User satisfaction/NPS surveys will now correctly provide a range from 0–10, rather than 0–9.
+
 ### Removed
 
 ## 3.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- User satisfaction/NPS surveys will now correctly provide a range from 0–10, rather than 0–9.
+- User satisfaction/NPS surveys will now correctly provide a range from 0–10, rather than 0–9. [#13163](https://github.com/sourcegraph/sourcegraph/pull/13163)
 
 ### Removed
 

--- a/web/src/marketing/SurveyToast.tsx
+++ b/web/src/marketing/SurveyToast.tsx
@@ -20,7 +20,7 @@ export class SurveyCTA extends React.PureComponent<SurveyCTAProps> {
     public render(): JSX.Element | null {
         return (
             <div className={this.props.className}>
-                {range(0, 10).map(score => {
+                {range(0, 11).map(score => {
                     const pressed = score === this.props.score
                     return (
                         /* eslint-disable react/jsx-no-bind */


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/13162