### PR TITLE
graphqlbackend: use FileMatchResolver methods more

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -86,11 +86,11 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 				if filesMap[key].partialFiles == nil {
 					filesMap[key].partialFiles = map[string]uint64{}
 				}
-				filesMap[key].partialFiles[fileMatch.JPath] += uint64(len(fileMatch.LineMatches()))
+				filesMap[key].partialFiles[fileMatch.path()] += uint64(len(fileMatch.LineMatches()))
 			} else {
 				// Count entire file.
 				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{
-					path:  fileMatch.JPath,
+					path:  fileMatch.path(),
 					isDir: fileMatch.File().IsDirectory(),
 				})
 			}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -113,6 +113,20 @@ func (fm *FileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver
 	return nil, false
 }
 
+// path returns the path in repository for the file. This isn't directly
+// exposed in the GraphQL API (we expose a URI), but is used a lot internally.
+func (fm *FileMatchResolver) path() string {
+	return fm.JPath
+}
+
+// appendMatches appends the line matches from src as well as updating match
+// counts and limit.
+func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
+	fm.JLineMatches = append(fm.JLineMatches, src.JLineMatches...)
+	fm.MatchCount += src.MatchCount
+	fm.JLimitHit = fm.JLimitHit || src.JLimitHit
+}
+
 func (fm *FileMatchResolver) searchResultURIs() (string, string) {
 	return fm.Repo.Name(), fm.JPath
 }


### PR DESCRIPTION
This is helping decouple many uses of FileMatchResolver in our
graphqlbackend to what it is actually resolving. This commit is purely a
refactor to make it easier to change out the fields on
FileMatchResolver.

This is motivated by experiments I did with the text search layer living
completely outside of graphqlbackend. Part of that experiment was
changing FileMatchResolver to instead store the types returned by that
layer. This is a change from that series which in general is an
improvement and will make future changes clearer.

We introduce two helpers:
- `path()` which returns the file's path. We often directly access JPath, so it makes it a pain to remove JPath. This change makes that easier to do.
- `appendMatches(*FileMatchResolver)` this was extracted from some and/or code.