### PR TITLE
search: don't fuzzify repo for GitHub-looking paths

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -203,7 +203,7 @@ func reporevToRegex(value string) (string, error) {
 	reporev := strings.SplitN(value, "@", 2)
 	containsNoRev := len(reporev) == 1
 	repo := reporev[0]
-	if containsNoRev && ContainsNoGlobSyntax(repo) {
+	if containsNoRev && ContainsNoGlobSyntax(repo) && !LooksLikeGitHubRepo(repo) {
 		repo = fuzzifyGlobPattern(repo)
 	}
 	repo, err := globToRegex(repo)
@@ -221,6 +221,17 @@ var globSyntax = lazyregexp.New(`[][*?]`)
 
 func ContainsNoGlobSyntax(value string) bool {
 	return !globSyntax.MatchString(value)
+}
+
+// LooksLikeGitHubRepo returns whether string value looks like a valid
+// GitHub repo path. This condition is used to guess whether we should
+// make a pattern fuzzy, or try it as an exact match.
+func LooksLikeGitHubRepo(value string) bool {
+	result, err := regexp.MatchString(`github\.com\/([a-z\d]+-)*[a-z\d]+\/(.+)`, value)
+	if err != nil {
+		panic(err)
+	}
+	return result
 }
 
 func fuzzifyGlobPattern(value string) string {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -223,15 +223,13 @@ func ContainsNoGlobSyntax(value string) bool {
 	return !globSyntax.MatchString(value)
 }
 
+var gitHubRepoPath = lazyregexp.New(`github\.com\/([a-z\d]+-)*[a-z\d]+\/(.+)`)
+
 // LooksLikeGitHubRepo returns whether string value looks like a valid
 // GitHub repo path. This condition is used to guess whether we should
 // make a pattern fuzzy, or try it as an exact match.
 func LooksLikeGitHubRepo(value string) bool {
-	result, err := regexp.MatchString(`github\.com\/([a-z\d]+-)*[a-z\d]+\/(.+)`, value)
-	if err != nil {
-		panic(err)
-	}
-	return result
+	return gitHubRepoPath.MatchString(value)
 }
 
 func fuzzifyGlobPattern(value string) string {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -699,8 +699,8 @@ func TestFuzzifyGlobPattern(t *testing.T) {
 			want: "**foo**",
 		},
 		{
-			in:   "github.com/foo/bar",
-			want: "github.com/foo/bar**",
+			in:   "sourcegraph/sourcegraph",
+			want: "**sourcegraph/sourcegraph**",
 		},
 		{
 			in:   "",
@@ -736,6 +736,10 @@ func TestMapGlobToRegex(t *testing.T) {
 		{
 			input: "repo:github.com/sourcegraph/sourcegraph@v3.18.0",
 			want:  `"repo:^github\\.com/sourcegraph/sourcegraph$@v3.18.0"`,
+		},
+		{
+			input: "github.com/foo/bar",
+			want:  `"github.com/foo/bar"`,
 		},
 		{
 			input: "repo:**sourcegraph",


### PR DESCRIPTION
The current globbing/wildcard syntax unconditionally fuzzifies repo paths. There are some unavoidable cases where this doesn't behave reasonably for results. The main example is, when searching for:

`github.com/sourcegraph/sourcegraph auth` there are hits in the exact repo `github.com/sourcegraph/sourcegraph`, but due to the order and nondeterminism that we search repositories (and return results quickly), you will see results for `auth` in repos other than `github.com/sourcegraph/sourcegraph` first:

<img width="1414" alt="Screen Shot 2020-08-20 at 2 40 42 AM" src="https://user-images.githubusercontent.com/888624/90754299-8ef6e500-e28e-11ea-8427-d37df54829b4.png">

So that we can go ahead with our user testing, this PR recognizes GH-like paths like `github.com/foo/bar` for repos and then does not fuzzify them. This gives us behavior that is similar to what we did for `rev` and what @keegancsmith mentioned in https://github.com/sourcegraph/sourcegraph/issues/12892#issuecomment-672410403. Note: I am choosing a method that has the smallest footprint of changes to get the desired result, not necessarily the most ideal. I [played around](https://github.com/sourcegraph/sourcegraph/commit/dd8f09d4f186bfec5b8ff71e64e44e56f3664199) with attempts that try to resolve the exact repo first, but it won't work well from a UX POV for other reasons. When search expressions are enabled, there is another route, by expressing the search as `repo:^exact-attempt$ or repo:fuzzy-attempt`, but that's not possible right now and also imposes other things like ordering how expression are evaluated. I think the hardcoded `github` case works fine for now for practical/testing/feedback purposes.

Obviously this means that GH-like paths that don't match an exact repo won't give results--here, a user needs to add explicit `*` syntax. I think this is a totally fair compromise (we can certainly do better to propose such queries, e.g., no repo resolved).
