### PR TITLE
search: read user settings from database once in search path

### DIFF
--- a/cmd/frontend/graphqlbackend/repo_groups.go
+++ b/cmd/frontend/graphqlbackend/repo_groups.go
@@ -16,7 +16,12 @@ func (g repoGroup) Name() string { return g.name }
 func (g repoGroup) Repositories() []string { return repoNamesToStrings(g.repositories) }
 
 func (r *schemaResolver) RepoGroups(ctx context.Context) ([]*repoGroup, error) {
-	groupsByName, err := resolveRepoGroups(ctx)
+	settings, err := decodedViewerFinalSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	groupsByName, err := resolveRepoGroups(settings)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -302,14 +302,17 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			mockDecodedViewerFinalSettings = &schema.Settings{SearchGlobbing: &test.globbing}
-			defer func() { mockDecodedViewerFinalSettings = nil }()
 			setMockResolveRepositories(test.repoRevs)
 			q, err := query.ProcessAndOr(test.query, query.ParserOptions{SearchType: query.SearchType(0), Globbing: test.globbing})
 			if err != nil {
 				t.Fatal(err)
 			}
-			sr := searchResolver{query: q}
+			sr := searchResolver{
+				query: q,
+				userSettings: &schema.Settings{
+					SearchGlobbing: &test.globbing,
+				},
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			if test.cancelContext {

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -15,7 +15,7 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 		return nil, err
 	}
 
-	groupsByName, err := resolveRepoGroups(ctx)
+	groupsByName, err := resolveRepoGroups(settings)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1912,7 +1912,7 @@ func compareSearchResults(a, b searchResultURIGetter, exactFilePatterns map[stri
 
 func (r *searchResolver) sortResults(ctx context.Context, results []SearchResultResolver) {
 	var exactPatterns map[string]struct{}
-	if settings, err := decodedViewerFinalSettings(ctx); err == nil && getBoolPtr(settings.SearchGlobbing, false) {
+	if getBoolPtr(r.userSettings.SearchGlobbing, false) {
 		exactPatterns = r.getExactFilePatterns()
 	}
 	sort.Slice(results, func(i, j int) bool { return compareSearchResults(results[i], results[j], exactPatterns) })

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -914,9 +914,6 @@ func TestSearchResultsHydration(t *testing.T) {
 			Fork:        false,
 		}}
 
-	mockDecodedViewerFinalSettings = &schema.Settings{}
-	defer func() { mockDecodedViewerFinalSettings = nil }()
-
 	db.Mocks.Repos.Get = func(ctx context.Context, id api.RepoID) (*types.Repo, error) {
 		return hydratedRepo, nil
 	}
@@ -962,7 +959,7 @@ func TestSearchResultsHydration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolver := &searchResolver{query: q, zoekt: z}
+	resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}}
 	results, err := resolver.Results(ctx)
 	if err != nil {
 		t.Fatal("Results:", err)
@@ -1423,9 +1420,6 @@ func TestEvaluateAnd(t *testing.T) {
 
 			ctx := context.Background()
 
-			mockDecodedViewerFinalSettings = &schema.Settings{}
-			defer func() { mockDecodedViewerFinalSettings = nil }()
-
 			db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 				return minimalRepos, nil
 			}
@@ -1438,7 +1432,7 @@ func TestEvaluateAnd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			resolver := &searchResolver{query: q, zoekt: z}
+			resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}}
 			results, err := resolver.Results(ctx)
 			if err != nil {
 				t.Fatal("Results:", err)

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -28,9 +28,6 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 
 	unindexedRepo := &types.Repo{Name: api.RepoName("unindexed/one")}
 
-	mockDecodedViewerFinalSettings = &schema.Settings{}
-	defer func() { mockDecodedViewerFinalSettings = nil }()
-
 	db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 		return []*types.Repo{indexedRepo, unindexedRepo}, nil
 	}
@@ -97,6 +94,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 		patternType:  query.SearchTypeStructural,
 		zoekt:        z,
 		searcherURLs: endpoint.Static("test"),
+		userSettings: &schema.Settings{},
 	}
 	results, err := resolver.Results(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -48,7 +48,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	// If globbing is activated, convert regex patterns of repo, file, and repohasfile
 	// from "field:^foo$" to "field:^foo".
 	globbing := false
-	if settings, err := decodedViewerFinalSettings(ctx); err == nil && getBoolPtr(settings.SearchGlobbing, false) {
+	if getBoolPtr(r.userSettings.SearchGlobbing, false) {
 		globbing = true
 	}
 	if AndOrQuery, isAndOr := r.query.(*query.AndOrQuery); globbing && isAndOr {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -539,9 +539,6 @@ func TestVersionContext(t *testing.T) {
 	})
 	defer conf.Mock(nil)
 
-	mockDecodedViewerFinalSettings = &schema.Settings{}
-	defer func() { mockDecodedViewerFinalSettings = nil }()
-
 	tcs := []struct {
 		name           string
 		searchQuery    string
@@ -632,6 +629,7 @@ func TestVersionContext(t *testing.T) {
 			resolver := searchResolver{
 				query:          qinfo,
 				versionContext: &tc.versionContext,
+				userSettings:   &schema.Settings{},
 			}
 
 			db.Mocks.Repos.List = func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -630,9 +630,6 @@ func BenchmarkSearchResults(b *testing.B) {
 
 	ctx := context.Background()
 
-	mockDecodedViewerFinalSettings = &schema.Settings{}
-	defer func() { mockDecodedViewerFinalSettings = nil }()
-
 	db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
 		return minimalRepos, nil
 	}
@@ -649,7 +646,7 @@ func BenchmarkSearchResults(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		resolver := &searchResolver{query: q, zoekt: z}
+		resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}}
 		results, err := resolver.Results(ctx)
 		if err != nil {
 			b.Fatal("Results:", err)


### PR DESCRIPTION
In a few places on our search path we called
decodedViewerFinalSettings. This seemed to be often used to decide to
use globbing or not. Each call in production seems to take roughly
25ms-40ms. We estimate that this will save about ~200ms on the critical
path for Sourcegraph.com search requests.

This removes most places we call it by passing down the user settings in
the searchResolver.

Co-Author: @eseliger 