### PR TITLE
monitoring: relax cpu provisioning alert with longer duration

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -728,7 +728,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _frontend: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _frontend: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -1052,7 +1052,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _gitserver: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _gitserver: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -1268,7 +1268,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _github-proxy: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _github-proxy: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -1671,7 +1671,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-bundle-manager: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _precise-code-intel-bundle-manager: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -2086,7 +2086,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-worker: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _precise-code-intel-worker: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -2533,7 +2533,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _precise-code-intel-indexer: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _precise-code-intel-indexer: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -2756,7 +2756,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _query-runner: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _query-runner: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -2979,7 +2979,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _repo-updater: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _repo-updater: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -3234,7 +3234,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _searcher: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _searcher: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -3489,7 +3489,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _symbols: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _symbols: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -3753,7 +3753,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _syntect-server: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _syntect-server: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -3940,7 +3940,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _zoekt-indexserver: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _zoekt-indexserver: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -4124,7 +4124,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _zoekt-webserver: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _zoekt-webserver: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 
@@ -4309,7 +4309,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _prometheus: 90%+ container cpu usage total (5m maximum) across all cores by instance_
+- _prometheus: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
 **Possible solutions:**
 

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -139,7 +139,7 @@ var sharedProvisioningCPUUsageShortTerm sharedObservable = func(containerName st
 		Description:     "container cpu usage total (5m maximum) across all cores by instance",
 		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_cpu_usage_percentage_total{%s}[5m])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
-		Warning:         Alert{GreaterOrEqual: 90},
+		Warning:         Alert{GreaterOrEqual: 90, For: 30 * time.Minute},
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Interval(100).Max(100).Min(0),
 		Owner:           owner,
 		PossibleSolutions: strings.Replace(`


### PR DESCRIPTION
Brief peaks for CPU usage are not particularly useful indicators that a service might be underprovisioned. If a service consistently experiences high CPU usage peaks, however, that's a stronger sign that a service might require more resources.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
