### PR TITLE
search: always set zoekt.MaxWallTime to deadline

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -261,9 +261,8 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	k := zoektResultCountFactor(len(repos.repoBranches), args.PatternInfo)
 	searchOpts := zoektSearchOpts(ctx, k, args.PatternInfo)
 
-	if args.UseFullDeadline {
+	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
-		deadline, _ := ctx.Deadline()
 		searchOpts.MaxWallTime = time.Until(deadline)
 
 		// We don't want our context's deadline to cut off zoekt so that we can get the results


### PR DESCRIPTION
We always have a timeout in search. Previously we would only use "nice"
behaviour for zoekt if the user explicitly opted in with a timeout. Now
we always use the timeout.

Before this change if we timedout in zoekt we would report that no
results were found.

Part of https://github.com/sourcegraph/sourcegraph/issues/13105

Co-Author: @beyang