### PR TITLE
Reduce alert box count to 1 on apply page

### DIFF
--- a/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
+++ b/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
 import { PageTitle } from '../../../components/PageTitle'
 import {
@@ -38,7 +38,6 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
     queryChangesetSpecs,
     queryChangesetSpecFileDiffs,
 }) => {
-    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
     const spec = useObservable(useMemo(() => fetchCampaignSpecById(specID), [specID, fetchCampaignSpecById]))
 
     if (spec === undefined) {
@@ -67,8 +66,6 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
                 history={history}
                 specID={spec.id}
                 campaign={spec.appliesToCampaign}
-                isLoading={isLoading}
-                setIsLoading={setIsLoading}
                 viewerCanAdminister={spec.viewerCanAdminister}
             />
             <CampaignDescription history={history} description={spec.description.description} className="mb-3" />
@@ -79,14 +76,6 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
                 isLightTheme={isLightTheme}
                 queryChangesetSpecs={queryChangesetSpecs}
                 queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
-            />
-            <CreateUpdateCampaignAlert
-                history={history}
-                specID={spec.id}
-                campaign={spec.appliesToCampaign}
-                isLoading={isLoading}
-                setIsLoading={setIsLoading}
-                viewerCanAdminister={spec.viewerCanAdminister}
             />
         </>
     )

--- a/web/src/enterprise/campaigns/apply/CreateUpdateCampaignAlert.story.tsx
+++ b/web/src/enterprise/campaigns/apply/CreateUpdateCampaignAlert.story.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import webStyles from '../../../enterprise.scss'
 import { Tooltip } from '../../../components/tooltip/Tooltip'
 import { CreateUpdateCampaignAlert } from './CreateUpdateCampaignAlert'
-import { noop } from 'lodash'
 
 const { add } = storiesOf('web/campaigns/apply/CreateUpdateCampaignAlert', module).addDecorator(story => {
     const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')
@@ -27,8 +26,6 @@ add('Create', () => {
             specID="123"
             campaign={null}
             history={history}
-            isLoading={false}
-            setIsLoading={noop}
             viewerCanAdminister={boolean('viewerCanAdminister', true)}
         />
     )
@@ -40,8 +37,6 @@ add('Update', () => {
             specID="123"
             campaign={{ id: '123', name: 'awesome-campaign', url: 'http://test.test/awesome' }}
             history={history}
-            isLoading={false}
-            setIsLoading={noop}
             viewerCanAdminister={boolean('viewerCanAdminister', true)}
         />
     )

--- a/web/src/enterprise/campaigns/apply/CreateUpdateCampaignAlert.tsx
+++ b/web/src/enterprise/campaigns/apply/CreateUpdateCampaignAlert.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { CampaignSpecFields } from '../../../graphql-operations'
 import { createCampaign, applyCampaign } from './backend'
 import { Link } from '../../../../../shared/src/components/Link'
@@ -10,8 +10,6 @@ import { ErrorAlert } from '../../../components/alerts'
 export interface CreateUpdateCampaignAlertProps {
     specID: string
     campaign: CampaignSpecFields['appliesToCampaign']
-    isLoading: boolean | Error
-    setIsLoading: (newValue: boolean | Error) => void
     viewerCanAdminister: boolean
     history: H.History
 }
@@ -19,12 +17,11 @@ export interface CreateUpdateCampaignAlertProps {
 export const CreateUpdateCampaignAlert: React.FunctionComponent<CreateUpdateCampaignAlertProps> = ({
     specID,
     campaign,
-    isLoading,
-    setIsLoading,
     viewerCanAdminister,
     history,
 }) => {
     const campaignID = campaign?.id
+    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
     const onApply = useCallback(async () => {
         if (!confirm(`Are you sure you want to ${campaignID ? 'update' : 'create'} this campaign?`)) {
             return


### PR DESCRIPTION
In the earlier designs, we had two of these preview alert boxes, in the current one we only have one anymore though. This adjusts the implementation to the design.