### PR TITLE
prometheus: disable alertmanager clustering by default

### DIFF
--- a/docker-images/prometheus/README.md
+++ b/docker-images/prometheus/README.md
@@ -24,7 +24,7 @@ Image expects two volumes mounted:
   - target files which must have the suffix `_targets.yml` in their filename (ie `local_targets.yml`)
   - if this directory contains a file named `prometheus.yml` it will be used as the main prometheus config file
 
-You can specify additional flags to pass to Prometheus by setting the environment variable `PROMETHEUS_ADDITIONAL_FLAGS`, and similarly for Alertmanager, you can set the environment variable `ALERTMANAGER_ADDITIONAL_FLAGS`. For example, this can be used to leverage [high-availability Alertmanager](https://github.com/prometheus/alertmanager#high-availability).
+You can specify additional flags to pass to Prometheus by setting the environment variable `PROMETHEUS_ADDITIONAL_FLAGS`, and similarly for Alertmanager, you can set the environment variable `ALERTMANAGER_ADDITIONAL_FLAGS`. For example, this can be used to leverage [high-availability Alertmanager](https://github.com/prometheus/alertmanager#high-availability) alongside `ALERTMANAGER_ENABLE_CLUSTER=true`.
 
 `prom-wrapper` also accepts a few configuration options through environment variables - see [`cmd/prom-wrapper/main.go`](./cmd/prom-wrapper/main.go) for more details.
 

--- a/docker-images/prometheus/cmd/prom-wrapper/cmd.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/cmd.go
@@ -34,6 +34,11 @@ func NewAlertmanagerCmd(configPath string) *exec.Cmd {
 	cmd := exec.Command("/alertmanager.sh",
 		fmt.Sprintf("--config.file=%s", configPath),
 		fmt.Sprintf("--web.route-prefix=/%s", alertmanagerPathPrefix))
+	// disable clustering unless otherwise configured - it is enabled by default, but
+	// can cause alertmanager to fail to start up in some environments: https://github.com/sourcegraph/sourcegraph/issues/13079
+	if alertmanagerEnableCluster != "true" {
+		cmd.Args = append(cmd.Args, "--cluster.listen-address=")
+	}
 	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout

--- a/docker-images/prometheus/cmd/prom-wrapper/main.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/main.go
@@ -28,8 +28,9 @@ var (
 
 	prometheusPort = env.Get("PROMETHEUS_INTERNAL_PORT", "9092", "internal Prometheus port")
 
-	alertmanagerPort       = env.Get("ALERTMANAGER_INTERNAL_PORT", "9093", "internal Alertmanager port")
-	alertmanagerConfigPath = env.Get("ALERTMANAGER_CONFIG_PATH", "/sg_config_prometheus/alertmanager.yml", "alertmanager configuration")
+	alertmanagerPort          = env.Get("ALERTMANAGER_INTERNAL_PORT", "9093", "internal Alertmanager port")
+	alertmanagerConfigPath    = env.Get("ALERTMANAGER_CONFIG_PATH", "/sg_config_prometheus/alertmanager.yml", "path to alertmanager configuration")
+	alertmanagerEnableCluster = env.Get("ALERTMANAGER_ENABLE_CLUSTER", "false", "enable alertmanager clustering")
 )
 
 func main() {


### PR DESCRIPTION
Alertmanager clustering is enabled by default. However, the default configuration can cause Alertmanager to fail to start up in some scenarios. This change disables this feature by default, unless otherwise configured with `ALERTMANAGER_ENABLE_CLUSTER=true`

Closes https://github.com/sourcegraph/sourcegraph/issues/13079


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
