### PR TITLE
src-cli: bump required version to 3.18.0

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.17.0"
+const MinimumVersion = "3.18.0"


### PR DESCRIPTION
This is required for the new campaign workflow.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
