### PR TITLE
updatecheck: redact k8s 3.19

### DIFF
--- a/cmd/frontend/internal/app/pkg/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/handler.go
@@ -39,7 +39,7 @@ var (
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("3.19.0")
+	latestReleaseKubernetesBuild = newBuild("3.18.0")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be


### PR DESCRIPTION
we have redacted v3.19.0 due to a db migration issue (read @slimsag excellent writeup here: https://github.com/sourcegraph/sourcegraph/pull/13194)

