### PR TITLE
search: and rev: alias and separate validation and transformation

### DIFF
--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -37,4 +37,5 @@ var allFields = map[string]struct{}{
 	FieldTimeout:            empty,
 	FieldCombyRule:          empty,
 	FieldRev:                empty,
+	"revision":              empty,
 }

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -12,7 +12,8 @@ type Mapper interface {
 
 // The BaseMapper is a mapper that recursively visits each node in a query and
 // maps it to itself. A BaseMapper's methods may be overriden by embedding it a
-// custom mapper's definition. See ParameterMapper for an example.
+// custom mapper's definition. See ParameterMapper for an example. If the
+// methods return nil, the respective node is removed.
 type BaseMapper struct{}
 
 func (*BaseMapper) MapNodes(mapper Mapper, nodes []Node) []Node {
@@ -20,11 +21,17 @@ func (*BaseMapper) MapNodes(mapper Mapper, nodes []Node) []Node {
 	for _, node := range nodes {
 		switch v := node.(type) {
 		case Pattern:
-			mapped = append(mapped, mapper.MapPattern(mapper, v.Value, v.Negated, v.Annotation))
+			if result := mapper.MapPattern(mapper, v.Value, v.Negated, v.Annotation); result != nil {
+				mapped = append(mapped, result)
+			}
 		case Parameter:
-			mapped = append(mapped, mapper.MapParameter(mapper, v.Field, v.Value, v.Negated, v.Annotation))
+			if result := mapper.MapParameter(mapper, v.Field, v.Value, v.Negated, v.Annotation); result != nil {
+				mapped = append(mapped, result)
+			}
 		case Operator:
-			mapped = append(mapped, mapper.MapOperator(mapper, v.Kind, v.Operands)...)
+			if result := mapper.MapOperator(mapper, v.Kind, v.Operands); result != nil {
+				mapped = append(mapped, result...)
+			}
 		}
 	}
 	return mapped

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -981,11 +981,6 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		query = Map(query, EmptyGroupsToLiteral, TrailingParensToLiteral)
 	}
 
-	query, err = concatRevFilters(query)
-	if err != nil {
-		return nil, err
-	}
-
 	if options.Globbing {
 		query, err = mapGlobToRegex(query)
 		if err != nil {
@@ -997,5 +992,7 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	query = concatRevFilters(query)
+
 	return &AndOrQuery{Query: query}, nil
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -22,6 +22,7 @@ func SubstituteAliases(nodes []Node) []Node {
 		"until":    FieldBefore,
 		"m":        FieldMessage,
 		"msg":      FieldMessage,
+		"revision": FieldRev,
 	}
 	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 		if field == "content" {
@@ -574,64 +575,20 @@ func FuzzifyRegexPatterns(nodes []Node) []Node {
 }
 
 // concatRevFilters removes rev: filters from []Node and attaches their value as @rev to the repo: filters.
-// Invariant: we assume that all rev: filters are at the top-level of []Node, or in one of it's direct children.
-// This invariant is ensured when the query is normalized to DNF.
-func concatRevFilters(nodes []Node) ([]Node, error) {
-	if len(nodes) == 0 {
-		return nodes, nil
+// Invariant: Guaranteed to succeed on a validated and DNF query.
+func concatRevFilters(nodes []Node) []Node {
+	var revision string
+	nodes = MapField(nodes, FieldRev, func(value string, _ bool) Node {
+		revision = value
+		return nil // remove this node
+	})
+	if revision == "" {
+		return nodes
 	}
-	// top-level And
-	if op, isOperator := nodes[0].(Operator); len(nodes) == 1 && isOperator && op.Kind == And {
-		nodes, err := concatRevFiltersFlat(op.Operands)
-		if err != nil {
-			return nil, err
+	return MapField(nodes, FieldRepo, func(value string, negated bool) Node {
+		if !negated {
+			return Parameter{Value: value + "@" + revision, Field: FieldRepo, Negated: negated}
 		}
-		return newOperator(nodes, And), nil
-	}
-	return concatRevFiltersFlat(nodes)
-}
-
-func concatRevFiltersFlat(nodes []Node) ([]Node, error) {
-	var revs []string
-	for _, n := range nodes {
-		if param, ok := n.(Parameter); !ok || param.Field != FieldRev {
-			continue
-		} else {
-			revs = append(revs, param.Value)
-		}
-	}
-	if len(revs) == 0 {
-		return nodes, nil
-	}
-	if len(revs) > 1 {
-		return nil, fmt.Errorf("invalid syntax. You have specified multiple revisions (%s) and"+
-			" I don't know how to interpret this. Remove all but one rev: keywords"+
-			" and try again", strings.Join(revs, ", "))
-	}
-	operands := make([]Node, len(nodes))
-	i := 0
-	for _, n := range nodes {
-		switch p := n.(type) {
-		case Parameter:
-			switch p.Field {
-			case FieldRepo:
-				if strings.ContainsRune(p.Value, '@') {
-					return nil, fmt.Errorf("invalid syntax. You have specified @ and rev: for the same" +
-						" repo: filter and I don't know how to interpret this. Remove either @ or rev: and try again")
-				}
-				p.Value += "@" + revs[0]
-				operands[i] = p
-				i++
-			case FieldRev:
-				continue
-			default:
-				operands[i] = n
-				i++
-			}
-		default:
-			operands[i] = n
-			i++
-		}
-	}
-	return operands[:i], nil
+		return Parameter{Value: value, Field: FieldRepo, Negated: negated}
+	})
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -807,10 +807,7 @@ func TestConcatRevFilters(t *testing.T) {
 
 			var queriesStr []string
 			for _, q := range queries {
-				qConcat, err := concatRevFilters(q)
-				if err != nil {
-					t.Fatal(err)
-				}
+				qConcat := concatRevFilters(q)
 				queriesStr = append(queriesStr, prettyPrint(qConcat))
 			}
 			got := "(" + strings.Join(queriesStr, ") OR (") + ")"
@@ -842,31 +839,9 @@ func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			qConcat, err := concatRevFilters(query)
-			if err != nil {
-				t.Fatal(err)
-			}
+			qConcat := concatRevFilters(query)
 			if diff := cmp.Diff(c.want, prettyPrint(qConcat)); diff != "" {
 				t.Error(diff)
-			}
-		})
-	}
-}
-
-func TestConcatRevFiltersForInvalidSyntax(t *testing.T) {
-	cases := []string{
-		"repo:foo rev:a rev:b",
-		"repo:foo@a rev:b",
-	}
-	for _, c := range cases {
-		t.Run(c, func(t *testing.T) {
-			query, _ := ParseAndOr(c, SearchTypeRegex)
-			queries := dnf(query)
-			for _, q := range queries {
-				_, err := concatRevFilters(q)
-				if err == nil {
-					t.Fatal("Expected err, but got nil")
-				}
 			}
 		})
 	}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/src-d/enry/v2"
 )
 
@@ -317,8 +318,33 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldTimeout,
 		FieldCombyRule:
 		return satisfies(isSingular, isNotNegated)
+	case
+		FieldRev:
+		return satisfies(isSingular, isNotNegated)
 	default:
 		return isUnrecognizedField()
+	}
+	return nil
+}
+
+// A query is invalid if it contains a rev: filter and a repo is specified with @.
+func validateRepoRevPair(nodes []Node) error {
+	var seenRepoWithCommit bool
+	VisitField(nodes, FieldRepo, func(value string, negated bool, _ Annotation) {
+		if !negated && strings.ContainsRune(value, '@') {
+			seenRepoWithCommit = true
+		}
+	})
+	revSpecified := exists(nodes, func(node Node) bool {
+		n, ok := node.(Parameter)
+		if ok && n.Field == FieldRev {
+			return true
+		}
+		return false
+	})
+	if seenRepoWithCommit && revSpecified {
+		return errors.New("invalid syntax. You specified both @ and rev: for a" +
+			" repo: filter and I don't know how to interpret this. Remove either @ or rev: and try again")
 	}
 	return nil
 }
@@ -341,5 +367,9 @@ func validate(nodes []Node) error {
 			_, err = regexp.Compile(value)
 		}
 	})
+	if err != nil {
+		return err
+	}
+	err = validateRepoRevPair(nodes)
 	return err
 }

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -64,6 +64,14 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			want:       "The query contains a negated search pattern. Structural search does not support negated search patterns at the moment.",
 			searchType: SearchTypeStructural,
 		},
+		{
+			input: "repo:foo rev:a rev:b",
+			want:  `field "rev" may not be used more than once`,
+		},
+		{
+			input: "repo:foo@a rev:b",
+			want:  "invalid syntax. You specified both @ and rev: for a repo: filter and I don't know how to interpret this. Remove either @ or rev: and try again",
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {


### PR DESCRIPTION
I started by adding the missing `revision` alias and felt inspired to rework the `rev` code into the validation function. The one reason is that previously we weren't checking for things like `-rev` and how `rev` can interact with `-repo`. The other reason is its nice to concentrate all validation in one place and use the existing visitor/mapper stuff for traversals, and don't have to worry about the top-level business. I made a small modification to the `mapper` interface to remove a node if the callback returns `nil` to help with this.

The only thing this PR loses is the admittedly nicer error message `You have specified multiple revisions (%s) and...` and replaces it with `rev may not be specified more than once`. We can reintroduce the nicer error message if the validation function first collects all the (possibly more than one) revisions and formats the error like before, but I didn't want to get into that.

---

Other notes on `repo:foo repo:bar` and `-repo:foo@bar` syntax (here be dragons):

I was tempted to remove the fact that we can specify `repo:foo repo:bar` and allow only one `repo:foo` as this is _usually_ meaningless, but I discovered we actually have the behavior that tries to match repos whose _names_ contain both `foo` and `bar` (previously, my mental model mapped this `and` operation to evaluating whether both the repos `foo` and `bar` exist on an instance). So, to not disrupt whatever existing behavior we have here, I'm just introducing a similar rev validation as before, but taking care not to raise an error if it were only `-repo`. 

I also played around with `-repo:foo@bar` syntax and combinations and this is typically not meaningful.  For example, just searching `-repo:github.com/sourcegraph/sourcegraph@HEAD` I think just excludes all of `github.com/sourcegraph/sourcegraph`. The point is that that I _think_ the `@commit` part is insignificant for `-repo` and thrown away, but I'm not changing the validation for that, because I don't think we have a well-defined behavior and I'm not sure. Further investigating might reveal that we should just alert on `-repo:foo@bar` and call it invalid.