### PR TITLE
Display current release by default on docs.sourcegraph.com and update it on every release

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -349,6 +349,17 @@ Key dates:
                     ],
                     title: `Update latest release to ${parsedVersion.version}`,
                 },
+                {
+                    owner: 'sourcegraph',
+                    repo: 'deploy-sourcegraph-dot-com',
+                    base: 'release',
+                    head: `publish-${parsedVersion.version}`,
+                    commitMessage: `Update latest release to ${parsedVersion.version}`,
+                    bashEditCommands: [
+                        `${sed} -i -E 's/"defaultContentBranch":"[[:alnum:]\\.]+"/"defaultContentBranch":"${parsedVersion.major}.${parsedVersion.minor}"/g' configure/docs-sourcegraph-com/docs-sourcegraph-com.Deployment.yaml`,
+                    ],
+                    title: `Update latest release to ${parsedVersion.version}`,
+                },
             ]
             for (const changeset of changes) {
                 await createBranchWithChanges(changeset)

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -8,15 +8,14 @@
 
 {{define "versionSelector"}}
     <div id="version-selector" class="dropdown version-dropdown ml-2">
+        {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.18.0"}} {{$previousReleaseVersion := "3.18"}} {{$currentReleaseRevspec := "v3.19.1"}} {{$currentReleaseVersion := "3.19"}} {{$nextReleaseVersion := "main"}}
         <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            {{.ContentVersion}}{{/* If no version is specified we are on the main branch */}}{{if eq .ContentVersion ""}}main{{end}}
+          {{.ContentVersion}}{{/* If no version is specified we are on the currentReleaseVersion */}}{{if eq .ContentVersion ""}}{{$currentReleaseVersion}}{{end}}
         </button>
         <details-menu aria-label="Sourcegraph version" class="dropdown-menu m-0 p-0" aria-labelledby="Version Dropdown">
-
-            {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.18.0"}} {{$previousReleaseVersion := "3.18"}} {{$currentReleaseRevspec := "v3.19.1"}} {{$currentReleaseVersion := "3.19"}} {{$nextReleaseVersion := "main"}}
-            <a rel="nofollow" class="dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">main</a>
-            <a rel="nofollow" class=" dropdown-item {{if eq $currentReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
+            <a rel="nofollow" class=" dropdown-item {{if eq .ContentVersion " "}}active{{end}}" href="/@{{$currentReleaseVersion}}/{{.ContentPagePath}}">{{$currentReleaseVersion}}<span class="current-branch ml-1">current</span></a>
             <a rel="nofollow" class=" dropdown-item {{if eq $previousReleaseVersion .ContentVersion " "}}active{{end}}" href="/@{{$previousReleaseVersion}}/{{.ContentPagePath}}">{{$previousReleaseVersion}}</a>
+            <a rel="nofollow" class="dropdown-item {{if eq $nextReleaseVersion .ContentVersion " "}}active{{end}}" href="/{{.ContentPagePath}}">main</a>
         </details-menu>
     </div>
 {{end}}


### PR DESCRIPTION
This PR does two things:

1. It changes the docs.sourcegraph.com templates to show the current release version ("3.19") as the default in the dropdown menu (when no version is selected) and reorders the items in the dropdown menu.
2. It extends the `yarn run release release:publish` command (that's [run as part of a release](https://about.sourcegraph.com/handbook/engineering/releases/release_issue_template#one-working-day-before-release-1-work-day-before-release-tag-final-release)) to rewrite the [`"defaultContentBranch"` in the `docsite` config in `deploy-sourcegraph-dot-com`](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/7d33dfb76ea0c2fc4db448009f2c2d73d4c1f009/configure/docs-sourcegraph-com/docs-sourcegraph-com.Deployment.yaml#L39) on every release.

The end result?

1. docs.sourcegraph.com shows the docs of the current release by default
2. We update docs.sourcegraph.com to the new release when we run `yarn run release release:publish`.

Did I test this?

Yes, I tested the `docsite` template changes locally and I ran the `yarn run release release:publish` script locally to automatically create this PR https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3254 which I will merge once this PR is merged.