### PR TITLE
search: show alerts before search results

### DIFF
--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -313,4 +313,38 @@ describe('SearchResultsList', () => {
         expect(link).toBeTruthy()
         expect(link.href).toStrictEqual('http://localhost/search?q=repo:test1%7Ctest2&patternType=regexp')
     })
+
+    it('shows both alerts and results if both are present', () => {
+        const resultsOrError = mockResults({ resultCount: 1, limitHit: false })
+        resultsOrError.alert = {
+            __typename: 'SearchAlert',
+            title: 'Test title',
+            description: 'Test description',
+            proposedQueries: [
+                {
+                    __typename: 'SearchQueryDescription',
+                    description: 'test',
+                    query: 'repo:test1|test2',
+                },
+            ],
+        }
+
+        const props = {
+            ...defaultProps,
+            resultsOrError,
+        }
+
+        const { container } = render(
+            <BrowserRouter>
+                <SearchResultsList {...props} />
+            </BrowserRouter>
+        )
+
+        const link = getByTestId(container, 'proposed-query-link') as HTMLAnchorElement
+        const result = getByTestId(container, 'result-container')
+
+        expect(link).toBeTruthy()
+        expect(result).toBeTruthy()
+        expect(link.compareDocumentPosition(result)).toStrictEqual(link.DOCUMENT_POSITION_FOLLOWING)
+    })
 })

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -356,6 +356,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     ) : (
                         (() => {
                             const results = this.props.resultsOrError
+
                             return (
                                 <>
                                     {/* Info Bar */}
@@ -374,45 +375,9 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         }
                                     />
 
-                                    {/* Results */}
-                                    <VirtualList
-                                        itemsToShow={this.state.resultsShown}
-                                        onShowMoreItems={this.onBottomHit(results.results.length)}
-                                        onVisibilityChange={this.nextItemVisibilityChange}
-                                        items={results.results
-                                            .map(result => this.renderResult(result))
-                                            .filter(isDefined)}
-                                        containment={this.scrollableElementRef || undefined}
-                                        onRef={this.nextVirtualListContainerElement}
-                                    />
-
-                                    {/*
-                                        Show more button
-
-                                        We only show this button at the bottom of the page when the
-                                        user has scrolled completely to the bottom of the virtual
-                                        list (i.e. when resultsShown is results.length).
-
-                                        Note however that when the bottom is hit, this.onBottomHit
-                                        is called to asynchronously update resultsShown to add 10
-                                        which means there is a race condition in which e.g.
-                                        results.length == 30 && resultsShown == 40 so we use >=
-                                        comparison below.
-                                    */}
-                                    {results.limitHit && this.state.resultsShown >= results.results.length && (
-                                        <button
-                                            type="button"
-                                            className="btn btn-secondary btn-block"
-                                            data-testid="search-show-more-button"
-                                            onClick={this.props.onShowMoreResultsClick}
-                                        >
-                                            Show more
-                                        </button>
-                                    )}
-
                                     {/* Server-provided help message */}
                                     {results.alert && (
-                                        <div className="alert alert-info m-2">
+                                        <div className="alert alert-info m-2" data-testid="alert-container">
                                             <h3>
                                                 <AlertCircleIcon className="icon-inline" /> {results.alert.title}
                                             </h3>
@@ -465,6 +430,42 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                                         : []
                                                 )}
                                         </div>
+                                    )}
+
+                                    {/* Results */}
+                                    <VirtualList
+                                        itemsToShow={this.state.resultsShown}
+                                        onShowMoreItems={this.onBottomHit(results.results.length)}
+                                        onVisibilityChange={this.nextItemVisibilityChange}
+                                        items={results.results
+                                            .map(result => this.renderResult(result))
+                                            .filter(isDefined)}
+                                        containment={this.scrollableElementRef || undefined}
+                                        onRef={this.nextVirtualListContainerElement}
+                                    />
+
+                                    {/*
+                                        Show more button
+
+                                        We only show this button at the bottom of the page when the
+                                        user has scrolled completely to the bottom of the virtual
+                                        list (i.e. when resultsShown is results.length).
+
+                                        Note however that when the bottom is hit, this.onBottomHit
+                                        is called to asynchronously update resultsShown to add 10
+                                        which means there is a race condition in which e.g.
+                                        results.length == 30 && resultsShown == 40 so we use >=
+                                        comparison below.
+                                    */}
+                                    {results.limitHit && this.state.resultsShown >= results.results.length && (
+                                        <button
+                                            type="button"
+                                            className="btn btn-secondary btn-block"
+                                            data-testid="search-show-more-button"
+                                            onClick={this.props.onShowMoreResultsClick}
+                                        >
+                                            Show more
+                                        </button>
                                     )}
 
                                     {results.matchCount === 0 && !results.alert && (


### PR DESCRIPTION
If GQL search results returns an alert along with results, we currently show the alert at the bottom of the results. However, because of the virtual list scrolling, this alert can get lost or be impossible to see. Moving to the top so we can in the future highlight scenarios like "did you mean".

![image](https://user-images.githubusercontent.com/206864/90921900-e5077d80-e39f-11ea-88ad-d619d386f30e.png)