### PR TITLE
Migrate enums to gql-operations

### DIFF
--- a/browser/src/end-to-end/bitbucket.test.ts
+++ b/browser/src/end-to-end/bitbucket.test.ts
@@ -2,9 +2,9 @@ import expect from 'expect'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
 import { retry } from '../../../shared/src/testing/utils'
-import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { testSingleFilePage } from './shared'
 import { getConfig } from '../../../shared/src/testing/config'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 // By default, these tests run against a local Bitbucket instance and a local Sourcegraph instance.
 // You can run them against other instances by setting the below env vars in addition to SOURCEGRAPH_BASE_URL.

--- a/browser/src/end-to-end/ghe.test.ts
+++ b/browser/src/end-to-end/ghe.test.ts
@@ -1,8 +1,8 @@
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
-import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { testSingleFilePage } from './shared'
 import { getConfig } from '../../../shared/src/testing/config'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 const GHE_BASE_URL = process.env.GHE_BASE_URL || 'https://ghe.sgdev.org'
 const GHE_USERNAME = process.env.GHE_USERNAME

--- a/browser/src/end-to-end/gitlab.test.ts
+++ b/browser/src/end-to-end/gitlab.test.ts
@@ -1,8 +1,8 @@
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
-import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { testSingleFilePage } from './shared'
 import { getConfig } from '../../../shared/src/testing/config'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 // By default, these tests run against gitlab.com and a local Sourcegraph instance.
 // You can run them against other instances by setting the below env vars in addition to SOURCEGRAPH_BASE_URL.

--- a/browser/src/end-to-end/phabricator.test.ts
+++ b/browser/src/end-to-end/phabricator.test.ts
@@ -1,11 +1,11 @@
 import expect from 'expect'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
-import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { PhabricatorMapping } from '../browser-extension/web-extension-api/types'
 import { isEqual } from 'lodash'
 import { getConfig } from '../../../shared/src/testing/config'
 import { retry } from '../../../shared/src/testing/utils'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 // By default, these tests run against a local Phabricator instance and a local Sourcegraph instance.
 // To run them against phabricator.sgdev.org and umami.sgdev.org, set the below env vars in addition to SOURCEGRAPH_BASE_URL.

--- a/browser/src/shared/backend/userEvents.tsx
+++ b/browser/src/shared/backend/userEvents.tsx
@@ -2,6 +2,7 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
+import { UserEvent, EventSource } from '../../graphql-operations'
 
 /**
  * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
@@ -10,7 +11,7 @@ import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
  * @deprecated Use logEvent
  */
 export const logUserEvent = (
-    event: GQL.UserEvent,
+    event: UserEvent,
     uid: string,
     url: string,
     requestGraphQL: PlatformContext['requestGraphQL']
@@ -67,7 +68,7 @@ export const logEvent = (
         `,
         variables: {
             ...event,
-            source: GQL.EventSource.CODEHOSTINTEGRATION,
+            source: EventSource.CODEHOSTINTEGRATION,
             argument: event.argument && JSON.stringify(event.argument),
         },
         mightContainPrivateInfo: false,

--- a/browser/src/shared/cli/search.ts
+++ b/browser/src/shared/cli/search.ts
@@ -3,12 +3,12 @@ import { PlatformContext } from '../../../../shared/src/platform/context'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { createSuggestionFetcher } from '../backend/search'
 import { observeSourcegraphURL, getAssetsURL, DEFAULT_SOURCEGRAPH_URL } from '../util/context'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 import { createPlatformContext } from '../platform/context'
 import { from } from 'rxjs'
 import { isDefined, isNot } from '../../../../shared/src/util/types'
 import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { Settings } from '../../../../shared/src/settings/settings'
+import { SearchPatternType } from '../../graphql-operations'
 
 const isURL = /^https?:\/\//
 const IS_EXTENSION = true // This feature is only supported in browser extension

--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -2,13 +2,13 @@ import { noop } from 'lodash'
 import { Observable, ReplaySubject } from 'rxjs'
 import { take } from 'rxjs/operators'
 import * as uuid from 'uuid'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { PlatformContext } from '../../../../shared/src/platform/context'
 import { TelemetryService } from '../../../../shared/src/telemetry/telemetryService'
 import { storage } from '../../browser-extension/web-extension-api/storage'
 import { isInPage } from '../context'
 import { logUserEvent, logEvent } from '../backend/userEvents'
 import { observeSourcegraphURL, getPlatformName } from '../util/context'
+import { UserEvent } from '../../graphql-operations'
 
 const uidKey = 'sourcegraphAnonymousUid'
 
@@ -71,11 +71,7 @@ export class EventLogger implements TelemetryService {
      * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
      * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
      */
-    public async logCodeIntelligenceEvent(
-        event: string,
-        userEvent: GQL.UserEvent,
-        eventProperties?: any
-    ): Promise<void> {
+    public async logCodeIntelligenceEvent(event: string, userEvent: UserEvent, eventProperties?: any): Promise<void> {
         const anonUserId = await this.getAnonUserID()
         const sourcegraphURL = await this.sourcegraphURLs.pipe(take(1)).toPromise()
         logUserEvent(userEvent, anonUserId, sourcegraphURL, this.requestGraphQL)
@@ -102,10 +98,10 @@ export class EventLogger implements TelemetryService {
             case 'goToDefinition':
             case 'goToDefinition.preloaded':
             case 'hover':
-                await this.logCodeIntelligenceEvent(eventName, GQL.UserEvent.CODEINTELINTEGRATION, eventProperties)
+                await this.logCodeIntelligenceEvent(eventName, UserEvent.CODEINTELINTEGRATION, eventProperties)
                 break
             case 'findReferences':
-                await this.logCodeIntelligenceEvent(eventName, GQL.UserEvent.CODEINTELINTEGRATIONREFS, eventProperties)
+                await this.logCodeIntelligenceEvent(eventName, UserEvent.CODEINTELINTEGRATIONREFS, eventProperties)
                 break
         }
     }

--- a/shared/dev/generateGraphQlOperations.js
+++ b/shared/dev/generateGraphQlOperations.js
@@ -69,7 +69,7 @@ async function generateGraphQlOperations({ watch } = {}) {
           config: {
             onlyOperationTypes: true,
             noExport: false,
-            enumValues: '../../shared/src/graphql/schema',
+            enumValues: '../../shared/src/graphql-operations',
             interfaceNameForOperations: 'BrowserGraphQlOperations',
           },
           plugins,
@@ -80,7 +80,7 @@ async function generateGraphQlOperations({ watch } = {}) {
           config: {
             onlyOperationTypes: true,
             noExport: false,
-            enumValues: '../../shared/src/graphql/schema',
+            enumValues: '../../shared/src/graphql-operations',
             interfaceNameForOperations: 'WebGraphQlOperations',
           },
           plugins,
@@ -91,7 +91,6 @@ async function generateGraphQlOperations({ watch } = {}) {
           config: {
             onlyOperationTypes: true,
             noExport: false,
-            enumValues: './graphql/schema',
             interfaceNameForOperations: 'SharedGraphQlOperations',
           },
           plugins,

--- a/shared/src/search/parser/completion.ts
+++ b/shared/src/search/parser/completion.ts
@@ -4,11 +4,12 @@ import { FILTERS, resolveFilter } from './filters'
 import { Sequence, toMonacoRange } from './parser'
 import { Omit } from 'utility-types'
 import { Observable } from 'rxjs'
-import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup, SymbolKind } from '../../graphql/schema'
+import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup } from '../../graphql/schema'
 import { SearchSuggestion } from '../suggestions'
 import { isDefined } from '../../util/types'
 import { FilterType, isNegatableFilter } from '../interactive/util'
 import { first } from 'rxjs/operators'
+import { SymbolKind } from '../../graphql-operations'
 
 export const repositoryCompletionItemKind = Monaco.languages.CompletionItemKind.Color
 const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Customcolor

--- a/shared/src/search/parser/diagnostics.test.ts
+++ b/shared/src/search/parser/diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { getDiagnostics } from './diagnostics'
 import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
-import { SearchPatternType } from '../../graphql/schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 describe('getDiagnostics()', () => {
     test('do not raise invalid filter type', () => {

--- a/shared/src/search/parser/diagnostics.ts
+++ b/shared/src/search/parser/diagnostics.ts
@@ -1,7 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { Sequence, toMonacoRange } from './parser'
 import { validateFilter } from './filters'
-import { SearchPatternType } from '../../graphql/schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 /**
  * Returns the diagnostics for a parsed search query to be displayed in the Monaco query input.

--- a/shared/src/search/parser/providers.ts
+++ b/shared/src/search/parser/providers.ts
@@ -6,8 +6,8 @@ import { getMonacoTokens } from './tokens'
 import { getDiagnostics } from './diagnostics'
 import { getCompletionItems } from './completion'
 import { getHoverResult } from './hover'
-import { SearchPatternType } from '../../graphql/schema'
 import { SearchSuggestion } from '../suggestions'
+import { SearchPatternType } from '../../graphql-operations'
 
 interface SearchFieldProviders {
     tokens: Monaco.languages.TokensProvider

--- a/shared/src/symbols/SymbolIcon.tsx
+++ b/shared/src/symbols/SymbolIcon.tsx
@@ -25,12 +25,12 @@ import TimetableIcon from 'mdi-react/TimetableIcon'
 import WebIcon from 'mdi-react/WebIcon'
 import WrenchIcon from 'mdi-react/WrenchIcon'
 import * as React from 'react'
-import * as GQL from '../graphql/schema'
+import { SymbolKind } from '../graphql-operations'
 
 /**
  * Returns the icon component for a given symbol kind
  */
-const getSymbolIconComponent = (kind: GQL.SymbolKind): MdiReactIconComponentType => {
+const getSymbolIconComponent = (kind: SymbolKind): MdiReactIconComponentType => {
     switch (kind) {
         case 'FILE':
             return FileDocumentIcon
@@ -91,7 +91,7 @@ const getSymbolIconComponent = (kind: GQL.SymbolKind): MdiReactIconComponentType
 }
 
 interface SymbolIconProps {
-    kind: GQL.SymbolKind
+    kind: SymbolKind
     className?: string
 }
 

--- a/shared/src/testing/driver.ts
+++ b/shared/src/testing/driver.ts
@@ -14,7 +14,7 @@ import puppeteer, {
 } from 'puppeteer'
 import { Key } from 'ts-key-enum'
 import { dataOrThrowErrors, gql, GraphQLResult } from '../graphql/graphql'
-import { IMutation, IQuery, ExternalServiceKind, IRepository } from '../graphql/schema'
+import { IMutation, IQuery, IRepository } from '../graphql/schema'
 import { readEnvironmentBoolean, retry } from './utils'
 import { formatPuppeteerConsoleMessage } from './console'
 import * as path from 'path'
@@ -28,6 +28,7 @@ import puppeteerFirefox from 'puppeteer-firefox'
 import webExt from 'web-ext'
 import { isDefined } from '../util/types'
 import { getConfig } from './config'
+import { ExternalServiceKind } from '../graphql-operations'
 
 /**
  * Returns a Promise for the next emission of the given event on the given Puppeteer page.

--- a/shared/src/util/url.test.ts
+++ b/shared/src/util/url.test.ts
@@ -11,7 +11,7 @@ import {
     appendSubtreeQueryParameter,
     RepoFile,
 } from './url'
-import { SearchPatternType } from '../graphql/schema'
+import { SearchPatternType } from '../graphql-operations'
 
 /**
  * Asserts deep object equality using node's assert.deepEqual, except it (1) ignores differences in the

--- a/shared/src/util/url.ts
+++ b/shared/src/util/url.ts
@@ -1,12 +1,12 @@
 import { Position, Range, Selection } from '@sourcegraph/extension-api-types'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
-import { SearchPatternType } from '../graphql/schema'
 import { FiltersToTypeAndValue } from '../search/interactive/util'
 import { isEmpty } from 'lodash'
 import { parseSearchQuery, CharacterRange } from '../search/parser/parser'
 import { replaceRange } from './strings'
 import { discreteValueAliases } from '../search/parser/filters'
 import { tryCatch } from './errors'
+import { SearchPatternType } from '../graphql-operations'
 
 export interface RepoSpec {
     /**

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -62,6 +62,7 @@ import { Remote } from 'comlink'
 import { FlatExtHostAPI } from '../../shared/src/api/contract'
 import { useBreadcrumbs } from './components/Breadcrumbs'
 import { AuthenticatedUser } from './auth'
+import { SearchPatternType } from './graphql-operations'
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,
@@ -118,7 +119,7 @@ export interface LayoutProps
     searchRequest: (
         query: QueryState['query'],
         version: string,
-        patternType: GQL.SearchPatternType,
+        patternType: SearchPatternType,
         versionContext: string | undefined,
         extensionHostPromise: Promise<Remote<FlatExtHostAPI>>
     ) => Observable<GQL.ISearchResults | ErrorLike>

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -13,7 +13,6 @@ import {
     Controller as ExtensionsController,
     createController as createExtensionsController,
 } from '../../shared/src/extensions/controller'
-import * as GQL from '../../shared/src/graphql/schema'
 import { Notifications } from '../../shared/src/notifications/Notifications'
 import { PlatformContext } from '../../shared/src/platform/context'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '../../shared/src/settings/settings'
@@ -69,6 +68,7 @@ import {
     defaultPatternTypeFromSettings,
     experimentalFeaturesFromSettings,
 } from './util/settings'
+import { SearchPatternType } from '../../shared/src/graphql-operations'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
     exploreSections: readonly ExploreSectionDescriptor[]
@@ -119,7 +119,7 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
     /**
      * The current search pattern type.
      */
-    searchPatternType: GQL.SearchPatternType
+    searchPatternType: SearchPatternType
 
     /**
      * Whether the current search is case sensitive.
@@ -226,7 +226,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
 
         // The patternType in the URL query parameter. If none is provided, default to literal.
         // This will be updated with the default in settings when the web app mounts.
-        const urlPatternType = parseSearchURLPatternType(window.location.search) || GQL.SearchPatternType.literal
+        const urlPatternType = parseSearchURLPatternType(window.location.search) || SearchPatternType.literal
         const urlCase = searchURLIsCaseSensitive(window.location.search)
         const currentSearchMode = localStorage.getItem(SEARCH_MODE_KEY)
         const availableVersionContexts = window.context.experimentalFeatures.versionContexts
@@ -442,7 +442,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         this.setState({ filtersInQuery })
     }
 
-    private setPatternType = (patternType: GQL.SearchPatternType): void => {
+    private setPatternType = (patternType: SearchPatternType): void => {
         this.setState({
             searchPatternType: patternType,
         })

--- a/web/src/components/ExternalServiceCard.tsx
+++ b/web/src/components/ExternalServiceCard.tsx
@@ -2,7 +2,7 @@ import * as H from 'history'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import React from 'react'
 import { Link } from 'react-router-dom'
-import * as GQL from '../../../shared/src/graphql/schema'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 interface ExternalServiceCardProps {
     /**
@@ -20,7 +20,7 @@ interface ExternalServiceCardProps {
      */
     shortDescription?: string
 
-    kind: GQL.ExternalServiceKind
+    kind: ExternalServiceKind
 
     to?: H.LocationDescriptor
     className?: string

--- a/web/src/enterprise/campaigns/apply/HiddenChangesetSpecNode.story.tsx
+++ b/web/src/enterprise/campaigns/apply/HiddenChangesetSpecNode.story.tsx
@@ -5,8 +5,7 @@ import webStyles from '../../../enterprise.scss'
 import { Tooltip } from '../../../components/tooltip/Tooltip'
 import { HiddenChangesetSpecNode } from './HiddenChangesetSpecNode'
 import { addDays } from 'date-fns'
-import { ChangesetSpecType } from '../../../../../shared/src/graphql/schema'
-import { HiddenChangesetSpecFields } from '../../../graphql-operations'
+import { HiddenChangesetSpecFields, ChangesetSpecType } from '../../../graphql-operations'
 
 const { add } = storiesOf('web/campaigns/apply/HiddenChangesetSpecNode', module).addDecorator(story => {
     const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')

--- a/web/src/enterprise/campaigns/apply/HiddenChangesetSpecNode.tsx
+++ b/web/src/enterprise/campaigns/apply/HiddenChangesetSpecNode.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { HiddenChangesetSpecFields } from '../../../graphql-operations'
-import { ChangesetSpecType } from '../../../../../shared/src/graphql/schema'
+import { HiddenChangesetSpecFields, ChangesetSpecType } from '../../../graphql-operations'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import { ChangesetSpecAction } from './ChangesetSpecAction'
 

--- a/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.story.tsx
+++ b/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.story.tsx
@@ -6,8 +6,7 @@ import webStyles from '../../../enterprise.scss'
 import { Tooltip } from '../../../components/tooltip/Tooltip'
 import { VisibleChangesetSpecNode } from './VisibleChangesetSpecNode'
 import { addDays } from 'date-fns'
-import { ChangesetSpecType } from '../../../../../shared/src/graphql/schema'
-import { VisibleChangesetSpecFields } from '../../../graphql-operations'
+import { VisibleChangesetSpecFields, ChangesetSpecType } from '../../../graphql-operations'
 import { of } from 'rxjs'
 
 let isLightTheme = true

--- a/web/src/enterprise/codeintel/CodeIntelIndexPage.story.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelIndexPage.story.tsx
@@ -3,11 +3,11 @@ import { Index } from './backend'
 import { of } from 'rxjs'
 import { storiesOf } from '@storybook/react'
 import { SuiteFunction } from 'mocha'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import * as H from 'history'
 import React from 'react'
 import webStyles from '../../SourcegraphWebApp.scss'
 import { SourcegraphContext } from '../../jscontext'
+import { LSIFIndexState } from '../../../../shared/src/graphql-operations'
 
 window.context = {} as SourcegraphContext & SuiteFunction
 
@@ -56,7 +56,7 @@ add('Completed', () => (
         fetchLsifIndex={() =>
             of({
                 ...index,
-                state: GQL.LSIFIndexState.COMPLETED,
+                state: LSIFIndexState.COMPLETED,
                 queuedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: '2020-06-15T12:25:30+00:00',
                 finishedAt: '2020-06-15T12:30:30+00:00',
@@ -73,7 +73,7 @@ add('Errored', () => (
         fetchLsifIndex={() =>
             of({
                 ...index,
-                state: GQL.LSIFIndexState.ERRORED,
+                state: LSIFIndexState.ERRORED,
                 queuedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: '2020-06-15T12:25:30+00:00',
                 finishedAt: '2020-06-15T12:30:30+00:00',
@@ -90,7 +90,7 @@ add('Processing', () => (
         fetchLsifIndex={() =>
             of({
                 ...index,
-                state: GQL.LSIFIndexState.PROCESSING,
+                state: LSIFIndexState.PROCESSING,
                 queuedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: '2020-06-15T12:25:30+00:00',
                 finishedAt: null,
@@ -107,7 +107,7 @@ add('Queued', () => (
         fetchLsifIndex={() =>
             of({
                 ...index,
-                state: GQL.LSIFIndexState.QUEUED,
+                state: LSIFIndexState.QUEUED,
                 queuedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: null,
                 finishedAt: null,

--- a/web/src/enterprise/codeintel/CodeIntelIndexPage.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelIndexPage.tsx
@@ -17,6 +17,7 @@ import { useObservable } from '../../../../shared/src/util/useObservable'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 import { SchedulerLike, timer } from 'rxjs'
 import * as H from 'history'
+import { LSIFIndexState } from '../../../../shared/src/graphql-operations'
 
 const REFRESH_INTERVAL_MS = 5000
 
@@ -32,7 +33,7 @@ interface Props extends RouteComponentProps<{ id: string }> {
     now?: () => Date
 }
 
-const terminalStates = new Set([GQL.LSIFIndexState.COMPLETED, GQL.LSIFIndexState.ERRORED])
+const terminalStates = new Set([LSIFIndexState.COMPLETED, LSIFIndexState.ERRORED])
 
 function shouldReload(index: Index | ErrorLike | null | undefined): boolean {
     return !isErrorLike(index) && !(index && terminalStates.has(index.state))
@@ -112,17 +113,17 @@ export const CodeIntelIndexPage: FunctionComponent<Props> = ({
                         </h2>
                     </div>
 
-                    {indexOrError.state === GQL.LSIFIndexState.PROCESSING ? (
+                    {indexOrError.state === LSIFIndexState.PROCESSING ? (
                         <div className="alert alert-primary mb-4 mt-3">
                             <LoadingSpinner className="icon-inline" />{' '}
                             <span className="test-index-state">Index is currently being processed...</span>
                         </div>
-                    ) : indexOrError.state === GQL.LSIFIndexState.COMPLETED ? (
+                    ) : indexOrError.state === LSIFIndexState.COMPLETED ? (
                         <div className="alert alert-success mb-4 mt-3">
                             <CheckIcon className="icon-inline" />{' '}
                             <span className="test-index-state">Index processed successfully.</span>
                         </div>
-                    ) : indexOrError.state === GQL.LSIFIndexState.ERRORED ? (
+                    ) : indexOrError.state === LSIFIndexState.ERRORED ? (
                         <div className="alert alert-danger mb-4 mt-3">
                             <AlertCircleIcon className="icon-inline" />{' '}
                             <span className="test-index-state">Index failed to complete:</span>{' '}
@@ -185,7 +186,7 @@ export const CodeIntelIndexPage: FunctionComponent<Props> = ({
 
                             <tr>
                                 <td>
-                                    {indexOrError.state === GQL.LSIFIndexState.ERRORED && indexOrError.finishedAt
+                                    {indexOrError.state === LSIFIndexState.ERRORED && indexOrError.finishedAt
                                         ? 'Failed'
                                         : 'Finished'}{' '}
                                     processing

--- a/web/src/enterprise/codeintel/CodeIntelIndexesPage.story.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelIndexesPage.story.tsx
@@ -3,11 +3,11 @@ import { Index } from './backend'
 import { of } from 'rxjs'
 import { storiesOf } from '@storybook/react'
 import { SuiteFunction } from 'mocha'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import * as H from 'history'
 import React from 'react'
 import webStyles from '../../SourcegraphWebApp.scss'
 import { SourcegraphContext } from '../../jscontext'
+import { LSIFIndexState } from '../../../../shared/src/graphql-operations'
 
 window.context = {} as SourcegraphContext & SuiteFunction
 
@@ -58,7 +58,7 @@ add('List', () => (
                 nodes: [
                     {
                         ...index,
-                        state: GQL.LSIFIndexState.COMPLETED,
+                        state: LSIFIndexState.COMPLETED,
                         queuedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: '2020-06-15T12:25:30+00:00',
                         finishedAt: '2020-06-15T12:30:30+00:00',
@@ -67,7 +67,7 @@ add('List', () => (
                     },
                     {
                         ...index,
-                        state: GQL.LSIFIndexState.ERRORED,
+                        state: LSIFIndexState.ERRORED,
                         queuedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: '2020-06-15T12:25:30+00:00',
                         finishedAt: '2020-06-15T12:30:30+00:00',
@@ -76,7 +76,7 @@ add('List', () => (
                     },
                     {
                         ...index,
-                        state: GQL.LSIFIndexState.PROCESSING,
+                        state: LSIFIndexState.PROCESSING,
                         queuedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: '2020-06-15T12:25:30+00:00',
                         finishedAt: null,
@@ -85,7 +85,7 @@ add('List', () => (
                     },
                     {
                         ...index,
-                        state: GQL.LSIFIndexState.QUEUED,
+                        state: LSIFIndexState.QUEUED,
                         queuedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: null,
                         finishedAt: null,

--- a/web/src/enterprise/codeintel/CodeIntelIndexesPage.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelIndexesPage.tsx
@@ -16,6 +16,7 @@ import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../components/alerts'
 import { Subject } from 'rxjs'
 import * as H from 'history'
+import { LSIFIndexState } from '../../../../shared/src/graphql-operations'
 
 const Header: FunctionComponent<{}> = () => (
     <thead>
@@ -82,11 +83,11 @@ const IndexNode: FunctionComponent<IndexNodeProps> = ({ node, onDelete, history,
             </td>
             <td>
                 <Link to={`./indexes/${node.id}`}>
-                    {node.state === GQL.LSIFIndexState.PROCESSING ? (
+                    {node.state === LSIFIndexState.PROCESSING ? (
                         <span>Processing</span>
-                    ) : node.state === GQL.LSIFIndexState.COMPLETED ? (
+                    ) : node.state === LSIFIndexState.COMPLETED ? (
                         <span className="text-success">Completed</span>
-                    ) : node.state === GQL.LSIFIndexState.ERRORED ? (
+                    ) : node.state === LSIFIndexState.ERRORED ? (
                         <span className="text-danger">Failed to process</span>
                     ) : (
                         <span>Waiting to process (#{node.placeInQueue} in line)</span>
@@ -153,19 +154,19 @@ export const CodeIntelIndexesPage: FunctionComponent<Props> = ({
             label: 'Completed',
             id: 'completed',
             tooltip: 'Show completed indexes only',
-            args: { state: GQL.LSIFIndexState.COMPLETED },
+            args: { state: LSIFIndexState.COMPLETED },
         },
         {
             label: 'Errored',
             id: 'errored',
             tooltip: 'Show errored indexes only',
-            args: { state: GQL.LSIFIndexState.ERRORED },
+            args: { state: LSIFIndexState.ERRORED },
         },
         {
             label: 'Queued',
             id: 'queued',
             tooltip: 'Show queued indexes only',
-            args: { state: GQL.LSIFIndexState.QUEUED },
+            args: { state: LSIFIndexState.QUEUED },
         },
     ]
 

--- a/web/src/enterprise/codeintel/CodeIntelUploadPage.story.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelUploadPage.story.tsx
@@ -3,11 +3,11 @@ import { of } from 'rxjs'
 import { storiesOf } from '@storybook/react'
 import { SuiteFunction } from 'mocha'
 import { Upload } from './backend'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import * as H from 'history'
 import React from 'react'
 import webStyles from '../../SourcegraphWebApp.scss'
 import { SourcegraphContext } from '../../jscontext'
+import { LSIFUploadState } from '../../../../shared/src/graphql-operations'
 
 window.context = {} as SourcegraphContext & SuiteFunction
 
@@ -59,7 +59,7 @@ add('Completed', () => (
         fetchLsifUpload={() =>
             of({
                 ...upload,
-                state: GQL.LSIFUploadState.COMPLETED,
+                state: LSIFUploadState.COMPLETED,
                 uploadedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: '2020-06-15T12:25:30+00:00',
                 finishedAt: '2020-06-15T12:30:30+00:00',
@@ -76,7 +76,7 @@ add('Errored', () => (
         fetchLsifUpload={() =>
             of({
                 ...upload,
-                state: GQL.LSIFUploadState.ERRORED,
+                state: LSIFUploadState.ERRORED,
                 uploadedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: '2020-06-15T12:25:30+00:00',
                 finishedAt: '2020-06-15T12:30:30+00:00',
@@ -93,7 +93,7 @@ add('Processing', () => (
         fetchLsifUpload={() =>
             of({
                 ...upload,
-                state: GQL.LSIFUploadState.PROCESSING,
+                state: LSIFUploadState.PROCESSING,
                 uploadedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: '2020-06-15T12:25:30+00:00',
                 finishedAt: null,
@@ -110,7 +110,7 @@ add('Queued', () => (
         fetchLsifUpload={() =>
             of({
                 ...upload,
-                state: GQL.LSIFUploadState.QUEUED,
+                state: LSIFUploadState.QUEUED,
                 uploadedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: null,
                 finishedAt: null,
@@ -127,7 +127,7 @@ add('Uploading', () => (
         fetchLsifUpload={() =>
             of({
                 ...upload,
-                state: GQL.LSIFUploadState.UPLOADING,
+                state: LSIFUploadState.UPLOADING,
                 uploadedAt: '2020-06-15T12:20:30+00:00',
                 startedAt: null,
                 finishedAt: null,

--- a/web/src/enterprise/codeintel/CodeIntelUploadPage.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelUploadPage.tsx
@@ -17,6 +17,7 @@ import { useObservable } from '../../../../shared/src/util/useObservable'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 import { SchedulerLike, timer } from 'rxjs'
 import * as H from 'history'
+import { LSIFUploadState } from '../../../../shared/src/graphql-operations'
 
 const REFRESH_INTERVAL_MS = 5000
 
@@ -32,7 +33,7 @@ interface Props extends RouteComponentProps<{ id: string }> {
     now?: () => Date
 }
 
-const terminalStates = new Set([GQL.LSIFUploadState.COMPLETED, GQL.LSIFUploadState.ERRORED])
+const terminalStates = new Set([LSIFUploadState.COMPLETED, LSIFUploadState.ERRORED])
 
 function shouldReload(upload: Upload | ErrorLike | null | undefined): boolean {
     return !isErrorLike(upload) && !(upload && terminalStates.has(upload.state))
@@ -121,22 +122,22 @@ export const CodeIntelUploadPage: FunctionComponent<Props> = ({
                         </h2>
                     </div>
 
-                    {uploadOrError.state === GQL.LSIFUploadState.UPLOADING ? (
+                    {uploadOrError.state === LSIFUploadState.UPLOADING ? (
                         <div className="alert alert-primary mb-4 mt-3">
                             <LoadingSpinner className="icon-inline" />{' '}
                             <span className="test-upload-state">Still uploading...</span>
                         </div>
-                    ) : uploadOrError.state === GQL.LSIFUploadState.PROCESSING ? (
+                    ) : uploadOrError.state === LSIFUploadState.PROCESSING ? (
                         <div className="alert alert-primary mb-4 mt-3">
                             <LoadingSpinner className="icon-inline" />{' '}
                             <span className="test-upload-state">Upload is currently being processed...</span>
                         </div>
-                    ) : uploadOrError.state === GQL.LSIFUploadState.COMPLETED ? (
+                    ) : uploadOrError.state === LSIFUploadState.COMPLETED ? (
                         <div className="alert alert-success mb-4 mt-3">
                             <CheckIcon className="icon-inline" />{' '}
                             <span className="test-upload-state">Upload processed successfully.</span>
                         </div>
-                    ) : uploadOrError.state === GQL.LSIFUploadState.ERRORED ? (
+                    ) : uploadOrError.state === LSIFUploadState.ERRORED ? (
                         <div className="alert alert-danger mb-4 mt-3">
                             <AlertCircleIcon className="icon-inline" />{' '}
                             <span className="test-upload-state">Upload failed to complete:</span>{' '}
@@ -230,7 +231,7 @@ export const CodeIntelUploadPage: FunctionComponent<Props> = ({
 
                             <tr>
                                 <td>
-                                    {uploadOrError.state === GQL.LSIFUploadState.ERRORED && uploadOrError.finishedAt
+                                    {uploadOrError.state === LSIFUploadState.ERRORED && uploadOrError.finishedAt
                                         ? 'Failed'
                                         : 'Finished'}{' '}
                                     processing

--- a/web/src/enterprise/codeintel/CodeIntelUploadsPage.story.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelUploadsPage.story.tsx
@@ -3,11 +3,11 @@ import { of } from 'rxjs'
 import { storiesOf } from '@storybook/react'
 import { SuiteFunction } from 'mocha'
 import { Upload } from './backend'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import * as H from 'history'
 import React from 'react'
 import webStyles from '../../SourcegraphWebApp.scss'
 import { SourcegraphContext } from '../../jscontext'
+import { LSIFUploadState } from '../../../../shared/src/graphql-operations'
 
 window.context = {} as SourcegraphContext & SuiteFunction
 
@@ -61,7 +61,7 @@ add('List', () => (
                 nodes: [
                     {
                         ...upload,
-                        state: GQL.LSIFUploadState.COMPLETED,
+                        state: LSIFUploadState.COMPLETED,
                         uploadedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: '2020-06-15T12:25:30+00:00',
                         finishedAt: '2020-06-15T12:30:30+00:00',
@@ -70,7 +70,7 @@ add('List', () => (
                     },
                     {
                         ...upload,
-                        state: GQL.LSIFUploadState.ERRORED,
+                        state: LSIFUploadState.ERRORED,
                         uploadedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: '2020-06-15T12:25:30+00:00',
                         finishedAt: '2020-06-15T12:30:30+00:00',
@@ -79,7 +79,7 @@ add('List', () => (
                     },
                     {
                         ...upload,
-                        state: GQL.LSIFUploadState.PROCESSING,
+                        state: LSIFUploadState.PROCESSING,
                         uploadedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: '2020-06-15T12:25:30+00:00',
                         finishedAt: null,
@@ -88,7 +88,7 @@ add('List', () => (
                     },
                     {
                         ...upload,
-                        state: GQL.LSIFUploadState.QUEUED,
+                        state: LSIFUploadState.QUEUED,
                         uploadedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: null,
                         finishedAt: null,
@@ -97,7 +97,7 @@ add('List', () => (
                     },
                     {
                         ...upload,
-                        state: GQL.LSIFUploadState.UPLOADING,
+                        state: LSIFUploadState.UPLOADING,
                         uploadedAt: '2020-06-15T12:20:30+00:00',
                         startedAt: null,
                         finishedAt: null,

--- a/web/src/enterprise/codeintel/CodeIntelUploadsPage.tsx
+++ b/web/src/enterprise/codeintel/CodeIntelUploadsPage.tsx
@@ -16,6 +16,7 @@ import { ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../components/alerts'
 import { Subject } from 'rxjs'
 import * as H from 'history'
+import { LSIFUploadState } from '../../../../shared/src/graphql-operations'
 
 const Header: FunctionComponent<{}> = () => (
     <thead>
@@ -94,13 +95,13 @@ const UploadNode: FunctionComponent<UploadNodeProps> = ({ node, onDelete, histor
             </td>
             <td>
                 <Link to={`./uploads/${node.id}`}>
-                    {node.state === GQL.LSIFUploadState.UPLOADING ? (
+                    {node.state === LSIFUploadState.UPLOADING ? (
                         <span>Uploading</span>
-                    ) : node.state === GQL.LSIFUploadState.PROCESSING ? (
+                    ) : node.state === LSIFUploadState.PROCESSING ? (
                         <span>Processing</span>
-                    ) : node.state === GQL.LSIFUploadState.COMPLETED ? (
+                    ) : node.state === LSIFUploadState.COMPLETED ? (
                         <span className="text-success">Completed</span>
-                    ) : node.state === GQL.LSIFUploadState.ERRORED ? (
+                    ) : node.state === LSIFUploadState.ERRORED ? (
                         <span className="text-danger">Failed to process</span>
                     ) : (
                         <span>Waiting to process (#{node.placeInQueue} in line)</span>
@@ -173,19 +174,19 @@ export const CodeIntelUploadsPage: FunctionComponent<Props> = ({
             label: 'Completed',
             id: 'completed',
             tooltip: 'Show completed uploads only',
-            args: { state: GQL.LSIFUploadState.COMPLETED },
+            args: { state: LSIFUploadState.COMPLETED },
         },
         {
             label: 'Errored',
             id: 'errored',
             tooltip: 'Show errored uploads only',
-            args: { state: GQL.LSIFUploadState.ERRORED },
+            args: { state: LSIFUploadState.ERRORED },
         },
         {
             label: 'Queued',
             id: 'queued',
             tooltip: 'Show queued uploads only',
-            args: { state: GQL.LSIFUploadState.QUEUED },
+            args: { state: LSIFUploadState.QUEUED },
         },
     ]
 

--- a/web/src/enterprise/search/stats/SearchStatsLanguages.tsx
+++ b/web/src/enterprise/search/stats/SearchStatsLanguages.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { numberWithCommas, pluralize } from '../../../../../shared/src/util/strings'
 import { buildSearchURLQuery } from '../../../../../shared/src/util/url'
+import { SearchPatternType } from '../../../graphql-operations'
 
 const OTHER_LANGUAGE = 'Other'
 const UNKNOWN_LANGUAGE = 'Unknown'
@@ -51,7 +52,7 @@ export const SearchStatsLanguages: React.FunctionComponent<Props> = ({ query, st
 
     const urlToSearchWithExtraQuery = useCallback(
         (extraQuery: string) =>
-            `/search?${buildSearchURLQuery(`${query} ${extraQuery}`, GQL.SearchPatternType.literal, false)}`,
+            `/search?${buildSearchURLQuery(`${query} ${extraQuery}`, SearchPatternType.literal, false)}`,
         [query]
     )
 

--- a/web/src/global/GlobalAlert.tsx
+++ b/web/src/global/GlobalAlert.tsx
@@ -7,6 +7,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import { DismissibleAlert } from '../components/DismissibleAlert'
 import * as H from 'history'
+import { AlertType } from '../../../shared/src/graphql-operations'
 
 /**
  * A global alert that is shown at the top of the viewport.
@@ -34,26 +35,26 @@ export const GlobalAlert: React.FunctionComponent<{ alert: GQL.IAlert; className
     return <div className={className}>{content}</div>
 }
 
-function alertIconForType(type: GQL.AlertType): React.ComponentType<{ className?: string }> {
+function alertIconForType(type: AlertType): React.ComponentType<{ className?: string }> {
     switch (type) {
-        case GQL.AlertType.INFO:
+        case AlertType.INFO:
             return InformationIcon
-        case GQL.AlertType.WARNING:
+        case AlertType.WARNING:
             return WarningIcon
-        case GQL.AlertType.ERROR:
+        case AlertType.ERROR:
             return ErrorIcon
         default:
             return WarningIcon
     }
 }
 
-function alertClassForType(type: GQL.AlertType): string {
+function alertClassForType(type: AlertType): string {
     switch (type) {
-        case GQL.AlertType.INFO:
+        case AlertType.INFO:
             return 'info'
-        case GQL.AlertType.WARNING:
+        case AlertType.WARNING:
             return 'warning'
-        case GQL.AlertType.ERROR:
+        case AlertType.ERROR:
             return 'danger'
         default:
             return 'warning'

--- a/web/src/integration/repository.test.ts
+++ b/web/src/integration/repository.test.ts
@@ -11,7 +11,7 @@ import {
 } from './graphQlResponseHelpers'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 import * as path from 'path'
-import { DiffHunkLineType } from '../../../shared/src/graphql/schema'
+import { DiffHunkLineType } from '../graphql-operations'
 
 describe('Repository', () => {
     let driver: Driver

--- a/web/src/marketing/backend.tsx
+++ b/web/src/marketing/backend.tsx
@@ -4,6 +4,7 @@ import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 import { SurveyResponse } from './SurveyPage'
+import { UserActivePeriod } from '../graphql-operations'
 
 /**
  * Submits a user satisfaction survey.
@@ -61,7 +62,7 @@ export function fetchAllSurveyResponses(args: { first?: number }): Observable<GQ
  * Fetches users, with their survey responses.
  */
 export function fetchAllUsersWithSurveyResponses(args: {
-    activePeriod?: GQL.UserActivePeriod
+    activePeriod?: UserActivePeriod
     first?: number
     query?: string
 }): Observable<GQL.IUserConnection> {

--- a/web/src/nav/GlobalNavbar.test.tsx
+++ b/web/src/nav/GlobalNavbar.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { setLinkComponent } from '../../../shared/src/components/Link'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { ThemePreference } from '../theme'
 import { GlobalNavbar } from './GlobalNavbar'
 import { createLocation, createMemoryHistory } from 'history'
 import { NOOP_SETTINGS_CASCADE } from '../../../shared/src/util/searchTestHelpers'
+import { SearchPatternType } from '../graphql-operations'
 
 const PROPS: GlobalNavbar['props'] = {
     authenticatedUser: null,
@@ -19,7 +19,7 @@ const PROPS: GlobalNavbar['props'] = {
     onThemePreferenceChange: () => undefined,
     isLightTheme: true,
     themePreference: ThemePreference.Light,
-    patternType: GQL.SearchPatternType.literal,
+    patternType: SearchPatternType.literal,
     setPatternType: () => undefined,
     caseSensitive: false,
     setCaseSensitivity: () => undefined,

--- a/web/src/nav/VersionContextDropdown.story.tsx
+++ b/web/src/nav/VersionContextDropdown.story.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 import { VersionContextDropdown, VersionContextDropdownProps } from './VersionContextDropdown'
 import webMainStyles from '../SourcegraphWebApp.scss'
 import { subtypeOf } from '../../../shared/src/util/types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import { action } from '@storybook/addon-actions'
+import { SearchPatternType } from '../graphql-operations'
 
 const { add } = storiesOf('web/VersionContextDropdown', module).addDecorator(story => (
     <>

--- a/web/src/nav/VersionContextDropdown.test.tsx
+++ b/web/src/nav/VersionContextDropdown.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { VersionContextDropdown, VersionContextDropdownProps } from './VersionContextDropdown'
 import sinon from 'sinon'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../graphql-operations'
 
 const commonProps: VersionContextDropdownProps = {
     setVersionContext: sinon.spy((_versionContext: string | undefined) => {}),

--- a/web/src/org/area/OrgInvitationPage.tsx
+++ b/web/src/org/area/OrgInvitationPage.tsx
@@ -19,6 +19,7 @@ import { OrgAvatar } from '../OrgAvatar'
 import { OrgAreaPageProps } from './OrgArea'
 import { ErrorAlert } from '../../components/alerts'
 import * as H from 'history'
+import { OrganizationInvitationResponseType } from '../../../../shared/src/graphql-operations'
 
 interface Props extends OrgAreaPageProps {
     authenticatedUser: AuthenticatedUser
@@ -43,7 +44,7 @@ export const OrgInvitationPage = withAuthenticatedUser(
         public state: State = {}
 
         private componentUpdates = new Subject<Props>()
-        private responses = new Subject<GQL.OrganizationInvitationResponseType>()
+        private responses = new Subject<OrganizationInvitationResponseType>()
         private subscriptions = new Subscription()
 
         public componentDidMount(): void {
@@ -179,12 +180,12 @@ export const OrgInvitationPage = withAuthenticatedUser(
 
         private onAcceptInvitation: React.MouseEventHandler<HTMLButtonElement> = event => {
             event.preventDefault()
-            this.responses.next(GQL.OrganizationInvitationResponseType.ACCEPT)
+            this.responses.next(OrganizationInvitationResponseType.ACCEPT)
         }
 
         private onDeclineInvitation: React.MouseEventHandler<HTMLButtonElement> = event => {
             event.preventDefault()
-            this.responses.next(GQL.OrganizationInvitationResponseType.REJECT)
+            this.responses.next(OrganizationInvitationResponseType.REJECT)
         }
 
         private respondToOrganizationInvitation = (

--- a/web/src/repo/GitReference.tsx
+++ b/web/src/repo/GitReference.tsx
@@ -9,6 +9,7 @@ import { memoizeObservable } from '../../../shared/src/util/memoizeObservable'
 import { numberWithCommas } from '../../../shared/src/util/strings'
 import { queryGraphQL } from '../backend/graphql'
 import { Timestamp } from '../components/time/Timestamp'
+import { GitRefType } from '../graphql-operations'
 
 interface GitReferenceNodeProps {
     node: GQL.IGitRef
@@ -96,7 +97,7 @@ export const queryGitReferences = memoizeObservable(
         repo: GQL.ID
         first?: number
         query?: string
-        type: GQL.GitRefType
+        type: GitRefType
         withBehindAhead?: boolean
     }): Observable<GQL.IGitRefConnection> =>
         queryGraphQL(
@@ -127,7 +128,7 @@ export const queryGitReferences = memoizeObservable(
             {
                 ...args,
                 withBehindAhead:
-                    args.withBehindAhead !== undefined ? args.withBehindAhead : args.type === GQL.GitRefType.GIT_BRANCH,
+                    args.withBehindAhead !== undefined ? args.withBehindAhead : args.type === GitRefType.GIT_BRANCH,
             }
         ).pipe(
             map(({ data, errors }) => {

--- a/web/src/repo/RevisionsPopover.tsx
+++ b/web/src/repo/RevisionsPopover.tsx
@@ -14,6 +14,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { replaceRevisionInURL } from '../util/url'
 import { GitReferenceNode, queryGitReferences } from './GitReference'
 import { RevisionSpec } from '../../../shared/src/util/url'
+import { GitRefType } from '../../../shared/src/graphql-operations'
 
 const fetchRepositoryCommits = memoizeObservable(
     (args: RevisionSpec & { repo: GQL.ID; first?: number; query?: string }): Observable<GQL.IGitCommitConnection> =>
@@ -157,7 +158,7 @@ interface RevisionsPopoverTab {
     label: string
     noun: string
     pluralNoun: string
-    type?: GQL.GitRefType
+    type?: GitRefType
 }
 
 /**
@@ -168,8 +169,8 @@ export class RevisionsPopover extends React.PureComponent<Props> {
     private static LAST_TAB_STORAGE_KEY = 'RevisionsPopover.lastTab'
 
     private static TABS: RevisionsPopoverTab[] = [
-        { id: 'branches', label: 'Branches', noun: 'branch', pluralNoun: 'branches', type: GQL.GitRefType.GIT_BRANCH },
-        { id: 'tags', label: 'Tags', noun: 'tag', pluralNoun: 'tags', type: GQL.GitRefType.GIT_TAG },
+        { id: 'branches', label: 'Branches', noun: 'branch', pluralNoun: 'branches', type: GitRefType.GIT_BRANCH },
+        { id: 'tags', label: 'Tags', noun: 'tag', pluralNoun: 'tags', type: GitRefType.GIT_TAG },
         { id: 'commits', label: 'Commits', noun: 'commit', pluralNoun: 'commits' },
     ]
 
@@ -195,7 +196,7 @@ export class RevisionsPopover extends React.PureComponent<Props> {
                                 noun={tab.noun}
                                 pluralNoun={tab.pluralNoun}
                                 queryConnection={
-                                    tab.type === GQL.GitRefType.GIT_BRANCH ? this.queryGitBranches : this.queryGitTags
+                                    tab.type === GitRefType.GIT_BRANCH ? this.queryGitBranches : this.queryGitTags
                                 }
                                 nodeComponent={GitReferencePopoverNode}
                                 nodeComponentProps={{
@@ -238,10 +239,10 @@ export class RevisionsPopover extends React.PureComponent<Props> {
     }
 
     private queryGitBranches = (args: FilteredConnectionQueryArgs): Observable<GQL.IGitRefConnection> =>
-        queryGitReferences({ ...args, repo: this.props.repo, type: GQL.GitRefType.GIT_BRANCH, withBehindAhead: false })
+        queryGitReferences({ ...args, repo: this.props.repo, type: GitRefType.GIT_BRANCH, withBehindAhead: false })
 
     private queryGitTags = (args: FilteredConnectionQueryArgs): Observable<GQL.IGitRefConnection> =>
-        queryGitReferences({ ...args, repo: this.props.repo, type: GQL.GitRefType.GIT_TAG, withBehindAhead: false })
+        queryGitReferences({ ...args, repo: this.props.repo, type: GitRefType.GIT_TAG, withBehindAhead: false })
 
     private queryRepositoryCommits = (args: FilteredConnectionQueryArgs): Observable<GQL.IGitCommitConnection> =>
         fetchRepositoryCommits({

--- a/web/src/repo/branches/RepositoryBranchesAllPage.tsx
+++ b/web/src/repo/branches/RepositoryBranchesAllPage.tsx
@@ -7,6 +7,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { GitReferenceNode, queryGitReferences } from '../GitReference'
 import { RepositoryBranchesAreaPageProps } from './RepositoryBranchesArea'
 import { Observable } from 'rxjs'
+import { GitRefType } from '../../graphql-operations'
 
 interface Props extends RepositoryBranchesAreaPageProps, RouteComponentProps<{}> {}
 
@@ -37,5 +38,5 @@ export class RepositoryBranchesAllPage extends React.PureComponent<Props> {
     }
 
     private queryBranches = (args: FilteredConnectionQueryArgs): Observable<GQL.IGitRefConnection> =>
-        queryGitReferences({ ...args, repo: this.props.repo.id, type: GQL.GitRefType.GIT_BRANCH })
+        queryGitReferences({ ...args, repo: this.props.repo.id, type: GitRefType.GIT_BRANCH })
 }

--- a/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
+++ b/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
@@ -7,6 +7,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { GitReferenceNode, queryGitReferences as queryGitReferencesFromBackend } from '../GitReference'
 import { RepositoryReleasesAreaPageProps } from './RepositoryReleasesArea'
 import { Observable } from 'rxjs'
+import { GitRefType } from '../../graphql-operations'
 
 interface Props extends RepositoryReleasesAreaPageProps {
     history: H.History
@@ -15,7 +16,7 @@ interface Props extends RepositoryReleasesAreaPageProps {
         repo: GQL.ID
         first?: number
         query?: string
-        type: GQL.GitRefType
+        type: GitRefType
         withBehindAhead?: boolean
     }) => Observable<GQL.IGitRefConnection>
 }
@@ -33,7 +34,7 @@ export const RepositoryReleasesTagsPage: React.FunctionComponent<Props> = ({
 
     const queryTags = useCallback(
         (args: FilteredConnectionQueryArgs): Observable<GQL.IGitRefConnection> =>
-            queryGitReferences({ ...args, repo: repo.id, type: GQL.GitRefType.GIT_TAG }),
+            queryGitReferences({ ...args, repo: repo.id, type: GitRefType.GIT_TAG }),
         [repo.id, queryGitReferences]
     )
 

--- a/web/src/repogroups/Android.tsx
+++ b/web/src/repogroups/Android.tsx
@@ -1,6 +1,6 @@
 import { RepogroupMetadata } from './types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import * as React from 'react'
+import { SearchPatternType } from '../graphql-operations'
 
 export const android: RepogroupMetadata = {
     title: 'Android',

--- a/web/src/repogroups/Golang.tsx
+++ b/web/src/repogroups/Golang.tsx
@@ -1,6 +1,6 @@
 import { RepogroupMetadata } from './types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import * as React from 'react'
+import { SearchPatternType } from '../graphql-operations'
 
 export const golang: RepogroupMetadata = {
     title: 'Go',

--- a/web/src/repogroups/Kubernetes.tsx
+++ b/web/src/repogroups/Kubernetes.tsx
@@ -1,6 +1,6 @@
 import { RepogroupMetadata } from './types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import * as React from 'react'
+import { SearchPatternType } from '../graphql-operations'
 
 export const kubernetes: RepogroupMetadata = {
     title: 'Kubernetes',

--- a/web/src/repogroups/Python2To3.tsx
+++ b/web/src/repogroups/Python2To3.tsx
@@ -1,6 +1,6 @@
 import { RepogroupMetadata } from './types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import * as React from 'react'
+import { SearchPatternType } from '../graphql-operations'
 
 export const python2To3Metadata: RepogroupMetadata = {
     title: 'Refactor Python 2 to 3',

--- a/web/src/repogroups/ReactHooks.tsx
+++ b/web/src/repogroups/ReactHooks.tsx
@@ -1,6 +1,6 @@
 import { RepogroupMetadata } from './types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import * as React from 'react'
+import { SearchPatternType } from '../../../shared/src/graphql-operations'
 export const reactHooks: RepogroupMetadata = {
     title: 'React Hooks',
     name: 'react-hooks',

--- a/web/src/repogroups/RepogroupPage.story.tsx
+++ b/web/src/repogroups/RepogroupPage.story.tsx
@@ -15,6 +15,7 @@ import { Services } from '../../../shared/src/api/client/services'
 import { MemoryRouter } from 'react-router'
 import webStyles from '../SourcegraphWebApp.scss'
 import { AuthenticatedUser } from '../auth'
+import { SearchPatternType } from '../graphql-operations'
 
 const { add } = storiesOf('web/RepogroupPage', module)
     .addParameters({
@@ -83,7 +84,7 @@ const commonProps: RepogroupPageProps = {
     isLightTheme: true,
     themePreference: ThemePreference.Light,
     onThemePreferenceChange: sinon.spy(() => {}),
-    patternType: GQL.SearchPatternType.literal,
+    patternType: SearchPatternType.literal,
     setPatternType: sinon.spy(() => {}),
     caseSensitive: false,
     copyQueryButton: false,

--- a/web/src/repogroups/RepogroupPage.tsx
+++ b/web/src/repogroups/RepogroupPage.tsx
@@ -20,7 +20,6 @@ import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { VersionContextProps } from '../../../shared/src/search/util'
 import { VersionContext } from '../schema/site.schema'
 import { submitSearch } from '../search/helpers'
-import * as GQL from '../../../shared/src/graphql/schema'
 import SourceRepositoryMultipleIcon from 'mdi-react/SourceRepositoryMultipleIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
 import GitlabIcon from 'mdi-react/GitlabIcon'
@@ -30,6 +29,7 @@ import { SearchPageInput } from '../search/input/SearchPageInput'
 import { displayRepoName } from '../../../shared/src/components/RepoFileLink'
 import { PrivateCodeCta } from '../search/input/PrivateCodeCta'
 import { AuthenticatedUser } from '../auth'
+import { SearchPatternType } from '../graphql-operations'
 
 export interface RepogroupPageProps
     extends SettingsCascadeProps<Settings>,
@@ -82,7 +82,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
     // Find the repositories for this specific repogroup.
     const repogroupRepoList = repogroups?.[props.repogroupMetadata.name]
 
-    const onSubmitExample = (query: string, patternType: GQL.SearchPatternType) => (
+    const onSubmitExample = (query: string, patternType: SearchPatternType) => (
         event?: React.MouseEvent<HTMLButtonElement>
     ): void => {
         eventLogger.log('RepositoryGroupSuggestionClicked')

--- a/web/src/repogroups/Stanford.tsx
+++ b/web/src/repogroups/Stanford.tsx
@@ -1,6 +1,6 @@
 import { RepogroupMetadata } from './types'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import * as React from 'react'
+import { SearchPatternType } from '../graphql-operations'
 
 export const stanford: RepogroupMetadata = {
     title: 'Stanford University',

--- a/web/src/repogroups/types.ts
+++ b/web/src/repogroups/types.ts
@@ -1,4 +1,4 @@
-import * as GQL from '../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../graphql-operations'
 
 export interface ExampleQuery {
     title: string
@@ -7,7 +7,7 @@ export interface ExampleQuery {
     exampleQuery: JSX.Element
     /** The raw query string. */
     rawQuery: string
-    patternType: GQL.SearchPatternType
+    patternType: SearchPatternType
 }
 
 export interface RepogroupMetadata {

--- a/web/src/search/ScopePage.test.tsx
+++ b/web/src/search/ScopePage.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router'
 import renderer from 'react-test-renderer'
 import { ScopePage } from './ScopePage'
 import * as H from 'history'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../graphql-operations'
 
 jest.mock('./input/QueryInput', () => ({ QueryInput: 'QueryInput' }))
 jest.mock('./input/SearchButton', () => ({ SearchButton: 'SearchButton' }))

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -10,11 +10,12 @@ import { Remote } from 'comlink'
 import { FlatExtHostAPI } from '../../../shared/src/api/contract'
 import { wrapRemoteObservable } from '../../../shared/src/api/client/api/common'
 import { DeployType } from '../jscontext'
+import { SearchPatternType } from '../graphql-operations'
 
 export function search(
     query: string,
     version: string,
-    patternType: GQL.SearchPatternType,
+    patternType: SearchPatternType,
     versionContext: string | undefined,
     extensionHostPromise: Promise<Remote<FlatExtHostAPI>>
 ): Observable<GQL.ISearchResults | ErrorLike> {

--- a/web/src/search/index.test.tsx
+++ b/web/src/search/index.test.tsx
@@ -1,5 +1,5 @@
 import { parseSearchURL, resolveVersionContext } from '.'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../graphql-operations'
 
 describe('search/index', () => {
     test('parseSearchURL', () => {

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -1,10 +1,10 @@
 import { escapeRegExp } from 'lodash'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import { FiltersToTypeAndValue } from '../../../shared/src/search/interactive/util'
 import { parseCaseSensitivityFromQuery, parsePatternTypeFromQuery } from '../../../shared/src/util/url'
 import { replaceRange } from '../../../shared/src/util/strings'
 import { discreteValueAliases } from '../../../shared/src/search/parser/filters'
 import { VersionContext } from '../schema/site.schema'
+import { SearchPatternType } from '../../../shared/src/graphql-operations'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it

--- a/web/src/search/input/LazyMonacoQueryInput.test.tsx
+++ b/web/src/search/input/LazyMonacoQueryInput.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { noop } from 'lodash'
 import { PlainQueryInput } from './LazyMonacoQueryInput'
 import { createMemoryHistory } from 'history'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 describe('PlainQueryInput', () => {
     const history = createMemoryHistory()

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -12,13 +12,13 @@ import { Omit } from 'utility-types'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { CaseSensitivityProps, PatternTypeProps, CopyQueryButtonProps } from '..'
 import { Toggles, TogglesProps } from './toggles/Toggles'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 import { hasProperty, isDefined } from '../../../../shared/src/util/types'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import { observeResize } from '../../util/dom'
 import Shepherd from 'shepherd.js'
 import { CallbackToAdvanceTourStep } from './SearchOnboardingTour'
+import { SearchPatternType } from '../../graphql-operations'
 
 export interface MonacoQueryInputProps
     extends Omit<TogglesProps, 'navbarSearchQuery' | 'filtersInQuery'>,

--- a/web/src/search/input/SearchOnboardingTour.ts
+++ b/web/src/search/input/SearchOnboardingTour.ts
@@ -2,8 +2,8 @@
  * This file contains utility functions for the search onboarding tour.
  */
 import Shepherd from 'shepherd.js'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
 import { eventLogger } from '../../tracking/eventLogger'
+import { SearchPatternType } from '../../graphql-operations'
 
 export const HAS_CANCELLED_TOUR_KEY = 'has-cancelled-onboarding-tour'
 export const HAS_SEEN_TOUR_KEY = 'has-seen-onboarding-tour'

--- a/web/src/search/input/SearchScopes.test.tsx
+++ b/web/src/search/input/SearchScopes.test.tsx
@@ -3,14 +3,14 @@ import renderer from 'react-test-renderer'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 import { SearchScopes } from './SearchScopes'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { Settings } from '../../schema/settings.schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 const BASE_PROPS = {
     authenticatedUser: {},
     history: createMemoryHistory(),
     query: 'abc',
-    patternType: GQL.SearchPatternType.literal,
+    patternType: SearchPatternType.literal,
     versionContext: undefined,
 }
 

--- a/web/src/search/input/Suggestion.tsx
+++ b/web/src/search/input/Suggestion.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { LanguageIcon } from '../../../../shared/src/components/languageIcons'
 import { dirname, basename } from '../../util/path'
 import FilterIcon from 'mdi-react/FilterIcon'
@@ -11,6 +10,7 @@ import { escapeRegExp } from 'lodash'
 import { FilterType } from '../../../../shared/src/search/interactive/util'
 import { SearchSuggestion } from '../../../../shared/src/search/suggestions'
 import { appendSubtreeQueryParameter } from '../../../../shared/src/util/url'
+import { SymbolKind } from '../../../../shared/src/graphql-operations'
 
 export const filterAliases: Record<string, FilterSuggestionTypes> = {
     r: FilterType.repo,
@@ -58,7 +58,7 @@ export interface Suggestion {
     /** Label informing what will happen when suggestion is selected */
     label?: string
     /** For suggestions of type `symbol` */
-    symbolKind?: GQL.SymbolKind
+    symbolKind?: SymbolKind
     /** If the suggestion was loaded from the fuzzy-search */
     fromFuzzySearch?: true
 }

--- a/web/src/search/input/toggles/Toggles.tsx
+++ b/web/src/search/input/toggles/Toggles.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import FormatLetterCaseIcon from 'mdi-react/FormatLetterCaseIcon'
 import { PatternTypeProps, CaseSensitivityProps, InteractiveSearchProps, CopyQueryButtonProps } from '../..'
 import { SettingsCascadeProps } from '../../../../../shared/src/settings/settings'
-import { SearchPatternType } from '../../../../../shared/src/graphql/schema'
 import { isEmpty } from 'lodash'
 import { submitSearch } from '../../helpers'
 import { QueryInputToggle } from './QueryInputToggle'
@@ -14,6 +13,7 @@ import CodeBracketsIcon from 'mdi-react/CodeBracketsIcon'
 import { generateFiltersQuery } from '../../../../../shared/src/util/url'
 import { CopyQueryButton } from './CopyQueryButton'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
+import { SearchPatternType } from '../../../graphql-operations'
 
 export interface TogglesProps
     extends PatternTypeProps,

--- a/web/src/search/queryBuilder/QueryBuilder.test.tsx
+++ b/web/src/search/queryBuilder/QueryBuilder.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { cleanup, fireEvent, getByDisplayValue, queryByTestId, render, waitFor } from '@testing-library/react'
 import sinon from 'sinon'
 import { QueryBuilder } from './QueryBuilder'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 describe('QueryBuilder', () => {
     afterAll(cleanup)

--- a/web/src/search/queryBuilder/QueryBuilder.tsx
+++ b/web/src/search/queryBuilder/QueryBuilder.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { InfoDropdown } from '../input/InfoDropdown'
 import { QueryBuilderInputRow } from './QueryBuilderInputRow'
 import { PatternTypeProps } from '..'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 export interface QueryBuilderProps extends Pick<PatternTypeProps, 'patternType'> {
     /**

--- a/web/src/search/queryBuilder/QueryBuilderPage.test.tsx
+++ b/web/src/search/queryBuilder/QueryBuilderPage.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { createRenderer } from 'react-test-renderer/shallow'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { QueryBuilderPage } from './QueryBuilderPage'
+import { SearchPatternType } from '../../graphql-operations'
 
 describe('QueryBuilderPage', () => {
     test('simple', () =>
         expect(
             createRenderer().render(
-                <QueryBuilderPage patternType={GQL.SearchPatternType.literal} versionContext={undefined} />
+                <QueryBuilderPage patternType={SearchPatternType.literal} versionContext={undefined} />
             )
         ).toMatchSnapshot())
 })

--- a/web/src/search/results/SearchResults.test.tsx
+++ b/web/src/search/results/SearchResults.test.tsx
@@ -11,7 +11,7 @@ import {
     OBSERVABLE_SEARCH_REQUEST,
 } from '../../../../shared/src/util/searchTestHelpers'
 import { SearchResults, SearchResultsProps } from './SearchResults'
-import { SearchPatternType } from '../../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../../graphql-operations'
 
 describe('SearchResults', () => {
     afterAll(cleanup)

--- a/web/src/search/results/SearchResults.tsx
+++ b/web/src/search/results/SearchResults.tsx
@@ -38,6 +38,7 @@ import { Remote } from 'comlink'
 import { FlatExtHostAPI } from '../../../../shared/src/api/contract'
 import { DeployType } from '../../jscontext'
 import { AuthenticatedUser } from '../../auth'
+import { SearchPatternType } from '../../../../shared/src/graphql-operations'
 
 export interface SearchResultsProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
@@ -58,7 +59,7 @@ export interface SearchResultsProps
     searchRequest: (
         query: string,
         version: string,
-        patternType: GQL.SearchPatternType,
+        patternType: SearchPatternType,
         versionContext: string | undefined,
         extensionHostPromise: Promise<Remote<FlatExtHostAPI>>
     ) => Observable<GQL.ISearchResults | ErrorLike>
@@ -119,7 +120,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                 '/search?' +
                 buildSearchURLQuery(
                     query,
-                    GQL.SearchPatternType.regexp,
+                    SearchPatternType.regexp,
                     this.props.caseSensitive,
                     this.props.versionContext
                 )
@@ -140,7 +141,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                             queryAndPatternTypeAndCase
                         ): queryAndPatternTypeAndCase is {
                             query: string
-                            patternType: GQL.SearchPatternType
+                            patternType: SearchPatternType
                             caseSensitive: boolean
                             versionContext: string | undefined
                         } => !!queryAndPatternTypeAndCase.query && !!queryAndPatternTypeAndCase.patternType

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -21,6 +21,7 @@ import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 import { PatternTypeProps } from '..'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import { AuthenticatedUser } from '../../auth'
+import { SearchPatternType } from '../../graphql-operations'
 
 interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,
@@ -60,7 +61,7 @@ interface SearchResultsInfoBarProps
  * informs them that this may be the case to avoid confusion.
  */
 const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInfoBarProps> = props =>
-    props.patternType === GQL.SearchPatternType.literal && props.query && props.query.includes('"') ? (
+    props.patternType === SearchPatternType.literal && props.query && props.query.includes('"') ? (
         <div
             className={`search-results-info-bar__notice${
                 props.results.results.length === 0 ? ' search-results-info-bar__notice--no-results' : ''

--- a/web/src/search/results/SearchResultsList.test.tsx
+++ b/web/src/search/results/SearchResultsList.test.tsx
@@ -17,6 +17,7 @@ import {
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
 import { NEVER } from 'rxjs'
 import { FiltersToTypeAndValue, FilterType } from '../../../../shared/src/search/interactive/util'
+import { SearchPatternType } from '../../../../shared/src/graphql-operations'
 
 let VISIBILITY_CHANGED_CALLBACKS: ((isVisible: boolean) => void)[] = []
 
@@ -113,7 +114,7 @@ describe('SearchResultsList', () => {
         extensionsController: { executeCommand: sinon.spy(), services: extensionsController.services },
         platformContext: { forceUpdateTooltip: sinon.spy(), settings: NEVER },
         telemetryService: NOOP_TELEMETRY_SERVICE,
-        patternType: GQL.SearchPatternType.regexp,
+        patternType: SearchPatternType.regexp,
         setPatternType: sinon.spy(),
         caseSensitive: false,
         setCaseSensitivity: sinon.spy(),

--- a/web/src/site-admin/SiteAdminExternalServiceForm.test.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceForm.test.tsx
@@ -6,9 +6,9 @@ import * as H from 'history'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { noop } from 'rxjs'
-import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { SiteAdminExternalServiceForm } from './SiteAdminExternalServiceForm'
 import { NOOP_TELEMETRY_SERVICE } from '../../../shared/src/telemetry/telemetryService'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 describe('<SiteAdminExternalServiceForm />', () => {
     const baseProps = {

--- a/web/src/site-admin/SiteAdminExternalServicePage.tsx
+++ b/web/src/site-admin/SiteAdminExternalServicePage.tsx
@@ -18,6 +18,7 @@ import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 import { gql, dataOrThrowErrors } from '../../../shared/src/graphql/graphql'
 import { SiteAdminExternalServiceWebhook } from './SiteAdminExternalServiceWebhook'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 type ExternalService = Pick<GQL.IExternalService, 'id' | 'kind' | 'displayName' | 'config' | 'warning' | 'webhookURL'>
 
@@ -112,10 +113,7 @@ export const SiteAdminExternalServicePage: React.FunctionComponent<Props> = ({
         undefined
 
     let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
-    if (
-        externalService &&
-        [GQL.ExternalServiceKind.GITHUB, GQL.ExternalServiceKind.GITLAB].includes(externalService.kind)
-    ) {
+    if (externalService && [ExternalServiceKind.GITHUB, ExternalServiceKind.GITLAB].includes(externalService.kind)) {
         const parsedConfig: unknown = parseJSONC(externalService.config)
         const url =
             typeof parsedConfig === 'object' &&
@@ -125,11 +123,11 @@ export const SiteAdminExternalServicePage: React.FunctionComponent<Props> = ({
                 ? new URL(parsedConfig.url)
                 : undefined
         // We have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the URL.
-        if (externalService.kind === GQL.ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
+        if (externalService.kind === ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
             externalServiceCategory = codeHostExternalServices.ghe
         }
         // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
-        if (externalService.kind === GQL.ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
+        if (externalService.kind === ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
             externalServiceCategory = codeHostExternalServices.gitlab
         }
     }

--- a/web/src/site-admin/SiteAdminExternalServiceWebhook.tsx
+++ b/web/src/site-admin/SiteAdminExternalServiceWebhook.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { CopyableText } from '../components/CopyableText'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 interface Props {
     externalService: Pick<GQL.IExternalService, 'kind' | 'webhookURL'>
@@ -16,7 +17,7 @@ export const SiteAdminExternalServiceWebhook: React.FunctionComponent<Props> = p
     let description = <p />
 
     switch (kind) {
-        case GQL.ExternalServiceKind.BITBUCKETSERVER:
+        case ExternalServiceKind.BITBUCKETSERVER:
             description = (
                 <p>
                     <a
@@ -42,11 +43,11 @@ export const SiteAdminExternalServiceWebhook: React.FunctionComponent<Props> = p
             )
             break
 
-        case GQL.ExternalServiceKind.GITHUB:
+        case ExternalServiceKind.GITHUB:
             description = commonDescription('github')
             break
 
-        case GQL.ExternalServiceKind.GITLAB:
+        case ExternalServiceKind.GITLAB:
             description = commonDescription('gitlab')
             break
     }

--- a/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -13,12 +13,12 @@ import phabricatorSchemaJSON from '../../../schema/phabricator.schema.json'
 import settingsSchemaJSON from '../../../schema/settings.schema.json'
 import siteSchemaJSON from '../../../schema/site.schema.json'
 import { PageTitle } from '../components/PageTitle'
-import { ExternalServiceKind } from '../../../shared/src/graphql/schema'
 import { useObservable } from '../../../shared/src/util/useObservable'
 import { mapValues, values } from 'lodash'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { ThemeProps } from '../../../shared/src/theme'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 /**
  * Minimal shape of a JSON Schema. These values are treated as opaque, so more specific types are

--- a/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -12,6 +12,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { fetchSiteUsageStatistics, fetchUserUsageStatistics } from './backend'
 import { ErrorAlert } from '../components/alerts'
 import FileDownloadIcon from 'mdi-react/FileDownloadIcon'
+import { UserActivePeriod } from '../../../shared/src/graphql-operations'
 
 interface ChartData {
     label: string
@@ -160,25 +161,25 @@ export const USER_ACTIVITY_FILTERS: FilteredConnectionFilter[] = [
         label: 'All users',
         id: 'all',
         tooltip: 'Show all users',
-        args: { activePeriod: GQL.UserActivePeriod.ALL_TIME },
+        args: { activePeriod: UserActivePeriod.ALL_TIME },
     },
     {
         label: 'Active today',
         id: 'today',
         tooltip: 'Show users active since this morning at 00:00 UTC',
-        args: { activePeriod: GQL.UserActivePeriod.TODAY },
+        args: { activePeriod: UserActivePeriod.TODAY },
     },
     {
         label: 'Active this week',
         id: 'week',
         tooltip: 'Show users active since Monday at 00:00 UTC',
-        args: { activePeriod: GQL.UserActivePeriod.THIS_WEEK },
+        args: { activePeriod: UserActivePeriod.THIS_WEEK },
     },
     {
         label: 'Active this month',
         id: 'month',
         tooltip: 'Show users active since the first day of the month at 00:00 UTC',
-        args: { activePeriod: GQL.UserActivePeriod.THIS_MONTH },
+        args: { activePeriod: UserActivePeriod.THIS_MONTH },
     },
 ]
 

--- a/web/src/site-admin/backend.tsx
+++ b/web/src/site-admin/backend.tsx
@@ -14,7 +14,7 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { resetAllMemoizationCaches } from '../../../shared/src/util/memoizeObservable'
 import { mutateGraphQL, queryGraphQL } from '../backend/graphql'
 import { Settings } from '../../../shared/src/settings/settings'
-import { RepositoriesVariables, RepositoriesResult } from '../graphql-operations'
+import { RepositoriesVariables, RepositoriesResult, ExternalServiceKind, UserActivePeriod } from '../graphql-operations'
 
 /**
  * Fetches all users.
@@ -251,7 +251,7 @@ export function scheduleUserPermissionsSync(args: { user: GQL.ID }): Observable<
  * @returns Observable that emits the list of users and their usage data
  */
 export function fetchUserUsageStatistics(args: {
-    activePeriod?: GQL.UserActivePeriod
+    activePeriod?: UserActivePeriod
     query?: string
     first?: number
 }): Observable<GQL.IUserConnection> {
@@ -356,7 +356,7 @@ type SettingsSubject = Pick<GQL.SettingsSubject, 'settingsURL' | '__typename'> &
  */
 interface AllConfig {
     site: GQL.ISiteConfiguration
-    externalServices: Partial<Record<GQL.ExternalServiceKind, ExternalServiceConfig>>
+    externalServices: Partial<Record<ExternalServiceKind, ExternalServiceConfig>>
     settings: {
         subjects: SettingsSubject[]
         final: Settings | null
@@ -418,12 +418,12 @@ export function fetchAllConfigAndSettings(): Observable<AllConfig> {
         map(dataOrThrowErrors),
         map(data => {
             const externalServices: Partial<Record<
-                GQL.ExternalServiceKind,
+                ExternalServiceKind,
                 ExternalServiceConfig[]
             >> = data.externalServices.nodes
                 .filter(svc => svc.config)
                 .map(svc => [svc.kind, parseJSONC(svc.config) as ExternalServiceConfig] as const)
-                .reduce<Partial<{ [k in GQL.ExternalServiceKind]: ExternalServiceConfig[] }>>(
+                .reduce<Partial<{ [k in ExternalServiceKind]: ExternalServiceConfig[] }>>(
                     (externalServicesByKind, [kind, config]) => {
                         let services = externalServicesByKind[kind]
                         if (!services) {

--- a/web/src/site-admin/externalServices.tsx
+++ b/web/src/site-admin/externalServices.tsx
@@ -15,14 +15,14 @@ import gitoliteSchemaJSON from '../../../schema/gitolite.schema.json'
 import otherExternalServiceSchemaJSON from '../../../schema/other_external_service.schema.json'
 import phabricatorSchemaJSON from '../../../schema/phabricator.schema.json'
 import { PhabricatorIcon } from '../../../shared/src/components/icons'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { EditorAction } from './configHelpers'
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
 
 /**
  * Metadata associated with adding a given external service.
  */
 export interface AddExternalServiceOptions {
-    kind: GQL.ExternalServiceKind
+    kind: ExternalServiceKind
 
     /**
      * Title to show in the external service "button"
@@ -496,7 +496,7 @@ const gitlabEditorActions = (isSelfManaged: boolean): EditorAction[] => [
 ]
 
 const GITHUB_DOTCOM: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.GITHUB,
+    kind: ExternalServiceKind.GITHUB,
     title: 'GitHub.com',
     icon: GithubIcon,
     jsonSchema: githubSchemaJSON,
@@ -521,7 +521,7 @@ const GITHUB_ENTERPRISE: AddExternalServiceOptions = {
     instructions: githubInstructions(true),
 }
 const AWS_CODE_COMMIT: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.AWSCODECOMMIT,
+    kind: ExternalServiceKind.AWSCODECOMMIT,
     title: 'AWS CodeCommit repositories',
     icon: AmazonIcon,
     jsonSchema: awsCodeCommitSchemaJSON,
@@ -641,7 +641,7 @@ const AWS_CODE_COMMIT: AddExternalServiceOptions = {
     ],
 }
 const BITBUCKET_CLOUD: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.BITBUCKETCLOUD,
+    kind: ExternalServiceKind.BITBUCKETCLOUD,
     title: 'Bitbucket.org',
     icon: BitbucketIcon,
     jsonSchema: bitbucketCloudSchemaJSON,
@@ -720,7 +720,7 @@ const BITBUCKET_CLOUD: AddExternalServiceOptions = {
     ),
 }
 const BITBUCKET_SERVER: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.BITBUCKETSERVER,
+    kind: ExternalServiceKind.BITBUCKETSERVER,
     title: 'Bitbucket Server',
     icon: BitbucketIcon,
     jsonSchema: bitbucketServerSchemaJSON,
@@ -883,7 +883,7 @@ const BITBUCKET_SERVER: AddExternalServiceOptions = {
     ],
 }
 const GITLAB_DOTCOM: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.GITLAB,
+    kind: ExternalServiceKind.GITLAB,
     title: 'GitLab.com',
     icon: GitLabIcon,
     jsonSchema: gitlabSchemaJSON,
@@ -912,7 +912,7 @@ const GITLAB_SELF_MANAGED: AddExternalServiceOptions = {
 }`,
 }
 const SRC_SERVE_GIT: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.OTHER,
+    kind: ExternalServiceKind.OTHER,
     title: 'Sourcegraph CLI Serve-Git',
     icon: GitIcon,
     jsonSchema: otherExternalServiceSchemaJSON,
@@ -952,7 +952,7 @@ const SRC_SERVE_GIT: AddExternalServiceOptions = {
     ],
 }
 const GITOLITE: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.GITOLITE,
+    kind: ExternalServiceKind.GITOLITE,
     title: 'Gitolite',
     icon: GitIcon,
     jsonSchema: gitoliteSchemaJSON,
@@ -1008,7 +1008,7 @@ const GITOLITE: AddExternalServiceOptions = {
     ],
 }
 const PHABRICATOR_SERVICE: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.PHABRICATOR,
+    kind: ExternalServiceKind.PHABRICATOR,
     title: 'Phabricator connection',
     icon: PhabricatorIcon,
     shortDescription:
@@ -1058,7 +1058,7 @@ const PHABRICATOR_SERVICE: AddExternalServiceOptions = {
     ],
 }
 const GENERIC_GIT: AddExternalServiceOptions = {
-    kind: GQL.ExternalServiceKind.OTHER,
+    kind: ExternalServiceKind.OTHER,
     title: 'Generic Git host',
     icon: GitIcon,
     jsonSchema: otherExternalServiceSchemaJSON,
@@ -1135,13 +1135,13 @@ export const allExternalServices = {
     ...nonCodeHostExternalServices,
 }
 
-export const defaultExternalServices: Record<GQL.ExternalServiceKind, AddExternalServiceOptions> = {
-    [GQL.ExternalServiceKind.GITHUB]: GITHUB_DOTCOM,
-    [GQL.ExternalServiceKind.BITBUCKETCLOUD]: BITBUCKET_CLOUD,
-    [GQL.ExternalServiceKind.BITBUCKETSERVER]: BITBUCKET_SERVER,
-    [GQL.ExternalServiceKind.GITLAB]: GITLAB_DOTCOM,
-    [GQL.ExternalServiceKind.GITOLITE]: GITOLITE,
-    [GQL.ExternalServiceKind.PHABRICATOR]: PHABRICATOR_SERVICE,
-    [GQL.ExternalServiceKind.OTHER]: GENERIC_GIT,
-    [GQL.ExternalServiceKind.AWSCODECOMMIT]: AWS_CODE_COMMIT,
+export const defaultExternalServices: Record<ExternalServiceKind, AddExternalServiceOptions> = {
+    [ExternalServiceKind.GITHUB]: GITHUB_DOTCOM,
+    [ExternalServiceKind.BITBUCKETCLOUD]: BITBUCKET_CLOUD,
+    [ExternalServiceKind.BITBUCKETSERVER]: BITBUCKET_SERVER,
+    [ExternalServiceKind.GITLAB]: GITLAB_DOTCOM,
+    [ExternalServiceKind.GITOLITE]: GITOLITE,
+    [ExternalServiceKind.PHABRICATOR]: PHABRICATOR_SERVICE,
+    [ExternalServiceKind.OTHER]: GENERIC_GIT,
+    [ExternalServiceKind.AWSCODECOMMIT]: AWS_CODE_COMMIT,
 }

--- a/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/web/src/tracking/services/serverAdminWrapper.tsx
@@ -1,6 +1,6 @@
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { authenticatedUser } from '../../auth'
 import { logUserEvent, logEvent } from '../../user/settings/backend'
+import { UserEvent } from '../../../../shared/src/graphql-operations'
 
 class ServerAdminWrapper {
     /**
@@ -20,11 +20,11 @@ class ServerAdminWrapper {
 
     public trackPageView(eventAction: string, logAsActiveUser: boolean = true): void {
         if (logAsActiveUser) {
-            logUserEvent(GQL.UserEvent.PAGEVIEW)
+            logUserEvent(UserEvent.PAGEVIEW)
         }
         if (this.isAuthenicated) {
             if (eventAction === 'ViewRepository' || eventAction === 'ViewBlob' || eventAction === 'ViewTree') {
-                logUserEvent(GQL.UserEvent.STAGECODE)
+                logUserEvent(UserEvent.STAGECODE)
             }
         }
         logEvent(eventAction)
@@ -33,18 +33,18 @@ class ServerAdminWrapper {
     public trackAction(eventAction: string, eventProperties?: any): void {
         if (this.isAuthenicated) {
             if (eventAction === 'SearchResultsQueried') {
-                logUserEvent(GQL.UserEvent.SEARCHQUERY)
-                logUserEvent(GQL.UserEvent.STAGECODE)
+                logUserEvent(UserEvent.SEARCHQUERY)
+                logUserEvent(UserEvent.STAGECODE)
             } else if (
                 eventAction === 'goToDefinition' ||
                 eventAction === 'goToDefinition.preloaded' ||
                 eventAction === 'hover'
             ) {
-                logUserEvent(GQL.UserEvent.CODEINTEL)
+                logUserEvent(UserEvent.CODEINTEL)
             } else if (eventAction === 'SavedSearchEmailClicked' || eventAction === 'SavedSearchSlackClicked') {
-                logUserEvent(GQL.UserEvent.STAGEVERIFY)
+                logUserEvent(UserEvent.STAGEVERIFY)
             } else if (eventAction === 'DiffSearchResultsQueried') {
-                logUserEvent(GQL.UserEvent.STAGEMONITOR)
+                logUserEvent(UserEvent.STAGEMONITOR)
             }
         }
         logEvent(eventAction, eventProperties)

--- a/web/src/tracking/withActivation.tsx
+++ b/web/src/tracking/withActivation.tsx
@@ -9,10 +9,10 @@ import {
     ActivationStep,
 } from '../../../shared/src/components/activation/Activation'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { queryGraphQL } from '../backend/graphql'
 import { logUserEvent, logEvent } from '../user/settings/backend'
 import { AuthenticatedUser } from '../auth'
+import { UserEvent } from '../../../shared/src/graphql-operations'
 
 /**
  * Fetches activation status from server.
@@ -174,7 +174,7 @@ const getActivationSteps = (authenticatedUser: AuthenticatedUser): ActivationSte
  */
 const recordUpdate = (update: Partial<ActivationCompletionStatus>): void => {
     if (update.FoundReferences) {
-        logUserEvent(GQL.UserEvent.CODEINTELREFS)
+        logUserEvent(UserEvent.CODEINTELREFS)
         logEvent('CodeIntelRefs')
     }
 }

--- a/web/src/user/settings/backend.tsx
+++ b/web/src/user/settings/backend.tsx
@@ -5,6 +5,7 @@ import * as GQL from '../../../../shared/src/graphql/schema'
 import { createAggregateError } from '../../../../shared/src/util/errors'
 import { mutateGraphQL } from '../../backend/graphql'
 import { eventLogger } from '../../tracking/eventLogger'
+import { UserEvent, EventSource } from '../../../../shared/src/graphql-operations'
 
 interface UpdateUserOptions {
     username: string | null
@@ -93,7 +94,7 @@ export function setUserEmailVerified(user: GQL.ID, email: string, verified: bool
  *
  * @deprecated Use logEvent
  */
-export function logUserEvent(event: GQL.UserEvent): void {
+export function logUserEvent(event: UserEvent): void {
     mutateGraphQL(
         gql`
             mutation logUserEvent($event: UserEvent!, $userCookieID: String!) {
@@ -142,7 +143,7 @@ export function logEvent(event: string, eventProperties?: any): void {
             event,
             userCookieID: eventLogger.getAnonUserID(),
             url: window.location.href,
-            source: GQL.EventSource.WEB,
+            source: EventSource.WEB,
             argument: eventProperties && JSON.stringify(eventProperties),
         }
     )

--- a/web/src/util/settings.ts
+++ b/web/src/util/settings.ts
@@ -5,6 +5,7 @@ import { LayoutProps } from '../Layout'
 import { parseSearchURLPatternType } from '../search'
 import { SettingsExperimentalFeatures } from '../schema/settings.schema'
 import { AuthenticatedUser } from '../auth'
+import { SearchPatternType } from '../../../shared/src/graphql-operations'
 
 /** A fallback settings subject that can be constructed synchronously at initialization time. */
 export const SITE_SUBJECT_NO_ADMIN: Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdminister'> = {
@@ -25,9 +26,7 @@ export function viewerSubjectFromSettings(
     return SITE_SUBJECT_NO_ADMIN
 }
 
-export function defaultPatternTypeFromSettings(
-    settingsCascade: SettingsCascadeOrError
-): GQL.SearchPatternType | undefined {
+export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeOrError): SearchPatternType | undefined {
     // When the web app mounts, if the current page does not have a patternType URL
     // parameter, set the search pattern type to the defaultPatternType from settings
     // (if it is set), otherwise default to literal.

--- a/web/src/views/ViewPage.test.tsx
+++ b/web/src/views/ViewPage.test.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import { create, act } from 'react-test-renderer'
 import { ViewPage } from './ViewPage'
 import * as H from 'history'
-import { SearchPatternType } from '../../../shared/src/graphql/schema'
 import { Controller } from '../../../shared/src/extensions/controller'
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
 import { of } from 'rxjs'
+import { SearchPatternType } from '../../../shared/src/graphql-operations'
 
 jest.mock('@sourcegraph/react-loading-spinner', () => ({ LoadingSpinner: 'LoadingSpinner' }))
 jest.mock('./QueryInputInViewContent', () => ({ QueryInputInViewContent: 'QueryInputInViewContent' }))


### PR DESCRIPTION
Makes use only enums from graphql-operations and export all enums from the shared types as well, so they're the new source of truth.