### PR TITLE
search: parse regex holes in structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1670,16 +1670,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 					multiErr = multierror.Append(multiErr, errors.Wrap(err, "text search failed"))
 					multiErrMu.Unlock()
 				}
-				if args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == defaultMaxSearchResults && len(fileResults) == 0 {
+				if args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == defaultMaxSearchResults && len(fileResults) == 0 && err == nil {
 					// No results for structural search? Automatically search again and force Zoekt to resolve
 					// more potential file matches by setting a higher FileMatchLimit.
 					args.PatternInfo.FileMatchLimit = 1000
 					fileResults, fileCommon, err = searchFilesInRepos(ctx, &args)
-					if err != nil && !isContextError(ctx, err) {
-						multiErrMu.Lock()
-						multiErr = multierror.Append(multiErr, errors.Wrap(err, "text search failed"))
-						multiErrMu.Unlock()
-					}
 					if len(fileResults) == 0 {
 						// Still no results? Give up.
 						log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
-	zoektquery "github.com/google/zoekt/query"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -111,77 +111,107 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Pattern  string
-		Function func(string, bool) (zoektquery.Q, error)
+		Function func(string, bool) string
 		Want     string
 	}{
 		{
 			Name:     "Just a hole",
 			Pattern:  ":[1]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()((?s:.))*?()")`,
+			Want:     `(.|\s)*?`,
 		},
 		{
 			Name:     "Adjacent holes",
 			Pattern:  ":[1]:[2]:[3]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()((?s:.))*?()((?s:.))*?()((?s:.))*?()")`,
+			Want:     `(.|\s)*?`,
 		},
 		{
 			Name:     "Substring between holes",
 			Pattern:  ":[1] substring :[2]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()((?s:.))*?([\\t-\\n\\f-\\r ]+substring[\\t-\\n\\f-\\r ]+)((?s:.))*?()")`,
+			Want:     `([\s]+substring[\s]+)`,
 		},
 		{
 			Name:     "Substring before and after different hole kinds",
 			Pattern:  "prefix :[[1]] :[2.] suffix",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(prefix[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+suffix)")`,
+			Want:     `(prefix[\s]+)(.|\s)*?([\s]+)(.|\s)*?([\s]+suffix)`,
 		},
 		{
 			Name:     "Substrings covering all hole kinds.",
 			Pattern:  `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(1\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+2\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+3\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+4\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+5\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+6\\.[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+done\\.)")`,
-		},
-		{
-			Name:     "Substrings across multiple lines.",
-			Pattern:  ``,
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()")`,
+			Want:     `(1\.[\s]+)(.|\s)*?([\s]+2\.[\s]+)(.|\s)*?([\s]+3\.[\s]+)(.|\s)*?([\s]+4\.[\s]+)(.|\s)*?([\s]+5\.[\s]+)(.|\s)*?([\s]+6\.[\s]+)(.|\s)*?([\s]+done\.)`,
 		},
 		{
 			Name:     "Allow alphanumeric identifiers in holes",
 			Pattern:  "sub :[alphanum_ident_123] string",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(sub[\\t-\\n\\f-\\r ]+)((?s:.))*?([\\t-\\n\\f-\\r ]+string)")`,
+			Want:     `(sub[\s]+)(.|\s)*?([\s]+string)`,
 		},
 
 		{
 			Name:     "Whitespace separated holes",
 			Pattern:  ":[1] :[2]",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"()((?s:.))*?([\\t-\\n\\f-\\r ]+)((?s:.))*?()")`,
+			Want:     `([\s]+)`,
 		},
 		{
 			Name:     "Expect newline separated pattern",
 			Pattern:  "ParseInt(:[stuff], :[x]) if err ",
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(ParseInt\\()((?s:.))*?(,[\\t-\\n\\f-\\r ]+)((?s:.))*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
+			Want:     `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
 		},
 		{
 			Name: "Contiguous whitespace is replaced by regex",
 			Pattern: `ParseInt(:[stuff],    :[x])
              if err `,
 			Function: StructuralPatToRegexpQuery,
-			Want:     `(and case_regex:"(ParseInt\\()((?s:.))*?(,[\\t-\\n\\f-\\r ]+)((?s:.))*?(\\)[\\t-\\n\\f-\\r ]+if[\\t-\\n\\f-\\r ]+err[\\t-\\n\\f-\\r ]+)")`,
+			Want:     `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
+		},
+		{
+			Name:     "Regex holes extracts regex",
+			Pattern:  `:[x~[yo]]`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(yo)`,
+		},
+		{
+			Name:     "Regex holes with escaped space",
+			Pattern:  `:[x~\ ]`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(\ )`,
+		},
+		{
+			Name:     "Shorthand",
+			Pattern:  ":[[1]]",
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(.|\s)*?`,
+		},
+		{
+			Name:     "Array-like preserved",
+			Pattern:  `[:[x]]`,
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(\[)(.|\s)*?(\])`,
+		},
+		{
+			Name:     "Shorthand",
+			Pattern:  ":[[1]]",
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(.|\s)*?`,
+		},
+		{
+			Name:     "Not well-formed is undefined",
+			Pattern:  ":[[",
+			Function: StructuralPatToRegexpQuery,
+			Want:     `(.|\s)*?`,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			got, _ := tt.Function(tt.Pattern, false)
-			if got.String() != tt.Want {
-				t.Fatalf("mismatched queries\ngot  %s\nwant %s", got.String(), tt.Want)
+			got := tt.Function(tt.Pattern, false)
+			if diff := cmp.Diff(tt.Want, got); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -109,110 +109,112 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 
 func TestStructuralPatToRegexpQuery(t *testing.T) {
 	cases := []struct {
-		Name     string
-		Pattern  string
-		Function func(string, bool) string
-		Want     string
+		Name    string
+		Pattern string
+		Want    string
 	}{
 		{
-			Name:     "Just a hole",
-			Pattern:  ":[1]",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(.|\s)*?`,
+			Name:    "Just a hole",
+			Pattern: ":[1]",
+			Want:    `(.|\s)*?`,
 		},
 		{
-			Name:     "Adjacent holes",
-			Pattern:  ":[1]:[2]:[3]",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(.|\s)*?`,
+			Name:    "Adjacent holes",
+			Pattern: ":[1]:[2]:[3]",
+			Want:    `(.|\s)*?`,
 		},
 		{
-			Name:     "Substring between holes",
-			Pattern:  ":[1] substring :[2]",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `([\s]+substring[\s]+)`,
+			Name:    "Substring between holes",
+			Pattern: ":[1] substring :[2]",
+			Want:    `([\s]+substring[\s]+)`,
 		},
 		{
-			Name:     "Substring before and after different hole kinds",
-			Pattern:  "prefix :[[1]] :[2.] suffix",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(prefix[\s]+)(.|\s)*?([\s]+)(.|\s)*?([\s]+suffix)`,
+			Name:    "Substring before and after different hole kinds",
+			Pattern: "prefix :[[1]] :[2.] suffix",
+			Want:    `(prefix[\s]+)(.|\s)*?([\s]+)(.|\s)*?([\s]+suffix)`,
 		},
 		{
-			Name:     "Substrings covering all hole kinds.",
-			Pattern:  `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(1\.[\s]+)(.|\s)*?([\s]+2\.[\s]+)(.|\s)*?([\s]+3\.[\s]+)(.|\s)*?([\s]+4\.[\s]+)(.|\s)*?([\s]+5\.[\s]+)(.|\s)*?([\s]+6\.[\s]+)(.|\s)*?([\s]+done\.)`,
+			Name:    "Substrings covering all hole kinds.",
+			Pattern: `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
+			Want:    `(1\.[\s]+)(.|\s)*?([\s]+2\.[\s]+)(.|\s)*?([\s]+3\.[\s]+)(.|\s)*?([\s]+4\.[\s]+)(.|\s)*?([\s]+5\.[\s]+)(.|\s)*?([\s]+6\.[\s]+)(.|\s)*?([\s]+done\.)`,
 		},
 		{
-			Name:     "Allow alphanumeric identifiers in holes",
-			Pattern:  "sub :[alphanum_ident_123] string",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(sub[\s]+)(.|\s)*?([\s]+string)`,
+			Name:    "Allow alphanumeric identifiers in holes",
+			Pattern: "sub :[alphanum_ident_123] string",
+			Want:    `(sub[\s]+)(.|\s)*?([\s]+string)`,
 		},
 
 		{
-			Name:     "Whitespace separated holes",
-			Pattern:  ":[1] :[2]",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `([\s]+)`,
+			Name:    "Whitespace separated holes",
+			Pattern: ":[1] :[2]",
+			Want:    `([\s]+)`,
 		},
 		{
-			Name:     "Expect newline separated pattern",
-			Pattern:  "ParseInt(:[stuff], :[x]) if err ",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
+			Name:    "Expect newline separated pattern",
+			Pattern: "ParseInt(:[stuff], :[x]) if err ",
+			Want:    `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
 		},
 		{
 			Name: "Contiguous whitespace is replaced by regex",
 			Pattern: `ParseInt(:[stuff],    :[x])
              if err `,
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
+			Want: `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
 		},
 		{
-			Name:     "Regex holes extracts regex",
-			Pattern:  `:[x~[yo]]`,
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(yo)`,
+			Name:    "Regex holes extracts regex",
+			Pattern: `:[x~[yo]]`,
+			Want:    `(yo)`,
 		},
 		{
-			Name:     "Regex holes with escaped space",
-			Pattern:  `:[x~\ ]`,
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(\ )`,
+			Name:    "Regex holes with escaped space",
+			Pattern: `:[x~\ ]`,
+			Want:    `(\ )`,
 		},
 		{
-			Name:     "Shorthand",
-			Pattern:  ":[[1]]",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(.|\s)*?`,
+			Name:    "Shorthand",
+			Pattern: ":[[1]]",
+			Want:    `(.|\s)*?`,
 		},
 		{
-			Name:     "Array-like preserved",
-			Pattern:  `[:[x]]`,
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(\[)(.|\s)*?(\])`,
+			Name:    "Array-like preserved",
+			Pattern: `[:[x]]`,
+			Want:    `(\[)(.|\s)*?(\])`,
 		},
 		{
-			Name:     "Shorthand",
-			Pattern:  ":[[1]]",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(.|\s)*?`,
+			Name:    "Shorthand",
+			Pattern: ":[[1]]",
+			Want:    `(.|\s)*?`,
 		},
 		{
-			Name:     "Not well-formed is undefined",
-			Pattern:  ":[[",
-			Function: StructuralPatToRegexpQuery,
-			Want:     `(.|\s)*?`,
+			Name:    "Not well-formed is undefined",
+			Pattern: ":[[",
+			Want:    `(.|\s)*?`,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			got := tt.Function(tt.Pattern, false)
+			got := StructuralPatToRegexpQuery(tt.Pattern, false)
 			if diff := cmp.Diff(tt.Want, got); diff != "" {
 				t.Error(diff)
 			}
 		})
 	}
+}
+
+func TestBuildQuery(t *testing.T) {
+	pattern := ":[x~*]"
+	want := "error parsing regexp: missing argument to repetition operator: `*`"
+	t.Run("build query", func(t *testing.T) {
+		_, err := buildQuery(
+			&search.TextParameters{
+				PatternInfo: &search.TextPatternInfo{Pattern: pattern},
+			},
+			nil,
+			nil,
+			false,
+		)
+		if diff := cmp.Diff(err.Error(), want); diff != "" {
+			t.Error(diff)
+		}
+	})
 }


### PR DESCRIPTION
comby 0.18.* supports regular expressions inside hole syntax like `:[hole~regex]`. This regex should be extracted and used to filter files like we did before. But because `regex` can contain character class syntax like `[...]` inside holes, these templates need to be parsed now for balancedness, the previous regex to extract things can't recognize it.

I also refactored the functions and tests to be cleaner/clearer about the regex string that's generated.