### PR TITLE
search: show alert for invalid rev syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - User satisfaction/NPS surveys will now correctly provide a range from 0–10, rather than 0–9. [#13163](https://github.com/sourcegraph/sourcegraph/pull/13163)
+- Fixed a bug where we returned repositories with invalid revisions in the search results. Now, if a user specifies an invalid revision, we show an alert. [#13271](https://github.com/sourcegraph/sourcegraph/pull/13271)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -392,6 +392,14 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 	}
 }
 
+func (r *searchResolver) alertForInvalidRevision(revision string) *searchAlert {
+	revision = strings.TrimSuffix(revision, "^0")
+	return &searchAlert{
+		title:       "Invalid revision syntax",
+		description: fmt.Sprintf("We don't know how to interpret the revision (%s) you specified. Modify the revision an try again.", revision),
+	}
+}
+
 func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert {
 	// Try to suggest the most helpful repo: filters to narrow the query.
 	//

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1436,6 +1436,11 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 			alert := alertForStalePermissions()
 			return nil, nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
 		}
+		e := git.BadCommitError{}
+		if errors.As(err, &e) {
+			alert := r.alertForInvalidRevision(e.Spec)
+			return nil, nil, nil, &SearchResultsResolver{alert: alert, start: start}, nil
+		}
 		return nil, nil, nil, nil, err
 	}
 


### PR DESCRIPTION
Relates to #10571 

#### Bug fixes

- timeout of [HTTP calls](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@1cdb0858feb179bb081245d19cb788efe7d30255/-/blob/internal/gitserver/client.go?subtree=true#L252:24) in resolveRepositories   are now reported as timeouts instead of as search results
- Previously if users entered [invalid revision syntax](https://sourcegraph.com/search?q=repo:%5Egithub.com/sourcegraph/sourcegraph%24%40v3.14.*&patternType=literal) we didn't propagate the error and added the revision to the search results anyways. Now we show an alert like this
![image](https://user-images.githubusercontent.com/26413131/91017778-fabeb200-e5ee-11ea-98a4-be2aa386aa3f.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
