### PR TITLE
search: add link to revision syntax doc page in alert

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -396,7 +396,7 @@ func (r *searchResolver) alertForInvalidRevision(revision string) *searchAlert {
 	revision = strings.TrimSuffix(revision, "^0")
 	return &searchAlert{
 		title:       "Invalid revision syntax",
-		description: fmt.Sprintf("We don't know how to interpret the revision (%s) you specified. Modify the revision an try again.", revision),
+		description: fmt.Sprintf("We don't know how to interpret the revision (%s) you specified. Learn more about the revision syntax in our documentation: https://docs.sourcegraph.com/user/search/queries#repository-revisions.", revision),
 	}
 }
 


### PR DESCRIPTION
Minor follow-up of #13271 which addresses a PR comment. Apparently I forgot to push this before I merged #13271.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
