### PR TITLE
Ignore dev/* in watchman configuration

### DIFF
--- a/dev/watchmanwrapper/watch.json
+++ b/dev/watchmanwrapper/watch.json
@@ -5,7 +5,7 @@
   {
     "expression": [
       "allof",
-      ["not", ["anyof", ["match", ".*"], ["suffix", "_test.go"]]],
+      ["not", ["anyof", ["match", ".*"], ["suffix", "_test.go"], ["dirname", "dev"]]],
       [
         "anyof",
         ["suffix", "go"],


### PR DESCRIPTION
I don't want watchman to try to recompile stuff when I change a script
in `./dev/`



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
