### PR TITLE
Don't run generate twice in gulp watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ const build = gulp.series(generate, webWebpack)
 /**
  * Watches everything and rebuilds on file changes.
  */
-const watch = gulp.series(generate, gulp.parallel(watchGenerate, webWebpackDevServer))
+const watch = gulp.parallel(watchGenerate, webWebpackDevServer)
 
 module.exports = {
   generate,


### PR DESCRIPTION
The `watchGenerate` task first runs `generate` and then, in parallel,
the `watch*` tasks.

But `watch` also first runs `generate` and then `watchGenerate`, which
also runs `generate` again.

That means we can simplify the `watch` task by using the `generate` of
`watchGenerate`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
