### PR TITLE
search: handle negated revisions during rev validation

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -902,7 +902,8 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolved resolv
 			// searches like "repo:@foobar" (where foobar is an invalid revspec on most repos)
 			// taking a long time because they all ask gitserver to try to fetch from the remote
 			// repo.
-			if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), nil, rev.RevSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); err != nil {
+			trimmedRefSpec := strings.TrimPrefix(rev.RevSpec, "^") // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
+			if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), nil, trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					return resolvedRepositories{}, context.DeadlineExceeded
 				}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	querytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
@@ -775,5 +777,156 @@ func mkFileMatch(repo *types.Repo, path string, lineNumbers ...int32) *FileMatch
 		JPath:        path,
 		JLineMatches: lines,
 		Repo:         &RepositoryResolver{repo: repo},
+	}
+}
+
+func TestRevisionValidation(t *testing.T) {
+
+	// mocks a repo repoFoo with revisions revBar and revBas
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+		// trigger errors
+		if spec == "bad_commit" {
+			return "", git.BadCommitError{}
+		}
+		if spec == "deadline_exceeded" {
+			return "", context.DeadlineExceeded
+		}
+
+		// known revisions
+		m := map[string]struct{}{
+			"revBar": {},
+			"revBas": {},
+		}
+		if _, ok := m[spec]; ok {
+			return "", nil
+		}
+		return "", &gitserver.RevisionNotFoundError{Repo: "repoFoo", Spec: spec}
+	}
+	defer func() { git.Mocks.ResolveRevision = nil }()
+
+	db.Mocks.Repos.List = func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
+		return []*types.Repo{{Name: "repoFoo"}}, nil
+	}
+	defer func() { db.Mocks.Repos.List = nil }()
+
+	tests := []struct {
+		repoFilters              []string
+		wantRepoRevs             []*search.RepositoryRevisions
+		wantMissingRepoRevisions []*search.RepositoryRevisions
+		wantErr                  error
+	}{
+		{
+			repoFilters: []string{"repoFoo@revBar:^revBas"},
+			wantRepoRevs: []*search.RepositoryRevisions{{
+				Repo: &types.Repo{Name: "repoFoo"},
+				Revs: []search.RevisionSpecifier{
+					{
+						RevSpec:        "revBar",
+						RefGlob:        "",
+						ExcludeRefGlob: "",
+					},
+					{
+						RevSpec:        "^revBas",
+						RefGlob:        "",
+						ExcludeRefGlob: "",
+					},
+				},
+			}},
+			wantMissingRepoRevisions: nil,
+		},
+		{
+			repoFilters: []string{"repoFoo@*revBar:*!revBas"},
+			wantRepoRevs: []*search.RepositoryRevisions{{
+				Repo: &types.Repo{Name: "repoFoo"},
+				Revs: []search.RevisionSpecifier{
+					{
+						RevSpec:        "",
+						RefGlob:        "revBar",
+						ExcludeRefGlob: "",
+					},
+					{
+						RevSpec:        "",
+						RefGlob:        "",
+						ExcludeRefGlob: "revBas",
+					},
+				},
+			}},
+			wantMissingRepoRevisions: nil,
+		},
+		{
+			repoFilters: []string{"repoFoo@revBar:^revQux"},
+			wantRepoRevs: []*search.RepositoryRevisions{{
+				Repo: &types.Repo{Name: "repoFoo"},
+				Revs: []search.RevisionSpecifier{
+					{
+						RevSpec:        "revBar",
+						RefGlob:        "",
+						ExcludeRefGlob: "",
+					},
+				},
+				ListRefs: nil,
+			}},
+			wantMissingRepoRevisions: []*search.RepositoryRevisions{{
+				Repo: &types.Repo{Name: "repoFoo"},
+				Revs: []search.RevisionSpecifier{
+					{
+						RevSpec:        "^revQux",
+						RefGlob:        "",
+						ExcludeRefGlob: "",
+					},
+				},
+			}},
+		},
+		{
+			repoFilters:              []string{"repoFoo@revBar:bad_commit"},
+			wantRepoRevs:             nil,
+			wantMissingRepoRevisions: nil,
+			wantErr:                  git.BadCommitError{},
+		},
+		{
+			repoFilters:              []string{"repoFoo@revBar:^bad_commit"},
+			wantRepoRevs:             nil,
+			wantMissingRepoRevisions: nil,
+			wantErr:                  git.BadCommitError{},
+		},
+		{
+			repoFilters:              []string{"repoFoo@revBar:deadline_exceeded"},
+			wantRepoRevs:             nil,
+			wantMissingRepoRevisions: nil,
+			wantErr:                  context.DeadlineExceeded,
+		},
+		{
+			repoFilters: []string{"repoFoo"},
+			wantRepoRevs: []*search.RepositoryRevisions{{
+				Repo: &types.Repo{Name: "repoFoo"},
+				Revs: []search.RevisionSpecifier{
+					{
+						RevSpec:        "",
+						RefGlob:        "",
+						ExcludeRefGlob: "",
+					},
+				},
+			}},
+			wantMissingRepoRevisions: nil,
+			wantErr:                  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.repoFilters[0], func(t *testing.T) {
+
+			op := resolveRepoOp{repoFilters: tt.repoFilters}
+			resolved, err := resolveRepositories(context.Background(), op)
+
+			if diff := cmp.Diff(tt.wantRepoRevs, resolved.repoRevs); diff != "" {
+				t.Error(diff)
+			}
+			if diff := cmp.Diff(tt.wantMissingRepoRevisions, resolved.missingRepoRevs); diff != "" {
+				t.Error(diff)
+			}
+			if tt.wantErr != err {
+				t.Errorf("got: %v, expected: %v", err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes a regression introduced in #13271

**Before #13271**
`^revision` caused a `BadCommitError` because `^revision` (with caret) could not be resolved to a commit. Because we did not handle `BadCommitError`, `^revision` was added to the list of resolved revisions anyway, which is required downstream for searches of type `diff` and `commit`.

**With #13271**
`^revision` causes a `BadCommitError` and a warning is returned to the user. `^revision` is not added to the slice of resolved revisions.

**After this PR**
we strip the prefix `^` and validate the revision. If the revision is valid, it is added to the resolved repositories. Otherwise, a warning is returned.

### Positive side effect:

- revisions with prefix `^` are now actually validated and reported missing just like other revisions
- I covered the logic with tests so introducing further regressions should be harder



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
