### PR TITLE
gitserver: record actor and trace in honeycomb

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -26,6 +26,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
@@ -856,6 +857,7 @@ func (c *Client) do(ctx context.Context, repo api.RepoName, method, op string, p
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("X-Sourcegraph-Actor", userFromContext(ctx))
 	req = req.WithContext(ctx)
 
 	if c.HTTPLimiter != nil {
@@ -870,6 +872,17 @@ func (c *Client) do(ctx context.Context, repo api.RepoName, method, op string, p
 	defer ht.Finish()
 
 	return c.HTTPClient.Do(req)
+}
+
+func userFromContext(ctx context.Context) string {
+	a := actor.FromContext(ctx)
+	if a == nil {
+		return "0"
+	}
+	if a.Internal {
+		return "internal"
+	}
+	return a.UIDString()
 }
 
 // CreateCommitFromPatch will attempt to create a commit from a patch


### PR DESCRIPTION
This is to help debug the source of bursts of activity we get in
gitserver every 15min. We think it is likely due to internal
httpapi. This will confirm that and/or tell us which user is
causing the issue.

Co-Author: @bobheadxi 