### PR TITLE
Minor fixes for campaigns UI

### DIFF
--- a/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -62,13 +62,14 @@ export const CreateCampaignPage: React.FunctionComponent<CreateCampaignPageProps
                 <pre className="m-0">{campaignSpec}</pre>
             </div>
             <p className="lead">
-                Use src-cli to execute the steps in the campaign spec and upload it, ready to be previewed and applied:
+                Use Sourcegraph's CLI tool, <code>src</code>, to execute the steps in the campaign spec and upload it,
+                ready to be previewed and applied:
             </p>
             <div className="bg-light rounded p-3 mb-3">
                 <pre className="m-0">{sourcePreviewCommand}</pre>
             </div>
             <p className="lead">
-                Download Sourcegraph's cli tool, src-cli at{' '}
+                Download <code>src</code> at{' '}
                 <a href="https://github.com/sourcegraph/src-cli" rel="noopener noreferrer" target="_blank">
                     github.com/sourcegraph/src-cli
                 </a>

--- a/web/src/enterprise/campaigns/detail/CampaignDescription.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDescription.tsx
@@ -18,7 +18,7 @@ export const CampaignDescription: React.FunctionComponent<CampaignDescriptionPro
     <div className={classNames(className)}>
         <h3>Campaign description</h3>
         <hr />
-        <div className="pl-3 pt-3">
+        <div className="pl-3 py-3">
             <Markdown dangerousInnerHTML={renderMarkdown(description || '_No description_')} history={history} />
         </div>
     </div>

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
       </h3>
       <hr />
       <div
-        className="pl-3 pt-3"
+        className="pl-3 py-3"
       >
         <Markdown
           dangerousInnerHTML="<p>d</p>
@@ -985,7 +985,7 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
       </h3>
       <hr />
       <div
-        className="pl-3 pt-3"
+        className="pl-3 py-3"
       >
         <Markdown
           dangerousInnerHTML="<p>d</p>


### PR DESCRIPTION
* Changes the wording to explain what `src` is before showing it in the example command.
* Adds bottom padding to the campaign description