### PR TITLE
search: add support for negated patterns to searcher

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -50,7 +50,7 @@ type PatternInfo struct {
 	// is true, otherwise a fixed string. eg "route variable"
 	Pattern string
 
-	// IsNegated if true will invert the matching logic text searches. IsNegated=true is currently
+	// IsNegated if true will invert the matching logic for regexp searches. IsNegated=true is
 	// not supported for structural searches.
 	IsNegated bool
 

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -50,6 +50,10 @@ type PatternInfo struct {
 	// is true, otherwise a fixed string. eg "route variable"
 	Pattern string
 
+	// IsNegated if true will invert the matching logic text searches. IsNegated=true is currently
+	// not supported for structural searches.
+	IsNegated bool
+
 	// IsRegExp if true will treat the Pattern as a regular expression.
 	IsRegExp bool
 

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -235,7 +235,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	if p.IsStructuralPat {
 		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, p.Repo)
 	} else {
-		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath)
+		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
 	}
 	return matches, limitHit, false, err
 }
@@ -251,6 +251,10 @@ func validateParams(p *protocol.Request) error {
 	if p.Pattern == "" && p.ExcludePattern == "" && len(p.IncludePatterns) == 0 {
 		return errors.New("At least one of pattern and include/exclude pattners must be non-empty")
 	}
+	if p.IsNegated && p.IsStructuralPat {
+		return errors.New("Negated patterns are not supported for structural searches")
+	}
+
 	return nil
 }
 

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -254,7 +254,6 @@ func validateParams(p *protocol.Request) error {
 	if p.IsNegated && p.IsStructuralPat {
 		return errors.New("Negated patterns are not supported for structural searches")
 	}
-
 	return nil
 }
 

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -295,7 +295,7 @@ func (rg *readerGrep) FindZip(zf *store.ZipFile, f *store.SrcFile) (protocol.Fil
 }
 
 // regexSearch concurrently searches files in zr looking for matches using rg.
-func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMatchLimit int, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool) (_ []protocol.FileMatch, limitHit bool, err error) {
+func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMatchLimit int, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool) (fm []protocol.FileMatch, limitHit bool, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "RegexSearch")
 	ext.Component.Set(span, "regex_search")
 	if rg.re != nil {

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -411,7 +411,6 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *store.ZipFile, fileMat
 						fm.Path = f.Name
 					}
 				}
-
 				if match == !isPatternNegated {
 					matchesmu.Lock()
 					if len(matches) < fileMatchLimit {

--- a/cmd/searcher/search/search_regex_test.go
+++ b/cmd/searcher/search/search_regex_test.go
@@ -265,7 +265,7 @@ func benchSearchRegex(b *testing.B, p *protocol.Request) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		_, _, err := regexSearch(ctx, rg, zf, 0, p.PatternMatchesContent, p.PatternMatchesPath)
+		_, _, err := regexSearch(ctx, rg, zf, 0, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -455,7 +455,7 @@ func TestMaxMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileMatches, limitHit, err := regexSearch(context.Background(), rg, zf, maxFileMatches, true, false)
+	fileMatches, limitHit, err := regexSearch(context.Background(), rg, zf, maxFileMatches, true, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +507,7 @@ func TestPathMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileMatches, _, err := regexSearch(context.Background(), rg, zf, 10, true, true)
+	fileMatches, _, err := regexSearch(context.Background(), rg, zf, 10, true, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func TestRegexSearch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFm, gotLimitHit, err := regexSearch(tt.args.ctx, tt.args.rg, tt.args.zf, tt.args.fileMatchLimit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths)
+			gotFm, gotLimitHit, err := regexSearch(tt.args.ctx, tt.args.rg, tt.args.zf, tt.args.fileMatchLimit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("regexSearch() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -189,6 +189,26 @@ main.go:7:}
 		}, `
 file++.plus:1:filename contains regex metachars
 `},
+
+		{protocol.PatternInfo{Pattern: "World", IsNegated: true}, `
+abc.txt
+file++.plus
+milton.png
+`},
+
+		{protocol.PatternInfo{Pattern: "World", IsCaseSensitive: true, IsNegated: true}, `
+abc.txt
+file++.plus
+main.go
+milton.png
+`},
+
+		{protocol.PatternInfo{Pattern: "fmt", IsNegated: true}, `
+README.md
+abc.txt
+file++.plus
+milton.png
+`},
 	}
 
 	store, cleanup, err := newStore(files)
@@ -336,6 +356,20 @@ func TestSearch_badrequest(t *testing.T) {
 				PathPatternsAreRegExps: true,
 			},
 		},
+
+		// structural search with negated pattern
+		{
+			Repo:   "foo",
+			URL:    "u",
+			Commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			PatternInfo: protocol.PatternInfo{
+				Pattern:                "fmt.Println(:[_])",
+				IsNegated:              true,
+				ExcludePattern:         "",
+				PathPatternsAreRegExps: true,
+				IsStructuralPat:        true,
+			},
+		},
 	}
 
 	store, cleanup, err := newStore(nil)
@@ -391,6 +425,9 @@ func doSearch(u string, p *protocol.Request) ([]protocol.FileMatch, error) {
 	}
 	if p.PatternMatchesPath {
 		form.Set("PatternMatchesPath", "true")
+	}
+	if p.IsNegated {
+		form.Set("IsNegated", "true")
 	}
 	resp, err := http.PostForm(u, form)
 	if err != nil {


### PR DESCRIPTION
relates to  #13274

This PR adds support for negated patterns to searcher. Upstream changes in `frontend` to enable negation for unindexed searches will follow in a separate PR. I ran all of searcher's benchmarks (main vs. this PR) and they don't show any difference.

**Limitation**
This PR does not add support for negated structural patterns. Why? For structural searches we first call zoekt to restrict the scope of the search before calling searcher. This means searcher doesn't know about the full scope of the request. However, we need the full scope to negate the matches, otherwise, we potentially miss out on all lot of matches. 

Example
A user searches for a structural pattern within a group of repos. Let's say the pattern is only contained in repoA and a single file, fileA, within repoA. Zoekt will return repoA and fileA and searcher will only be called on repoA and fileA. However, the negated search would have to return all files in all repos (including repoA) except fileA.

If we want to enable negated patterns for structural search we need to do it (mostly) outside searcher. We should discuss this and then handle it in a different PR.

A request with a negated structural pattern will return a `400`. However, [we have a guard in frontend](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@c213392/-/blob/internal/search/query/parser.go?subtree=true#L977:73) that prevents negated patterns for structural searches, so we should never see the `400` in production.





<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
