### PR TITLE
repo-updater: Allow filtering external services by owner.

### DIFF
--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -166,6 +166,17 @@ func (s FakeStore) ListExternalServices(ctx context.Context, args StoreListExter
 	for _, svc := range s.svcByID {
 		k := strings.ToLower(svc.Kind)
 
+		switch {
+		case args.NamespaceUserID == -1:
+			if svc.NamespaceUserID != 0 {
+				continue
+			}
+		case args.NamespaceUserID > 0:
+			if svc.NamespaceUserID != args.NamespaceUserID {
+				continue
+			}
+		}
+
 		if !set[svc] &&
 			((len(kinds) == 0 && k != extsvc.TypePhabricator) || kinds[k]) &&
 			(len(ids) == 0 || ids[svc.ID]) &&
@@ -173,7 +184,6 @@ func (s FakeStore) ListExternalServices(ctx context.Context, args StoreListExter
 
 			svcs = append(svcs, svc)
 			set[svc] = true
-
 		}
 	}
 


### PR DESCRIPTION
Adds NamespaceUserID to StoreListExternalServicesArgs

When set to the zero value, don't filter
When set to an id > 0, filter to a single user
When set to -1, filter to sevices with NO owner



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
