### PR TITLE
Update code intel quick start

### DIFF
--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -69,7 +69,7 @@ LSIF dump successfully uploaded for processing.
 View processing status at <link to your Sourcegraph instance LSIF status>.
 ```
 
-### 5. Automate code indexing
+## Automate code indexing
 
 Now that you have successfully enabled code intelligence for your repository, you can automate source code indexing to ensure precise code intelligence stays up to date with the most recent code changes in the repository. See our [continuous integration guide](adding_lsif_to_workflows.md) to setup automation.
 


### PR DESCRIPTION
Removed list number since automating code indexing is not part of the initial getting started steps.
