### PR TITLE
Fix switching back to default filter not reflected in URL

### DIFF
--- a/web/src/components/FilteredConnection.tsx
+++ b/web/src/components/FilteredConnection.tsx
@@ -717,8 +717,12 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         if (first !== this.props.defaultFirst) {
             searchParameters.set('first', String(first))
         }
-        if (filter && this.props.filters && filter !== this.props.filters[0]) {
-            searchParameters.set('filter', filter.id)
+        if (filter && this.props.filters) {
+            if (filter !== this.props.filters[0]) {
+                searchParameters.set('filter', filter.id)
+            } else {
+                searchParameters.delete('filter')
+            }
         }
         if (visible !== 0 && visible !== first) {
             searchParameters.set('visible', String(visible))


### PR DESCRIPTION
Currently, when switching back from a filter at index != 0, no change to the URL is taken, but that keeps the previous filter in, changing the filter on a page reload. This fixes it by unsetting the filter.