### PR TITLE
Fix campaign becoming out of date

### DIFF
--- a/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
@@ -35,7 +35,6 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
-    campaignUpdates: Subject<void>
     willClose: boolean
 
     /** For testing only. */
@@ -53,7 +52,6 @@ export const CampaignCloseChangesetsList: React.FunctionComponent<Props> = ({
     history,
     location,
     isLightTheme,
-    campaignUpdates,
     extensionsController,
     platformContext,
     telemetryService,
@@ -141,7 +139,6 @@ export const CampaignCloseChangesetsList: React.FunctionComponent<Props> = ({
                     viewerCanAdminister,
                     history,
                     location,
-                    campaignUpdates,
                     extensionInfo: { extensionsController, hoverifier },
                     queryExternalChangesetWithFileDiffs,
                     willClose,

--- a/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
@@ -4,7 +4,6 @@ import { PageTitle } from '../../../components/PageTitle'
 import { CampaignHeader } from '../detail/CampaignHeader'
 import { CampaignCloseAlert } from './CampaignCloseAlert'
 import { Scalars } from '../../../graphql-operations'
-import { Subject } from 'rxjs'
 import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
     queryChangesets as _queryChangesets,
@@ -53,7 +52,6 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
     queryExternalChangesetWithFileDiffs,
     closeCampaign,
 }) => {
-    const campaignUpdates = useMemo(() => new Subject<void>(), [])
     const [closeChangesets, setCloseChangesets] = useState<boolean>(false)
     const campaign = useObservable(useMemo(() => fetchCampaignById(campaignID), [campaignID, fetchCampaignById]))
 
@@ -98,7 +96,6 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
             {!closeChangesets && <h2>The following changesets will remain open:</h2>}
             <CampaignCloseChangesetsList
                 campaignID={campaignID}
-                campaignUpdates={campaignUpdates}
                 history={history}
                 location={location}
                 viewerCanAdminister={campaign.viewerCanAdminister}

--- a/web/src/enterprise/campaigns/close/ChangesetCloseNode.tsx
+++ b/web/src/enterprise/campaigns/close/ChangesetCloseNode.tsx
@@ -1,6 +1,5 @@
 import * as H from 'history'
 import React from 'react'
-import { Observer } from 'rxjs'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { ChangesetFields } from '../../../graphql-operations'
@@ -15,7 +14,6 @@ import { HiddenExternalChangesetCloseNode } from './HiddenExternalChangesetClose
 export interface ChangesetCloseNodeProps extends ThemeProps {
     node: ChangesetFields
     viewerCanAdminister: boolean
-    campaignUpdates?: Pick<Observer<void>, 'next'>
     history: H.History
     location: H.Location
     extensionInfo?: {

--- a/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.tsx
+++ b/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.tsx
@@ -1,4 +1,3 @@
-import { Observer } from 'rxjs'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import * as H from 'history'
 import React, { useState, useCallback } from 'react'
@@ -23,7 +22,6 @@ export interface ExternalChangesetCloseNodeProps extends ThemeProps {
     node: ExternalChangesetFields
     willClose: boolean
     viewerCanAdminister: boolean
-    campaignUpdates?: Pick<Observer<void>, 'next'>
     history: H.History
     location: H.Location
     extensionInfo?: {
@@ -37,7 +35,6 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
     node,
     willClose,
     viewerCanAdminister,
-    campaignUpdates,
     isLightTheme,
     history,
     location,
@@ -68,11 +65,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
                 )}
             </button>
             {willClose ? <ChangesetCloseActionClose /> : <ChangesetCloseActionKept />}
-            <ExternalChangesetInfoCell
-                node={node}
-                viewerCanAdminister={viewerCanAdminister}
-                campaignUpdates={campaignUpdates}
-            />
+            <ExternalChangesetInfoCell node={node} viewerCanAdminister={viewerCanAdminister} />
             <span>{node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}</span>
             <span>{node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}</span>
             <div className="external-changeset-close-node__diffstat">

--- a/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import classNames from 'classnames'
-import { CampaignFields } from '../../../graphql-operations'
+import { CampaignFields, ChangesetStatsFields } from '../../../graphql-operations'
 import { CampaignStateBadge } from './CampaignStateBadge'
 import {
     ChangesetStatusUnpublished,
@@ -12,7 +12,8 @@ import {
 } from './changesets/ChangesetStatusCell'
 import { pluralize } from '../../../../../shared/src/util/strings'
 
-interface CampaignStatsCardProps extends Pick<CampaignFields['changesets'], 'stats'> {
+interface CampaignStatsCardProps {
+    stats: ChangesetStatsFields
     closedAt: CampaignFields['closedAt']
     className?: string
 }

--- a/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
@@ -5,7 +5,6 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import { CampaignFields } from '../../../graphql-operations'
-import { Subject } from 'rxjs'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
@@ -21,7 +20,6 @@ type SelectedTab = 'changesets' | 'chart'
 
 export interface CampaignTabsProps extends ExtensionsControllerProps, ThemeProps, PlatformContextProps, TelemetryProps {
     campaign: CampaignFields
-    campaignUpdates: Subject<void>
     history: H.History
     location: H.Location
     /** For testing only. */
@@ -40,7 +38,6 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
     platformContext,
     telemetryService,
     campaign,
-    campaignUpdates,
     queryChangesets,
     queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,
@@ -93,8 +90,6 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
                 <CampaignChangesets
                     campaignID={campaign.id}
                     viewerCanAdminister={campaign.viewerCanAdminister}
-                    changesetUpdates={campaignUpdates}
-                    campaignUpdates={campaignUpdates}
                     history={history}
                     location={location}
                     isLightTheme={isLightTheme}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetails.test.tsx.snap
@@ -371,7 +371,6 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
         "viewerCanAdminister": false,
       }
     }
-    campaignUpdates="[Subject]"
     history="[History]"
     isLightTheme={true}
     location="[Location path=/]"
@@ -417,8 +416,6 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
     </ul>
     <CampaignChangesets
       campaignID="c"
-      campaignUpdates="[Subject]"
-      changesetUpdates="[Subject]"
       history="[History]"
       isLightTheme={true}
       location="[Location path=/]"
@@ -623,7 +620,6 @@ exports[`CampaignDetails viewerCanAdminister: false viewing existing 1`] = `
           nodeComponent={[Function]}
           nodeComponentProps={
             Object {
-              "campaignUpdates": "[Subject]",
               "extensionInfo": Object {
                 "extensionsController": undefined,
                 "hoverifier": Object {
@@ -1044,7 +1040,6 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
         "viewerCanAdminister": true,
       }
     }
-    campaignUpdates="[Subject]"
     history="[History]"
     isLightTheme={true}
     location="[Location path=/]"
@@ -1090,8 +1085,6 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
     </ul>
     <CampaignChangesets
       campaignID="c"
-      campaignUpdates="[Subject]"
-      changesetUpdates="[Subject]"
       history="[History]"
       isLightTheme={true}
       location="[Location path=/]"
@@ -1296,7 +1289,6 @@ exports[`CampaignDetails viewerCanAdminister: true viewing existing 1`] = `
           nodeComponent={[Function]}
           nodeComponentProps={
             Object {
-              "campaignUpdates": "[Subject]",
               "extensionInfo": Object {
                 "extensionsController": undefined,
                 "hoverifier": Object {

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -21,6 +21,16 @@ import {
     DeleteCampaignVariables,
 } from '../../../graphql-operations'
 
+const changesetStatsFragment = gql`
+    fragment ChangesetStatsFields on ChangesetConnectionStats {
+        total
+        closed
+        merged
+        open
+        unpublished
+    }
+`
+
 const campaignFragment = gql`
     fragment CampaignFields on Campaign {
         __typename
@@ -42,11 +52,7 @@ const campaignFragment = gql`
         viewerCanAdminister
         changesets {
             stats {
-                total
-                closed
-                merged
-                open
-                unpublished
+                ...ChangesetStatsFields
             }
         }
         diffStat {
@@ -55,6 +61,8 @@ const campaignFragment = gql`
     }
 
     ${diffStatFields}
+
+    ${changesetStatsFragment}
 `
 
 const changesetLabelFragment = gql`

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.story.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.story.tsx
@@ -6,7 +6,7 @@ import webStyles from '../../../../enterprise.scss'
 import { Tooltip } from '../../../../components/tooltip/Tooltip'
 import { CampaignChangesets } from './CampaignChangesets'
 import { addHours } from 'date-fns'
-import { of, Subject } from 'rxjs'
+import { of } from 'rxjs'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../../shared/src/telemetry/telemetryService'
 import {
     ChangesetFields,
@@ -83,7 +83,6 @@ const nodes: ChangesetFields[] = [
     ),
 ]
 const queryChangesets = () => of({ totalCount: nodes.length, nodes, pageInfo: { endCursor: null, hasNextPage: false } })
-const updates = new Subject<void>()
 
 const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWithFileDiffs = () =>
     of({
@@ -108,8 +107,6 @@ add('List of changesets', () => (
         platformContext={undefined as any}
         campaignID="campaignid"
         viewerCanAdminister={boolean('viewerCanAdminister', true)}
-        campaignUpdates={updates}
-        changesetUpdates={updates}
         telemetryService={NOOP_TELEMETRY_SERVICE}
         history={history}
         location={history.location}

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { CampaignChangesets } from './CampaignChangesets'
 import * as H from 'history'
-import { of, Subject } from 'rxjs'
+import { of } from 'rxjs'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../../shared/src/telemetry/telemetryService'
 import { mount } from 'enzyme'
 import {
@@ -42,8 +42,6 @@ describe('CampaignChangesets', () => {
                     history={history}
                     location={history.location}
                     isLightTheme={true}
-                    campaignUpdates={new Subject<void>()}
-                    changesetUpdates={new Subject<void>()}
                     extensionsController={undefined as any}
                     platformContext={undefined as any}
                     telemetryService={NOOP_TELEMETRY_SERVICE}

--- a/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -3,12 +3,12 @@ import * as H from 'history'
 import { ChangesetNodeProps, ChangesetNode } from './ChangesetNode'
 import { ThemeProps } from '../../../../../../shared/src/theme'
 import { FilteredConnection, FilteredConnectionQueryArgs } from '../../../../components/FilteredConnection'
-import { Subject, merge, of } from 'rxjs'
+import { Subject } from 'rxjs'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
 } from '../backend'
-import { repeatWhen, delay, withLatestFrom, map, filter, switchMap } from 'rxjs/operators'
+import { repeatWhen, delay, withLatestFrom, map, filter } from 'rxjs/operators'
 import { ExtensionsControllerProps } from '../../../../../../shared/src/extensions/controller'
 import { createHoverifier } from '@sourcegraph/codeintellify'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '../../../../../../shared/src/util/url'
@@ -31,8 +31,6 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
-    campaignUpdates: Subject<void>
-    changesetUpdates: Subject<void>
 
     hideFilters?: boolean
 
@@ -51,8 +49,6 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
     history,
     location,
     isLightTheme,
-    changesetUpdates,
-    campaignUpdates,
     extensionsController,
     platformContext,
     telemetryService,
@@ -69,21 +65,17 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
     })
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArgs) =>
-            merge(of(undefined), changesetUpdates).pipe(
-                switchMap(() =>
-                    queryChangesets({
-                        externalState: changesetFilters.externalState,
-                        reviewState: changesetFilters.reviewState,
-                        checkState: changesetFilters.checkState,
-                        publicationState: changesetFilters.publicationState,
-                        reconcilerState: changesetFilters.reconcilerState,
-                        first: args.first ?? null,
-                        after: args.after ?? null,
-                        campaign: campaignID,
-                        onlyPublishedByThisCampaign: null,
-                    }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000))))
-                )
-            ),
+            queryChangesets({
+                externalState: changesetFilters.externalState,
+                reviewState: changesetFilters.reviewState,
+                checkState: changesetFilters.checkState,
+                publicationState: changesetFilters.publicationState,
+                reconcilerState: changesetFilters.reconcilerState,
+                first: args.first ?? null,
+                after: args.after ?? null,
+                campaign: campaignID,
+                onlyPublishedByThisCampaign: null,
+            }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000)))),
         [
             campaignID,
             changesetFilters.externalState,
@@ -92,7 +84,6 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
             changesetFilters.reconcilerState,
             changesetFilters.publicationState,
             queryChangesets,
-            changesetUpdates,
         ]
     )
 
@@ -166,7 +157,6 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                         viewerCanAdminister,
                         history,
                         location,
-                        campaignUpdates,
                         extensionInfo: { extensionsController, hoverifier },
                         queryExternalChangesetWithFileDiffs,
                     }}

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetLastSynced.tsx
@@ -4,7 +4,6 @@ import { formatDistance, parseISO } from 'date-fns'
 import { syncChangeset } from '../backend'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import SyncIcon from 'mdi-react/SyncIcon'
-import { Observer } from 'rxjs'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import { isErrorLike } from '../../../../../../shared/src/util/errors'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
@@ -13,29 +12,20 @@ import { ChangesetFields } from '../../../../graphql-operations'
 interface Props {
     changeset: Pick<ChangesetFields, 'id' | 'nextSyncAt' | 'updatedAt'>
     viewerCanAdminister: boolean
-    campaignUpdates?: Pick<Observer<void>, 'next'>
     /** For testing purposes only */
     _now?: Date
 }
 
-export const ChangesetLastSynced: React.FunctionComponent<Props> = ({
-    changeset,
-    viewerCanAdminister,
-    campaignUpdates,
-    _now,
-}) => {
+export const ChangesetLastSynced: React.FunctionComponent<Props> = ({ changeset, viewerCanAdminister, _now }) => {
     // initially, the changeset was never last updated
     const [lastUpdatedAt, setLastUpdatedAt] = useState<string | Error | null>(null)
     // .. if it was, and the changesets current updatedAt doesn't match the previous updated at, we know that it has been synced
     const lastUpdatedAtChanged = lastUpdatedAt && !isErrorLike(lastUpdatedAt) && changeset.updatedAt !== lastUpdatedAt
     useEffect(() => {
         if (lastUpdatedAtChanged) {
-            if (campaignUpdates) {
-                campaignUpdates.next()
-            }
             setLastUpdatedAt(null)
         }
-    }, [campaignUpdates, lastUpdatedAtChanged, changeset.updatedAt])
+    }, [lastUpdatedAtChanged, changeset.updatedAt])
     const enqueueChangeset = useCallback<React.MouseEventHandler>(async () => {
         if (!viewerCanAdminister) {
             return

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.test.tsx
@@ -1,7 +1,6 @@
 import * as H from 'history'
 import React from 'react'
 import { ChangesetNode } from './ChangesetNode'
-import { Subject } from 'rxjs'
 import { shallow } from 'enzyme'
 
 describe('ChangesetNode', () => {
@@ -15,7 +14,6 @@ describe('ChangesetNode', () => {
                     history={history}
                     location={location}
                     viewerCanAdminister={false}
-                    campaignUpdates={new Subject<void>()}
                     node={{ __typename: 'ExternalChangeset' } as any}
                 />
             )
@@ -29,7 +27,6 @@ describe('ChangesetNode', () => {
                     history={history}
                     location={location}
                     viewerCanAdminister={false}
-                    campaignUpdates={new Subject<void>()}
                     node={{ __typename: 'HiddenExternalChangeset' } as any}
                 />
             )

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.tsx
@@ -1,7 +1,6 @@
 import * as H from 'history'
 import React from 'react'
 import { ThemeProps } from '../../../../../../shared/src/theme'
-import { Observer } from 'rxjs'
 import { ExtensionsControllerProps } from '../../../../../../shared/src/extensions/controller'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '../../../../../../shared/src/util/url'
@@ -15,7 +14,6 @@ import { queryExternalChangesetWithFileDiffs } from '../backend'
 export interface ChangesetNodeProps extends ThemeProps {
     node: ChangesetFields
     viewerCanAdminister: boolean
-    campaignUpdates?: Pick<Observer<void>, 'next'>
     history: H.History
     location: H.Location
     extensionInfo?: {

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -4,7 +4,6 @@ import {
     ChangesetExternalState,
     ChangesetPublicationState,
 } from '../../../../graphql-operations'
-import { Observer } from 'rxjs'
 import { LinkOrSpan } from '../../../../../../shared/src/components/LinkOrSpan'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import { ChangesetLabel } from './ChangesetLabel'
@@ -14,13 +13,11 @@ import { ChangesetLastSynced } from './ChangesetLastSynced'
 export interface ExternalChangesetInfoCellProps {
     node: ExternalChangesetFields
     viewerCanAdminister: boolean
-    campaignUpdates?: Pick<Observer<void>, 'next'>
 }
 
 export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangesetInfoCellProps> = ({
     node,
     viewerCanAdminister,
-    campaignUpdates,
 }) => (
     <div className="d-flex flex-column">
         <div className="m-0 mb-2">
@@ -60,11 +57,7 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                 </Link>
             </strong>
             {node.publicationState === ChangesetPublicationState.PUBLISHED && (
-                <ChangesetLastSynced
-                    changeset={node}
-                    viewerCanAdminister={viewerCanAdminister}
-                    campaignUpdates={campaignUpdates}
-                />
+                <ChangesetLastSynced changeset={node} viewerCanAdminister={viewerCanAdminister} />
             )}
         </div>
     </div>

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.test.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.test.tsx
@@ -1,7 +1,6 @@
 import * as H from 'history'
 import React from 'react'
 import { ExternalChangesetNode } from './ExternalChangesetNode'
-import { Subject } from 'rxjs'
 import { shallow } from 'enzyme'
 import {
     ChangesetReviewState,
@@ -58,7 +57,6 @@ describe('ExternalChangesetNode', () => {
                         updatedAt: new Date('2020-01-01').toISOString(),
                         nextSyncAt: null,
                     }}
-                    campaignUpdates={new Subject<void>()}
                 />
             )
         ).toMatchSnapshot()

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -1,5 +1,4 @@
 import { ThemeProps } from '../../../../../../shared/src/theme'
-import { Observer } from 'rxjs'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '../../../../../../shared/src/util/url'
 import { HoverMerged } from '../../../../../../shared/src/api/client/types/hover'
@@ -22,7 +21,6 @@ import { ExternalChangesetInfoCell } from './ExternalChangesetInfoCell'
 export interface ExternalChangesetNodeProps extends ThemeProps {
     node: ExternalChangesetFields
     viewerCanAdminister: boolean
-    campaignUpdates?: Pick<Observer<void>, 'next'>
     history: H.History
     location: H.Location
     extensionInfo?: {
@@ -35,7 +33,6 @@ export interface ExternalChangesetNodeProps extends ThemeProps {
 export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNodeProps> = ({
     node,
     viewerCanAdminister,
-    campaignUpdates,
     isLightTheme,
     history,
     location,
@@ -66,11 +63,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                 )}
             </button>
             <ChangesetStatusCell changeset={node} />
-            <ExternalChangesetInfoCell
-                node={node}
-                viewerCanAdminister={viewerCanAdminister}
-                campaignUpdates={campaignUpdates}
-            />
+            <ExternalChangesetInfoCell node={node} viewerCanAdminister={viewerCanAdminister} />
             <span>{node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}</span>
             <span>{node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}</span>
             <div className="external-changeset-node__diffstat">

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/CampaignChangesets.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/CampaignChangesets.test.tsx.snap
@@ -3,8 +3,6 @@
 exports[`CampaignChangesets renders 1`] = `
 <CampaignChangesets
   campaignID="123"
-  campaignUpdates="[Subject]"
-  changesetUpdates="[Subject]"
   history="[History]"
   isLightTheme={true}
   location="[Location path=/]"
@@ -210,7 +208,6 @@ exports[`CampaignChangesets renders 1`] = `
       nodeComponent={[Function]}
       nodeComponentProps={
         Object {
-          "campaignUpdates": "[Subject]",
           "extensionInfo": Object {
             "extensionsController": undefined,
             "hoverifier": Object {
@@ -273,7 +270,6 @@ exports[`CampaignChangesets renders 1`] = `
           nodeComponent={[Function]}
           nodeComponentProps={
             Object {
-              "campaignUpdates": "[Subject]",
               "extensionInfo": Object {
                 "extensionsController": undefined,
                 "hoverifier": Object {
@@ -360,7 +356,6 @@ exports[`CampaignChangesets renders 1`] = `
               </h5>
             </CampaignChangesetsHeader>
             <ChangesetNode
-              campaignUpdates="[Subject]"
               extensionInfo={
                 Object {
                   "extensionsController": undefined,
@@ -400,7 +395,6 @@ exports[`CampaignChangesets renders 1`] = `
                 className="changeset-node__separator"
               />
               <HiddenExternalChangesetNode
-                campaignUpdates="[Subject]"
                 extensionInfo={
                   Object {
                     "extensionsController": undefined,

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ChangesetNode.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`ChangesetNode renders ExternalChangeset 1`] = `
     className="changeset-node__separator"
   />
   <ExternalChangesetNode
-    campaignUpdates="[Subject]"
     history="[History]"
     isLightTheme={true}
     location="[Location path=/campaigns]"
@@ -26,7 +25,6 @@ exports[`ChangesetNode renders HiddenExternalChangeset 1`] = `
     className="changeset-node__separator"
   />
   <HiddenExternalChangesetNode
-    campaignUpdates="[Subject]"
     history="[History]"
     isLightTheme={true}
     location="[Location path=/campaigns]"

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
@@ -54,7 +54,6 @@ exports[`ExternalChangesetNode renders an externalchangeset 1`] = `
     }
   />
   <ExternalChangesetInfoCell
-    campaignUpdates="[Subject]"
     node={
       Object {
         "__typename": "ExternalChangeset",


### PR DESCRIPTION
Before, we very manually fetched the campaign again, but I think the better approach here is to do it like we do with changesets: polling.

Since other users can also modify the campaign while you're looking at it, our "update only when the user triggered something" doesn't really work anyways.

Closes https://github.com/sourcegraph/sourcegraph/issues/13183