### PR TITLE
search: don't use pointer for excluded repo type

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -288,7 +288,7 @@ func getBoolPtr(b *bool, def bool) bool {
 type resolvedRepositories struct {
 	repoRevs        []*search.RepositoryRevisions
 	missingRepoRevs []*search.RepositoryRevisions
-	excludedRepos   *excludedRepos
+	excludedRepos   excludedRepos
 	overLimit       bool
 }
 
@@ -426,9 +426,9 @@ type excludedRepos struct {
 
 // computeExcludedRepositories returns a list of excluded repositories (forks or
 // archives) based on the search query.
-func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op db.ReposListOptions) (excluded *excludedRepos) {
+func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op db.ReposListOptions) (excluded excludedRepos) {
 	if q == nil {
-		return &excludedRepos{}
+		return excludedRepos{}
 	}
 
 	// PERF: We query concurrently since each count call can be slow on
@@ -476,7 +476,7 @@ func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op db.R
 
 	wg.Wait()
 
-	return &excludedRepos{forks: numExcludedForks, archived: numExcludedArchived}
+	return excludedRepos{forks: numExcludedForks, archived: numExcludedArchived}
 }
 
 // resolveRepositories calls doResolveRepositories, caching the result for the common
@@ -501,7 +501,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	if effectiveRepoFieldValues == nil {
 		r.reposMu.Lock()
 		defer r.reposMu.Unlock()
-		if r.resolved.repoRevs != nil || r.resolved.missingRepoRevs != nil || r.resolved.excludedRepos != nil || r.repoErr != nil {
+		if r.resolved.repoRevs != nil || r.resolved.missingRepoRevs != nil || r.repoErr != nil {
 			tr.LazyPrintf("cached")
 			return r.resolved, r.repoErr
 		}
@@ -810,7 +810,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 	}
 
 	var repos []*types.Repo
-	var excluded *excludedRepos
+	var excluded excludedRepos
 	if len(defaultRepos) > 0 {
 		repos = defaultRepos
 		if len(repos) > maxRepoListSize {
@@ -835,7 +835,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 
 		// PERF: We query concurrently since Count and List call can be slow
 		// on Sourcegraph.com (100ms+).
-		excludedC := make(chan *excludedRepos)
+		excludedC := make(chan excludedRepos)
 		go func() {
 			excludedC <- computeExcludedRepositories(ctx, op.query, options)
 		}()

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1583,9 +1583,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return &optionalWg
 	}
 
-	if resolved.excludedRepos != nil {
-		common.excluded = *resolved.excludedRepos
-	}
+	common.excluded = resolved.excludedRepos
 
 	// Apply search limits and generate warnings before firing off workers.
 	// This currently limits diff and commit search to a set number of

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -666,7 +666,7 @@ func TestComputeExcludedRepositories(t *testing.T) {
 		Name              string
 		Query             string
 		Repos             []types.Repo
-		WantExcludedRepos *excludedRepos
+		WantExcludedRepos excludedRepos
 	}{
 		{
 			Name:  "filter out forks and archived repos",
@@ -689,7 +689,7 @@ func TestComputeExcludedRepositories(t *testing.T) {
 					RepoFields: &types.RepoFields{Archived: true},
 				},
 			},
-			WantExcludedRepos: &excludedRepos{forks: 2, archived: 1},
+			WantExcludedRepos: excludedRepos{forks: 2, archived: 1},
 		},
 		{
 			Name:  "exact repo match does not exclude fork",
@@ -700,7 +700,7 @@ func TestComputeExcludedRepositories(t *testing.T) {
 					RepoFields: &types.RepoFields{Fork: true},
 				},
 			},
-			WantExcludedRepos: &excludedRepos{forks: 0, archived: 0},
+			WantExcludedRepos: excludedRepos{forks: 0, archived: 0},
 		},
 		{
 			Name:  "when fork is set don't populate exclude",
@@ -715,7 +715,7 @@ func TestComputeExcludedRepositories(t *testing.T) {
 					RepoFields: &types.RepoFields{Fork: true},
 				},
 			},
-			WantExcludedRepos: &excludedRepos{forks: 0, archived: 0},
+			WantExcludedRepos: excludedRepos{forks: 0, archived: 0},
 		},
 	}
 


### PR DESCRIPTION
With this change being a good idea, I was wondering why I made this type a pointer (I did introduce this type after all). See inline comment for why I think I did this.

(Follow up to https://github.com/sourcegraph/sourcegraph/pull/13312#discussion_r476471982)