### PR TITLE
Tracking issue: support issues with multiple assignees

### DIFF
--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -280,7 +280,16 @@ func Assignee(assignees []string) string {
 	if len(assignees) == 0 {
 		return "Unassigned"
 	}
+
 	return assignees[0]
+}
+
+func ListOfAssignees(assignees []string) []string {
+	if len(assignees) == 0 {
+		return []string{"Unassigned"}
+	}
+
+	return assignees
 }
 
 type TrackingIssue struct {
@@ -345,25 +354,36 @@ func (t *TrackingIssue) Workloads() Workloads {
 			continue
 		}
 
-		w := workload(Assignee(issue.Assignees))
-
-		w.AddIssue(issue)
-
-		linked := issue.LinkedPullRequests(t.PRs)
-		for _, pr := range linked {
-			issue.LinkedPRs = append(issue.LinkedPRs, pr)
-			pr.LinkedIssues = append(pr.LinkedIssues, issue)
-		}
-
-		if t.Milestone == "" || issue.Milestone == t.Milestone {
-			estimate := Estimate(issue.Labels)
-			w.Days += Days(estimate)
+		issueAssignees := ListOfAssignees(issue.Assignees)
+		if len(issueAssignees) > 1 {
+			for _, assignee := range issueAssignees {
+				w := workload(assignee)
+				t.AddIssueToWorkload(w, issue)
+			}
 		} else {
-			issue.Deprioritised = true
+			w := workload(Assignee(issue.Assignees))
+			t.AddIssueToWorkload(w, issue)
 		}
 	}
 
 	return workloads
+}
+
+func (t *TrackingIssue) AddIssueToWorkload(workload *Workload, issue *Issue) {
+	workload.AddIssue(issue)
+
+	linked := issue.LinkedPullRequests(t.PRs)
+	for _, pr := range linked {
+		issue.LinkedPRs = append(issue.LinkedPRs, pr)
+		pr.LinkedIssues = append(pr.LinkedIssues, issue)
+	}
+
+	if t.Milestone == "" || issue.Milestone == t.Milestone {
+		estimate := Estimate(issue.Labels)
+		workload.Days += Days(estimate)
+	} else {
+		issue.Deprioritised = true
+	}
 }
 
 type Issue struct {

--- a/internal/cmd/tracking-issue/testdata/issue.md
+++ b/internal/cmd/tracking-issue/testdata/issue.md
@@ -5,6 +5,12 @@
 - [x] Alert admins if LSIF uploads are too large for DBS_DIR_MAXIMUM_SIZE_BYTES [#9989](https://github.com/sourcegraph/sourcegraph/issues/9989) `lsif-reliability` 
 <!-- END ASSIGNEE -->
 
+<!-- BEGIN ASSIGNEE: attfarhan -->
+@attfarhan
+
+- [ ] Add Cobol support (lang filters, codeintel, and syntax highlighting) [#10154](https://github.com/sourcegraph/sourcegraph/issues/10154) 
+<!-- END ASSIGNEE -->
+
 <!-- BEGIN ASSIGNEE: efritz -->
 @efritz
 
@@ -53,4 +59,10 @@
 @keegancsmith
 
 - [x] GraphQL code intel doesn't work [#9756](https://github.com/sourcegraph/sourcegraph/issues/9756) 🐛
+<!-- END ASSIGNEE -->
+
+<!-- BEGIN ASSIGNEE: slimsag -->
+@slimsag
+
+- [ ] Add Cobol support (lang filters, codeintel, and syntax highlighting) [#10154](https://github.com/sourcegraph/sourcegraph/issues/10154) 
 <!-- END ASSIGNEE -->


### PR DESCRIPTION
Some issues are assigned to multiple people, but only show up for one assignee in the tracking issue. This makes it so that the same issue can be assigned to multiple people.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
