### PR TITLE
search: check patterns for field prefix

### DIFF
--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -36,18 +35,8 @@ func ScanAnyPatternLiteral(buf []byte) (scanned string, count int) {
 
 // isField returns whether the prefix of the string matches a recognized field.
 func isField(buf []byte) bool {
-	field, _ := ScanField(buf)
-	if field == "" {
-		return false
-	}
-
-	negated := field[0] == '-'
-	if negated {
-		field = field[1:]
-	}
-
-	_, exists := allFields[strings.ToLower(field)]
-	return exists
+	field, _, _ := ScanField(buf)
+	return field != ""
 }
 
 // ScanBalancedPatternLiteral attempts to scan parentheses as literal patterns.

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -174,11 +174,13 @@ func TestParseParameterList(t *testing.T) {
 func TestScanField(t *testing.T) {
 	type value struct {
 		Field   string
+		Negated bool
 		Advance int
 	}
 	cases := []struct {
-		Input string
-		Want  value
+		Input   string
+		Negated bool
+		Want    value
 	}{
 		// Valid field.
 		{
@@ -205,7 +207,8 @@ func TestScanField(t *testing.T) {
 		{
 			Input: "-repo:",
 			Want: value{
-				Field:   "-repo",
+				Field:   "repo",
+				Negated: true,
 				Advance: 6,
 			},
 		},
@@ -276,8 +279,8 @@ func TestScanField(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("scan field", func(t *testing.T) {
-			gotField, gotAdvance := ScanField([]byte(c.Input))
-			if diff := cmp.Diff(c.Want, value{gotField, gotAdvance}); diff != "" {
+			gotField, gotNegated, gotAdvance := ScanField([]byte(c.Input))
+			if diff := cmp.Diff(c.Want, value{gotField, gotNegated, gotAdvance}); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -761,6 +761,16 @@ func TestParse(t *testing.T) {
 			WantGrammar:   `(and "file:(a)" "file:(b)")`,
 			WantHeuristic: Same,
 		},
+		{
+			Input:         `(repohascommitafter:"7 days")`,
+			WantGrammar:   `"repohascommitafter:7 days"`,
+			WantHeuristic: Same,
+		},
+		{
+			Input:         `(foo repohascommitafter:"7 days")`,
+			WantGrammar:   `(and "repohascommitafter:7 days" "foo")`,
+			WantHeuristic: Same,
+		},
 		// Fringe tests cases at the boundary of heuristics and invalid syntax.
 		{
 			Input:         `(0(F)(:())(:())(<0)0()`,


### PR DESCRIPTION
Part of #13128. Fixes a minor issue where prior to this PR:

`(repocommitafter:"thing with a space")` => interpreted as a search pattern `(repocommitafter:"thing with a space")`.

Desired meaning: interpret this as `repocommitafter:"thing with a space"`.

First commit performs the change and adds the test. The second commit factors out the shared code we use for parsing and checking, and updates some tests.

---

Long version:

The previous behavior erroneously interpreted a pattern instead of the desired group containing parameters when the group syntax `(...)` contained a parameter with a quoted value containing a space. This is because the search pattern parser heuristic would terminate at a space, and not realize that the quotes mean that it is a single value. Because its too tricky to try and also recognize well-quoted values for these in that function, I'm changing the heuristic to recognize valid fields by prefix earlier, rather than consider the values.