### PR TITLE
search: add ellipses alias for structural search holes

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -973,6 +973,7 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	switch options.SearchType {
 	case SearchTypeLiteral:
 		query = substituteConcat(query, " ")
+		query = ellipsesForHoles(query)
 	case SearchTypeStructural:
 		if containsNegatedPattern(query) {
 			return nil, errors.New("the query contains a negated search pattern. Structural search does not support negated search patterns at the moment")

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -592,3 +592,14 @@ func concatRevFilters(nodes []Node) []Node {
 		return Parameter{Value: value, Field: FieldRepo, Negated: negated}
 	})
 }
+
+// ellipsesForHoles substitutes ellipses ... for :[_] holes in structural search queries.
+func ellipsesForHoles(nodes []Node) []Node {
+	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
+		return Pattern{
+			Value:      strings.ReplaceAll(value, "...", ":[_]"),
+			Negated:    negated,
+			Annotation: annotation,
+		}
+	})
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -263,6 +263,18 @@ func TestSubstituteConcat(t *testing.T) {
 	}
 }
 
+func TestEllipsesForHoles(t *testing.T) {
+	input := "if ... { ... }"
+	want := `(concat "if" ":[_]" "{" ":[_]" "}")`
+	t.Run("Ellipses for holes", func(t *testing.T) {
+		query, _ := ParseAndOr(input, SearchTypeStructural)
+		got := prettyPrint(ellipsesForHoles(query))
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}
+
 func TestConvertEmptyGroupsToLiteral(t *testing.T) {
 	cases := []struct {
 		input      string


### PR DESCRIPTION
I want `...` to be an alias for `:[_]`, just easier to type out in a search query, and arguably better readability for just matching things. I implemented it natively in comby, but we still need to transform things here because the regex converter code doesn't recognize `...` and will look for that string literally.

Aside: since comby now supports regex, to search literally for ... you can do something like `:[~[.]{3}]`or whatever.

I'll bundle structural search changelog entries in a separate PR.