### PR TITLE
search: enable negated patterns for unindexed search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Campaigns are enabled by default for all users, with site admins having read/write access and users only read access. The new site configuration property `campaigns.enabled` can be used to disable campaigns for all users. The properties `campaigns.readAccess`, `automation.readAccess.enabled`, and `"experimentalFeatures": { "automation": "enabled" }}` are deprecated and no longer have any effect.
 - In 3.11 we removed the 50-repository limit for diff and commit search which contains `before:` or `after:` filters. However, for large collections of repositories the searches would still fail. We introduce a limit of 10,000 repositories. This may affect your saved searches if you have any over more than 10,000 repositories. [#13386](https://github.com/sourcegraph/sourcegraph/pull/13386)
 - Campaign URLs have changed to use the campaign name instead of its ID. The old URLs no longer work. [#13368](https://github.com/sourcegraph/sourcegraph/pull/13368)
+- Negated content search is now also supported for unindexed repositories. Previously it was only supported for indexed repositories. Negated content search requires setting `"search.migrateParser": true` in settings and is only supported for literal and regexp queries.
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -327,14 +327,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return nil, nil, errors.New("no indexed repositories for structural search")
 	}
 
-	// unindexed search does not yet support negated patterns. If there are no indexed repos
-	// and the pattern is negated, raise a friendly alert.
-	if args.PatternInfo.IsNegated && len(indexed.Repos()) == 0 {
-		return nil, nil, errors.New("Your search query contained a negated search pattern for file content " +
-			fmt.Sprintf("\"%s\" ", args.PatternInfo.Pattern) + "but there are no indexed repositories to search over. " +
-			"Negated file contents are not supported for unindexed repositories yet.")
-	}
-
 	common.repos = make([]*types.Repo, len(args.Repos))
 	for i, repo := range args.Repos {
 		common.repos[i] = repo.Repo
@@ -584,7 +576,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	// This guard disables
 	// - unindexed structural search
 	// - unindexed search of negated content
-	if !(args.PatternInfo.IsStructuralPat || args.PatternInfo.IsNegated) {
+	if !args.PatternInfo.IsStructuralPat {
 		if err := callSearcherOverRepos(searcherRepos, nil); err != nil {
 			mu.Lock()
 			searchErr = err

--- a/doc/user/search/queries.md
+++ b/doc/user/search/queries.md
@@ -197,4 +197,4 @@ Example: [`type:path repo:/docker/ registry`](https://sourcegraph.com/search?q=t
 
 ## Negated content search
 
-To exclude code or text matches with `not pattern` or `-content:pattern`, set the `"search.migrateParser": true` option in global settings. Negated content search is currently supported for literal and regexp queries on indexed repositories. Negated content search on unindexed repositories is not yet supported.
+To exclude code or text matches with `not pattern` or `-content:pattern`, set the `"search.migrateParser": true` option in global settings. Negated content search is currently supported for literal and regexp queries.

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -91,6 +91,9 @@ func Search(ctx context.Context, searcherURLs *endpoint.Map, repo gitserver.Repo
 	if p.PathPatternsAreCaseSensitive {
 		q.Set("PathPatternsAreCaseSensitive", "true")
 	}
+	if p.IsNegated {
+		q.Set("IsNegated", "true")
+	}
 	// TEMP BACKCOMPAT: always set even if false so that searcher can distinguish new frontends that send
 	// these fields from old frontends that do not (and provide a default in the latter case).
 	q.Set("PatternMatchesContent", strconv.FormatBool(p.PatternMatchesContent))


### PR DESCRIPTION
Relates to #13274
Should be merged after #13323 

This PR removes guards in frontend that currently prevent searches with negated patterns on unindexed repos.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
