### PR TITLE
Define diff stats next to diff in tests

### DIFF
--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
@@ -43,13 +42,6 @@ func TestReconcilerProcess(t *testing.T) {
 		VCS:  protocol.VCSInfo{URL: rs[0].URI},
 	})
 	defer state.Unmock()
-
-	// diffStat is the diff stat that MockChangesetSyncState will provide from the source.
-	diffStat := &diff.Stat{
-		Added:   1,
-		Changed: 1,
-		Deleted: 3,
-	}
 
 	githubPR := buildGithubPR(clock(), "12345", "Remote title", "Remote body", "head-ref-on-github")
 
@@ -92,7 +84,7 @@ func TestReconcilerProcess(t *testing.T) {
 				unsynced:         false,
 				title:            "Remote title",
 				body:             "Remote body",
-				diffStat:         diffStat,
+				diffStat:         state.DiffStat,
 			},
 		},
 		"unpublished changeset stay unpublished": {
@@ -135,7 +127,7 @@ func TestReconcilerProcess(t *testing.T) {
 				externalBranch:   "head-ref-on-github",
 				title:            "Remote title",
 				body:             "Remote body",
-				diffStat:         diffStat,
+				diffStat:         state.DiffStat,
 			},
 		},
 		"retry publish changeset": {
@@ -164,7 +156,7 @@ func TestReconcilerProcess(t *testing.T) {
 				externalBranch:   "head-ref-on-github",
 				title:            "Remote title",
 				body:             "Remote body",
-				diffStat:         diffStat,
+				diffStat:         state.DiffStat,
 			},
 		},
 		"update published changeset metadata": {
@@ -199,7 +191,7 @@ func TestReconcilerProcess(t *testing.T) {
 				publicationState: campaigns.ChangesetPublicationStatePublished,
 				externalID:       "12345",
 				externalBranch:   "head-ref-on-github",
-				diffStat:         diffStat,
+				diffStat:         state.DiffStat,
 				// We update the title/body but want the title/body returned by the code host.
 				title: "Remote title",
 				body:  "Remote body",
@@ -240,7 +232,7 @@ func TestReconcilerProcess(t *testing.T) {
 				externalBranch:   "head-ref-on-github",
 				title:            "Remote title",
 				body:             "Remote body",
-				diffStat:         diffStat,
+				diffStat:         state.DiffStat,
 				// failureMessage should be nil
 			},
 		},

--- a/enterprise/internal/campaigns/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service_apply_campaign_test.go
@@ -47,13 +47,6 @@ func TestServiceApplyCampaign(t *testing.T) {
 	store := NewStoreWithClock(dbconn.Global, clock)
 	svc := NewService(store, httpcli.NewExternalHTTPClientFactory())
 
-	// The diff stat that corresponds to what's stored in the spec.
-	diffStat := &diff.Stat{
-		Added:   10,
-		Changed: 5,
-		Deleted: 2,
-	}
-
 	t.Run("campaignSpec without changesetSpecs", func(t *testing.T) {
 		t.Run("new campaign", func(t *testing.T) {
 			campaignSpec := createCampaignSpec(t, ctx, store, "campaign1", admin.ID)
@@ -255,7 +248,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				ownedByCampaign:  campaign.ID,
 				reconcilerState:  campaigns.ReconcilerStateQueued,
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
-				diffStat:         diffStat,
+				diffStat:         testChangsetSpecDiffStat,
 			})
 		})
 
@@ -383,7 +376,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				ownedByCampaign:  campaign.ID,
 				reconcilerState:  campaigns.ReconcilerStateQueued,
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
-				diffStat:         diffStat,
+				diffStat:         testChangsetSpecDiffStat,
 			})
 
 			c4 := cs.Find(campaigns.WithCurrentSpecID(spec4.ID))
@@ -393,7 +386,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				ownedByCampaign:  campaign.ID,
 				reconcilerState:  campaigns.ReconcilerStateQueued,
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
-				diffStat:         diffStat,
+				diffStat:         testChangsetSpecDiffStat,
 			})
 
 			c5 := cs.Find(campaigns.WithCurrentSpecID(spec5.ID))
@@ -403,7 +396,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				ownedByCampaign:  campaign.ID,
 				reconcilerState:  campaigns.ReconcilerStateQueued,
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
-				diffStat:         diffStat,
+				diffStat:         testChangsetSpecDiffStat,
 			})
 		})
 
@@ -444,7 +437,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				externalID:       c.ExternalID,
 				reconcilerState:  campaigns.ReconcilerStateCompleted,
 				publicationState: campaigns.ChangesetPublicationStatePublished,
-				diffStat:         diffStat,
+				diffStat:         testChangsetSpecDiffStat,
 			})
 
 			// Now we stop tracking it in the second campaign
@@ -746,6 +739,8 @@ type testSpecOpts struct {
 	commitDiff    string
 }
 
+var testChangsetSpecDiffStat = &diff.Stat{Added: 10, Changed: 5, Deleted: 2}
+
 func createChangesetSpec(
 	t *testing.T,
 	ctx context.Context,
@@ -775,9 +770,9 @@ func createChangesetSpec(
 				},
 			},
 		},
-		DiffStatAdded:   10,
-		DiffStatChanged: 5,
-		DiffStatDeleted: 2,
+		DiffStatAdded:   testChangsetSpecDiffStat.Added,
+		DiffStatChanged: testChangsetSpecDiffStat.Changed,
+		DiffStatDeleted: testChangsetSpecDiffStat.Deleted,
 	}
 
 	if err := store.CreateChangesetSpec(ctx, spec); err != nil {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -615,11 +614,7 @@ func TestService(t *testing.T) {
 				t.Fatalf("wrong spec fields (-want +got):\n%s", diff)
 			}
 
-			wantDiffStat := diff.Stat{
-				Added:   1,
-				Changed: 2,
-				Deleted: 1,
-			}
+			wantDiffStat := *ct.ChangesetSpecDiffStat
 			if diff := cmp.Diff(wantDiffStat, spec.DiffStat()); diff != "" {
 				t.Fatalf("wrong diff stat (-want +got):\n%s", diff)
 			}

--- a/enterprise/internal/campaigns/testing/mock_sync_state.go
+++ b/enterprise/internal/campaigns/testing/mock_sync_state.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -13,6 +14,9 @@ import (
 )
 
 type MockedChangesetSyncState struct {
+	// DiffStat is the diff.Stat of the mocked "git diff" call to gitserver.
+	DiffStat *diff.Stat
+
 	execReader      func([]string) (io.ReadCloser, error)
 	mockRepoLookup  func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
 	resolveRevision func(string, git.ResolveRevisionOptions) (api.CommitID, error)
@@ -25,6 +29,9 @@ type MockedChangesetSyncState struct {
 // state.Unmock() must called to clean up, usually via defer.
 func MockChangesetSyncState(repo *protocol.RepoInfo) *MockedChangesetSyncState {
 	state := &MockedChangesetSyncState{
+		// This diff.Stat matches the testGitHubDiff below
+		DiffStat: &diff.Stat{Added: 1, Changed: 1, Deleted: 3},
+
 		execReader:      git.Mocks.ExecReader,
 		mockRepoLookup:  repoupdater.MockRepoLookup,
 		resolveRevision: git.Mocks.ResolveRevision,

--- a/enterprise/internal/campaigns/testing/specs.go
+++ b/enterprise/internal/campaigns/testing/specs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/go-diff/diff"
 )
 
 const TestRawCampaignSpec = `{
@@ -52,6 +53,8 @@ changesetTemplate:
     message: Append Hello World to all README.md files
   published: false
 `
+
+var ChangesetSpecDiffStat = &diff.Stat{Added: 1, Changed: 2, Deleted: 1}
 
 func NewRawChangesetSpecGitBranch(repo graphql.ID, baseRev string) string {
 	diff := `diff --git INSTALL.md INSTALL.md


### PR DESCRIPTION
I that we had a few of these diff.Stats lying around, refering to
different diffs, so I put them next to the diffs themselves.

In the case of MockChangesetSyncState I actually defined it on the
`state` itself, which I'm not 100% sure about yet, but I think it's
pretty neat to be able to access the properties of the mocked state
through the `state` itself.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
