### PR TITLE
Make "don't build ctags image" check less agressive

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -5,10 +5,10 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -eu
 
-# If CTAGS_COMMAND is set, we don't need to build the image. See
-# ./universal-ctags-dev.
-if [[ -n "${CTAGS_COMMAND}" ]]; then
-  echo "CTAGS_COMMAND set. Building of Docker image not necessary."
+# If CTAGS_COMMAND is set to a custom executable, we don't need to build the
+# image. See ./universal-ctags-dev.
+if [[ "${CTAGS_COMMAND}" != "cmd/symbols/universal-ctags-dev" ]]; then
+  echo "CTAGS_COMMAND set to custom executable. Building of Docker image not necessary."
   exit 0
 fi
 


### PR DESCRIPTION
Turns out my previous PR #13218 was a regression.

We set `CTAGS_COMMAND` to `cmd/symbols/universal-ctags-dev` in
`./dev/start.sh` by default. That means if you've never built the Docker
image, we'd never build it with the old code.

This changes the fix so that we only don't build the image if you have a
custom executable specified.

Thanks to @macraig for uncovering this!


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
