### PR TITLE
Use campaign name in URL for better readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Introduced the new `external_service_repos` join table. Please note that the migration required to make this change could take a couple of minutes.
 - Campaigns are enabled by default for all users, with site admins having read/write access and users only read access. The new site configuration property `campaigns.enabled` can be used to disable campaigns for all users. The properties `campaigns.readAccess`, `automation.readAccess.enabled`, and `"experimentalFeatures": { "automation": "enabled" }}` are deprecated and no longer have any effect.
 - In 3.11 we removed the 50-repository limit for diff and commit search which contains `before:` or `after:` filters. However, for large collections of repositories the searches would still fail. We introduce a limit of 10,000 repositories. This may affect your saved searches if you have any over more than 10,000 repositories. [#13386](https://github.com/sourcegraph/sourcegraph/pull/13386)
+- Campaign URLs have changed to use the campaign name instead of its ID. The old URLs no longer work. [#13368](https://github.com/sourcegraph/sourcegraph/pull/13368)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -25,7 +25,7 @@ type MoveCampaignArgs struct {
 	NewNamespace *graphql.ID
 }
 
-type ListCampaignArgs struct {
+type ListCampaignsArgs struct {
 	First               *int32
 	After               *string
 	State               *string
@@ -63,6 +63,11 @@ type ChangesetSpecsConnectionArgs struct {
 	After *string
 }
 
+type CampaignArgs struct {
+	Namespace string
+	Name      string
+}
+
 type CampaignsResolver interface {
 	// Mutations
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
@@ -75,7 +80,8 @@ type CampaignsResolver interface {
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
 
 	// Queries
-	Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error)
+	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
+	Campaign(ctx context.Context, args *CampaignArgs) (CampaignResolver, error)
 	CampaignByID(ctx context.Context, id graphql.ID) (CampaignResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
 
@@ -246,7 +252,7 @@ type ChangesetResolver interface {
 	PublicationState() campaigns.ChangesetPublicationState
 	ReconcilerState() campaigns.ReconcilerState
 	ExternalState() *campaigns.ChangesetExternalState
-	Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error)
+	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
 
 	ToExternalChangeset() (ExternalChangesetResolver, bool)
 	ToHiddenExternalChangeset() (HiddenExternalChangesetResolver, bool)
@@ -350,7 +356,11 @@ func (defaultCampaignsResolver) CampaignByID(ctx context.Context, id graphql.ID)
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error) {
+func (defaultCampaignsResolver) Campaign(ctx context.Context, args *CampaignArgs) (CampaignResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -171,7 +171,7 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 
 func (o *OrgResolver) NamespaceName() string { return o.org.Name }
 
-func (o *OrgResolver) Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error) {
+func (o *OrgResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error) {
 	id := o.ID()
 	args.Namespace = &id
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1246,6 +1246,13 @@ type Query {
         # Only include campaigns that the viewer can administer.
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+    # Looks up a campaign by namespace and campaign name.
+    campaign(
+        # The namespace where the campaign lives.
+        namespace: ID!
+        # The campaigns name.
+        name: String!
+    ): Campaign
 
     # Looks up a repository by either name or cloneURL.
     repository(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1253,6 +1253,13 @@ type Query {
         # Only include campaigns that the viewer can administer.
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+    # Looks up a campaign by namespace and campaign name.
+    campaign(
+        # The namespace where the campaign lives.
+        namespace: ID!
+        # The campaigns name.
+        name: String!
+    ): Campaign
 
     # Looks up a repository by either name or cloneURL.
     repository(

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -317,7 +317,7 @@ func (r *UserResolver) ViewerCanChangeUsername(ctx context.Context) bool {
 	return viewerCanChangeUsername(ctx, r.user.ID)
 }
 
-func (r *UserResolver) Campaigns(ctx context.Context, args *ListCampaignArgs) (CampaignsConnectionResolver, error) {
+func (r *UserResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error) {
 	id := r.ID()
 	args.Namespace = &id
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -67,17 +67,18 @@ func TestCampaignResolver(t *testing.T) {
 	}
 
 	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
+	namespaceAPIID := string(graphqlbackend.MarshalOrgID(org.ID))
 	apiUser := &apitest.User{DatabaseID: userID, SiteAdmin: true}
 	wantCampaign := apitest.Campaign{
 		ID:             campaignAPIID,
 		Name:           campaign.Name,
 		Description:    campaign.Description,
-		Namespace:      apitest.UserOrg{ID: string(graphqlbackend.MarshalOrgID(org.ID)), Name: org.Name},
+		Namespace:      apitest.UserOrg{ID: namespaceAPIID, Name: org.Name},
 		InitialApplier: apiUser,
 		LastApplier:    apiUser,
 		SpecCreator:    apiUser,
 		LastAppliedAt:  marshalDateTime(t, now),
-		URL:            fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaignAPIID),
+		URL:            fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaign.Name),
 		CreatedAt:      marshalDateTime(t, now),
 		UpdatedAt:      marshalDateTime(t, now),
 		// Not closed.
@@ -90,6 +91,16 @@ func TestCampaignResolver(t *testing.T) {
 		apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
 
 		if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
+			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+		}
+	}
+	// Test resolver by namespace and name
+	byNameInput := map[string]interface{}{"name": campaign.Name, "namespace": namespaceAPIID}
+	{
+		var response struct{ Campaign apitest.Campaign }
+		apitest.MustExec(ctx, t, s, byNameInput, &response, queryCampaignByName)
+
+		if diff := cmp.Diff(wantCampaign, response.Campaign); diff != "" {
 			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
 		}
 	}
@@ -149,6 +160,28 @@ query($campaign: ID!){
       }
       url
     }
+  }
+}
+`
+const queryCampaignByName = `
+fragment u on User { databaseID, siteAdmin }
+fragment o on Org  { id, name }
+
+query($namespace: ID!, $name: String!){
+  campaign(namespace: $namespace, name: $name) {
+    id, name, description
+    initialApplier { ...u }
+    lastApplier    { ...u }
+    specCreator    { ...u }
+    lastAppliedAt
+    createdAt
+    updatedAt
+    closedAt
+    namespace {
+      ... on User { ...u }
+      ... on Org  { ...o }
+    }
+    url
   }
 }
 `

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -165,7 +165,7 @@ func (r *changesetResolver) Repository(ctx context.Context) *graphqlbackend.Repo
 	return r.repoResolver
 }
 
-func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
+func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignsArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
 	opts := ee.ListCampaignsOpts{
 		ChangesetID: r.changeset.ID,
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -532,9 +532,10 @@ func TestMoveCampaign(t *testing.T) {
 
 	// Move to a new name
 	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
+	newCampaignName := "new-name"
 	input := map[string]interface{}{
 		"campaign": campaignAPIID,
-		"newName":  "new-name",
+		"newName":  newCampaignName,
 	}
 
 	var response struct{ MoveCampaign apitest.Campaign }
@@ -546,7 +547,7 @@ func TestMoveCampaign(t *testing.T) {
 		t.Fatalf("unexpected name (-want +got):\n%s", diff)
 	}
 
-	wantURL := fmt.Sprintf("/users/%s/campaigns/%s", username, campaignAPIID)
+	wantURL := fmt.Sprintf("/users/%s/campaigns/%s", username, newCampaignName)
 	if diff := cmp.Diff(wantURL, haveCampaign.URL); diff != "" {
 		t.Fatalf("unexpected URL (-want +got):\n%s", diff)
 	}
@@ -564,7 +565,7 @@ func TestMoveCampaign(t *testing.T) {
 	if diff := cmp.Diff(string(orgAPIID), haveCampaign.Namespace.ID); diff != "" {
 		t.Fatalf("unexpected namespace (-want +got):\n%s", diff)
 	}
-	wantURL = fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, campaignAPIID)
+	wantURL = fmt.Sprintf("/organizations/%s/campaigns/%s", org.Name, newCampaignName)
 	if diff := cmp.Diff(wantURL, haveCampaign.URL); diff != "" {
 		t.Fatalf("unexpected URL (-want +got):\n%s", diff)
 	}

--- a/enterprise/internal/campaigns/resolvers/urls.go
+++ b/enterprise/internal/campaigns/resolvers/urls.go
@@ -9,5 +9,5 @@ func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignSpec
 }
 
 func campaignURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignResolver) string {
-	return n.URL() + "/campaigns/" + string(c.ID())
+	return n.URL() + "/campaigns/" + string(c.Name())
 }

--- a/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -8,7 +8,7 @@ import { CampaignClosePage } from './CampaignClosePage'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs,
-    fetchCampaignById,
+    fetchCampaignByNamespace,
 } from '../detail/backend'
 import { of } from 'rxjs'
 import { subDays } from 'date-fns'
@@ -208,7 +208,7 @@ add('Overview', () => {
         }),
         [viewerCanAdminister]
     )
-    const fetchCampaign: typeof fetchCampaignById = useCallback(() => of(campaign), [campaign])
+    const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
     return (
         <CampaignClosePage
             {...breadcrumbsProps}
@@ -216,8 +216,9 @@ add('Overview', () => {
             location={history.location}
             queryChangesets={queryChangesets}
             queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
-            campaignID="123"
-            fetchCampaignById={fetchCampaign}
+            namespaceID="n123"
+            campaignName="c123"
+            fetchCampaignByNamespace={fetchCampaign}
             extensionsController={{} as any}
             platformContext={{} as any}
             telemetryService={NOOP_TELEMETRY_SERVICE}

--- a/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
@@ -3,11 +3,11 @@ import * as H from 'history'
 import { PageTitle } from '../../../components/PageTitle'
 import { CampaignHeader } from '../detail/CampaignHeader'
 import { CampaignCloseAlert } from './CampaignCloseAlert'
-import { Scalars } from '../../../graphql-operations'
+import { CampaignFields, Scalars } from '../../../graphql-operations'
 import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
     queryChangesets as _queryChangesets,
-    fetchCampaignById as _fetchCampaignById,
+    fetchCampaignByNamespace as _fetchCampaignByNamespace,
 } from '../detail/backend'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
@@ -29,12 +29,19 @@ export interface CampaignClosePageProps
         PlatformContextProps,
         BreadcrumbSetters,
         ExtensionsControllerProps {
-    campaignID: Scalars['ID']
+    /**
+     * The namespace ID.
+     */
+    namespaceID: Scalars['ID']
+    /**
+     * The campaign name.
+     */
+    campaignName: CampaignFields['name']
     history: H.History
     location: H.Location
 
     /** For testing only. */
-    fetchCampaignById?: typeof _fetchCampaignById
+    fetchCampaignByNamespace?: typeof _fetchCampaignByNamespace
     /** For testing only. */
     queryChangesets?: typeof _queryChangesets
     /** For testing only. */
@@ -44,7 +51,8 @@ export interface CampaignClosePageProps
 }
 
 export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> = ({
-    campaignID,
+    namespaceID,
+    campaignName,
     history,
     location,
     extensionsController,
@@ -52,13 +60,19 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
     platformContext,
     telemetryService,
     useBreadcrumb,
-    fetchCampaignById = _fetchCampaignById,
+    fetchCampaignByNamespace = _fetchCampaignByNamespace,
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
     closeCampaign,
 }) => {
     const [closeChangesets, setCloseChangesets] = useState<boolean>(false)
-    const campaign = useObservable(useMemo(() => fetchCampaignById(campaignID), [campaignID, fetchCampaignById]))
+    const campaign = useObservable(
+        useMemo(() => fetchCampaignByNamespace(namespaceID, campaignName), [
+            namespaceID,
+            campaignName,
+            fetchCampaignByNamespace,
+        ])
+    )
 
     useBreadcrumb(
         useMemo(
@@ -99,7 +113,7 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
                 className="mb-3"
             />
             <CampaignCloseAlert
-                campaignID={campaignID}
+                campaignID={campaign.id}
                 campaignURL={campaign.url}
                 closeChangesets={closeChangesets}
                 setCloseChangesets={setCloseChangesets}
@@ -114,7 +128,7 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
             )}
             {!closeChangesets && <h2>The following changesets will remain open:</h2>}
             <CampaignCloseChangesetsList
-                campaignID={campaignID}
+                campaignID={campaign.id}
                 history={history}
                 location={location}
                 viewerCanAdminister={campaign.viewerCanAdminister}

--- a/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -15,7 +15,7 @@ import {
     ChangesetReviewState,
 } from '../../../graphql-operations'
 import {
-    fetchCampaignById,
+    fetchCampaignByNamespace,
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
@@ -269,14 +269,15 @@ add('Overview', () => {
         [viewerCanAdminister, isClosed]
     )
 
-    const fetchCampaign: typeof fetchCampaignById = useCallback(() => of(campaign), [campaign])
+    const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
     const history = H.createMemoryHistory({ initialEntries: [window.location.href] })
     const breadcrumbsProps = useBreadcrumbs()
     return (
         <CampaignDetailsPage
             {...breadcrumbsProps}
-            campaignID="123123"
-            fetchCampaignById={fetchCampaign}
+            namespaceID="namespace123"
+            campaignName="awesome-campaign"
+            fetchCampaignByNamespace={fetchCampaign}
             queryChangesets={queryChangesets}
             queryChangesetCountsOverTime={queryChangesetCountsOverTime}
             queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}

--- a/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
@@ -20,14 +20,15 @@ describe('CampaignDetailsPage', () => {
 
     const renderCampaignDetailsPage = ({ viewerCanAdminister }: { viewerCanAdminister: boolean }) => (
         <CampaignDetailsPage
-            campaignID="c"
+            namespaceID="namespace123"
+            campaignName="c"
             history={history}
             location={history.location}
             isLightTheme={true}
             extensionsController={undefined as any}
             platformContext={undefined as any}
             telemetryService={NOOP_TELEMETRY_SERVICE}
-            fetchCampaignById={() =>
+            fetchCampaignByNamespace={() =>
                 of({
                     __typename: 'Campaign',
                     id: 'c',

--- a/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -5,7 +5,7 @@ import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
 import { isEqual } from 'lodash'
 import {
-    fetchCampaignById as _fetchCampaignById,
+    fetchCampaignByNamespace as _fetchCampaignByNamespace,
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
@@ -34,14 +34,18 @@ export interface CampaignDetailsPageProps
         BreadcrumbSetters,
         TelemetryProps {
     /**
-     * The campaign ID.
+     * The namespace ID.
      */
-    campaignID: Scalars['ID']
+    namespaceID: Scalars['ID']
+    /**
+     * The campaign name.
+     */
+    campaignName: CampaignFields['name']
     history: H.History
     location: H.Location
 
     /** For testing only. */
-    fetchCampaignById?: typeof _fetchCampaignById
+    fetchCampaignByNamespace?: typeof _fetchCampaignByNamespace
     /** For testing only. */
     queryChangesets?: typeof _queryChangesets
     /** For testing only. */
@@ -56,7 +60,8 @@ export interface CampaignDetailsPageProps
  * The area for a single campaign.
  */
 export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPageProps> = ({
-    campaignID,
+    namespaceID,
+    campaignName,
     history,
     location,
     isLightTheme,
@@ -64,7 +69,7 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
     platformContext,
     telemetryService,
     useBreadcrumb,
-    fetchCampaignById = _fetchCampaignById,
+    fetchCampaignByNamespace = _fetchCampaignByNamespace,
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime,
@@ -77,11 +82,11 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
     const campaign: CampaignFields | null | undefined = useObservable(
         useMemo(
             () =>
-                fetchCampaignById(campaignID).pipe(
+                fetchCampaignByNamespace(namespaceID, campaignName).pipe(
                     repeatWhen(notifier => notifier.pipe(delay(5000))),
                     distinctUntilChanged((a, b) => isEqual(a, b))
                 ),
-            [campaignID, fetchCampaignById]
+            [namespaceID, campaignName, fetchCampaignByNamespace]
         )
     )
 

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
@@ -2,12 +2,13 @@
 
 exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
 <CampaignDetailsPage
-  campaignID="c"
+  campaignName="c"
   deleteCampaign={[Function]}
-  fetchCampaignById={[Function]}
+  fetchCampaignByNamespace={[Function]}
   history="[History]"
   isLightTheme={true}
   location="[Location path=/]"
+  namespaceID="namespace123"
   queryChangesetCountsOverTime={[Function]}
   setBreadcrumb={[Function]}
   telemetryService={
@@ -761,12 +762,13 @@ exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
 
 exports[`CampaignDetailsPage viewerCanAdminister: true viewing existing 1`] = `
 <CampaignDetailsPage
-  campaignID="c"
+  campaignName="c"
   deleteCampaign={[Function]}
-  fetchCampaignById={[Function]}
+  fetchCampaignByNamespace={[Function]}
   history="[History]"
   isLightTheme={true}
   location="[Location path=/]"
+  namespaceID="namespace123"
   queryChangesetCountsOverTime={[Function]}
   setBreadcrumb={[Function]}
   telemetryService={

--- a/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
+++ b/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
@@ -150,24 +150,26 @@ export const UserCampaignsArea = withAuthenticatedUser<
                         render={props => <CreateCampaignPage {...outerProps} {...props} {...breadcrumbSetters} />}
                     />
                     <Route
-                        path={`${match.url}/:campaignID/close`}
-                        render={({ match, ...props }: RouteComponentProps<{ campaignID: string }>) => (
+                        path={`${match.url}/:campaignName/close`}
+                        render={({ match, ...props }: RouteComponentProps<{ campaignName: string }>) => (
                             <CampaignClosePage
                                 {...outerProps}
                                 {...props}
                                 {...breadcrumbSetters}
-                                campaignID={match.params.campaignID}
+                                namespaceID={userID}
+                                campaignName={match.params.campaignName}
                             />
                         )}
                     />
                     <Route
-                        path={`${match.url}/:campaignID`}
-                        render={({ match, ...props }: RouteComponentProps<{ campaignID: string }>) => (
+                        path={`${match.url}/:campaignName`}
+                        render={({ match, ...props }: RouteComponentProps<{ campaignName: string }>) => (
                             <CampaignDetailsPage
                                 {...outerProps}
                                 {...props}
                                 {...breadcrumbSetters}
-                                campaignID={match.params.campaignID}
+                                namespaceID={userID}
+                                campaignName={match.params.campaignName}
                             />
                         )}
                     />
@@ -224,24 +226,26 @@ export const OrgCampaignsArea = withAuthenticatedUser<OrgCampaignsAreaProps & { 
                             render={props => <CreateCampaignPage {...props} {...outerProps} {...breadcrumbSetters} />}
                         />
                         <Route
-                            path={`${match.url}/:campaignID/close`}
-                            render={({ match, ...props }: RouteComponentProps<{ campaignID: string }>) => (
+                            path={`${match.url}/:campaignName/close`}
+                            render={({ match, ...props }: RouteComponentProps<{ campaignName: string }>) => (
                                 <CampaignClosePage
                                     {...props}
                                     {...outerProps}
                                     {...breadcrumbSetters}
-                                    campaignID={match.params.campaignID}
+                                    namespaceID={orgID}
+                                    campaignName={match.params.campaignName}
                                 />
                             )}
                         />
                         <Route
-                            path={`${match.url}/:campaignID`}
-                            render={({ match, ...props }: RouteComponentProps<{ campaignID: string }>) => (
+                            path={`${match.url}/:campaignName`}
+                            render={({ match, ...props }: RouteComponentProps<{ campaignName: string }>) => (
                                 <CampaignDetailsPage
                                     {...props}
                                     {...outerProps}
                                     {...breadcrumbSetters}
-                                    campaignID={match.params.campaignID}
+                                    namespaceID={orgID}
+                                    campaignName={match.params.campaignName}
                                 />
                             )}
                         />

--- a/web/src/integration/campaigns.test.ts
+++ b/web/src/integration/campaigns.test.ts
@@ -17,18 +17,18 @@ import {
     CampaignChangesetsVariables,
     CampaignChangesetsResult,
     WebGraphQlOperations,
-    CampaignByIDResult,
     ExternalChangesetFileDiffsFields,
     DiffHunkLineType,
     ChangesetSpecType,
     ListCampaign,
+    CampaignByNamespaceResult,
 } from '../graphql-operations'
 import { SharedGraphQlOperations } from '../../../shared/src/graphql-operations'
 
 const campaignListNode: ListCampaign = {
     id: 'campaign123',
-    url: '/users/alice/campaigns/campaign123',
-    name: 'campaign123',
+    url: '/users/alice/campaigns/test-campaign',
+    name: 'test-campaign',
     createdAt: subDays(new Date(), 5).toISOString(),
     changesets: { stats: { closed: 4, merged: 10, open: 5 } },
     closedAt: null,
@@ -205,7 +205,7 @@ const CampaignChangesets: (variables: CampaignChangesetsVariables) => CampaignCh
 
 function mockCommonGraphQLResponses(
     entityType: 'user' | 'org',
-    campaignOverrides?: Partial<NonNullable<CampaignByIDResult['node']>>
+    campaignOverrides?: Partial<NonNullable<CampaignByNamespaceResult['campaign']>>
 ): Partial<WebGraphQlOperations & SharedGraphQlOperations> {
     const namespaceURL = entityType === 'user' ? '/users/alice' : '/organizations/test-org'
     return {
@@ -241,8 +241,8 @@ function mockCommonGraphQLResponses(
                 permissionsInfo: null,
             },
         }),
-        CampaignByID: () => ({
-            node: {
+        CampaignByNamespace: () => ({
+            campaign: {
                 __typename: 'Campaign',
                 id: 'campaign123',
                 changesets: { stats: { closed: 2, merged: 3, open: 10, total: 5, unpublished: 3 } },
@@ -259,7 +259,7 @@ function mockCommonGraphQLResponses(
                     namespaceName: entityType === 'user' ? 'alice' : 'test-org',
                     url: namespaceURL,
                 },
-                url: `${namespaceURL}/campaigns/campaign123`,
+                url: `${namespaceURL}/campaigns/test-campaign`,
                 diffStat: {
                     added: 1000,
                     changed: 29,
@@ -323,7 +323,7 @@ describe('Campaigns', () => {
                 await driver.page.evaluate(
                     () => document.querySelector<HTMLAnchorElement>('.test-campaign-link')?.href
                 ),
-                testContext.driver.sourcegraphBaseUrl + '/users/alice/campaigns/campaign123'
+                testContext.driver.sourcegraphBaseUrl + '/users/alice/campaigns/test-campaign'
             )
         })
 
@@ -353,7 +353,7 @@ describe('Campaigns', () => {
                 await driver.page.evaluate(
                     () => document.querySelector<HTMLAnchorElement>('.test-campaign-link')?.href
                 ),
-                testContext.driver.sourcegraphBaseUrl + '/users/alice/campaigns/campaign123'
+                testContext.driver.sourcegraphBaseUrl + '/users/alice/campaigns/test-campaign'
             )
             assert.strictEqual(await driver.page.$('.test-campaign-namespace-link'), null)
         })
@@ -369,7 +369,7 @@ describe('Campaigns', () => {
                             nodes: [
                                 {
                                     ...campaignListNode,
-                                    url: '/organizations/test-org/campaigns/campaign123',
+                                    url: '/organizations/test-org/campaigns/test-campaign',
                                     namespace: {
                                         namespaceName: 'test-org',
                                         url: '/organizations/test-org',
@@ -394,7 +394,7 @@ describe('Campaigns', () => {
                 await driver.page.evaluate(
                     () => document.querySelector<HTMLAnchorElement>('.test-campaign-link')?.href
                 ),
-                testContext.driver.sourcegraphBaseUrl + '/organizations/test-org/campaigns/campaign123'
+                testContext.driver.sourcegraphBaseUrl + '/organizations/test-org/campaigns/test-campaign'
             )
             assert.strictEqual(await driver.page.$('.test-campaign-namespace-link'), null)
         })
@@ -412,7 +412,7 @@ describe('Campaigns', () => {
                 })
                 const namespaceURL = entityType === 'user' ? '/users/alice' : '/organizations/test-org'
 
-                await driver.page.goto(driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/campaign123')
+                await driver.page.goto(driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/test-campaign')
                 // View overview page.
                 await driver.page.waitForSelector('.test-campaign-details-page')
 
@@ -429,7 +429,7 @@ describe('Campaigns', () => {
                 await Promise.all([driver.page.waitForNavigation(), driver.page.click('.test-campaigns-close-btn')])
                 assert.strictEqual(
                     await driver.page.evaluate(() => window.location.href),
-                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/campaign123/close'
+                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/test-campaign/close'
                 )
                 await driver.page.waitForSelector('.test-campaign-close-page')
                 // Change overrides to make campaign appear closed.
@@ -454,7 +454,7 @@ describe('Campaigns', () => {
                 await driver.page.waitForSelector('.test-campaign-details-page')
                 assert.strictEqual(
                     await driver.page.evaluate(() => window.location.href),
-                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/campaign123'
+                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/test-campaign'
                 )
 
                 // Delete the closed campaign.
@@ -566,7 +566,7 @@ describe('Campaigns', () => {
                     CreateCampaign: () => ({
                         createCampaign: {
                             id: 'campaign123',
-                            url: namespaceURL + '/campaigns/campaign123',
+                            url: namespaceURL + '/campaigns/test-campaign',
                         },
                     }),
                 })
@@ -589,7 +589,7 @@ describe('Campaigns', () => {
                 // Expect to be back at campaign overview page.
                 assert.strictEqual(
                     await driver.page.evaluate(() => window.location.href),
-                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/campaign123'
+                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/test-campaign'
                 )
             })
         }
@@ -611,7 +611,7 @@ describe('Campaigns', () => {
                 })
                 const namespaceURL = entityType === 'user' ? '/users/alice' : '/organizations/test-org'
 
-                await driver.page.goto(driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/campaign123/close')
+                await driver.page.goto(driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/test-campaign/close')
                 // View overview page.
                 await driver.page.waitForSelector('.test-campaign-close-page')
 
@@ -633,7 +633,7 @@ describe('Campaigns', () => {
                 // Expect to be back at campaign overview page.
                 assert.strictEqual(
                     await driver.page.evaluate(() => window.location.href),
-                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/campaign123'
+                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/campaigns/test-campaign'
                 )
             })
         }


### PR DESCRIPTION
After the breadcrumbs work and refactoring all campaigns components into a global Area, this was rather simple to achieve.

Closes #13086