### PR TITLE
Fix race condition in campaigns.Service tests

### DIFF
--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -228,13 +228,6 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("CloseCampaign", func(t *testing.T) {
-		// After close, the changesets will be synced, so we need to mock that operation.
-		state := ct.MockChangesetSyncState(&protocol.RepoInfo{
-			Name: api.RepoName(rs[0].Name),
-			VCS:  protocol.VCSInfo{URL: rs[0].URI},
-		})
-		defer state.Unmock()
-
 		createCampaign := func(t *testing.T) *campaigns.Campaign {
 			t.Helper()
 


### PR DESCRIPTION
This mock was set up by this subtest and the one for
`CloseOpenChangesets`, but only used by the latter.

Since setting up and tearing down the mock modifies global state, we
reduce the second setup (since we don't need it) to get rid of the race
condition.

And in #13367 the CloseOpenChangesets method will be removed.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
