### PR TITLE
search: Improve performance of zoektIndexedRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -633,6 +633,10 @@ type indexedRepoRevs struct {
 	NotHEADOnlySearch bool
 }
 
+// headBranch is used as a singleton of the indexedRepoRevs.repoBranches to save
+// common-case allocations within indexedRepoRevs.Add.
+var headBranch = []string{"HEAD"}
+
 // Add will add reporev and repo to the list of repository and branches to
 // search if reporev's refs are a subset of repo's branches. It will return
 // the revision specifiers it can't add.
@@ -651,6 +655,12 @@ func (rb *indexedRepoRevs) Add(reporev *search.RepositoryRevisions, repo *zoekt.
 		// TODO we could only process the explicit revs and return the non
 		// explicit ones as unindexed.
 		return reporev.Revs
+	}
+
+	if len(reporev.Revs) == 1 && (reporev.Revs[0].RevSpec == "" || reporev.Revs[0].RevSpec == "HEAD") {
+		rb.repoRevs[string(reporev.Repo.Name)] = reporev
+		rb.repoBranches[string(reporev.Repo.Name)] = headBranch
+		return nil
 	}
 
 	// notHEADOnlySearch is set to true if we search any branch other than

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -405,7 +405,7 @@ func Benchmark_zoektIndexedRepos(b *testing.B) {
 	repoNames := []string{}
 	zoektRepos := map[string]*zoekt.Repository{}
 
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 200000; i++ {
 		indexedName := fmt.Sprintf("foo/indexed-%d@", i)
 		unindexedName := fmt.Sprintf("foo/unindexed-%d@", i)
 


### PR DESCRIPTION
During a hack hour, @keegancsmith and I found that 300ms of global search was being taken by determining which repositories are indexed. This change makes the common case faster and reduces allocations by 98% and wall time by 22% when no branches are specified.

```
$ benchstat old.txt new.txt
name                   old time/op    new time/op    delta
_zoektIndexedRepos-16     151ms ± 5%     118ms ±16%  -22.22%  (p=0.008 n=5+5)

name                   old alloc/op   new alloc/op   delta
_zoektIndexedRepos-16    33.6MB ± 0%    20.8MB ± 0%  -38.09%  (p=0.008 n=5+5)

name                   old allocs/op  new allocs/op  delta
_zoektIndexedRepos-16      407k ± 0%        7k ± 0%  -98.37%  (p=0.008 n=5+5)
```