### PR TITLE
Don't open Renovate PRs for typescript nightly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,15 +9,6 @@
   },
   "packageRules": [
     {
-      "packageNames": ["typescript"],
-      "ignoreUnstable": false,
-      "followTag": "next",
-      "schedule": null,
-      "reviewers": [],
-      "automerge": false,
-      "labels": ["bot", "npm", "nightly"]
-    },
-    {
       "packageNames": ["@octokit/rest", "@slack/web-api", "googleapis"],
       "reviewers": ["beyang"]
     }


### PR DESCRIPTION
This hasn't given us much value, is still bugged in Renovate, prevents us from getting stable update PRs, and since we pay Chromatic per snapshot also costs us money to run daily for little benefit.