### PR TITLE
search: always limit commit and diff to less than 10,000 repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Introduced the new `external_service_repos` join table. Please note that the migration required to make this change could take a couple of minutes.
 - Campaigns are enabled by default for all users, with site admins having read/write access and users only read access. The new site configuration property `campaigns.enabled` can be used to disable campaigns for all users. The properties `campaigns.readAccess`, `automation.readAccess.enabled`, and `"experimentalFeatures": { "automation": "enabled" }}` are deprecated and no longer have any effect.
+- In 3.11 we removed the 50-repository limit for diff and commit search which contains `before:` or `after:` filters. However, for large collections of repositories the searches would still fail. We introduce a limit of 10,000 repositories. This may affect your saved searches if you have any over more than 10,000 repositories. [#13386](https://github.com/sourcegraph/sourcegraph/pull/13386)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1465,19 +1465,22 @@ func alertOnSearchLimit(resultTypes []string, args *search.TextParameters) ([]st
 	}
 
 	for _, resultType := range resultTypes {
-		switch resultType {
-		case "commit", "diff":
-			if _, afterPresent := args.Query.Fields()["after"]; afterPresent {
-				break
-			}
-			if _, beforePresent := args.Query.Fields()["before"]; beforePresent {
-				break
-			}
-			return []string{}, &searchAlert{
-				prometheusType: "exceeded_diff_commit_search_limit",
-				title:          fmt.Sprintf("Too many matching repositories for %s search to handle", resultType),
-				description:    fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
-			}
+		if resultType != "commit" && resultType != "diff" {
+			continue
+		}
+
+		// Allow commit/diff search if after or before is specified.
+		if _, afterPresent := args.Query.Fields()["after"]; afterPresent {
+			continue
+		}
+		if _, beforePresent := args.Query.Fields()["before"]; beforePresent {
+			continue
+		}
+
+		return []string{}, &searchAlert{
+			prometheusType: "exceeded_diff_commit_search_limit",
+			title:          fmt.Sprintf("Too many matching repositories for %s search to handle", resultType),
+			description:    fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(resultType), repoLimit),
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1464,8 +1464,7 @@ func alertOnSearchLimit(resultTypes []string, args *search.TextParameters) ([]st
 		return resultTypes, nil
 	}
 
-	if len(resultTypes) == 1 {
-		resultType := resultTypes[0]
+	for _, resultType := range resultTypes {
 		switch resultType {
 		case "commit", "diff":
 			if _, afterPresent := args.Query.Fields()["after"]; afterPresent {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1028,6 +1028,14 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
+			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
+			fields:               map[string][]*searchquerytypes.Value{"after": nil},
+			resultTypes:          []string{"commit"},
+			numRepoRevs:          20000,
+			wantResultTypes:      []string{},
+			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+		},
+		{
 			name:                 "no_warning_when_commit_search_within_search_limit",
 			resultTypes:          []string{"commit"},
 			numRepoRevs:          50,
@@ -1084,8 +1092,8 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			haveAlertDescription = *alert.Description()
 		}
 
-		if haveAlertDescription != test.wantAlertDescription {
-			t.Fatalf("test %s, have alert %q, want: %q", test.name, haveAlertDescription, test.wantAlertDescription)
+		if diff := cmp.Diff(test.wantAlertDescription, haveAlertDescription); diff != "" {
+			t.Fatalf("test %s, mismatched alert (-want, +got):\n%s", test.name, diff)
 		}
 		if !reflect.DeepEqual(haveResultTypes, test.wantResultTypes) {
 			haveResultType := "is empty"

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1058,11 +1058,11 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			wantAlertDescription: "",
 		},
 		{
-			name:                 "multiple_result_type_search_is_unaffected",
+			name:                 "multiple_result_type_search_is_affected",
 			resultTypes:          []string{"file", "commit"},
 			numRepoRevs:          200,
-			wantResultTypes:      []string{"file", "commit"},
-			wantAlertDescription: "",
+			wantResultTypes:      []string{},
+			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 	}
 


### PR DESCRIPTION
We have been noticing spikes in search latency on Sourcegraph.com. Turns out the root cause is saved searches doing diff searches. [Ops Log](https://docs.google.com/document/d/1dtrOHs5STJYKvyjigL1kMm6u-W0mlyRSyVxPfKIOfEw/edit#bookmark=id.7bmlvlgpkt06). The diff searches would be run over 200k repos, and would constantly fail and keep getting retried.

In https://github.com/sourcegraph/sourcegraph/issues/7215 (https://github.com/sourcegraph/sourcegraph/pull/7272) we removed any limit if `before:` or `after:` is specified. This was to ensure saved searches worked. However, we need some limit since diff search won't work over 200k repos. This only recently become a problem due to us increasing default repos from 10k to 200k. This PR introduces a limit of 10,000. This may affect customers. If so I can increase to a higher number.

Additionally this PR enforces these limits if we search commits at all. For example `type:diff type:path foo` will try search 200k repos with diff search. If you try this out it returns, but that is due to some weird timeout behaviour. We don't report diff didn't work. I think its likely better to just alert to the user and not search.

cc people who have investigated this @pecigonzalo @bobheadxi @daxmc99 