### PR TITLE
Add tab to display the current campaign spec

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -216,6 +216,7 @@ type CampaignResolver interface {
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
 	ClosedAt() *DateTime
 	DiffStat(ctx context.Context) (*DiffStat, error)
+	CurrentSpec(ctx context.Context) (CampaignSpecResolver, error)
 }
 
 type CampaignsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1153,6 +1153,9 @@ type Campaign implements Node {
     The diff stat for all the changesets in the campaign.
     """
     diffStat: DiffStat!
+
+    # The current campaign spec this campaign reflects.
+    currentSpec: CampaignSpec!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1154,7 +1154,9 @@ type Campaign implements Node {
     """
     diffStat: DiffStat!
 
-    # The current campaign spec this campaign reflects.
+    """
+    The current campaign spec this campaign reflects.
+    """
     currentSpec: CampaignSpec!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1147,7 +1147,9 @@ type Campaign implements Node {
     """
     diffStat: DiffStat!
 
-    # The current campaign spec this campaign reflects.
+    """
+    The current campaign spec this campaign reflects.
+    """
     currentSpec: CampaignSpec!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1146,6 +1146,9 @@ type Campaign implements Node {
     The diff stat for all the changesets in the campaign.
     """
     diffStat: DiffStat!
+
+    # The current campaign spec this campaign reflects.
+    currentSpec: CampaignSpec!
 }
 
 """

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -227,3 +227,13 @@ func (r *campaignResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffSt
 
 	return totalStat, nil
 }
+
+func (r *campaignResolver) CurrentSpec(ctx context.Context) (graphqlbackend.CampaignSpecResolver, error) {
+	campaignSpec, err := r.store.GetCampaignSpec(ctx, ee.GetCampaignSpecOpts{ID: r.Campaign.CampaignSpecID})
+	if err != nil {
+		// This spec should always exist, so fail hard on not found errors as well.
+		return nil, err
+	}
+
+	return &campaignSpecResolver{store: r.store, httpFactory: r.httpFactory, campaignSpec: campaignSpec}, nil
+}

--- a/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -205,6 +205,9 @@ add('Overview', () => {
                 url: '/users/bob',
                 username: 'bob',
             },
+            currentSpec: {
+                originalInput: 'name: awesome-campaign\ndescription: somestring',
+            },
         }),
         [viewerCanAdminister]
     )

--- a/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -224,70 +224,81 @@ const queryChangesetCountsOverTime: typeof _queryChangesetCountsOverTime = () =>
 
 const deleteCampaign = () => Promise.resolve(undefined)
 
-add('Overview', () => {
-    const viewerCanAdminister = boolean('viewerCanAdminister', true)
-    const isClosed = boolean('isClosed', false)
-    const campaign: CampaignFields = useMemo(
-        () => ({
-            __typename: 'Campaign',
-            changesets: {
-                stats: {
-                    closed: 1,
-                    merged: 2,
-                    open: 3,
-                    total: 10,
-                    unpublished: 5,
-                },
-            },
-            createdAt: subDays(new Date(), 5).toISOString(),
-            initialApplier: {
-                url: '/users/alice',
-                username: 'alice',
-            },
-            diffStat: {
-                added: 10,
-                changed: 8,
-                deleted: 10,
-            },
-            id: 'specid',
-            url: '/users/alice/campaigns/specid',
-            namespace: {
-                namespaceName: 'alice',
-                url: '/users/alice',
-            },
-            viewerCanAdminister,
-            closedAt: isClosed ? subDays(new Date(), 1).toISOString() : null,
-            description: '## What this campaign does\n\nTruly awesome things for example.',
-            name: 'awesome-campaign',
-            updatedAt: subDays(new Date(), 5).toISOString(),
-            lastAppliedAt: subDays(new Date(), 5).toISOString(),
-            lastApplier: {
-                url: '/users/bob',
-                username: 'bob',
-            },
-        }),
-        [viewerCanAdminister, isClosed]
-    )
+const stories: Record<string, string> = {
+    Overview: '/users/alice/campaigns/awesome-campaign',
+    'Burndown chart': '/users/alice/campaigns/awesome-campaign?tab=chart',
+    'Spec file': '/users/alice/campaigns/awesome-campaign?tab=spec',
+}
 
-    const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
-    const history = H.createMemoryHistory({ initialEntries: [window.location.href] })
-    const breadcrumbsProps = useBreadcrumbs()
-    return (
-        <CampaignDetailsPage
-            {...breadcrumbsProps}
-            namespaceID="namespace123"
-            campaignName="awesome-campaign"
-            fetchCampaignByNamespace={fetchCampaign}
-            queryChangesets={queryChangesets}
-            queryChangesetCountsOverTime={queryChangesetCountsOverTime}
-            queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
-            deleteCampaign={deleteCampaign}
-            history={history}
-            location={history.location}
-            isLightTheme={isLightTheme}
-            telemetryService={NOOP_TELEMETRY_SERVICE}
-            platformContext={{} as any}
-            extensionsController={{} as any}
-        />
-    )
-})
+for (const [name, url] of Object.entries(stories)) {
+    add(name, () => {
+        const viewerCanAdminister = boolean('viewerCanAdminister', true)
+        const isClosed = boolean('isClosed', false)
+        const campaign: CampaignFields = useMemo(
+            () => ({
+                __typename: 'Campaign',
+                changesets: {
+                    stats: {
+                        closed: 1,
+                        merged: 2,
+                        open: 3,
+                        total: 10,
+                        unpublished: 5,
+                    },
+                },
+                createdAt: subDays(new Date(), 5).toISOString(),
+                initialApplier: {
+                    url: '/users/alice',
+                    username: 'alice',
+                },
+                diffStat: {
+                    added: 10,
+                    changed: 8,
+                    deleted: 10,
+                },
+                id: 'specid',
+                url: '/users/alice/campaigns/awesome-campaign',
+                namespace: {
+                    namespaceName: 'alice',
+                    url: '/users/alice',
+                },
+                viewerCanAdminister,
+                closedAt: isClosed ? subDays(new Date(), 1).toISOString() : null,
+                description: '## What this campaign does\n\nTruly awesome things for example.',
+                name: 'awesome-campaign',
+                updatedAt: subDays(new Date(), 5).toISOString(),
+                lastAppliedAt: subDays(new Date(), 5).toISOString(),
+                lastApplier: {
+                    url: '/users/bob',
+                    username: 'bob',
+                },
+                currentSpec: {
+                    originalInput: 'name: awesome-campaign\ndescription: somestring',
+                },
+            }),
+            [viewerCanAdminister, isClosed]
+        )
+
+        const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
+        const history = H.createMemoryHistory({ initialEntries: [url] })
+        const breadcrumbsProps = useBreadcrumbs()
+        return (
+            <CampaignDetailsPage
+                {...breadcrumbsProps}
+                namespaceID="namespace123"
+                campaignName="awesome-campaign"
+                fetchCampaignByNamespace={fetchCampaign}
+                queryChangesets={queryChangesets}
+                queryChangesetCountsOverTime={queryChangesetCountsOverTime}
+                queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
+                deleteCampaign={deleteCampaign}
+                history={history}
+                location={history.location}
+                isLightTheme={isLightTheme}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                platformContext={{} as any}
+                extensionsController={{} as any}
+            />
+        )
+    })
+}

--- a/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
@@ -56,6 +56,9 @@ describe('CampaignDetailsPage', () => {
                         url: '/users/bob',
                         username: 'bob',
                     },
+                    currentSpec: {
+                        originalInput: 'name: awesome-campaign\ndescription: somestring',
+                    },
                 })
             }
             deleteCampaign={() => Promise.resolve(undefined)}

--- a/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
@@ -1,0 +1,31 @@
+import FileDownloadIcon from 'mdi-react/FileDownloadIcon'
+import React, { useMemo } from 'react'
+import { CampaignFields } from '../../../graphql-operations'
+
+export interface CampaignSpecTabProps {
+    originalInput: CampaignFields['currentSpec']['originalInput']
+}
+
+export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({ originalInput }) => {
+    const downloadUrl = useMemo(() => 'data:text/plain;charset=utf-8,' + encodeURIComponent(originalInput), [
+        originalInput,
+    ])
+    return (
+        <>
+            <div className="d-flex justify-content-between align-items-center mb-2">
+                <p className="m-0">This campaign was created from the folowing spec:</p>
+                <a
+                    download="campaign-spec.yaml"
+                    href={downloadUrl}
+                    className="text-right btn btn-secondary text-nowrap"
+                    data-tooltip="Download campaign-spec.yaml"
+                >
+                    <FileDownloadIcon className="icon-inline" /> Download yaml
+                </a>
+            </div>
+            <div className="bg-light rounded p-2 mb-3 col-lg-8 offset-lg-2">
+                <pre className="m-0">{originalInput}</pre>
+            </div>
+        </>
+    )
+}

--- a/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
@@ -3,10 +3,11 @@ import React, { useMemo } from 'react'
 import { CampaignFields } from '../../../graphql-operations'
 
 export interface CampaignSpecTabProps {
+    campaignName: CampaignFields['name']
     originalInput: CampaignFields['currentSpec']['originalInput']
 }
 
-export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({ originalInput }) => {
+export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({ originalInput, campaignName }) => {
     const downloadUrl = useMemo(() => 'data:text/plain;charset=utf-8,' + encodeURIComponent(originalInput), [
         originalInput,
     ])
@@ -15,7 +16,7 @@ export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({
             <div className="d-flex justify-content-between align-items-center mb-2 test-campaigns-spec">
                 <p className="m-0">This campaign was created by applying the following campaign spec:</p>
                 <a
-                    download="campaign-spec.yaml"
+                    download={`${campaignName}.spec.yaml`}
                     href={downloadUrl}
                     className="text-right btn btn-secondary text-nowrap"
                     data-tooltip="Download campaign-spec.yaml"

--- a/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
@@ -13,7 +13,7 @@ export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({
     return (
         <>
             <div className="d-flex justify-content-between align-items-center mb-2 test-campaigns-spec">
-                <p className="m-0">This campaign was created from the folowing spec:</p>
+                <p className="m-0">This campaign was created by applying the following campaign spec:</p>
                 <a
                     download="campaign-spec.yaml"
                     href={downloadUrl}

--- a/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
@@ -12,7 +12,7 @@ export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({
     ])
     return (
         <>
-            <div className="d-flex justify-content-between align-items-center mb-2">
+            <div className="d-flex justify-content-between align-items-center mb-2 test-campaigns-spec">
                 <p className="m-0">This campaign was created from the folowing spec:</p>
                 <a
                     download="campaign-spec.yaml"

--- a/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import * as H from 'history'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { ThemeProps } from '../../../../../shared/src/theme'
@@ -15,8 +15,10 @@ import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import ChartLineVariantIcon from 'mdi-react/ChartLineVariantIcon'
 import { CampaignBurndownChart } from './BurndownChart'
 import { CampaignChangesets } from './changesets/CampaignChangesets'
+import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
+import { CampaignSpecTab } from './CampaignSpecTab'
 
-type SelectedTab = 'changesets' | 'chart'
+type SelectedTab = 'changesets' | 'chart' | 'spec'
 
 export interface CampaignTabsProps extends ExtensionsControllerProps, ThemeProps, PlatformContextProps, TelemetryProps {
     campaign: CampaignFields
@@ -73,6 +75,13 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
         },
         [history, location]
     )
+    const onSelectSpec = useCallback<React.MouseEventHandler>(
+        event => {
+            event.preventDefault()
+            setSelectedTab('spec')
+        },
+        [setSelectedTab]
+    )
     return (
         <>
             <ul className="nav nav-tabs mb-2">
@@ -92,6 +101,15 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
                         className={classNames('nav-link', selectedTab === 'chart' && 'active')}
                     >
                         <ChartLineVariantIcon className="icon-inline text-muted mr-1" /> Burndown chart
+                    </a>
+                </li>
+                <li className="nav-item">
+                    <a
+                        href=""
+                        onClick={onSelectSpec}
+                        className={classNames('nav-link', selectedTab === 'spec' && 'active')}
+                    >
+                        <FileDocumentIcon className="icon-inline text-muted mr-1" /> Spec file
                     </a>
                 </li>
             </ul>
@@ -116,6 +134,7 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
                     queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                 />
             )}
+            {selectedTab === 'spec' && <CampaignSpecTab originalInput={campaign.currentSpec.originalInput} />}
         </>
     )
 }

--- a/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
@@ -142,7 +142,9 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
                     queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                 />
             )}
-            {selectedTab === 'spec' && <CampaignSpecTab originalInput={campaign.currentSpec.originalInput} />}
+            {selectedTab === 'spec' && (
+                <CampaignSpecTab campaignName={campaign.name} originalInput={campaign.currentSpec.originalInput} />
+            )}
         </>
     )
 }

--- a/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
@@ -117,7 +117,7 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
                         onClick={onSelectSpec}
                         className={classNames('nav-link', selectedTab === 'spec' && 'active')}
                     >
-                        <FileDocumentIcon className="icon-inline text-muted mr-1" /> Spec file
+                        <FileDocumentIcon className="icon-inline text-muted mr-1" /> Campaign spec
                     </a>
                 </li>
             </ul>

--- a/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback } from 'react'
 import * as H from 'history'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { ThemeProps } from '../../../../../shared/src/theme'
@@ -49,6 +49,9 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
         if (urlParameters.get('tab') === 'chart') {
             return 'chart'
         }
+        if (urlParameters.get('tab') === 'spec') {
+            return 'spec'
+        }
         return 'changesets'
     })
     const onSelectChangesets = useCallback<React.MouseEventHandler>(
@@ -79,8 +82,13 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
         event => {
             event.preventDefault()
             setSelectedTab('spec')
+            const urlParameters = new URLSearchParams(location.search)
+            urlParameters.set('tab', 'spec')
+            if (location.search !== urlParameters.toString()) {
+                history.replace({ ...location, search: urlParameters.toString() })
+            }
         },
-        [setSelectedTab]
+        [history, location]
     )
     return (
         <>
@@ -103,7 +111,7 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
                         <ChartLineVariantIcon className="icon-inline text-muted mr-1" /> Burndown chart
                     </a>
                 </li>
-                <li className="nav-item">
+                <li className="nav-item test-campaigns-spec-tab">
                     <a
                         href=""
                         onClick={onSelectSpec}

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
@@ -432,6 +432,10 @@ exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
         },
         "closedAt": null,
         "createdAt": "2020-01-01",
+        "currentSpec": Object {
+          "originalInput": "name: awesome-campaign
+description: somestring",
+        },
         "description": "d",
         "diffStat": Object {
           "added": 5,
@@ -498,6 +502,20 @@ exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
             className="icon-inline text-muted mr-1"
           />
            Burndown chart
+        </a>
+      </li>
+      <li
+        className="nav-item test-campaigns-spec-tab"
+      >
+        <a
+          className="nav-link"
+          href=""
+          onClick={[Function]}
+        >
+          <Memo(FileDocumentIcon)
+            className="icon-inline text-muted mr-1"
+          />
+           Spec file
         </a>
       </li>
     </ul>
@@ -1188,6 +1206,10 @@ exports[`CampaignDetailsPage viewerCanAdminister: true viewing existing 1`] = `
         },
         "closedAt": null,
         "createdAt": "2020-01-01",
+        "currentSpec": Object {
+          "originalInput": "name: awesome-campaign
+description: somestring",
+        },
         "description": "d",
         "diffStat": Object {
           "added": 5,
@@ -1254,6 +1276,20 @@ exports[`CampaignDetailsPage viewerCanAdminister: true viewing existing 1`] = `
             className="icon-inline text-muted mr-1"
           />
            Burndown chart
+        </a>
+      </li>
+      <li
+        className="nav-item test-campaigns-spec-tab"
+      >
+        <a
+          className="nav-link"
+          href=""
+          onClick={[Function]}
+        >
+          <Memo(FileDocumentIcon)
+            className="icon-inline text-muted mr-1"
+          />
+           Spec file
         </a>
       </li>
     </ul>

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
@@ -515,7 +515,7 @@ description: somestring",
           <Memo(FileDocumentIcon)
             className="icon-inline text-muted mr-1"
           />
-           Spec file
+           Campaign spec
         </a>
       </li>
     </ul>
@@ -1289,7 +1289,7 @@ description: somestring",
           <Memo(FileDocumentIcon)
             className="icon-inline text-muted mr-1"
           />
-           Spec file
+           Campaign spec
         </a>
       </li>
     </ul>

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -58,13 +58,19 @@ const campaignFragment = gql`
         updatedAt
         closedAt
         viewerCanAdminister
+
         changesets {
             stats {
                 ...ChangesetStatsFields
             }
         }
+
         diffStat {
             ...DiffStatFields
+        }
+
+        currentSpec {
+            originalInput
         }
     }
 


### PR DESCRIPTION
This is a first implementation without the final design, but the general structure shouldn't change much.

I've included stories, screenshot tests and an integration test to see if the tab works and if URL persistence does its job.

Works on #13210