### PR TITLE
Add validation for first parameter passed for campaign resolver lists

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -26,7 +26,7 @@ type MoveCampaignArgs struct {
 }
 
 type ListCampaignArgs struct {
-	First               *int32
+	graphqlutil.ConnectionArgs
 	After               *string
 	State               *string
 	ViewerCanAdminister *bool
@@ -59,7 +59,7 @@ type CreateCampaignSpecArgs struct {
 }
 
 type ChangesetSpecsConnectionArgs struct {
-	First *int32
+	graphqlutil.ConnectionArgs
 	After *string
 }
 
@@ -179,7 +179,7 @@ type ChangesetCountsArgs struct {
 }
 
 type ListChangesetsArgs struct {
-	First                       *int32
+	graphqlutil.ConnectionArgs
 	After                       *string
 	PublicationState            *campaigns.ChangesetPublicationState
 	ReconcilerState             *campaigns.ReconcilerState

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection.go
@@ -1,6 +1,10 @@
 package graphqlutil
 
-import "github.com/sourcegraph/sourcegraph/internal/db"
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/db"
+)
 
 // ConnectionArgs is the common set of arguments to GraphQL fields that return connections (lists).
 type ConnectionArgs struct {
@@ -21,4 +25,20 @@ func (a ConnectionArgs) GetFirst() int32 {
 		return 0
 	}
 	return *a.First
+}
+
+func (a ConnectionArgs) GetFirstMin(min int32) (int32, error) {
+	first := a.GetFirst()
+	if first < min {
+		return first, fmt.Errorf("invalid first argument given, min=%d", min)
+	}
+	return first, nil
+}
+
+func (a ConnectionArgs) GetFirstMinMax(min, max int32) (int32, error) {
+	first := a.GetFirst()
+	if first < min || first > max {
+		return first, fmt.Errorf("invalid first argument given, min=%d, max=%d", min, max)
+	}
+	return first, nil
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -54,9 +54,13 @@ func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 
 func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
 	opts := ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID}
-	if args.First != nil {
-		opts.Limit = int(*args.First)
+
+	first, err := args.GetFirstMin(0)
+	if err != nil {
+		return nil, err
 	}
+	opts.Limit = int(first)
+
 	if args.After != nil {
 		id, err := strconv.Atoi(*args.After)
 		if err != nil {

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -175,9 +175,13 @@ func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 	opts.State = state
-	if args.First != nil {
-		opts.Limit = int(*args.First)
+
+	first, err := args.GetFirstMin(0)
+	if err != nil {
+		return nil, err
 	}
+	opts.Limit = int(first)
+
 	if args.After != nil {
 		cursor, err := strconv.ParseInt(*args.After, 10, 32)
 		if err != nil {
@@ -355,12 +359,16 @@ func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.Change
 func (r *changesetResolver) Events(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 }) (graphqlbackend.ChangesetEventsConnectionResolver, error) {
+	first, err := args.GetFirstMin(0)
+	if err != nil {
+		return nil, err
+	}
 	// TODO: We already need to fetch all events for ReviewState and Labels
 	// perhaps we can use the cached data here
 	return &changesetEventsConnectionResolver{
 		store:             r.store,
 		changesetResolver: r,
-		first:             int(args.GetFirst()),
+		first:             int(first),
 	}, nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -432,9 +432,13 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 		return nil, err
 	}
 	opts.State = state
-	if args.First != nil {
-		opts.Limit = int(*args.First)
+
+	first, err := args.GetFirstMin(0)
+	if err != nil {
+		return nil, err
 	}
+	opts.Limit = int(first)
+
 	if args.After != nil {
 		cursor, err := strconv.ParseInt(*args.After, 10, 32)
 		if err != nil {
@@ -488,9 +492,11 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 
 	safe := true
 
-	if args.First != nil {
-		opts.Limit = int(*args.First)
+	first, err := args.GetFirstMin(0)
+	if err != nil {
+		return opts, false, err
 	}
+	opts.Limit = int(first)
 
 	if args.After != nil {
 		cursor, err := strconv.ParseInt(*args.After, 10, 32)

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
@@ -619,7 +620,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 		// First argument is set in opts, and considered safe.
 		{
 			args: &graphqlbackend.ListChangesetsArgs{
-				First: &wantFirst,
+				ConnectionArgs: graphqlutil.ConnectionArgs{First: &wantFirst},
 			},
 			wantSafe:   true,
 			wantParsed: ee.ListChangesetsOpts{Limit: 10},


### PR DESCRIPTION
I've added two convenience methods on the graphqlutils `ConnectionArgs` to validate the `first` argument. This disallows any values `< 0`, in particular `-1`, which has a special meaning internally, but also `-2` and below, which cause DB errors.

Works on https://github.com/sourcegraph/sourcegraph/issues/13369
