### PR TITLE
search: fix ellipses conversion for structural search

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -973,12 +973,12 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	switch options.SearchType {
 	case SearchTypeLiteral:
 		query = substituteConcat(query, " ")
-		query = ellipsesForHoles(query)
 	case SearchTypeStructural:
 		if containsNegatedPattern(query) {
 			return nil, errors.New("the query contains a negated search pattern. Structural search does not support negated search patterns at the moment")
 		}
 		query = substituteConcat(query, " ")
+		query = ellipsesForHoles(query)
 	case SearchTypeRegex:
 		query = Map(query, EmptyGroupsToLiteral, TrailingParensToLiteral)
 	}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -265,10 +265,10 @@ func TestSubstituteConcat(t *testing.T) {
 
 func TestEllipsesForHoles(t *testing.T) {
 	input := "if ... { ... }"
-	want := `(concat "if" ":[_]" "{" ":[_]" "}")`
+	want := `"if :[_] { :[_] }"`
 	t.Run("Ellipses for holes", func(t *testing.T) {
-		query, _ := ParseAndOr(input, SearchTypeStructural)
-		got := prettyPrint(ellipsesForHoles(query))
+		query, _ := ProcessAndOr(input, ParserOptions{SearchType: SearchTypeStructural})
+		got := prettyPrint(query.(*AndOrQuery).Query)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatal(diff)
 		}


### PR DESCRIPTION
Ugh, I added the conversion function to the literal search queries case statement. That part wasn't covered by the test. I updated the test so that the top level function is included.

Will merge without review since this is a clear bug. Please do review post merge if needed.