### PR TITLE
campaigns: prototype changesetTemplate specialisation

### DIFF
--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -32,6 +32,9 @@
                 "type": "string",
                 "description": "A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.",
                 "examples": ["file:README.md"]
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           },
@@ -50,6 +53,9 @@
               "branch": {
                 "type": "string",
                 "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           }
@@ -110,13 +116,24 @@
       }
     },
     "changesetTemplate": {
+      "$ref": "#/definitions/changesetTemplate"
+    }
+  },
+  "definitions": {
+    "changesetTemplate": {
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
       "additionalProperties": false,
       "required": ["title", "branch", "commit", "published"],
       "properties": {
-        "title": { "type": "string", "description": "The title of the changeset." },
-        "body": { "type": "string", "description": "The body (description) of the changeset." },
+        "title": {
+          "type": "string",
+          "description": "The title of the changeset."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body (description) of the changeset."
+        },
         "branch": {
           "type": "string",
           "description": "The name of the Git branch to create or update on each repository with the changes."

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -37,6 +37,9 @@ const CampaignSpecSchemaJSON = `{
                 "type": "string",
                 "description": "A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.",
                 "examples": ["file:README.md"]
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           },
@@ -55,6 +58,9 @@ const CampaignSpecSchemaJSON = `{
               "branch": {
                 "type": "string",
                 "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           }
@@ -115,13 +121,24 @@ const CampaignSpecSchemaJSON = `{
       }
     },
     "changesetTemplate": {
+      "$ref": "#/definitions/changesetTemplate"
+    }
+  },
+  "definitions": {
+    "changesetTemplate": {
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
       "additionalProperties": false,
       "required": ["title", "branch", "commit", "published"],
       "properties": {
-        "title": { "type": "string", "description": "The title of the changeset." },
-        "body": { "type": "string", "description": "The body (description) of the changeset." },
+        "title": {
+          "type": "string",
+          "description": "The title of the changeset."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body (description) of the changeset."
+        },
         "branch": {
           "type": "string",
           "description": "The name of the Git branch to create or update on each repository with the changes."

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -313,7 +313,6 @@ type BuiltinAuthProvider struct {
 
 // CampaignSpec description: A campaign specification, which describes the campaign and what kinds of changes to make (or what existing changesets to track).
 type CampaignSpec struct {
-	// ChangesetTemplate description: A template describing how to create (and update) changesets with the file changes produced by the command steps.
 	ChangesetTemplate *ChangesetTemplate `json:"changesetTemplate,omitempty"`
 	// Description description: The description of the campaign.
 	Description string `json:"description,omitempty"`
@@ -872,6 +871,7 @@ type ObservabilityTracing struct {
 
 // OnQuery description: A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the campaign will be run on.
 type OnQuery struct {
+	ChangesetTemplate *ChangesetTemplate `json:"changesetTemplate,omitempty"`
 	// RepositoriesMatchingQuery description: A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.
 	RepositoriesMatchingQuery string `json:"repositoriesMatchingQuery"`
 }
@@ -879,7 +879,8 @@ type OnQuery struct {
 // OnRepository description: A specific repository (and branch) that is added to the list of repositories that the campaign will be run on.
 type OnRepository struct {
 	// Branch description: The branch on the repository to propose changes to. If unset, the repository's default branch is used.
-	Branch string `json:"branch,omitempty"`
+	Branch            string             `json:"branch,omitempty"`
+	ChangesetTemplate *ChangesetTemplate `json:"changesetTemplate,omitempty"`
 	// Repository description: The name of the repository (as it is known to Sourcegraph).
 	Repository string `json:"repository"`
 }


### PR DESCRIPTION
This is the backend half of sourcegraph/src-cli#281.

This is only required to avoid campaign specs failing validation; all behavioural changes are in src-cli.

Related to #13139.