### PR TITLE
schema: remove deprecated authz fields

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -185,9 +185,8 @@ func publicSiteConfiguration() schema.SiteConfiguration {
 		updateChannel = "release"
 	}
 	return schema.SiteConfiguration{
-		AuthPublic:                c.AuthPublic,
-		PermissionsBackgroundSync: c.PermissionsBackgroundSync,
-		UpdateChannel:             updateChannel,
+		AuthPublic:    c.AuthPublic,
+		UpdateChannel: updateChannel,
 	}
 }
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -18,9 +18,7 @@ Then, [add or edit a GitHub connection](../external_service/github.md#repository
 {
    "url": "https://github.com",
    "token": "$PERSONAL_ACCESS_TOKEN",
-   "authorization": {
-     "ttl": "3h"
-   }
+   "authorization": {}
 }
 ```
 
@@ -49,8 +47,7 @@ Then, [add or edit a GitLab connection](../external_service/gitlab.md#repository
   "authorization": {
     "identityProvider": {
       "type": "oauth"
-    },
-    "ttl": "3h"
+    }
   }
 }
 ```
@@ -72,8 +69,7 @@ Then, [add or edit a GitLab connection](../external_service/gitlab.md#repository
       "authProviderID": "$AUTH_PROVIDER_ID",
       "authProviderType": "$AUTH_PROVIDER_TYPE",
       "gitlabProvider": "$AUTH_PROVIDER_GITLAB_ID"
-    },
-    "ttl": "3h"
+    }
   }
 }
 ```
@@ -98,8 +94,7 @@ because Sourcegraph usernames are mutable.
   "authorization": {
     "identityProvider": {
       "type": "username"
-    },
-    "ttl": "3h"
+    }
   }
 }
 ```
@@ -167,14 +162,6 @@ Scroll to the bottom and check the *Allow 2-Legged OAuth* checkbox, then write y
 Go to your Sourcegraph's *Manage repositories* page (i.e. `https://sourcegraph.example.com/site-admin/external-services`) and either edit or create a new *Bitbucket Server* connection. Click on the *Enforce permissions* quick action on top of the configuration editor. Copy the *Consumer Key* you generated before to the `oauth.consumerKey` field and the output of the command `base64 sourcegraph.pem | tr -d '\n'` to the `oauth.signingKey` field.
 
 <img src="https://imgur.com/ucetesA.png" width="800">
-
----
-
-### Caching
-
-Permissions for each user are cached for the configured `ttl` duration (**3h** by default). When the `ttl` expires for a given user, during request that needs to be authorized, permissions will be refetched from Bitbucket Server again in the background, during which time the previously cached permissions will be used to authorize the user's actions. A lower `ttl` makes Sourcegraph refresh permissions for each user more often which increases load on Bitbucket Server, so have that in consideration when changing this value.
-
-The default `hardTTL` is **3 days**, after which a user's cached permissions must be updated before any user action can be authorized. While the update is happening an error is returned to the user. The default `hardTTL` value was chosen so that it reduces the chances of users being forced to wait for their permissions to be updated after a weekend of inactivity.
 
 ### Fast permission sync with Bitbucket Server plugin
 

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -102,7 +102,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				{
 					Authorization: &schema.GitLabAuthorization{
 						IdentityProvider: schema.IdentityProvider{Oauth: &schema.OAuthIdentity{Type: "oauth"}},
-						Ttl:              "48h",
 					},
 					Url:   "https://gitlab.mine",
 					Token: "asdf",
@@ -138,7 +137,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				{
 					Authorization: &schema.GitLabAuthorization{
 						IdentityProvider: schema.IdentityProvider{Oauth: &schema.OAuthIdentity{Type: "oauth"}},
-						Ttl:              "48h",
 					},
 					Url:   "https://gitlab.mine",
 					Token: "asdf",
@@ -160,7 +158,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				{
 					Authorization: &schema.GitLabAuthorization{
 						IdentityProvider: schema.IdentityProvider{Oauth: &schema.OAuthIdentity{Type: "oauth"}},
-						Ttl:              "48h",
 					},
 					Url:   "https://gitlab.mine",
 					Token: "asdf",
@@ -352,7 +349,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 							ConsumerKey: "sourcegraph",
 							SigningKey:  "Invalid Key",
 						},
-						Ttl: "15m",
 					},
 					Url:      "https://bitbucketserver.mycorp.org",
 					Username: "admin",
@@ -377,7 +373,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 							ConsumerKey: "sourcegraph",
 							SigningKey:  bogusKey,
 						},
-						Ttl: "15m",
 					},
 					Url:      "https://bitbucketserver.mycorp.org",
 					Username: "admin",
@@ -420,7 +415,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				{
 					Authorization: &schema.GitLabAuthorization{
 						IdentityProvider: schema.IdentityProvider{Oauth: &schema.OAuthIdentity{Type: "oauth"}},
-						Ttl:              "48h",
 					},
 					Url:   "https://gitlab.mine",
 					Token: "asdf",
@@ -451,7 +445,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 							ConsumerKey: "sourcegraph",
 							SigningKey:  bogusKey,
 						},
-						Ttl: "15m",
 					},
 					Url:      "https://bitbucketserver.mycorp.org",
 					Username: "admin",

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -277,14 +277,6 @@ func SearchSymbolsParallelism() int {
 	return val
 }
 
-func PermissionsBackgroundSyncEnabled() bool {
-	val := Get().PermissionsBackgroundSync
-	if val == nil {
-		return false
-	}
-	return val.Enabled
-}
-
 func BitbucketServerPluginPerm() bool {
 	val := Get().ExperimentalFeatures.BitbucketServerFastPerm
 	return val == "enabled"

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -237,16 +237,6 @@
               "minLength": 1
             }
           }
-        },
-        "ttl": {
-          "description": "DEPRECATED: Duration after which a user's cached permissions will be updated in the background (during which time the previously cached permissions will be used). This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
-          "type": "string",
-          "default": "3h"
-        },
-        "hardTTL": {
-          "description": "DEPRECATED: Duration after which a user's cached permissions must be updated before authorizing any user actions. This is 3 days by default.",
-          "type": "string",
-          "default": "72h"
         }
       }
     }

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -242,16 +242,6 @@ const BitbucketServerSchemaJSON = `{
               "minLength": 1
             }
           }
-        },
-        "ttl": {
-          "description": "DEPRECATED: Duration after which a user's cached permissions will be updated in the background (during which time the previously cached permissions will be used). This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).",
-          "type": "string",
-          "default": "3h"
-        },
-        "hardTTL": {
-          "description": "DEPRECATED: Duration after which a user's cached permissions must be updated before authorizing any user actions. This is 3 days by default.",
-          "type": "string",
-          "default": "72h"
         }
       }
     }

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -164,11 +164,6 @@
       "description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type \"github\" with the same `url` field as specified in this `GitHubConnection`.",
       "type": "object",
       "properties": {
-        "ttl": {
-          "description": "DEPRECATED: The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X private repositories on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur up to X*Y/100 API requests per cache refresh period (depending on user activity).\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).\n\nPublic repositories are cached once for all users per cache TTL period.",
-          "type": "string",
-          "default": "3h"
-        }
       }
     }
   }

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -163,8 +163,7 @@
       "title": "GitHubAuthorization",
       "description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type \"github\" with the same `url` field as specified in this `GitHubConnection`.",
       "type": "object",
-      "properties": {
-      }
+      "properties": {}
     }
   }
 }

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -169,11 +169,6 @@ const GitHubSchemaJSON = `{
       "description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the ` + "`" + `auth.providers` + "`" + ` field of type \"github\" with the same ` + "`" + `url` + "`" + ` field as specified in this ` + "`" + `GitHubConnection` + "`" + `.",
       "type": "object",
       "properties": {
-        "ttl": {
-          "description": "DEPRECATED: The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X private repositories on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur up to X*Y/100 API requests per cache refresh period (depending on user activity).\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).\n\nPublic repositories are cached once for all users per cache TTL period.",
-          "type": "string",
-          "default": "3h"
-        }
       }
     }
   }

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -168,8 +168,7 @@ const GitHubSchemaJSON = `{
       "title": "GitHubAuthorization",
       "description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the ` + "`" + `auth.providers` + "`" + ` field of type \"github\" with the same ` + "`" + `url` + "`" + ` field as specified in this ` + "`" + `GitHubConnection` + "`" + `.",
       "type": "object",
-      "properties": {
-      }
+      "properties": {}
     }
   }
 }

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -174,11 +174,6 @@
           "!go": {
             "taggedUnionType": true
           }
-        },
-        "ttl": {
-          "description": "DEPRECATED: The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X private repositories on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur up to X*Y/100 API requests per cache refresh period (depending on user activity).\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).\n\nPublic and internal repositories are cached once for all users per cache TTL period.",
-          "type": "string",
-          "default": "3h"
         }
       }
     },
@@ -209,16 +204,6 @@
         "type": {
           "type": "string",
           "const": "oauth"
-        },
-        "minBatchingThreshold": {
-          "description": "DEPRECATED: The minimum number of GitLab projects to fetch at which to start batching requests to fetch project visibility. Please consult with the Sourcegraph support team before modifying this.",
-          "type": "integer",
-          "default": 200
-        },
-        "maxBatchRequests": {
-          "description": "DEPRECATED: The maximum number of batch API requests to make for GitLab Project visibility. Please consult with the Sourcegraph support team before modifying this.",
-          "type": "integer",
-          "default": 300
         }
       }
     },

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -179,11 +179,6 @@ const GitLabSchemaJSON = `{
           "!go": {
             "taggedUnionType": true
           }
-        },
-        "ttl": {
-          "description": "DEPRECATED: The TTL of how long to cache permissions data. This is 3 hours by default.\n\nDecreasing the TTL will increase the load on the code host API. If you have X private repositories on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur up to X*Y/100 API requests per cache refresh period (depending on user activity).\n\nIf set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).\n\nPublic and internal repositories are cached once for all users per cache TTL period.",
-          "type": "string",
-          "default": "3h"
         }
       }
     },
@@ -214,16 +209,6 @@ const GitLabSchemaJSON = `{
         "type": {
           "type": "string",
           "const": "oauth"
-        },
-        "minBatchingThreshold": {
-          "description": "DEPRECATED: The minimum number of GitLab projects to fetch at which to start batching requests to fetch project visibility. Please consult with the Sourcegraph support team before modifying this.",
-          "type": "integer",
-          "default": 200
-        },
-        "maxBatchRequests": {
-          "description": "DEPRECATED: The maximum number of batch API requests to make for GitLab Project visibility. Please consult with the Sourcegraph support team before modifying this.",
-          "type": "integer",
-          "default": 300
         }
       }
     },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -155,18 +155,10 @@ type BitbucketCloudRateLimit struct {
 
 // BitbucketServerAuthorization description: If non-null, enforces Bitbucket Server repository permissions.
 type BitbucketServerAuthorization struct {
-	// HardTTL description: DEPRECATED: Duration after which a user's cached permissions must be updated before authorizing any user actions. This is 3 days by default.
-	HardTTL string `json:"hardTTL,omitempty"`
 	// IdentityProvider description: The source of identity to use when computing permissions. This defines how to compute the Bitbucket Server identity to use for a given Sourcegraph user. When 'username' is used, Sourcegraph assumes usernames are identical in Sourcegraph and Bitbucket Server accounts and `auth.enableUsernameChanges` must be set to false for security reasons.
 	IdentityProvider BitbucketServerIdentityProvider `json:"identityProvider"`
 	// Oauth description: OAuth configuration specified when creating the Bitbucket Server Application Link with incoming authentication. Two Legged OAuth with 'ExecuteAs=admin' must be enabled as well as user impersonation.
 	Oauth BitbucketServerOAuth `json:"oauth"`
-	// Ttl description: DEPRECATED: Duration after which a user's cached permissions will be updated in the background (during which time the previously cached permissions will be used). This is 3 hours by default.
-	//
-	// Decreasing the TTL will increase the load on the code host API. If you have X repos on your instance, it will take ~X/1000 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur X*Y/1000 API requests per cache refresh period.
-	//
-	// If set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).
-	Ttl string `json:"ttl,omitempty"`
 }
 
 // BitbucketServerConnection description: Configuration for a connection to Bitbucket Server.
@@ -494,14 +486,6 @@ type GitHubAuthProvider struct {
 
 // GitHubAuthorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type "github" with the same `url` field as specified in this `GitHubConnection`.
 type GitHubAuthorization struct {
-	// Ttl description: DEPRECATED: The TTL of how long to cache permissions data. This is 3 hours by default.
-	//
-	// Decreasing the TTL will increase the load on the code host API. If you have X private repositories on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur up to X*Y/100 API requests per cache refresh period (depending on user activity).
-	//
-	// If set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).
-	//
-	// Public repositories are cached once for all users per cache TTL period.
-	Ttl string `json:"ttl,omitempty"`
 }
 
 // GitHubConnection description: Configuration for a connection to GitHub or GitHub Enterprise.
@@ -591,14 +575,6 @@ type GitLabAuthProvider struct {
 type GitLabAuthorization struct {
 	// IdentityProvider description: The source of identity to use when computing permissions. This defines how to compute the GitLab identity to use for a given Sourcegraph user.
 	IdentityProvider IdentityProvider `json:"identityProvider"`
-	// Ttl description: DEPRECATED: The TTL of how long to cache permissions data. This is 3 hours by default.
-	//
-	// Decreasing the TTL will increase the load on the code host API. If you have X private repositories on your instance, it will take ~X/100 API requests to fetch the complete list for 1 user.  If you have Y users, you will incur up to X*Y/100 API requests per cache refresh period (depending on user activity).
-	//
-	// If set to zero, Sourcegraph will sync a user's entire accessible repository list on every request (NOT recommended).
-	//
-	// Public and internal repositories are cached once for all users per cache TTL period.
-	Ttl string `json:"ttl,omitempty"`
 }
 
 // GitLabConnection description: Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).
@@ -846,11 +822,7 @@ type NotifierWebhook struct {
 	Username    string `json:"username,omitempty"`
 }
 type OAuthIdentity struct {
-	// MaxBatchRequests description: DEPRECATED: The maximum number of batch API requests to make for GitLab Project visibility. Please consult with the Sourcegraph support team before modifying this.
-	MaxBatchRequests int `json:"maxBatchRequests,omitempty"`
-	// MinBatchingThreshold description: DEPRECATED: The minimum number of GitLab projects to fetch at which to start batching requests to fetch project visibility. Please consult with the Sourcegraph support team before modifying this.
-	MinBatchingThreshold int    `json:"minBatchingThreshold,omitempty"`
-	Type                 string `json:"type"`
+	Type string `json:"type"`
 }
 type ObservabilityAlerts struct {
 	// DisableSendResolved description: Disable notifications when alerts resolve themselves.
@@ -921,12 +893,6 @@ type OtherExternalServiceConnection struct {
 // ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 type ParentSourcegraph struct {
 	Url string `json:"url,omitempty"`
-}
-
-// PermissionsBackgroundSync description: DEPRECATED: Sync code host repository and user permissions in the background.
-type PermissionsBackgroundSync struct {
-	// Enabled description: Whether syncing permissions in the background is enabled.
-	Enabled bool `json:"enabled,omitempty"`
 }
 
 // PermissionsUserMapping description: Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).
@@ -1221,8 +1187,6 @@ type SiteConfiguration struct {
 	ObservabilityTracing *ObservabilityTracing `json:"observability.tracing,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 	ParentSourcegraph *ParentSourcegraph `json:"parentSourcegraph,omitempty"`
-	// PermissionsBackgroundSync description: DEPRECATED: Sync code host repository and user permissions in the background.
-	PermissionsBackgroundSync *PermissionsBackgroundSync `json:"permissions.backgroundSync,omitempty"`
 	// PermissionsUserMapping description: Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).
 	PermissionsUserMapping *PermissionsUserMapping `json:"permissions.userMapping,omitempty"`
 	// RepoListUpdateInterval description: Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -413,23 +413,6 @@
       "examples": [{ "bindID": "email" }, { "bindID": "username" }],
       "group": "Security"
     },
-    "permissions.backgroundSync": {
-      "description": "DEPRECATED: Sync code host repository and user permissions in the background.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "description": "Whether syncing permissions in the background is enabled.",
-          "type": "boolean",
-          "default": true
-        }
-      },
-      "default": {
-        "enabled": true
-      },
-      "examples": [{ "enabled": true }],
-      "group": "Security"
-    },
     "branding": {
       "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -418,23 +418,6 @@ const SiteSchemaJSON = `{
       "examples": [{ "bindID": "email" }, { "bindID": "username" }],
       "group": "Security"
     },
-    "permissions.backgroundSync": {
-      "description": "DEPRECATED: Sync code host repository and user permissions in the background.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "description": "Whether syncing permissions in the background is enabled.",
-          "type": "boolean",
-          "default": true
-        }
-      },
-      "default": {
-        "enabled": true
-      },
-      "examples": [{ "enabled": true }],
-      "group": "Security"
-    },
     "branding": {
       "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",


### PR DESCRIPTION
We no longer support these fields since 3.19.

Fixes https://github.com/sourcegraph/sourcegraph/issues/12357