### PR TITLE
search: resolve revisions for repo searches

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -84,7 +84,15 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 			common.limitHit = true
 			break
 		}
-		for _, rev := range r.RevSpecs() {
+
+		err = r.ExpandedRevSpecs(ctx)
+		if err != nil { // fall back to just return revspecs
+			for _, rev := range r.RevSpecs() {
+				results = append(results, &RepositoryResolver{repo: r.Repo, icon: repoIcon, rev: rev})
+			}
+			continue
+		}
+		for _, rev := range r.ResolvedRevs() {
 			results = append(results, &RepositoryResolver{repo: r.Repo, icon: repoIcon, rev: rev})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -85,14 +85,12 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 			break
 		}
 
-		err = r.ExpandedRevSpecs(ctx)
-		if err != nil { // fall back to just return revspecs
-			for _, rev := range r.RevSpecs() {
-				results = append(results, &RepositoryResolver{repo: r.Repo, icon: repoIcon, rev: rev})
-			}
-			continue
+		var revs []string
+		revs, err = r.ExpandedRevSpecs(ctx)
+		if err != nil { // fallback to just return revspecs
+			revs = r.RevSpecs()
 		}
-		for _, rev := range r.ResolvedRevs() {
+		for _, rev := range revs {
 			results = append(results, &RepositoryResolver{repo: r.Repo, icon: repoIcon, rev: rev})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -429,13 +429,11 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			if len(repoAllRevs.Revs) == 0 {
 				continue
 			}
-
-			revSpecs, err := repoAllRevs.ExpandedRevSpecs(ctx)
+			err := repoAllRevs.ExpandedRevSpecs(ctx)
 			if err != nil {
 				return err
 			}
-
-			for _, rev := range revSpecs {
+			for _, rev := range repoAllRevs.ResolvedRevs() {
 				// Only reason acquire can fail is if ctx is cancelled. So we can stop
 				// looping through searcherRepos.
 				limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -429,11 +429,11 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			if len(repoAllRevs.Revs) == 0 {
 				continue
 			}
-			resolvedRevs, err := repoAllRevs.ExpandedRevSpecs(ctx)
+			revSpecs, err := repoAllRevs.ExpandedRevSpecs(ctx)
 			if err != nil {
 				return err
 			}
-			for _, rev := range resolvedRevs {
+			for _, rev := range revSpecs {
 				// Only reason acquire can fail is if ctx is cancelled. So we can stop
 				// looping through searcherRepos.
 				limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -429,10 +429,12 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			if len(repoAllRevs.Revs) == 0 {
 				continue
 			}
+
 			revSpecs, err := repoAllRevs.ExpandedRevSpecs(ctx)
 			if err != nil {
 				return err
 			}
+
 			for _, rev := range revSpecs {
 				// Only reason acquire can fail is if ctx is cancelled. So we can stop
 				// looping through searcherRepos.

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -429,11 +429,11 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 			if len(repoAllRevs.Revs) == 0 {
 				continue
 			}
-			err := repoAllRevs.ExpandedRevSpecs(ctx)
+			resolvedRevs, err := repoAllRevs.ExpandedRevSpecs(ctx)
 			if err != nil {
 				return err
 			}
-			for _, rev := range repoAllRevs.ResolvedRevs() {
+			for _, rev := range resolvedRevs {
 				// Only reason acquire can fail is if ctx is cancelled. So we can stop
 				// looping through searcherRepos.
 				limitCtx, limitDone, acquireErr := textSearchLimiter.Acquire(ctx)

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -106,8 +106,18 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		}, nil
 	}
 
-	// Fallback to Unindexed if index:no or if the query contains ref-globs anywhere
-	if indexParam == No || containsRefGlobs(args.Query) {
+	// Fallback to Unindexed if the query contains ref-globs
+	if containsRefGlobs(args.Query) {
+		if indexParam == Only {
+			return nil, fmt.Errorf("invalid index:%q (revsions with glob pattern cannot be resolved for indexed searches)", indexParam)
+		}
+		return &indexedSearchRequest{
+			Unindexed: args.Repos,
+		}, nil
+	}
+
+	// Fallback to Unindexed if index:no
+	if indexParam == No {
 		return &indexedSearchRequest{
 			Unindexed: args.Repos,
 		}, nil

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1027,7 +1027,7 @@ func TestContainsRefGlobs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			qInfo, err := query.ProcessAndOr(tt.query, query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: true})
+			qInfo, err := query.ProcessAndOr(tt.query, query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: tt.globbing})
 			if err != nil {
 				t.Error(err)
 			}

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -199,8 +199,8 @@ func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) ([]string, e
 // git.CompileRefGlobs for information on how ref include/exclude globs are handled.
 func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, error) {
 	var (
-		globs    []git.RefGlob
 		revSpecs = map[string]struct{}{}
+		globs    []git.RefGlob
 	)
 	for _, rev := range r.Revs {
 		switch {
@@ -213,22 +213,17 @@ func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, err
 		}
 	}
 
-	var (
-		allRefs []git.Ref
-		err     error
-		rg      git.RefGlobs
-	)
 	listRefs := r.ListRefs
 	if listRefs == nil {
 		listRefs = git.ListRefs
 	}
 	if len(globs) > 0 {
-		allRefs, err = listRefs(ctx, r.GitserverRepo())
+		allRefs, err := listRefs(ctx, r.GitserverRepo())
 		if err != nil {
 			return nil, err
 		}
 
-		rg, err = git.CompileRefGlobs(globs)
+		rg, err := git.CompileRefGlobs(globs)
 		if err != nil {
 			return nil, err
 		}
@@ -244,6 +239,5 @@ func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, err
 	for revSpec := range revSpecs {
 		revSpecsList = append(revSpecsList, revSpec)
 	}
-
 	return revSpecsList, nil
 }

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -71,10 +71,6 @@ type RepositoryRevisions struct {
 	ListRefs func(context.Context, gitserver.Repo) ([]git.Ref, error)
 }
 
-func (r *RepositoryRevisions) ResolvedRevs() []string {
-	return r.resolvedRevs
-}
-
 func (r *RepositoryRevisions) Equal(other *RepositoryRevisions) bool {
 	return reflect.DeepEqual(r.Repo, other.Repo) && reflect.DeepEqual(r.Revs, other.Revs)
 }
@@ -172,14 +168,14 @@ func (r *RepositoryRevisions) RevSpecs() []string {
 	return revspecs
 }
 
-// ExpandedRevSpecs evaluates all of r's ref glob expressions and sets r's resolvedRevs to
+// ExpandedRevSpecs evaluates all of r's ref glob expressions and returns
 // the full, current list of refs matched or resolved by them, plus the explicitly listed Git revspecs. See
 // git.CompileRefGlobs for information on how ref include/exclude globs are handled.
 //
 // Note that not all callers need to expand these. If a caller is passing the ref globs as
 // command-line args to `git` directly (e.g., to `git log --glob ... --exclude ...`), it does not
 // need to use this function.
-func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) error {
+func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) ([]string, error) {
 	var err error
 	r.resolveOnce.Do(func() {
 		listRefs := r.ListRefs
@@ -226,5 +222,5 @@ func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) error {
 		}
 		r.resolvedRevs = revSpecsList
 	})
-	return err
+	return r.resolvedRevs, err
 }

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -59,12 +59,12 @@ type RepositoryRevisions struct {
 	Repo *types.Repo
 	Revs []RevisionSpecifier
 
+	// resolveOnce protects resolvedRevs
+	resolveOnce sync.Once
+
 	// resolvedRevs is set by ExpandedRevSpecs and contains all revisions
 	// including resolved ref-globs.
 	resolvedRevs []string
-
-	// resolveOnce protects resolvedRevs
-	resolveOnce sync.Once
 
 	// resolveErr stores the error returned by the first call to ExpandedRevSpecs. It
 	// gives the caller the chance to distinguish between an error and an empty resolvedRevs.

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -217,7 +217,6 @@ func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, err
 			revSpecs[rev.RevSpec] = struct{}{}
 		}
 	}
-
 	if len(globs) > 0 {
 		allRefs, err := listRefs(ctx, r.GitserverRepo())
 		if err != nil {

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -198,6 +198,11 @@ func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) ([]string, e
 // refs matched or resolved by them, plus the explicitly listed Git revspecs. See
 // git.CompileRefGlobs for information on how ref include/exclude globs are handled.
 func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, error) {
+	listRefs := r.ListRefs
+	if listRefs == nil {
+		listRefs = git.ListRefs
+	}
+
 	var (
 		revSpecs = map[string]struct{}{}
 		globs    []git.RefGlob
@@ -213,10 +218,6 @@ func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, err
 		}
 	}
 
-	listRefs := r.ListRefs
-	if listRefs == nil {
-		listRefs = git.ListRefs
-	}
 	if len(globs) > 0 {
 		allRefs, err := listRefs(ctx, r.GitserverRepo())
 		if err != nil {

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -168,8 +168,8 @@ func (r *RepositoryRevisions) RevSpecs() []string {
 	return revspecs
 }
 
-// ExpandedRevSpecs evaluates all of r's ref glob expressions and returns
-// the full, current list of refs matched or resolved by them, plus the explicitly listed Git revspecs. See
+// ExpandedRevSpecs evaluates all of r's ref glob expressions and returns the full, current list of
+// refs matched or resolved by them, plus the explicitly listed Git revspecs. See
 // git.CompileRefGlobs for information on how ref include/exclude globs are handled.
 //
 // Note that not all callers need to expand these. If a caller is passing the ref globs as


### PR DESCRIPTION
Closes #10571

This PR adds the rev-resolution to repo-searches.

**Why?**
We would expect this query to return results, but it doesn't return anything because we resolve ref-globs only for unindexed search. 

[`repo:^github\.com/sourcegraph/sourcegraph$@*refs/tags/v3.15.*`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40*refs/tags/v3.15.*&patternType=literal)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
