### PR TITLE
search: interpret values of /.../ as regexp, not literal

### DIFF
--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -134,6 +134,12 @@ func TestParseParameterList(t *testing.T) {
 			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":9}}`,
 			WantLabels: Regexp | HeuristicDanglingParens,
 		},
+		{
+			Input:      `/a regex pattern/`,
+			Want:       `{"value":"a regex pattern","negated":false}`,
+			WantRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":17}}`,
+			WantLabels: Regexp,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
When I added `/.../` in https://github.com/sourcegraph/sourcegraph/pull/12964 I didn't add a change that would interpret the quoted value as regexp, it was treated as literal. This PR treats it as regexp as expected.