### PR TITLE
Use default limit in graphql layer

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -26,7 +26,7 @@ type MoveCampaignArgs struct {
 }
 
 type ListCampaignsArgs struct {
-	First               *int32
+	First               int32
 	After               *string
 	State               *string
 	ViewerCanAdminister *bool
@@ -59,13 +59,17 @@ type CreateCampaignSpecArgs struct {
 }
 
 type ChangesetSpecsConnectionArgs struct {
-	First *int32
+	First int32
 	After *string
 }
 
 type CampaignArgs struct {
 	Namespace string
 	Name      string
+}
+
+type ChangesetEventsConnectionArgs struct {
+	First int32
 }
 
 type CampaignsResolver interface {
@@ -185,7 +189,7 @@ type ChangesetCountsArgs struct {
 }
 
 type ListChangesetsArgs struct {
-	First                       *int32
+	First                       int32
 	After                       *string
 	PublicationState            *campaigns.ChangesetPublicationState
 	ReconcilerState             *campaigns.ReconcilerState
@@ -281,7 +285,7 @@ type ExternalChangesetResolver interface {
 	CheckState() *campaigns.ChangesetCheckState
 	Repository(ctx context.Context) *RepositoryResolver
 
-	Events(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) (ChangesetEventsConnectionResolver, error)
+	Events(ctx context.Context, args *ChangesetEventsConnectionArgs) (ChangesetEventsConnectionResolver, error)
 	Diff(ctx context.Context) (RepositoryComparisonInterface, error)
 	DiffStat(ctx context.Context) (*DiffStat, error)
 	Labels(ctx context.Context) ([]ChangesetLabelResolver, error)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -965,7 +965,7 @@ type CampaignSpec implements Node {
     """
     The specs for changesets associated with this campaign.
     """
-    changesetSpecs(first: Int, after: String): ChangesetSpecConnection!
+    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
 
     """
     The user who created this campaign spec (or null if the user no longer exists).
@@ -1102,7 +1102,7 @@ type Campaign implements Node {
     The changesets in this campaign that already exist on the code host.
     """
     changesets(
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1319,7 +1319,7 @@ interface Changeset {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1381,7 +1381,7 @@ type HiddenExternalChangeset implements Node & Changeset {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1454,7 +1454,7 @@ type ExternalChangeset implements Node & Changeset {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1472,7 +1472,7 @@ type ExternalChangeset implements Node & Changeset {
     """
     The events belonging to this changeset.
     """
-    events(first: Int): ChangesetEventConnection!
+    events(first: Int = 50): ChangesetEventConnection!
 
     """
     The date and time when the changeset was created.
@@ -1931,7 +1931,7 @@ type Query {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -5455,7 +5455,7 @@ type User implements Node & SettingsSubject & Namespace {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -5812,7 +5812,7 @@ type Org implements Node & SettingsSubject & Namespace {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -958,7 +958,7 @@ type CampaignSpec implements Node {
     """
     The specs for changesets associated with this campaign.
     """
-    changesetSpecs(first: Int, after: String): ChangesetSpecConnection!
+    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
 
     """
     The user who created this campaign spec (or null if the user no longer exists).
@@ -1095,7 +1095,7 @@ type Campaign implements Node {
     The changesets in this campaign that already exist on the code host.
     """
     changesets(
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1312,7 +1312,7 @@ interface Changeset {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1374,7 +1374,7 @@ type HiddenExternalChangeset implements Node & Changeset {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1447,7 +1447,7 @@ type ExternalChangeset implements Node & Changeset {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -1465,7 +1465,7 @@ type ExternalChangeset implements Node & Changeset {
     """
     The events belonging to this changeset.
     """
-    events(first: Int): ChangesetEventConnection!
+    events(first: Int = 50): ChangesetEventConnection!
 
     """
     The date and time when the changeset was created.
@@ -1924,7 +1924,7 @@ type Query {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -5448,7 +5448,7 @@ type User implements Node & SettingsSubject & Namespace {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """
@@ -5805,7 +5805,7 @@ type Org implements Node & SettingsSubject & Namespace {
         """
         Returns the first n campaigns from the list.
         """
-        first: Int
+        first: Int = 50
         """
         Opaque pagination cursor.
         """

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -156,7 +156,7 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	resolvers := []graphqlbackend.ChangesetCountsResolver{}
 
 	publishedState := campaigns.ChangesetPublicationStatePublished
-	opts := ee.ListChangesetsOpts{CampaignID: r.Campaign.ID, Limit: -1, PublicationState: &publishedState}
+	opts := ee.ListChangesetsOpts{CampaignID: r.Campaign.ID, PublicationState: &publishedState}
 	cs, _, err := r.store.ListChangesets(ctx, opts)
 	if err != nil {
 		return resolvers, err
@@ -178,7 +178,7 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 		end = args.To.Time.UTC()
 	}
 
-	eventsOpts := ee.ListChangesetEventsOpts{ChangesetIDs: cs.IDs(), Limit: -1}
+	eventsOpts := ee.ListChangesetEventsOpts{ChangesetIDs: cs.IDs()}
 	es, _, err := r.store.ListChangesetEvents(ctx, eventsOpts)
 	if err != nil {
 		return resolvers, err
@@ -201,7 +201,6 @@ func (r *campaignResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffSt
 		store: r.store,
 		opts: ee.ListChangesetsOpts{
 			CampaignID: r.Campaign.ID,
-			Limit:      -1, // Get all changesets
 		},
 		optsSafe: true,
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -54,9 +54,7 @@ func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 
 func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
 	opts := ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID}
-	if args.First != nil {
-		opts.Limit = int(*args.First)
-	}
+	opts.Limit = int(args.First)
 	if args.After != nil {
 		id, err := strconv.Atoi(*args.After)
 		if err != nil {
@@ -154,7 +152,6 @@ func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.Di
 		httpFactory: r.httpFactory,
 		opts: ee.ListChangesetSpecsOpts{
 			CampaignSpecID: r.campaignSpec.ID,
-			Limit:          -1,
 		},
 	}
 

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -102,7 +102,7 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) (allChangese
 		}
 
 		opts := r.opts
-		opts.Limit = -1
+		opts.Limit = 0
 		opts.Cursor = 0
 
 		cs, _, err := r.store.ListChangesets(ctx, opts)

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection.go
@@ -59,7 +59,7 @@ func (r *changesetEventsConnectionResolver) compute(ctx context.Context) ([]*cam
 	r.once.Do(func() {
 		opts := ee.ListChangesetEventsOpts{
 			ChangesetIDs: []int64{r.changesetResolver.changeset.ID},
-			Limit:        r.first,
+			LimitOpts:    ee.LimitOpts{Limit: r.first},
 		}
 		r.changesetEvents, r.next, r.err = r.store.ListChangesetEvents(ctx, opts)
 	})

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -105,7 +105,7 @@ func TestPermissionLevels(t *testing.T) {
 	cleanUpCampaigns := func(t *testing.T, s *ee.Store) {
 		t.Helper()
 
-		campaigns, next, err := s.ListCampaigns(ctx, ee.ListCampaignsOpts{Limit: 1000})
+		campaigns, next, err := s.ListCampaigns(ctx, ee.ListCampaignsOpts{LimitOpts: ee.LimitOpts{Limit: 1000}})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -437,9 +437,7 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 		return nil, err
 	}
 	opts.State = state
-	if args.First != nil {
-		opts.Limit = int(*args.First)
-	}
+	opts.Limit = int(args.First)
 	if args.After != nil {
 		cursor, err := strconv.ParseInt(*args.After, 10, 32)
 		if err != nil {
@@ -486,9 +484,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 
 	safe := true
 
-	if args.First != nil {
-		opts.Limit = int(*args.First)
-	}
+	opts.Limit = int(args.First)
 
 	if args.After != nil {
 		cursor, err := strconv.ParseInt(*args.After, 10, 32)

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -620,10 +620,10 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 		// First argument is set in opts, and considered safe.
 		{
 			args: &graphqlbackend.ListChangesetsArgs{
-				First: &wantFirst,
+				First: wantFirst,
 			},
 			wantSafe:   true,
-			wantParsed: ee.ListChangesetsOpts{Limit: 10},
+			wantParsed: ee.ListChangesetsOpts{LimitOpts: ee.LimitOpts{Limit: 10}},
 		},
 		// Setting publication state is safe and transferred to opts.
 		{

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -81,7 +81,7 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 		return spec, s.store.CreateCampaignSpec(ctx, spec)
 	}
 
-	listOpts := ListChangesetSpecsOpts{Limit: -1, RandIDs: opts.ChangesetSpecRandIDs}
+	listOpts := ListChangesetSpecsOpts{RandIDs: opts.ChangesetSpecRandIDs}
 	cs, _, err := s.store.ListChangesetSpecs(ctx, listOpts)
 	if err != nil {
 		return nil, err
@@ -330,7 +330,6 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 			OwnedByCampaignID: campaign.ID,
 			ExternalState:     &open,
 			PublicationState:  &published,
-			Limit:             -1,
 		})
 		if err != nil {
 			return err

--- a/enterprise/internal/campaigns/service_apply_campaign.go
+++ b/enterprise/internal/campaigns/service_apply_campaign.go
@@ -379,7 +379,6 @@ func (r *changesetRewirer) updateChangesetToNewSpec(c *campaigns.Changeset, spec
 func (r *changesetRewirer) loadAssociations() (err error) {
 	// Load all of the new ChangesetSpecs
 	r.newChangesetSpecs, _, err = r.tx.ListChangesetSpecs(r.ctx, ListChangesetSpecsOpts{
-		Limit:          -1,
 		CampaignSpecID: r.campaign.CampaignSpecID,
 	})
 	if err != nil {
@@ -388,7 +387,6 @@ func (r *changesetRewirer) loadAssociations() (err error) {
 
 	// Load all Changesets attached to this Campaign.
 	r.changesets, _, err = r.tx.ListChangesets(r.ctx, ListChangesetsOpts{
-		Limit:      -1,
 		CampaignID: r.campaign.ID,
 	})
 	if err != nil {

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -261,7 +261,6 @@ func TestService(t *testing.T) {
 
 			cs, _, err := store.ListChangesets(ctx, ListChangesetsOpts{
 				OwnedByCampaignID: c.ID,
-				Limit:             -1,
 			})
 			if err != nil {
 				t.Fatalf("listing changesets failed: %s", err)

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -171,5 +172,15 @@ func (o LimitOpts) DBLimit() int {
 	if o.Limit == 0 {
 		return o.Limit
 	}
+	// We always request one item more than actually requested, to determine the next ID for pagination.
+	// The store should make sure to strip the last element in a result set, if len(rs) == o.DBLimit().
 	return o.Limit + 1
+}
+
+func (o LimitOpts) ToDB() string {
+	var limitClause string
+	if o.Limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", o.DBLimit())
+	}
+	return limitClause
 }

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -162,3 +162,14 @@ func nullStringColumn(s string) *string {
 	}
 	return &s
 }
+
+type LimitOpts struct {
+	Limit int
+}
+
+func (o LimitOpts) DBLimit() int {
+	if o.Limit == 0 {
+		return o.Limit
+	}
+	return o.Limit + 1
+}

--- a/enterprise/internal/campaigns/store_campaign_specs.go
+++ b/enterprise/internal/campaigns/store_campaign_specs.go
@@ -3,7 +3,6 @@ package campaigns
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/dineshappavoo/basex"
@@ -246,17 +245,12 @@ ORDER BY id ASC
 `
 
 func listCampaignSpecsQuery(opts *ListCampaignSpecsOpts) *sqlf.Query {
-	var limitClause string
-	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
-	}
-
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
 	}
 
 	return sqlf.Sprintf(
-		listCampaignSpecsQueryFmtstr+limitClause,
+		listCampaignSpecsQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(campaignSpecColumns, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)

--- a/enterprise/internal/campaigns/store_campaign_specs_test.go
+++ b/enterprise/internal/campaigns/store_campaign_specs_test.go
@@ -86,36 +86,31 @@ func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos
 
 	t.Run("List", func(t *testing.T) {
 		t.Run("NoLimit", func(t *testing.T) {
-			opts := []ListCampaignSpecsOpts{
-				{},          // Empty limit should return default limit
-				{Limit: -1}, // -1 should return all entries
+			// Empty should return all entries
+			opts := ListCampaignSpecsOpts{}
+
+			ts, next, err := s.ListCampaignSpecs(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			for _, o := range opts {
-				ts, next, err := s.ListCampaignSpecs(ctx, o)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if have, want := next, int64(0); have != want {
-					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
-				}
-
-				have, want := ts, campaignSpecs
-				if len(have) != len(want) {
-					t.Fatalf("listed %d campaignSpecs, want: %d", len(have), len(want))
-				}
-
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatalf("opts: %+v, diff: %s", opts, diff)
-				}
+			if have, want := next, int64(0); have != want {
+				t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
 			}
 
+			have, want := ts, campaignSpecs
+			if len(have) != len(want) {
+				t.Fatalf("listed %d campaignSpecs, want: %d", len(have), len(want))
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatalf("opts: %+v, diff: %s", opts, diff)
+			}
 		})
 
 		t.Run("WithLimit", func(t *testing.T) {
 			for i := 1; i <= len(campaignSpecs); i++ {
-				cs, next, err := s.ListCampaignSpecs(ctx, ListCampaignSpecsOpts{Limit: i})
+				cs, next, err := s.ListCampaignSpecs(ctx, ListCampaignSpecsOpts{LimitOpts: LimitOpts{Limit: i}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -148,7 +143,7 @@ func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos
 		t.Run("WithLimitAndCursor", func(t *testing.T) {
 			var cursor int64
 			for i := 1; i <= len(campaignSpecs); i++ {
-				opts := ListCampaignSpecsOpts{Cursor: cursor, Limit: 1}
+				opts := ListCampaignSpecsOpts{Cursor: cursor, LimitOpts: LimitOpts{Limit: 1}}
 				have, next, err := s.ListCampaignSpecs(ctx, opts)
 				if err != nil {
 					t.Fatal(err)

--- a/enterprise/internal/campaigns/store_campaigns.go
+++ b/enterprise/internal/campaigns/store_campaigns.go
@@ -2,7 +2,6 @@ package campaigns
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -324,11 +323,6 @@ ORDER BY id DESC
 `
 
 func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
-	var limitClause string
-	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
-	}
-
 	preds := []*sqlf.Query{}
 
 	if opts.Cursor != 0 {
@@ -363,7 +357,7 @@ func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listCampaignsQueryFmtstr+limitClause,
+		listCampaignsQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(campaignColumns, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -181,7 +181,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 
 		t.Run("With Limit", func(t *testing.T) {
 			for i := 1; i <= len(reversedCampaigns); i++ {
-				cs, next, err := s.ListCampaigns(ctx, ListCampaignsOpts{Limit: i})
+				cs, next, err := s.ListCampaigns(ctx, ListCampaignsOpts{LimitOpts: LimitOpts{Limit: i}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -213,7 +213,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 		t.Run("With Cursor", func(t *testing.T) {
 			var cursor int64
 			for i := 1; i <= len(reversedCampaigns); i++ {
-				opts := ListCampaignsOpts{Cursor: cursor, Limit: 1}
+				opts := ListCampaignsOpts{Cursor: cursor, LimitOpts: LimitOpts{Limit: 1}}
 				have, next, err := s.ListCampaigns(ctx, opts)
 				if err != nil {
 					t.Fatal(err)

--- a/enterprise/internal/campaigns/store_changeset_events.go
+++ b/enterprise/internal/campaigns/store_changeset_events.go
@@ -3,7 +3,6 @@ package campaigns
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -120,11 +119,6 @@ ORDER BY id ASC
 `
 
 func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
-	var limitClause string
-	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
-	}
-
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("id >= %s", opts.Cursor),
 	}
@@ -141,7 +135,7 @@ func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listChangesetEventsQueryFmtstr+limitClause,
+		listChangesetEventsQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(preds, "\n AND "),
 	)
 }

--- a/enterprise/internal/campaigns/store_changeset_events.go
+++ b/enterprise/internal/campaigns/store_changeset_events.go
@@ -77,16 +77,16 @@ func getChangesetEventQuery(opts *GetChangesetEventOpts) *sqlf.Query {
 // ListChangesetEventsOpts captures the query options needed for
 // listing changeset events.
 type ListChangesetEventsOpts struct {
+	LimitOpts
 	ChangesetIDs []int64
 	Cursor       int64
-	Limit        int
 }
 
 // ListChangesetEvents lists ChangesetEvents with the given filters.
 func (s *Store) ListChangesetEvents(ctx context.Context, opts ListChangesetEventsOpts) (cs []*campaigns.ChangesetEvent, next int64, err error) {
 	q := listChangesetEventsQuery(&opts)
 
-	cs = make([]*campaigns.ChangesetEvent, 0, opts.Limit)
+	cs = make([]*campaigns.ChangesetEvent, 0, opts.DBLimit())
 	err = s.query(ctx, q, func(sc scanner) (err error) {
 		var c campaigns.ChangesetEvent
 		if err = scanChangesetEvent(&c, sc); err != nil {
@@ -96,7 +96,7 @@ func (s *Store) ListChangesetEvents(ctx context.Context, opts ListChangesetEvent
 		return nil
 	})
 
-	if opts.Limit != 0 && len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.DBLimit() {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}
@@ -120,14 +120,9 @@ ORDER BY id ASC
 `
 
 func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
-	if opts.Limit == 0 {
-		opts.Limit = defaultListLimit
-	}
-	opts.Limit++
-
 	var limitClause string
 	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
 	}
 
 	preds := []*sqlf.Query{

--- a/enterprise/internal/campaigns/store_changeset_events_test.go
+++ b/enterprise/internal/campaigns/store_changeset_events_test.go
@@ -182,7 +182,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 
 		t.Run("WithLimit", func(t *testing.T) {
 			for i := 1; i <= len(events); i++ {
-				cs, next, err := s.ListChangesetEvents(ctx, ListChangesetEventsOpts{Limit: i})
+				cs, next, err := s.ListChangesetEvents(ctx, ListChangesetEventsOpts{LimitOpts: LimitOpts{Limit: i}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -214,7 +214,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 		t.Run("WithCursor", func(t *testing.T) {
 			var cursor int64
 			for i := 1; i <= len(events); i++ {
-				opts := ListChangesetEventsOpts{Cursor: cursor, Limit: 1}
+				opts := ListChangesetEventsOpts{Cursor: cursor, LimitOpts: LimitOpts{Limit: 1}}
 				have, next, err := s.ListChangesetEvents(ctx, opts)
 				if err != nil {
 					t.Fatal(err)
@@ -230,7 +230,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 		})
 
 		t.Run("EmptyResultListingAll", func(t *testing.T) {
-			opts := ListChangesetEventsOpts{ChangesetIDs: []int64{99999}, Limit: -1}
+			opts := ListChangesetEventsOpts{ChangesetIDs: []int64{99999}}
 
 			ts, next, err := s.ListChangesetEvents(ctx, opts)
 			if err != nil {

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -3,7 +3,6 @@ package campaigns
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/dineshappavoo/basex"
@@ -295,11 +294,6 @@ ORDER BY changeset_specs.id ASC
 `
 
 func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
-	var limitClause string
-	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
-	}
-
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("changeset_specs.id >= %s", opts.Cursor),
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
@@ -320,7 +314,7 @@ func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listChangesetSpecsQueryFmtstr+limitClause,
+		listChangesetSpecsQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(changesetSpecColumns, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)

--- a/enterprise/internal/campaigns/store_changeset_specs.go
+++ b/enterprise/internal/campaigns/store_changeset_specs.go
@@ -257,8 +257,8 @@ func getChangesetSpecQuery(opts *GetChangesetSpecOpts) *sqlf.Query {
 // ListChangesetSpecsOpts captures the query options needed for
 // listing code mods.
 type ListChangesetSpecsOpts struct {
+	LimitOpts
 	Cursor int64
-	Limit  int
 
 	CampaignSpecID int64
 	RandIDs        []string
@@ -268,7 +268,7 @@ type ListChangesetSpecsOpts struct {
 func (s *Store) ListChangesetSpecs(ctx context.Context, opts ListChangesetSpecsOpts) (cs campaigns.ChangesetSpecs, next int64, err error) {
 	q := listChangesetSpecsQuery(&opts)
 
-	cs = make(campaigns.ChangesetSpecs, 0, opts.Limit)
+	cs = make(campaigns.ChangesetSpecs, 0, opts.DBLimit())
 	err = s.query(ctx, q, func(sc scanner) error {
 		var c campaigns.ChangesetSpec
 		if err := scanChangesetSpec(&c, sc); err != nil {
@@ -278,7 +278,7 @@ func (s *Store) ListChangesetSpecs(ctx context.Context, opts ListChangesetSpecsO
 		return nil
 	})
 
-	if opts.Limit != 0 && len(cs) == opts.Limit {
+	if opts.Limit != 0 && len(cs) == opts.DBLimit() {
 		next = cs[len(cs)-1].ID
 		cs = cs[:len(cs)-1]
 	}
@@ -295,14 +295,9 @@ ORDER BY changeset_specs.id ASC
 `
 
 func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
-	if opts.Limit == 0 {
-		opts.Limit = defaultListLimit
-	}
-	opts.Limit++
-
 	var limitClause string
 	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
+		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
 	}
 
 	preds := []*sqlf.Query{

--- a/enterprise/internal/campaigns/store_changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store_changeset_specs_test.go
@@ -126,35 +126,30 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 
 	t.Run("List", func(t *testing.T) {
 		t.Run("NoLimit", func(t *testing.T) {
-			opts := []ListChangesetSpecsOpts{
-				{},          // Empty limit should return default limit
-				{Limit: -1}, // -1 should return all entries
+			// Empty limit should return all entries.
+			opts := ListChangesetSpecsOpts{}
+			ts, next, err := s.ListChangesetSpecs(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			for _, o := range opts {
-				ts, next, err := s.ListChangesetSpecs(ctx, o)
-				if err != nil {
-					t.Fatal(err)
-				}
+			if have, want := next, int64(0); have != want {
+				t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+			}
 
-				if have, want := next, int64(0); have != want {
-					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
-				}
+			have, want := ts, changesetSpecs
+			if len(have) != len(want) {
+				t.Fatalf("listed %d changesetSpecs, want: %d", len(have), len(want))
+			}
 
-				have, want := ts, changesetSpecs
-				if len(have) != len(want) {
-					t.Fatalf("listed %d changesetSpecs, want: %d", len(have), len(want))
-				}
-
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatalf("opts: %+v, diff: %s", opts, diff)
-				}
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatalf("opts: %+v, diff: %s", opts, diff)
 			}
 		})
 
 		t.Run("WithLimit", func(t *testing.T) {
 			for i := 1; i <= len(changesetSpecs); i++ {
-				cs, next, err := s.ListChangesetSpecs(ctx, ListChangesetSpecsOpts{Limit: i})
+				cs, next, err := s.ListChangesetSpecs(ctx, ListChangesetSpecsOpts{LimitOpts: LimitOpts{Limit: i}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -186,7 +181,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs rep
 		t.Run("WithLimitAndCursor", func(t *testing.T) {
 			var cursor int64
 			for i := 1; i <= len(changesetSpecs); i++ {
-				opts := ListChangesetSpecsOpts{Cursor: cursor, Limit: 1}
+				opts := ListChangesetSpecsOpts{Cursor: cursor, LimitOpts: LimitOpts{Limit: 1}}
 				have, next, err := s.ListChangesetSpecs(ctx, opts)
 				if err != nil {
 					t.Fatal(err)

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
@@ -422,11 +421,6 @@ ORDER BY id ASC
 `
 
 func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
-	var limitClause string
-	if opts.Limit > 0 {
-		limitClause = fmt.Sprintf("LIMIT %d", opts.DBLimit())
-	}
-
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("changesets.id >= %s", opts.Cursor),
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
@@ -474,7 +468,7 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	}
 
 	return sqlf.Sprintf(
-		listChangesetsQueryFmtstr+limitClause,
+		listChangesetsQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(changesetColumns, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -329,7 +329,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		}
 
 		for i := 1; i <= len(changesets); i++ {
-			ts, next, err := s.ListChangesets(ctx, ListChangesetsOpts{Limit: i})
+			ts, next, err := s.ListChangesets(ctx, ListChangesetsOpts{LimitOpts: LimitOpts{Limit: i}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -372,7 +372,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		{
 			var cursor int64
 			for i := 1; i <= len(changesets); i++ {
-				opts := ListChangesetsOpts{Cursor: cursor, Limit: 1}
+				opts := ListChangesetsOpts{Cursor: cursor, LimitOpts: LimitOpts{Limit: 1}}
 				have, next, err := s.ListChangesets(ctx, opts)
 				if err != nil {
 					t.Fatal(err)
@@ -432,9 +432,9 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			}
 		}
 
-		// Limit of -1 should return all Changesets
+		// No Limit should return all Changesets
 		{
-			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{Limit: -1})
+			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -479,7 +479,7 @@ func (s *ChangesetSyncer) computeSchedule(ctx context.Context) ([]scheduledSync,
 }
 
 func (s *ChangesetSyncer) prioritizeChangesetsWithoutDiffStats(ctx context.Context) error {
-	changesets, _, err := s.SyncStore.ListChangesets(ctx, ListChangesetsOpts{OnlyWithoutDiffStats: true, Limit: -1})
+	changesets, _, err := s.SyncStore.ListChangesets(ctx, ListChangesetsOpts{OnlyWithoutDiffStats: true})
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -169,7 +169,6 @@ func (h Webhook) upsertChangesetEvent(
 	// event we are currently handling
 	events, _, err := tx.ListChangesetEvents(ctx, ListChangesetEventsOpts{
 		ChangesetIDs: []int64{cs.ID},
-		Limit:        -1,
 	})
 	SetDerivedState(ctx, cs, events)
 	if err := tx.UpdateChangeset(ctx, cs); err != nil {

--- a/enterprise/internal/campaigns/webhooks_gitlab_test.go
+++ b/enterprise/internal/campaigns/webhooks_gitlab_test.go
@@ -868,7 +868,7 @@ func assertBodyIncludes(t *testing.T, r io.Reader, want string) {
 func assertChangesetEventForChangeset(t *testing.T, ctx context.Context, store *Store, changeset *campaigns.Changeset, want campaigns.ChangesetEventKind) {
 	ces, _, err := store.ListChangesetEvents(ctx, ListChangesetEventsOpts{
 		ChangesetIDs: []int64{changeset.ID},
-		Limit:        100,
+		LimitOpts:    LimitOpts{Limit: 100},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -170,7 +170,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					}
 				}
 
-				have, _, err := store.ListChangesetEvents(ctx, ListChangesetEventsOpts{Limit: -1})
+				have, _, err := store.ListChangesetEvents(ctx, ListChangesetEventsOpts{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -352,7 +352,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					}
 				}
 
-				have, _, err := store.ListChangesetEvents(ctx, ListChangesetEventsOpts{Limit: -1})
+				have, _, err := store.ListChangesetEvents(ctx, ListChangesetEventsOpts{})
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Helps us remove the -1 special case for Limit, which caused a lot of bad bugs in the past.

Works on https://github.com/sourcegraph/sourcegraph/issues/13369