### PR TITLE
Validate first param is within an acceptable range

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -54,7 +54,7 @@ func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 
 func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
 	opts := ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID}
-	if err := validateFirstParam(args.First, 0, 100); err != nil {
+	if err := validateFirstParam(args.First, 0, 1000); err != nil {
 		return nil, err
 	}
 	opts.Limit = int(args.First)

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -54,7 +54,7 @@ func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 
 func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
 	opts := ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID}
-	if err := validateFirstParam(args.First, 0, 1000); err != nil {
+	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
 	opts.Limit = int(args.First)

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -54,6 +54,9 @@ func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 
 func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
 	opts := ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID}
+	if err := validateFirstParam(args.First, 0, 100); err != nil {
+		return nil, err
+	}
 	opts.Limit = int(args.First)
 	if args.After != nil {
 		id, err := strconv.Atoi(*args.After)

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -173,6 +173,9 @@ func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 	opts.State = state
+	if err := validateFirstParam(args.First, 0, 100); err != nil {
+		return nil, err
+	}
 	opts.Limit = int(args.First)
 	if args.After != nil {
 		cursor, err := strconv.ParseInt(*args.After, 10, 32)
@@ -349,6 +352,9 @@ func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.Change
 }
 
 func (r *changesetResolver) Events(ctx context.Context, args *graphqlbackend.ChangesetEventsConnectionArgs) (graphqlbackend.ChangesetEventsConnectionResolver, error) {
+	if err := validateFirstParam(args.First, 0, 100); err != nil {
+		return nil, err
+	}
 	// TODO: We already need to fetch all events for ReviewState and Labels
 	// perhaps we can use the cached data here
 	return &changesetEventsConnectionResolver{

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -173,7 +173,7 @@ func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 	opts.State = state
-	if err := validateFirstParam(args.First, 0, 100); err != nil {
+	if err := validateFirstParam(args.First, 0, 1000); err != nil {
 		return nil, err
 	}
 	opts.Limit = int(args.First)
@@ -352,7 +352,7 @@ func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.Change
 }
 
 func (r *changesetResolver) Events(ctx context.Context, args *graphqlbackend.ChangesetEventsConnectionArgs) (graphqlbackend.ChangesetEventsConnectionResolver, error) {
-	if err := validateFirstParam(args.First, 0, 100); err != nil {
+	if err := validateFirstParam(args.First, 0, 1000); err != nil {
 		return nil, err
 	}
 	// TODO: We already need to fetch all events for ReviewState and Labels

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -173,7 +173,7 @@ func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 	opts.State = state
-	if err := validateFirstParam(args.First, 0, 1000); err != nil {
+	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
 	opts.Limit = int(args.First)
@@ -352,7 +352,7 @@ func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.Change
 }
 
 func (r *changesetResolver) Events(ctx context.Context, args *graphqlbackend.ChangesetEventsConnectionArgs) (graphqlbackend.ChangesetEventsConnectionResolver, error) {
-	if err := validateFirstParam(args.First, 0, 1000); err != nil {
+	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
 	// TODO: We already need to fetch all events for ReviewState and Labels

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -437,7 +437,7 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 		return nil, err
 	}
 	opts.State = state
-	if err := validateFirstParam(args.First, 0, 100); err != nil {
+	if err := validateFirstParam(args.First, 0, 1000); err != nil {
 		return nil, err
 	}
 	opts.Limit = int(args.First)

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -487,7 +487,9 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 
 	safe := true
 
-	if err := validateFirstParam(args.First, 0, 100); err != nil {
+	// TODO: Reduce this number, once we use cursor based pagination in the frontend for ChangesetConnections.
+	// Currently we cannot, because we want to re-fetch the whole list periodically to check to change in changeset states.
+	if err := validateFirstParam(args.First, 0, 100000); err != nil {
 		return opts, false, err
 	}
 	opts.Limit = int(args.First)


### PR DESCRIPTION
- Forbids negative values as they cause DB errors
- Forbids large values, because API consumers should be using pagination to retrieve giant amounts of results. In the frontend, we always request 15 at a time, since on average screens, you wouldn't fit more anyways.
- Currently loosens the constraint for changesets, as we don't yet have a good solution to otherwise detect change in the frontend and update the changeset nodes as they're being processed.

This should help us prevent overloading the frontend instance (and perhaps other services, that we reach out N+1 times to).

Closes #13369

## Question: What is the magic number we want to set here? ~~100~~ 1000? The UI only needs 15, but going way below 1000 seems very restrictive.