### PR TITLE
codeintel: Wrap index commands in a firecracker VM

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/env.go
@@ -15,8 +15,8 @@ var (
 	rawIndexerPollInterval      = env.Get("PRECISE_CODE_INTEL_INDEXER_POLL_INTERVAL", "1s", "Interval between queries to the precise-code-intel-index-manager.")
 	rawIndexerHeartbeatInterval = env.Get("PRECISE_CODE_INTEL_INDEXER_HEARTBEAT_INTERVAL", "1s", "Interval between heartbeat requests.")
 	rawMaxContainers            = env.Get("PRECISE_CODE_INTEL_MAXIMUM_CONTAINERS", "1", "Number of index containers that can be running at once.")
-	rawFirecrackerImage         = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_IMAGE", "TODO", "TODO.")
-	rawUseFirecracker           = env.Get("PRECISE_CODE_INTEL_USE_FIRECRACKER", "true", "TODO.")
+	rawFirecrackerImage         = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu", "The base image to use for firecracker VMs.")
+	rawUseFirecracker           = env.Get("PRECISE_CODE_INTEL_USE_FIRECRACKER", "true", "Whether to isolate index containers in firecracker VMs.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.

--- a/enterprise/cmd/precise-code-intel-indexer-vm/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/env.go
@@ -15,6 +15,8 @@ var (
 	rawIndexerPollInterval      = env.Get("PRECISE_CODE_INTEL_INDEXER_POLL_INTERVAL", "1s", "Interval between queries to the precise-code-intel-index-manager.")
 	rawIndexerHeartbeatInterval = env.Get("PRECISE_CODE_INTEL_INDEXER_HEARTBEAT_INTERVAL", "1s", "Interval between heartbeat requests.")
 	rawMaxContainers            = env.Get("PRECISE_CODE_INTEL_MAXIMUM_CONTAINERS", "1", "Number of index containers that can be running at once.")
+	rawFirecrackerImage         = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_IMAGE", "TODO", "TODO.")
+	rawUseFirecracker           = env.Get("PRECISE_CODE_INTEL_USE_FIRECRACKER", "true", "TODO.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.
@@ -44,4 +46,14 @@ func mustParseInterval(rawValue, name string) time.Duration {
 	}
 
 	return d
+}
+
+// mustParseBool returns the boolean version of the given raw value fatally logs on failure.
+func mustParseBool(rawValue, name string) bool {
+	v, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		log.Fatalf("invalid bool %q for %s: %s", rawValue, name, err)
+	}
+
+	return v
 }

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -7,22 +7,17 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	indexmanager "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer-vm/internal/index_manager"
 	queuemocks "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/queue/client/mocks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
 )
 
-var testHandlerOptions = HandlerOptions{
-	FrontendURL:           "https://sourcegraph.test:1234",
-	FrontendURLFromDocker: "https://sourcegraph.test:5432",
-	AuthToken:             "hunter2",
-}
-
 func init() {
 	makeTempDir = func() (string, error) { return "/tmp/testing", nil }
 }
 
-func TestHandle(t *testing.T) {
+func TestHandleWithDocker(t *testing.T) {
 	queueClient := queuemocks.NewMockClient()
 	indexManager := indexmanager.New()
 	commander := NewMockCommander()
@@ -31,7 +26,12 @@ func TestHandle(t *testing.T) {
 		queueClient:  queueClient,
 		indexManager: indexManager,
 		commander:    commander,
-		options:      testHandlerOptions,
+		options: HandlerOptions{
+			FrontendURL:           "https://sourcegraph.test:1234",
+			FrontendURLFromDocker: "https://sourcegraph.test:5432",
+			AuthToken:             "hunter2",
+		},
+		uuidGenerator: uuid.NewRandom,
 	}
 
 	index := store.Index{
@@ -44,14 +44,69 @@ func TestHandle(t *testing.T) {
 		t.Fatalf("unexpected error handling index: %s", err)
 	}
 
-	if callCount := len(commander.RunFunc.History()); callCount != 4 {
-		t.Errorf("unexpected run call count. want=%d have=%d", 4, callCount)
+	if callCount := len(commander.RunFunc.History()); callCount != 5 {
+		t.Errorf("unexpected run call count. want=%d have=%d", 5, callCount)
 	} else {
 		expectedCalls := []string{
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
-			"docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest bash -c lsif-go && SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 src lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
+			"docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest lsif-go",
+			"docker run --rm -v /tmp/testing:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
+		}
+
+		calls := commander.RunFunc.History()
+
+		for i, expectedCall := range expectedCalls {
+			if diff := cmp.Diff(expectedCall, fmt.Sprintf("%s %s", calls[i].Arg1, strings.Join(calls[i].Arg2, " "))); diff != "" {
+				t.Errorf("unexpected command (-want +got):\n%s", diff)
+			}
+		}
+	}
+}
+
+func TestHandleWithFirecracker(t *testing.T) {
+	queueClient := queuemocks.NewMockClient()
+	indexManager := indexmanager.New()
+	commander := NewMockCommander()
+
+	handler := &Handler{
+		queueClient:  queueClient,
+		indexManager: indexManager,
+		commander:    commander,
+		options: HandlerOptions{
+			FrontendURL:           "https://sourcegraph.test:1234",
+			FrontendURLFromDocker: "https://sourcegraph.test:5432",
+			AuthToken:             "hunter2",
+			UseFirecracker:        true,
+			FirecrackerImage:      "sourcegraph/ignite-ubuntu:latest",
+		},
+		uuidGenerator: func() (uuid.UUID, error) {
+			return uuid.MustParse("97b45daf-53d1-48ad-b992-547469d8e438"), nil
+		},
+	}
+
+	index := store.Index{
+		ID:             42,
+		RepositoryName: "github.com/sourcegraph/sourcegraph",
+		Commit:         "e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+	}
+
+	if err := handler.Handle(context.Background(), nil, index); err != nil {
+		t.Fatalf("unexpected error handling index: %s", err)
+	}
+
+	if callCount := len(commander.RunFunc.History()); callCount != 7 {
+		t.Errorf("unexpected run call count. want=%d have=%d", 7, callCount)
+	} else {
+		expectedCalls := []string{
+			"git -C /tmp/testing init",
+			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+			"ignite run --runtime docker --copy-files /tmp/testing:/tmp/testing --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest lsif-go",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 docker run --rm -v /tmp/testing:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
+			"ignite stop --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
 		}
 
 		calls := commander.RunFunc.History()

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/indexer.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/indexer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	indexmanager "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-indexer-vm/internal/index_manager"
 	queue "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/queue/client"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -18,10 +19,11 @@ type IndexerOptions struct {
 
 func NewIndexer(ctx context.Context, queueClient queue.Client, indexManager *indexmanager.Manager, options IndexerOptions) *workerutil.Worker {
 	handler := &Handler{
-		queueClient:  queueClient,
-		indexManager: indexManager,
-		commander:    DefaultCommander,
-		options:      options.HandlerOptions,
+		queueClient:   queueClient,
+		indexManager:  indexManager,
+		commander:     DefaultCommander,
+		options:       options.HandlerOptions,
+		uuidGenerator: uuid.NewRandom,
 	}
 
 	workerMetrics := workerutil.WorkerMetrics{

--- a/enterprise/cmd/precise-code-intel-indexer-vm/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/main.go
@@ -33,6 +33,8 @@ func main() {
 		indexerPollInterval      = mustParseInterval(rawIndexerPollInterval, "PRECISE_CODE_INTEL_INDEXER_POLL_INTERVAL")
 		indexerHeartbeatInterval = mustParseInterval(rawIndexerHeartbeatInterval, "PRECISE_CODE_INTEL_INDEXER_HEARTBEAT_INTERVAL")
 		numContainers            = mustParseInt(rawMaxContainers, "PRECISE_CODE_INTEL_MAXIMUM_CONTAINERS")
+		firecrackerImage         = mustGet(rawFirecrackerImage, "PRECISE_CODE_INTEL_FIRECRACKER_IMAGE")
+		useFirecracker           = mustParseBool(rawUseFirecracker, "PRECISE_CODE_INTEL_USE_FIRECRACKER")
 	)
 
 	if frontendURLFromDocker == "" {
@@ -66,6 +68,8 @@ func main() {
 			FrontendURL:           frontendURL,
 			FrontendURLFromDocker: frontendURLFromDocker,
 			AuthToken:             internalProxyAuthToken,
+			FirecrackerImage:      firecrackerImage,
+			UseFirecracker:        useFirecracker,
 		},
 	})
 

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -45,6 +45,7 @@ export PRECISE_CODE_INTEL_EXTERNAL_URL_FROM_DOCKER=http://host.docker.internal:3
 export PRECISE_CODE_INTEL_INDEX_MANAGER_URL=http://localhost:3189
 export PRECISE_CODE_INTEL_INTERNAL_PROXY_AUTH_TOKEN=hunter2
 export PRECISE_CODE_INTEL_DISABLE_INDEXER=true
+export PRECISE_CODE_INTEL_USE_FIRECRACKER=false
 
 export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"
 export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-indexer-vm precise-code-intel-worker "

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,6 @@ require (
 	github.com/src-d/enry/v2 v2.1.0
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/stripe/stripe-go v70.15.0+incompatible
-	github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775
 	github.com/temoto/robotstxt v1.1.1
 	github.com/tidwall/gjson v1.6.0
 	github.com/tinylib/msgp v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1263,8 +1263,6 @@ github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08Yu
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775 h1:BLNsFR8l/hj/oGjnJXkd4Vi3s4kQD3/3x8HSAE4bzN0=
-github.com/teivah/onecontext v0.0.0-20200513185103-40f981bfd775/go.mod h1:XUZ4x3oGhWfiOnUvTslnKKs39AWUct3g3yJvXTQSJOQ=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=


### PR DESCRIPTION
Modify the docker commands so that they run in a firecracker VM instead, as described in [RFC 199: User code execution in the auto-indexer](https://docs.google.com/document/d/1rCduWqaLAbMu2s43RwJTBbRlhL6qS3oqq4iawiGdoVE).

Previously the indexer would clone the repo on the local disk, then run lsif-go/src upload in an lsif-go container running on the host. This PR changes the set of commands to instead spin up a fresh firecracker VM, then run the same set of docker commands inside the new VM, which is isolated from the host.

Closes https://github.com/sourcegraph/sourcegraph/issues/12708.