### PR TITLE
search: create experimental feature flag for enterprise home panels

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1077,6 +1077,8 @@ type SettingsExperimentalFeatures struct {
 	SearchStats *bool `json:"searchStats,omitempty"`
 	// ShowBadgeAttachments description: Enables the UI indicators for code intelligence precision.
 	ShowBadgeAttachments *bool `json:"showBadgeAttachments,omitempty"`
+	// ShowEnterpriseHomePanels description: Enabled the homepage panels in the Enterprise homepage
+	ShowEnterpriseHomePanels *bool `json:"showEnterpriseHomePanels,omitempty"`
 	// ShowOnboardingTour description: Enables the onboarding tour.
 	ShowOnboardingTour *bool `json:"showOnboardingTour,omitempty"`
 	// ShowRepogroupHomepage description: Enables the repository group homepage

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -53,6 +53,12 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "showEnterpriseHomePanels": {
+          "description": "Enabled the homepage panels in the Enterprise homepage",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -58,6 +58,12 @@ const SettingsSchemaJSON = `{
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "showEnterpriseHomePanels": {
+          "description": "Enabled the homepage panels in the Enterprise homepage",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"

--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -39,6 +39,7 @@ import {
     CopyQueryButtonProps,
     RepogroupHomepageProps,
     OnboardingTourProps,
+    EnterpriseHomePanelsProps,
 } from './search'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
@@ -80,7 +81,8 @@ export interface LayoutProps
         CopyQueryButtonProps,
         VersionContextProps,
         RepogroupHomepageProps,
-        OnboardingTourProps {
+        OnboardingTourProps,
+        EnterpriseHomePanelsProps {
     exploreSections: readonly ExploreSectionDescriptor[]
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
     extensionAreaHeaderNavItems: readonly ExtensionAreaHeaderNavItem[]

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -170,6 +170,8 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
 
     showOnboardingTour: boolean
 
+    showEnterpriseHomePanels: boolean
+
     /**
      * Whether globbing is enabled for filters.
      */
@@ -254,6 +256,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             previousVersionContext,
             showRepogroupHomepage: false,
             showOnboardingTour: false,
+            showEnterpriseHomePanels: false,
             globbing: false,
         }
     }
@@ -413,6 +416,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     previousVersionContext={this.state.previousVersionContext}
                                     showRepogroupHomepage={this.state.showRepogroupHomepage}
                                     showOnboardingTour={this.state.showOnboardingTour}
+                                    showEnterpriseHomePanels={this.state.showEnterpriseHomePanels}
                                     globbing={this.state.globbing}
                                 />
                             )}

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -162,6 +162,11 @@ export interface RepogroupHomepageProps {
 export interface OnboardingTourProps {
     showOnboardingTour: boolean
 }
+
+export interface EnterpriseHomePanelsProps {
+    showEnterpriseHomePanels: boolean
+}
+
 /**
  * Verifies whether a version context exists on an instance.
  *

--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -7,6 +7,7 @@ import {
     CopyQueryButtonProps,
     RepogroupHomepageProps,
     OnboardingTourProps,
+    EnterpriseHomePanelsProps,
 } from '..'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
@@ -48,7 +49,8 @@ interface Props
         CopyQueryButtonProps,
         VersionContextProps,
         RepogroupHomepageProps,
-        OnboardingTourProps {
+        OnboardingTourProps,
+        EnterpriseHomePanelsProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -310,6 +312,12 @@ export const SearchPage: React.FunctionComponent<Props> = props => {
                             </div>
                         </div>
                     </div>
+                </>
+            )}
+
+            {!props.isSourcegraphDotCom && props.showEnterpriseHomePanels && (
+                <>
+                    <div>Hello from Enterprise Home with panels enabled</div>
                 </>
             )}
         </div>

--- a/web/src/util/settings.ts
+++ b/web/src/util/settings.ts
@@ -51,6 +51,7 @@ export function experimentalFeaturesFromSettings(
     copyQueryButton: boolean
     showRepogroupHomepage: boolean
     showOnboardingTour: boolean
+    showEnterpriseHomePanels: boolean
 } {
     const experimentalFeatures: SettingsExperimentalFeatures =
         (settingsCascade.final && !isErrorLike(settingsCascade.final) && settingsCascade.final.experimentalFeatures) ||
@@ -61,7 +62,8 @@ export function experimentalFeaturesFromSettings(
         copyQueryButton = false,
         showRepogroupHomepage = false,
         showOnboardingTour = false,
+        showEnterpriseHomePanels = false,
     } = experimentalFeatures
 
-    return { splitSearchModes, copyQueryButton, showRepogroupHomepage, showOnboardingTour }
+    return { splitSearchModes, copyQueryButton, showRepogroupHomepage, showOnboardingTour, showEnterpriseHomePanels }
 }


### PR DESCRIPTION
Closes #13418

Can be enabled by adding the following to user settings:
```json
"experimentalFeatures": {
    "showEnterpriseHomePanels": true
}
```

For now this just contains some placeholder content for now if the feature flag is enabled.

![image](https://user-images.githubusercontent.com/206864/91505079-96685080-e883-11ea-8009-5db1eb3cc4e3.png)
