### PR TITLE
external_services: check user-added code host in backend

### DIFF
--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -109,6 +109,19 @@ type ValidateExternalServiceConfigOptions struct {
 func (e *ExternalServicesStore) ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) error {
 	// For user-added external services, we need to prevent them from using disallowed fields.
 	if opt.HasNamespace {
+		// We do not allow users to add external service other than GitHub.com, GitLab.com and Bitbucket.org
+		result := gjson.Get(opt.Config, "url")
+		baseURL, err := url.Parse(result.String())
+		if err != nil {
+			return errors.Wrap(err, "parse base URL")
+		}
+		normalizedURL := extsvc.NormalizeBaseURL(baseURL).String()
+		if normalizedURL != "https://github.com/" &&
+			normalizedURL != "https://gitlab.com/" &&
+			normalizedURL != "https://bitbucket.org/" {
+			return errors.New("users are only allowed to add external service for https://github.com/, https://gitlab.com/ and https://bitbucket.org/")
+		}
+
 		disallowedFields := []string{"repositoryPathPattern"}
 		results := gjson.GetMany(opt.Config, disallowedFields...)
 		for i, r := range results {

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -88,9 +88,21 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 		wantErr      string
 	}{
 		{
-			name:    "0 errors",
+			name:    "0 errors - GitHub.com",
 			kind:    extsvc.KindGitHub,
 			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			wantErr: "<nil>",
+		},
+		{
+			name:    "0 errors - GitLab.com",
+			kind:    extsvc.KindGitLab,
+			config:  `{"url": "https://github.com", "projectQuery": ["none"], "token": "abc"}`,
+			wantErr: "<nil>",
+		},
+		{
+			name:    "0 errors - Bitbucket.org",
+			kind:    extsvc.KindBitbucketCloud,
+			config:  `{"url": "https://bitbucket.org", "username": "ceo", "appPassword": "abc"}`,
 			wantErr: "<nil>",
 		},
 		{
@@ -139,6 +151,13 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 				}
 			},
 			wantErr: "1 error occurred:\n\t* existing external service, \"GITHUB 1\", already has a rate limit set\n\n",
+		},
+		{
+			name:         "prevent code hosts that are not allowed",
+			kind:         extsvc.KindGitHub,
+			config:       `{"url": "https://github.example.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			hasNamespace: true,
+			wantErr:      `users are only allowed to add external service for https://github.com/, https://gitlab.com/ and https://bitbucket.org/`,
 		},
 		{
 			name:         "prevent disallowed fields",


### PR DESCRIPTION
Add backend validation to prevent users from adding external services other than allowed public hostings.

Part of #12699