### PR TITLE
search: fix regex scanner for certain patterns

### DIFF
--- a/internal/search/query/literal_parser.go
+++ b/internal/search/query/literal_parser.go
@@ -94,7 +94,7 @@ loop:
 			result = append(result, r)
 		case r == '\\':
 			// Handle escape sequence.
-			if len(buf) > advance {
+			if len(buf) > 0 {
 				r = next()
 				// Accept anything anything escaped. The point
 				// is to consume escaped spaces like "\ " so

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -546,6 +546,7 @@ func TrailingParensToLiteral(nodes []Node) []Node {
 func EmptyGroupsToLiteral(nodes []Node) []Node {
 	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
 		if ok, _ := regexp.MatchString(`\(\)`, value); ok {
+			annotation.Labels.set(HeuristicParensAsPatterns)
 			annotation.Labels.set(Literal)
 			annotation.Labels.unset(Regexp)
 		}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -286,7 +286,7 @@ func TestConvertEmptyGroupsToLiteral(t *testing.T) {
 		},
 		{
 			input:      "func(.*)",
-			wantLabels: HeuristicParensAsPatterns | Regexp,
+			wantLabels: Regexp,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/13128. Issue prior to this PR, a pattern

`Search()\(` 

would be interpreted as `(concat "Search" "()" "\(")` due to how the scanner code tries to extract whether parens are parts of patterns or groups. The concat interpretation wasn't a complete disaster, since it meant we searched `Search.*\(\).*\(`. But that's not correct. This change reuses the scanner for contiguous patterns with parentheses in `ParsePattern` so we get `Search()\(`out.

Changing where this scanning happens affected some other inputs in a good or neutral way (in line comments).