### PR TITLE
dev: script for searching without results

### DIFF
--- a/dev/src-search-meta.sh
+++ b/dev/src-search-meta.sh
@@ -38,15 +38,15 @@ endpoint=${SRC_ENDPOINT:-https://sourcegraph.com}
 headers="$(mktemp -d)" || exit 1
 trap 'rm -rf "$headers"' EXIT
 
-echo 'X-Sourcegraph-Should-Trace: 1' >> "$headers/request"
+echo 'X-Sourcegraph-Should-Trace: 1' >>"$headers/request"
 if [ -n "$SRC_ACCESS_TOKEN" ]; then
-    echo "Authorization: token $SRC_ACCESS_TOKEN" >> "$headers/request"
+  echo "Authorization: token $SRC_ACCESS_TOKEN" >>"$headers/request"
 fi
 
 curl --silent \
-     -H "@$headers/request" \
-     -d "$body" \
-     -D "$headers/response" \
-     "$endpoint/.api/graphql?SearchMeta" | jq .
+  -H "@$headers/request" \
+  -d "$body" \
+  -D "$headers/response" \
+  "$endpoint/.api/graphql?SearchMeta" | jq .
 
 grep x-trace "$headers/response"

--- a/dev/src-search-meta.sh
+++ b/dev/src-search-meta.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Bash script to query sourcegraph search API via graphql. It only returns
+# meta information (such as result count), not the actual results. This is
+# especially useful for viewing traces with large result.
+
+# shellcheck disable=SC2016
+query='query($q: String!) {
+  site {
+    buildVersion
+  }
+  search(query: $q) {
+    results {
+      limitHit
+      resultCount
+      elapsedMilliseconds
+      ...SearchResultsAlertFields
+    }
+  }
+}
+
+fragment SearchResultsAlertFields on SearchResults {
+  alert {
+    title
+    description
+    proposedQueries {
+      description
+      query
+    }
+  }
+}'
+
+q="$1"
+body="$(jq -n --arg query "$query" --arg q "$q" '{"query": $query, "variables": {"q": $q}}')"
+endpoint=${SRC_ENDPOINT:-https://sourcegraph.com}
+
+# Create and capture request/response headers
+headers="$(mktemp -d)" || exit 1
+trap 'rm -rf "$headers"' EXIT
+
+echo 'X-Sourcegraph-Should-Trace: 1' >> "$headers/request"
+if [ -n "$SRC_ACCESS_TOKEN" ]; then
+    echo "Authorization: token $SRC_ACCESS_TOKEN" >> "$headers/request"
+fi
+
+curl --silent \
+     -H "@$headers/request" \
+     -d "$body" \
+     -D "$headers/response" \
+     "$endpoint/.api/graphql?SearchMeta" | jq .
+
+grep x-trace "$headers/response"


### PR DESCRIPTION
I find this script quite useful when testing search. It avoids
requesting results so avoids the time needed for the user to download
the results. This also results in smaller spans.

I think it is also an instructive script for how to do graphql queries
from bash.

This probably isn't the best place to put it, but good enough for now.
Soon someone will be frustrated with `dev/` and organise this (and
others) into a better place :)

![image](https://user-images.githubusercontent.com/187831/91561890-99734780-e93c-11ea-8810-f028b2fb3ed6.png)
