### PR TITLE
search: add site configuration for maxTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- The site configuration `search.limits`. This allows configuring the maximum timeout (defaults to 1 minute). Also allows configuring the maximum repositories to search in different scenarios. [#13448](https://github.com/sourcegraph/sourcegraph/pull/13448)
+
 ### Changed
 
 - Introduced the new `external_service_repos` join table. Please note that the migration required to make this change could take a couple of minutes.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -735,6 +735,7 @@ func searchLimits() schema.SearchLimits {
 	withDefault(&limits.MaxRepos, math.MaxInt32>>1)
 	withDefault(&limits.CommitDiffMaxRepos, 50)
 	withDefault(&limits.CommitDiffWithTimeFilterMaxRepos, 10000)
+	withDefault(&limits.MaxTimeoutSeconds, 60)
 
 	return limits
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -985,7 +985,7 @@ type SMTPServerConfig struct {
 	Username string `json:"username,omitempty"`
 }
 
-// SearchLimits description: Limits that search applies for number of repositories searched.
+// SearchLimits description: Limits that search applies for number of repositories searched and timeouts.
 type SearchLimits struct {
 	// CommitDiffMaxRepos description: The maximum number of repositories to search across when doing a "type:diff" or "type:commit". The user is prompted to narrow their query if exceeded. There is a seperate limit (commitDiffWithTimeFilterMaxRepos) when "after:" or "before:" is specified since those queries are faster. Value must be positive. Defaults to 50.
 	CommitDiffMaxRepos int `json:"commitDiffMaxRepos,omitempty"`
@@ -993,6 +993,8 @@ type SearchLimits struct {
 	CommitDiffWithTimeFilterMaxRepos int `json:"commitDiffWithTimeFilterMaxRepos,omitempty"`
 	// MaxRepos description: The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
 	MaxRepos int `json:"maxRepos,omitempty"`
+	// MaxTimeoutSeconds description: The maximum value for "timeout:" that search will respect. "timeout:" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values.
+	MaxTimeoutSeconds int `json:"maxTimeoutSeconds,omitempty"`
 }
 type SearchSavedQueries struct {
 	// Description description: Description of this saved query
@@ -1209,7 +1211,7 @@ type SiteConfiguration struct {
 	SearchIndexSymbolsEnabled *bool `json:"search.index.symbols.enabled,omitempty"`
 	// SearchLargeFiles description: A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.
 	SearchLargeFiles []string `json:"search.largeFiles,omitempty"`
-	// SearchLimits description: Limits that search applies for number of repositories searched.
+	// SearchLimits description: Limits that search applies for number of repositories searched and timeouts.
 	SearchLimits *SearchLimits `json:"search.limits,omitempty"`
 	// UpdateChannel description: The channel on which to automatically check for Sourcegraph updates.
 	UpdateChannel string `json:"update.channel,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -993,7 +993,7 @@ type SearchLimits struct {
 	CommitDiffWithTimeFilterMaxRepos int `json:"commitDiffWithTimeFilterMaxRepos,omitempty"`
 	// MaxRepos description: The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
 	MaxRepos int `json:"maxRepos,omitempty"`
-	// MaxTimeoutSeconds description: The maximum value for "timeout:" that search will respect. "timeout:" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values.
+	// MaxTimeoutSeconds description: The maximum value for "timeout:" that search will respect. "timeout:" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values. Note: Too many large rearch requests may harm Soucregraph for other users. Defaults to 1 minute.
 	MaxTimeoutSeconds int `json:"maxTimeoutSeconds,omitempty"`
 }
 type SearchSavedQueries struct {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -349,11 +349,17 @@
       "group": "Search"
     },
     "search.limits": {
-      "description": "Limits that search applies for number of repositories searched.",
+      "description": "Limits that search applies for number of repositories searched and timeouts.",
       "type": "object",
       "group": "Search",
       "additionalProperties": false,
       "properties": {
+        "maxTimeoutSeconds": {
+          "description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values.",
+          "type": "integer",
+          "default": "60",
+          "minimum": 1
+        },
         "maxRepos": {
           "description": "The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
           "type": "integer",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -355,7 +355,7 @@
       "additionalProperties": false,
       "properties": {
         "maxTimeoutSeconds": {
-          "description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values.",
+          "description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values. Note: Too many large rearch requests may harm Soucregraph for other users. Defaults to 1 minute.",
           "type": "integer",
           "default": "60",
           "minimum": 1

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -360,7 +360,7 @@ const SiteSchemaJSON = `{
       "additionalProperties": false,
       "properties": {
         "maxTimeoutSeconds": {
-          "description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values.",
+          "description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values. Note: Too many large rearch requests may harm Soucregraph for other users. Defaults to 1 minute.",
           "type": "integer",
           "default": "60",
           "minimum": 1

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -354,11 +354,17 @@ const SiteSchemaJSON = `{
       "group": "Search"
     },
     "search.limits": {
-      "description": "Limits that search applies for number of repositories searched.",
+      "description": "Limits that search applies for number of repositories searched and timeouts.",
       "type": "object",
       "group": "Search",
       "additionalProperties": false,
       "properties": {
+        "maxTimeoutSeconds": {
+          "description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values.",
+          "type": "integer",
+          "default": "60",
+          "minimum": 1
+        },
         "maxRepos": {
           "description": "The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
           "type": "integer",


### PR DESCRIPTION
We default to 1 minute. However, some large customers require exhaustive
searching with slow regular expressions. This can take more than 1
minute. This commit allows these customers to configure a larger
timeout.

Depends on https://github.com/sourcegraph/sourcegraph/pull/13439