### PR TITLE
RFC: Add RetryAfter to dbworker.StoreOptions

### DIFF
--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -79,6 +79,34 @@ func testScanFirstRecordView(rows *sql.Rows, queryErr error) (v workerutil.Recor
 	return nil, false, nil
 }
 
+type TestRecordRetry struct {
+	ID        int
+	State     string
+	NumResets int
+}
+
+func (v TestRecordRetry) RecordID() int {
+	return v.ID
+}
+
+func testScanFirstRecordRetry(rows *sql.Rows, queryErr error) (v workerutil.Record, exists bool, err error) {
+	if queryErr != nil {
+		return nil, false, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if rows.Next() {
+		var record TestRecordRetry
+		if err := rows.Scan(&record.ID, &record.State, &record.NumResets); err != nil {
+			return nil, false, err
+		}
+
+		return record, true, nil
+	}
+
+	return nil, false, nil
+}
+
 func setupStoreTest(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -155,6 +183,26 @@ func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField in
 	}
 	if val := record.(TestRecordView).NewField; val != expectedNewField {
 		t.Errorf("unexpected new field. want=%d have=%d", expectedNewField, val)
+	}
+}
+
+func assertDequeueRecordRetryResult(t *testing.T, expectedID, expectedNumResets int, record interface{}, tx Store, ok bool, err error) {
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("expected a dequeueable record")
+	}
+	defer func() { _ = tx.Done(nil) }()
+
+	if val := record.(TestRecordRetry).ID; val != expectedID {
+		t.Errorf("unexpected id. want=%d have=%d", expectedID, val)
+	}
+	if val := record.(TestRecordRetry).State; val != "processing" {
+		t.Errorf("unexpected state. want=%s have=%s", "processing", val)
+	}
+	if val := record.(TestRecordRetry).NumResets; val != expectedNumResets {
+		t.Errorf("unexpected num resets. want=%d have=%d", expectedNumResets, val)
 	}
 }
 

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -175,6 +175,46 @@ func TestStoreDequeueConcurrent(t *testing.T) {
 	}
 }
 
+func TestStoreDequeueRetryAfter(t *testing.T) {
+	setupStoreTest(t)
+
+	if _, err := dbconn.Global.Exec(`
+		INSERT INTO workerutil_test (id, state, finished_at, failure_message, num_resets, uploaded_at)
+		VALUES
+			(1, 'errored', NOW() - '6 minute'::interval, 'error', 3, NOW() - '2 minutes'::interval),
+			(2, 'errored', NOW() - '4 minute'::interval, 'error', 0, NOW() - '3 minutes'::interval),
+			(3, 'errored', NOW() - '6 minute'::interval, 'error', 5, NOW() - '4 minutes'::interval),
+			(4, 'queued',                          NULL,    NULL, 0, NOW() - '1 minutes'::interval)
+	`); err != nil {
+		t.Fatalf("unexpected error inserting records: %s", err)
+	}
+
+	options := StoreOptions{
+		TableName:     defaultTestStoreOptions.TableName,
+		StalledMaxAge: defaultTestStoreOptions.StalledMaxAge,
+
+		Scan: testScanFirstRecordRetry,
+		ColumnExpressions: []*sqlf.Query{
+			sqlf.Sprintf("w.id"),
+			sqlf.Sprintf("w.state"),
+			sqlf.Sprintf("w.num_resets"),
+		},
+		OrderByExpression: sqlf.Sprintf("w.uploaded_at"),
+		MaxNumResets:      5,
+		RetryAfter:        5 * time.Minute,
+	}
+
+	store := testStore(options)
+
+	// Dequeue errored record
+	record1, tx, ok, err := store.Dequeue(context.Background(), nil)
+	assertDequeueRecordRetryResult(t, 1, 4, record1, tx, ok, err)
+
+	// Dequeue non-errored record
+	record2, tx, ok, err := store.Dequeue(context.Background(), nil)
+	assertDequeueRecordRetryResult(t, 4, 0, record2, tx, ok, err)
+}
+
 func TestStoreRequeue(t *testing.T) {
 	setupStoreTest(t)
 


### PR DESCRIPTION
In campaigns we need the ability to retry jobs multiple times. (See https://github.com/sourcegraph/sourcegraph/issues/12700#issuecomment-671798531 for additional context.)

This is what I think is the easiest-to-understand and simplest solution.

I did have another solution that involved a PreDequeue hook (that
returned the custom conditions you see here now) and boolean in the
StoreOptions to switch between AND'ing or OR'ing the custom conditions
to the selectCandidateQuery.

This felt a bit hacky. It was less code, but also easier to miss and
misudnerstand.

What do you think of this?
