### PR TITLE
Extract ID marshal code into resolvers

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
@@ -27,8 +28,19 @@ type campaignResolver struct {
 	namespaceErr  error
 }
 
+const campaignIDKind = "Campaign"
+
+func marshalCampaignID(id int64) graphql.ID {
+	return relay.MarshalID(campaignIDKind, id)
+}
+
+func unmarshalCampaignID(id graphql.ID) (campaignID int64, err error) {
+	err = relay.UnmarshalSpec(id, &campaignID)
+	return
+}
+
 func (r *campaignResolver) ID() graphql.ID {
-	return campaigns.MarshalCampaignID(r.Campaign.ID)
+	return marshalCampaignID(r.Campaign.ID)
 }
 
 func (r *campaignResolver) Name() string {

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -84,10 +84,10 @@ func TestCampaignConnectionResolver(t *testing.T) {
 	// Campaigns are returned in reverse order.
 	nodes := []apitest.Campaign{
 		{
-			ID: string(campaigns.MarshalCampaignID(campaign2.ID)),
+			ID: string(marshalCampaignID(campaign2.ID)),
 		},
 		{
-			ID: string(campaigns.MarshalCampaignID(campaign1.ID)),
+			ID: string(marshalCampaignID(campaign1.ID)),
 		},
 	}
 
@@ -238,7 +238,7 @@ func TestCampaignsListing(t *testing.T) {
 			Campaigns: apitest.CampaignConnection{
 				TotalCount: 1,
 				Nodes: []apitest.Campaign{
-					{ID: string(campaigns.MarshalCampaignID(campaign.ID))},
+					{ID: string(marshalCampaignID(campaign.ID))},
 				},
 			},
 		}
@@ -271,7 +271,7 @@ func TestCampaignsListing(t *testing.T) {
 			Campaigns: apitest.CampaignConnection{
 				TotalCount: 1,
 				Nodes: []apitest.Campaign{
-					{ID: string(campaigns.MarshalCampaignID(campaign.ID))},
+					{ID: string(marshalCampaignID(campaign.ID))},
 				},
 			},
 		}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -135,7 +135,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		},
 
 		AppliesToCampaign: apitest.Campaign{
-			ID: string(campaigns.MarshalCampaignID(matchingCampaign.ID)),
+			ID: string(marshalCampaignID(matchingCampaign.ID)),
 		},
 	}
 

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -66,7 +66,7 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(marshalCampaignID(campaign.ID))
 	namespaceAPIID := string(graphqlbackend.MarshalOrgID(org.ID))
 	apiUser := &apitest.User{DatabaseID: userID, SiteAdmin: true}
 	wantCampaign := apitest.Campaign{

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -114,7 +114,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(marshalCampaignID(campaign.ID))
 	nodes := []apitest.Changeset{
 		{
 			Typename:   "ExternalChangeset",

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -103,7 +103,7 @@ func TestChangesetCountsOverTimeResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(marshalCampaignID(campaign.ID))
 	input := map[string]interface{}{"campaign": campaignAPIID}
 	var response struct{ Node apitest.Campaign }
 	apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryChangesetCountsConnection)

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -163,7 +163,7 @@ func TestPermissionLevels(t *testing.T) {
 
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
-					graphqlID := string(campaigns.MarshalCampaignID(tc.campaign))
+					graphqlID := string(marshalCampaignID(tc.campaign))
 
 					var res struct{ Node apitest.Campaign }
 
@@ -283,7 +283,7 @@ func TestPermissionLevels(t *testing.T) {
 					actorCtx := actor.WithActor(context.Background(), actor.FromUser(tc.currentUser))
 					expectedIDs := make(map[string]bool, len(tc.wantCampaigns))
 					for _, c := range tc.wantCampaigns {
-						graphqlID := string(campaigns.MarshalCampaignID(c))
+						graphqlID := string(marshalCampaignID(c))
 						expectedIDs[graphqlID] = true
 					}
 
@@ -401,7 +401,7 @@ func TestPermissionLevels(t *testing.T) {
 						}
 
 						mutation := m.mutationFunc(
-							string(campaigns.MarshalCampaignID(campaignID)),
+							string(marshalCampaignID(campaignID)),
 							string(marshalChangesetID(changeset.ID)),
 							string(marshalCampaignSpecRandID(campaignSpecRandID)),
 						)
@@ -611,7 +611,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
 		input := map[string]interface{}{
-			"campaign": string(campaigns.MarshalCampaignID(campaign.ID)),
+			"campaign": string(marshalCampaignID(campaign.ID)),
 		}
 		testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
 			changesetTypes:  map[string]int{"ExternalChangeset": 2},
@@ -663,7 +663,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// should not be returned, since that would leak information about the
 		// hidden changesets.
 		input = map[string]interface{}{
-			"campaign":   string(campaigns.MarshalCampaignID(campaign.ID)),
+			"campaign":   string(marshalCampaignID(campaign.ID)),
 			"checkState": string(campaigns.ChangesetCheckStatePassed),
 		}
 		wantCheckStateResponse := want
@@ -676,7 +676,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		testCampaignResponse(t, s, userCtx, input, wantCheckStateResponse)
 
 		input = map[string]interface{}{
-			"campaign":    string(campaigns.MarshalCampaignID(campaign.ID)),
+			"campaign":    string(marshalCampaignID(campaign.ID)),
 			"reviewState": string(campaigns.ChangesetReviewStateChangesRequested),
 		}
 		wantReviewStateResponse := wantCheckStateResponse

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -98,7 +98,7 @@ func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlback
 		return nil, err
 	}
 
-	campaignID, err := campaigns.UnmarshalCampaignID(id)
+	campaignID, err := unmarshalCampaignID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 	}
 
 	if args.EnsureCampaign != nil {
-		opts.EnsureCampaignID, err = campaigns.UnmarshalCampaignID(*args.EnsureCampaign)
+		opts.EnsureCampaignID, err = unmarshalCampaignID(*args.EnsureCampaign)
 		if err != nil {
 			return nil, err
 		}
@@ -368,7 +368,7 @@ func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCa
 		return nil, err
 	}
 
-	campaignID, err := campaigns.UnmarshalCampaignID(args.Campaign)
+	campaignID, err := unmarshalCampaignID(args.Campaign)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	campaignID, err := campaigns.UnmarshalCampaignID(args.Campaign)
+	campaignID, err := unmarshalCampaignID(args.Campaign)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		return nil, err
 	}
 
-	campaignID, err := campaigns.UnmarshalCampaignID(args.Campaign)
+	campaignID, err := unmarshalCampaignID(args.Campaign)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -34,7 +34,7 @@ func TestNullIDResilience(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 
 	ids := []graphql.ID{
-		campaigns.MarshalCampaignID(0),
+		marshalCampaignID(0),
 		marshalChangesetID(0),
 		marshalCampaignSpecRandID(""),
 		marshalChangesetSpecRandID(""),
@@ -52,12 +52,12 @@ func TestNullIDResilience(t *testing.T) {
 	}
 
 	mutations := []string{
-		fmt.Sprintf(`mutation { closeCampaign(campaign: %q) { id } }`, campaigns.MarshalCampaignID(0)),
-		fmt.Sprintf(`mutation { deleteCampaign(campaign: %q) { alwaysNil } }`, campaigns.MarshalCampaignID(0)),
+		fmt.Sprintf(`mutation { closeCampaign(campaign: %q) { id } }`, marshalCampaignID(0)),
+		fmt.Sprintf(`mutation { deleteCampaign(campaign: %q) { alwaysNil } }`, marshalCampaignID(0)),
 		fmt.Sprintf(`mutation { syncChangeset(changeset: %q) { alwaysNil } }`, marshalChangesetID(0)),
 		fmt.Sprintf(`mutation { applyCampaign(campaignSpec: %q) { id } }`, marshalCampaignSpecRandID("")),
 		fmt.Sprintf(`mutation { createCampaign(campaignSpec: %q) { id } }`, marshalCampaignSpecRandID("")),
-		fmt.Sprintf(`mutation { moveCampaign(campaign: %q, newName: "foobar") { id } }`, campaigns.MarshalCampaignID(0)),
+		fmt.Sprintf(`mutation { moveCampaign(campaign: %q, newName: "foobar") { id } }`, marshalCampaignID(0)),
 	}
 
 	for _, m := range mutations {
@@ -379,11 +379,11 @@ func TestApplyCampaign(t *testing.T) {
 	}
 
 	// Execute it again but ensureCampaign set to wrong campaign ID
-	campaignID, err := campaigns.UnmarshalCampaignID(graphql.ID(have3.ID))
+	campaignID, err := unmarshalCampaignID(graphql.ID(have3.ID))
 	if err != nil {
 		t.Fatal(err)
 	}
-	input["ensureCampaign"] = campaigns.MarshalCampaignID(campaignID + 999)
+	input["ensureCampaign"] = marshalCampaignID(campaignID + 999)
 	errs := apitest.Exec(actorCtx, t, s, input, &response, mutationApplyCampaign)
 	if len(errs) == 0 {
 		t.Fatalf("expected errors, got none")
@@ -531,7 +531,7 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	// Move to a new name
-	campaignAPIID := string(campaigns.MarshalCampaignID(campaign.ID))
+	campaignAPIID := string(marshalCampaignID(campaign.ID))
 	newCampaignName := "new-name"
 	input := map[string]interface{}{
 		"campaign": campaignAPIID,
@@ -555,7 +555,7 @@ func TestMoveCampaign(t *testing.T) {
 	// Move to a new namespace
 	orgAPIID := graphqlbackend.MarshalOrgID(org.ID)
 	input = map[string]interface{}{
-		"campaign":     string(campaigns.MarshalCampaignID(campaign.ID)),
+		"campaign":     string(marshalCampaignID(campaign.ID)),
 		"newNamespace": orgAPIID,
 	}
 

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
@@ -95,15 +94,6 @@ func (c *Campaign) RemoveChangesetID(id int64) {
 
 // Closed returns true when the ClosedAt timestamp has been set.
 func (c *Campaign) Closed() bool { return !c.ClosedAt.IsZero() }
-
-// GenChangesetBody creates the markdown to be used as the body of a changeset.
-// It includes a URL back to the campaign on the Sourcegraph instance.
-func (c *Campaign) GenChangesetBody(externalURL string) string {
-	campaignID := MarshalCampaignID(c.ID)
-	campaignURL := fmt.Sprintf("%s/campaigns/%s", externalURL, string(campaignID))
-	description := fmt.Sprintf("%s\n\n---\n\nThis pull request was created by a Sourcegraph campaign. [Click here to see the campaign](%s).", c.Description, campaignURL)
-	return description
-}
 
 // ChangesetPublicationState defines the possible publication states of a Changeset.
 type ChangesetPublicationState string
@@ -1674,15 +1664,6 @@ type ChangesetSyncData struct {
 	// RepoExternalServiceID is the external_service_id in the repo table, usually
 	// represented by the code host URL
 	RepoExternalServiceID string
-}
-
-func MarshalCampaignID(id int64) graphql.ID {
-	return relay.MarshalID("Campaign", id)
-}
-
-func UnmarshalCampaignID(id graphql.ID) (campaignID int64, err error) {
-	err = relay.UnmarshalSpec(id, &campaignID)
-	return
 }
 
 func unixMilliToTime(ms int64) time.Time {


### PR DESCRIPTION
Not needed outside of resolvers anymore, so making it in line with the other resolvers.

Works on #13174