### PR TITLE
Ensure ignite exec payload flags/args are not treated as flags/args to ignite

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/env.go
@@ -15,7 +15,7 @@ var (
 	rawIndexerPollInterval      = env.Get("PRECISE_CODE_INTEL_INDEXER_POLL_INTERVAL", "1s", "Interval between queries to the precise-code-intel-index-manager.")
 	rawIndexerHeartbeatInterval = env.Get("PRECISE_CODE_INTEL_INDEXER_HEARTBEAT_INTERVAL", "1s", "Interval between heartbeat requests.")
 	rawMaxContainers            = env.Get("PRECISE_CODE_INTEL_MAXIMUM_CONTAINERS", "1", "Number of index containers that can be running at once.")
-	rawFirecrackerImage         = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu", "The base image to use for firecracker VMs.")
+	rawFirecrackerImage         = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for firecracker VMs.")
 	rawUseFirecracker           = env.Get("PRECISE_CODE_INTEL_USE_FIRECRACKER", "true", "Whether to isolate index containers in firecracker VMs.")
 )
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -96,17 +96,18 @@ func TestHandleWithFirecracker(t *testing.T) {
 		t.Fatalf("unexpected error handling index: %s", err)
 	}
 
-	if callCount := len(commander.RunFunc.History()); callCount != 7 {
-		t.Errorf("unexpected run call count. want=%d have=%d", 7, callCount)
+	if callCount := len(commander.RunFunc.History()); callCount != 8 {
+		t.Errorf("unexpected run call count. want=%d have=%d", 8, callCount)
 	} else {
 		expectedCalls := []string{
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"ignite run --runtime docker --copy-files /tmp/testing:/tmp/testing --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
-			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest lsif-go",
-			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 docker run --rm -v /tmp/testing:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest lsif-go",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm -v /tmp/testing:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
 			"ignite stop --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
+			"ignite rm -f --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
 		}
 
 		calls := commander.RunFunc.History()


### PR DESCRIPTION
Currently `ignite exec name docker run --rm ...` treats `--rm` as an ignite flag and not a docker flag. This fixes that.