### PR TITLE
codeintel: Firecracker mount points should not assume the same names

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/command.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"sync"
 
 	"github.com/inconshreveable/log15"
@@ -17,6 +18,8 @@ func runCommand(ctx context.Context, command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+
+	log15.Debug("Running command: %s %s\n", command, strings.Join(args, " "))
 
 	wg := parallel(
 		func() { processStream("stdout", stdout) },

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -62,11 +62,14 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 		return err
 	}
 
+	mountPoint := repoDir
 	if h.options.UseFirecracker {
+		mountPoint = "/repo-dir"
+
 		args := []string{
 			"ignite", "run",
 			"--runtime", "docker",
-			"--copy-files", fmt.Sprintf("%s:%s", repoDir, repoDir),
+			"--copy-files", fmt.Sprintf("%s:%s", repoDir, mountPoint),
 			"--ssh",
 			"--name", name.String(),
 			h.options.FirecrackerImage,
@@ -97,7 +100,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 
 	indexArgs := []string{
 		"docker", "run", "--rm",
-		"-v", fmt.Sprintf("%s:/data", repoDir),
+		"-v", fmt.Sprintf("%s:/data", mountPoint),
 		"-w", "/data",
 		"sourcegraph/lsif-go:latest",
 		"lsif-go",
@@ -111,7 +114,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 
 	uploadArgs := []string{
 		"docker", "run", "--rm",
-		"-v", fmt.Sprintf("%s:/data", repoDir),
+		"-v", fmt.Sprintf("%s:/data", mountPoint),
 		"-w", "/data",
 		"-e", fmt.Sprintf("SRC_ENDPOINT=%s", uploadURL.String()),
 		"sourcegraph/src-cli:latest",

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -103,9 +103,9 @@ func TestHandleWithFirecracker(t *testing.T) {
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
-			"ignite run --runtime docker --copy-files /tmp/testing:/tmp/testing --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
-			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm -v /tmp/testing:/data -w /data sourcegraph/lsif-go:latest lsif-go",
-			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm -v /tmp/testing:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
+			"ignite run --runtime docker --copy-files /tmp/testing:/repo-dir --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm -v /repo-dir:/data -w /data sourcegraph/lsif-go:latest lsif-go",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm -v /repo-dir:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
 			"ignite stop --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
 			"ignite rm -f --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
 		}


### PR DESCRIPTION
There is an issue with `--copy-files` which seems to work better when given a non-existing name in the VM. The files fail to copy (or are overwritten during boot) if you give it something common like `/tmp`.