### PR TITLE
schema: fix incorrectly nested prop in settings

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1051,6 +1051,8 @@ type Settings struct {
 	SearchDefaultPatternType string `json:"search.defaultPatternType,omitempty"`
 	// SearchGlobbing description: Enables globbing for supported field values
 	SearchGlobbing *bool `json:"search.globbing,omitempty"`
+	// SearchHideSuggestions description: Disable search suggestions below the search bar when constructing queries. Defaults to false.
+	SearchHideSuggestions *bool `json:"search.hideSuggestions,omitempty"`
 	// SearchIncludeArchived description: Whether searches should include searching archived repositories.
 	SearchIncludeArchived *bool `json:"search.includeArchived,omitempty"`
 	// SearchIncludeForks description: Whether searches should include searching forked repositories.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -219,6 +219,12 @@
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }
+    },
+    "search.hideSuggestions": {
+      "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
     }
   },
   "definitions": {
@@ -264,11 +270,5 @@
         }
       }
     }
-  },
-  "search.hideSuggestions": {
-    "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
-    "type": "boolean",
-    "default": false,
-    "!go": { "pointer": true }
   }
 }

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -224,6 +224,12 @@ const SettingsSchemaJSON = `{
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }
+    },
+    "search.hideSuggestions": {
+      "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
     }
   },
   "definitions": {
@@ -269,12 +275,6 @@ const SettingsSchemaJSON = `{
         }
       }
     }
-  },
-  "search.hideSuggestions": {
-    "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
-    "type": "boolean",
-    "default": false,
-    "!go": { "pointer": true }
   }
 }
 `


### PR DESCRIPTION
This was introduced in #8059, but appears to have been placed in the wrong part of the schema document. Since this setting is only used by the web frontend, and it's accessed from a object by its string key, there should be no functional change, besides the slim chance that a user has a non-boolean value at present, and the user settings textarea now autocompleting for `search.hideSuggestions`.