### PR TITLE
Use RetryAfter in campaigns workers

### DIFF
--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -43,10 +43,15 @@ func RunWorkers(
 		AlternateColumnNames: map[string]string{"state": "reconciler_state"},
 		ColumnExpressions:    changesetColumns,
 		Scan:                 scanFirstChangesetRecord,
-		OrderByExpression:    sqlf.Sprintf("changesets.updated_at"),
-		StalledMaxAge:        60 * time.Second,
-		MaxNumResets:         60,
-		RetryAfter:           5 * time.Second,
+
+		// Order changesets by state, so that freshly enqueued changesets have
+		// higher priority.
+		// If state is equal, prefer the newer ones.
+		OrderByExpression: sqlf.Sprintf("reconciler_state = 'errored', changesets.updated_at DESC"),
+
+		StalledMaxAge: 60 * time.Second,
+		MaxNumResets:  60,
+		RetryAfter:    5 * time.Second,
 	})
 
 	worker := dbworker.NewWorker(ctx, workerStore, options)

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -45,7 +45,8 @@ func RunWorkers(
 		Scan:                 scanFirstChangesetRecord,
 		OrderByExpression:    sqlf.Sprintf("changesets.updated_at"),
 		StalledMaxAge:        60 * time.Second,
-		MaxNumResets:         5,
+		MaxNumResets:         60,
+		RetryAfter:           5 * time.Second,
 	})
 
 	worker := dbworker.NewWorker(ctx, workerStore, options)

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -79,6 +79,34 @@ func testScanFirstRecordView(rows *sql.Rows, queryErr error) (v workerutil.Recor
 	return nil, false, nil
 }
 
+type TestRecordRetry struct {
+	ID        int
+	State     string
+	NumResets int
+}
+
+func (v TestRecordRetry) RecordID() int {
+	return v.ID
+}
+
+func testScanFirstRecordRetry(rows *sql.Rows, queryErr error) (v workerutil.Record, exists bool, err error) {
+	if queryErr != nil {
+		return nil, false, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if rows.Next() {
+		var record TestRecordRetry
+		if err := rows.Scan(&record.ID, &record.State, &record.NumResets); err != nil {
+			return nil, false, err
+		}
+
+		return record, true, nil
+	}
+
+	return nil, false, nil
+}
+
 func setupStoreTest(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -155,6 +183,26 @@ func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField in
 	}
 	if val := record.(TestRecordView).NewField; val != expectedNewField {
 		t.Errorf("unexpected new field. want=%d have=%d", expectedNewField, val)
+	}
+}
+
+func assertDequeueRecordRetryResult(t *testing.T, expectedID, expectedNumResets int, record interface{}, tx Store, ok bool, err error) {
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("expected a dequeueable record")
+	}
+	defer func() { _ = tx.Done(nil) }()
+
+	if val := record.(TestRecordRetry).ID; val != expectedID {
+		t.Errorf("unexpected id. want=%d have=%d", expectedID, val)
+	}
+	if val := record.(TestRecordRetry).State; val != "processing" {
+		t.Errorf("unexpected state. want=%s have=%s", "processing", val)
+	}
+	if val := record.(TestRecordRetry).NumResets; val != expectedNumResets {
+		t.Errorf("unexpected num resets. want=%d have=%d", expectedNumResets, val)
 	}
 }
 

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -175,6 +175,46 @@ func TestStoreDequeueConcurrent(t *testing.T) {
 	}
 }
 
+func TestStoreDequeueRetryAfter(t *testing.T) {
+	setupStoreTest(t)
+
+	if _, err := dbconn.Global.Exec(`
+		INSERT INTO workerutil_test (id, state, finished_at, failure_message, num_resets, uploaded_at)
+		VALUES
+			(1, 'errored', NOW() - '6 minute'::interval, 'error', 3, NOW() - '2 minutes'::interval),
+			(2, 'errored', NOW() - '4 minute'::interval, 'error', 0, NOW() - '3 minutes'::interval),
+			(3, 'errored', NOW() - '6 minute'::interval, 'error', 5, NOW() - '4 minutes'::interval),
+			(4, 'queued',                          NULL,    NULL, 0, NOW() - '1 minutes'::interval)
+	`); err != nil {
+		t.Fatalf("unexpected error inserting records: %s", err)
+	}
+
+	options := StoreOptions{
+		TableName:     defaultTestStoreOptions.TableName,
+		StalledMaxAge: defaultTestStoreOptions.StalledMaxAge,
+
+		Scan: testScanFirstRecordRetry,
+		ColumnExpressions: []*sqlf.Query{
+			sqlf.Sprintf("w.id"),
+			sqlf.Sprintf("w.state"),
+			sqlf.Sprintf("w.num_resets"),
+		},
+		OrderByExpression: sqlf.Sprintf("w.uploaded_at"),
+		MaxNumResets:      5,
+		RetryAfter:        5 * time.Minute,
+	}
+
+	store := testStore(options)
+
+	// Dequeue errored record
+	record1, tx, ok, err := store.Dequeue(context.Background(), nil)
+	assertDequeueRecordRetryResult(t, 1, 4, record1, tx, ok, err)
+
+	// Dequeue non-errored record
+	record2, tx, ok, err := store.Dequeue(context.Background(), nil)
+	assertDequeueRecordRetryResult(t, 4, 0, record2, tx, ok, err)
+}
+
 func TestStoreRequeue(t *testing.T) {
 	setupStoreTest(t)
 


### PR DESCRIPTION
This is based on and requires #13457. 

In combination with #13457 this PR fixes the first and most important part of https://github.com/sourcegraph/sourcegraph/issues/12700 by adding automatic retrying of failed changesets to the reconciler.

It retries failed changesets every 5 seconds, if there are no newer, non-errored changesets to be dequeued.

The new order clause is strictly speaking not necessary *yet*, but I think it's a bug that we don't update a changeset's `UpdatedAt` when saving it back to the database. I want to tackle that in another PR.