### PR TITLE
authz: ignore missing records for pending permissions

### DIFF
--- a/enterprise/internal/db/integration_test.go
+++ b/enterprise/internal/db/integration_test.go
@@ -30,6 +30,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"PermsStore/SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
 		{"PermsStore/ListPendingUsers", testPermsStore_ListPendingUsers(db)},
 		{"PermsStore/GrantPendingPermissions", testPermsStore_GrantPendingPermissions(db)},
+		{"PermsStore/SetPendingPermissionsAfterGrant", testPermsStore_SetPendingPermissionsAfterGrant(db)},
 		{"PermsStore/DeleteAllUserPermissions", testPermsStore_DeleteAllUserPermissions(db)},
 		{"PermsStore/DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"PermsStore/DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},

--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -645,8 +645,8 @@ func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 		// (i.e. moved from `user_pending_permissions` to `user_permissions` table), therefore the record
 		// in `user_pending_permissions` table no longer exists. The reason we still have references to
 		// these missing records is because we do not clean up `repo_pending_permissions` table after
-		// granting a user's pending permissions to avoid database deadlock, given the fact once the record
-		// is removed from `user_pending_permissions` table, the user ID become invalid automatically.
+		// granting a user's pending permissions to avoid database deadlock, given the fact that once the
+		// record is removed from `user_pending_permissions` table, the user ID becomes invalid automatically.
 		spec, ok := idToSpecs[userID]
 		if !ok {
 			continue

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -1602,6 +1602,64 @@ func testPermsStore_GrantPendingPermissions(db *sql.DB) func(*testing.T) {
 	}
 }
 
+// This test is used to detect the handle of the following error:
+// 	execute upsert user pending permissions batch query: pq: ON CONFLICT DO UPDATE command cannot affect row a second time
+func testPermsStore_SetPendingPermissionsAfterGrant(db *sql.DB) func(*testing.T) {
+	return func(t *testing.T) {
+		s := NewPermsStore(db, clock)
+		defer cleanupPermsTables(t, s)
+
+		ctx := context.Background()
+
+		// Set up pending permissions for at least two users
+		if err := s.SetRepoPendingPermissions(ctx, &extsvc.Accounts{
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
+			AccountIDs:  []string{"alice", "bob"},
+		}, &authz.RepoPermissions{
+			RepoID: 1,
+			Perm:   authz.Read,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Now grant permissions for these two users, which effectively remove corresponding rows
+		// from the `user_pending_permissions` table.
+		if err := s.GrantPendingPermissions(ctx, 1, &authz.UserPendingPermissions{
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
+			BindID:      "alice",
+			Perm:        authz.Read,
+			Type:        authz.PermRepos,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := s.GrantPendingPermissions(ctx, 1, &authz.UserPendingPermissions{
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
+			BindID:      "bob",
+			Perm:        authz.Read,
+			Type:        authz.PermRepos,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Now the `repo_pending_permissions` table has references to these two deleted rows,
+		// it should just ignore them.
+		if err := s.SetRepoPendingPermissions(ctx, &extsvc.Accounts{
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
+			AccountIDs:  []string{"cindy"},
+		}, &authz.RepoPermissions{
+			RepoID: 1,
+			Perm:   authz.Read,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func testPermsStore_DeleteAllUserPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, clock)


### PR DESCRIPTION
On a high level, adds a quick check to ignore _legitimately_ invalid/missing records when set repository pending permissions. Code comments have added to explain why it is needed.

A test case is added to simulate such scenario.

Fixed an issue a customer has encountered.