### PR TITLE
Only render direct tree children

### DIFF
--- a/web/src/repo/backend.ts
+++ b/web/src/repo/backend.ts
@@ -20,6 +20,7 @@ import {
     ResolvedRevisionSpec,
 } from '../../../shared/src/util/url'
 import { queryGraphQL } from '../backend/graphql'
+import { TreeFields } from '../graphql-operations'
 
 /**
  * Fetch the repository.
@@ -244,7 +245,7 @@ export const fetchFileExternalLinks = memoizeObservable(
 )
 
 export const fetchTreeEntries = memoizeObservable(
-    (args: AbsoluteRepoFile & { first?: number }): Observable<GQL.IGitTree> =>
+    (args: AbsoluteRepoFile & { first?: number }): Observable<TreeFields> =>
         queryGraphQL(
             gql`
                 query TreeEntries(
@@ -257,22 +258,28 @@ export const fetchTreeEntries = memoizeObservable(
                     repository(name: $repoName) {
                         commit(rev: $commitID, inputRevspec: $revision) {
                             tree(path: $filePath) {
-                                isRoot
-                                url
-                                entries(first: $first, recursiveSingleChild: true) {
-                                    name
-                                    path
-                                    isDirectory
-                                    url
-                                    submodule {
-                                        url
-                                        commit
-                                    }
-                                    isSingleChild
-                                }
+                                ...TreeFields
                             }
                         }
                     }
+                }
+                fragment TreeFields on GitTree {
+                    isRoot
+                    url
+                    entries(first: $first, recursiveSingleChild: true) {
+                        ...TreeEntryFields
+                    }
+                }
+                fragment TreeEntryFields on TreeEntry {
+                    name
+                    path
+                    isDirectory
+                    url
+                    submodule {
+                        url
+                        commit
+                    }
+                    isSingleChild
                 }
             `,
             args

--- a/web/src/repo/tree/TreeEntriesSection.scss
+++ b/web/src/repo/tree/TreeEntriesSection.scss
@@ -1,0 +1,46 @@
+.tree-entries-section {
+    // To avoid having empty columns (and thus the items appearing not flush with the left margin),
+    // the component only applies this class when there are >= 6 items. This number is chosen
+    // because it is greater than the maximum number of columns that will be shown and ensures that
+    // at least 1 column has more than 1 item.
+    //
+    // See also MIN_ENTRIES_FOR_COLUMN_LAYOUT.
+    &--columns {
+        column-gap: 2.25rem;
+        column-width: 13rem;
+
+        @media (max-width: $media-sm) {
+            column-count: 1;
+        }
+        @media (max-width: $media-md) {
+            column-count: 3;
+        }
+        @media (max-width: $media-lg) {
+            column-count: 4;
+        }
+        @media (min-width: $media-lg) {
+            column-count: 5;
+        }
+    }
+}
+
+.tree-entry {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    margin-left: -0.25rem;
+    padding: 0.125rem 0.25rem;
+    &:hover {
+        background-color: $color-bg-1;
+    }
+}
+
+.theme-light {
+    .tree-entry {
+        &:hover {
+            background-color: $color-light-bg-2;
+        }
+    }
+}

--- a/web/src/repo/tree/TreeEntriesSection.test.tsx
+++ b/web/src/repo/tree/TreeEntriesSection.test.tsx
@@ -7,7 +7,6 @@ describe('TreeEntriesSection', () => {
         expect(
             render(
                 <TreeEntriesSection
-                    title="Files and directories"
                     parentPath=""
                     entries={[
                         {
@@ -43,7 +42,6 @@ describe('TreeEntriesSection', () => {
         expect(
             render(
                 <TreeEntriesSection
-                    title="Files and directories"
                     parentPath="src"
                     entries={[
                         {
@@ -79,7 +77,6 @@ describe('TreeEntriesSection', () => {
         expect(
             render(
                 <TreeEntriesSection
-                    title="Files and directories"
                     parentPath="x"
                     entries={[
                         {

--- a/web/src/repo/tree/TreeEntriesSection.test.tsx
+++ b/web/src/repo/tree/TreeEntriesSection.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { render } from 'enzyme'
+import { TreeEntriesSection } from './TreeEntriesSection'
+
+describe('TreeEntriesSection', () => {
+    it('should render a grid of tree entries at the root', () => {
+        expect(
+            render(
+                <TreeEntriesSection
+                    title="Files and directories"
+                    parentPath=""
+                    entries={[
+                        {
+                            name: 'src',
+                            path: 'src',
+                            isDirectory: true,
+                            url: '/github.com/sourcegraph/codeintellify/-/tree/src',
+                        },
+                        {
+                            name: 'testdata',
+                            path: 'testdata',
+                            isDirectory: true,
+                            url: '/github.com/sourcegraph/codeintellify/-/tree/testdata',
+                        },
+                        {
+                            name: '.editorconfig',
+                            path: '.editorconfig',
+                            isDirectory: false,
+                            url: '/github.com/sourcegraph/codeintellify/-/blob/.editorconfig',
+                        },
+                        {
+                            name: '.eslintrc.json',
+                            path: '.eslintrc.json',
+                            isDirectory: false,
+                            url: '/github.com/sourcegraph/codeintellify/-/blob/.eslintrc.json',
+                        },
+                    ]}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+    it('should render a grid of tree entries in a subdirectory', () => {
+        expect(
+            render(
+                <TreeEntriesSection
+                    title="Files and directories"
+                    parentPath="src"
+                    entries={[
+                        {
+                            name: 'testutils',
+                            path: 'src/testutils',
+                            isDirectory: true,
+                            url: '/github.com/sourcegraph/codeintellify/-/tree/src/testutils',
+                        },
+                        {
+                            name: 'typings',
+                            path: 'src/typings',
+                            isDirectory: true,
+                            url: '/github.com/sourcegraph/codeintellify/-/tree/src/typings',
+                        },
+                        {
+                            name: 'errors.ts',
+                            path: 'src/errors.ts',
+                            isDirectory: false,
+                            url: '/github.com/sourcegraph/codeintellify/-/blob/src/errors.ts',
+                        },
+                        {
+                            name: 'helpers.ts',
+                            path: 'src/helpers.ts',
+                            isDirectory: false,
+                            url: '/github.com/sourcegraph/codeintellify/-/blob/src/helpers.ts',
+                        },
+                    ]}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+    it('should render only direct children', () => {
+        expect(
+            render(
+                <TreeEntriesSection
+                    title="Files and directories"
+                    parentPath="x"
+                    entries={[
+                        {
+                            name: 'ref',
+                            path: 'x/ref',
+                            isDirectory: true,
+                            url: '/github.com/vanadium/core/-/tree/x/ref',
+                        },
+                        {
+                            name: 'cmd',
+                            path: 'x/ref/cmd',
+                            isDirectory: true,
+                            url: '/github.com/vanadium/core/-/tree/x/ref/cmd',
+                        },
+                        {
+                            name: 'examples',
+                            path: 'x/ref/examples',
+                            isDirectory: true,
+                            url: '/github.com/vanadium/core/-/tree/x/ref/examples',
+                        },
+                        {
+                            name: 'README.md',
+                            path: 'x/ref/README.md',
+                            isDirectory: false,
+                            url: '/github.com/vanadium/core/-/blob/x/ref/README.md',
+                        },
+                        {
+                            name: 'envvar.go',
+                            path: 'x/ref/envvar.go',
+                            isDirectory: false,
+                            url: '/github.com/vanadium/core/-/blob/x/ref/envvar.go',
+                        },
+                    ]}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+})

--- a/web/src/repo/tree/TreeEntriesSection.tsx
+++ b/web/src/repo/tree/TreeEntriesSection.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import * as GQL from '../../../../shared/src/graphql/schema'
+import classNames from 'classnames'
+import { Link } from '../../../../shared/src/components/Link'
+
+/**
+ * Use a multi-column layout for tree entries when there are at least this many. See TreePage.scss
+ * for more information.
+ */
+const MIN_ENTRIES_FOR_COLUMN_LAYOUT = 6
+
+const TreeEntry: React.FunctionComponent<{
+    isDir: boolean
+    name: string
+    parentPath: string
+    url: string
+}> = ({ isDir, name, parentPath, url }) => {
+    const filePath = parentPath ? parentPath + '/' + name : name
+    return (
+        <Link
+            to={url}
+            className={classNames(
+                'tree-entry',
+                isDir && 'font-weight-bold',
+                `test-tree-entry-${isDir ? 'directory' : 'file'}`
+            )}
+            title={filePath}
+        >
+            {name}
+            {isDir && '/'}
+        </Link>
+    )
+}
+export const TreeEntriesSection: React.FunctionComponent<{
+    title: string
+    parentPath: string
+    entries: Pick<GQL.ITreeEntry, 'name' | 'isDirectory' | 'url' | 'path'>[]
+}> = ({ title, parentPath, entries }) => {
+    const directChildren = entries.filter(entry => entry.path === [parentPath, entry.name].filter(Boolean).join('/'))
+    if (directChildren.length === 0) {
+        return null
+    }
+    return (
+        <section className="tree-page__section test-tree-entries">
+            <h3 className="tree-page__section-header">{title}</h3>
+            <div
+                className={
+                    directChildren.length > MIN_ENTRIES_FOR_COLUMN_LAYOUT ? 'tree-page__entries--columns' : undefined
+                }
+            >
+                {directChildren.map((entry, index) => (
+                    <TreeEntry
+                        key={entry.name + String(index)}
+                        isDir={entry.isDirectory}
+                        name={entry.name}
+                        parentPath={parentPath}
+                        url={entry.url}
+                    />
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/web/src/repo/tree/TreeEntriesSection.tsx
+++ b/web/src/repo/tree/TreeEntriesSection.tsx
@@ -32,32 +32,28 @@ const TreeEntry: React.FunctionComponent<{
     )
 }
 export const TreeEntriesSection: React.FunctionComponent<{
-    title: string
     parentPath: string
     entries: Pick<GQL.ITreeEntry, 'name' | 'isDirectory' | 'url' | 'path'>[]
-}> = ({ title, parentPath, entries }) => {
+}> = ({ parentPath, entries }) => {
     const directChildren = entries.filter(entry => entry.path === [parentPath, entry.name].filter(Boolean).join('/'))
     if (directChildren.length === 0) {
         return null
     }
     return (
-        <section className="tree-page__section test-tree-entries">
-            <h3 className="tree-page__section-header">{title}</h3>
-            <div
-                className={
-                    directChildren.length > MIN_ENTRIES_FOR_COLUMN_LAYOUT ? 'tree-page__entries--columns' : undefined
-                }
-            >
-                {directChildren.map((entry, index) => (
-                    <TreeEntry
-                        key={entry.name + String(index)}
-                        isDir={entry.isDirectory}
-                        name={entry.name}
-                        parentPath={parentPath}
-                        url={entry.url}
-                    />
-                ))}
-            </div>
-        </section>
+        <div
+            className={
+                directChildren.length > MIN_ENTRIES_FOR_COLUMN_LAYOUT ? 'tree-entries-section--columns' : undefined
+            }
+        >
+            {directChildren.map((entry, index) => (
+                <TreeEntry
+                    key={entry.name + String(index)}
+                    isDir={entry.isDirectory}
+                    name={entry.name}
+                    parentPath={parentPath}
+                    url={entry.url}
+                />
+            ))}
+        </div>
     )
 }

--- a/web/src/repo/tree/TreePage.scss
+++ b/web/src/repo/tree/TreePage.scss
@@ -33,30 +33,6 @@
         }
     }
 
-    // To avoid having empty columns (and thus the items appearing not flush with the left margin),
-    // the component only applies this class when there are >= 6 items. This number is chosen
-    // because it is greater than the maximum number of columns that will be shown and ensures that
-    // at least 1 column has more than 1 item.
-    //
-    // See also MIN_ENTRIES_FOR_COLUMN_LAYOUT.
-    &__entries--columns {
-        column-gap: 2.25rem;
-        column-width: 13rem;
-
-        @media (max-width: $media-sm) {
-            column-count: 1;
-        }
-        @media (max-width: $media-md) {
-            column-count: 3;
-        }
-        @media (max-width: $media-lg) {
-            column-count: 4;
-        }
-        @media (min-width: $media-lg) {
-            column-count: 5;
-        }
-    }
-
     .git-commit-node {
         padding-left: 0;
         padding-right: 0;
@@ -65,27 +41,6 @@
         }
         .btn {
             opacity: 0.85;
-        }
-    }
-}
-
-.tree-entry {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    margin-left: -0.25rem;
-    padding: 0.125rem 0.25rem;
-    &:hover {
-        background-color: $color-bg-1;
-    }
-}
-
-.theme-light {
-    .tree-entry {
-        &:hover {
-            background-color: $color-light-bg-2;
         }
     }
 }

--- a/web/src/repo/tree/TreePage.tsx
+++ b/web/src/repo/tree/TreePage.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
 import FolderIcon from 'mdi-react/FolderIcon'
@@ -45,57 +44,7 @@ import { VersionContextProps } from '../../../../shared/src/search/util'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
-
-const TreeEntry: React.FunctionComponent<{
-    isDir: boolean
-    name: string
-    parentPath: string
-    url: string
-}> = ({ isDir, name, parentPath, url }) => {
-    const filePath = parentPath ? parentPath + '/' + name : name
-    return (
-        <Link
-            to={url}
-            className={classNames(
-                'tree-entry',
-                isDir && 'font-weight-bold',
-                `test-tree-entry-${isDir ? 'directory' : 'file'}`
-            )}
-            title={filePath}
-        >
-            {name}
-            {isDir && '/'}
-        </Link>
-    )
-}
-
-/**
- * Use a multi-column layout for tree entries when there are at least this many. See TreePage.scss
- * for more information.
- */
-const MIN_ENTRIES_FOR_COLUMN_LAYOUT = 6
-
-const TreeEntriesSection: React.FunctionComponent<{
-    title: string
-    parentPath: string
-    entries: Pick<GQL.ITreeEntry, 'name' | 'isDirectory' | 'url'>[]
-}> = ({ title, parentPath, entries }) =>
-    entries.length > 0 ? (
-        <section className="tree-page__section test-tree-entries">
-            <h3 className="tree-page__section-header">{title}</h3>
-            <div className={entries.length > MIN_ENTRIES_FOR_COLUMN_LAYOUT ? 'tree-page__entries--columns' : undefined}>
-                {entries.map((entry, index) => (
-                    <TreeEntry
-                        key={entry.name + String(index)}
-                        isDir={entry.isDirectory}
-                        name={entry.name}
-                        parentPath={parentPath}
-                        url={entry.url}
-                    />
-                ))}
-            </div>
-        </section>
-    ) : null
+import { TreeEntriesSection } from './TreeEntriesSection'
 
 const fetchTreeCommits = memoizeObservable(
     (args: {

--- a/web/src/repo/tree/TreePage.tsx
+++ b/web/src/repo/tree/TreePage.tsx
@@ -346,11 +346,10 @@ export const TreePage: React.FunctionComponent<Props> = ({
                             caseSensitive={caseSensitive}
                         />
                     )}
-                    <TreeEntriesSection
-                        title="Files and directories"
-                        parentPath={filePath}
-                        entries={treeOrError.entries}
-                    />
+                    <section className="tree-page__section test-tree-entries">
+                        <h3 className="tree-page__section-header">Files and directories</h3>
+                        <TreeEntriesSection parentPath={filePath} entries={treeOrError.entries} />
+                    </section>
                     {/* eslint-disable react/jsx-no-bind */}
                     <ActionsContainer
                         {...props}

--- a/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
+++ b/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
@@ -1,106 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TreeEntriesSection should render a grid of tree entries at the root 1`] = `
-<section
-  class="tree-page__section test-tree-entries"
->
-  <h3
-    class="tree-page__section-header"
+<div>
+  <a
+    class="tree-entry font-weight-bold test-tree-entry-directory"
+    href="/github.com/sourcegraph/codeintellify/-/tree/src"
+    title="src"
   >
-    Files and directories
-  </h3>
-  <div>
-    <a
-      class="tree-entry font-weight-bold test-tree-entry-directory"
-      href="/github.com/sourcegraph/codeintellify/-/tree/src"
-      title="src"
-    >
-      src/
-    </a>
-    <a
-      class="tree-entry font-weight-bold test-tree-entry-directory"
-      href="/github.com/sourcegraph/codeintellify/-/tree/testdata"
-      title="testdata"
-    >
-      testdata/
-    </a>
-    <a
-      class="tree-entry test-tree-entry-file"
-      href="/github.com/sourcegraph/codeintellify/-/blob/.editorconfig"
-      title=".editorconfig"
-    >
-      .editorconfig
-    </a>
-    <a
-      class="tree-entry test-tree-entry-file"
-      href="/github.com/sourcegraph/codeintellify/-/blob/.eslintrc.json"
-      title=".eslintrc.json"
-    >
-      .eslintrc.json
-    </a>
-  </div>
-</section>
+    src/
+  </a>
+  <a
+    class="tree-entry font-weight-bold test-tree-entry-directory"
+    href="/github.com/sourcegraph/codeintellify/-/tree/testdata"
+    title="testdata"
+  >
+    testdata/
+  </a>
+  <a
+    class="tree-entry test-tree-entry-file"
+    href="/github.com/sourcegraph/codeintellify/-/blob/.editorconfig"
+    title=".editorconfig"
+  >
+    .editorconfig
+  </a>
+  <a
+    class="tree-entry test-tree-entry-file"
+    href="/github.com/sourcegraph/codeintellify/-/blob/.eslintrc.json"
+    title=".eslintrc.json"
+  >
+    .eslintrc.json
+  </a>
+</div>
 `;
 
 exports[`TreeEntriesSection should render a grid of tree entries in a subdirectory 1`] = `
-<section
-  class="tree-page__section test-tree-entries"
->
-  <h3
-    class="tree-page__section-header"
+<div>
+  <a
+    class="tree-entry font-weight-bold test-tree-entry-directory"
+    href="/github.com/sourcegraph/codeintellify/-/tree/src/testutils"
+    title="src/testutils"
   >
-    Files and directories
-  </h3>
-  <div>
-    <a
-      class="tree-entry font-weight-bold test-tree-entry-directory"
-      href="/github.com/sourcegraph/codeintellify/-/tree/src/testutils"
-      title="src/testutils"
-    >
-      testutils/
-    </a>
-    <a
-      class="tree-entry font-weight-bold test-tree-entry-directory"
-      href="/github.com/sourcegraph/codeintellify/-/tree/src/typings"
-      title="src/typings"
-    >
-      typings/
-    </a>
-    <a
-      class="tree-entry test-tree-entry-file"
-      href="/github.com/sourcegraph/codeintellify/-/blob/src/errors.ts"
-      title="src/errors.ts"
-    >
-      errors.ts
-    </a>
-    <a
-      class="tree-entry test-tree-entry-file"
-      href="/github.com/sourcegraph/codeintellify/-/blob/src/helpers.ts"
-      title="src/helpers.ts"
-    >
-      helpers.ts
-    </a>
-  </div>
-</section>
+    testutils/
+  </a>
+  <a
+    class="tree-entry font-weight-bold test-tree-entry-directory"
+    href="/github.com/sourcegraph/codeintellify/-/tree/src/typings"
+    title="src/typings"
+  >
+    typings/
+  </a>
+  <a
+    class="tree-entry test-tree-entry-file"
+    href="/github.com/sourcegraph/codeintellify/-/blob/src/errors.ts"
+    title="src/errors.ts"
+  >
+    errors.ts
+  </a>
+  <a
+    class="tree-entry test-tree-entry-file"
+    href="/github.com/sourcegraph/codeintellify/-/blob/src/helpers.ts"
+    title="src/helpers.ts"
+  >
+    helpers.ts
+  </a>
+</div>
 `;
 
 exports[`TreeEntriesSection should render only direct children 1`] = `
-<section
-  class="tree-page__section test-tree-entries"
->
-  <h3
-    class="tree-page__section-header"
+<div>
+  <a
+    class="tree-entry font-weight-bold test-tree-entry-directory"
+    href="/github.com/vanadium/core/-/tree/x/ref"
+    title="x/ref"
   >
-    Files and directories
-  </h3>
-  <div>
-    <a
-      class="tree-entry font-weight-bold test-tree-entry-directory"
-      href="/github.com/vanadium/core/-/tree/x/ref"
-      title="x/ref"
-    >
-      ref/
-    </a>
-  </div>
-</section>
+    ref/
+  </a>
+</div>
 `;

--- a/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
+++ b/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TreeEntriesSection should render a grid of tree entries at the root 1`] = `
+<section
+  class="tree-page__section test-tree-entries"
+>
+  <h3
+    class="tree-page__section-header"
+  >
+    Files and directories
+  </h3>
+  <div>
+    <a
+      class="tree-entry font-weight-bold test-tree-entry-directory"
+      href="/github.com/sourcegraph/codeintellify/-/tree/src"
+      title="src"
+    >
+      src/
+    </a>
+    <a
+      class="tree-entry font-weight-bold test-tree-entry-directory"
+      href="/github.com/sourcegraph/codeintellify/-/tree/testdata"
+      title="testdata"
+    >
+      testdata/
+    </a>
+    <a
+      class="tree-entry test-tree-entry-file"
+      href="/github.com/sourcegraph/codeintellify/-/blob/.editorconfig"
+      title=".editorconfig"
+    >
+      .editorconfig
+    </a>
+    <a
+      class="tree-entry test-tree-entry-file"
+      href="/github.com/sourcegraph/codeintellify/-/blob/.eslintrc.json"
+      title=".eslintrc.json"
+    >
+      .eslintrc.json
+    </a>
+  </div>
+</section>
+`;
+
+exports[`TreeEntriesSection should render a grid of tree entries in a subdirectory 1`] = `
+<section
+  class="tree-page__section test-tree-entries"
+>
+  <h3
+    class="tree-page__section-header"
+  >
+    Files and directories
+  </h3>
+  <div>
+    <a
+      class="tree-entry font-weight-bold test-tree-entry-directory"
+      href="/github.com/sourcegraph/codeintellify/-/tree/src/testutils"
+      title="src/testutils"
+    >
+      testutils/
+    </a>
+    <a
+      class="tree-entry font-weight-bold test-tree-entry-directory"
+      href="/github.com/sourcegraph/codeintellify/-/tree/src/typings"
+      title="src/typings"
+    >
+      typings/
+    </a>
+    <a
+      class="tree-entry test-tree-entry-file"
+      href="/github.com/sourcegraph/codeintellify/-/blob/src/errors.ts"
+      title="src/errors.ts"
+    >
+      errors.ts
+    </a>
+    <a
+      class="tree-entry test-tree-entry-file"
+      href="/github.com/sourcegraph/codeintellify/-/blob/src/helpers.ts"
+      title="src/helpers.ts"
+    >
+      helpers.ts
+    </a>
+  </div>
+</section>
+`;
+
+exports[`TreeEntriesSection should render only direct children 1`] = `
+<section
+  class="tree-page__section test-tree-entries"
+>
+  <h3
+    class="tree-page__section-header"
+  >
+    Files and directories
+  </h3>
+  <div>
+    <a
+      class="tree-entry font-weight-bold test-tree-entry-directory"
+      href="/github.com/vanadium/core/-/tree/x/ref"
+      title="x/ref"
+    >
+      ref/
+    </a>
+  </div>
+</section>
+`;

--- a/web/src/tree/TreeLayer.tsx
+++ b/web/src/tree/TreeLayer.tsx
@@ -12,7 +12,6 @@ import {
     switchMap,
     takeUntil,
 } from 'rxjs/operators'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { AbsoluteRepo } from '../../../shared/src/util/url'
 import { fetchTreeEntries } from '../repo/backend'
@@ -30,6 +29,7 @@ import {
 } from './util'
 import { ErrorAlert } from '../components/alerts'
 import classNames from 'classnames'
+import { TreeFields } from '../graphql-operations'
 
 export interface TreeLayerProps extends AbsoluteRepo {
     history: H.History
@@ -54,7 +54,7 @@ export interface TreeLayerProps extends AbsoluteRepo {
 
 const LOADING = 'loading' as const
 interface TreeLayerState {
-    treeOrError?: typeof LOADING | GQL.IGitTree | ErrorLike
+    treeOrError?: typeof LOADING | TreeFields | ErrorLike
 }
 
 export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {

--- a/web/src/tree/TreeRoot.tsx
+++ b/web/src/tree/TreeRoot.tsx
@@ -13,7 +13,6 @@ import {
     switchMap,
     takeUntil,
 } from 'rxjs/operators'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { AbsoluteRepo } from '../../../shared/src/util/url'
 import { fetchTreeEntries } from '../repo/backend'
@@ -21,6 +20,7 @@ import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeNode } from './Tree'
 import { hasSingleChild, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
 import { ErrorAlert } from '../components/alerts'
+import { TreeFields } from '../graphql-operations'
 
 const maxEntries = 2500
 
@@ -50,7 +50,7 @@ export interface TreeRootProps extends AbsoluteRepo {
 
 const LOADING = 'loading' as const
 interface TreeRootState {
-    treeOrError?: typeof LOADING | GQL.IGitTree | ErrorLike
+    treeOrError?: typeof LOADING | TreeFields | ErrorLike
 }
 
 export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {

--- a/web/src/tree/util.tsx
+++ b/web/src/tree/util.tsx
@@ -1,14 +1,12 @@
-import * as GQL from '../../../shared/src/graphql/schema'
+import { TreeEntryFields } from '../graphql-operations'
 
 /** TreeEntryInfo is the information we need to render an entry in the file tree */
 export interface TreeEntryInfo {
     path: string
     name: string
     isDirectory: boolean
-    commit: GQL.IGitCommit
-    repository: GQL.IRepository
     url: string
-    submodule: GQL.ISubmodule | null
+    submodule: TreeEntryFields['submodule']
     isSingleChild: boolean
 }
 


### PR DESCRIPTION
Fixes #13231 by making sure we ignore the pre-fetched deep children (it's still beneficial to fetch them for caching).

Moves the TreeEntriesSection component into its own file, adds tests for it and uses the new GQL types.