### PR TITLE
codeintel: Use scratch image as base for indexer-vm dockerfile

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/Dockerfile
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/Dockerfile
@@ -1,21 +1,9 @@
-FROM sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
+FROM scratch
 
-ARG COMMIT_SHA="unknown"
-ARG DATE="unknown"
-ARG VERSION="unknown"
-
-LABEL org.opencontainers.image.revision=${COMMIT_SHA}
-LABEL org.opencontainers.image.created=${DATE}
-LABEL org.opencontainers.image.version=${VERSION}
-LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
-
-# hadolint ignore=DL3018
-RUN apk update && apk add --no-cache \
-    git \
-    tini \
-    docker
-
-USER sourcegraph
-EXPOSE 3190
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/precise-code-intel-indexer-vm"]
+# NOTE: We use this container only for distribution of this binary, not for a containerized
+# way to _run_ the application. This binary is extracted from the container during the init
+# process of the compute node that runs the indexer, as it need direct access to the host's
+# ignite binary and firecracker state.
+#
+# See https://github.com/sourcegraph/infrastructure/blob/master/code-intel/startup-script.sh.
 COPY precise-code-intel-indexer-vm /usr/local/bin/


### PR DESCRIPTION
https://github.com/sourcegraph/infrastructure/pull/2083 changes the requirements for this container. As we're only using it for distribution, we can save on the layers that don't contribute to just having a dumb wrapper around a binary.