### PR TITLE
authz: correctly marshal Perms for logging

### DIFF
--- a/internal/authz/perms.go
+++ b/internal/authz/perms.go
@@ -8,6 +8,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 var ErrPermsNotFound = errors.New("permissions not found")
@@ -125,7 +126,7 @@ func (p *UserPermissions) AuthorizedRepos(repos []*types.Repo) []RepoPerms {
 func (p *UserPermissions) TracingFields() []otlog.Field {
 	fs := []otlog.Field{
 		otlog.Int32("UserPermissions.UserID", p.UserID),
-		otlog.String("UserPermissions.Perm", string(p.Perm)),
+		trace.Stringer("UserPermissions.Perm", p.Perm),
 		otlog.String("UserPermissions.Type", string(p.Type)),
 	}
 
@@ -158,7 +159,7 @@ func (p *RepoPermissions) Expired(ttl time.Duration, now time.Time) bool {
 func (p *RepoPermissions) TracingFields() []otlog.Field {
 	fs := []otlog.Field{
 		otlog.Int32("RepoPermissions.RepoID", p.RepoID),
-		otlog.String("RepoPermissions.Perm", string(p.Perm)),
+		trace.Stringer("RepoPermissions.Perm", p.Perm),
 	}
 
 	if p.UserIDs != nil {
@@ -209,7 +210,7 @@ func (p *UserPendingPermissions) TracingFields() []otlog.Field {
 		otlog.String("UserPendingPermissions.ServiceType", p.ServiceType),
 		otlog.String("UserPendingPermissions.ServiceID", p.ServiceID),
 		otlog.String("UserPendingPermissions.BindID", p.BindID),
-		otlog.String("UserPendingPermissions.Perm", string(p.Perm)),
+		trace.Stringer("UserPendingPermissions.Perm", p.Perm),
 		otlog.String("UserPendingPermissions.Type", string(p.Type)),
 	}
 


### PR DESCRIPTION
In go1.15 the authz tests fail with the following: conversion from
Perms (uint32) to string yields a string of one rune, not a string of
digits (did you mean fmt.Sprint(x)?)

Instead of directly calling "Perm.String()" (or indirectly via
"fmt.Sprint") we use trace.Stringer which is a lazy logger. It will only
call the function if we actually consume the log somewhere (so will
avoid the work if we are not tracing that request).

There is an alternative implementation of this change in https://github.com/sourcegraph/sourcegraph/pull/13433. I would like to land this now since it will fix go test for those who have already upgraded.