### PR TITLE
graphql: Add eventName arg to eventLogs

### DIFF
--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -10,6 +10,7 @@ import (
 
 func (r *UserResolver) EventLogs(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
+	EventName *string // return only event logs matching the event name
 }) (*userEventLogsConnectionResolver, error) {
 	// 🚨 SECURITY: Event logs can only be viewed by the user or site admin.
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
@@ -18,6 +19,7 @@ func (r *UserResolver) EventLogs(ctx context.Context, args *struct {
 	var opt db.EventLogsListOptions
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	opt.UserID = r.user.ID
+	opt.EventName = args.EventName
 	return &userEventLogsConnectionResolver{opt: opt}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -5382,6 +5382,10 @@ type User implements Node & SettingsSubject & Namespace {
         Returns the first n event logs from the list.
         """
         first: Int
+        """
+        Only return events matching this event name
+        """
+        eventName: String
     ): EventLogsConnection!
     """
     The user's email addresses.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5375,6 +5375,10 @@ type User implements Node & SettingsSubject & Namespace {
         Returns the first n event logs from the list.
         """
         first: Int
+        """
+        Only return events matching this event name
+        """
+        eventName: String
     ): EventLogsConnection!
     """
     The user's email addresses.

--- a/internal/db/event_logs.go
+++ b/internal/db/event_logs.go
@@ -85,6 +85,8 @@ type EventLogsListOptions struct {
 	UserID int32
 
 	*LimitOffset
+
+	EventName *string
 }
 
 // ListAll gets all event logs in descending order of timestamp.
@@ -92,6 +94,9 @@ func (l *eventLogs) ListAll(ctx context.Context, opt EventLogsListOptions) ([]*t
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if opt.UserID != 0 {
 		conds = append(conds, sqlf.Sprintf("user_id = %d", opt.UserID))
+	}
+	if opt.EventName != nil {
+		conds = append(conds, sqlf.Sprintf("name = %s", opt.EventName))
 	}
 	return l.getBySQL(ctx, sqlf.Sprintf("WHERE %s ORDER BY timestamp DESC %s", sqlf.Join(conds, "AND"), opt.LimitOffset.SQL()))
 }

--- a/internal/db/event_logs_test.go
+++ b/internal/db/event_logs_test.go
@@ -430,6 +430,66 @@ func TestEventLogs_AggregatedEventsSparseEvents(t *testing.T) {
 	}
 }
 
+func TestEventLogs_ListAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now()
+
+	startDate, _ := calcStartDate(now, Daily, 3)
+
+	events := []*Event{
+		{
+			UserID:    1,
+			Name:      "SearchResultsQueried",
+			URL:       "test",
+			Source:    "test",
+			Timestamp: startDate,
+		}, {
+			UserID:    2,
+			Name:      "codeintel",
+			URL:       "test",
+			Source:    "test",
+			Timestamp: startDate,
+		},
+		{
+			UserID:    2,
+			Name:      "ViewRepository",
+			URL:       "test",
+			Source:    "test",
+			Timestamp: startDate,
+		},
+		{
+			UserID:    2,
+			Name:      "SearchResultsQueried",
+			URL:       "test",
+			Source:    "test",
+			Timestamp: startDate,
+		}}
+
+	for _, event := range events {
+		if err := EventLogs.Insert(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+
+	}
+
+	searchResultQueriedEvent := "SearchResultsQueried"
+	have, err := EventLogs.ListAll(ctx, EventLogsListOptions{EventName: &searchResultQueriedEvent})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := 2
+
+	if diff := cmp.Diff(want, len(have)); diff != "" {
+		t.Error(diff)
+	}
+}
+
 // makeTestEvent sets the required (uninteresting) fields that are required on insertion
 // due to db constraints. This method will also add some sub-day jitter to the timestamp.
 func makeTestEvent(e *Event) *Event {

--- a/web/src/user/UserEventLogsPage.tsx
+++ b/web/src/user/UserEventLogsPage.tsx
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { Link } from '../../../shared/src/components/Link'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
-import { requestGraphQL } from '../backend/graphql'
+import { queryGraphQL } from '../backend/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { FilteredConnection } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
@@ -73,7 +73,7 @@ export class UserEventLogsPage extends React.PureComponent<UserEventLogsPageProp
     }
 
     private queryUserEventLogs = (args: { first?: number }): Observable<GQL.IEventLogsConnection> =>
-        requestGraphQL<GQL.IUser>(
+        queryGraphQL(
             gql`
                 query UserEventLogs($user: ID!, $first: Int) {
                     node(id: $user) {
@@ -97,6 +97,6 @@ export class UserEventLogsPage extends React.PureComponent<UserEventLogsPageProp
             { ...args, user: this.props.user.id }
         ).pipe(
             map(dataOrThrowErrors),
-            map(data => data.eventLogs)
+            map(data => (data.node as GQL.IUser).eventLogs)
         )
 }

--- a/web/src/user/UserEventLogsPage.tsx
+++ b/web/src/user/UserEventLogsPage.tsx
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { Link } from '../../../shared/src/components/Link'
 import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
-import { queryGraphQL } from '../backend/graphql'
+import { requestGraphQL } from '../backend/graphql'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { FilteredConnection } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
@@ -73,7 +73,7 @@ export class UserEventLogsPage extends React.PureComponent<UserEventLogsPageProp
     }
 
     private queryUserEventLogs = (args: { first?: number }): Observable<GQL.IEventLogsConnection> =>
-        queryGraphQL(
+        requestGraphQL<GQL.IUser>(
             gql`
                 query UserEventLogs($user: ID!, $first: Int) {
                     node(id: $user) {
@@ -97,6 +97,6 @@ export class UserEventLogsPage extends React.PureComponent<UserEventLogsPageProp
             { ...args, user: this.props.user.id }
         ).pipe(
             map(dataOrThrowErrors),
-            map(data => (data.node as GQL.IUser).eventLogs)
+            map(data => data.eventLogs)
         )
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/13486.

Adds eventName argument to eventLogs endpoint so we can request only events matching a particular event name.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
