### PR TITLE
Remove ON CONFLICT ... DO NOTHING when creating changesets

### DIFF
--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -174,9 +174,6 @@ var createChangesetQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store.go:CreateChangeset
 INSERT INTO changesets (%s)
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-ON CONFLICT ON CONSTRAINT
-changesets_repo_external_id_unique
-DO NOTHING
 RETURNING %s
 `
 


### PR DESCRIPTION
This is a leftover from the old batch-based query we had. With the new
model it doesn't serve a purpose except... that it swallows errors :|