### PR TITLE
Apply cursor pagination pattern to last campaigns connection

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -70,6 +70,7 @@ type CampaignArgs struct {
 
 type ChangesetEventsConnectionArgs struct {
 	First int32
+	After *string
 }
 
 type CampaignsResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1477,7 +1477,7 @@ type ExternalChangeset implements Node & Changeset {
     """
     The events belonging to this changeset.
     """
-    events(first: Int = 50): ChangesetEventConnection!
+    events(first: Int = 50, after: String): ChangesetEventConnection!
 
     """
     The date and time when the changeset was created.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1470,7 +1470,7 @@ type ExternalChangeset implements Node & Changeset {
     """
     The events belonging to this changeset.
     """
-    events(first: Int = 50): ChangesetEventConnection!
+    events(first: Int = 50, after: String): ChangesetEventConnection!
 
     """
     The date and time when the changeset was created.

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -355,12 +355,21 @@ func (r *changesetResolver) Events(ctx context.Context, args *graphqlbackend.Cha
 	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
+	var cursor int64
+	if args.After != nil {
+		var err error
+		cursor, err = strconv.ParseInt(*args.After, 10, 32)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse after cursor")
+		}
+	}
 	// TODO: We already need to fetch all events for ReviewState and Labels
 	// perhaps we can use the cached data here
 	return &changesetEventsConnectionResolver{
 		store:             r.store,
 		changesetResolver: r,
 		first:             int(args.First),
+		cursor:            cursor,
 	}, nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strconv"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -16,6 +17,7 @@ type changesetEventsConnectionResolver struct {
 	httpFactory       *httpcli.Factory
 	changesetResolver *changesetResolver
 	first             int
+	cursor            int64
 
 	// cache results because they are used by multiple fields
 	once            sync.Once
@@ -52,7 +54,10 @@ func (r *changesetEventsConnectionResolver) PageInfo(ctx context.Context) (*grap
 	if err != nil {
 		return nil, err
 	}
-	return graphqlutil.HasNextPage(next != 0), nil
+	if next != 0 {
+		return graphqlutil.NextPageCursor(strconv.Itoa(int(next))), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
 }
 
 func (r *changesetEventsConnectionResolver) compute(ctx context.Context) ([]*campaigns.ChangesetEvent, int64, error) {
@@ -60,6 +65,7 @@ func (r *changesetEventsConnectionResolver) compute(ctx context.Context) ([]*cam
 		opts := ee.ListChangesetEventsOpts{
 			ChangesetIDs: []int64{r.changesetResolver.changeset.ID},
 			LimitOpts:    ee.LimitOpts{Limit: r.first},
+			Cursor:       r.cursor,
 		}
 		r.changesetEvents, r.next, r.err = r.store.ListChangesetEvents(ctx, opts)
 	})

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -129,6 +129,8 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 				TotalCount: tc.wantTotalCount,
 				PageInfo: apitest.PageInfo{
 					HasNextPage: tc.wantHasNextPage,
+					// This test doesn't check on the cursors, the below test does that.
+					EndCursor: response.Node.Events.PageInfo.EndCursor,
 				},
 				Nodes: tc.wantNodes,
 			}
@@ -138,16 +140,47 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 			}
 		})
 	}
+
+	var endCursor *string
+	for i := range nodes {
+		input := map[string]interface{}{"changeset": changesetAPIID, "first": 1}
+		if endCursor != nil {
+			input["after"] = *endCursor
+		}
+		wantHasNextPage := i != len(nodes)-1
+
+		var response struct{ Node apitest.Changeset }
+		apitest.MustExec(ctx, t, s, input, &response, queryChangesetEventConnection)
+
+		events := response.Node.Events
+		if diff := cmp.Diff(1, len(events.Nodes)); diff != "" {
+			t.Fatalf("unexpected number of nodes (-want +got):\n%s", diff)
+		}
+
+		if diff := cmp.Diff(len(nodes), events.TotalCount); diff != "" {
+			t.Fatalf("unexpected total count (-want +got):\n%s", diff)
+		}
+
+		if diff := cmp.Diff(wantHasNextPage, events.PageInfo.HasNextPage); diff != "" {
+			t.Fatalf("unexpected hasNextPage (-want +got):\n%s", diff)
+		}
+
+		endCursor = events.PageInfo.EndCursor
+		if want, have := wantHasNextPage, endCursor != nil; have != want {
+			t.Fatalf("unexpected endCursor existence. want=%t, have=%t", want, have)
+		}
+	}
 }
 
 const queryChangesetEventConnection = `
-query($changeset: ID!, $first: Int){
+query($changeset: ID!, $first: Int, $after: String){
   node(id: $changeset) {
     ... on ExternalChangeset {
-      events(first: $first) {
+      events(first: $first, after: $after) {
         totalCount
         pageInfo {
           hasNextPage
+          endCursor
         }
         nodes {
          id


### PR DESCRIPTION
Migrates the last connection resolver in the campaigns codebase to use cursor based pagination