### PR TITLE
gqltest: ignore transient repo-updater error

### DIFF
--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,7 +36,9 @@ func TestExternalService(t *testing.T) {
 				RepositoryPathPattern: "foobar/{host}/{nameWithOwner}",
 			}),
 		})
-		if err != nil {
+		// The repo-updater might not be up yet but it will eventually catch up for the external
+		// service we just added, thus it is OK to ignore this transient error.
+		if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 			t.Fatal(err)
 		}
 		defer func() {
@@ -92,7 +95,9 @@ func TestExternalService_AWSCodeCommit(t *testing.T) {
 			},
 		}),
 	})
-	if err != nil {
+	// The repo-updater might not be up yet but it will eventually catch up for the external
+	// service we just added, thus it is OK to ignore this transient error.
+	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
 	defer func() {
@@ -142,7 +147,9 @@ func TestExternalService_BitbucketServer(t *testing.T) {
 			RepositoryPathPattern: "bbs/{projectKey}/{repositorySlug}",
 		}),
 	})
-	if err != nil {
+	// The repo-updater might not be up yet but it will eventually catch up for the external
+	// service we just added, thus it is OK to ignore this transient error.
+	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
 	defer func() {


### PR DESCRIPTION
Quick stats since added backend integration tests in CI builds for `main` branch on last Friday (2020-08-28):


Out of 66 builds, there are:
- 1x Cannot test connectivity to Docker within 60s:
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72138#79af0720-719e-4d3a-9ab9-c1d17bc95314
- 6x repo-updater somehow is not up: 
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72177#8545d934-8693-4306-96e2-b94112932694
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72208#98e727e5-d9f8-4145-b134-8f9f6190db73
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72229#bcfad510-360e-475b-b6c8-5fb15afab26c
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72278#fe1c1942-2699-4e7a-8392-b1b2bcd998ca
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72407#9579dbae-ab12-4889-afd4-4f790829fb69
	- https://buildkite.com/sourcegraph/sourcegraph/builds/72430#2b4c85aa-9151-4f62-a05f-96177c904d74

This is an attempt to ignore the transient repo-updater error as it should eventually catch up.