### PR TITLE
Fix race conditions in CloseCampaign by blocking

### DIFF
--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -364,6 +364,37 @@ func TestReconcilerProcess(t *testing.T) {
 				diffStat: state.DiffStat,
 			},
 		},
+		"closing non-open changeset": {
+			currentSpec: &testSpecOpts{
+				headRef:   "refs/heads/head-ref-on-github",
+				published: true,
+
+				title: "title",
+				body:  "body",
+			},
+			changeset: testChangesetOpts{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				externalID:       githubPR.ID,
+				externalBranch:   githubPR.HeadRefName,
+				externalState:    campaigns.ChangesetExternalStateClosed,
+				closing:          true,
+			},
+			// We return a closed GitHub PR here, but since it's a noop, we
+			// don't sync and thus don't set its attributes on the changeset.
+			sourcerMetadata: closedGitHubPR,
+
+			// Should be a noop
+			wantCloseOnCodeHost: false,
+
+			wantChangeset: changesetAssertions{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				closing:          false,
+
+				externalID:     closedGitHubPR.ID,
+				externalBranch: closedGitHubPR.HeadRefName,
+				externalState:  campaigns.ChangesetExternalStateClosed,
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -296,7 +296,7 @@ func (s *Service) CloseCampaign(ctx context.Context, id int64, closeChangesets b
 	}
 	defer func() { err = tx.Done(err) }()
 
-	campaign.ClosedAt = time.Now().UTC()
+	campaign.ClosedAt = s.clock()
 	if err := tx.UpdateCampaign(ctx, campaign); err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -197,7 +197,10 @@ func TestService(t *testing.T) {
 		t.Fatal("user is admin, want non-admin")
 	}
 
-	store := NewStore(dbconn.Global)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time { return now }
+
+	store := NewStoreWithClock(dbconn.Global, clock)
 	rs, _ := createTestRepos(t, ctx, dbconn.Global, 4)
 
 	fakeSource := &ct.FakeChangesetSource{}
@@ -251,7 +254,7 @@ func TestService(t *testing.T) {
 			if err != nil {
 				t.Fatalf("campaign not closed: %s", err)
 			}
-			if closedCampaign.ClosedAt.IsZero() {
+			if !closedCampaign.ClosedAt.Equal(now) {
 				t.Fatalf("campaign ClosedAt is zero")
 			}
 

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -281,31 +281,18 @@ func TestService(t *testing.T) {
 			closeConfirm(t, campaign, false)
 		})
 
-		t.Run("processing changesets", func(t *testing.T) {
+		t.Run("changesets", func(t *testing.T) {
 			campaign := createCampaign(t)
 
-			changeset := testChangeset(rs[0].ID, campaign.ID, campaigns.ChangesetExternalStateOpen)
-			changeset.ReconcilerState = campaigns.ReconcilerStateProcessing
-			if err := store.CreateChangeset(ctx, changeset); err != nil {
+			changeset1 := testChangeset(rs[0].ID, campaign.ID, campaigns.ChangesetExternalStateOpen)
+			changeset1.ReconcilerState = campaigns.ReconcilerStateCompleted
+			if err := store.CreateChangeset(ctx, changeset1); err != nil {
 				t.Fatal(err)
 			}
 
-			// should fail
-			_, err := svc.CloseCampaign(adminCtx, campaign.ID, true)
-			if err != ErrCloseProcessingCampaign {
-				t.Fatalf("CloseCampaign returned unexpected error: %s", err)
-			}
-
-			// without trying to close changesets, it should succeed:
-			closeConfirm(t, campaign, false)
-		})
-
-		t.Run("non-processing changesets", func(t *testing.T) {
-			campaign := createCampaign(t)
-
-			changeset := testChangeset(rs[0].ID, campaign.ID, campaigns.ChangesetExternalStateOpen)
-			changeset.ReconcilerState = campaigns.ReconcilerStateCompleted
-			if err := store.CreateChangeset(ctx, changeset); err != nil {
+			changeset2 := testChangeset(rs[1].ID, campaign.ID, campaigns.ChangesetExternalStateOpen)
+			changeset2.ReconcilerState = campaigns.ReconcilerStateCompleted
+			if err := store.CreateChangeset(ctx, changeset2); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
This is one of the PRs to fix #12827.

Yesterday [we found out][1] that there were race conditions in the old `CloseCampaign` code:

- Changesets could switch from "queued" to "processing" between our "count all processing changesets" call and the "return if count is > 0" check.
- Changesets could switch from "unpublished" to "published & open" after we did the "list all open changesets" call

On top of that the `UpdateChangeset` calls would block if a changeset was processing.

So what we do now instead is cleaner and more consistent.

We mark _all_ changesets associated with the campaign as to-be-closed and enqueue them. That avoids the race conditions of changesets currently being published while we try to close the campaign.

And it works because the set of changesets doesn't change while we do this, since we close the campaign in a transaction and hold the row lock on it, meaning that another user cannot `ApplyCampaign` while we're in this code path and add/remove changesets. 

Each `UpdateChangeset` call will then block again, if one of the changesets is currently being processed. That's good, because it leaves us in a consistent state where we don't overwrite data the reconciler wants to write. 

That means that the `CloseCampaign` mutation might block until all currently processing changesets are done being processed, *if* there are processing changesets.

We lose the "cannot close currently processing campaign" error, but that wouldn't work anyway with the new model. This here is far more consistent.

~We just need to make sure that we show a spinner on the "close campaign" confirmation button, maybe.~ We do have a spinner.

[1]: https://github.com/sourcegraph/sourcegraph/issues/12827#issuecomment-684936536
