### PR TITLE
repo-updater: add metrics for user-added external services

### DIFF
--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -115,29 +115,17 @@ WHERE external_service_id IN (
 	})
 
 	promauto.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "src_repoupdater_user_repos_average",
-		Help: "The average number of repositories added by users",
+		Name: "src_repoupdater_user_with_external_services_total",
+		Help: "The total number of users who have added external services",
 	}, func() float64 {
 		count, err := scanCount(`
--- source: cmd/repo-updater/repos/metrics.go:src_repoupdater_user_repos_average
-WITH users AS (
-	SELECT DISTINCT(namespace_user_id) AS total FROM external_services
-	WHERE namespace_user_id IS NOT NULL
-)
-
-SELECT
-	CASE MAX(users.total)
-		WHEN 0 THEN 0
-		ELSE COUNT(*) / MAX(users.total)
-	END AS average
-FROM external_service_repos, users
-WHERE external_service_id IN (
-		SELECT DISTINCT(id) FROM external_services
-		WHERE namespace_user_id IS NOT NULL
-	)
+-- source: cmd/repo-updater/repos/metrics.go:src_repoupdater_user_with_external_services_total
+SELECT DISTINCT(namespace_user_id) AS total
+FROM external_services
+WHERE namespace_user_id IS NOT NULL
 `)
 		if err != nil {
-			log15.Error("Failed to get average user repositories", "err", err)
+			log15.Error("Failed to get total users with external services", "err", err)
 			return 0
 		}
 		return count

--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -120,7 +120,7 @@ WHERE external_service_id IN (
 	}, func() float64 {
 		count, err := scanCount(`
 -- source: cmd/repo-updater/repos/metrics.go:src_repoupdater_user_with_external_services_total
-SELECT DISTINCT(namespace_user_id) AS total
+SELECT COUNT(DISTINCT(namespace_user_id)) AS total
 FROM external_services
 WHERE namespace_user_id IS NOT NULL
 `)

--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -1,12 +1,13 @@
 package repos
 
 import (
+	"context"
+
 	"github.com/inconshreveable/log15"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 var (
@@ -66,13 +67,9 @@ var (
 	})
 )
 
-func init() {
+func MustRegisterMetrics(db dbutil.DB) {
 	scanCount := func(sql string) (float64, error) {
-		if dbconn.Global == nil {
-			return 0, errors.New("database connection is not available")
-		}
-
-		row := dbconn.Global.QueryRow(sql)
+		row := db.QueryRowContext(context.Background(), sql)
 		var count int64
 		err := row.Scan(&count)
 		if err != nil {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
@@ -75,6 +76,8 @@ func Main(enterpriseInit EnterpriseInit) {
 	if err != nil {
 		log.Fatalf("failed to initialize db store: %v", err)
 	}
+
+	repos.MustRegisterMetrics(db)
 
 	var store repos.Store
 	{


### PR DESCRIPTION
Adds three Prometheus metrics:
- Track number of code host connections added by users
- Track total number of repositories added by users
- Total number of users who have added external services

Part of #12699