### PR TITLE
Re-enqueue and reset failed changesets in ApplyCampaign

### DIFF
--- a/enterprise/internal/campaigns/service_apply_campaign.go
+++ b/enterprise/internal/campaigns/service_apply_campaign.go
@@ -244,7 +244,14 @@ func (r *changesetRewirer) Rewire() (err error) {
 			k := repoExternalID{repo: spec.RepoID, externalID: spec.Spec.ExternalID}
 
 			c, ok := r.changesetsByRepoExternalID[k]
-			if !ok {
+			if ok {
+				// If it's already attached to the campaign and errored, we re-enqueue it.
+				if c.ReconcilerState == campaigns.ReconcilerStateErrored {
+					if err := r.updateAndReenqueue(c); err != nil {
+						return err
+					}
+				}
+			} else {
 				// If we don't have a changeset attached to the campaign, we need to find or create one with the externalID in that repository.
 				c, err = r.updateOrCreateTrackingChangeset(repo, k.externalID)
 				if err != nil {
@@ -366,6 +373,8 @@ func (r *changesetRewirer) updateChangesetToNewSpec(c *campaigns.Changeset, spec
 	// reconciler wakes up, compares old and new spec and, if
 	// necessary, updates the changesets accordingly.
 	c.ReconcilerState = campaigns.ReconcilerStateQueued
+	c.FailureMessage = nil
+	c.NumResets = 0
 
 	// Copy over diff stat from the new spec.
 	diffStat := spec.DiffStat()
@@ -462,6 +471,11 @@ func (r *changesetRewirer) updateOrCreateTrackingChangeset(repo *types.Repo, ext
 		existing.AddedToCampaign = true
 		existing.CampaignIDs = append(existing.CampaignIDs, r.campaign.ID)
 
+		// If it errored, we re-enqueue it.
+		if existing.ReconcilerState == campaigns.ReconcilerStateErrored {
+			return existing, r.updateAndReenqueue(existing)
+		}
+
 		return existing, r.tx.UpdateChangeset(r.ctx, existing)
 	}
 
@@ -482,4 +496,12 @@ func (r *changesetRewirer) updateOrCreateTrackingChangeset(repo *types.Repo, ext
 	}
 
 	return newChangeset, r.tx.CreateChangeset(r.ctx, newChangeset)
+}
+
+func (r *changesetRewirer) updateAndReenqueue(ch *campaigns.Changeset) error {
+	ch.ReconcilerState = campaigns.ReconcilerStateQueued
+	ch.NumResets = 0
+	ch.FailureMessage = nil
+
+	return r.tx.UpdateChangeset(r.ctx, ch)
 }

--- a/enterprise/internal/campaigns/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service_apply_campaign_test.go
@@ -524,6 +524,69 @@ func TestServiceApplyCampaign(t *testing.T) {
 				t.Fatalf("wrong repository ID in RepoNotFoundErr: %d", notFoundErr.ID)
 			}
 		})
+
+		t.Run("campaign with errored changeset", func(t *testing.T) {
+			campaignSpec1 := createCampaignSpec(t, ctx, store, "errored-changeset-campaign", admin.ID)
+
+			spec1Opts := testSpecOpts{
+				user:         admin.ID,
+				repo:         repos[0].ID,
+				campaignSpec: campaignSpec1.ID,
+				externalID:   "1234",
+			}
+			createChangesetSpec(t, ctx, store, spec1Opts)
+
+			spec2Opts := testSpecOpts{
+				user:         admin.ID,
+				repo:         repos[1].ID,
+				campaignSpec: campaignSpec1.ID,
+				headRef:      "refs/heads/repo-1-branch-1",
+			}
+			oldSpec2 := createChangesetSpec(t, ctx, store, spec2Opts)
+
+			_, oldChangesets := applyAndListChangesets(adminCtx, t, svc, campaignSpec1.RandID, 2)
+
+			// Set the changesets to look like they failed in the reconciler
+			for _, c := range oldChangesets {
+				setChangesetFailed(t, ctx, store, c)
+			}
+
+			// Now we create another campaign spec with the same campaign name
+			// and namespace.
+			campaignSpec2 := createCampaignSpec(t, ctx, store, "errored-changeset-campaign", admin.ID)
+			spec1Opts.campaignSpec = campaignSpec2.ID
+			newSpec1 := createChangesetSpec(t, ctx, store, spec1Opts)
+			spec2Opts.campaignSpec = campaignSpec2.ID
+			newSpec2 := createChangesetSpec(t, ctx, store, spec2Opts)
+
+			campaign, cs := applyAndListChangesets(adminCtx, t, svc, campaignSpec2.RandID, 2)
+
+			c1 := cs.Find(campaigns.WithExternalID(newSpec1.Spec.ExternalID))
+			reloadAndAssertChangeset(t, ctx, store, c1, changesetAssertions{
+				repo:             spec1Opts.repo,
+				externalID:       "1234",
+				unsynced:         true,
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+
+				reconcilerState: campaigns.ReconcilerStateQueued,
+				failureMessage:  nil,
+				numResets:       0,
+			})
+
+			c2 := cs.Find(campaigns.WithCurrentSpecID(newSpec2.ID))
+			assertChangeset(t, c2, changesetAssertions{
+				repo:             newSpec2.RepoID,
+				currentSpec:      newSpec2.ID,
+				previousSpec:     oldSpec2.ID,
+				ownedByCampaign:  campaign.ID,
+				publicationState: campaigns.ChangesetPublicationStateUnpublished,
+				diffStat:         testChangsetSpecDiffStat,
+
+				reconcilerState: campaigns.ReconcilerStateQueued,
+				failureMessage:  nil,
+				numResets:       0,
+			})
+		})
 	})
 
 	t.Run("applying to closed campaign", func(t *testing.T) {
@@ -562,6 +625,7 @@ type changesetAssertions struct {
 	body  string
 
 	failureMessage *string
+	numResets      int64
 }
 
 func assertChangeset(t *testing.T, c *campaigns.Changeset, a changesetAssertions) {
@@ -632,6 +696,10 @@ func assertChangeset(t *testing.T, c *campaigns.Changeset, a changesetAssertions
 		}
 	}
 
+	if diff := cmp.Diff(a.numResets, c.NumResets); diff != "" {
+		t.Fatalf("changeset NumResets wrong. (-want +got):\n%s", diff)
+	}
+
 	if have, want := c.ExternalBranch, a.externalBranch; have != want {
 		t.Fatalf("changeset ExternalBranch wrong. want=%s, have=%s", want, have)
 	}
@@ -671,6 +739,8 @@ func reloadAndAssertChangeset(t *testing.T, ctx context.Context, s *Store, c *ca
 }
 
 func applyAndListChangesets(ctx context.Context, t *testing.T, svc *Service, campaignSpecRandID string, wantChangesets int) (*campaigns.Campaign, campaigns.Changesets) {
+	t.Helper()
+
 	campaign, err := svc.ApplyCampaign(ctx, ApplyCampaignOpts{
 		CampaignSpecRandID: campaignSpecRandID,
 	})
@@ -702,6 +772,19 @@ func setChangesetPublished(t *testing.T, ctx context.Context, s *Store, c *campa
 	c.PublicationState = campaigns.ChangesetPublicationStatePublished
 	c.ReconcilerState = campaigns.ReconcilerStateCompleted
 	c.Unsynced = false
+
+	if err := s.UpdateChangeset(ctx, c); err != nil {
+		t.Fatalf("failed to update changeset: %s", err)
+	}
+}
+
+func setChangesetFailed(t *testing.T, ctx context.Context, s *Store, c *campaigns.Changeset) {
+	t.Helper()
+
+	c.ReconcilerState = campaigns.ReconcilerStateErrored
+	message := "failure message"
+	c.FailureMessage = &message
+	c.NumResets = 5
 
 	if err := s.UpdateChangeset(ctx, c); err != nil {
 		t.Fatalf("failed to update changeset: %s", err)

--- a/internal/campaigns/types.go
+++ b/internal/campaigns/types.go
@@ -496,6 +496,13 @@ func (c *Changeset) URL() (s string, err error) {
 	}
 }
 
+// ResetQueued resets the failure message and reset count and sets the changesets ReconcilerState to queued.
+func (c *Changeset) ResetQueued() {
+	c.ReconcilerState = ReconcilerStateQueued
+	c.NumResets = 0
+	c.FailureMessage = nil
+}
+
 // ChangesetSpecs is a slice of *ChangesetSpecs.
 type ChangesetSpecs []*ChangesetSpec
 


### PR DESCRIPTION
This is an add-on to #12700 and makes sure that when we apply a new
campaign spec to an existing campaign all the failed changesets are
retried and properly resets (including NumResets and FailureMessage).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
