### PR TITLE
Stop changesets from being published while applying new spec

### DIFF
--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -583,7 +583,10 @@ type testChangesetOpts struct {
 	externalState       campaigns.ChangesetExternalState
 
 	publicationState campaigns.ChangesetPublicationState
-	failureMessage   string
+
+	reconcilerState campaigns.ReconcilerState
+	failureMessage  string
+	numResets       int64
 
 	createdByCampaign bool
 	ownedByCampaign   int64
@@ -621,6 +624,9 @@ func createChangeset(
 
 		Unsynced: opts.unsynced,
 		Closing:  opts.closing,
+
+		ReconcilerState: opts.reconcilerState,
+		NumResets:       opts.numResets,
 	}
 
 	if opts.failureMessage != "" {

--- a/enterprise/internal/campaigns/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service_apply_campaign_test.go
@@ -696,8 +696,8 @@ func assertChangeset(t *testing.T, c *campaigns.Changeset, a changesetAssertions
 		}
 	}
 
-	if diff := cmp.Diff(a.numResets, c.NumResets); diff != "" {
-		t.Fatalf("changeset NumResets wrong. (-want +got):\n%s", diff)
+	if have, want := c.NumResets, a.numResets; have != want {
+		t.Fatalf("changeset NumResets wrong. want=%d, have=%d", want, have)
 	}
 
 	if have, want := c.ExternalBranch, a.externalBranch; have != want {
@@ -782,8 +782,7 @@ func setChangesetFailed(t *testing.T, ctx context.Context, s *Store, c *campaign
 	t.Helper()
 
 	c.ReconcilerState = campaigns.ReconcilerStateErrored
-	message := "failure message"
-	c.FailureMessage = &message
+	c.FailureMessage = &canceledChangesetFailureMessage
 	c.NumResets = 5
 
 	if err := s.UpdateChangeset(ctx, c); err != nil {

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -486,7 +486,7 @@ func (s *Store) UpdateChangeset(ctx context.Context, cs *campaigns.Changeset) er
 }
 
 var updateChangesetQueryFmtstr = `
--- source: enterprise/internal/campaigns/store_changeset_specs.go:UpdateChangeset
+-- source: enterprise/internal/campaigns/store_changesets.go:UpdateChangeset
 UPDATE changesets
 SET (%s) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
@@ -521,6 +521,48 @@ func (s *Store) GetChangesetExternalIDs(ctx context.Context, spec api.ExternalRe
 	q := sqlf.Sprintf(queryFmtString, spec.ServiceType, sqlf.Join(inClause, ","), spec.ID, spec.ServiceType, spec.ServiceID)
 	return basestore.ScanStrings(s.Store.Query(ctx, q))
 }
+
+// canceledChangesetFailureMessage is set on changesets as the FailureMessage
+// by CancelQueuedCampaignChangesets which is called at the beginning of
+// ApplyCampaign to stop enqueued changesets being processed while we're
+// applying the new campaign spec.
+var canceledChangesetFailureMessage = "Canceled"
+
+func (s *Store) CancelQueuedCampaignChangesets(ctx context.Context, campaignID int64) error {
+	// Note that we don't cancel queued "syncing" changesets, since their
+	// owned_by_campaign_id is not set. That's on purpose. It's okay if they're
+	// being processed after this, since they only pull data and not create
+	// changesets on the code hosts.
+	q := sqlf.Sprintf(
+		cancelQueuedCampaignChangesetsFmtstr,
+		campaignID,
+		reconcilerMaxNumResets,
+		canceledChangesetFailureMessage,
+		reconcilerMaxNumResets,
+	)
+	return s.Store.Exec(ctx, q)
+}
+
+const cancelQueuedCampaignChangesetsFmtstr = `
+-- source: enterprise/internal/campaigns/store_changesets.go:CancelQueuedCampaignChangesets
+WITH changeset_ids AS (
+  SELECT id FROM changesets
+  WHERE
+    owned_by_campaign_id = %s
+  AND
+    (reconciler_state = 'queued' OR
+	 reconciler_state = 'processing' OR
+	 (reconciler_state = 'errored' AND num_resets < %d))
+  FOR UPDATE
+)
+UPDATE
+  changesets
+SET
+  reconciler_state = 'errored',
+  failure_message = %s,
+  num_resets = %d
+WHERE id IN (SELECT id FROM changeset_ids);
+`
 
 func scanFirstChangeset(rows *sql.Rows, err error) (*campaigns.Changeset, bool, error) {
 	changesets, err := scanChangesets(rows, err)

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -50,13 +50,17 @@ func RunWorkers(
 		OrderByExpression: sqlf.Sprintf("reconciler_state = 'errored', changesets.updated_at DESC"),
 
 		StalledMaxAge: 60 * time.Second,
-		MaxNumResets:  60,
+		MaxNumResets:  reconcilerMaxNumResets,
 		RetryAfter:    5 * time.Second,
 	})
 
 	worker := dbworker.NewWorker(ctx, workerStore, options)
 	worker.Start()
 }
+
+// reconcilerMaxNumResets is the maximum number of attempts the reconciler
+// makes to process a changeset.
+const reconcilerMaxNumResets = 60
 
 func scanFirstChangesetRecord(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	return scanFirstChangeset(rows, err)


### PR DESCRIPTION
This is stacked on top of #13591 and is the next bit needed for #12827.

This implements the behavior described in [this comment][comment]:

- `ApplyCampaign` first loads the spec/campaign from the database and checks whether applying a new spec is possible
- It then cancels all currently enqueued/erorred-but-retryable  changesets so they're not published in the background.
- The cancel *blocks* if there are changesets being processed.

The reason why we wait for the changesets to finish processing is that we have consistent data when we later in `ApplyCampaign` need to, for example, decide whether to close or simply delete a changeset. That depends on the external state of the changeset and we might make a wrong decision if we didn't finish for the changeset to finish processing.

@efritz I didn't see a way to make the "cancel all enqueued/retryable/processing changesets" query work with `skip locked ... returning ID`. If I were to call that in a loop, since I skip the locked ones I wouldn't know when I should exit the loop, since I don't cancel _all_ changesets.

[comment]: https://github.com/sourcegraph/sourcegraph/issues/12827#issuecomment-684936536
