### PR TITLE
trace: Move init body into a function called explicitly

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -37,13 +37,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/processrestart"
 	"github.com/sourcegraph/sourcegraph/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/internal/vfsutil"
 )
 
 var (
-	trace          = env.Get("SRC_LOG_TRACE", "HTTP", "space separated list of trace logs to show. Options: all, HTTP, build, github")
+	traceFields    = env.Get("SRC_LOG_TRACE", "HTTP", "space separated list of trace logs to show. Options: all, HTTP, build, github")
 	traceThreshold = env.Get("SRC_LOG_TRACE_THRESHOLD", "", "show traces that take longer than this")
 
 	printLogo, _ = strconv.ParseBool(env.Get("LOGO", "false", "print Sourcegraph logo upon startup"))
@@ -133,8 +134,9 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 
 	// Filter trace logs
 	d, _ := time.ParseDuration(traceThreshold)
-	logging.Init(logging.Filter(loghandlers.Trace(strings.Fields(trace), d)))
+	logging.Init(logging.Filter(loghandlers.Trace(strings.Fields(traceFields), d)))
 	tracer.Init()
+	trace.Init(true)
 
 	// Run enterprise setup hook
 	enterprise := enterpriseSetupHook()

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
@@ -63,6 +64,7 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	go func() {
 		c := make(chan os.Signal, 1)

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -36,6 +37,7 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	if reposDir == "" {
 		log.Fatal("git-server: SRC_REPOS_DIR is required")

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
@@ -36,6 +37,7 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	go func() {
 		c := make(chan os.Signal, 1)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -46,6 +46,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	clock := func() time.Time { return time.Now().UTC() }
 

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -38,6 +39,7 @@ func main() {
 	log.SetFlags(0)
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	go debugserver.Start()
 

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -42,6 +43,7 @@ func main() {
 	log.SetFlags(0)
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	sqliteutil.MustRegisterSqlite3WithPcre()
 

--- a/enterprise/cmd/precise-code-intel-bundle-manager/main.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/main.go
@@ -29,6 +29,7 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	sqliteutil.MustRegisterSqlite3WithPcre()
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/main.go
@@ -24,7 +24,7 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	logging.Init()
-	//	tracer.Init() // TODO(efritz) - disabled as it requires internal API access
+	trace.Init(false)
 
 	var (
 		frontendURL              = mustGet(rawFrontendURL, "PRECISE_CODE_INTEL_EXTERNAL_URL")

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -31,6 +31,7 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	var (
 		resetInterval                    = mustParseInterval(rawResetInterval, "PRECISE_CODE_INTEL_RESET_INTERVAL")

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -33,6 +33,7 @@ func main() {
 	env.HandleHelpFlag()
 	logging.Init()
 	tracer.Init()
+	trace.Init(true)
 
 	sqliteutil.MustRegisterSqlite3WithPcre()
 

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -54,23 +54,28 @@ var requestHeartbeat = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Last time a request finished for a http endpoint.",
 }, metricLabels)
 
-func init() {
-	if err := raven.SetDSN(os.Getenv("SENTRY_DSN_BACKEND")); err != nil {
-		log15.Error("sentry.dsn", "error", err)
-	}
-
+func Init(shouldInitSentry bool) {
 	if origin := os.Getenv("METRICS_TRACK_ORIGIN"); origin != "" {
 		trackOrigin = origin
+	}
+
+	prometheus.MustRegister(requestDuration)
+	prometheus.MustRegister(requestHeartbeat)
+
+	if shouldInitSentry {
+		initSentry()
+	}
+}
+
+func initSentry() {
+	if err := raven.SetDSN(os.Getenv("SENTRY_DSN_BACKEND")); err != nil {
+		log15.Error("sentry.dsn", "error", err)
 	}
 
 	raven.SetRelease(version.Version())
 	raven.SetTagsContext(map[string]string{
 		"service": filepath.Base(os.Args[0]),
 	})
-
-	prometheus.MustRegister(requestDuration)
-	prometheus.MustRegister(requestHeartbeat)
-
 	go func() {
 		conf.Watch(func() {
 			if conf.Get().Log == nil {


### PR DESCRIPTION
Call `internal/trace.init` explicitly so that we can control whether or not to enable sentry. This is required by the precise-code-intel-indexer-vm, which does not have access to the internal API as it's deployed outside the cluster. Logs are really noisy currently because of this.