### PR TITLE
codecov: disable annotations in PRs

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -40,3 +40,6 @@ ignore:
 flags:
   typescript:
     carryforward: true
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
It is very annoying to see the following annotations when review PRs:

![image](https://user-images.githubusercontent.com/2946214/92061126-12a0ed80-edc8-11ea-925b-7b383cf8c8f5.png)



Refs: https://docs.codecov.io/docs/github-checks-beta