### PR TITLE
golangci: remove misspell

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    - misspell
     - nakedret
     - nolintlint
     - rowserrcheck


### PR DESCRIPTION
I do not know anyone is taking values out of this particular lint rule, but has been annoyed by it quite often. Thus disable it now.