### PR TITLE
gqltestutil: always return external service ID

### DIFF
--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -39,8 +39,9 @@ mutation AddExternalService($input: AddExternalServiceInput!) {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
 
+	// Return the ID along with the warning so we can still clean up properly.
 	if resp.Data.AddExternalService.Warning != "" {
-		return "", errors.New(resp.Data.AddExternalService.Warning)
+		return resp.Data.AddExternalService.ID, errors.New(resp.Data.AddExternalService.Warning)
 	}
 	return resp.Data.AddExternalService.ID, nil
 }


### PR DESCRIPTION
We've hit 3x empty external service ID since [yesterday's attempt to ignore transient repo-updater error](https://github.com/sourcegraph/sourcegraph/pull/13587):
- https://buildkite.com/sourcegraph/sourcegraph/builds/72443#f7a403c6-0222-4320-8f50-fd1d32912dfa
- https://buildkite.com/sourcegraph/sourcegraph/builds/72483#41b2d46d-d732-467d-b2f7-49c349c728e4
- https://buildkite.com/sourcegraph/sourcegraph/builds/72471#83d46bbb-b4aa-476b-bd43-5fa103344ab0

It turns out that the external service ID is not collected correctly, so fixing it.

_Previously sent a PR as `master-dry-run` but one of the other tests had been failed consistently._