### PR TITLE
Use stable IDs in org integration tests

### DIFF
--- a/web/src/integration/org.test.ts
+++ b/web/src/integration/org.test.ts
@@ -60,8 +60,12 @@ describe('Organizations', () => {
                 }),
             }
             testContext.overrideGraphQL(graphQLResults)
+
             await driver.page.goto(driver.sourcegraphBaseUrl + '/site-admin/organizations')
-            await driver.findElementWithText('Create organization', { action: 'click', wait: { timeout: 2000 } })
+
+            await driver.page.waitForSelector('.test-create-org-button')
+            await driver.page.click('.test-create-org-button')
+
             await driver.replaceText({
                 selector: '.test-new-org-name-input',
                 newText: testOrg.name,
@@ -72,7 +76,7 @@ describe('Organizations', () => {
             })
 
             const variables = await testContext.waitForGraphQLRequest(async () => {
-                await driver.findElementWithText('Create organization', { action: 'click' })
+                await driver.page.click('.test-create-org-submit-button')
             }, 'createOrganization')
             assert.deepStrictEqual(variables, {
                 displayName: testOrg.displayName,
@@ -130,7 +134,7 @@ describe('Organizations', () => {
                 })
 
                 const variables = await testContext.waitForGraphQLRequest(async () => {
-                    await driver.findElementWithText('Save changes', { action: 'click' })
+                    await driver.page.click('.test-save-toolbar-save')
                 }, 'OverwriteSettings')
 
                 assert.deepStrictEqual(variables, {

--- a/web/src/org/new/NewOrganizationPage.tsx
+++ b/web/src/org/new/NewOrganizationPage.tsx
@@ -130,7 +130,11 @@ export class NewOrganizationPage extends React.Component<Props, State> {
                         />
                     </div>
 
-                    <button type="submit" className="btn btn-primary" disabled={this.state.loading}>
+                    <button
+                        type="submit"
+                        className="btn btn-primary test-create-org-submit-button"
+                        disabled={this.state.loading}
+                    >
                         Create organization
                     </button>
                     {this.state.loading && <LoadingSpinner className="icon-inline" />}

--- a/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -151,7 +151,7 @@ export class SiteAdminOrgsPage extends React.Component<Props, State> {
                 <PageTitle title="Organizations - Admin" />
                 <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Organizations</h2>
-                    <Link to="/organizations/new" className="btn btn-primary">
+                    <Link to="/organizations/new" className="btn btn-primary test-create-org-button">
                         <AddIcon className="icon-inline" /> Create organization
                     </Link>
                 </div>


### PR DESCRIPTION
Flakiness reported in https://sourcegraph.slack.com/archives/C07KZF47K/p1599087022046000, hope this fixes it. This test was mostly copied from the regression test suite and used `findElementWithText()` which failed in the flaky build. That API is pretty complex so I don't know what's wrong in there,  `waitForSelector()` is reliable and easier to debug.