### PR TITLE
doc: Fix broken codeintel image links

### DIFF
--- a/doc/dev/codeintel/extensions.md
+++ b/doc/dev/codeintel/extensions.md
@@ -10,8 +10,8 @@ Code intelligence queries are resolved favoring [precise](http://localhost:5080/
 
 The definitions provider returns the set of locations that define the symbol at the hover location. This provider supports the `Go to definition` button on the hover tooltip. If there is only one result, the button will act as a link to that location. If there are multiple results, they are shown in a definitions panel at the bottom of the screen.
 
-<a href="/dev/codeintel/diagrams/extension-definitions.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/extension-definitions.svg">
+<a href="diagrams/extension-definitions.svg" target="_blank">
+  <img src="diagrams/extension-definitions.svg">
 </a>
 
 The LSIF provider is invoked first. This provider will make two types of queries:
@@ -27,8 +27,8 @@ If the LSIF provider did not return any results (due to the repository or the ta
 
 The definitions provider returns the set of locations that reference the symbol at the hover location. This provider supports the `Find references` button on the hover tooltip. These results are shown in a references panel at the bottom of the screen.
 
-<a href="/dev/codeintel/diagrams/extension-references.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/extension-references.svg">
+<a href="diagrams/extension-references.svg" target="_blank">
+  <img src="diagrams/extension-references.svg">
 </a>
 
 The LSIF provider is invoked first. This provider will make a paginated `References` query, returning each page of results to the extension host as they are resolved (up to a maximum number of pages).
@@ -39,8 +39,8 @@ This result set is then supplemented by results from the search provider. The se
 
 The definitions provider returns the hover text associated with the symbol at the hover location. This provider populates the text shown in the hover tooltip.
 
-<a href="/dev/codeintel/diagrams/extension-hover.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/extension-hover.svg">
+<a href="diagrams/extension-hover.svg" target="_blank">
+  <img src="diagrams/extension-hover.svg">
 </a>
 
 The LSIF provider is invoked first. This provider will make two types of queries:

--- a/doc/dev/codeintel/queries.md
+++ b/doc/dev/codeintel/queries.md
@@ -9,8 +9,8 @@ Precise code intelligence results are obtained by making [GraphQL requests](http
 
 A definitions request returns the set of locations that define the symbol at a particular location (defined uniquely by a repository, commit, path, line offset, and character offset). The sequence of actions required to resolve a definitions query is shown below (click to enlarge).
 
-<a href="/dev/codeintel/diagrams/definitions.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/definitions.svg">
+<a href="/diagrams/definitions.svg" target="_blank">
+  <img src="/diagrams/definitions.svg">
 </a>
 
 First, the repository, commit, and path inputs are used to determine the set of LSIF uploads that can answer queries for that data. Such an upload may have been indexed on another commit. In this case, the output of `git diff` between the two commits is used to adjust the input path and line number.
@@ -31,8 +31,8 @@ Finally, if the resulting locations were provided by an upload that was indexed 
 
 A references request returns the set of locations that reference the symbol at a particular location (defined uniquely by a repository, commit, path, line offset, and character offset). Unlike the set of definitions, which should generally have only member, the set of references can unbounded for popular repositories. The resolution of references is therefore done in chunks, allowing the user to request reference results page-by-page. The sequence of actions required to resolve a references query is shown below (click to enlarge).
 
-<a href="/dev/codeintel/diagrams/references.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/references.svg">
+<a href="diagrams/references.svg" target="_blank">
+  <img src="diagrams/references.svg">
 </a>
 
 First, the repository, commit, and path inputs are used to determine the set of LSIF uploads that can answer queries for that data. Such an upload may have been indexed on another commit. In this case, the output of `git diff` between the two commits is used to adjust the input path and line number.
@@ -47,8 +47,8 @@ Finally, if the resulting locations were provided by an upload that was indexed 
 
 The sequence of actions required to resolve a page of references given a cursor is shown below (click to enlarge).
 
-<a href="/dev/codeintel/diagrams/resolve-page.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/resolve-page.svg">
+<a href="diagrams/resolve-page.svg" target="_blank">
+  <img src="diagrams/resolve-page.svg">
 </a>
 
 The cursor can be in one of five _phases_, ordered as follows. Each phase handles a distinct segment of the result set. A phase may return no results, or it may return multiple pages worth of results. In the later case, the cursor encodes sufficient information (e.g. number of uploads, references previously returned in the phase) to be able to skip duplicate results.
@@ -72,8 +72,8 @@ The cursor can be in one of five _phases_, ordered as follows. Each phase handle
 
 A hover request returns the hover text associated with the symbol at a particular location (defined uniquely by a repository, commit, path, line offset, and character offset), as well as the range of the hovered symbol. The sequence of actions required to resolve a hover query is shown below (click to enlarge).
 
-<a href="/dev/codeintel/diagrams/hover.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/hover.svg">
+<a href="diagrams/hover.svg" target="_blank">
+  <img src="diagrams/hover.svg">
 </a>
 
 First, the repository, commit, and path inputs are used to determine the set of LSIF uploads that can answer queries for that data. Such an upload may have been indexed on another commit. In this case, the output of `git diff` between the two commits is used to adjust the input path and line number.

--- a/doc/dev/codeintel/queries.md
+++ b/doc/dev/codeintel/queries.md
@@ -9,8 +9,8 @@ Precise code intelligence results are obtained by making [GraphQL requests](http
 
 A definitions request returns the set of locations that define the symbol at a particular location (defined uniquely by a repository, commit, path, line offset, and character offset). The sequence of actions required to resolve a definitions query is shown below (click to enlarge).
 
-<a href="/diagrams/definitions.svg" target="_blank">
-  <img src="/diagrams/definitions.svg">
+<a href="diagrams/definitions.svg" target="_blank">
+  <img src="diagrams/definitions.svg">
 </a>
 
 First, the repository, commit, and path inputs are used to determine the set of LSIF uploads that can answer queries for that data. Such an upload may have been indexed on another commit. In this case, the output of `git diff` between the two commits is used to adjust the input path and line number.

--- a/doc/dev/codeintel/uploads.md
+++ b/doc/dev/codeintel/uploads.md
@@ -4,8 +4,8 @@ An LSIF indexer produces a file containing the definition, reference, hover, and
 
 The sequence of actions required to to upload and convert this data is shown below (click to enlarge).
 
-<a href="/dev/codeintel/diagrams/upload.svg" target="_blank">
-  <img src="/dev/codeintel/diagrams/upload.svg">
+<a href="diagrams/upload.svg" target="_blank">
+  <img src="diagrams/upload.svg">
 </a>
 
 ## Uploading


### PR DESCRIPTION
I _think_ this should work.

The architecture diagram uses a relative path instead of an absolute one, so switching to that style may fix the broken links after we've introduced multiple versions to the public docsite.