### PR TITLE
codeintel: Configure indexer registry mirror

### DIFF
--- a/docker-images/ignite-ubuntu/Dockerfile
+++ b/docker-images/ignite-ubuntu/Dockerfile
@@ -6,3 +6,5 @@ RUN set -ex && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     docker.io
+
+RUN mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["http://registry:5000" ]}' >/etc/docker/daemon.json

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -71,6 +71,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 		args := []string{
 			"ignite", "run",
 			"--runtime", "docker",
+			"--network-plugin", "docker-bridge",
 			"--cpus", fmt.Sprintf("%d", h.options.FirecrackerNumCPUs),
 			"--memory", h.options.FirecrackerMemory,
 			"--copy-files", fmt.Sprintf("%s:%s", repoDir, mountPoint),
@@ -85,6 +86,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 			stopArgs := []string{
 				"ignite", "stop",
 				"--runtime", "docker",
+				"--network-plugin", "docker-bridge",
 				name.String(),
 			}
 			if err := h.commander.Run(ctx, stopArgs[0], stopArgs[1:]...); err != nil {
@@ -94,6 +96,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 			removeArgs := []string{
 				"ignite", "rm", "-f",
 				"--runtime", "docker",
+				"--network-plugin", "docker-bridge",
 				name.String(),
 			}
 			if err := h.commander.Run(ctx, removeArgs[0], removeArgs[1:]...); err != nil {

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -107,11 +107,11 @@ func TestHandleWithFirecracker(t *testing.T) {
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
-			"ignite run --runtime docker --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data sourcegraph/lsif-go:latest lsif-go --noProgress",
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -no-progress -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
-			"ignite stop --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
-			"ignite rm -f --runtime docker 97b45daf-53d1-48ad-b992-547469d8e438",
+			"ignite stop --runtime docker --network-plugin docker-bridge 97b45daf-53d1-48ad-b992-547469d8e438",
+			"ignite rm -f --runtime docker --network-plugin docker-bridge 97b45daf-53d1-48ad-b992-547469d8e438",
 		}
 
 		calls := commander.RunFunc.History()


### PR DESCRIPTION
https://github.com/sourcegraph/infrastructure/pull/2117 introduces a local docker registry cache on the indexer machine. This modifies the VM base image to mirror that registry so that we do not need to fetch from the public hub several times on every index job.