### PR TITLE
Do not change working directory in ./enterprise/dev/start.sh

### DIFF
--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 set -euf -o pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
-DEV_PRIVATE_PATH=$PWD/../../dev-private
+DEV_PRIVATE_PATH=$PWD/../dev-private
 
 if [ ! -d "$DEV_PRIVATE_PATH" ]; then
   echo "Expected to find github.com/sourcegraph/dev-private checked out to $DEV_PRIVATE_PATH, but path wasn't a directory" 1>&2
@@ -28,7 +27,7 @@ source "$DEV_PRIVATE_PATH/enterprise/dev/env"
 if [ -z "${DEV_NO_CONFIG-}" ]; then
   export SITE_CONFIG_FILE=${SITE_CONFIG_FILE:-$DEV_PRIVATE_PATH/enterprise/dev/site-config.json}
   export EXTSVC_CONFIG_FILE=${EXTSVC_CONFIG_FILE:-$DEV_PRIVATE_PATH/enterprise/dev/external-services-config.json}
-  export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-$PWD/../dev/global-settings.json}
+  export GLOBAL_SETTINGS_FILE=${GLOBAL_SETTINGS_FILE:-$PWD/dev/global-settings.json}
   export SITE_CONFIG_ALLOW_EDITS=true
   export GLOBAL_SETTINGS_ALLOW_EDITS=true
   export EXTSVC_CONFIG_ALLOW_EDITS=true
@@ -51,4 +50,4 @@ export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code
 export ENTERPRISE_COMMANDS="frontend repo-updater ${ENTERPRISE_ONLY_COMMANDS}"
 export ENTERPRISE=1
 export PROCFILE=enterprise/dev/Procfile
-../dev/start.sh "$@"
+./dev/start.sh "$@"


### PR DESCRIPTION
This has tripped me up so many times when I launch a new terminal in
tmux from window where `./enterprise/dev/start.sh` is running: the
working directory is `./enterprise`.

Since `./dev/start.sh` doesn't change the working directory, I don't see
why this should.
