### PR TITLE
Update campaign docs to include examples and YAML reference

### DIFF
--- a/doc/user/campaigns/campaign_spec_yaml_reference.md
+++ b/doc/user/campaigns/campaign_spec_yaml_reference.md
@@ -31,13 +31,14 @@ description: This campaign changes all `fmt.Sprintf` calls to `strconv.Iota`.
 ```
 
 ```yaml
-description: "This campaign changes all imports from
-
-`gopkg.in/sourcegraph/sourcegraph-in-x86-asm`
-
-to
-
-`github.com/sourcegraph/sourcegraph-in-x86-asm`"
+description: |
+  This campaign changes all imports from
+  
+  `gopkg.in/sourcegraph/sourcegraph-in-x86-asm`
+  
+  to
+  
+  `github.com/sourcegraph/sourcegraph-in-x86-asm`
 ```
 
 ## [`on`](#on)

--- a/doc/user/campaigns/campaign_spec_yaml_reference.md
+++ b/doc/user/campaigns/campaign_spec_yaml_reference.md
@@ -1,0 +1,224 @@
+# Campaign spec YAML reference
+
+<style>.markdown-body h2 { margin-top: 50px; }</style>
+
+[Sourcegraph campaigns](../index.md) use [campaign specs](../index.md#campaign-specs) to define campaigns.
+
+This page is a reference guide to the campaign spec YAML format in which campaign specs are defined. If you're new to YAML and want a short introduction, see "[Learn YAML in five minutes](https://learnxinyminutes.com/docs/yaml/)."
+
+## [`name`](#name)
+
+The name of the campaign, which is unique among all campaigns in the namespace. A campaign's name is case-preserving.
+
+### Examples
+
+```yaml
+name: update-go-import-statements
+```
+
+```yaml
+name: update-node.js
+```
+
+## [`description`](#description)
+
+The description of the campaign. It's rendered as Markdown.
+
+### Examples
+
+```yaml
+description: This campaign changes all `fmt.Sprintf` calls to `strconv.Iota`.
+```
+
+```yaml
+description: "This campaign changes all imports from
+
+`gopkg.in/sourcegraph/sourcegraph-in-x86-asm`
+
+to
+
+`github.com/sourcegraph/sourcegraph-in-x86-asm`"
+```
+
+## [`on`](#on)
+
+The set of repositories (and branches) to run the campaign on, specified as a list of search queries (that match repositories) and/or specific repositories.
+
+### Examples
+
+```yaml
+on:
+  - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural
+  - repository: github.com/sourcegraph/sourcegraph
+```
+
+## [`on.repositoriesMatchingQuery`](#on-repositoriesMatchingQuery)
+
+A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the campaign will be run on.
+
+See "[Code search](../search/index.md)" for more information on Sourcegraph search queries.
+
+### Examples
+
+```yaml
+on:
+  - repositoriesMatchingQuery: file:README.md -repo:github.com/sourcegraph/src-cli
+```
+
+```yaml
+on:
+  - repositoriesMatchingQuery: lang:typescript file:web const changesetStatsFragment
+```
+
+## [`on.repository`](#on-repository)
+
+A specific repository (and branch) that is added to the list of repositories that the campaign will be run on.
+
+A `branch` attribute specifies the branch on the repository to propose changes to. If unset, the repository's default branch is used.
+
+### Examples
+
+```yaml
+on:
+  - repository: github.com/sourcegraph/src-cli
+```
+
+```yaml
+on:
+  - repository: github.com/sourcegraph/sourcegraph
+    branch: 3.19-beta
+  - repository: github.com/sourcegraph/src-cli
+```
+
+## [`steps`](#steps)
+
+The sequence of commands to run (for each repository branch matched in the `on` property) to produce the campaign's changes.
+
+### Examples
+
+```yaml
+steps:
+  - run: echo "Hello World!" >> README.md
+    container: alpine:3
+```
+
+```yaml
+steps:
+  - run: comby -in-place 'fmt.Sprintf("%d", :[v])' 'strconv.Itoa(:[v])' .go -matcher .go -exclude-dir .,vendor
+    container: comby/comby
+  - run: gofmt -w ./
+    container: golang:1.15-alpine
+```
+
+```yaml
+steps:
+  - run: ./update_dependency.sh
+    container: our-custom-image
+    env:
+      OLD_VERSION: 1.31.7
+      NEW_VERSION: 1.33.0
+```
+
+## [`steps.run`](#steps-run)
+
+The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.
+
+## [`steps.container`](#steps-run)
+
+The Docker image used to launch the Docker container in which the shell command is run.
+
+The image has to have either the `/bin/sh` or the `/bin/bash` shell.
+
+It is executed using `docker` on the machine on which the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) is executed. If the image exists locally, that is used. Otherwise it's pulled using `docker pull`.
+
+## [`steps.env`](#steps-env)
+
+Environment variables to set in the environment when running this command.
+
+## [`importChangesets`](#importChangesets)
+
+An array describing which already-existing changesets should be imported from the code host into the campaign.
+
+### Examples
+
+```yaml
+importChangesets:
+  - repository: github.com/sourcegraph/sourcegraph
+    externalIDs: [13323, "13343", 13342, 13380]
+  - repository: github.com/sourcegraph/src-cli
+    externalIDs: [260, 271]
+```
+
+## [`importChangesets.repository`](#importChangesets-repository)
+
+The repository name as configured on your Sourcegraph instance.
+
+## [`importChangesets.externalIDs`](#importChangesets-externalIDs)
+
+The changesets to import from the code host. For GitHub this is the pull request number, for GitLab this is the merge request number, for Bitbucket Server this is the pull request number.
+
+## [`changesetTemplate`](#changesetTemplate)
+
+A template describing how to create (and update) changesets with the file changes produced by the command steps.
+
+This defines what the changesets on the code hosts (pull requests on GitHub, merge requests on Gitlab, ...) will look like.
+
+### Examples
+
+```yaml
+changesetTemplate:
+  title: Replace equivalent fmt.Sprintf calls with strconv.Itoa
+  body: This campaign replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls
+  branch: campaigns/sprintf-to-itoa
+  commit:
+    message: Replacing fmt.Sprintf with strconv.Iota
+  published: false
+```
+
+```yaml
+changesetTemplate:
+  title: Update rxjs in package.json to newest version
+  body: This pull request updates rxjs to the newest version, `6.6.2`.
+  branch: campaigns/update-rxjs
+  commit:
+    message: Update rxjs to 6.6.2
+  published: false
+```
+
+```yaml
+changesetTemplate:
+  title: Run go fmt over all Go files
+  body: Regular `go fmt` run over all our Go files.
+  branch: go-fmt
+  commit:
+    message: Run go fmt
+  published: true
+```
+
+## [`changesetTemplate.title`](#changesetTemplate-title)
+
+The title of the changeset on the code host.
+
+## [`changesetTemplate.body`](#changesetTemplate-body)
+
+The body (description) of the changeset on the code host. If the code supports Markdown you can use it here.
+
+## [`changesetTemplate.branch`](#changesetTemplate-branch)
+
+The name of the Git branch to create or update on each repository with the changes.
+
+## [`changesetTemplate.commit`](#changesetTemplate-commit)
+
+The Git commit to create with the changes.
+
+## [`changesetTemplate.commit.message`](#changesetTemplate-commit-message)
+
+The Git commit message.
+
+## [`changesetTemplate.published`](#changesetTemplate-published)
+
+Whether to publish the changeset.
+
+An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host.
+
+A published changeset results in a commit, branch, and pull request being created on the code host.

--- a/doc/user/campaigns/examples/index.md
+++ b/doc/user/campaigns/examples/index.md
@@ -1,0 +1,6 @@
+# Example Campaigns
+
+The following is a list of examples that show how to use [Sourcegraph campaigns](../index.md) to make useful, real-world changes:
+
+- [Refactoring Go code using Comby](refactor_go_comby.md)
+- [Updating Go import statements using Comby](updating_go_import_statements.md)

--- a/doc/user/campaigns/examples/refactor_go_comby.md
+++ b/doc/user/campaigns/examples/refactor_go_comby.md
@@ -47,7 +47,7 @@ changesetTemplate:
 1. Save the campaign spec above as `YOUR_CAMPAIGN_SPEC.campaign.yaml`.
 1. Create a campaign from the campaign spec by running the following [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command:
 
-    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -namespace USERNAME_OR_ORG</code></pre>
 
 1. Open the preview URL that the command printed out.
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.

--- a/doc/user/campaigns/examples/refactor_go_comby.md
+++ b/doc/user/campaigns/examples/refactor_go_comby.md
@@ -1,0 +1,54 @@
+# Refactor Go code using Comby
+
+This campaign rewrites Go statements from
+
+```go
+fmt.Sprintf("%d", number)
+```
+
+to
+
+```go
+strconv.Itoa(number)
+```
+
+since they are equivalent.
+
+Since the replacements could change the formatting of the code, it also runs `gofmt` over the repository.
+
+## Campaign spec
+
+```yaml
+name: sprintf-to-itoa
+description: Run `comby` to replace `fmt.Sprintf("%d", integer)` calls with `strconv.Iota`
+
+# Find all repositories that contain the `fmt.Sprintf` statement using structural search
+on:
+  - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural
+
+steps:
+  - run: comby -in-place 'fmt.Sprintf("%d", :[v])' 'strconv.Itoa(:[v])' .go -matcher .go -exclude-dir .,vendor
+    container: comby/comby
+  - run: gofmt -w ./
+    container: golang:1.15-alpine
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Replace equivalent fmt.Sprintf calls with strconv.Itoa
+  body: This campaign replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls
+  branch: campaigns/sprintf-to-itoa # Push the commit to this branch.
+  commit:
+    message: Replacing fmt.Sprintf with strconv.Iota
+  published: false
+```
+
+## Instructions
+
+1. Save the campaign spec above as `YOUR_CAMPAIGN_SPEC.campaign.yaml`.
+1. Create a campaign from the campaign spec by running the following [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command:
+
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+
+1. Open the preview URL that the command printed out.
+1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.
+1. Click the **Create campaign** button.

--- a/doc/user/campaigns/examples/updating_go_import_statements.md
+++ b/doc/user/campaigns/examples/updating_go_import_statements.md
@@ -53,7 +53,7 @@ changesetTemplate:
 1. Save the campaign spec above as `YOUR_CAMPAIGN_SPEC.campaign.yaml`.
 1. Create a campaign from the campaign spec by running the following [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command:
 
-    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -namespace USERNAME_OR_ORG</code></pre>
 
 1. Open the preview URL that the command printed out.
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.

--- a/doc/user/campaigns/examples/updating_go_import_statements.md
+++ b/doc/user/campaigns/examples/updating_go_import_statements.md
@@ -1,0 +1,60 @@
+# Updating Go import statements using Comby
+
+This campaign rewrites Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/).
+
+It can handle single-package import statements like these
+
+```go
+import "gopkg.in/inconshreveable/log15.v2"
+```
+
+and multi-package import statements like these:
+
+```go
+import (
+	"io"
+
+	"github.com/pkg/errors"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+```
+
+## Campaign spec
+
+```yaml
+name: update-log15-import
+description: This campaign updates Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/)
+
+# Find all repositories that contain the import we want to change.
+on:
+  - repositoriesMatchingQuery: lang:go gopkg.in/inconshreveable/log15.v2
+
+# In each repository
+steps:
+  # we first replace the import when it's part of a multi-package import statement
+  - run: comby -in-place 'import (:[before]"gopkg.in/inconshreveable/log15.v2":[after])' 'import (:[before]"github.com/inconshreveable/log15":[after])' .go -matcher .go -exclude-dir .,vendor
+    container: comby/comby
+  # ... and when it's a single import line.
+  - run: comby -in-place 'import "gopkg.in/inconshreveable/log15.v2"' 'import "github.com/inconshreveable/log15"' .go -matcher .go -exclude-dir .,vendor
+    container: comby/comby
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Update import path for log15 package to use GitHub
+  body: Updates Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/)
+  branch: campaigns/update-log15-import # Push the commit to this branch.
+  commit:
+    message: Fix import path for log15 package
+  published: false
+```
+
+## Instructions
+
+1. Save the campaign spec above as `YOUR_CAMPAIGN_SPEC.campaign.yaml`.
+1. Create a campaign from the campaign spec by running the following [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command:
+
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+
+1. Open the preview URL that the command printed out.
+1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.
+1. Click the **Create campaign** button.

--- a/doc/user/campaigns/hello_world_campaign.md
+++ b/doc/user/campaigns/hello_world_campaign.md
@@ -64,7 +64,7 @@ Let's see the changes that will be made. Don't worry---no commits, branches, or 
 
     <pre><code>src campaign preview -f hello-world.campaign.yaml -namespace <em>USERNAME_OR_ORG</em></code></pre>
 
-    > The `namespace` can be your Sourcegraph user name or the name of an organisation on Sourcegraph under which you want to create the campaign.
+    > The `namespace` can be your Sourcegraph username or the name of a Sourcegraph organisation under which you want to create the campaign.
 1. Wait for it to run and compute the changes for each repository.
 1. When it's done, click the displayed link to see all of the changes that will be made.
 1. Make sure the changes look right.

--- a/doc/user/campaigns/hello_world_campaign.md
+++ b/doc/user/campaigns/hello_world_campaign.md
@@ -62,7 +62,9 @@ Let's see the changes that will be made. Don't worry---no commits, branches, or 
 
 1. In your terminal, run this command:
 
-    <pre><code>src campaign preview -f hello-world.campaign.yaml</code></pre>
+    <pre><code>src campaign preview -f hello-world.campaign.yaml -namespace <em>USERNAME_OR_ORG</em></code></pre>
+
+    > The `namespace` can be your Sourcegraph user name or the name of an organisation on Sourcegraph under which you want to create the campaign.
 1. Wait for it to run and compute the changes for each repository.
 1. When it's done, click the displayed link to see all of the changes that will be made.
 1. Make sure the changes look right.
@@ -76,12 +78,14 @@ You created your first campaign! The campaign's changesets are still unpublished
 
 Publishing causes commits, branches, and changesets to be created on your code host.
 
-You probably don't want to publish these toy "Hello World" changesets to actively developed repositories, because that might confuse people ("Why did you add this line to our READMEs?"). On a real campaign, you would click the **Publish** button next to a changeset to publish it (or the **Publish all** button to publish all changesets).
+You probably don't want to publish these toy "Hello World" changesets to actively developed repositories, because that might confuse people ("Why did you add this line to our READMEs?").
+
+On a real campaign, you would change the `published: false` in the `hello-world.campaign.yaml` to `published: true` and run the `src campaign preview` command again.
 
 ## Congratulations!
 
 You've created your first campaign! 🎉🎉
 
-You can customize your campaign spec and experiment with making other types of changes. To update your campaign, edit `hello-world.campaign.yaml` and run `src campaign preview -f hello-world.campaign.yaml` again. (As before, you'll see a preview before any changes are applied.)
+You can customize your campaign spec and experiment with making other types of changes. To update your campaign, edit `hello-world.campaign.yaml` and run `src campaign preview` again. (As before, you'll see a preview before any changes are applied.)
 
 To learn what else you can do with campaigns, see "[Campaigns](index.md)" in Sourcegraph documentation.

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -39,7 +39,7 @@ Use the filters to switch between showing all campaigns, open campaigns, or clos
 
 If you lack read access to a repository in a campaign, you can only see [limited information about the changes to that repository](managing_access.md#repository-permissions-for-campaigns).
 
-### Campaign specs
+## Campaign specs
 
 You can create or update a campaign from a campaign spec, which is a YAML file that defines a campaign. You then use the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) to apply the campaign spec.
 
@@ -50,8 +50,7 @@ For more information, see:
 - [Creating a campaign](#creating-a-campaign)
 - [Updating a campaign](#creating-a-campaign)
 - [Example campaign specs](examples.md)
-
-<!-- - TODO(sqs) <u>Campaign spec YAML reference</u> -->
+- [Campaign spec YAML reference](campaign_spec_yaml_reference.md)
 
 ## Creating a campaign
 

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -48,7 +48,7 @@ See the [Creating a campaign](#creating-a-campaign) section for an example campa
 For more information, see:
 
 - [Creating a campaign](#creating-a-campaign)
-- [Updating a campaign](#creating-a-campaign)
+- [Updating a campaign](#updating-a-campaign)
 - [Example campaign specs](examples.md)
 - [Campaign spec YAML reference](campaign_spec_yaml_reference.md)
 
@@ -85,9 +85,11 @@ changesetTemplate:
 
 1. Get started by running the following [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command:
 
-    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -namespace <em>USERNAME_OR_ORG</em></code></pre>
 
     > **Don't worry!** Before any branches are pushed or changesets (e.g., GitHub pull requests) are created, you will see a preview of all changes and can confirm each one before proceeding.
+
+    The `namespace` can be your Sourcegraph user name or the name of an organisation on Sourcegraph under which you want to create the camapign.
 
 1. Wait for it to run and compute the changes for each repository (using the repositories and commands in the campaign spec).
 1. Open the preview URL that the command printed out.
@@ -164,7 +166,7 @@ To update a campaign, you need [admin access to the campaign](managing_access.md
 1. Update the [campaign spec](#campaign-specs) to include the changes you want to make to the campaign. For example, change the `description` of the campaign or change the commit message in the `changesetTemplate`.
 1. In your terminal, run the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command shown. The command will execute your campaign spec to generate changes and then upload them to the campaign for you to preview and accept.
 
-    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -namespace USERNAME_OR_ORG</code></pre>
 
     > **Don't worry!** Before any branches or changesets are modified, you will see a preview of all changes and can confirm before proceeding.
 
@@ -173,6 +175,9 @@ To update a campaign, you need [admin access to the campaign](managing_access.md
 1. Click the **Update campaign** button.
 
 All of the changesets on your code host will be updated to the desired state that was shown in the preview.
+
+> NOTE: If you are sure about the changes you want to make and don't need to preview them, you can run `src campaign apply` to apply the campaign spec directly:
+> <pre><code>src campaign apply -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -namespace USERNAME_OR_ORG</code></pre>
 
 ## Tracking existing changesets
 
@@ -195,7 +200,7 @@ importChangesets:
 
 1. Create a campaign from the campaign spec by running the following [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command:
 
-    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+    <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em> -namespace USERNAME_OR_ORG</code></pre>
 
 1. Open the preview URL that the command printed out.
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -41,9 +41,15 @@ If you lack read access to a repository in a campaign, you can only see [limited
 
 ### Campaign specs
 
-You can create or update a campaign from a campaign spec, which is a YAML file that defines a campaign.
+You can create or update a campaign from a campaign spec, which is a YAML file that defines a campaign. You then use the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) to apply the campaign spec.
 
 See the [Creating a campaign](#creating-a-campaign) section for an example campaign spec YAML file.
+
+For more information, see:
+
+- [Creating a campaign](#creating-a-campaign)
+- [Updating a campaign](#creating-a-campaign)
+- [Example campaign specs](examples.md)
 
 <!-- - TODO(sqs) <u>Campaign spec YAML reference</u> -->
 
@@ -97,6 +103,13 @@ If a person viewing the campaign lacks read access to a repository in the campai
 
 You can update a campaign's changes at any time, even after you've published changesets. For more information, see [Updating a campaign](#updating-a-campaign).
 
+### Example campaigns
+
+The [example campaigns](examples/index.md) show how to use campaigns to make useful, real-world changes:
+
+- [Refactoring Go code using Comby](examples/refactor_go_comby.md)
+- [Updating Go import statements using Comby](examples/updating_go_import_statements.md)
+
 ## Publishing changesets to the code host
 
 After you've added patches, you can see a preview of the changesets (e.g., GitHub pull requests) that will be created from the patches. Publishing the changesets will, for each repository:
@@ -145,12 +158,11 @@ If you lack read access to a repository, you can only see [limited information a
 
 ## Updating a campaign
 
-<!-- TODO(sqs): needs wireframes/mocks -->
-
 You can edit a campaign's name, description, and any other part of its campaign spec at any time.
 
 To update a campaign, you need [admin access to the campaign](managing_access.md#campaign-access-for-each-permission-level), and [write access to all affected repositories](managing_access.md#repository-permissions-for-campaigns) with published changesets.
 
+1. Update the [campaign spec](#campaign-specs) to include the changes you want to make to the campaign. For example, change the `description` of the campaign or change the commit message in the `changesetTemplate`.
 1. In your terminal, run the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command shown. The command will execute your campaign spec to generate changes and then upload them to the campaign for you to preview and accept.
 
     <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
@@ -201,10 +213,10 @@ Any person with [admin access to the campaign](managing_access.md#permission-lev
 1. Click the <img src="campaigns-icon.svg" alt="Campaigns icon" /> campaigns icon in the top navigation bar.
 1. In the list of campaigns, click the campaign that you'd like to close or delete.
 1. In the top right, click the **Close** button.
-1. Select whether you want to close all of the campaign's changesets (e.g., closing all associated GitHub pull requests on the code host).
+1. Select whether you want to close all of the campaign's open changesets (e.g., closing all associated GitHub pull requests on the code host).
 1. Click **Close campaign**.
 
-## [Managing access to campaigns]
+## Managing access to campaigns
 
 See [Managing access to campaigns](managing_access.md).
 
@@ -238,9 +250,9 @@ To learn about the internals of campaigns, see [Campaigns](../../dev/campaigns_d
 
 ### Known issues
 
-<!-- TODO(sqs): This section is rough/incomplete/outline-only. -->
-
 - Campaigns currently support **GitHub**, **GitLab** and **Bitbucket Server** repositories. If you're interested in using campaigns on other code hosts, [let us know](https://about.sourcegraph.com/contact).
 - It is not yet possible for a campaign to create multiple changesets in a single repository (e.g., to make changes to multiple subtrees in a monorepo).
 - Forking a repository and creating a pull request on the fork is not yet supported. Because of this limitation, you need write access to each repository that your campaign will change (in order to push a branch to it).
 - Campaign steps are run locally (in the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli)). Sourcegraph does not yet support executing campaign steps (which can be arbitrary commands) on the server. For this reason, the APIs for creating and updating a campaign require you to upload all of the changeset specs (which are produced by executing the campaign spec locally). {#server-execution}
+- It is not yet possible for multiple users to edit the same campaign that was created under an organization.
+- It is currently not yet possible to reuse a branch in a repository across multiple campaigns.

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -208,6 +208,8 @@ importChangesets:
 
 You'll see the existing changeset in the list. The campaign will track the changeset's status and include it in the overall campaign progress (in the same way as if it had been created by the campaign). For more information, see [Tracking campaign progress and changeset statuses](#tracking-campaign-progress-and-changeset-statuses).
 
+> NOTE: You can combine the tracking of existing changesets and creating new ones by adding `importChangesets:` to your campaign specs that have `on:`, `steps:` and `changesetTemplate:` properties.
+
 ## Closing or deleting a campaign
 
 You can close a campaign when you don't need it anymore, when all changes have been merged, or when you decide not to proceed with making changes. A closed campaign still appears in the [campaigns list](#viewing-campaigns). To completely remove it, you can delete the campaign.

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -89,7 +89,7 @@ changesetTemplate:
 
     > **Don't worry!** Before any branches are pushed or changesets (e.g., GitHub pull requests) are created, you will see a preview of all changes and can confirm each one before proceeding.
 
-    The `namespace` can be your Sourcegraph user name or the name of an organisation on Sourcegraph under which you want to create the camapign.
+    The `namespace` can be your Sourcegraph username or the name of a Sourcegraph organisation under which you want to create the camapign.
 
 1. Wait for it to run and compute the changes for each repository (using the repositories and commands in the campaign spec).
 1. Open the preview URL that the command printed out.

--- a/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -29,7 +29,7 @@ changesetTemplate:
 const helloWorldDownloadUrl = 'data:text/plain;charset=utf-8,' + encodeURIComponent(campaignSpec)
 
 const sourcePreviewCommand =
-    'src campaign preview -f hello-world.campaign.yaml -namespace <sourcegraph-user-name-or-organisation>'
+    'src campaign preview -f hello-world.campaign.yaml -namespace sourcegraph-username-or-organisation'
 
 export interface CreateCampaignPageProps extends BreadcrumbSetters {
     // Nothing for now, but using it so once this changes we get type errors in the routing files.

--- a/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -28,7 +28,8 @@ changesetTemplate:
 
 const helloWorldDownloadUrl = 'data:text/plain;charset=utf-8,' + encodeURIComponent(campaignSpec)
 
-const sourcePreviewCommand = 'src campaign preview -f hello-world.campaign.yaml'
+const sourcePreviewCommand =
+    'src campaign preview -f hello-world.campaign.yaml -namespace <sourcegraph-user-name-or-organisation>'
 
 export interface CreateCampaignPageProps extends BreadcrumbSetters {
     // Nothing for now, but using it so once this changes we get type errors in the routing files.


### PR DESCRIPTION
This adds back the examples we previously had, adopted to the new campaign specs.

Where and how the examples are referenced follows what was proposed in https://github.com/sourcegraph/sourcegraph/pull/10921 but temporarily removed.

Edit:

It also does a bunch of other things, like making the wording clearer, etc.
