### PR TITLE
chore: add debugging log to renovate-downstream

### DIFF
--- a/.github/workflows/renovate-downstream.yml
+++ b/.github/workflows/renovate-downstream.yml
@@ -4,11 +4,19 @@ on:
     types: [ completed ]
 
 jobs:
+  report-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output event
+        run: |
+          echo ${{ github.ref }}
+          echo ${{ toJson(github.event) }}
+
   # This job should trigger rennovate to run on the repositories defined in renovate-downstream.json
   renovate:
     runs-on: ubuntu-latest
     # Run on buildkite success on branch main
-    if: github.ref == 'refs/heads/main' && github.event.name == 'buildkite/sourcegraph' && github.event.conclusion == 'success'
+    if: ${{ github.ref == 'refs/heads/main' && github.event.name == 'buildkite/sourcegraph' && github.event.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
all the renovate-downstream jobs are just marked as "cancelled" now, but there doesn't seem to be a way to see why :( this PR adds a debug job for outputting metadata about the event

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
