### PR TITLE
repos: remove Cloned as criteria for modified

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -402,7 +402,7 @@ func (d Diff) Repos() Repos {
 
 // NewDiff returns a diff from the given sourced and stored repos.
 func NewDiff(sourced, stored []*Repo) (diff Diff) {
-	// Sort sourced so we merge determinstically
+	// Sort sourced so we merge deterministically
 	sort.Sort(Repos(sourced))
 
 	byID := make(map[api.ExternalRepoSpec]*Repo, len(sourced))

--- a/cmd/repo-updater/repos/types.go
+++ b/cmd/repo-updater/repos/types.go
@@ -13,6 +13,8 @@ import (
 	"github.com/goware/urlx"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -25,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"github.com/xeipuuv/gojsonschema"
 )
 
 // A Changeset of an existing Repo.
@@ -663,10 +664,6 @@ func (r *Repo) Update(n *Repo) (modified bool) {
 
 	if r.Archived != n.Archived {
 		r.Archived, modified = n.Archived, true
-	}
-
-	if r.Cloned != n.Cloned {
-		r.Cloned, modified = n.Cloned, true
 	}
 
 	if r.Fork != n.Fork {


### PR DESCRIPTION
`Cloned` has been ineffective since it's addition because implementations of `repos.Source` interface would never set `Cloned` field to true because they're only responsible for getting information from code hosts, and "has it been cloned" is our internal state.