### PR TITLE
conf: watch for changes in config override files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The site configuration `search.limits`. This allows configuring the maximum timeout (defaults to 1 minute). Also allows configuring the maximum repositories to search in different scenarios. [#13448](https://github.com/sourcegraph/sourcegraph/pull/13448)
+- Sourcegraph watches the [advanced config files](https://docs.sourcegraph.com/admin/config/advanced_config_file) and automatically applies the changes to Sourcegraph's configuration when they change. For example this allows Sourcegraph to notice when Kubernetes updates ConfigMap for the configuration. [#13646](https://github.com/sourcegraph/sourcegraph/pull/13646)
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/felixge/fgprof v0.9.0
 	github.com/felixge/httpsnoop v1.0.1
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gchaincl/sqlhooks v1.3.0
 	github.com/getsentry/raven-go v0.2.0
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
The main reason for doing this is for allowing frontend to update the
configuration when kubernetes updates configuration files (from the
configmap mounts). Before this change we required restarting frontend
when pushing new configuration changes.