### PR TITLE
Make clear the campaign name cannot be changed using the update path

### DIFF
--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -160,7 +160,7 @@ If you lack read access to a repository, you can only see [limited information a
 ## Updating a campaign
 
 Campaigns are identified by their name. It must be unique within a single namespace (your user account on Sourcegraph, or an organization you are a member of).
-Updating a campaign works by targetting an **existing** campaign in the namespace by specifying the name in the spec. If the name matches an existing campaign, it will update the campaign.
+Updating a campaign works by targetting an **existing** campaign in the namespace by specifying the name in the spec. If the name matches an existing campaign, it will update the campaign. (Otherwise, a new campaign will be created.)
 
 You can edit a the campaign's description, and any other part of its campaign spec at any time.
 

--- a/doc/user/campaigns/index.md
+++ b/doc/user/campaigns/index.md
@@ -159,7 +159,10 @@ If you lack read access to a repository, you can only see [limited information a
 
 ## Updating a campaign
 
-You can edit a campaign's name, description, and any other part of its campaign spec at any time.
+Campaigns are identified by their name. It must be unique within a single namespace (your user account on Sourcegraph, or an organization you are a member of).
+Updating a campaign works by targetting an **existing** campaign in the namespace by specifying the name in the spec. If the name matches an existing campaign, it will update the campaign.
+
+You can edit a the campaign's description, and any other part of its campaign spec at any time.
 
 To update a campaign, you need [admin access to the campaign](managing_access.md#campaign-access-for-each-permission-level), and [write access to all affected repositories](managing_access.md#repository-permissions-for-campaigns) with published changesets.
 


### PR DESCRIPTION
Updating the name of a campaign is not possible anymore using the update workflow, so I've adjusted the wording and also added a short explanation to explain what special role the name of a campaign plays.