### PR TITLE
Properly align diff-stat in changeset nodes like all other states

### DIFF
--- a/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.scss
+++ b/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.scss
@@ -3,8 +3,4 @@
         // Make it full width in the current row.
         grid-column: 1 / -1;
     }
-    &__diffstat {
-        justify-self: end;
-        align-self: start;
-    }
 }

--- a/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.tsx
+++ b/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.tsx
@@ -90,7 +90,7 @@ export const VisibleChangesetSpecNode: React.FunctionComponent<VisibleChangesetS
                     </div>
                 </div>
             </div>
-            <div className="visible-changeset-spec-node__diffstat">
+            <div>
                 {node.description.__typename === 'GitBranchChangesetDescription' && (
                     <DiffStat {...node.description.diffStat} expandedCounts={true} separateLines={true} />
                 )}

--- a/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.scss
+++ b/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.scss
@@ -3,8 +3,4 @@
         // Make it full width in the current row.
         grid-column: 1 / -1;
     }
-    &__diffstat {
-        justify-self: end;
-        align-self: start;
-    }
 }

--- a/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.tsx
+++ b/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.tsx
@@ -68,9 +68,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
             <ExternalChangesetInfoCell node={node} viewerCanAdminister={viewerCanAdminister} />
             <span>{node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}</span>
             <span>{node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}</span>
-            <div className="external-changeset-close-node__diffstat">
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
-            </div>
+            <div>{node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}</div>
             {isExpanded && (
                 <div className="external-changeset-close-node__expanded-section">
                     {node.error && <ErrorAlert error={node.error} history={history} />}

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.scss
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.scss
@@ -3,8 +3,4 @@
         // Make it full width in the current row.
         grid-column: 1 / -1;
     }
-    &__diffstat {
-        justify-self: end;
-        align-self: start;
-    }
 }

--- a/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -66,9 +66,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             <ExternalChangesetInfoCell node={node} viewerCanAdminister={viewerCanAdminister} />
             <span>{node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}</span>
             <span>{node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}</span>
-            <div className="external-changeset-node__diffstat">
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
-            </div>
+            <div>{node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}</div>
             {isExpanded && (
                 <div className="external-changeset-node__expanded-section">
                     {node.error && <ErrorAlert error={node.error} history={history} />}

--- a/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/changesets/__snapshots__/ExternalChangesetNode.test.tsx.snap
@@ -110,9 +110,7 @@ exports[`ExternalChangesetNode renders an externalchangeset 1`] = `
       reviewState="PENDING"
     />
   </span>
-  <div
-    className="external-changeset-node__diffstat"
-  >
+  <div>
     <Memo(DiffStat)
       added={100}
       changed={200}


### PR DESCRIPTION
Was still top right aligned as it was before, but since we now have it in the same look as the other status columns, it really should be aligned