### PR TITLE
Enterprise search: Implement Recent Searches panel

### DIFF
--- a/web/src/search/input/SearchPage.tsx
+++ b/web/src/search/input/SearchPage.tsx
@@ -323,7 +323,9 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                 </>
             )}
 
-            {!props.isSourcegraphDotCom && props.showEnterpriseHomePanels && <EnterpriseHomePanels />}
+            {!props.isSourcegraphDotCom && props.showEnterpriseHomePanels && (
+                <EnterpriseHomePanels authenticatedUser={props.authenticatedUser} />
+            )}
         </div>
     )
 }

--- a/web/src/search/panels/EnterpriseHomePanels.scss
+++ b/web/src/search/panels/EnterpriseHomePanels.scss
@@ -1,4 +1,5 @@
 @import './PanelContainer.scss';
+@import './RecentSearchesPanel.scss';
 
 .enterprise-home-panels {
     margin-top: 4rem;

--- a/web/src/search/panels/EnterpriseHomePanels.story.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.story.tsx
@@ -10,7 +10,7 @@ const { add } = storiesOf('web/search/panels/EnterpriseHomePanels', module)
             type: 'figma',
             url: 'https://www.figma.com/file/sPRyyv3nt5h0284nqEuAXE/12192-Sourcegraph-server-page-v1?node-id=255%3A3',
         },
-        chromatic: { viewports: [480, 769, 993, 1200] },
+        chromatic: { viewports: [480, 1200] },
     })
     .addDecorator(story => <>{story()}</>)
 

--- a/web/src/search/panels/EnterpriseHomePanels.story.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.story.tsx
@@ -14,4 +14,4 @@ const { add } = storiesOf('web/search/panels/EnterpriseHomePanels', module)
     })
     .addDecorator(story => <>{story()}</>)
 
-add('Panels', () => <WebStory>{() => <EnterpriseHomePanels />}</WebStory>)
+add('Panels', () => <WebStory>{() => <EnterpriseHomePanels authenticatedUser={null} />}</WebStory>)

--- a/web/src/search/panels/EnterpriseHomePanels.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react'
+import { AuthenticatedUser } from '../../auth'
 import { RecentFilesPanel } from './RecentFilesPanel'
 import { RecentSearchesPanel } from './RecentSearchesPanel'
 import { RepositoriesPanel } from './RepositoriesPanel'
 import { SavedSearchesPanel } from './SavedSearchesPanel'
 
-export const EnterpriseHomePanels: React.FunctionComponent<{}> = () => (
+export const EnterpriseHomePanels: React.FunctionComponent<{
+    authenticatedUser: AuthenticatedUser | null
+}> = ({ authenticatedUser }) => (
     <div className="enterprise-home-panels container">
         <div className="row">
             <RepositoriesPanel className="enterprise-home-panels__panel col-lg-4" />
-            <RecentSearchesPanel className="enterprise-home-panels__panel col-lg-8" />
+            <RecentSearchesPanel
+                authenticatedUser={authenticatedUser}
+                className="enterprise-home-panels__panel col-lg-8"
+            />
         </div>
         <div className="row">
             <RecentFilesPanel className="enterprise-home-panels__panel col-lg-7" />

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -1,8 +1,14 @@
 .panel-container {
+    margin-bottom: 1rem;
+
     &__header {
         &-text {
             margin-bottom: 0.25rem;
             flex-grow: 1;
         }
+    }
+
+    &__content {
+        overflow-y: auto;
     }
 }

--- a/web/src/search/panels/PanelContainer.tsx
+++ b/web/src/search/panels/PanelContainer.tsx
@@ -23,14 +23,16 @@ export const PanelContainer: React.FunctionComponent<Props> = ({
     actionButtons,
     className,
 }) => (
-    <div className={classNames(className, 'panel-container')}>
+    <div className={classNames(className, 'panel-container', 'd-flex', 'flex-column')}>
         <div className="panel-container__header d-flex border-bottom">
             <h3 className="panel-container__header-text">{title}</h3>
             {actionButtons}
         </div>
 
-        {state === 'loading' && loadingDisplay}
-        {state === 'populated' && contentDisplay}
-        {state === 'empty' && emptyDisplay}
+        <div className="panel-container__content">
+            {state === 'loading' && loadingDisplay}
+            {state === 'populated' && contentDisplay}
+            {state === 'empty' && emptyDisplay}
+        </div>
     </div>
 )

--- a/web/src/search/panels/RecentSearchesPanel.scss
+++ b/web/src/search/panels/RecentSearchesPanel.scss
@@ -1,0 +1,5 @@
+.recent-searches-panel {
+    &__results-table {
+        width: 100%;
+    }
+}

--- a/web/src/search/panels/RecentSearchesPanel.tsx
+++ b/web/src/search/panels/RecentSearchesPanel.tsx
@@ -1,17 +1,92 @@
-import * as React from 'react'
+import React, { useState, useEffect } from 'react'
 import classNames from 'classnames'
+import { AuthenticatedUser } from '../../auth'
+import { dataOrThrowErrors, gql, requestGraphQL } from '../../../../shared/src/graphql/graphql'
+import { map } from 'rxjs/operators'
 import { PanelContainer } from './PanelContainer'
+import { RecentSearchesPanelDataResult, RecentSearchesPanelDataVariables } from '../../graphql-operations'
+import { Maybe } from '../../../../shared/src/graphql-operations'
 
-export const RecentSearchesPanel: React.FunctionComponent<{ className?: string }> = ({ className }) => {
+interface EventLogResult {
+    totalCount: number
+    nodes: { argument: Maybe<string>; timestamp: string; url: string }[]
+    pageInfo: { endCursor: Maybe<string>; hasNextPage: boolean }
+}
+
+const getData = ({ userId, first }: RecentSearchesPanelDataVariables): Promise<EventLogResult> => {
+    const result = requestGraphQL<RecentSearchesPanelDataResult, RecentSearchesPanelDataVariables>({
+        request: gql`
+            query RecentSearchesPanelData($userId: ID!, $first: Int) {
+                node(id: $userId) {
+                    ... on User {
+                        recentSearches: eventLogs(first: $first, eventName: "SearchResultsQueried") {
+                            nodes {
+                                argument
+                                timestamp
+                                url
+                            }
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
+                            totalCount
+                        }
+                    }
+                }
+            }
+        `,
+        variables: { userId, first: first ?? null },
+    })
+
+    return result
+        .pipe(
+            map(dataOrThrowErrors),
+            map(
+                (data: RecentSearchesPanelDataResult): EventLogResult => {
+                    if (!data.node) {
+                        throw new Error('User not found')
+                    }
+                    return data.node.recentSearches
+                }
+            )
+        )
+        .toPromise()
+}
+
+export const RecentSearchesPanel: React.FunctionComponent<{
+    className?: string
+    authenticatedUser: AuthenticatedUser | null
+}> = ({ className, authenticatedUser }) => {
+    const [state, setState] = useState<'loading' | 'populated' | 'empty'>('loading')
+    const [eventLogResult, setEventLogResult] = useState<EventLogResult | null>(null)
+
+    useEffect(() => {
+        const getDataAsync = async (): Promise<void> => {
+            if (!authenticatedUser) {
+                return
+            }
+            const data = await getData({ userId: authenticatedUser.id, first: 100 })
+            setEventLogResult(data)
+            if (data.totalCount === 0) {
+                setState('empty')
+            } else {
+                setState('populated')
+            }
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        getDataAsync()
+    }, [authenticatedUser])
+
     const loadingDisplay = <div>Loading</div>
-    const contentDisplay = <div>Content</div>
+    const contentDisplay = <div>{JSON.stringify(eventLogResult)}</div>
     const emptyDisplay = <div>Empty</div>
 
     return (
         <PanelContainer
             className={classNames(className, 'recent-searches-panel')}
             title="Recent searches"
-            state="loading"
+            state={state}
             loadingContent={loadingDisplay}
             populatedContent={contentDisplay}
             emptyContent={emptyDisplay}


### PR DESCRIPTION
This is a very early draft PR for the Recent Searches panel. This is far from where I want it to be before checking in, but wanted to send it in for early feedback.

Eventually, I'd like the end state of this to have the following:

- Initial data for all panels is loaded together in a single GraphQL query and this query can be dependency injected
- Panels support pagination and GraphQL query to load more pages is dependency injected to each panel
- All panels have a common component for empty view, loading view and content/table view that provides basic styles and functionality