### PR TITLE
add "LSIF" to title of LSIF quickstart page

### DIFF
--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart guide
+# LSIF quickstart guide
 
 > NOTE: We are working on creating guides by language, so first check out [language documentation](languages/index.md)! This general guide can be used when a language specific guide is not available.
 


### PR DESCRIPTION
Avoids confusion about whether this is quickstart for all of Sourcegraph vs. just for LSIF.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
