### PR TITLE
repos: add ListExternalRepoSpecs to only collect ExternalRepoSpec

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -60,6 +60,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/UpsertSources", testStoreUpsertSources},
 		{"DBStore/ListRepos", testStoreListRepos},
 		{"DBStore/ListRepos/Pagination", testStoreListReposPagination},
+		{"DBStore/ListExternalRepoSpecs", testStoreListExternalRepoSpecs(db)},
 		{"DBStore/SetClonedRepos", testStoreSetClonedRepos},
 		{"DBStore/CountNotClonedRepos", testStoreCountNotClonedRepos},
 		{"DBStore/Syncer/Sync", testSyncerSync},
@@ -74,6 +75,7 @@ func TestIntegration(t *testing.T) {
 DELETE FROM external_service_sync_jobs;
 DELETE FROM external_service_repos;
 DELETE FROM external_services;
+DELETE FROM repo;
 `); err != nil {
 					t.Fatalf("cleaning up external services failed: %v", err)
 				}

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -502,6 +502,27 @@ func (o *ObservedStore) ListRepos(ctx context.Context, args StoreListReposArgs) 
 	return o.store.ListRepos(ctx, args)
 }
 
+// ListExternalRepoSpecs calls into the inner Store and registers the observed results.
+func (o *ObservedStore) ListExternalRepoSpecs(ctx context.Context) (ids map[api.ExternalRepoSpec]struct{}, err error) {
+	tr, ctx := o.trace(ctx, "Store.ListExternalRepoSpecs")
+
+	defer func(began time.Time) {
+		secs := time.Since(began).Seconds()
+		count := float64(len(ids))
+
+		o.metrics.ListRepos.Observe(secs, count, &err)
+		logging.Log(o.log, "store.list-external-repo-specs", &err,
+			"count", len(ids),
+		)
+
+		tr.LogFields(otlog.Int("count", len(ids)))
+		tr.SetError(err)
+		tr.Finish()
+	}(time.Now())
+
+	return o.store.ListExternalRepoSpecs(ctx)
+}
+
 // UpsertRepos calls into the inner Store and registers the observed results.
 func (o *ObservedStore) UpsertRepos(ctx context.Context, repos ...*Repo) (err error) {
 	tr, ctx := o.trace(ctx, "Store.UpsertRepos")

--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -134,6 +134,7 @@ type StoreMetrics struct {
 	UpsertRepos            *metrics.OperationMetrics
 	UpsertSources          *metrics.OperationMetrics
 	ListRepos              *metrics.OperationMetrics
+	ListExternalRepoSpecs  *metrics.OperationMetrics
 	UpsertExternalServices *metrics.OperationMetrics
 	ListExternalServices   *metrics.OperationMetrics
 	SetClonedRepos         *metrics.OperationMetrics
@@ -147,6 +148,7 @@ func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
 		sm.Transact,
 		sm.Done,
 		sm.ListRepos,
+		sm.ListExternalRepoSpecs,
 		sm.InsertRepos,
 		sm.DeleteRepos,
 		sm.UpsertRepos,
@@ -261,6 +263,20 @@ func NewStoreMetrics() StoreMetrics {
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_list_repos_errors_total",
 				Help: "Total number of errors when listing repos",
+			}, []string{}),
+		},
+		ListExternalRepoSpecs: &metrics.OperationMetrics{
+			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name: "src_repoupdater_store_list_external_repo_specs_duration_seconds",
+				Help: "Time spent listing external repo specs",
+			}, []string{}),
+			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_store_list_external_repo_specs_total",
+				Help: "Total number of listed external repo specs",
+			}, []string{}),
+			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "src_repoupdater_store_list_external_repo_specs_errors_total",
+				Help: "Total number of errors when listing external repo specs",
 			}, []string{}),
 		},
 		UpsertExternalServices: &metrics.OperationMetrics{
@@ -510,7 +526,7 @@ func (o *ObservedStore) ListExternalRepoSpecs(ctx context.Context) (ids map[api.
 		secs := time.Since(began).Seconds()
 		count := float64(len(ids))
 
-		o.metrics.ListRepos.Observe(secs, count, &err)
+		o.metrics.ListExternalRepoSpecs.Observe(secs, count, &err)
 		logging.Log(o.log, "store.list-external-repo-specs", &err,
 			"count", len(ids),
 		)

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -28,6 +29,7 @@ type Store interface {
 
 	InsertRepos(context.Context, ...*Repo) error
 	ListRepos(context.Context, StoreListReposArgs) ([]*Repo, error)
+	ListExternalRepoSpecs(context.Context) (map[api.ExternalRepoSpec]struct{}, error)
 	DeleteRepos(ctx context.Context, ids ...api.RepoID) error
 	UpsertRepos(ctx context.Context, repos ...*Repo) error
 	UpsertSources(ctx context.Context, inserts, updates, deletes map[api.RepoID][]SourceInfo) error
@@ -714,6 +716,45 @@ func listReposQuery(args StoreListReposArgs) paginatedQuery {
 			limit,
 		)
 	}
+}
+
+func (s DBStore) ListExternalRepoSpecs(ctx context.Context) (map[api.ExternalRepoSpec]struct{}, error) {
+	const ListExternalRepoSpecsQueryFmtstr = `
+-- source: cmd/repo-updater/repos/store.go:DBStore.ListExternalRepoSpecs
+SELECT
+	id,
+	external_id,
+	external_service_type,
+	external_service_id
+FROM repo
+WHERE
+	deleted_at IS NULL
+AND	external_id IS NOT NULL
+AND	external_service_type IS NOT NULL
+AND	external_service_id IS NOT NULL
+AND	id > %s
+ORDER BY id ASC LIMIT %s
+`
+	paginatedQuery := func(cursor, limit int64) *sqlf.Query {
+		return sqlf.Sprintf(
+			ListExternalRepoSpecsQueryFmtstr,
+			cursor,
+			limit,
+		)
+	}
+	ids := make(map[api.ExternalRepoSpec]struct{})
+	return ids, s.paginate(ctx, 0, 0, 0, paginatedQuery,
+		func(sc scanner) (last, count int64, err error) {
+			var id int64
+			var spec api.ExternalRepoSpec
+			if err := sc.Scan(&id, &spec.ID, &spec.ServiceType, &spec.ServiceID); err != nil {
+				return 0, 0, err
+			}
+
+			ids[spec] = struct{}{}
+			return id, 1, nil
+		},
+	)
 }
 
 func (s DBStore) UpsertSources(ctx context.Context, inserts, updates, deletes map[api.RepoID][]SourceInfo) error {

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -2,6 +2,7 @@ package repos_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -1822,6 +1824,43 @@ func testStoreListReposPagination(t *testing.T, store repos.Store) func(*testing
 				}
 			}
 		}))
+	}
+}
+
+func testStoreListExternalRepoSpecs(db *sql.DB) func(t *testing.T, repoStore repos.Store) func(*testing.T) {
+	return func(t *testing.T, store repos.Store) func(*testing.T) {
+		return func(t *testing.T) {
+			ctx := context.Background()
+
+			// Insert test repositories
+			_, err := db.ExecContext(ctx, `
+INSERT INTO repo (id, name, description, language, fork, external_id, external_service_type, external_service_id, deleted_at)
+VALUES
+	(1, 'github.com/user/repo1', '', '', FALSE, NULL, 'github', 'https://github.com/', NULL),
+	(2, 'github.com/user/repo2', '', '', FALSE, 'MDEwOlJlcG9zaXRvcnky', NULL, 'https://github.com/', NULL),
+	(3, 'github.com/user/repo3', '', '', FALSE, 'MDEwOlJlcG9zaXRvcnkz', 'github', NULL, NULL),
+	(4, 'github.com/user/repo4', '', '', FALSE, 'MDEwOlJlcG9zaXRvcnk0', 'github', 'https://github.com/', NOW()),
+	(5, 'github.com/user/repo5', '', '', FALSE, 'MDEwOlJlcG9zaXRvcnk1', 'github', 'https://github.com/', NULL)
+`)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ids, err := store.ListExternalRepoSpecs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := map[api.ExternalRepoSpec]struct{}{
+				api.ExternalRepoSpec{
+					ID:          "MDEwOlJlcG9zaXRvcnk1",
+					ServiceType: "github",
+					ServiceID:   "https://github.com/",
+				}: {},
+			}
+			if diff := cmp.Diff(want, ids); diff != "" {
+				t.Fatalf("IDs mismatch (-want +got):\n%s", diff)
+			}
+		}
 	}
 }
 

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -1851,7 +1851,7 @@ VALUES
 				t.Fatal(err)
 			}
 			want := map[api.ExternalRepoSpec]struct{}{
-				api.ExternalRepoSpec{
+				{
 					ID:          "MDEwOlJlcG9zaXRvcnk1",
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -484,7 +484,7 @@ func (s *Syncer) makeNewRepoInserter(ctx context.Context) (func(*Repo), error) {
 	// repositories will already have related repos, so to avoid that cost we
 	// ask the store for all repositories and only do syncsubset if it might
 	// be an insert.
-	ids, err := s.storedExternalIDs(ctx)
+	ids, err := s.Store.ListExternalRepoSpecs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -501,18 +501,6 @@ func (s *Syncer) makeNewRepoInserter(ctx context.Context) (func(*Repo), error) {
 			s.Logger.Warn("streaming insert failed", "external_id", r.ExternalRepo, "error", err)
 		}
 	}, nil
-}
-
-func (s *Syncer) storedExternalIDs(ctx context.Context) (map[api.ExternalRepoSpec]struct{}, error) {
-	stored, err := s.Store.ListRepos(ctx, StoreListReposArgs{})
-	if err != nil {
-		return nil, errors.Wrap(err, "syncer.storedExternalIDs")
-	}
-	ids := make(map[api.ExternalRepoSpec]struct{}, len(stored))
-	for _, r := range stored {
-		ids[r.ExternalRepo] = struct{}{}
-	}
-	return ids, nil
 }
 
 func (s *Syncer) setOrResetLastSyncErr(perr *error) {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -92,6 +92,10 @@ func (s *mockReposStore) ListRepos(ctx context.Context, args repos.StoreListRepo
 	return s.listRepos(ctx, args)
 }
 
+func (s *mockReposStore) ListExternalRepoSpecs(ctx context.Context) (map[api.ExternalRepoSpec]struct{}, error) {
+	return nil, nil
+}
+
 func (s *mockReposStore) InsertRepos(context.Context, ...*repos.Repo) error {
 	return nil
 }


### PR DESCRIPTION
Fetching all fields of all repos just for fields of `api.ExternalRepoSpec` is wasteful, so adds a dedicated method to do this job.

Part of #12699