### PR TITLE
schema: feature flag search.streaming

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1077,6 +1077,8 @@ type Settings struct {
 	SearchSavedQueries []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
 	// SearchScopes description: Predefined search scopes
 	SearchScopes []*SearchScope `json:"search.scopes,omitempty"`
+	// SearchStreaming description: Enables experimental streaming support.
+	SearchStreaming *bool `json:"search.streaming,omitempty"`
 	// SearchUppercase description: When active, any uppercase characters in the pattern will make the entire query case-sensitive.
 	SearchUppercase *bool `json:"search.uppercase,omitempty"`
 }

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -104,6 +104,12 @@
       "default": false,
       "!go": { "pointer": true }
     },
+    "search.streaming": {
+      "description": "Enables experimental streaming support.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
+    },
     "search.scopes": {
       "description": "Predefined search scopes",
       "type": "array",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -109,6 +109,12 @@ const SettingsSchemaJSON = `{
       "default": false,
       "!go": { "pointer": true }
     },
+    "search.streaming": {
+      "description": "Enables experimental streaming support.",
+      "type": "boolean",
+      "default": false,
+      "!go": { "pointer": true }
+    },
     "search.scopes": {
       "description": "Predefined search scopes",
       "type": "array",


### PR DESCRIPTION
This setting will be used to enable streaming search in the webapp.

Part of https://github.com/sourcegraph/sourcegraph/issues/13067