### PR TITLE
db: remove redundant test prefix for PermsStore

### DIFF
--- a/enterprise/internal/db/integration_test.go
+++ b/enterprise/internal/db/integration_test.go
@@ -22,27 +22,27 @@ func TestIntegration_PermsStore(t *testing.T) {
 		name string
 		test func(*testing.T)
 	}{
-		{"PermsStore/LoadUserPermissions", testPermsStore_LoadUserPermissions(db)},
-		{"PermsStore/LoadRepoPermissions", testPermsStore_LoadRepoPermissions(db)},
-		{"PermsStore/SetUserPermissions", testPermsStore_SetUserPermissions(db)},
-		{"PermsStore/SetRepoPermissions", testPermsStore_SetRepoPermissions(db)},
-		{"PermsStore/LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
-		{"PermsStore/SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
-		{"PermsStore/ListPendingUsers", testPermsStore_ListPendingUsers(db)},
-		{"PermsStore/GrantPendingPermissions", testPermsStore_GrantPendingPermissions(db)},
-		{"PermsStore/SetPendingPermissionsAfterGrant", testPermsStore_SetPendingPermissionsAfterGrant(db)},
-		{"PermsStore/DeleteAllUserPermissions", testPermsStore_DeleteAllUserPermissions(db)},
-		{"PermsStore/DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
-		{"PermsStore/DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
+		{"LoadUserPermissions", testPermsStore_LoadUserPermissions(db)},
+		{"LoadRepoPermissions", testPermsStore_LoadRepoPermissions(db)},
+		{"SetUserPermissions", testPermsStore_SetUserPermissions(db)},
+		{"SetRepoPermissions", testPermsStore_SetRepoPermissions(db)},
+		{"LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
+		{"SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
+		{"ListPendingUsers", testPermsStore_ListPendingUsers(db)},
+		{"GrantPendingPermissions", testPermsStore_GrantPendingPermissions(db)},
+		{"SetPendingPermissionsAfterGrant", testPermsStore_SetPendingPermissionsAfterGrant(db)},
+		{"DeleteAllUserPermissions", testPermsStore_DeleteAllUserPermissions(db)},
+		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
+		{"DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 
-		{"PermsStore/ListExternalAccounts", testPermsStore_ListExternalAccounts(db)},
-		{"PermsStore/GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
+		{"ListExternalAccounts", testPermsStore_ListExternalAccounts(db)},
+		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
 
-		{"PermsStore/UserIDsWithNoPerms", testPermsStore_UserIDsWithNoPerms(db)},
-		{"PermsStore/RepoIDsWithNoPerms", testPermsStore_RepoIDsWithNoPerms(db)},
-		{"PermsStore/UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
-		{"PermsStore/ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},
-		{"PermsStore/Metrics", testPermsStore_Metrics(db)},
+		{"UserIDsWithNoPerms", testPermsStore_UserIDsWithNoPerms(db)},
+		{"RepoIDsWithNoPerms", testPermsStore_RepoIDsWithNoPerms(db)},
+		{"UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
+		{"ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},
+		{"Metrics", testPermsStore_Metrics(db)},
 	} {
 		t.Run(tc.name, tc.test)
 	}


### PR DESCRIPTION
The `TestIntegration_PermsStore` already implies these are integration tests for `PermsStore`, no need to prepend it in individual subtest.