### PR TITLE
make GlobalNavbar a React.FunctionComponent

### DIFF
--- a/web/src/nav/GlobalNavbar.test.tsx
+++ b/web/src/nav/GlobalNavbar.test.tsx
@@ -7,7 +7,9 @@ import { createLocation, createMemoryHistory } from 'history'
 import { NOOP_SETTINGS_CASCADE } from '../../../shared/src/util/searchTestHelpers'
 import { SearchPatternType } from '../graphql-operations'
 
-const PROPS: GlobalNavbar['props'] = {
+jest.mock('../search/input/SearchNavbarItem', () => ({ SearchNavbarItem: 'SearchNavbarItem' }))
+
+const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
     authenticatedUser: null,
     extensionsController: {} as any,
     location: createLocation('/'),

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -1,11 +1,10 @@
 import * as H from 'history'
-import * as React from 'react'
-import { Subscription } from 'rxjs'
+import React, { useEffect, useMemo } from 'react'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
-import { authRequired, AuthenticatedUser } from '../auth'
+import { authRequired as authRequiredObservable, AuthenticatedUser } from '../auth'
 import {
     parseSearchURLQuery,
     PatternTypeProps,
@@ -30,6 +29,7 @@ import { VersionContextDropdown } from './VersionContextDropdown'
 import { VersionContextProps } from '../../../shared/src/search/util'
 import { VersionContext } from '../schema/site.schema'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
+import { useObservable } from '../../../shared/src/util/useObservable'
 
 interface Props
     extends SettingsCascadeProps,
@@ -78,186 +78,189 @@ interface Props
     hideNavLinks: boolean
 }
 
-interface State {
-    authRequired?: boolean
-}
+export const GlobalNavbar: React.FunctionComponent<Props> = ({
+    isSearchRelatedPage,
+    splitSearchModes,
+    interactiveSearchMode,
+    navbarSearchQueryState,
+    versionContext,
+    setVersionContext,
+    availableVersionContexts,
+    caseSensitive,
+    patternType,
+    onNavbarQueryChange,
+    onFiltersInQueryChange,
+    hideNavLinks,
+    variant,
+    isLightTheme,
+    location,
+    history,
+    ...props
+}) => {
+    const authRequired = useObservable(authRequiredObservable)
 
-export class GlobalNavbar extends React.PureComponent<Props, State> {
-    public state: State = {}
+    const query = useMemo(() => parseSearchURLQuery(location.search || ''), [location.search])
 
-    private subscriptions = new Subscription()
-
-    constructor(props: Props) {
-        super(props)
-
+    useEffect(() => {
         // In interactive search mode, the InteractiveModeInput component will handle updating the inputs.
-        if (!props.interactiveSearchMode) {
-            // Reads initial state from the props (i.e. URL parameters).
-            const query = parseSearchURLQuery(props.location.search || '')
+        if (!interactiveSearchMode) {
             if (query) {
-                props.onNavbarQueryChange({ query, cursorPosition: query.length })
+                onNavbarQueryChange({ query, cursorPosition: query.length })
             } else {
                 // If we have no component state, then we may have gotten unmounted during a route change.
-                const query = props.location.state ? props.location.state.query : ''
-                props.onNavbarQueryChange({
+                const query = location.state ? location.state.query : ''
+                onNavbarQueryChange({
                     query,
                     cursorPosition: query.length,
                 })
             }
         }
-    }
 
-    public componentDidMount(): void {
-        this.subscriptions.add(authRequired.subscribe(authRequired => this.setState({ authRequired })))
-    }
-
-    public componentDidUpdate(previousProps: Props): void {
-        if (previousProps.location !== this.props.location) {
-            if (!this.props.isSearchRelatedPage) {
+        if (query) {
+            if (!isSearchRelatedPage) {
                 // On a non-search related page or non-repo page, we clear the query in
                 // the main query input and interactive mode UI to avoid misleading users
                 // that the query is relevant in any way on those pages.
-                this.props.onNavbarQueryChange({ query: '', cursorPosition: 0 })
-                this.props.onFiltersInQueryChange({})
+                onNavbarQueryChange({ query: '', cursorPosition: 0 })
+                onFiltersInQueryChange({})
+            }
+
+            if (interactiveSearchMode) {
+                let filtersInQuery: FiltersToTypeAndValue = {}
+                const { filtersInQuery: newFiltersInQuery, navbarQuery } = convertPlainTextToInteractiveQuery(query)
+                filtersInQuery = { ...filtersInQuery, ...newFiltersInQuery }
+                onNavbarQueryChange({ query: navbarQuery, cursorPosition: navbarQuery.length })
+                onFiltersInQueryChange(filtersInQuery)
             }
         }
+    }, [interactiveSearchMode, isSearchRelatedPage, location, onFiltersInQueryChange, onNavbarQueryChange, query])
 
-        if (previousProps.location.search !== this.props.location.search) {
-            const query = parseSearchURLQuery(this.props.location.search || '')
-            if (query) {
-                if (this.props.interactiveSearchMode) {
-                    let filtersInQuery: FiltersToTypeAndValue = {}
-                    const { filtersInQuery: newFiltersInQuery, navbarQuery } = convertPlainTextToInteractiveQuery(query)
-                    filtersInQuery = { ...filtersInQuery, ...newFiltersInQuery }
-                    this.props.onNavbarQueryChange({ query: navbarQuery, cursorPosition: navbarQuery.length })
+    let logoSource = '/.assets/img/sourcegraph-mark.svg'
+    let logoLinkClassName = 'global-navbar__logo-link global-navbar__logo-animated'
+    const logoWithNameSource = '/.assets/img/sourcegraph-head-logo.svg'
+    const logoWithNameLightSource = '/.assets/img/sourcegraph-light-head-logo.svg'
 
-                    this.props.onFiltersInQueryChange(filtersInQuery)
-                } else {
-                    this.props.onNavbarQueryChange({ query, cursorPosition: query.length })
-                }
+    const branding = window.context ? window.context.branding : null
+    if (branding) {
+        if (isLightTheme) {
+            if (branding.light?.symbol) {
+                logoSource = branding.light.symbol
             }
+        } else if (branding.dark?.symbol) {
+            logoSource = branding.dark.symbol
+        }
+        if (branding.disableSymbolSpin) {
+            logoLinkClassName = 'global-navbar__logo-link'
         }
     }
 
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
+    const logo = <img className="global-navbar__logo" src={logoSource} />
+    const logoWithNameLink = (
+        <Link to="/search">
+            <img
+                className="global-navbar__logo-with-name pl-2"
+                src={isLightTheme ? logoWithNameLightSource : logoWithNameSource}
+            />
+        </Link>
+    )
 
-    public render(): JSX.Element | null {
-        let logoSource = '/.assets/img/sourcegraph-mark.svg'
-        let logoLinkClassName = 'global-navbar__logo-link global-navbar__logo-animated'
-        const logoWithNameSource = '/.assets/img/sourcegraph-head-logo.svg'
-        const logoWithNameLightSource = '/.assets/img/sourcegraph-light-head-logo.svg'
+    const logoLink = !authRequired ? (
+        <Link to="/search" className={logoLinkClassName}>
+            {logo}
+        </Link>
+    ) : (
+        <div className={logoLinkClassName}>{logo}</div>
+    )
+    const navLinks = !authRequired && !hideNavLinks && (
+        <NavLinks
+            showDotComMarketing={showDotComMarketing}
+            location={location}
+            history={history}
+            isLightTheme={isLightTheme}
+            {...props}
+        />
+    )
 
-        const branding = window.context ? window.context.branding : null
-        if (branding) {
-            if (this.props.isLightTheme) {
-                if (branding.light?.symbol) {
-                    logoSource = branding.light.symbol
-                }
-            } else if (branding.dark?.symbol) {
-                logoSource = branding.dark.symbol
-            }
-            if (branding.disableSymbolSpin) {
-                logoLinkClassName = 'global-navbar__logo-link'
-            }
-        }
-
-        const logo = <img className="global-navbar__logo" src={logoSource} />
-        const logoWithNameLink = (
-            <Link to="/search">
-                <img
-                    className="global-navbar__logo-with-name pl-2"
-                    src={this.props.isLightTheme ? logoWithNameLightSource : logoWithNameSource}
-                />
-            </Link>
-        )
-
-        const logoLink = !this.state.authRequired ? (
-            <Link to="/search" className={logoLinkClassName}>
-                {logo}
-            </Link>
-        ) : (
-            <div className={logoLinkClassName}>{logo}</div>
-        )
-        const navLinks = !this.state.authRequired && !this.props.hideNavLinks && (
-            <NavLinks {...this.props} showDotComMarketing={showDotComMarketing} />
-        )
-
-        return (
-            <div
-                className={`global-navbar ${
-                    this.props.variant === 'low-profile' || this.props.variant === 'low-profile-with-logo'
-                        ? ''
-                        : 'global-navbar--bg border-bottom'
-                } py-1`}
-            >
-                {this.props.variant === 'low-profile' || this.props.variant === 'low-profile-with-logo' ? (
-                    <>
-                        {this.props.variant === 'low-profile-with-logo' && (
-                            <div className="nav-item flex-1">{logoWithNameLink}</div>
-                        )}
-                        <div className="flex-1" />
-                        {!this.state.authRequired && !this.props.hideNavLinks && (
-                            <NavLinks {...this.props} showDotComMarketing={showDotComMarketing} />
-                        )}
-                    </>
-                ) : this.props.variant === 'no-search-input' ? (
-                    <>
-                        {logoLink}
-                        <div className="nav-item flex-1">
-                            <Link to="/search" className="nav-link">
-                                Search
-                            </Link>
-                        </div>
-                        {navLinks}
-                    </>
-                ) : (
-                    <>
-                        {this.props.splitSearchModes && this.props.interactiveSearchMode ? (
-                            !this.state.authRequired && (
-                                <InteractiveModeInput
-                                    {...this.props}
-                                    authRequired={this.state.authRequired}
-                                    navbarSearchState={this.props.navbarSearchQueryState}
-                                    onNavbarQueryChange={this.props.onNavbarQueryChange}
-                                    lowProfile={!this.props.isSearchRelatedPage}
-                                    versionContext={this.props.versionContext}
-                                />
-                            )
-                        ) : (
-                            <>
-                                {logoLink}
-                                {!this.state.authRequired && (
-                                    <div className="global-navbar__search-box-container d-none d-sm-flex flex-row">
-                                        {this.props.splitSearchModes && (
-                                            <SearchModeToggle
-                                                {...this.props}
-                                                interactiveSearchMode={this.props.interactiveSearchMode}
-                                            />
-                                        )}
-                                        <VersionContextDropdown
-                                            history={this.props.history}
-                                            navbarSearchQuery={this.props.navbarSearchQueryState.query}
-                                            caseSensitive={this.props.caseSensitive}
-                                            patternType={this.props.patternType}
-                                            versionContext={this.props.versionContext}
-                                            setVersionContext={this.props.setVersionContext}
-                                            availableVersionContexts={this.props.availableVersionContexts}
-                                        />
-                                        <SearchNavbarItem
-                                            {...this.props}
-                                            navbarSearchState={this.props.navbarSearchQueryState}
-                                            onChange={this.props.onNavbarQueryChange}
-                                        />
-                                    </div>
-                                )}
-                                {navLinks}
-                            </>
-                        )}
-                    </>
-                )}
-            </div>
-        )
-    }
+    return (
+        <div
+            className={`global-navbar ${
+                variant === 'low-profile' || variant === 'low-profile-with-logo'
+                    ? ''
+                    : 'global-navbar--bg border-bottom'
+            } py-1`}
+        >
+            {variant === 'low-profile' || variant === 'low-profile-with-logo' ? (
+                <>
+                    {variant === 'low-profile-with-logo' && <div className="nav-item flex-1">{logoWithNameLink}</div>}
+                    <div className="flex-1" />
+                    {navLinks}
+                </>
+            ) : variant === 'no-search-input' ? (
+                <>
+                    {logoLink}
+                    <div className="nav-item flex-1">
+                        <Link to="/search" className="nav-link">
+                            Search
+                        </Link>
+                    </div>
+                    {navLinks}
+                </>
+            ) : (
+                <>
+                    {splitSearchModes && interactiveSearchMode ? (
+                        !authRequired && (
+                            <InteractiveModeInput
+                                {...props}
+                                authRequired={authRequired}
+                                navbarSearchState={navbarSearchQueryState}
+                                onNavbarQueryChange={onNavbarQueryChange}
+                                lowProfile={!isSearchRelatedPage}
+                                versionContext={versionContext}
+                                location={location}
+                                history={history}
+                                setVersionContext={setVersionContext}
+                                availableVersionContexts={availableVersionContexts}
+                                isLightTheme={isLightTheme}
+                                patternType={patternType}
+                                caseSensitive={caseSensitive}
+                                onFiltersInQueryChange={onFiltersInQueryChange}
+                            />
+                        )
+                    ) : (
+                        <>
+                            {logoLink}
+                            {!authRequired && (
+                                <div className="global-navbar__search-box-container d-none d-sm-flex flex-row">
+                                    {splitSearchModes && (
+                                        <SearchModeToggle {...props} interactiveSearchMode={interactiveSearchMode} />
+                                    )}
+                                    <VersionContextDropdown
+                                        history={history}
+                                        navbarSearchQuery={navbarSearchQueryState.query}
+                                        caseSensitive={caseSensitive}
+                                        patternType={patternType}
+                                        versionContext={versionContext}
+                                        setVersionContext={setVersionContext}
+                                        availableVersionContexts={availableVersionContexts}
+                                    />
+                                    <SearchNavbarItem
+                                        {...props}
+                                        navbarSearchState={navbarSearchQueryState}
+                                        onChange={onNavbarQueryChange}
+                                        location={location}
+                                        history={history}
+                                        versionContext={versionContext}
+                                        isLightTheme={isLightTheme}
+                                        patternType={patternType}
+                                        caseSensitive={caseSensitive}
+                                    />
+                                </div>
+                            )}
+                            {navLinks}
+                        </>
+                    )}
+                </>
+            )}
+        </div>
+    )
 }

--- a/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -4,12 +4,92 @@ exports[`GlobalNavbar default 1`] = `
 <div
   className="global-navbar global-navbar--bg border-bottom py-1"
 >
-  <div
+  <a
     className="global-navbar__logo-link global-navbar__logo-animated"
+    to="/search"
   >
     <img
       className="global-navbar__logo"
       src="/.assets/img/sourcegraph-mark.svg"
+    />
+  </a>
+  <div
+    className="global-navbar__search-box-container d-none d-sm-flex flex-row"
+  >
+    <SearchNavbarItem
+      authenticatedUser={null}
+      caseSensitive={false}
+      copyQueryButton={false}
+      extensionsController={Object {}}
+      filtersInQuery={Object {}}
+      globbing={false}
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": undefined,
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": undefined,
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+      isLightTheme={true}
+      isSourcegraphDotCom={false}
+      keyboardShortcuts={Array []}
+      location={
+        Object {
+          "hash": "",
+          "key": undefined,
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      navbarSearchState={
+        Object {
+          "cursorPosition": 0,
+          "query": "q",
+        }
+      }
+      onChange={[Function]}
+      onThemePreferenceChange={[Function]}
+      patternType="literal"
+      platformContext={Object {}}
+      setCaseSensitivity={[Function]}
+      setPatternType={[Function]}
+      settingsCascade={
+        Object {
+          "final": null,
+          "subjects": null,
+        }
+      }
+      showCampaigns={false}
+      showOnboardingTour={false}
+      telemetryService={Object {}}
+      themePreference="light"
+      toggleSearchMode={[Function]}
     />
   </div>
 </div>


### PR DESCRIPTION
The diff in the snapshot is because the `authRequired` value from the Observable is `undefined` when the component is rendered by the test renderer. Previously, when the subscription was manually set up, it was `true` because there is no global `authenticatedUser` when the test runs.

It's actually more helpful for the test snapshot to render the `authRequired=undefined|false` case because more things are rendered then. It would be ideal to test both cases, but to do so cleanly would require refactoring out the global `authRequired` to be passed down through props.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->