### PR TITLE
Update tour tooltip background color and next button styling

### DIFF
--- a/web/src/search/input/SearchOnboardingTour.scss
+++ b/web/src/search/input/SearchOnboardingTour.scss
@@ -1,3 +1,11 @@
+.search-onboarding-tour {
+    &__structural-next-button {
+        .theme-dark & {
+            border-color: $gray-12;
+        }
+    }
+}
+
 .tour-card {
     border: none;
     border-radius: 10px;
@@ -8,7 +16,7 @@
 }
 
 .shepherd-element {
-    background: #1d2535;
+    background: $gray-19;
 }
 
 .shepherd-arrow::after {
@@ -19,7 +27,7 @@
     box-sizing: border-box;
     // stylelint-disable-next-line declaration-property-unit-whitelist
     border: 8px solid #000000;
-    border-color: transparent transparent $gray-21 transparent;
+    border-color: transparent transparent $gray-19 transparent;
     transform-origin: 0 0;
     margin-left: -0.5rem;
 }

--- a/web/src/search/input/SearchOnboardingTour.ts
+++ b/web/src/search/input/SearchOnboardingTour.ts
@@ -240,7 +240,8 @@ export function createStructuralSearchTourTooltip(tour: Shepherd.Tour): HTMLElem
     const nextButtonRow = document.createElement('div')
     nextButtonRow.className = 'd-flex justify-content-end'
     const nextButton = document.createElement('button')
-    nextButton.className = 'btn btn-link test-tour-structural-next-button p-0 font-weight-bold'
+    nextButton.className =
+        'btn btn-outline-secondary test-tour-structural-next-button search-onboarding-tour__structural-next-button'
     nextButton.textContent = 'Next'
     nextButton.addEventListener('click', () => {
         tour.getById('view-search-reference').updateStepOptions({


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/pull/13431#issuecomment-687499317 and an additional request from @rrhyne to update the "next" button styling. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
