### PR TITLE
chore: use status event instead of checks

### DIFF
--- a/.github/workflows/renovate-downstream.yml
+++ b/.github/workflows/renovate-downstream.yml
@@ -1,22 +1,13 @@
 name: Renovate downstream
 on:
-  check_run:
-    types: [ completed ]
+  status
 
 jobs:
-  report-event:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Output event ${{ github.event.check_run.name }}
-        run: |
-          echo "${{ github.ref }}"
-          echo "${{ toJson(github.event) }}"
-
   # This job should trigger rennovate to run on the repositories defined in renovate-downstream.json
   renovate:
     runs-on: ubuntu-latest
-    # Run on buildkite success on branch main
-    if: ${{ github.ref == 'refs/heads/main' && github.event.check_run.name == 'buildkite/sourcegraph' && github.event.check_run.conclusion == 'success' }}
+    # Run on commit status success on branch main
+    if: ${{ github.ref == 'refs/heads/main' && github.event.status.state == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Looks like buildkite doesnt show up in checks, but I'm pretty sure they they show up in commit status. This change simplifies the run to just renovate whenever the main branch goes green. Another follow-up to #13449 

Can't filter on just buildkite status changes, because Actions be like that (https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#status)