### PR TITLE
monitoring: add duration for running git commands alert

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -832,9 +832,9 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 **Descriptions:**
 
-- _gitserver: 50+ running git commands (signals load)_
+- _gitserver: 50+ running git commands (signals load) for 2m0s_
 
-- _gitserver: 100+ running git commands (signals load)_
+- _gitserver: 100+ running git commands (signals load) for 5m0s_
 
 **Possible solutions:**
 

--- a/monitoring/git_server.go
+++ b/monitoring/git_server.go
@@ -34,8 +34,8 @@ func GitServer() *Container {
 							Description:     "running git commands (signals load)",
 							Query:           "max(src_gitserver_exec_running)",
 							DataMayNotExist: true,
-							Warning:         Alert{GreaterOrEqual: 50},
-							Critical:        Alert{GreaterOrEqual: 100},
+							Warning:         Alert{GreaterOrEqual: 50, For: 2 * time.Minute},
+							Critical:        Alert{GreaterOrEqual: 100, For: 5 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("running commands"),
 							Owner:           ObservableOwnerCloud,
 							PossibleSolutions: `


### PR DESCRIPTION
It is firing a lot at the moment and quickly closes itself. We need to
fully investigate why. However, for now we adjust the alert to only fire
if gitserver has been underload for 5m. From looking at the graphs this
problem autoresolves itself in 1m.

Part of https://github.com/sourcegraph/sourcegraph/issues/13683