### PR TITLE
search: log requests to honeycomb

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -674,7 +674,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 		ev.AddField("type", trace.GraphQLRequestName(ctx))
 		ev.AddField("source", string(trace.RequestSource(ctx)))
 		ev.AddField("status", status)
-		ev.AddField("alertType", alertType)
+		ev.AddField("alert_type", alertType)
 		ev.AddField("duration_ms", time.Since(start).Milliseconds())
 
 		if honey.Enabled() {

--- a/internal/honey/honey.go
+++ b/internal/honey/honey.go
@@ -39,20 +39,6 @@ func init() {
 	}
 	err := libhoney.Init(libhoney.Config{
 		APIKey: apiKey,
-		// Send 1 in 16 events. This is hardcoded since we only use this for
-		// Sourcegraph.com.
-		//
-		// 2020-05-29 1 in 4. We are currently at the top tier for honeycomb
-		// (before enterprise) and using double our quota. This gives us room
-		// to grow. If you find we keep bumping this / missing data we care
-		// about we can look into more dynamic ways to sample in our
-		// application code.
-		//
-		// 2020-07-20 1 in 16. Again hitting very high usage. Likely due to
-		// recent scaling up of the indexed search cluster. Will require more
-		// investigation, but we should probably segment user request path
-		// traffic vs internal batch traffic.
-		SampleRate: 16,
 	})
 	if err != nil {
 		log.Println("Failed to init libhoney:", err)


### PR DESCRIPTION
We want to explore every search done on sourcegraph.com in honeycomb. We hook into the existing logging we have. We could be logging a lot more (repos searched/etc), and more often (for example it seems errors and paginated search skip this). For now this is sufficient.

Best reviewed commit by commit.

Part of https://github.com/sourcegraph/sourcegraph/issues/13683