### PR TITLE
ci: build candidate images sooner

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -10,13 +10,18 @@ import (
 )
 
 var allDockerImages = []string{
+	// Slow images first for faster CI
+	"server",
 	"frontend",
+	"grafana",
+	"prometheus",
+	"ignite-ubuntu",
+
 	"github-proxy",
 	"gitserver",
 	"query-runner",
 	"repo-updater",
 	"searcher",
-	"server",
 	"symbols",
 	"precise-code-intel-bundle-manager",
 	"precise-code-intel-worker",
@@ -25,17 +30,14 @@ var allDockerImages = []string{
 
 	// Images under docker-images/
 	"cadvisor",
-	"grafana",
 	"indexed-searcher",
 	"postgres-11.4",
-	"prometheus",
 	"redis-cache",
 	"redis-store",
 	"search-indexer",
 	"syntax-highlighter",
 	"jaeger-agent",
 	"jaeger-all-in-one",
-	"ignite-ubuntu",
 }
 
 // Verifies the docs formatting and builds the `docsite` command.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -130,6 +130,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
+			addDockerImages(c, false),
 			addBackendIntegrationTests(c), // ~11m
 			addLint,                       // ~4.5m
 			addSharedTests(c),             // ~4.5m
@@ -140,7 +141,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addGoBuild,                    // ~0.5m
 			addPostgresBackcompat,         // ~0.25m
 			addDockerfileLint,             // ~0.2m
-			addDockerImages(c, false),
 			wait,
 			addDockerImages(c, true),
 		}


### PR DESCRIPTION
Building the server and frontend images are the slowest steps on master
CI runs. This change ensures we run those steps first (and some other
slow images earlier as well). The earlier a step runs, the less time it
potentially waits (vs other steps) for a free agent.