### PR TITLE
ci: include the correct sha256 in docker-publish summary

### DIFF
--- a/dev/ci/docker-publish.sh
+++ b/dev/ci/docker-publish.sh
@@ -32,7 +32,7 @@ for dst in "$@"; do
 done
 
 echo "+++ summary"
-id="$(docker inspect --format='{{.Id}}' "$src")"
+
 for dst in "$@"; do
-  echo "$dst@$id"
+  docker inspect --format='{{index .RepoDigests 0}}' "$dst"
 done

--- a/dev/ci/docker-publish.sh
+++ b/dev/ci/docker-publish.sh
@@ -33,6 +33,7 @@ done
 
 echo "+++ summary"
 
+id=$(docker inspect --format='{{index .RepoDigests 0}}' "$src" | grep -o '@sha256:.*')
 for dst in "$@"; do
-  docker inspect --format='{{index .RepoDigests 0}}' "$dst"
+  echo "$dst$id"
 done


### PR DESCRIPTION
ID is no the correct field for the sha256. It does work sometimes
though, which is weird. Instead we rely on the full image name per
image, which should include the correct sha256.