### PR TITLE
Check if no-test branch before isGoOnly

### DIFF
--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -68,15 +68,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addDocs,
 		}
 
-	case c.isPR() && c.isGoOnly():
-		// If this is a go-only PR, run only the steps necessary to verify the go code.
-		pipelineOperations = []func(*bk.Pipeline){
-			addGoTests,            // ~1.5m
-			addCheck,              // ~1m
-			addGoBuild,            // ~0.5m
-			addPostgresBackcompat, // ~0.25m
-		}
-
 	case c.patchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
 		app := c.branch[27:]
@@ -84,6 +75,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addCandidateDockerImage(c, app),
 			wait,
 			addFinalDockerImage(c, app, false),
+		}
+
+	case c.isPR() && c.isGoOnly():
+		// If this is a go-only PR, run only the steps necessary to verify the go code.
+		pipelineOperations = []func(*bk.Pipeline){
+			addGoTests,            // ~1.5m
+			addCheck,              // ~1m
+			addGoBuild,            // ~0.5m
+			addPostgresBackcompat, // ~0.25m
 		}
 
 	case c.isBextReleaseBranch:


### PR DESCRIPTION
The changes from #12321 make is so we only run Go checks if required, but we need to maintain the workflow of building docker images in no-test branches.

Im not sure if that steps needs `addGoBuild` as well, but since in #12321 it was not there, I assume it can build without it.


/cc @keegancsmith 