### PR TITLE
httpapi: PoC of streaming API using SSE

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	uirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
@@ -69,6 +70,7 @@ const (
 	routeViews          = "views"
 
 	routeSearchQueryBuilder = "search.query-builder"
+	routeSearchStream       = "search.stream"
 
 	// Legacy redirects
 	routeLegacyLogin                   = "login"
@@ -110,6 +112,7 @@ func newRouter() *mux.Router {
 	r.Path("/search").Methods("GET").Name(routeSearch)
 	r.Path("/search/badge").Methods("GET").Name(routeSearchBadge)
 	r.Path("/search/query-builder").Methods("GET").Name(routeSearchQueryBuilder)
+	r.Path("/search/stream").Methods("GET").Name(routeSearchStream)
 	r.Path("/sign-in").Methods("GET").Name(uirouter.RouteSignIn)
 	r.Path("/sign-up").Methods("GET").Name(uirouter.RouteSignUp)
 	r.PathPrefix("/insights").Methods("GET").Name(routeInsights)
@@ -248,6 +251,9 @@ func initRouter() {
 		// e.g. "myquery - Sourcegraph"
 		return brandNameSubtitle(shortQuery)
 	})))
+
+	// streaming search
+	router.Get(routeSearchStream).HandlerFunc(search.ServeStream)
 
 	// search badge
 	router.Get(routeSearchBadge).Handler(searchBadgeHandler)

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/pkg/updatecheck"
 	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/pkg/handlerutil"
+	frontendsearch "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -59,6 +60,8 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, gitlabWebh
 	}
 
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
+
+	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(http.HandlerFunc(frontendsearch.ServeStream)))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCliVersion).Handler(trace.TraceRoute(handler(srcCliVersionServe)))

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -10,6 +10,8 @@ const (
 	LSIFUpload = "lsif.upload"
 	GraphQL    = "graphql"
 
+	SearchStream = "search.stream"
+
 	SrcCliVersion  = "src-cli.version"
 	SrcCliDownload = "src-cli.download"
 
@@ -69,6 +71,7 @@ func New(base *mux.Router) *mux.Router {
 	base.Path("/gitlab-webhooks").Methods("POST").Name(GitLabWebhooks)
 	base.Path("/bitbucket-server-webhooks").Methods("POST").Name(BitbucketServerWebhooks)
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
+	base.Path("/search/stream").Methods("GET").Name(SearchStream)
 	base.Path("/src-cli/version").Methods("GET").Name(SrcCliVersion)
 	base.Path("/src-cli/{rest:.*}").Methods("GET").Name(SrcCliDownload)
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -1,0 +1,170 @@
+// package search is search specific logic for the frontend. Also see
+// github.com/sourcegraph/sourcegraph/internal/search for more generic search
+// code.
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+// ServeStream is an http handler which streams back search results.
+func ServeStream(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	qvals := r.URL.Query()
+	queryStr := qvals.Get("q")
+	if queryStr == "" {
+		http.Error(w, "no query found", http.StatusBadRequest)
+		return
+	}
+
+	eventWriter, err := newEventStreamWriter(w)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	search, err := graphqlbackend.NewSearchImplementer(ctx, &graphqlbackend.SearchArgs{
+		Query:   queryStr,
+		Version: "V2",
+	})
+	if err != nil {
+		eventWriter.Event("error", err.Error())
+		return
+	}
+
+	resultsResolver, err := search.Results(ctx)
+	if err != nil {
+		eventWriter.Event("error", err.Error())
+		return
+	}
+
+	const filematchesChunk = 1000
+	filematchesBuf := make([]eventFileMatch, 0, filematchesChunk)
+
+	for _, result := range resultsResolver.Results() {
+		fm, ok := result.ToFileMatch()
+		if !ok {
+			continue
+		}
+
+		lineMatches := make([]eventLineMatch, 0, len(fm.JLineMatches))
+		for _, lm := range fm.JLineMatches {
+			lineMatches = append(lineMatches, eventLineMatch{
+				Line:             lm.JPreview,
+				LineNumber:       lm.JLineNumber,
+				OffsetAndLengths: lm.JOffsetAndLengths,
+			})
+		}
+
+		var branches []string
+		if fm.InputRev != nil {
+			branches = []string{*fm.InputRev}
+		}
+
+		filematchesBuf = append(filematchesBuf, eventFileMatch{
+			Path:        fm.JPath,
+			Repository:  fm.Repo.Name(),
+			Branches:    branches,
+			Version:     string(fm.CommitID),
+			LineMatches: lineMatches,
+		})
+
+		if len(filematchesBuf) == cap(filematchesBuf) {
+			if err := eventWriter.Event("filematches", filematchesBuf); err != nil {
+				// EOF
+				return
+			}
+			filematchesBuf = filematchesBuf[:0]
+		}
+	}
+
+	if len(filematchesBuf) > 0 {
+		if err := eventWriter.Event("filematches", filematchesBuf); err != nil {
+			// EOF
+			return
+		}
+		filematchesBuf = filematchesBuf[:0]
+	}
+
+	// TODO stats
+	_ = eventWriter.Event("done", map[string]interface{}{})
+}
+
+type eventStreamWriter struct {
+	w     io.Writer
+	enc   *json.Encoder
+	flush func()
+}
+
+func newEventStreamWriter(w http.ResponseWriter) (*eventStreamWriter, error) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, errors.New("http flushing not supported")
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	return &eventStreamWriter{
+		w:     w,
+		enc:   json.NewEncoder(w),
+		flush: flusher.Flush,
+	}, nil
+}
+
+func (e *eventStreamWriter) Event(event string, data interface{}) error {
+	if event != "" {
+		// event: $event\n
+		if _, err := e.w.Write([]byte("event: ")); err != nil {
+			return err
+		}
+		if _, err := e.w.Write([]byte(event)); err != nil {
+			return err
+		}
+		if _, err := e.w.Write([]byte("\n")); err != nil {
+			return err
+		}
+	}
+
+	// data: json(data)\n\n
+	if _, err := e.w.Write([]byte("data: ")); err != nil {
+		return err
+	}
+	if err := e.enc.Encode(data); err != nil {
+		return err
+	}
+	// Encode writes a newline, so only need to write one newline.
+	if _, err := e.w.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	e.flush()
+
+	return nil
+}
+
+// eventFileMatch is a subset of zoekt.FileMatch for our event API.
+type eventFileMatch struct {
+	Path       string   `json:"name"`
+	Repository string   `json:"repository"`
+	Branches   []string `json:"branches,omitempty"`
+	Version    string   `json:"version,omitempty"`
+
+	LineMatches []eventLineMatch `json:"lineMatches"`
+}
+
+// eventLineMatch is a subset of zoekt.LineMatch for our event API.
+type eventLineMatch struct {
+	Line             string     `json:"line"`
+	LineNumber       int32      `json:"lineNumber"`
+	OffsetAndLengths [][2]int32 `json:"offsetAndLengths"`
+}


### PR DESCRIPTION
This is a proof of concept for the streaming API using server sent
events. It is very minimal and doesn't send everything we need yet.
For example it doesn't stream from the backend, misses out on important
information (filters, stats), sends too much information for the normal
use-case, etc. However, it is a good starting point for improvement and
to develop the webapp against. This is based on an earlier fully
featured prototype I did for streaming Zoekt which worked well.

SSE (Server-Sent Events) has been very nice to develop with. It is very
well supported, simple to understand and simple to interact with. For
example the simplest client for this API is as easy as this:

    curl \
      -H 'Authorization: token REDACTED' \
      -H 'accept: text/event-stream' \
      'http://localhost:3080/.api/search/stream?q=my-query'

I intend for this API to be the same we use for communicating with
backends such as Zoekt and Searcher. The frontend then may
hydrate/enrich the data with extra information the webapp will find
useful.

I'll create a later PR which documents the current protocol as it
stands. But for people who develop against this right now I encourage
just curling the endpoint and seeing what the response looks like. And
then feel free to adjust it to suit the webapp's needs in particular.

We also mount this API on the UI endpoints. UI API allows requests from
the webapp, while httpapi is useful for people accessing via an access
token.

Part of https://github.com/sourcegraph/sourcegraph/issues/13067