### PR TITLE
Correctly filter UI processing changesets using filters

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -193,7 +193,7 @@ type ListChangesetsArgs struct {
 	First                       int32
 	After                       *string
 	PublicationState            *campaigns.ChangesetPublicationState
-	ReconcilerState             *campaigns.ReconcilerState
+	ReconcilerState             *[]campaigns.ReconcilerState
 	ExternalState               *campaigns.ChangesetExternalState
 	ReviewState                 *campaigns.ChangesetReviewState
 	CheckState                  *campaigns.ChangesetCheckState

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1108,9 +1108,9 @@ type Campaign implements Node {
         """
         after: String
         """
-        Only include changesets with the given reconciler state.
+        Only include changesets with any of the given reconciler states.
         """
-        reconcilerState: ChangesetReconcilerState
+        reconcilerState: [ChangesetReconcilerState!]
         """
         Only include changesets with the given publication state.
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1101,9 +1101,9 @@ type Campaign implements Node {
         """
         after: String
         """
-        Only include changesets with the given reconciler state.
+        Only include changesets with any of the given reconciler states.
         """
-        reconcilerState: ChangesetReconcilerState
+        reconcilerState: [ChangesetReconcilerState!]
         """
         Only include changesets with the given publication state.
         """

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -513,11 +513,12 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 	}
 
 	if args.ReconcilerState != nil {
-		reconcilerState := *args.ReconcilerState
-		if !reconcilerState.Valid() {
-			return opts, false, errors.New("changeset reconciler state not valid")
+		for _, reconcilerState := range *args.ReconcilerState {
+			if !reconcilerState.Valid() {
+				return opts, false, errors.New("changeset reconciler state not valid")
+			}
 		}
-		opts.ReconcilerState = &reconcilerState
+		opts.ReconcilerStates = *args.ReconcilerState
 	}
 
 	if args.ExternalState != nil {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -594,10 +595,10 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 		"PUBLISHED",
 		"INVALID",
 	}
-	reconcilerStates := []campaigns.ReconcilerState{
-		"PROCESSING",
-		campaigns.ReconcilerStateProcessing,
-		"INVALID",
+	reconcilerStates := [][]campaigns.ReconcilerState{
+		{"PROCESSING"},
+		{campaigns.ReconcilerStateProcessing},
+		{"INVALID"},
 	}
 	wantExternalStates := []campaigns.ChangesetExternalState{"OPEN", "INVALID"}
 	wantReviewStates := []campaigns.ChangesetReviewState{"APPROVED", "INVALID"}
@@ -649,7 +650,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			},
 			wantSafe: true,
 			wantParsed: ee.ListChangesetsOpts{
-				ReconcilerState: &reconcilerStates[1],
+				ReconcilerStates: reconcilerStates[1],
 			},
 		},
 		// Setting invalid reconciler state fails.
@@ -716,24 +717,26 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range tcs {
-		haveParsed, haveSafe, err := listChangesetOptsFromArgs(tc.args, campaignID)
-		if tc.wantErr == "" && err != nil {
-			t.Fatal(err)
-		}
-		haveErr := fmt.Sprintf("%v", err)
-		wantErr := tc.wantErr
-		if wantErr == "" {
-			wantErr = "<nil>"
-		}
-		if have, want := haveErr, wantErr; have != want {
-			t.Errorf("wrong error returned. have=%q want=%q", have, want)
-		}
-		if diff := cmp.Diff(haveParsed, tc.wantParsed); diff != "" {
-			t.Errorf("wrong args returned. diff=%s", diff)
-		}
-		if have, want := haveSafe, tc.wantSafe; have != want {
-			t.Errorf("wrong safe value returned. have=%t want=%t", have, want)
-		}
+	for i, tc := range tcs {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			haveParsed, haveSafe, err := listChangesetOptsFromArgs(tc.args, campaignID)
+			if tc.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			haveErr := fmt.Sprintf("%v", err)
+			wantErr := tc.wantErr
+			if wantErr == "" {
+				wantErr = "<nil>"
+			}
+			if have, want := haveErr, wantErr; have != want {
+				t.Errorf("wrong error returned. have=%q want=%q", have, want)
+			}
+			if diff := cmp.Diff(haveParsed, tc.wantParsed); diff != "" {
+				t.Errorf("wrong args returned. diff=%s", diff)
+			}
+			if have, want := haveSafe, tc.wantSafe; have != want {
+				t.Errorf("wrong safe value returned. have=%t want=%t", have, want)
+			}
+		})
 	}
 }

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -193,7 +193,7 @@ type CountChangesetsOpts struct {
 	ExternalState       *campaigns.ChangesetExternalState
 	ExternalReviewState *campaigns.ChangesetReviewState
 	ExternalCheckState  *campaigns.ChangesetCheckState
-	ReconcilerState     *campaigns.ReconcilerState
+	ReconcilerStates    []campaigns.ReconcilerState
 	OwnedByCampaignID   int64
 }
 
@@ -227,9 +227,12 @@ func countChangesetsQuery(opts *CountChangesetsOpts) *sqlf.Query {
 	if opts.ExternalCheckState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.external_check_state = %s", *opts.ExternalCheckState))
 	}
-	if opts.ReconcilerState != nil {
-		state := (*opts.ReconcilerState).ToDB()
-		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state = %s", state))
+	if len(opts.ReconcilerStates) != 0 {
+		states := make([]*sqlf.Query, len(opts.ReconcilerStates))
+		for i, reconcilerState := range opts.ReconcilerStates {
+			states[i] = sqlf.Sprintf("%s", reconcilerState.ToDB())
+		}
+		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state IN (%s)", sqlf.Join(states, ",")))
 	}
 	if opts.OwnedByCampaignID != 0 {
 		preds = append(preds, sqlf.Sprintf("changesets.owned_by_campaign_id = %s", opts.OwnedByCampaignID))
@@ -379,7 +382,7 @@ type ListChangesetsOpts struct {
 	IDs                  []int64
 	WithoutDeleted       bool
 	PublicationState     *campaigns.ChangesetPublicationState
-	ReconcilerState      *campaigns.ReconcilerState
+	ReconcilerStates     []campaigns.ReconcilerState
 	ExternalState        *campaigns.ChangesetExternalState
 	ExternalReviewState  *campaigns.ChangesetReviewState
 	ExternalCheckState   *campaigns.ChangesetCheckState
@@ -444,8 +447,12 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	if opts.PublicationState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.publication_state = %s", *opts.PublicationState))
 	}
-	if opts.ReconcilerState != nil {
-		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state = %s", (*opts.ReconcilerState).ToDB()))
+	if len(opts.ReconcilerStates) != 0 {
+		states := make([]*sqlf.Query, len(opts.ReconcilerStates))
+		for i, reconcilerState := range opts.ReconcilerStates {
+			states[i] = sqlf.Sprintf("%s", reconcilerState.ToDB())
+		}
+		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state IN (%s)", sqlf.Join(states, ",")))
 	}
 	if opts.ExternalState != nil {
 		preds = append(preds, sqlf.Sprintf("changesets.external_state = %s", *opts.ExternalState))

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -273,7 +273,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 
 		t.Run("ReconcilerState", func(t *testing.T) {
 			completed := campaigns.ReconcilerStateCompleted
-			countCompleted, err := s.CountChangesets(ctx, CountChangesetsOpts{ReconcilerState: &completed})
+			countCompleted, err := s.CountChangesets(ctx, CountChangesetsOpts{ReconcilerStates: []campaigns.ReconcilerState{completed}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -283,7 +283,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			}
 
 			processing := campaigns.ReconcilerStateProcessing
-			countProcessing, err := s.CountChangesets(ctx, CountChangesetsOpts{ReconcilerState: &processing})
+			countProcessing, err := s.CountChangesets(ctx, CountChangesetsOpts{ReconcilerStates: []campaigns.ReconcilerState{processing}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -473,13 +473,13 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			},
 			{
 				opts: ListChangesetsOpts{
-					ReconcilerState: &stateQueued,
+					ReconcilerStates: []campaigns.ReconcilerState{stateQueued},
 				},
 				wantCount: 0,
 			},
 			{
 				opts: ListChangesetsOpts{
-					ReconcilerState: &stateCompleted,
+					ReconcilerStates: []campaigns.ReconcilerState{stateCompleted},
 				},
 				wantCount: 3,
 			},

--- a/web/src/enterprise/campaigns/detail/backend.ts
+++ b/web/src/enterprise/campaigns/detail/backend.ts
@@ -203,7 +203,7 @@ export const queryChangesets = ({
                 $reviewState: ChangesetReviewState
                 $checkState: ChangesetCheckState
                 $publicationState: ChangesetPublicationState
-                $reconcilerState: ChangesetReconcilerState
+                $reconcilerState: [ChangesetReconcilerState!]
                 $onlyPublishedByThisCampaign: Boolean
             ) {
                 node(id: $campaign) {

--- a/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
+++ b/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
@@ -20,7 +20,7 @@ export interface ChangesetFilters {
     externalState: ChangesetExternalState | null
     reviewState: ChangesetReviewState | null
     checkState: ChangesetCheckState | null
-    reconcilerState: ChangesetReconcilerState | null
+    reconcilerState: ChangesetReconcilerState[] | null
     publicationState: ChangesetPublicationState | null
 }
 
@@ -147,43 +147,42 @@ function changesetUIStateToChangesetFilters(
         case ChangesetUIState.OPEN:
             return {
                 externalState: ChangesetExternalState.OPEN,
-                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                reconcilerState: [ChangesetReconcilerState.COMPLETED],
                 publicationState: ChangesetPublicationState.PUBLISHED,
             }
         case ChangesetUIState.CLOSED:
             return {
                 externalState: ChangesetExternalState.CLOSED,
-                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                reconcilerState: [ChangesetReconcilerState.COMPLETED],
                 publicationState: ChangesetPublicationState.PUBLISHED,
             }
         case ChangesetUIState.MERGED:
             return {
                 externalState: ChangesetExternalState.MERGED,
-                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                reconcilerState: [ChangesetReconcilerState.COMPLETED],
                 publicationState: ChangesetPublicationState.PUBLISHED,
             }
         case ChangesetUIState.DELETED:
             return {
                 externalState: ChangesetExternalState.DELETED,
-                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                reconcilerState: [ChangesetReconcilerState.COMPLETED],
                 publicationState: ChangesetPublicationState.PUBLISHED,
             }
         case ChangesetUIState.UNPUBLISHED:
             return {
-                reconcilerState: ChangesetReconcilerState.COMPLETED,
+                reconcilerState: [ChangesetReconcilerState.COMPLETED],
                 externalState: null,
                 publicationState: ChangesetPublicationState.UNPUBLISHED,
             }
         case ChangesetUIState.PROCESSING:
             return {
-                reconcilerState: ChangesetReconcilerState.PROCESSING,
-                // TODO: reconcilerState: [ChangesetReconcilerState.QUEUED, ChangesetReconcilerState.PROCESSING],
+                reconcilerState: [ChangesetReconcilerState.QUEUED, ChangesetReconcilerState.PROCESSING],
                 externalState: null,
                 publicationState: null,
             }
         case ChangesetUIState.ERRORED:
             return {
-                reconcilerState: ChangesetReconcilerState.ERRORED,
+                reconcilerState: [ChangesetReconcilerState.ERRORED],
                 publicationState: null,
                 externalState: null,
             }


### PR DESCRIPTION
Filtering by multiple reconciler states allows us to correctly determine the changesets that are marked "processing" in the UI.
I could not find a way to make it accept scalars and arrays, but I think this is fine for now.

Closes https://github.com/sourcegraph/sourcegraph/issues/13136