### PR TITLE
codeintel: Load docker images into vm via docker save/load

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/env.go
@@ -19,6 +19,7 @@ var (
 	rawUseFirecracker           = env.Get("PRECISE_CODE_INTEL_USE_FIRECRACKER", "true", "Whether to isolate index containers in virtual machines.")
 	rawFirecrackerNumCPUs       = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_NUM_CPUS", "4", "How many CPUs to allocate to each virtual machine or container.")
 	rawFirecrackerMemory        = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_MEMORY", "12G", "How much memory to allocate to each virtual machine or container.")
+	rawImageArchivePath         = env.Get("PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH", "", "Where to store tar archives of docker images shared by virtual machines.")
 )
 
 // mustGet returns the non-empty version of the given raw value fatally logs on failure.

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -80,11 +80,9 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 			tarfile := filepath.Join(h.options.ImageArchivePath, fmt.Sprintf("%s.tar", image))
 			copyfiles = append(copyfiles, "--copy-files", fmt.Sprintf("%s:%s", tarfile, fmt.Sprintf("/%s.tar", image)))
 
-			_, err := os.Stat(fmt.Sprintf("%s.tar", image))
-			if err == nil {
+			if _, err := os.Stat(tarfile); err == nil {
 				continue
-			}
-			if !os.IsNotExist(err) {
+			} else if !os.IsNotExist(err) {
 				return err
 			}
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -36,6 +37,7 @@ type HandlerOptions struct {
 	UseFirecracker        bool
 	FirecrackerNumCPUs    int
 	FirecrackerMemory     string
+	ImageArchivePath      string
 }
 
 // Handle clones the target code into a temporary directory, invokes the target indexer in a fresh
@@ -68,6 +70,32 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 	if h.options.UseFirecracker {
 		mountPoint = "/repo-dir"
 
+		images := []string{
+			"lsif-go",
+			"src-cli",
+		}
+
+		copyfiles := []string{}
+		for _, image := range images {
+			tarfile := filepath.Join(h.options.ImageArchivePath, fmt.Sprintf("%s.tar", image))
+			copyfiles = append(copyfiles, "--copy-files", fmt.Sprintf("%s:%s", tarfile, fmt.Sprintf("/%s.tar", image)))
+
+			_, err := os.Stat(fmt.Sprintf("%s.tar", image))
+			if err == nil {
+				continue
+			}
+			if !os.IsNotExist(err) {
+				return err
+			}
+
+			if err := h.commander.Run(ctx, "docker", "pull", fmt.Sprintf("sourcegraph/%s:latest", image)); err != nil {
+				return errors.Wrap(err, fmt.Sprintf("failed to pull sourcegraph/%s:latest", image))
+			}
+			if err := h.commander.Run(ctx, "docker", "save", "-o", tarfile, fmt.Sprintf("sourcegraph/%s:latest", image)); err != nil {
+				return errors.Wrap(err, fmt.Sprintf("failed to save sourcegraph/%s:latest", image))
+			}
+		}
+
 		args := []string{
 			"ignite", "run",
 			"--runtime", "docker",
@@ -75,10 +103,14 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 			"--cpus", fmt.Sprintf("%d", h.options.FirecrackerNumCPUs),
 			"--memory", h.options.FirecrackerMemory,
 			"--copy-files", fmt.Sprintf("%s:%s", repoDir, mountPoint),
+		}
+		args = append(args, copyfiles...)
+		args = append(
+			args,
 			"--ssh",
 			"--name", name.String(),
 			sanitizeImage(h.options.FirecrackerImage),
-		}
+		)
 		if err := h.commander.Run(ctx, args[0], args[1:]...); err != nil {
 			return errors.Wrap(err, "failed to start firecracker vm")
 		}
@@ -103,6 +135,12 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 				log15.Warn("failed to remove firecracker vm", "name", name.String(), "err", err)
 			}
 		}()
+
+		for _, image := range images {
+			if err := h.commander.Run(ctx, "ignite", "exec", name.String(), "--", "docker", "load", "-i", fmt.Sprintf("/%s.tar", image)); err != nil {
+				return errors.Wrap(err, fmt.Sprintf("failed to load sourcegraph/%s:latest", image))
+			}
+		}
 	}
 
 	indexArgs := []string{

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -84,6 +84,7 @@ func TestHandleWithFirecracker(t *testing.T) {
 			FirecrackerImage:      "sourcegraph/ignite-ubuntu:latest",
 			FirecrackerNumCPUs:    8,
 			FirecrackerMemory:     "32G",
+			ImageArchivePath:      "/images",
 		},
 		uuidGenerator: func() (uuid.UUID, error) {
 			return uuid.MustParse("97b45daf-53d1-48ad-b992-547469d8e438"), nil
@@ -100,14 +101,20 @@ func TestHandleWithFirecracker(t *testing.T) {
 		t.Fatalf("unexpected error handling index: %s", err)
 	}
 
-	if callCount := len(commander.RunFunc.History()); callCount != 8 {
-		t.Errorf("unexpected run call count. want=%d have=%d", 8, callCount)
+	if callCount := len(commander.RunFunc.History()); callCount != 14 {
+		t.Errorf("unexpected run call count. want=%d have=%d", 14, callCount)
 	} else {
 		expectedCalls := []string{
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
-			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			"docker pull sourcegraph/lsif-go:latest",
+			"docker save -o /images/lsif-go.tar sourcegraph/lsif-go:latest",
+			"docker pull sourcegraph/src-cli:latest",
+			"docker save -o /images/src-cli.tar sourcegraph/src-cli:latest",
+			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --copy-files /images/lsif-go.tar:/lsif-go.tar --copy-files /images/src-cli.tar:/src-cli.tar --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /lsif-go.tar",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /src-cli.tar",
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data sourcegraph/lsif-go:latest lsif-go --no-animation",
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -no-progress -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload",
 			"ignite stop --runtime docker --network-plugin docker-bridge 97b45daf-53d1-48ad-b992-547469d8e438",

--- a/enterprise/cmd/precise-code-intel-indexer-vm/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/main.go
@@ -37,6 +37,7 @@ func main() {
 		useFirecracker           = mustParseBool(rawUseFirecracker, "PRECISE_CODE_INTEL_USE_FIRECRACKER")
 		firecrackerNumCPUs       = mustParseInt(rawFirecrackerNumCPUs, "PRECISE_CODE_INTEL_FIRECRACKER_NUM_CPUS")
 		firecrackerMemory        = mustGet(rawFirecrackerMemory, "PRECISE_CODE_INTEL_FIRECRACKER_MEMORY")
+		imageArchivePath         = mustGet(rawImageArchivePath, "PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH")
 	)
 
 	if frontendURLFromDocker == "" {
@@ -74,6 +75,7 @@ func main() {
 			UseFirecracker:        useFirecracker,
 			FirecrackerNumCPUs:    firecrackerNumCPUs,
 			FirecrackerMemory:     firecrackerMemory,
+			ImageArchivePath:      imageArchivePath,
 		},
 	})
 

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -44,6 +44,7 @@ export PRECISE_CODE_INTEL_EXTERNAL_URL_FROM_DOCKER=http://host.docker.internal:3
 export PRECISE_CODE_INTEL_INDEX_MANAGER_URL=http://localhost:3189
 export PRECISE_CODE_INTEL_INTERNAL_PROXY_AUTH_TOKEN=hunter2
 export PRECISE_CODE_INTEL_USE_FIRECRACKER=false
+export PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH=$HOME/.sourcegraph/images
 
 export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"
 export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-indexer-vm precise-code-intel-worker "


### PR DESCRIPTION
@Strum355 and I thought we could get away with running a docker registry on the host for caching, but it seems like this has some issues with ignite (it doesn't support non-docker-bridge networking at the current time).

This is likely a temporary solution to reduce traffic to dockerhub and we'll have to see how it performs in GCP whether it needs to be replaced sooner than later. I still believe this is a net win, even if temporary.

Changes in this PR:
- prior to a VM starting, we ensure that the lsif-go/src-cli images used in the container are pulled and saved into a tar archive
- these archives are moved into the vm
- before indexing, these archives are expanded into images inside of the vm

Alternate permanent solutions would be to:
- upstream changes to ignite to select a docker network by name (unknown effort + possible fork maintenance burden)
- expose the docker proxy via DNS available to the vm (will not use loopback, packets will hit NIC)
- mount volume files instead of tar files (requires vm and host have same docker filesystems)