### PR TITLE
workerutil: demote log15.Info to Debug

### DIFF
--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -143,7 +143,7 @@ func (w *Worker) dequeueAndHandle() (dequeued bool, err error) {
 		return false, nil
 	}
 
-	log15.Info("Dequeued record for processing", "name", w.options.Name, "id", record.RecordID())
+	log15.Debug("Dequeued record for processing", "name", w.options.Name, "id", record.RecordID())
 
 	if hook, ok := w.options.Handler.(WithHooks); ok {
 		hook.PreHandle(w.ctx, record)
@@ -197,11 +197,11 @@ func (w *Worker) handle(tx Store, record Record) (err error) {
 		if marked, markErr := tx.MarkComplete(ctx, record.RecordID()); markErr != nil {
 			return errors.Wrap(markErr, "store.MarkComplete")
 		} else if marked {
-			log15.Info("Marked record as complete", "name", w.options.Name, "id", record.RecordID())
+			log15.Debug("Marked record as complete", "name", w.options.Name, "id", record.RecordID())
 		}
 	}
 
-	log15.Info("Handled record", "name", w.options.Name, "id", record.RecordID())
+	log15.Debug("Handled record", "name", w.options.Name, "id", record.RecordID())
 	return nil
 }
 


### PR DESCRIPTION
These logs seem quite noisy and are not that useful unless we are trying
to debug something. As such I suggest demoting the level to debug.

You don't have to merge this, this just seemed like the most appropriate way to raise the discussion since it was so easy to change.

Noticed these in my dev environment logs. Ignore the opentracing log, that is from me enabling verbose logging mode for OT:

![image](https://user-images.githubusercontent.com/187831/92603175-4a6bd180-f2af-11ea-832b-e0f0fd54d621.png)
