### PR TITLE
codeowners: specify top-level catches earlier

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,8 @@
 *.js @sourcegraph/web
 *.ts @sourcegraph/web
 *.tsx @sourcegraph/web
+/cmd @slimsag
+/internal @slimsag
 /enterprise/cmd/frontend @slimsag
 /enterprise/cmd/server @slimsag
 /cmd/frontend/shared @slimsag
@@ -82,8 +84,6 @@
 /prettier.config.js @sourcegraph/web
 /.editorconfig @sourcegraph/web
 /jest.config.js @sourcegraph/web
-/cmd @slimsag
-/internal @slimsag
 
 # Web
 /shared @sourcegraph/web


### PR DESCRIPTION
There were a bunch of rules put in before this old top-level rule. For
example internal/workerutil was assigned as owned by Stephen, even
though we had a rule for it to be owned by Eric. This was because that
rule was before this catch all rule.