### PR TITLE
Add use timeout hook with tests

### DIFF
--- a/shared/src/util/useTimeout.test.ts
+++ b/shared/src/util/useTimeout.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react-hooks'
+import * as sinon from 'sinon'
+import { useTimeout } from './useTimeout'
+
+describe('useTimeout()', () => {
+    let clock: sinon.SinonFakeTimers
+    beforeAll(() => {
+        clock = sinon.useFakeTimers()
+    })
+
+    afterAll(() => {
+        clock.restore()
+    })
+
+    it('should call the callback after specified time elapses', () => {
+        const callback = sinon.spy(() => {
+            // noop
+        })
+
+        const { result } = renderHook(() => useTimeout())
+        result.current(callback, 2000)
+        sinon.assert.notCalled(callback)
+        clock.tick(2000)
+        sinon.assert.calledOnce(callback)
+    })
+
+    it('should cancel previous timeout on subsequent invocation', () => {
+        const callbackOne = sinon.spy(() => {
+            // noop
+        })
+        const callbackTwo = sinon.spy(() => {
+            // noop
+        })
+
+        const { result } = renderHook(() => useTimeout())
+        result.current(callbackOne, 1000)
+        clock.tick(500)
+        result.current(callbackTwo, 1000)
+        clock.tick(500)
+        sinon.assert.notCalled(callbackOne)
+        sinon.assert.notCalled(callbackTwo)
+        clock.tick(500)
+        sinon.assert.notCalled(callbackOne)
+        sinon.assert.calledOnce(callbackTwo)
+    })
+
+    it('should cancel timeout on component unmount', () => {
+        const callback = sinon.spy(() => {
+            // noop
+        })
+
+        const { result, unmount } = renderHook(() => useTimeout())
+        result.current(callback, 1000)
+        unmount()
+        clock.tick(1000)
+        sinon.assert.notCalled(callback)
+    })
+})

--- a/shared/src/util/useTimeout.ts
+++ b/shared/src/util/useTimeout.ts
@@ -1,0 +1,41 @@
+import { useRef, useEffect, useCallback } from 'react'
+
+type CancelTimeout = () => void
+type TimeoutSetter = (
+    callback: (...args: unknown[]) => void,
+    timeout: number | undefined,
+    ...args: unknown[]
+) => CancelTimeout
+
+/**
+ * React hook that returns a TimeoutSetter function that automates timeout management.
+ * It clears previously queued timeouts when called and on component unmount.
+ *
+ * NOTE: Each instance of TimeoutSetter is meant to manage one timeout at a time.
+ * Create a new TimeoutSetter instance when you want to set concurrent timeouts
+ *
+ * @returns A function with the same parameters as `window.setTimeout` that returns
+ * a convenience `clearTimeout` function
+ */
+export function useTimeout(): TimeoutSetter {
+    const timeoutIDReference = useRef<number | undefined>()
+
+    // eslint-disable-next-line arrow-body-style
+    useEffect(() => {
+        return () => clearTimeout(timeoutIDReference.current)
+    }, [])
+
+    return useCallback(function timeoutSetter(callback, timeout, ...args) {
+        if (timeoutIDReference.current) {
+            clearTimeout(timeoutIDReference.current)
+        }
+
+        const timeoutID = window.setTimeout(callback, timeout, args)
+        timeoutIDReference.current = timeoutID
+        return function cancelTimeout() {
+            clearTimeout(timeout)
+            // don't void `timeoutIDReference` to prevent invocations of
+            // old `cancelTimeout` functions from breaking cleanup
+        }
+    }, [])
+}


### PR DESCRIPTION
This hook would be used multiple times in RFC 209 code for visual feedback and hover event state management.