### PR TITLE
codeintel: Reduce data returned from code intel ranges requests

### DIFF
--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/database/database_test.go
@@ -64,7 +64,6 @@ func TestDatabaseRanges(t *testing.T) {
 					{Path: "protocol/writer.go", Range: newRange(12, 5, 12, 11)},
 				},
 				References: []bundles.Location{
-					{Path: "internal/index/indexer.go", Range: newRange(36, 26, 36, 32)},
 					{Path: "protocol/writer.go", Range: newRange(12, 5, 12, 11)},
 					{Path: "protocol/writer.go", Range: newRange(20, 47, 20, 53)},
 					{Path: "protocol/writer.go", Range: newRange(21, 9, 21, 15)},

--- a/enterprise/internal/codeintel/resolvers/query.go
+++ b/enterprise/internal/codeintel/resolvers/query.go
@@ -85,7 +85,8 @@ func NewQueryResolver(
 }
 
 // Ranges returns code intelligence for the ranges that fall within the given range of lines. These
-// results do not include any data that requires cross-linking of bundles (cross-repo or cross-root).
+// results are partial and do not include references outside the current file, or any location that
+// requires cross-linking of bundles (cross-repo or cross-root).
 func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) ([]AdjustedCodeIntelligenceRange, error) {
 	var adjustedRanges []AdjustedCodeIntelligenceRange
 	for i := range r.uploads {


### PR DESCRIPTION
This is a partial resolution to https://github.com/sourcegraph/sourcegraph/issues/13733.

This PR drastically reduces the amount of data that needs to be returned by removing any references to locations outside of the current document, which is all we currently care about. This is done in a bit of a naive way which doesn't save any backend time, but does reduce the time spent transferring data, parsing the JSON, converting the data in the extension. This should also reduce the memory footprint of the extension.