### PR TITLE
Add useTimeoutManager hook

### DIFF
--- a/shared/src/util/useTimeoutManager.test.ts
+++ b/shared/src/util/useTimeoutManager.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react-hooks'
+import * as sinon from 'sinon'
+import { useTimeoutManager } from './useTimeoutManager'
+
+describe('useTimeoutManager()', () => {
+    let clock: sinon.SinonFakeTimers
+    beforeAll(() => {
+        clock = sinon.useFakeTimers()
+    })
+
+    afterAll(() => {
+        clock.restore()
+    })
+
+    it('should call the callback after specified time elapses', () => {
+        const callback = sinon.spy(() => {
+            // noop
+        })
+
+        const { result } = renderHook(() => useTimeoutManager())
+        result.current.setTimeout(callback, 2000)
+        sinon.assert.notCalled(callback)
+        clock.tick(2000)
+        sinon.assert.calledOnce(callback)
+    })
+
+    it('should cancel previous timeout on subsequent invocation', () => {
+        const callbackOne = sinon.spy(() => {
+            // noop
+        })
+        const callbackTwo = sinon.spy(() => {
+            // noop
+        })
+
+        const { result } = renderHook(() => useTimeoutManager())
+        result.current.setTimeout(callbackOne, 1000)
+        clock.tick(500)
+        result.current.setTimeout(callbackTwo, 1000)
+        clock.tick(500)
+        sinon.assert.notCalled(callbackOne)
+        sinon.assert.notCalled(callbackTwo)
+        clock.tick(500)
+        sinon.assert.notCalled(callbackOne)
+        sinon.assert.calledOnce(callbackTwo)
+    })
+
+    it('should cancel timeout on component unmount', () => {
+        const callback = sinon.spy(() => {
+            // noop
+        })
+
+        const { result, unmount } = renderHook(() => useTimeoutManager())
+        result.current.setTimeout(callback, 1000)
+        unmount()
+        clock.tick(1000)
+        sinon.assert.notCalled(callback)
+    })
+
+    it('should cancel timeout after calling `cancelTimeout`', () => {
+        const callback = sinon.spy(() => {
+            // noop
+        })
+
+        const { result } = renderHook(() => useTimeoutManager())
+        result.current.setTimeout(callback, 1000)
+        clock.tick(500)
+        result.current.cancelTimeout()
+        clock.tick(500)
+        sinon.assert.notCalled(callback)
+    })
+})

--- a/shared/src/util/useTimeoutManager.ts
+++ b/shared/src/util/useTimeoutManager.ts
@@ -1,0 +1,45 @@
+import { useRef, useEffect, useMemo } from 'react'
+
+export interface TimeoutManager {
+    setTimeout: (callback: (...args: unknown[]) => void, timeout: number | undefined, ...args: unknown[]) => void
+    cancelTimeout: () => void
+}
+
+/**
+ * React hook that returns a TimeoutManager object that makes timeout management
+ * sane in function components.
+ *
+ * It clears previously queued timeouts when called and on component unmount, and
+ * provides `setTimeout` and `cancelTimeout` methods
+ *
+ * NOTE: Each instance of TimeoutSetter is meant to manage one timeout at a time.
+ * Create a new TimeoutSetter instance when you want to set concurrent timeouts
+ *
+ * @returns A object with a `setTimeout` method with the same parameters
+ * as `window.setTimeout`, and a `cancelTimeout` method
+ */
+export function useTimeoutManager(): TimeoutManager {
+    const timeoutIDReference = useRef<number | undefined>()
+
+    // eslint-disable-next-line arrow-body-style
+    useEffect(() => {
+        return () => clearTimeout(timeoutIDReference.current)
+    }, [])
+
+    return useMemo(
+        () => ({
+            setTimeout(callback, timeout, ...args) {
+                if (timeoutIDReference.current) {
+                    this.cancelTimeout()
+                }
+
+                timeoutIDReference.current = window.setTimeout(callback, timeout, ...args)
+            },
+            cancelTimeout() {
+                clearTimeout(timeoutIDReference.current)
+                timeoutIDReference.current = undefined
+            },
+        }),
+        []
+    )
+}


### PR DESCRIPTION
#### Motivation

Keeping track of timeouts is harder in function components than class components. You have to remember to register effect cleanup so the timeout is cleared when the component unmounts, and you need a way to keep track of the timeout ID between renders in case you want to cancel it. Timeout management boilerplate ends up polluting your component code when you need multiple timeouts. I've been working on components with multiple transitions for the last few days, and I needed this hook to clean them up (used [here](https://github.com/sourcegraph/sourcegraph/blob/91626a0521066ff80c5b83b4a93c9c73e08f56a5/web/src/extensions/ExtensionCard.tsx#L76)). 

#### Refactoring `setTimeout` calls in function components

I only found one function component that set timeouts: `GitCommitNode`. I missed this in review a few days ago, and `useTimeoutManager` made it easier to change. Before, other tooltips would be cleared when users moved away from the 'copy to clipboard' button before the timeout. It probably wasn't a big problem here, but as we introduce more animations, it'll be nice to have a timeout manager for function components.

TODO: Consider effect of [React 17 changes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#potential-issues) for `useTimeoutManager`