### PR TITLE
search: implement Recent Files homepage panel

### DIFF
--- a/browser/src/shared/tracking/eventLogger.tsx
+++ b/browser/src/shared/tracking/eventLogger.tsx
@@ -46,9 +46,9 @@ export class ConditionalTelemetryService implements TelemetryService {
             this.innerTelemetryService.log(eventName, eventProperties)
         }
     }
-    public logViewEvent(eventName: string): void {
+    public logViewEvent(eventName: string, eventProperties?: any): void {
         if (this.isEnabled) {
-            this.innerTelemetryService.logViewEvent(eventName)
+            this.innerTelemetryService.logViewEvent(eventName, eventProperties)
         }
     }
 
@@ -156,7 +156,7 @@ export class EventLogger implements TelemetryService {
      *
      * @param pageTitle The title of the page being viewed.
      */
-    public async logViewEvent(pageTitle: string): Promise<void> {
+    public async logViewEvent(pageTitle: string, eventProperties?: any): Promise<void> {
         const anonUserId = await this.getAnonUserID()
         const sourcegraphURL = await this.sourcegraphURLs.pipe(take(1)).toPromise()
         logEvent(
@@ -164,7 +164,7 @@ export class EventLogger implements TelemetryService {
                 name: `View${pageTitle}`,
                 userCookieID: anonUserId,
                 url: sourcegraphURL,
-                argument: { platform: this.platform },
+                argument: { ...eventProperties, platform: this.platform },
             },
             this.requestGraphQL
         )

--- a/shared/src/telemetry/telemetryService.ts
+++ b/shared/src/telemetry/telemetryService.ts
@@ -19,7 +19,7 @@ export interface TelemetryService {
     /**
      * Log a pageview event (by sending it to the server).
      */
-    logViewEvent(eventName: string): void
+    logViewEvent(eventName: string, eventProperties?: any): void
 }
 
 /**

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -37,7 +37,7 @@ import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
 import { LayoutRouteProps } from './routes'
-import { search, fetchSavedSearches, fetchRecentSearches, fetchRecentFiles } from './search/backend'
+import { search, fetchSavedSearches, fetchRecentSearches, fetchRecentFileViews } from './search/backend'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { ThemePreference } from './theme'
@@ -420,7 +420,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     globbing={this.state.globbing}
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
-                                    fetchRecentFiles={fetchRecentFiles}
+                                    fetchRecentFileViews={fetchRecentFileViews}
                                 />
                             )}
                         />

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -37,7 +37,7 @@ import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
 import { LayoutRouteProps } from './routes'
-import { search, fetchSavedSearches, fetchRecentSearches } from './search/backend'
+import { search, fetchSavedSearches, fetchRecentSearches, fetchRecentFiles } from './search/backend'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { ThemePreference } from './theme'
@@ -420,6 +420,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     globbing={this.state.globbing}
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
+                                    fetchRecentFiles={fetchRecentFiles}
                                 />
                             )}
                         />

--- a/web/src/auth/SignInPage.tsx
+++ b/web/src/auth/SignInPage.tsx
@@ -16,7 +16,7 @@ interface SignInPageProps {
 }
 
 export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
-    useEffect(() => eventLogger.logViewEvent('SignIn', false))
+    useEffect(() => eventLogger.logViewEvent('SignIn', null, false))
 
     if (props.authenticatedUser) {
         const returnTo = getReturnTo(props.location)

--- a/web/src/auth/SignUpPage.tsx
+++ b/web/src/auth/SignUpPage.tsx
@@ -17,7 +17,7 @@ interface SignUpPageProps {
 
 export class SignUpPage extends React.Component<SignUpPageProps> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SignUp', false)
+        eventLogger.logViewEvent('SignUp', null, false)
     }
 
     public render(): JSX.Element | null {

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -111,7 +111,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
 
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {
-        props.telemetryService.logViewEvent('Blob')
+        props.telemetryService.logViewEvent('Blob', { repoName, filePath })
     }, [repoName, commitID, filePath, isLightTheme, renderMode, props.telemetryService])
 
     useBreadcrumb(

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -10,11 +10,7 @@ import { Remote } from 'comlink'
 import { FlatExtHostAPI } from '../../../shared/src/api/contract'
 import { wrapRemoteObservable } from '../../../shared/src/api/client/api/common'
 import { DeployType } from '../jscontext'
-import {
-    SearchPatternType,
-    RecentSearchesPanelDataVariables,
-    RecentSearchesPanelDataResult,
-} from '../graphql-operations'
+import { SearchPatternType, EventLogsDataResult, EventLogsDataVariables } from '../graphql-operations'
 
 export function search(
     query: string,
@@ -532,17 +528,17 @@ export interface EventLogResult {
     pageInfo: { endCursor: string | null; hasNextPage: boolean }
 }
 
-export function fetchRecentSearches(userId: GQL.ID, first: number): Observable<EventLogResult | null> {
+function fetchEvents(userId: GQL.ID, first: number, eventName: string): Observable<EventLogResult | null> {
     if (!userId) {
         return of(null)
     }
 
-    const result = requestGraphQL<RecentSearchesPanelDataResult, RecentSearchesPanelDataVariables>({
+    const result = requestGraphQL<EventLogsDataResult, EventLogsDataVariables>({
         request: gql`
-            query RecentSearchesPanelData($userId: ID!, $first: Int) {
+            query EventLogsData($userId: ID!, $first: Int, $eventName: String!) {
                 node(id: $userId) {
                     ... on User {
-                        recentSearches: eventLogs(first: $first, eventName: "SearchResultsQueried") {
+                        eventLogs(first: $first, eventName: $eventName) {
                             nodes {
                                 argument
                                 timestamp
@@ -558,18 +554,26 @@ export function fetchRecentSearches(userId: GQL.ID, first: number): Observable<E
                 }
             }
         `,
-        variables: { userId, first: first ?? null },
+        variables: { userId, first: first ?? null, eventName },
     })
 
     return result.pipe(
         map(dataOrThrowErrors),
         map(
-            (data: RecentSearchesPanelDataResult): EventLogResult => {
+            (data: EventLogsDataResult): EventLogResult => {
                 if (!data.node) {
                     throw new Error('User not found')
                 }
-                return data.node.recentSearches
+                return data.node.eventLogs
             }
         )
     )
+}
+
+export function fetchRecentSearches(userId: GQL.ID, first: number): Observable<EventLogResult | null> {
+    return fetchEvents(userId, first, 'SearchResultsQueried')
+}
+
+export function fetchRecentFiles(userId: GQL.ID, first: number): Observable<EventLogResult | null> {
+    return fetchEvents(userId, first, 'ViewBlob')
 }

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -574,6 +574,6 @@ export function fetchRecentSearches(userId: GQL.ID, first: number): Observable<E
     return fetchEvents(userId, first, 'SearchResultsQueried')
 }
 
-export function fetchRecentFiles(userId: GQL.ID, first: number): Observable<EventLogResult | null> {
+export function fetchRecentFileViews(userId: GQL.ID, first: number): Observable<EventLogResult | null> {
     return fetchEvents(userId, first, 'ViewBlob')
 }

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -170,6 +170,7 @@ export interface EnterpriseHomePanelsProps {
     showEnterpriseHomePanels: boolean
     fetchSavedSearches: () => Observable<ISavedSearch[]>
     fetchRecentSearches: (userId: string, first: number) => Observable<EventLogResult | null>
+    fetchRecentFiles: (userId: string, first: number) => Observable<EventLogResult | null>
 }
 
 /**

--- a/web/src/search/index.tsx
+++ b/web/src/search/index.tsx
@@ -170,7 +170,7 @@ export interface EnterpriseHomePanelsProps {
     showEnterpriseHomePanels: boolean
     fetchSavedSearches: () => Observable<ISavedSearch[]>
     fetchRecentSearches: (userId: string, first: number) => Observable<EventLogResult | null>
-    fetchRecentFiles: (userId: string, first: number) => Observable<EventLogResult | null>
+    fetchRecentFileViews: (userId: string, first: number) => Observable<EventLogResult | null>
 }
 
 /**

--- a/web/src/search/input/SearchPage.story.tsx
+++ b/web/src/search/input/SearchPage.story.tsx
@@ -8,7 +8,7 @@ import { storiesOf } from '@storybook/react'
 import { ThemePreference } from '../../theme'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { WebStory } from '../../components/WebStory'
-import { _fetchSavedSearches, _fetchRecentSearches } from '../panels/utils'
+import { _fetchSavedSearches, _fetchRecentSearches, _fetchRecentFiles } from '../panels/utils'
 
 const history = createMemoryHistory()
 const defaultProps = (props: ThemeProps): SearchPageProps => ({
@@ -48,6 +48,7 @@ const defaultProps = (props: ThemeProps): SearchPageProps => ({
     isLightTheme: props.isLightTheme,
     fetchSavedSearches: _fetchSavedSearches,
     fetchRecentSearches: _fetchRecentSearches,
+    fetchRecentFiles: _fetchRecentFiles,
 })
 
 const { add } = storiesOf('web/search/input/SearchPage', module).addParameters({

--- a/web/src/search/input/SearchPage.story.tsx
+++ b/web/src/search/input/SearchPage.story.tsx
@@ -8,7 +8,7 @@ import { storiesOf } from '@storybook/react'
 import { ThemePreference } from '../../theme'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { WebStory } from '../../components/WebStory'
-import { _fetchSavedSearches, _fetchRecentSearches, _fetchRecentFiles } from '../panels/utils'
+import { _fetchSavedSearches, _fetchRecentSearches, _fetchRecentFileViews } from '../panels/utils'
 
 const history = createMemoryHistory()
 const defaultProps = (props: ThemeProps): SearchPageProps => ({
@@ -48,7 +48,7 @@ const defaultProps = (props: ThemeProps): SearchPageProps => ({
     isLightTheme: props.isLightTheme,
     fetchSavedSearches: _fetchSavedSearches,
     fetchRecentSearches: _fetchRecentSearches,
-    fetchRecentFiles: _fetchRecentFiles,
+    fetchRecentFileViews: _fetchRecentFileViews,
 })
 
 const { add } = storiesOf('web/search/input/SearchPage', module).addParameters({

--- a/web/src/search/input/SearchPage.test.tsx
+++ b/web/src/search/input/SearchPage.test.tsx
@@ -56,6 +56,7 @@ describe('SearchPage', () => {
         isLightTheme: true,
         fetchSavedSearches: () => of([]),
         fetchRecentSearches: () => of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } }),
+        fetchRecentFiles: () => of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } }),
     }
 
     it('should not show enterprise home panels if on Sourcegraph.com', () => {

--- a/web/src/search/input/SearchPage.test.tsx
+++ b/web/src/search/input/SearchPage.test.tsx
@@ -56,7 +56,7 @@ describe('SearchPage', () => {
         isLightTheme: true,
         fetchSavedSearches: () => of([]),
         fetchRecentSearches: () => of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } }),
-        fetchRecentFiles: () => of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } }),
+        fetchRecentFileViews: () => of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } }),
     }
 
     it('should not show enterprise home panels if on Sourcegraph.com', () => {

--- a/web/src/search/panels/EnterpriseHomePanels.story.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.story.tsx
@@ -3,7 +3,7 @@ import { EnterpriseHomePanels } from './EnterpriseHomePanels'
 import { SearchPatternType } from '../../graphql-operations'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
-import { authUser, _fetchSavedSearches, _fetchRecentSearches } from './utils'
+import { authUser, _fetchSavedSearches, _fetchRecentSearches, _fetchRecentFiles } from './utils'
 
 const { add } = storiesOf('web/search/panels/EnterpriseHomePanels', module).addParameters({
     design: {
@@ -18,6 +18,7 @@ const props = {
     patternType: SearchPatternType.literal,
     fetchSavedSearches: _fetchSavedSearches,
     fetchRecentSearches: _fetchRecentSearches,
+    fetchRecentFiles: _fetchRecentFiles,
 }
 
 add('Panels', () => <WebStory>{() => <EnterpriseHomePanels {...props} />}</WebStory>)

--- a/web/src/search/panels/EnterpriseHomePanels.story.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.story.tsx
@@ -3,7 +3,7 @@ import { EnterpriseHomePanels } from './EnterpriseHomePanels'
 import { SearchPatternType } from '../../graphql-operations'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
-import { authUser, _fetchSavedSearches, _fetchRecentSearches, _fetchRecentFiles } from './utils'
+import { authUser, _fetchSavedSearches, _fetchRecentSearches, _fetchRecentFileViews } from './utils'
 
 const { add } = storiesOf('web/search/panels/EnterpriseHomePanels', module).addParameters({
     design: {
@@ -18,7 +18,7 @@ const props = {
     patternType: SearchPatternType.literal,
     fetchSavedSearches: _fetchSavedSearches,
     fetchRecentSearches: _fetchRecentSearches,
-    fetchRecentFiles: _fetchRecentFiles,
+    fetchRecentFileViews: _fetchRecentFileViews,
 }
 
 add('Panels', () => <WebStory>{() => <EnterpriseHomePanels {...props} />}</WebStory>)

--- a/web/src/search/panels/EnterpriseHomePanels.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.tsx
@@ -23,8 +23,8 @@ export const EnterpriseHomePanels: React.FunctionComponent<Props> = (props: Prop
             <RecentSearchesPanel {...props} className="enterprise-home-panels__panel col-lg-8" />
         </div>
         <div className="row">
-            <RecentFilesPanel className="enterprise-home-panels__panel col-md-7" />
-            <SavedSearchesPanel {...props} className="enterprise-home-panels__panel col-md-5" />
+            <RecentFilesPanel {...props} className="enterprise-home-panels__panel col-lg-7" />
+            <SavedSearchesPanel {...props} className="enterprise-home-panels__panel col-lg-5" />
         </div>
     </div>
 )

--- a/web/src/search/panels/EnterpriseHomePanels.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.tsx
@@ -13,6 +13,7 @@ interface Props extends Pick<PatternTypeProps, 'patternType'> {
     authenticatedUser: AuthenticatedUser | null
     fetchSavedSearches: () => Observable<GQL.ISavedSearch[]>
     fetchRecentSearches: (userId: string, first: number) => Observable<EventLogResult | null>
+    fetchRecentFiles: (userId: string, first: number) => Observable<EventLogResult | null>
 }
 
 export const EnterpriseHomePanels: React.FunctionComponent<Props> = (props: Props) => (

--- a/web/src/search/panels/EnterpriseHomePanels.tsx
+++ b/web/src/search/panels/EnterpriseHomePanels.tsx
@@ -13,7 +13,7 @@ interface Props extends Pick<PatternTypeProps, 'patternType'> {
     authenticatedUser: AuthenticatedUser | null
     fetchSavedSearches: () => Observable<GQL.ISavedSearch[]>
     fetchRecentSearches: (userId: string, first: number) => Observable<EventLogResult | null>
-    fetchRecentFiles: (userId: string, first: number) => Observable<EventLogResult | null>
+    fetchRecentFileViews: (userId: string, first: number) => Observable<EventLogResult | null>
 }
 
 export const EnterpriseHomePanels: React.FunctionComponent<Props> = (props: Props) => (

--- a/web/src/search/panels/RecentFilesPanel.story.tsx
+++ b/web/src/search/panels/RecentFilesPanel.story.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { of, NEVER } from 'rxjs'
+import { RecentFilesPanel } from './RecentFilesPanel'
+import { storiesOf } from '@storybook/react'
+import { WebStory } from '../../components/WebStory'
+import { _fetchRecentFiles } from './utils'
+
+const { add } = storiesOf('web/search/panels/RecentFilesPanel', module)
+    .addParameters({
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/sPRyyv3nt5h0284nqEuAXE/12192-Sourcegraph-server-page-v1?node-id=255%3A3',
+        },
+        chromatic: { viewports: [800] },
+    })
+    .addDecorator(story => <div style={{ width: '800px' }}>{story()}</div>)
+
+const emptyRecentFiles = {
+    totalCount: 0,
+    nodes: [],
+    pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+    },
+}
+
+const props = {
+    authenticatedUser: null,
+    fetchRecentFiles: _fetchRecentFiles,
+}
+
+add('Populated', () => <WebStory>{() => <RecentFilesPanel {...props} />}</WebStory>)
+
+add('Loading', () => <WebStory>{() => <RecentFilesPanel {...props} fetchRecentFiles={() => NEVER} />}</WebStory>)
+
+add('Empty', () => (
+    <WebStory>{() => <RecentFilesPanel {...props} fetchRecentFiles={() => of(emptyRecentFiles)} />}</WebStory>
+))

--- a/web/src/search/panels/RecentFilesPanel.story.tsx
+++ b/web/src/search/panels/RecentFilesPanel.story.tsx
@@ -3,7 +3,7 @@ import { of, NEVER } from 'rxjs'
 import { RecentFilesPanel } from './RecentFilesPanel'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
-import { _fetchRecentFiles } from './utils'
+import { _fetchRecentFileViews } from './utils'
 
 const { add } = storiesOf('web/search/panels/RecentFilesPanel', module)
     .addParameters({
@@ -26,13 +26,13 @@ const emptyRecentFiles = {
 
 const props = {
     authenticatedUser: null,
-    fetchRecentFiles: _fetchRecentFiles,
+    fetchRecentFileViews: _fetchRecentFileViews,
 }
 
 add('Populated', () => <WebStory>{() => <RecentFilesPanel {...props} />}</WebStory>)
 
-add('Loading', () => <WebStory>{() => <RecentFilesPanel {...props} fetchRecentFiles={() => NEVER} />}</WebStory>)
+add('Loading', () => <WebStory>{() => <RecentFilesPanel {...props} fetchRecentFileViews={() => NEVER} />}</WebStory>)
 
 add('Empty', () => (
-    <WebStory>{() => <RecentFilesPanel {...props} fetchRecentFiles={() => of(emptyRecentFiles)} />}</WebStory>
+    <WebStory>{() => <RecentFilesPanel {...props} fetchRecentFileViews={() => of(emptyRecentFiles)} />}</WebStory>
 ))

--- a/web/src/search/panels/RecentFilesPanel.test.tsx
+++ b/web/src/search/panels/RecentFilesPanel.test.tsx
@@ -32,7 +32,7 @@ describe('RecentFilesPanel', () => {
 
         const props = {
             authenticatedUser: null,
-            fetchRecentFiles: () => of(recentFiles),
+            fetchRecentFileViews: () => of(recentFiles),
         }
 
         const component = mount(<RecentFilesPanel {...props} />)
@@ -65,7 +65,7 @@ describe('RecentFilesPanel', () => {
 
         const props = {
             authenticatedUser: null,
-            fetchRecentFiles: () => of(recentFiles),
+            fetchRecentFileViews: () => of(recentFiles),
         }
 
         const component = mount(<RecentFilesPanel {...props} />)
@@ -97,7 +97,7 @@ describe('RecentFilesPanel', () => {
 
         const props = {
             authenticatedUser: null,
-            fetchRecentFiles: () => of(recentFiles),
+            fetchRecentFileViews: () => of(recentFiles),
         }
 
         const component = mount(<RecentFilesPanel {...props} />)
@@ -128,7 +128,7 @@ describe('RecentFilesPanel', () => {
 
         const props = {
             authenticatedUser: null,
-            fetchRecentFiles: () => of(recentFiles),
+            fetchRecentFileViews: () => of(recentFiles),
         }
 
         const component = mount(<RecentFilesPanel {...props} />)

--- a/web/src/search/panels/RecentFilesPanel.test.tsx
+++ b/web/src/search/panels/RecentFilesPanel.test.tsx
@@ -42,7 +42,7 @@ describe('RecentFilesPanel', () => {
         expect(listItems.at(1).text()).toStrictEqual('github.com/sourcegraph/sourcegraph › .eslintrc.js')
     })
 
-    test('files with missing data are not rendered', () => {
+    test('files with missing data can extract it from the URL if available', () => {
         const recentFiles = {
             nodes: [
                 {
@@ -54,6 +54,11 @@ describe('RecentFilesPanel', () => {
                     argument: '{}',
                     timestamp: '2020-09-10T22:55:06Z',
                     url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+                },
+                {
+                    argument: '{}',
+                    timestamp: '2020-09-10T22:55:06Z',
+                    url: 'https://sourcegraph.test:3443/bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2',
                 },
             ],
             pageInfo: {
@@ -70,8 +75,9 @@ describe('RecentFilesPanel', () => {
 
         const component = mount(<RecentFilesPanel {...props} />)
         const listItems = component.find('.test-recent-files-item')
-        expect(listItems.length).toStrictEqual(1)
+        expect(listItems.length).toStrictEqual(2)
         expect(listItems.at(0).text()).toStrictEqual('github.com/sourcegraph/sourcegraph › .eslintrc.js')
+        expect(listItems.at(1).text()).toStrictEqual('ghe.sgdev.org/sourcegraph/gorilla-mux › go.mod')
     })
 
     test('Show More button shown when more items can be loaded', () => {

--- a/web/src/search/panels/RecentFilesPanel.test.tsx
+++ b/web/src/search/panels/RecentFilesPanel.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { RecentFilesPanel } from './RecentFilesPanel'
+import { of } from 'rxjs'
+
+describe('RecentFilesPanel', () => {
+    test('duplicate files are only shown once', () => {
+        const recentFiles = {
+            nodes: [
+                {
+                    argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                    timestamp: '2020-09-10T22:55:30Z',
+                    url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+                },
+                {
+                    argument: '{"filePath": ".eslintrc.js", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                    timestamp: '2020-09-10T22:55:18Z',
+                    url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/.eslintrc.js',
+                },
+                {
+                    argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                    timestamp: '2020-09-10T22:55:06Z',
+                    url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+                },
+            ],
+            pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
+            },
+            totalCount: 3,
+        }
+
+        const props = {
+            authenticatedUser: null,
+            fetchRecentFiles: () => of(recentFiles),
+        }
+
+        const component = mount(<RecentFilesPanel {...props} />)
+        const listItems = component.find('.test-recent-files-item')
+        expect(listItems.length).toStrictEqual(2)
+        expect(listItems.at(0).text()).toStrictEqual('ghe.sgdev.org/sourcegraph/gorilla-mux › go.mod')
+        expect(listItems.at(1).text()).toStrictEqual('github.com/sourcegraph/sourcegraph › .eslintrc.js')
+    })
+
+    test('files with missing data are not rendered', () => {
+        const recentFiles = {
+            nodes: [
+                {
+                    argument: '{"filePath": ".eslintrc.js", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                    timestamp: '2020-09-10T22:55:18Z',
+                    url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/.eslintrc.js',
+                },
+                {
+                    argument: '{}',
+                    timestamp: '2020-09-10T22:55:06Z',
+                    url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+                },
+            ],
+            pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
+            },
+            totalCount: 2,
+        }
+
+        const props = {
+            authenticatedUser: null,
+            fetchRecentFiles: () => of(recentFiles),
+        }
+
+        const component = mount(<RecentFilesPanel {...props} />)
+        const listItems = component.find('.test-recent-files-item')
+        expect(listItems.length).toStrictEqual(1)
+        expect(listItems.at(0).text()).toStrictEqual('github.com/sourcegraph/sourcegraph › .eslintrc.js')
+    })
+
+    test('Show More button shown when more items can be loaded', () => {
+        const recentFiles = {
+            nodes: [
+                {
+                    argument: '{"filePath": ".eslintrc.js", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                    timestamp: '2020-09-10T22:55:18Z',
+                    url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/.eslintrc.js',
+                },
+                {
+                    argument: '{}',
+                    timestamp: '2020-09-10T22:55:06Z',
+                    url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+                },
+            ],
+            pageInfo: {
+                endCursor: null,
+                hasNextPage: true,
+            },
+            totalCount: 2,
+        }
+
+        const props = {
+            authenticatedUser: null,
+            fetchRecentFiles: () => of(recentFiles),
+        }
+
+        const component = mount(<RecentFilesPanel {...props} />)
+        const showMoreButton = component.find('.test-recent-files-panel-show-more')
+        expect(showMoreButton.length).toStrictEqual(1)
+    })
+
+    test('Show More button not shown when more items cannot be loaded', () => {
+        const recentFiles = {
+            nodes: [
+                {
+                    argument: '{"filePath": ".eslintrc.js", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                    timestamp: '2020-09-10T22:55:18Z',
+                    url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/.eslintrc.js',
+                },
+                {
+                    argument: '{}',
+                    timestamp: '2020-09-10T22:55:06Z',
+                    url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+                },
+            ],
+            pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
+            },
+            totalCount: 2,
+        }
+
+        const props = {
+            authenticatedUser: null,
+            fetchRecentFiles: () => of(recentFiles),
+        }
+
+        const component = mount(<RecentFilesPanel {...props} />)
+        const showMoreButton = component.find('.test-recent-files-panel-show-more')
+        expect(showMoreButton.length).toStrictEqual(0)
+    })
+})

--- a/web/src/search/panels/RecentFilesPanel.tsx
+++ b/web/src/search/panels/RecentFilesPanel.tsx
@@ -12,15 +12,15 @@ import { Link } from '../../../../shared/src/components/Link'
 export const RecentFilesPanel: React.FunctionComponent<{
     className?: string
     authenticatedUser: AuthenticatedUser | null
-    fetchRecentFiles: (userId: string, first: number) => Observable<EventLogResult | null>
-}> = ({ className, authenticatedUser, fetchRecentFiles }) => {
+    fetchRecentFileViews: (userId: string, first: number) => Observable<EventLogResult | null>
+}> = ({ className, authenticatedUser, fetchRecentFileViews }) => {
     const pageSize = 20
 
     const [itemsToLoad, setItmesToLoad] = useState(pageSize)
     const recentFiles = useObservable(
-        useMemo(() => fetchRecentFiles(authenticatedUser?.id || '', itemsToLoad), [
+        useMemo(() => fetchRecentFileViews(authenticatedUser?.id || '', itemsToLoad), [
             authenticatedUser?.id,
-            fetchRecentFiles,
+            fetchRecentFileViews,
             itemsToLoad,
         ])
     )

--- a/web/src/search/panels/RecentFilesPanel.tsx
+++ b/web/src/search/panels/RecentFilesPanel.tsx
@@ -110,7 +110,7 @@ function processRecentFiles(eventLogResult?: EventLogResult): RecentFile[] | nul
             let filePath = parsedArguments?.filePath as string
 
             if (!repoName || !filePath) {
-                [repoName, filePath] = extractFileInfoFromUrl(node.url)
+                ;({ repoName, filePath } = extractFileInfoFromUrl(node.url))
             }
 
             if (
@@ -132,14 +132,14 @@ function processRecentFiles(eventLogResult?: EventLogResult): RecentFile[] | nul
     return recentFiles
 }
 
-function extractFileInfoFromUrl(url: string): [repoName: string, filePath: string] {
+function extractFileInfoFromUrl(url: string): { repoName: string; filePath: string } {
     const parsedUrl = new URL(url)
 
     // Remove first character as it's a '/'
     const [repoName, filePath] = parsedUrl.pathname.slice(1).split('/-/blob/')
     if (!repoName || !filePath) {
-        return ['', '']
+        return { repoName: '', filePath: '' }
     }
 
-    return [repoName, filePath]
+    return { repoName, filePath }
 }

--- a/web/src/search/panels/RecentFilesPanel.tsx
+++ b/web/src/search/panels/RecentFilesPanel.tsx
@@ -1,20 +1,129 @@
-import * as React from 'react'
 import classNames from 'classnames'
+import FileCodeIcon from 'mdi-react/FileCodeIcon'
+import React, { useEffect, useMemo, useState } from 'react'
+import { AuthenticatedUser } from '../../auth'
+import { EventLogResult } from '../backend'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { Observable } from 'rxjs'
 import { PanelContainer } from './PanelContainer'
+import { useObservable } from '../../../../shared/src/util/useObservable'
+import { Link } from '../../../../shared/src/components/Link'
 
-export const RecentFilesPanel: React.FunctionComponent<{ className?: string }> = ({ className }) => {
-    const loadingDisplay = <div>Loading</div>
-    const contentDisplay = <div>Content</div>
-    const emptyDisplay = <div>Empty</div>
+export const RecentFilesPanel: React.FunctionComponent<{
+    className?: string
+    authenticatedUser: AuthenticatedUser | null
+    fetchRecentFiles: (userId: string, first: number) => Observable<EventLogResult | null>
+}> = ({ className, authenticatedUser, fetchRecentFiles }) => {
+    const pageSize = 20
+
+    const [itemsToLoad, setItmesToLoad] = useState(pageSize)
+    const recentFiles = useObservable(
+        useMemo(() => fetchRecentFiles(authenticatedUser?.id || '', itemsToLoad), [
+            authenticatedUser?.id,
+            fetchRecentFiles,
+            itemsToLoad,
+        ])
+    )
+
+    const [processedResults, setProcessedResults] = useState<RecentFile[] | null>(null)
+
+    // Only update processed results when results are valid to prevent
+    // flashing loading screen when "Show more" button is clicked
+    useEffect(() => {
+        if (recentFiles) {
+            setProcessedResults(processRecentFiles(recentFiles))
+        }
+    }, [recentFiles])
+
+    const loadingDisplay = (
+        <div className="d-flex justify-content-center align-items-center panel-container__empty-container">
+            <div className="icon-inline">
+                <LoadingSpinner />
+            </div>
+            Loading recent files
+        </div>
+    )
+
+    const emptyDisplay = (
+        <div className="panel-container__empty-container align-items-center">
+            <FileCodeIcon className="mb-2" size="2rem" />
+            <small className="mb-2">This panel will display your most recently viewed files.</small>
+        </div>
+    )
+
+    const contentDisplay = (
+        <div>
+            <small className="mb-1">File</small>
+            <dl className="list-group-flush">
+                {processedResults?.map((recentFile, index) => (
+                    <dd key={index} className="text-monospace">
+                        <Link to={recentFile.url}>
+                            {recentFile.repoName} › {recentFile.filePath}
+                        </Link>
+                    </dd>
+                ))}
+            </dl>
+            {recentFiles?.pageInfo.hasNextPage && (
+                <div className="text-center">
+                    <button
+                        type="button"
+                        className="btn btn-secondary test-recent-searches-panel-show-more"
+                        onClick={() => setItmesToLoad(current => current + pageSize)}
+                    >
+                        Show more
+                    </button>
+                </div>
+            )}
+        </div>
+    )
 
     return (
         <PanelContainer
             className={classNames(className, 'recent-files-panel')}
             title="Recent files"
-            state="populated"
+            state={processedResults ? (processedResults.length > 0 ? 'populated' : 'empty') : 'loading'}
             loadingContent={loadingDisplay}
             populatedContent={contentDisplay}
             emptyContent={emptyDisplay}
         />
     )
+}
+
+interface RecentFile {
+    repoName: string
+    filePath: string
+    timestamp: string
+    url: string
+}
+
+function processRecentFiles(eventLogResult?: EventLogResult): RecentFile[] | null {
+    if (!eventLogResult) {
+        return null
+    }
+
+    const recentFiles: RecentFile[] = []
+
+    for (const node of eventLogResult.nodes) {
+        if (node.argument) {
+            const parsedArguments = JSON.parse(node.argument)
+            const repoName = parsedArguments?.repoName as string
+            const filePath = parsedArguments?.filePath as string
+
+            if (
+                filePath &&
+                repoName &&
+                !recentFiles.some(file => file.repoName === repoName && file.filePath === filePath) // Don't show the same file twice
+            ) {
+                const parsedUrl = new URL(node.url)
+                recentFiles.push({
+                    url: parsedUrl.pathname + parsedUrl.search, // Strip domain from URL so clicking on it doesn't reload page
+                    repoName,
+                    filePath,
+                    timestamp: node.timestamp,
+                })
+            }
+        }
+    }
+
+    return recentFiles
 }

--- a/web/src/search/panels/RecentFilesPanel.tsx
+++ b/web/src/search/panels/RecentFilesPanel.tsx
@@ -56,7 +56,7 @@ export const RecentFilesPanel: React.FunctionComponent<{
             <small className="mb-1">File</small>
             <dl className="list-group-flush">
                 {processedResults?.map((recentFile, index) => (
-                    <dd key={index} className="text-monospace">
+                    <dd key={index} className="text-monospace test-recent-files-item">
                         <Link to={recentFile.url}>
                             {recentFile.repoName} › {recentFile.filePath}
                         </Link>
@@ -67,7 +67,7 @@ export const RecentFilesPanel: React.FunctionComponent<{
                 <div className="text-center">
                     <button
                         type="button"
-                        className="btn btn-secondary test-recent-searches-panel-show-more"
+                        className="btn btn-secondary test-recent-files-panel-show-more"
                         onClick={() => setItmesToLoad(current => current + pageSize)}
                     >
                         Show more

--- a/web/src/search/panels/RecentFilesPanel.tsx
+++ b/web/src/search/panels/RecentFilesPanel.tsx
@@ -106,8 +106,12 @@ function processRecentFiles(eventLogResult?: EventLogResult): RecentFile[] | nul
     for (const node of eventLogResult.nodes) {
         if (node.argument) {
             const parsedArguments = JSON.parse(node.argument)
-            const repoName = parsedArguments?.repoName as string
-            const filePath = parsedArguments?.filePath as string
+            let repoName = parsedArguments?.repoName as string
+            let filePath = parsedArguments?.filePath as string
+
+            if (!repoName || !filePath) {
+                [repoName, filePath] = extractFileInfoFromUrl(node.url)
+            }
 
             if (
                 filePath &&
@@ -126,4 +130,16 @@ function processRecentFiles(eventLogResult?: EventLogResult): RecentFile[] | nul
     }
 
     return recentFiles
+}
+
+function extractFileInfoFromUrl(url: string): [repoName: string, filePath: string] {
+    const parsedUrl = new URL(url)
+
+    // Remove first character as it's a '/'
+    const [repoName, filePath] = parsedUrl.pathname.slice(1).split('/-/blob/')
+    if (!repoName || !filePath) {
+        return ['', '']
+    }
+
+    return [repoName, filePath]
 }

--- a/web/src/search/panels/utils.ts
+++ b/web/src/search/panels/utils.ts
@@ -227,4 +227,122 @@ export const _fetchRecentSearches = (): Observable<EventLogResult | null> =>
     })
 
 export const _fetchRecentFiles = (): Observable<EventLogResult | null> =>
-    of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } })
+    of({
+        nodes: [
+            {
+                argument: '{"filePath": "web/src/tree/Tree.tsx", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:55Z',
+                url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/src/tree/Tree.tsx',
+            },
+            {
+                argument: '{"filePath": "web/src/tree/TreeRoot.tsx", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:55Z',
+                url:
+                    'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/src/tree/TreeRoot.tsx',
+            },
+            {
+                argument:
+                    '{"filePath": "web/src/tree/SingleChildTreeLayer.tsx", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:54Z',
+                url:
+                    'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/src/tree/SingleChildTreeLayer.tsx',
+            },
+            {
+                argument:
+                    '{"filePath": "web/src/tree/Directory.tsx", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:54Z',
+                url:
+                    'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/src/tree/Directory.tsx',
+            },
+            {
+                argument:
+                    '{"filePath": "web/src/site/FreeUsersExceededAlert.tsx", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:51Z',
+                url:
+                    'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/src/site/FreeUsersExceededAlert.tsx',
+            },
+            {
+                argument:
+                    '{"filePath": "web/src/site/DockerForMacAlert.scss", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:50Z',
+                url:
+                    'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/src/site/DockerForMacAlert.scss',
+            },
+            {
+                argument: '{"filePath": "web/jest.config.js", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T23:07:45Z',
+                url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/web/jest.config.js',
+            },
+            {
+                argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T22:55:30Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+            },
+            {
+                argument: '{"filePath": ".eslintrc.js", "repoName": "github.com/sourcegraph/sourcegraph"}',
+                timestamp: '2020-09-10T22:55:18Z',
+                url: 'https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/.eslintrc.js',
+            },
+            {
+                argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T22:55:06Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+            },
+            {
+                argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T22:54:54Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+            },
+            {
+                argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T22:54:50Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+            },
+            {
+                argument: '{"filePath": "AUTHORS", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:23Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/AUTHORS',
+            },
+            {
+                argument: '{"filePath": "LICENSE", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:23Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/LICENSE',
+            },
+            {
+                argument: '{"filePath": "README.md", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:22Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/README.md',
+            },
+            {
+                argument:
+                    '{"filePath": "example_authentication_middleware_test.go", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:21Z',
+                url:
+                    'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/example_authentication_middleware_test.go',
+            },
+            {
+                argument:
+                    '{"filePath": "example_cors_method_middleware_test.go", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:20Z',
+                url:
+                    'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/example_cors_method_middleware_test.go',
+            },
+            {
+                argument: '{"filePath": "example_route_test.go", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:19Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/example_route_test.go',
+            },
+            {
+                argument: '{"filePath": "go.mod", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:16Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/go.mod',
+            },
+            {
+                argument: '{"filePath": "mux_test.go", "repoName": "ghe.sgdev.org/sourcegraph/gorilla-mux"}',
+                timestamp: '2020-09-10T21:21:03Z',
+                url: 'https://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/gorilla-mux/-/blob/mux_test.go',
+            },
+        ],
+        totalCount: 500,
+        pageInfo: { hasNextPage: true, endCursor: null },
+    })

--- a/web/src/search/panels/utils.ts
+++ b/web/src/search/panels/utils.ts
@@ -226,7 +226,7 @@ export const _fetchRecentSearches = (): Observable<EventLogResult | null> =>
         totalCount: 436,
     })
 
-export const _fetchRecentFiles = (): Observable<EventLogResult | null> =>
+export const _fetchRecentFileViews = (): Observable<EventLogResult | null> =>
     of({
         nodes: [
             {

--- a/web/src/search/panels/utils.ts
+++ b/web/src/search/panels/utils.ts
@@ -225,3 +225,6 @@ export const _fetchRecentSearches = (): Observable<EventLogResult | null> =>
         },
         totalCount: 436,
     })
+
+export const _fetchRecentFiles = (): Observable<EventLogResult | null> =>
+    of({ nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } })

--- a/web/src/tracking/eventLogger.ts
+++ b/web/src/tracking/eventLogger.ts
@@ -33,7 +33,7 @@ export class EventLogger implements TelemetryService {
         pageTitle = `View${pageTitle}`
 
         const props = pageViewQueryParameters(window.location.href)
-        serverAdmin.trackPageView(pageTitle, true, eventProperties)
+        serverAdmin.trackPageView(pageTitle, logAsActiveUser, eventProperties)
         this.logToConsole(pageTitle, props)
 
         // Use flag to ensure URL query params are only stripped once

--- a/web/src/tracking/eventLogger.ts
+++ b/web/src/tracking/eventLogger.ts
@@ -26,14 +26,14 @@ export class EventLogger implements TelemetryService {
      * Log a pageview.
      * Page titles should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
      */
-    public logViewEvent(pageTitle: string, logAsActiveUser = true): void {
+    public logViewEvent(pageTitle: string, eventProperties?: any, logAsActiveUser = true): void {
         if (window.context?.userAgentIsBot || !pageTitle) {
             return
         }
         pageTitle = `View${pageTitle}`
 
         const props = pageViewQueryParameters(window.location.href)
-        serverAdmin.trackPageView(pageTitle, logAsActiveUser)
+        serverAdmin.trackPageView(pageTitle, true, eventProperties)
         this.logToConsole(pageTitle, props)
 
         // Use flag to ensure URL query params are only stripped once

--- a/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/web/src/tracking/services/serverAdminWrapper.tsx
@@ -18,7 +18,7 @@ class ServerAdminWrapper {
         })
     }
 
-    public trackPageView(eventAction: string, logAsActiveUser: boolean = true): void {
+    public trackPageView(eventAction: string, logAsActiveUser: boolean = true, eventProperties?: any): void {
         if (logAsActiveUser) {
             logUserEvent(UserEvent.PAGEVIEW)
         }
@@ -27,7 +27,7 @@ class ServerAdminWrapper {
                 logUserEvent(UserEvent.STAGECODE)
             }
         }
-        logEvent(eventAction)
+        logEvent(eventAction, eventProperties)
     }
 
     public trackAction(eventAction: string, eventProperties?: any): void {


### PR DESCRIPTION
Fixes #13423

- Adds event logging details when ViewBlob is logged to also log the repo name and file path. This required a bit of refactoring of `trackPageView` and `logViewEvent`
- Populates the Recent Files panel with data based on the ViewBlob event. Each file is only shown once and files without the new data from the ViewBlob event are not shown. Panel supports pagination via a "Show More" button.
- Refactored the data fetching from the Recent Searches panel to also work fo the Recent Files panel, as the data queried is the same except for the event type.

![image](https://user-images.githubusercontent.com/206864/92822493-1234c380-f381-11ea-9444-a999313301d1.png)

![image](https://user-images.githubusercontent.com/206864/92822518-19f46800-f381-11ea-8480-1b1e1a075c36.png)

![image](https://user-images.githubusercontent.com/206864/92822558-24aefd00-f381-11ea-9164-8560e36adece.png)

![image](https://user-images.githubusercontent.com/206864/92822592-2c6ea180-f381-11ea-9cb7-c1d1f6e984de.png)



