### PR TITLE
search: respect literal vs regex mode for NOT patterns

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -895,7 +895,7 @@ loop:
 				nodes = append(nodes, parameter)
 				break loop
 			}
-			pattern := p.ParsePatternRegexp()
+			pattern := p.ParsePatternLiteral()
 			pattern.Negated = true
 			pattern.Annotation.Range = newRange(start, p.pos)
 			nodes = append(nodes, pattern)

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -1220,6 +1220,11 @@ func TestParseAndOrLiteral(t *testing.T) {
 			Want:       `(concat "a:b" "\"patterntype:regexp\"")`,
 			WantLabels: "Literal",
 		},
+		{
+			Input:      `not literal.*pattern`,
+			Want:       `"NOT literal.*pattern"`,
+			WantLabels: "Literal",
+		},
 		// Whitespace is removed. content: exists for preserving whitespace.
 		{
 			Input:      `lang:go func  main`,


### PR DESCRIPTION
Stacked on #13755

This fixes a bug, see the test case comment while I was refactoring part of #13754.  The first commit is just a mechanical refactor that inlines `parseNegatedLeafNode`. Having the shared function before was good, but makes it hard to fix this easily _and_ I also want to refactor the functions that call this function, so it is easier/better to inline the function on the way to the final refactor.

The second commit fixes the bug.