### PR TITLE
gitserver: create reposstats endpoint

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -72,7 +72,7 @@ func TestCleanup_computeStats(t *testing.T) {
 	}
 
 	if got.UpdatedAt.Before(want.UpdatedAt) {
-		t.Fatal("want should of been computed after we called cleanupRepos")
+		t.Fatal("want should have been computed after we called cleanupRepos")
 	}
 	if got.UpdatedAt.After(time.Now()) {
 		t.Fatal("want.UpdatedAt is in the future")

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -266,7 +266,7 @@ func TestCleanupOldLocks(t *testing.T) {
 	s.cleanupRepos()
 
 	assertPaths(t, root,
-		"stats.json",
+		"repos-stats.json",
 
 		"github.com/foo/empty/.git/HEAD",
 		"github.com/foo/empty/.git/info/attributes",

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -97,7 +97,7 @@ func (s *Server) handleRepoInfo(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleReposStats(w http.ResponseWriter, r *http.Request) {
 	b, err := ioutil.ReadFile(filepath.Join(s.ReposDir, reposStatsName))
 	if err != nil && errors.Is(err, os.ErrNotExist) {
-		// So when a gitserver is new this file might not have been computed
+		// When a gitserver is new this file might not have been computed
 		// yet. Clients are expected to handle this case by noticing UpdatedAt
 		// is not set.
 		b = []byte("{}")

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -231,6 +231,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
 	mux.HandleFunc("/is-repo-cloned", s.handleIsRepoCloned)
 	mux.HandleFunc("/repos", s.handleRepoInfo)
+	mux.HandleFunc("/repos-stats", s.handleReposStats)
 	mux.HandleFunc("/repo-clone-progress", s.handleRepoCloneProgress)
 	mux.HandleFunc("/delete", s.handleRepoDelete)
 	mux.HandleFunc("/repo-update", s.handleRepoUpdate)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -805,6 +805,48 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol
 	return &res, err.ErrorOrNil()
 }
 
+// ReposStats will return a map of the ReposStats for each gitserver in a
+// map. If we fail to fetch a stat from a gitserver, it won't be in the
+// returned map and will be appended to the error. If no errors occur err will
+// be nil.
+//
+// Note: If the statistics for a gitserver have not been computed, the
+// UpdatedAt field will zero. This can happen for new gitservers.
+func (c *Client) ReposStats(ctx context.Context) (map[string]*protocol.ReposStats, error) {
+	stats := map[string]*protocol.ReposStats{}
+	var allErr error
+	for _, addr := range c.Addrs(ctx) {
+		stat, err := c.doReposStats(ctx, addr)
+		if err != nil {
+			allErr = multierror.Append(allErr, err)
+		} else {
+			stats[addr] = stat
+		}
+	}
+	return stats, allErr
+}
+
+func (c *Client) doReposStats(ctx context.Context, addr string) (*protocol.ReposStats, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://"+addr+"/repos-stats", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var stats protocol.ReposStats
+	err = json.NewDecoder(resp.Body).Decode(&stats)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
 // Remove removes the repository clone from gitserver.
 func (c *Client) Remove(ctx context.Context, repo api.RepoName) error {
 	req := &protocol.RepoDeleteRequest{

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -811,7 +811,7 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol
 // be nil.
 //
 // Note: If the statistics for a gitserver have not been computed, the
-// UpdatedAt field will zero. This can happen for new gitservers.
+// UpdatedAt field will be zero. This can happen for new gitservers.
 func (c *Client) ReposStats(ctx context.Context) (map[string]*protocol.ReposStats, error) {
 	stats := map[string]*protocol.ReposStats{}
 	var allErr error

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -131,6 +131,17 @@ type RepoInfoResponse struct {
 	Results map[api.RepoName]*RepoInfo
 }
 
+// ReposStats is an aggregation of statistics from a gitserver.
+type ReposStats struct {
+	// UpdatedAt is the time these statistics were computed. If UpdateAt is
+	// zero, the statistics have not yet been computed. This can happen on a
+	// new gitserver.
+	UpdatedAt time.Time
+
+	// GitDirBytes is the amount of bytes stored in .git directories.
+	GitDirBytes int64
+}
+
 // RepoCloneProgressRequest is a request for information about the clone progress of multiple
 // repositories on gitserver.
 type RepoCloneProgressRequest struct {


### PR DESCRIPTION
We want to compute the total number of bytes for git repos on a
gitserver. This commit adds a new endpoint to gitserver for
ReposStats. ReposStats currently has a field for total number of bytes
of all git repos. In future we could also add other relevant statistics.

We compute the total size of the repositories as part of our janitor
jobs. We do this because this can be slow to compute. The janitor jobs
are useful infrastructure which periodically run over all repositories
on a gitserver.

There are no callers of the client yet. We intend to use this in site
pings.

Part of https://github.com/sourcegraph/sourcegraph/issues/13713

Co-authored-by: ᴜɴᴋɴᴡᴏɴ <joe@sourcegraph.com>