### PR TITLE
search: show new lines count on repo settings page

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -88,6 +88,18 @@ func (r *repositoryTextSearchIndexStatus) IndexShardsCount() int32 {
 	return int32(r.entry.Stats.Shards + 1)
 }
 
+func (r *repositoryTextSearchIndexStatus) NewLinesCount() int32 {
+	return int32(r.entry.Stats.NewLinesCount)
+}
+
+func (r *repositoryTextSearchIndexStatus) DefaultBranchNewLinesCount() int32 {
+	return int32(r.entry.Stats.DefaultBranchNewLinesCount)
+}
+
+func (r *repositoryTextSearchIndexStatus) OtherBranchesNewLinesCount() int32 {
+	return int32(r.entry.Stats.OtherBranchesNewLinesCount)
+}
+
 func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*repositoryTextSearchIndexedRef, error) {
 	// We assume that the default branch for enabled repositories is always configured to be indexed.
 	//

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3547,6 +3547,21 @@ type RepositoryTextSearchIndexStatus {
     The number of index shards.
     """
     indexShardsCount: Int!
+
+    """
+    EXPERIMENTAL: The number of newlines appearing in the index.
+    """
+    newLinesCount: Int!
+
+    """
+    EXPERIMENTAL: The number of newlines in the default branch.
+    """
+    defaultBranchNewLinesCount: Int!
+
+    """
+    EXPERIMENTAL: The number of newlines in the other branches.
+    """
+    otherBranchesNewLinesCount: Int!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3540,6 +3540,21 @@ type RepositoryTextSearchIndexStatus {
     The number of index shards.
     """
     indexShardsCount: Int!
+
+    """
+    EXPERIMENTAL: The number of newlines appearing in the index.
+    """
+    newLinesCount: Int!
+
+    """
+    EXPERIMENTAL: The number of newlines in the default branch.
+    """
+    defaultBranchNewLinesCount: Int!
+
+    """
+    EXPERIMENTAL: The number of newlines in the other branches.
+    """
+    otherBranchesNewLinesCount: Int!
 }
 
 """

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200908080019-f95cecffc54f
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200911142020-36f86e63516f
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1203,6 +1203,10 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20200908080019-f95cecffc54f h1:Utx9Yq9NlgWURzjFVdEl9dtutgiM2uyevi+VPnsZI0w=
 github.com/sourcegraph/zoekt v0.0.0-20200908080019-f95cecffc54f/go.mod h1:Cj/TaflDEk8QLJnV9mJP5hVswI9bEePpod/d9iLR4Kk=
+github.com/sourcegraph/zoekt v0.0.0-20200911123057-422d5b68c06e h1:arEEamCq+/vT8iayW5jDeR6RRu2r0MNj9bhrY15YvAU=
+github.com/sourcegraph/zoekt v0.0.0-20200911123057-422d5b68c06e/go.mod h1:Cj/TaflDEk8QLJnV9mJP5hVswI9bEePpod/d9iLR4Kk=
+github.com/sourcegraph/zoekt v0.0.0-20200911142020-36f86e63516f h1:JgRyqVKhF2UQB/YrLHkk9B4gjrBTjz3Pq0PQrfJ4XD4=
+github.com/sourcegraph/zoekt v0.0.0-20200911142020-36f86e63516f/go.mod h1:Cj/TaflDEk8QLJnV9mJP5hVswI9bEePpod/d9iLR4Kk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -34,6 +34,9 @@ function fetchRepositoryTextSearchIndex(id: GQL.ID): Observable<GQL.IRepositoryT
                                 contentFilesCount
                                 indexByteSize
                                 indexShardsCount
+                                newLinesCount
+                                defaultBranchNewLinesCount
+                                otherBranchesNewLinesCount
                             }
                             refs {
                                 ref {
@@ -211,6 +214,17 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                         'shard',
                                                         this.state.textSearchIndex.status.indexShardsCount
                                                     )}
+                                                    )
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <th>New lines count</th>
+                                                <td>
+                                                    {this.state.textSearchIndex.status.newLinesCount.toLocaleString()}{' '}
+                                                    (default branch:{' '}
+                                                    {this.state.textSearchIndex.status.defaultBranchNewLinesCount.toLocaleString()}
+                                                    ) (other branches:{' '}
+                                                    {this.state.textSearchIndex.status.otherBranchesNewLinesCount.toLocaleString()}
                                                     )
                                                 </td>
                                             </tr>


### PR DESCRIPTION
We update Zoekt to include the new line count statistics. We expose this
in the repository index settings page. We are displaying them here for
debugging purposes.

There will be another commit which includes this information in the
pings.

![image](https://user-images.githubusercontent.com/187831/92931505-d9115780-f443-11ea-9abe-1459c579eefa.png)

Depends on https://github.com/sourcegraph/zoekt/pull/57

Part of https://github.com/sourcegraph/sourcegraph/issues/13713