### PR TITLE
schema: move search.streaming to experimental settings

### DIFF
--- a/schema/gen.sh
+++ b/schema/gen.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export GOBIN="$PWD/.bin"
+# Use .bin outside of schema since schema dir is watched by watchman.
+export GOBIN="$PWD/../.bin"
 export GO111MODULE=on
 
 go install github.com/sourcegraph/go-jsonschema/cmd/go-jsonschema-compiler

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1091,8 +1091,6 @@ type Settings struct {
 	SearchSavedQueries []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
 	// SearchScopes description: Predefined search scopes
 	SearchScopes []*SearchScope `json:"search.scopes,omitempty"`
-	// SearchStreaming description: Enables experimental streaming support.
-	SearchStreaming *bool `json:"search.streaming,omitempty"`
 	// SearchUppercase description: When active, any uppercase characters in the pattern will make the entire query case-sensitive.
 	SearchUppercase *bool `json:"search.uppercase,omitempty"`
 }
@@ -1105,6 +1103,8 @@ type SettingsExperimentalFeatures struct {
 	CopyQueryButton *bool `json:"copyQueryButton,omitempty"`
 	// SearchStats description: Enables a new page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`
+	// SearchStreaming description: Enables experimental streaming support.
+	SearchStreaming *bool `json:"searchStreaming,omitempty"`
 	// ShowBadgeAttachments description: Enables the UI indicators for code intelligence precision.
 	ShowBadgeAttachments *bool `json:"showBadgeAttachments,omitempty"`
 	// ShowEnterpriseHomePanels description: Enabled the homepage panels in the Enterprise homepage

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -30,6 +30,12 @@
           "default": false,
           "!go": { "pointer": true }
         },
+        "searchStreaming": {
+          "description": "Enables experimental streaming support.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
         "showBadgeAttachments": {
           "description": "Enables the UI indicators for code intelligence precision.",
           "type": "boolean",
@@ -100,12 +106,6 @@
     },
     "search.globbing": {
       "description": "Enables globbing for supported field values",
-      "type": "boolean",
-      "default": false,
-      "!go": { "pointer": true }
-    },
-    "search.streaming": {
-      "description": "Enables experimental streaming support.",
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -35,6 +35,12 @@ const SettingsSchemaJSON = `{
           "default": false,
           "!go": { "pointer": true }
         },
+        "searchStreaming": {
+          "description": "Enables experimental streaming support.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
         "showBadgeAttachments": {
           "description": "Enables the UI indicators for code intelligence precision.",
           "type": "boolean",
@@ -105,12 +111,6 @@ const SettingsSchemaJSON = `{
     },
     "search.globbing": {
       "description": "Enables globbing for supported field values",
-      "type": "boolean",
-      "default": false,
-      "!go": { "pointer": true }
-    },
-    "search.streaming": {
-      "description": "Enables experimental streaming support.",
       "type": "boolean",
       "default": false,
       "!go": { "pointer": true }


### PR DESCRIPTION
Also renamed it to searchStreaming to be consistent with other setting
names. Additionally fixed a minor dev environment issue where
recompiling triggered the file watcher due to the binaries being
compiled.