### PR TITLE
search: log result size to honeycomb

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -673,6 +673,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (*SearchResultsResolv
 		ev.AddField("status", status)
 		ev.AddField("alert_type", alertType)
 		ev.AddField("duration_ms", time.Since(start).Milliseconds())
+		ev.AddField("result_size", len(rr.SearchResults))
 
 		if honey.Enabled() {
 			_ = ev.Send()


### PR DESCRIPTION
Relates to #13686

we want to track the result size to segment queries for performance analysis



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
