### PR TITLE
remove dead symlinks

### DIFF
--- a/client/browser/node_modules/.bin
+++ b/client/browser/node_modules/.bin
@@ -1,1 +1,0 @@
-../../../node_modules/.bin

--- a/client/browser/node_modules/.bin
+++ b/client/browser/node_modules/.bin
@@ -1,0 +1,1 @@
+../../../node_modules/.bin

--- a/packages/sourcegraph-extension-api/node_modules/.bin
+++ b/packages/sourcegraph-extension-api/node_modules/.bin
@@ -1,1 +1,0 @@
-../../../node_modules/.bin/

--- a/packages/sourcegraph-extension-api/node_modules/.bin
+++ b/packages/sourcegraph-extension-api/node_modules/.bin
@@ -1,0 +1,1 @@
+../../../node_modules/.bin/

--- a/shared/node_modules/.bin
+++ b/shared/node_modules/.bin
@@ -1,1 +1,0 @@
-../../node_modules/.bin

--- a/shared/node_modules/.bin
+++ b/shared/node_modules/.bin
@@ -1,0 +1,1 @@
+../../node_modules/.bin

--- a/web/node_modules/.bin
+++ b/web/node_modules/.bin
@@ -1,1 +1,0 @@
-../../node_modules/.bin

--- a/web/node_modules/.bin
+++ b/web/node_modules/.bin
@@ -1,0 +1,1 @@
+../../node_modules/.bin


### PR DESCRIPTION
These symlinks no longer resolve to anything and stop rsync operations when copying this repo into vagrant boxes. This directly impacts the work being done for e2e testing. 