### PR TITLE
Add repository_access_level issue to GitLab FAQ

### DIFF
--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -113,3 +113,13 @@ To set up webhooks:
 1. Confirm that the new webhook is listed below **Project Hooks**.
 
 Done! Sourcegraph will now receive webhook events from GitLab and use them to sync merge request events, used by [campaigns](../../user/campaigns/index.md), faster and more efficiently.
+
+## GitLab integration FAQ
+
+### Why is one of my projects failing to clone?
+
+If a project fails to clone in Sourcegraph, you may need to change its `repository_access_level` property in GitLab. To change this property in the GitLab UI:
+
+- Go to the Project > **Settings** > **General**
+- Expand **Visibility, project features, permissions**
+- Change **Repository Access** from "Only Project Members" to “Everyone with Access”


### PR DESCRIPTION
Reported by https://app.hubspot.com/contacts/2762526/company/1783614661 in https://sourcegraph.atlassian.net/jira/servicedesk/projects/SG/queues/custom/1/SG-320

Is this the wrong place for this to go? I don't like the idea of a bunch of different FAQs, but this feels too specific to go into the main admin FAQ. Curious what you think @kghopson 