### PR TITLE
Implement breadcrumb links, replace element links with breadcrumb links

### DIFF
--- a/web/src/components/Breadcrumbs.story.tsx
+++ b/web/src/components/Breadcrumbs.story.tsx
@@ -1,69 +1,70 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Breadcrumbs } from './Breadcrumbs'
-import webStyles from '../SourcegraphWebApp.scss'
+import { WebStory } from './WebStory'
 
 const { add } = storiesOf('web/Breadcrumbs', module).addDecorator(story => (
-    <>
-        <style>{webStyles}</style>
-        <div className="container mt-3 theme-light">{story()}</div>
-    </>
+    <div className="container mt-3">{story()}</div>
 ))
 
 add(
     'Example',
     () => (
-        <Breadcrumbs
-            breadcrumbs={[
-                {
-                    depth: 0,
-                    breadcrumb: { key: 'home', element: <a href="#">Home</a>, divider: null },
-                },
-                {
-                    depth: 1,
-                    breadcrumb: { key: 'repo_area', element: <a href="#">Repositories</a> },
-                },
-                {
-                    depth: 2,
-                    breadcrumb: {
-                        key: 'repo',
-                        element: (
-                            <a href="#">
-                                sourcegraph/<span className="font-weight-semibold">sourcegraph</span>
-                            </a>
-                        ),
-                    },
-                },
-                {
-                    depth: 3,
-                    breadcrumb: {
-                        key: 'revision',
-                        divider: <span className="mx-1">@</span>,
-                        element: <span className="text-muted">fb/my-branch</span>,
-                    },
-                },
-                {
-                    depth: 4,
-                    breadcrumb: { key: 'directory1', element: <a href="#">path</a> },
-                },
-                {
-                    depth: 5,
-                    breadcrumb: {
-                        key: 'directory2',
-                        divider: <span className="mx-1">/</span>,
-                        element: <a href="#">to</a>,
-                    },
-                },
-                {
-                    depth: 6,
-                    breadcrumb: {
-                        key: 'fileName',
-                        divider: <span className="mx-1">/</span>,
-                        element: <a href="#">file.tsx</a>,
-                    },
-                },
-            ]}
-        />
+        <WebStory>
+            {() => (
+                <Breadcrumbs
+                    breadcrumbs={[
+                        {
+                            depth: 0,
+                            breadcrumb: { key: 'home', element: <a href="#">Home</a>, divider: null },
+                        },
+                        {
+                            depth: 1,
+                            breadcrumb: { key: 'repo_area', element: <a href="#">Repositories</a> },
+                        },
+                        {
+                            depth: 2,
+                            breadcrumb: {
+                                key: 'repo',
+                                element: (
+                                    <a href="#">
+                                        sourcegraph/<span className="font-weight-semibold">sourcegraph</span>
+                                    </a>
+                                ),
+                            },
+                        },
+                        {
+                            depth: 3,
+                            breadcrumb: {
+                                key: 'revision',
+                                divider: <span className="mx-1">@</span>,
+                                element: <span className="text-muted">fb/my-branch</span>,
+                            },
+                        },
+                        {
+                            depth: 4,
+                            breadcrumb: { key: 'directory1', element: <a href="#">path</a> },
+                        },
+                        {
+                            depth: 5,
+                            breadcrumb: {
+                                key: 'directory2',
+                                divider: <span className="mx-1">/</span>,
+                                element: <a href="#">to</a>,
+                            },
+                        },
+                        {
+                            depth: 6,
+                            breadcrumb: {
+                                key: 'fileName',
+                                divider: <span className="mx-1">/</span>,
+                                element: <a href="#">file.tsx</a>,
+                            },
+                        },
+                    ]}
+                />
+            )}
+        </WebStory>
     ),
     {
         design: {

--- a/web/src/components/Breadcrumbs.story.tsx
+++ b/web/src/components/Breadcrumbs.story.tsx
@@ -11,8 +11,9 @@ add(
     'Example',
     () => (
         <WebStory>
-            {() => (
+            {webProps => (
                 <Breadcrumbs
+                    {...webProps}
                     breadcrumbs={[
                         {
                             depth: 0,

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -26,7 +26,10 @@ interface LinkBreadcrumb {
     /** A unique key for the breadcrumb. */
     key: string
 
-    /** Specification for links */
+    /**
+     * Specification for links. When this breadcrumb is the last breadcrumb and
+     * the URL hash is empty, the label is rendered as plain text instead of a link.
+     */
     link: { label: string; to: string }
 
     /**
@@ -169,7 +172,7 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[] }> = ({ br
                             <span className="font-weight-semibold">{divider}</span>
                             {isElementBreadcrumb(breadcrumb) ? (
                                 breadcrumb.element
-                            ) : // When this is the last breadcrumb and the hash is empty, render as plain text
+                            ) : // When the last breadcrumb is a link and the hash is empty, render as plain text
                             index === validBreadcrumbs.length - 1 && !location.hash ? (
                                 breadcrumb.link.label
                             ) : (

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -111,7 +111,6 @@ export const useBreadcrumbs = (): BreadcrumbsProps & BreadcrumbSetters => {
         /** Shared logic between plain function and hook */
         function internalSetBreadcrumb(breadcrumb: NullableBreadcrumb): () => void {
             const entry: BreadcrumbAtDepth = { depth, breadcrumb }
-            console.log(breadcrumb)
             setBreadcrumbsByDepth(breadcrumbs => [...breadcrumbs, entry])
             // cleanup
             return () => {

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -4,7 +4,7 @@ import { Link } from '../../../shared/src/components/Link'
 import { sortBy } from 'lodash'
 import { Unsubscribable } from 'sourcegraph'
 import { isDefined } from '../../../shared/src/util/types'
-import { useLocation } from 'react-router'
+import * as H from 'history'
 
 export type Breadcrumb = ElementBreadcrumb | LinkBreadcrumb
 
@@ -152,38 +152,33 @@ export const useBreadcrumbs = (): BreadcrumbsProps & BreadcrumbSetters => {
 /**
  * Renders breadcrumbs by depth.
  */
-export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[] }> = ({ breadcrumbs }) => {
-    const location = useLocation()
-
-    return (
-        <nav className="d-flex p-2" aria-label="Breadcrumbs">
-            {sortBy(breadcrumbs, 'depth')
-                .map(({ breadcrumb }) => breadcrumb)
-                .filter(isDefined)
-                .map((breadcrumb, index, validBreadcrumbs) => {
-                    const divider =
-                        breadcrumb.divider === undefined ? (
-                            <ChevronRightIcon className="icon-inline" />
+export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location: H.Location }> = ({
+    breadcrumbs,
+    location,
+}) => (
+    <nav className="d-flex p-2" aria-label="Breadcrumbs">
+        {sortBy(breadcrumbs, 'depth')
+            .map(({ breadcrumb }) => breadcrumb)
+            .filter(isDefined)
+            .map((breadcrumb, index, validBreadcrumbs) => {
+                const divider =
+                    breadcrumb.divider === undefined ? <ChevronRightIcon className="icon-inline" /> : breadcrumb.divider
+                return (
+                    <span key={breadcrumb.key} className="text-muted d-flex align-items-center test-breadcrumb">
+                        <span className="font-weight-semibold">{divider}</span>
+                        {isElementBreadcrumb(breadcrumb) ? (
+                            breadcrumb.element
+                        ) : // When the last breadcrumb is a link and the hash is empty, render as plain text
+                        index === validBreadcrumbs.length - 1 && !location.hash ? (
+                            breadcrumb.link.label
                         ) : (
-                            breadcrumb.divider
-                        )
-                    return (
-                        <span key={breadcrumb.key} className="text-muted d-flex align-items-center test-breadcrumb">
-                            <span className="font-weight-semibold">{divider}</span>
-                            {isElementBreadcrumb(breadcrumb) ? (
-                                breadcrumb.element
-                            ) : // When the last breadcrumb is a link and the hash is empty, render as plain text
-                            index === validBreadcrumbs.length - 1 && !location.hash ? (
-                                breadcrumb.link.label
-                            ) : (
-                                <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>
-                            )}
-                        </span>
-                    )
-                })}
-        </nav>
-    )
-}
+                            <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>
+                        )}
+                    </span>
+                )
+            })}
+    </nav>
+)
 
 /**
  * To be used in unit tests, it minimally fulfills the BreadcrumbSetters interface.

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -163,13 +163,14 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location:
             .map((breadcrumb, index, validBreadcrumbs) => {
                 const divider =
                     breadcrumb.divider === undefined ? <ChevronRightIcon className="icon-inline" /> : breadcrumb.divider
+                // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
+                // render link breadcrumbs as plain text
                 return (
                     <span key={breadcrumb.key} className="text-muted d-flex align-items-center test-breadcrumb">
                         <span className="font-weight-semibold">{divider}</span>
                         {isElementBreadcrumb(breadcrumb) ? (
                             breadcrumb.element
-                        ) : // When the last breadcrumb is a link and the hash is empty, render as plain text
-                        index === validBreadcrumbs.length - 1 && !location.hash ? (
+                        ) : index === validBreadcrumbs.length - 1 && !location.hash ? (
                             breadcrumb.link.label
                         ) : (
                             <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>

--- a/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
+++ b/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
@@ -20,7 +20,6 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { HeroPage } from '../../../components/HeroPage'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import { BreadcrumbSetters } from '../../../components/Breadcrumbs'
-import { Link } from '../../../../../shared/src/components/Link'
 import { CampaignInfoByline } from '../detail/CampaignInfoByline'
 
 export interface CampaignClosePageProps
@@ -79,7 +78,7 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
             () =>
                 campaign
                     ? {
-                          element: <Link to={campaign.url}>{campaign.name}</Link>,
+                          link: { to: campaign.url, label: campaign.name },
                           key: 'CampaignClosePage',
                       }
                     : null,

--- a/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
+++ b/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
@@ -15,7 +15,6 @@ import { CreateCampaignPageProps } from '../create/CreateCampaignPage'
 import { CampaignDetailsPageProps } from '../detail/CampaignDetailsPage'
 import { CampaignClosePageProps } from '../close/CampaignClosePage'
 import { CampaignsDotComPageProps } from './marketing/CampaignsDotComPage'
-import { Link } from '../../../../../shared/src/components/Link'
 
 const CampaignListPage = lazyComponent<CampaignListPageProps, 'CampaignListPage'>(
     () => import('../list/CampaignListPage'),
@@ -81,7 +80,7 @@ export const AuthenticatedCampaignsArea = withAuthenticatedUser<AuthenticatedPro
         useMemo(
             () => ({
                 key: 'CampaignsArea',
-                element: <Link to={match.url}>Campaigns</Link>,
+                link: { to: match.url, label: 'Campaigns' },
             }),
             [match.url]
         )
@@ -120,7 +119,7 @@ export const UserCampaignsArea = withAuthenticatedUser<
         useMemo(
             () => ({
                 key: 'CampaignsArea',
-                element: <Link to={match.url}>Campaigns</Link>,
+                link: { to: match.url, label: 'Campaigns' },
             }),
             [match.url]
         )
@@ -196,7 +195,7 @@ export const OrgCampaignsArea = withAuthenticatedUser<OrgCampaignsAreaProps & { 
             useMemo(
                 () => ({
                     key: 'CampaignsArea',
-                    element: <Link to={match.url}>Campaigns</Link>,
+                    link: { to: match.url, label: 'Campaigns' },
                 }),
                 [match.url]
             )

--- a/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
+++ b/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
@@ -87,7 +87,7 @@ export const AuthenticatedCampaignsArea = withAuthenticatedUser<AuthenticatedPro
     )
     return (
         <div className="w-100 web-content">
-            <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} />
+            <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} location={outerProps.location} />
             <div className="container">
                 {/* eslint-disable react/jsx-no-bind */}
                 <Switch>
@@ -129,7 +129,7 @@ export const UserCampaignsArea = withAuthenticatedUser<
     }
     return (
         <div className="w-100 web-content">
-            <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} />
+            <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} location={outerProps.location} />
             <div className="container">
                 <Switch>
                     {/* eslint-disable react/jsx-no-bind */}
@@ -205,7 +205,7 @@ export const OrgCampaignsArea = withAuthenticatedUser<OrgCampaignsAreaProps & { 
         }
         return (
             <div className="w-100 web-content">
-                <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} />
+                <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} location={outerProps.location} />
                 <div className="container">
                     <Switch>
                         {/* eslint-disable react/jsx-no-bind */}

--- a/web/src/explore/ExploreArea.tsx
+++ b/web/src/explore/ExploreArea.tsx
@@ -76,7 +76,7 @@ export const ExploreArea: React.FunctionComponent<ExploreAreaProps> = ({
 
     return (
         <div className="explore-area w-100">
-            <Breadcrumbs breadcrumbs={breadcrumbs} />
+            <Breadcrumbs breadcrumbs={breadcrumbs} location={location} />
             <div className="container web-content">
                 <PageHeader title="Explore" icon={CompassOutlineIcon} />
                 {exploreSections.map(

--- a/web/src/insights/InsightsPage.tsx
+++ b/web/src/insights/InsightsPage.tsx
@@ -40,7 +40,7 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
     )
     return (
         <div className="w-100">
-            <Breadcrumbs breadcrumbs={props.breadcrumbs} />
+            <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
             <div className="container mt-3 web-content">
                 <PageHeader
                     icon={InsightsIcon}

--- a/web/src/org/area/OrgArea.tsx
+++ b/web/src/org/area/OrgArea.tsx
@@ -24,7 +24,6 @@ import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryServic
 import { AuthenticatedUser } from '../../auth'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { OrganizationResult, OrganizationVariables, OrgAreaOrganizationFields } from '../../graphql-operations'
-import { Link } from '../../../../shared/src/components/Link'
 import { requestGraphQL } from '../../backend/graphql'
 
 function queryOrganization(args: { name: string }): Observable<OrgAreaOrganizationFields> {
@@ -175,7 +174,7 @@ export class OrgArea extends React.Component<Props> {
                         if (stateUpdate.orgOrError && !isErrorLike(stateUpdate.orgOrError)) {
                             const childBreadcrumbSetters = this.props.setBreadcrumb({
                                 key: 'OrgArea',
-                                element: <Link to={stateUpdate.orgOrError.url}>{stateUpdate.orgOrError.name}</Link>,
+                                link: { to: stateUpdate.orgOrError.url, label: stateUpdate.orgOrError.name },
                             })
                             this.subscriptions.add(childBreadcrumbSetters)
                             this.setState({

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -182,7 +182,7 @@ export const RepoHeader: React.FunctionComponent<Props> = ({ onLifecyclePropsCha
         <nav className="repo-header navbar navbar-expand">
             <div className="d-flex align-items-center">
                 {/* Breadcrumb for the nav elements */}
-                <Breadcrumbs breadcrumbs={props.breadcrumbs} />
+                <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
             </div>
             <ul className="navbar-nav">
                 {leftActions.map((a, index) => (

--- a/web/src/user/area/UserArea.tsx
+++ b/web/src/user/area/UserArea.tsx
@@ -26,7 +26,6 @@ import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryServic
 import { AuthenticatedUser } from '../../auth'
 import { UserAreaUserFields } from '../../graphql-operations'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { Link } from '../../../../shared/src/components/Link'
 import { queryGraphQL } from '../../backend/graphql'
 
 const fetchUser = (args: { username: string; siteAdmin: boolean }): Observable<UserAreaUserFields> =>
@@ -208,9 +207,7 @@ export class UserArea extends React.Component<UserAreaProps, UserAreaState> {
                         if (stateUpdate.userOrError && !isErrorLike(stateUpdate.userOrError)) {
                             const childBreadcrumbSetters = this.props.setBreadcrumb({
                                 key: 'UserArea',
-                                element: (
-                                    <Link to={stateUpdate.userOrError.url}>{stateUpdate.userOrError.username}</Link>
-                                ),
+                                link: { to: stateUpdate.userOrError.url, label: stateUpdate.userOrError.username },
                             })
                             this.subscriptions.add(childBreadcrumbSetters)
                             this.setState({


### PR DESCRIPTION
Closes #13651 

`useBreadcrumb` and `setBreadcrumb` now accept a `link` object as an alternative to `element`. This allows `Breadcrumbs` to make decisions on whether to render a link or plain text depending on breadcrumb position, which is something that the caller would have insufficient information to do.

Also replaces `<Link />` elements with `link` objects.