### PR TITLE
new CreateCampaignPage

### DIFF
--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -18,7 +18,7 @@ ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e
   ':(exclude)docker-images/alpine' \
   ':(exclude)doc/dev/campaigns_design.md' \
   ':(exclude)doc/user/campaigns/' \
-  ':(exclude)web/src/enterprise/campaigns/create/CreateCampaignPage.tsx' \
+  ':(exclude)web/src/enterprise/campaigns/create/exampleCampaignSpecs.ts' \
   ':(exclude)vendor')
 set -e
 

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "@reach/accordion": "^0.10.2",
     "@reach/listbox": "^0.10.1",
     "@reach/menu-button": "0.10.2",
+    "@reach/tabs": "^0.11.2",
     "@sentry/browser": "^5.19.0",
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^7.1.0",

--- a/web/src/SourcegraphWebApp.scss
+++ b/web/src/SourcegraphWebApp.scss
@@ -312,3 +312,5 @@ body,
     --reach-menu-button: 1;
     --reach-accordion: 1;
 }
+
+@import '~@reach/tabs/styles.css';

--- a/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -49,15 +49,6 @@ export const CreateCampaignPage: React.FunctionComponent<CreateCampaignPageProps
                 }
             />
             <div className="container pt-3">
-                <h2>New to campaigns?</h2>
-                <p className="lead">
-                    Read the{' '}
-                    <a href="https://docs.sourcegraph.com/user/campaigns" rel="noopener noreferrer" target="_blank">
-                        campaigns documentation page
-                    </a>{' '}
-                    to learn how to create campaign specifications, using Sourcegraph's CLI tool src-cli and publishing
-                    changesets.
-                </p>
                 <h2>Quick start</h2>
                 <p className="m-0 lead">This campaign specification adds "Hello World" to all README.md files:</p>
                 <div className="bg-light rounded p-2 mb-3">

--- a/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -3,30 +3,10 @@ import { PageTitle } from '../../../components/PageTitle'
 import { PageHeader } from '../../../components/PageHeader'
 import { CampaignsIcon } from '../icons'
 import { BreadcrumbSetters } from '../../../components/Breadcrumbs'
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs'
+import { exampleCampaignSpecs } from './exampleCampaignSpecs'
 
-const campaignSpec = `name: hello-world
-description: Add Hello World to READMEs
-
-# Find all repositories that contain a README.md file.
-on:
-  - repositoriesMatchingQuery: file:README.md
-
-# In each repository, run this command. Each repository's resulting diff is captured.
-steps:
-  - run: echo Hello World | tee -a $(find -name README.md)
-    container: alpine:3
-
-# Describe the changeset (e.g., GitHub pull request) you want for each repository.
-changesetTemplate:
-  title: Hello World
-  body: My first campaign!
-  branch: hello-world # Push the commit to this branch.
-  commit:
-    message: Append Hello World to all README.md files
-  published: false`
-
-const sourcePreviewCommand =
-    'src campaign preview -f hello-world.campaign.yaml -namespace sourcegraph-username-or-organisation'
+const sourcePreviewCommand = 'src campaign preview -f hello-world.campaign.yaml -namespace sqs'
 
 export interface CreateCampaignPageProps extends BreadcrumbSetters {
     // Nothing for now, but using it so once this changes we get type errors in the routing files.
@@ -49,23 +29,58 @@ export const CreateCampaignPage: React.FunctionComponent<CreateCampaignPageProps
                 }
             />
             <div className="container pt-3">
-                <h2>Quick start</h2>
-                <p className="m-0 lead">This campaign specification adds "Hello World" to all README.md files:</p>
-                <div className="bg-light rounded p-2 mb-3">
-                    <pre className="m-0">{campaignSpec}</pre>
-                </div>
-                <p className="lead">
-                    Use Sourcegraph's CLI tool, <code>src</code>, to execute the steps in the campaign spec and upload
-                    it, ready to be previewed and applied:
-                </p>
-                <div className="bg-light rounded p-3 mb-3">
-                    <pre className="m-0">{sourcePreviewCommand}</pre>
-                </div>
-                <p className="lead">
-                    Download <code>src</code> at{' '}
-                    <a href="https://github.com/sourcegraph/src-cli" rel="noopener noreferrer" target="_blank">
-                        github.com/sourcegraph/src-cli
+                <h2>1. Write a campaign spec YAML file</h2>
+                <p>
+                    The campaign spec (
+                    <a
+                        href="https://docs.sourcegraph.com/user/campaigns#campaign-specs"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        syntax reference
                     </a>
+                    ) describes what the campaign does. You'll provide it when previewing, creating, and updating
+                    campaigns. We recommend committing it to source control.
+                </p>
+                <Tabs>
+                    <TabList className="align-items-center">
+                        <span className="font-weight-bold text-muted px-1">Examples:</span>
+                        {exampleCampaignSpecs.map(({ name }) => (
+                            <Tab key={name}>{name}</Tab>
+                        ))}
+                    </TabList>
+                    <TabPanels>
+                        {exampleCampaignSpecs.map(({ yaml }) => (
+                            <TabPanel key={name}>
+                                <div className="border p-2 mb-3">
+                                    <pre className="m-0">{yaml}</pre>
+                                </div>
+                            </TabPanel>
+                        ))}
+                    </TabPanels>
+                </Tabs>
+                <h2 className="mt-4">2. Preview the campaign</h2>
+                <p>
+                    Use the{' '}
+                    <a href="https://github.com/sourcegraph/src-cli" rel="noopener noreferrer" target="_blank">
+                        Sourcegraph CLI (src)
+                    </a>{' '}
+                    to preview the commits and changesets that your campaign will make:
+                </p>
+                <pre>
+                    <code>{sourcePreviewCommand}</code>
+                </pre>
+                <p>
+                    Follow the URL printed in your terminal to see the preview and (when you're ready) create the
+                    campaign.
+                </p>
+                <hr className="mt-5" />
+                <p className="mt-2 text-muted">
+                    Want more help? See{' '}
+                    <a href="/help/user/campaigns" rel="noopener noreferrer" target="_blank">
+                        campaigns documentation
+                    </a>
+                    .
                 </p>
             </div>
         </>

--- a/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react'
 import { PageTitle } from '../../../components/PageTitle'
-import FileDownloadIcon from 'mdi-react/FileDownloadIcon'
 import { PageHeader } from '../../../components/PageHeader'
 import { CampaignsIcon } from '../icons'
 import { BreadcrumbSetters } from '../../../components/Breadcrumbs'
@@ -25,8 +24,6 @@ changesetTemplate:
   commit:
     message: Append Hello World to all README.md files
   published: false`
-
-const helloWorldDownloadUrl = 'data:text/plain;charset=utf-8,' + encodeURIComponent(campaignSpec)
 
 const sourcePreviewCommand =
     'src campaign preview -f hello-world.campaign.yaml -namespace sourcegraph-username-or-organisation'
@@ -62,17 +59,7 @@ export const CreateCampaignPage: React.FunctionComponent<CreateCampaignPageProps
                     changesets.
                 </p>
                 <h2>Quick start</h2>
-                <div className="d-flex justify-content-between align-items-center mb-2">
-                    <p className="m-0 lead">This campaign specification adds "Hello World" to all README.md files:</p>
-                    <a
-                        download="hello-world.campaign.yaml"
-                        href={helloWorldDownloadUrl}
-                        className="text-right btn btn-secondary text-nowrap"
-                        data-tooltip="Download hello-world.campaign.yaml"
-                    >
-                        <FileDownloadIcon className="icon-inline" /> Download yaml
-                    </a>
-                </div>
+                <p className="m-0 lead">This campaign specification adds "Hello World" to all README.md files:</p>
                 <div className="bg-light rounded p-2 mb-3">
                     <pre className="m-0">{campaignSpec}</pre>
                 </div>

--- a/web/src/enterprise/campaigns/create/exampleCampaignSpecs.ts
+++ b/web/src/enterprise/campaigns/create/exampleCampaignSpecs.ts
@@ -1,0 +1,35 @@
+export const exampleCampaignSpecs: {
+    name: string
+    yaml: string
+}[] = [
+    {
+        name: 'hello-world.campaign.yaml',
+        yaml: `name: hello-world
+description: Add Hello World to READMEs
+
+# Find all repositories that contain a README.md file.
+on:
+  - repositoriesMatchingQuery: file:README.md
+
+# In each repository, run this command. Each repository's resulting diff is captured.
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Hello World
+  body: My first campaign!
+  branch: hello-world # Push the commit to this branch.
+  commit:
+    message: Append Hello World to all README.md files
+  published: false`,
+    },
+    {
+        name: 'minimal.campaign.yaml',
+        yaml: `name: my-campaign
+
+# Add your own description, query, steps, changesetTemplate, etc.
+# See https://docs.sourcegraph.com/user/campaigns for help.`,
+    },
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,6 +2419,14 @@
     "@reach/utils" "^0.10.2"
     tslib "^1.11.2"
 
+"@reach/auto-id@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.11.2.tgz#c66a905c5401d1ac3da8d26165b8d27d6e778fa6"
+  integrity sha512-YZ21b0Kb88wJ0t7QjSznWOYskARQMnmXY9Y2XZ5RyYcZ2krT4s3+ghghpfaPs6BKcrZDonZCrU65OFDJPa1jAw==
+  dependencies:
+    "@reach/utils" "0.11.2"
+    tslib "^2.0.0"
+
 "@reach/auto-id@^0.10.1", "@reach/auto-id@^0.10.2":
   version "0.10.2"
   resolved "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.10.2.tgz#a447af67241123dcb701ecd61931a2c786ed111e"
@@ -2426,6 +2434,14 @@
   dependencies:
     "@reach/utils" "^0.10.2"
     tslib "^1.11.2"
+
+"@reach/descendants@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.npmjs.org/@reach/descendants/-/descendants-0.11.2.tgz#49ea1b5eb91aba8ae6dce57f6575c38aff1f9756"
+  integrity sha512-63Wdx32/RyjGRJc4UZKK7F1sIrb6jeGkDwvQH0hv0lRAhEjsiSQ1t2JTYDml3testFP48J0B2xS7JzNeY0zoQw==
+  dependencies:
+    "@reach/utils" "0.11.2"
+    tslib "^2.0.0"
 
 "@reach/descendants@^0.10.1", "@reach/descendants@^0.10.2":
   version "0.10.2"
@@ -2512,6 +2528,26 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
+
+"@reach/tabs@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.npmjs.org/@reach/tabs/-/tabs-0.11.2.tgz#75a73d069ff4832259a191e7e321818c9d09a2c8"
+  integrity sha512-iVDXfmdpJmBavyyiJbm9sUddlelra+x5MaF5Y4QwV7Q+w3t9RLqTePQAOX+2MX0BJgvasX/YItMBO2JumWxGPQ==
+  dependencies:
+    "@reach/auto-id" "0.11.2"
+    "@reach/descendants" "0.11.2"
+    "@reach/utils" "0.11.2"
+    prop-types "^15.7.2"
+    tslib "^2.0.0"
+
+"@reach/utils@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.npmjs.org/@reach/utils/-/utils-0.11.2.tgz#be1f03650db56fd67a16d3fc70e5262cdb139cec"
+  integrity sha512-fBTolYj+rKTROXmf0zHO0rCWSvw7J0ALmYj5QxW4DmITMOH5uyRuWDWOfqohIGFbOtF/sum50WTB3tvx76d+Aw==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^2.0.0"
+    warning "^4.0.3"
 
 "@reach/utils@^0.10.1", "@reach/utils@^0.10.2":
   version "0.10.2"
@@ -2728,7 +2764,8 @@
   integrity sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==
 
 "@sourcegraph/extension-api-types@link:packages/@sourcegraph/extension-api-types":
-  version "2.1.0"
+  version "0.0.0"
+  uid ""
 
 "@sourcegraph/prettierrc@^3.0.3":
   version "3.0.3"
@@ -20881,7 +20918,8 @@ sourcegraph@^24.0.0:
   integrity sha512-PlGvkdBy5r5iHdKAVNY/jsPgWb3oY+2iAdIQ3qR83UHhvBFVgoctDAnyfJ1eMstENY3etBWtAJ8Kleoar3ecaA==
 
 "sourcegraph@link:packages/sourcegraph-extension-api":
-  version "24.7.0"
+  version "0.0.0"
+  uid ""
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
I tried to achieve the following with this new CreateCampaignPage:

1. A screen that feels "product-y" rather than "lots of text"
2. Language that subtly introduces other concepts: what a spec is, that campaigns are updatable, that campaign specs are serious files deserving of being committed to git.

See https://www.figma.com/file/5Ap3Iqjv81Dh0Hc6cLtSqN/Campaign-create-page-(%2313115)?node-id=357%3A0 for screenshot in Figma:

![image](https://user-images.githubusercontent.com/1976/92990254-b4db6800-f48f-11ea-934a-9495b55059f1.png)


Also:

- Remove "New to campaigns?" As a user, I don't like it when I can't dismiss the "new user info" step.
- Remove "Download YAML" button. You'd need to open this in an editor anyway to customize it, and it's faster to copy-paste than to download and then find the file. That way, you know exactly what you're starting with.
- Fix problems with `bg-white` code blocks in the dark color theme. The text was very light gray, which was difficult to read.
- Fix left-alignment. The inner `container` made the page contents not left-aligned with the page title.
- Clarify mentions of the src CLI.