### PR TITLE
search: document .sourcegraph/ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph watches the [advanced config files](https://docs.sourcegraph.com/admin/config/advanced_config_file) and automatically applies the changes to Sourcegraph's configuration when they change. For example this allows Sourcegraph to notice when Kubernetes updates ConfigMap for the configuration. [#13646](https://github.com/sourcegraph/sourcegraph/pull/13646)
 - Experimental: New homepage UI for Sourcegraph Server which shows the user their recent searches, repositories, files, and saved searches. It can be enabled with `experimentalFeatures.showEnterpriseHomePanels`. [#13407](https://github.com/sourcegraph/sourcegraph/issues/13407)
 - To define repository groups (`search.repositoryGroups` in global, org, or user settings), you can now specify regular expressions in addition to single repository names. [#13730](https://github.com/sourcegraph/sourcegraph/pull/13730)
-- Files and directories can now be excluded from search by adding the file _.sourcegraph/ignore_ to the root directory of a repository. Each line in the _ignore_ file is interpreted as a globbing pattern. [#13690](https://github.com/sourcegraph/sourcegraph/pull/13690) 
+- Files and directories can now be excluded from search by adding the file _.sourcegraph/ignore_ to the root directory of a repository. Each line in the _ignore_ file is interpreted as a globbing pattern. [#13690](https://github.com/sourcegraph/sourcegraph/pull/13690)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph watches the [advanced config files](https://docs.sourcegraph.com/admin/config/advanced_config_file) and automatically applies the changes to Sourcegraph's configuration when they change. For example this allows Sourcegraph to notice when Kubernetes updates ConfigMap for the configuration. [#13646](https://github.com/sourcegraph/sourcegraph/pull/13646)
 - Experimental: New homepage UI for Sourcegraph Server which shows the user their recent searches, repositories, files, and saved searches. It can be enabled with `experimentalFeatures.showEnterpriseHomePanels`. [#13407](https://github.com/sourcegraph/sourcegraph/issues/13407)
 - To define repository groups (`search.repositoryGroups` in global, org, or user settings), you can now specify regular expressions in addition to single repository names. [#13730](https://github.com/sourcegraph/sourcegraph/pull/13730)
+- Files and directories can now be excluded from search by adding the file _.sourcegraph/ignore_ to the root directory of a repository. Each line in the _ignore_ file is interpreted as a globbing pattern. [#13690](https://github.com/sourcegraph/sourcegraph/pull/13690) 
 
 ### Changed
 

--- a/doc/user/search/index.md
+++ b/doc/user/search/index.md
@@ -169,7 +169,7 @@ By default, files larger than 1 MB are excluded from search results. Use the [se
 ### Exclude files and directories
 
 You can exclude files and directories from search by adding the file _.sourcegraph/ignore_ to
-the root of your repository. Sourcegraph interprets each line in the _ignore_ file as globbing
+the root directory of your repository. Sourcegraph interprets each line in the _ignore_ file as globbing
 pattern. Files or directories matching those patterns will not show up in the search results.
  
 The _ignore_ file is tied to a commit. This means, if you committed an _ignore_ file to a 

--- a/doc/user/search/index.md
+++ b/doc/user/search/index.md
@@ -166,6 +166,55 @@ Unscoped search results over large repository sets may trail latest default bran
 
 By default, files larger than 1 MB are excluded from search results. Use the [search.largeFiles](../../admin/config/site_config.md#search-largeFiles) keyword to specify files to be indexed and searched regardless of size.
 
+### Exclude files and directories
+
+You can exclude files and directories from search by adding the file _.sourcegraph/ignore_ to
+the root of your repository. Sourcegraph interprets each line in the _ignore_ file as globbing
+pattern. Files or directories matching those patterns will not show up in the search results.
+ 
+The _ignore_ file is tied to a commit. This means, if you committed an _ignore_ file to a 
+feature branch but not to your default branch, then only search results for the feature branch
+will be filtered while the default branch will show all results.
+
+Example:
+```
+# .sourcegraph/ignore
+# lines starting with # are comments and are ignored
+# empty lines are ignored, too
+
+# ignore the directory node_modules/
+node_modules/
+
+# ignore the directory src/data/
+src/data/
+
+# ** matches all characters, while * matches all characters except /
+# ignore all JSON files
+**.json
+
+# ignore all JSON files at the root of the repository
+*.json
+
+# ignore all JSON files within the directory data/
+data/**.json
+
+# ignore all data folders
+data/
+**/data/
+
+# ignore all files that start with numbers
+[0-9]*.*
+**/[0-9]*.*
+```
+
+Our syntax follows closely what is documented in 
+[the linux documentation project](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm).
+However, we distinguish between `*` and `**`: While `**` matches all characters, `*` matches all characters 
+except the path separator `/`.
+
+Note that invalid globbing patterns will cause an error and searches over commits containing a broken _ignore_ file 
+will not return any result.
+
 ---
 
 ## Other tips


### PR DESCRIPTION
This PR documents _.sourcegraph/ignore_ in the user docs and updates the changelog.

Closes #6870 

Related PRs:
- https://github.com/sourcegraph/zoekt/pull/56
- https://github.com/sourcegraph/sourcegraph/pull/13690

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
