### PR TITLE
search: update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200911142020-36f86e63516f
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200914142346-dad3e87a4b8f
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1205,6 +1205,8 @@ github.com/sourcegraph/zoekt v0.0.0-20200911123057-422d5b68c06e h1:arEEamCq+/vT8
 github.com/sourcegraph/zoekt v0.0.0-20200911123057-422d5b68c06e/go.mod h1:Cj/TaflDEk8QLJnV9mJP5hVswI9bEePpod/d9iLR4Kk=
 github.com/sourcegraph/zoekt v0.0.0-20200911142020-36f86e63516f h1:JgRyqVKhF2UQB/YrLHkk9B4gjrBTjz3Pq0PQrfJ4XD4=
 github.com/sourcegraph/zoekt v0.0.0-20200911142020-36f86e63516f/go.mod h1:Cj/TaflDEk8QLJnV9mJP5hVswI9bEePpod/d9iLR4Kk=
+github.com/sourcegraph/zoekt v0.0.0-20200914142346-dad3e87a4b8f h1:mvXDW0kvLnRwXgIc3+mzw/lB4EoDL3Mb3dGmZZ/SlUk=
+github.com/sourcegraph/zoekt v0.0.0-20200914142346-dad3e87a4b8f/go.mod h1:Cj/TaflDEk8QLJnV9mJP5hVswI9bEePpod/d9iLR4Kk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/issues/6870 and https://github.com/sourcegraph/zoekt/pull/58

Sets `zoekt-git-index` as default for all customers. This setting can be reverted by setting the env variable `DISABLE_GIT_INDEX=1 ` for zoekt-indexserver.

We have tested this setting for +7 days on Sourcegraph.com without any issue. Setting `zoekt-git-index` as default unlocks #6870 and reduces the number of moving parts because we won't use `zoekt-archive-index` anymore.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
