### PR TITLE
Fix nil panic in reconciler by setting repo when closing changesets

### DIFF
--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -280,7 +280,7 @@ func (r *reconciler) closeChangeset(ctx context.Context, tx *Store, ch *campaign
 		return err
 	}
 
-	cs := &repos.Changeset{Changeset: ch}
+	cs := &repos.Changeset{Changeset: ch, Repo: repo}
 
 	if err := ccs.CloseChangeset(ctx, cs); err != nil {
 		return errors.Wrap(err, "creating changeset")

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -51,6 +51,10 @@ func (s *FakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Chan
 		return s.ChangesetExists, s.Err
 	}
 
+	if c.Repo == nil {
+		return false, NoReposErr
+	}
+
 	if c.HeadRef != s.WantHeadRef {
 		return s.ChangesetExists, fmt.Errorf("wrong HeadRef. want=%s, have=%s", s.WantHeadRef, c.HeadRef)
 	}
@@ -71,6 +75,9 @@ func (s *FakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Chan
 
 	if s.Err != nil {
 		return s.Err
+	}
+	if c.Repo == nil {
+		return NoReposErr
 	}
 
 	if c.BaseRef != s.WantBaseRef {
@@ -101,6 +108,10 @@ func (s *FakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.C
 	}
 
 	for _, c := range cs {
+		if c.Repo == nil {
+			return NoReposErr
+		}
+
 		if err := c.SetMetadata(s.FakeMetadata); err != nil {
 			return err
 		}
@@ -109,12 +120,20 @@ func (s *FakeChangesetSource) LoadChangesets(ctx context.Context, cs ...*repos.C
 	s.LoadedChangesets = append(s.LoadedChangesets, cs...)
 	return nil
 }
+
+var NoReposErr = errors.New("no repository set on repos.Changeset")
+
 func (s *FakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Changeset) error {
 	s.CloseChangesetCalled = true
 
 	if s.Err != nil {
 		return s.Err
 	}
+
+	if c.Repo == nil {
+		return NoReposErr
+	}
+
 	s.ClosedChangesets = append(s.ClosedChangesets, c)
 	return nil
 }


### PR DESCRIPTION
This fixes the crash in this stacktrace https://github.com/sourcegraph/sourcegraph/issues/13648#issuecomment-690817025

It was only a problem in `CloseChangesets`, but I added the check to the `FakeChangesetSource` in every call.
