### PR TITLE
search: merge and fix parens heuristics

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1227,7 +1227,7 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		query = substituteConcat(query, " ")
 		query = ellipsesForHoles(query)
 	case SearchTypeRegex:
-		query = Map(query, EmptyGroupsToLiteral, TrailingParensToLiteral)
+		query = escapeParensHeuristic(query)
 	}
 
 	if options.Globbing {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -278,21 +278,52 @@ func TestEllipsesForHoles(t *testing.T) {
 func TestConvertEmptyGroupsToLiteral(t *testing.T) {
 	cases := []struct {
 		input      string
+		want       string
 		wantLabels labels
 	}{
 		{
 			input:      "func()",
-			wantLabels: HeuristicParensAsPatterns | Literal,
+			want:       `"func\\(\\)"`,
+			wantLabels: Regexp,
 		},
 		{
 			input:      "func(.*)",
+			want:       `"func(.*)"`,
 			wantLabels: Regexp,
+		},
+		{
+			input:      `(search\()`,
+			want:       `"(search\\()"`,
+			wantLabels: Regexp,
+		},
+		{
+			input:      `()search\(()`,
+			want:       `"\\(\\)search\\(\\(\\)"`,
+			wantLabels: Regexp,
+		},
+		{
+			input:      `search\(`,
+			want:       `"search\\("`,
+			wantLabels: Regexp,
+		},
+		{
+			input:      `\`,
+			want:       `"\\"`,
+			wantLabels: Regexp,
+		},
+		{
+			input:      `search(`,
+			want:       `"search\\("`,
+			wantLabels: Regexp | HeuristicDanglingParens,
 		},
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			got := EmptyGroupsToLiteral(query)[0].(Pattern)
+			got := escapeParensHeuristic(query)[0].(Pattern)
+			if diff := cmp.Diff(c.want, prettyPrint([]Node{got})); diff != "" {
+				t.Error(diff)
+			}
 			if diff := cmp.Diff(c.wantLabels, got.Annotation.Labels); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Part of #13128 (fixes first bullet). Basically we had some heuristic to convert certain parentheses in patterns (see the function comment in this PR). 

Previously the heuristics didn't properly consider that the parentheses might be escaped. This PR takes escape sequences into account so we interpret the original pattern correctly, and merges two existing heuristic since they need basically the same linear pass.