### PR TITLE
Update the example comby-sprintf-to-itoa campaign to use goimports

### DIFF
--- a/doc/user/campaigns/examples/refactor_go_comby.md
+++ b/doc/user/campaigns/examples/refactor_go_comby.md
@@ -1,6 +1,6 @@
 # Refactor Go code using Comby
 
-This campaign rewrites Go statements from
+This campaign uses Sourcegraph's [structural search](../../search/structural.md) and [Comby](https://comby.dev/) to rewrite Go statements from
 
 ```go
 fmt.Sprintf("%d", number)
@@ -12,31 +12,31 @@ to
 strconv.Itoa(number)
 ```
 
-since they are equivalent.
+The statements are semantically equivalent, but the latter is clearer.
 
-Since the replacements could change the formatting of the code, it also runs `gofmt` over the repository.
+Since the replacements could require importing the `strconv` package, it uses [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports) to update the list of imported packages in all `*.go` files.
 
 ## Campaign spec
 
 ```yaml
 name: sprintf-to-itoa
-description: Run `comby` to replace `fmt.Sprintf("%d", integer)` calls with `strconv.Iota`
+description: |
+  This campaign uses [Comby](https://comby.dev) to replace `fmt.Sprintf` calls
+  in Go code with the equivalent but clearer `strconv.Iota` call.
 
-# Find all repositories that contain the `fmt.Sprintf` statement using structural search
 on:
   - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural
 
 steps:
   - run: comby -in-place 'fmt.Sprintf("%d", :[v])' 'strconv.Itoa(:[v])' .go -matcher .go -exclude-dir .,vendor
     container: comby/comby
-  - run: gofmt -w ./
-    container: golang:1.15-alpine
+  - run: goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*")
+    container: unibeautify/goimports
 
-# Describe the changeset (e.g., GitHub pull request) you want for each repository.
 changesetTemplate:
-  title: Replace equivalent fmt.Sprintf calls with strconv.Itoa
-  body: This campaign replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls
-  branch: campaigns/sprintf-to-itoa # Push the commit to this branch.
+  title: Replace fmt.Sprintf with equivalent strconv.Itoa
+  body: This campaign replaces `fmt.Sprintf` with `strconv.Itoa`
+  branch: campaigns/sprintf-to-itoa
   commit:
     message: Replacing fmt.Sprintf with strconv.Iota
   published: false

--- a/web/src/enterprise/campaigns/create/samples/comby.campaign.yaml
+++ b/web/src/enterprise/campaigns/create/samples/comby.campaign.yaml
@@ -1,15 +1,19 @@
 name: sprintf-to-itoa
-description: Run `comby` to replace `fmt.Sprintf("%d", integer)` calls with `strconv.Iota`
+description: |
+  This campaign uses [Comby](https://comby.dev) to replace `fmt.Sprintf` calls
+  in Go code with the equivalent but clearer `strconv.Iota` call.
 
 # Find all repositories that contain the `fmt.Sprintf` statement using structural search
 on:
   - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural
 
 steps:
+  # Run Comby (https://comby.dev) to replace the Go statements...
   - run: comby -in-place 'fmt.Sprintf("%d", :[v])' 'strconv.Itoa(:[v])' .go -matcher .go -exclude-dir .,vendor
     container: comby/comby
-  - run: gofmt -w ./
-    container: golang:1.15-alpine
+  # ... and then run goimports to make sure `strconv` is imported.
+  - run: goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*")
+    container: unibeautify/goimports
 
 # Describe the changeset (e.g., GitHub pull request) you want for each repository.
 changesetTemplate:


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
