### PR TITLE
oauth2: use external http client when doing oauth2 calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where we returned repositories with invalid revisions in the search results. Now, if a user specifies an invalid revision, we show an alert. [#13271](https://github.com/sourcegraph/sourcegraph/pull/13271)
 - Previously it wasn't possible to search for certain patterns containing `:` because they would not be considered valid filters. We made these checks less strict. [#10920](https://github.com/sourcegraph/sourcegraph/pull/10920)
 - Logging out of a user's account will now invalidate all user sessions, not just the session that was signed out of. Resetting or changing the user's password will also invalidate all sesions, requiring the user to sign in with their new password. [#13647](https://github.com/sourcegraph/sourcegraph/pull/13647)
+- GitLab oauth2 login will respect `tls.external` site setting. [#13814](https://github.com/sourcegraph/sourcegraph/pull/13814)
 
 ### Removed
 

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -75,7 +75,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("invalid def %s (must have 1 or 2 path components)", def)
 	}
 
-	dir, err := gosrc.ResolveImportPath(httpcli.ExternalHTTPClient(), importPath)
+	dir, err := gosrc.ResolveImportPath(httpcli.ExternalDoer(), importPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/internal/app/pkg/updatecheck/client.go
+++ b/cmd/frontend/internal/app/pkg/updatecheck/client.go
@@ -328,7 +328,7 @@ func check() {
 		req.Header.Set("Content-Type", "application/json")
 		req = req.WithContext(ctx)
 
-		resp, err := httpcli.ExternalHTTPClient().Do(req)
+		resp, err := httpcli.ExternalDoer().Do(req)
 		if err != nil {
 			return "", err
 		}

--- a/enterprise/cmd/frontend/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/auth/oauth/middleware.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewHandler(serviceType, authPrefix string, isAPIHandler bool, next http.Handler) http.Handler {
-	oauthFlowHandler := http.StripPrefix(authPrefix, NewOAuthFlowHandler(serviceType))
+	oauthFlowHandler := http.StripPrefix(authPrefix, newOAuthFlowHandler(serviceType))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Delegate to the auth flow handler
 		if !isAPIHandler && strings.HasPrefix(r.URL.Path, authPrefix+"/") {
@@ -44,7 +44,7 @@ func NewHandler(serviceType, authPrefix string, isAPIHandler bool, next http.Han
 	})
 }
 
-func NewOAuthFlowHandler(serviceType string) http.Handler {
+func newOAuthFlowHandler(serviceType string) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/login", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		id := req.URL.Query().Get("pc")
@@ -83,7 +83,7 @@ func getExactlyOneOAuthProvider() *Provider {
 	if !ok {
 		return nil
 	}
-	if !IsOAuth(p.Config()) {
+	if !isOAuth(p.Config()) {
 		return nil
 	}
 	return p
@@ -95,7 +95,7 @@ func AddIsOAuth(f func(p schema.AuthProviders) bool) {
 	isOAuths = append(isOAuths, f)
 }
 
-func IsOAuth(p schema.AuthProviders) bool {
+func isOAuth(p schema.AuthProviders) bool {
 	for _, f := range isOAuths {
 		if f(p) {
 			return true

--- a/enterprise/cmd/frontend/auth/oauth/testutil.go
+++ b/enterprise/cmd/frontend/auth/oauth/testutil.go
@@ -1,1 +1,0 @@
-package oauth

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -86,13 +86,13 @@ var (
 	externalDoer Doer
 )
 
-// ExternalHTTPClient returns a shared client for external communication. This
-// is a convenience for existing uses of http.DefaultClient.
+// ExternalDoer returns a shared client for external communication. This is a
+// convenience for existing uses of http.DefaultClient.
 //
 // NOTE: Use this for legacy code. New code should generally take in a
 // httpcli.Doer and at a high level NewExternalHTTPClientFactory() is called
 // and passed down.
-func ExternalHTTPClient() Doer {
+func ExternalDoer() Doer {
 	externalOnce.Do(func() {
 		var err error
 		externalDoer, err = NewExternalHTTPClientFactory().Doer()

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -82,9 +82,24 @@ func NewExternalHTTPClientFactory() *Factory {
 }
 
 var (
-	externalOnce sync.Once
-	externalDoer Doer
+	externalOnce       sync.Once
+	externalDoer       Doer
+	externalHTTPClient *http.Client
 )
+
+func externalInit() {
+	externalOnce.Do(func() {
+		var err error
+		externalDoer, err = NewExternalHTTPClientFactory().Doer()
+		if err != nil {
+			panic("httpcli: failed to create the default ExternalDoer. This should not happen: " + err.Error())
+		}
+		externalHTTPClient, err = NewExternalHTTPClientFactory().Client()
+		if err != nil {
+			panic("httpcli: failed to create the default ExternalHTTPClient. This should not happen: " + err.Error())
+		}
+	})
+}
 
 // ExternalDoer returns a shared client for external communication. This is a
 // convenience for existing uses of http.DefaultClient.
@@ -93,14 +108,19 @@ var (
 // httpcli.Doer and at a high level NewExternalHTTPClientFactory() is called
 // and passed down.
 func ExternalDoer() Doer {
-	externalOnce.Do(func() {
-		var err error
-		externalDoer, err = NewExternalHTTPClientFactory().Doer()
-		if err != nil {
-			panic("httpcli: failed to create the default ExternalHTTPClient. This should not happen: " + err.Error())
-		}
-	})
+	externalInit()
 	return externalDoer
+}
+
+// ExternalHTTPClient returns a shared client for external communication. This is
+// a convenience for existing uses of http.DefaultClient.
+//
+// NOTE: Use this for legacy code. New code should generally take in a
+// httpcli.Doer and at a high level NewExternalHTTPClientFactory() is called
+// and passed down.
+func ExternalHTTPClient() Doer {
+	externalInit()
+	return externalHTTPClient
 }
 
 // Doer returns a new Doer wrapped with the middleware stack

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -89,7 +89,7 @@ func httpGet(ctx context.Context, op, urlStr string, result interface{}) (err er
 	req.Header.Set("User-Agent", "Sourcegraph registry client v"+APIVersion)
 	req = req.WithContext(ctx)
 
-	resp, err := httpcli.ExternalHTTPClient().Do(req)
+	resp, err := httpcli.ExternalDoer().Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
You can configure TLS settings via our site settings. In the future we
may have other settings which affect sourcegraph's ability to
communicate with the outside world. httpcli's external client takes into
account those settings. This commit ensures golang.org/x/oauth2 will use
that client. This commit injects the client at the top-level oauth
middleware.

For example this should ensure that oauth against a gitlab with a self
signed certificate will work.

This also includes some other refactorings and additions to make this possible.

Fixes https://github.com/sourcegraph/sourcegraph/issues/4652