### PR TITLE
Bump src-cli MinimumVersion to 3.20.0

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.18.0"
+const MinimumVersion = "3.20.0"


### PR DESCRIPTION
A new version of src-cli, 3.20.0, is out and I want to bump the
MinimumVersion before the branch cut:

https://github.com/sourcegraph/src-cli/releases/tag/3.20.0

