### PR TITLE
Update commit when author email/name changed

### DIFF
--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -598,6 +598,32 @@ func CompareChangesetSpecs(previous, current *campaigns.ChangesetSpec) (*changes
 		delta.commitMessageChanged = true
 	}
 
+	// AuthorName
+	currentAuthorName, err := current.Spec.AuthorName()
+	if err != nil {
+		return nil, nil
+	}
+	previousAuthorName, err := previous.Spec.AuthorName()
+	if err != nil {
+		return nil, err
+	}
+	if previousAuthorName != currentAuthorName {
+		delta.authorNameChanged = true
+	}
+
+	// AuthorEmail
+	currentAuthorEmail, err := current.Spec.AuthorEmail()
+	if err != nil {
+		return nil, nil
+	}
+	previousAuthorEmail, err := previous.Spec.AuthorEmail()
+	if err != nil {
+		return nil, err
+	}
+	if previousAuthorEmail != currentAuthorEmail {
+		delta.authorEmailChanged = true
+	}
+
 	return delta, nil
 }
 
@@ -607,12 +633,14 @@ type changesetSpecDelta struct {
 	baseRefChanged       bool
 	diffChanged          bool
 	commitMessageChanged bool
+	authorNameChanged    bool
+	authorEmailChanged   bool
 }
 
 func (d *changesetSpecDelta) String() string { return fmt.Sprintf("%#v", d) }
 
 func (d *changesetSpecDelta) NeedCommitUpdate() bool {
-	return d.diffChanged || d.commitMessageChanged
+	return d.diffChanged || d.commitMessageChanged || d.authorNameChanged || d.authorEmailChanged
 }
 
 func (d *changesetSpecDelta) NeedCodeHostUpdate() bool {

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -309,6 +309,45 @@ func TestReconcilerProcess(t *testing.T) {
 				// failureMessage should be nil
 			},
 		},
+		"update published changeset commit author": {
+			currentSpec: &testSpecOpts{
+				headRef:   "refs/heads/head-ref-on-github",
+				published: true,
+
+				// Everything the same, except author changed
+				commitAuthorName:  "Fernando the fish",
+				commitAuthorEmail: "fernando@deep.sea",
+			},
+			previousSpec: &testSpecOpts{
+				headRef:   "refs/heads/head-ref-on-github",
+				published: true,
+
+				// Old author data
+				commitAuthorName:  "Larry the Llama",
+				commitAuthorEmail: "larry@winamp.com",
+			},
+			changeset: testChangesetOpts{
+				publicationState:  campaigns.ChangesetPublicationStatePublished,
+				externalID:        "12345",
+				externalBranch:    "head-ref-on-github",
+				externalState:     campaigns.ChangesetExternalStateOpen,
+				createdByCampaign: true,
+			},
+			sourcerMetadata: githubPR,
+
+			// We don't want an update on the code host, only a new commit pushed.
+			wantGitserverCommit: true,
+			// And we want the changeset to be synced after pushing the commit.
+			wantLoadFromCodeHost: true,
+
+			wantChangeset: changesetAssertions{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				externalState:    campaigns.ChangesetExternalStateOpen,
+				externalID:       githubPR.ID,
+				externalBranch:   githubPR.HeadRefName,
+				diffStat:         state.DiffStat,
+			},
+		},
 		"reprocess published changeset without changes": {
 			// ChangesetSpec is already published and has no previous spec.
 			// Simply a reprocessing of the same changeset.

--- a/enterprise/internal/campaigns/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service_apply_campaign_test.go
@@ -807,10 +807,12 @@ type testSpecOpts struct {
 	// set.
 	published bool
 
-	title         string
-	body          string
-	commitMessage string
-	commitDiff    string
+	title             string
+	body              string
+	commitMessage     string
+	commitDiff        string
+	commitAuthorEmail string
+	commitAuthorName  string
 }
 
 var testChangsetSpecDiffStat = &diff.Stat{Added: 10, Changed: 5, Deleted: 2}
@@ -839,8 +841,10 @@ func createChangesetSpec(
 
 			Commits: []campaigns.GitCommitDescription{
 				{
-					Message: opts.commitMessage,
-					Diff:    opts.commitDiff,
+					Message:     opts.commitMessage,
+					Diff:        opts.commitDiff,
+					AuthorEmail: opts.commitAuthorEmail,
+					AuthorName:  opts.commitAuthorName,
 				},
 			},
 		},


### PR DESCRIPTION
I noticed that the reconciler didn't create and push a new commit when I
changed the author in my campaign spec and applied it.

This fixes that issue. The code is simply an addition to what was there
before and doesn't change anything.

I want to investigate how/whether I can make CompareChangesetSpecs
nicer, but I'll leave that for a follow-up.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
