### PR TITLE
search: don't run paren heuristics on quoted values

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -584,8 +584,11 @@ func escapeParens(s string) string {
 // escapeParensHeuristic escapes certain parentheses in search patterns (see escapeParens).
 func escapeParensHeuristic(nodes []Node) []Node {
 	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
+		if !annotation.Labels.isSet(Quoted) {
+			value = escapeParens(value)
+		}
 		return Pattern{
-			Value:      escapeParens(value),
+			Value:      value,
 			Negated:    negated,
 			Annotation: annotation,
 		}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -316,6 +316,16 @@ func TestConvertEmptyGroupsToLiteral(t *testing.T) {
 			want:       `"search\\("`,
 			wantLabels: Regexp | HeuristicDanglingParens,
 		},
+		{
+			input:      `"search("`,
+			want:       `"search("`,
+			wantLabels: Quoted | Literal,
+		},
+		{
+			input:      `"search()"`,
+			want:       `"search()"`,
+			wantLabels: Quoted | Literal,
+		},
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {


### PR DESCRIPTION
Introduced in #13803: the heuristic there applies to quoted patterns in regex mode, when it should not.