### PR TITLE
PrivateCodeCta: increase contrast/readability

### DIFF
--- a/web/src/search/input/PrivateCodeCta.scss
+++ b/web/src/search/input/PrivateCodeCta.scss
@@ -1,18 +1,8 @@
 .private-code-cta {
-    color: $gray-06;
     padding: 1.5rem;
     border-radius: 3px;
-    background: $gray-21;
-    border: 1px solid $gray-18;
 
     &__icon-column {
         margin-right: 1.5rem;
-    }
-}
-
-.theme-light {
-    .private-code-cta {
-        background: $white;
-        border: 1px solid $color-light-bg-2;
     }
 }


### PR DESCRIPTION
Removes custom color overrides. The colors were very hard to read in the light theme. Also simplifies the CSS.


## Before

![image](https://user-images.githubusercontent.com/1976/93288162-19e4d580-f790-11ea-8a7f-76fdae36f30a.png)

## After (ignore broken image and different spacing, it's bc I screenshotted it in storybook)

![image](https://user-images.githubusercontent.com/1976/93288226-41d43900-f790-11ea-9485-593d5f411aaf.png)
