### PR TITLE
secrets: use base64 and make interface private

### DIFF
--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -291,3 +291,8 @@ func RotateEncryption(ciphertext string) (string, error) {
 func PrimaryKeyHash() string {
 	return defaultEncryptor.PrimaryKeyHash()
 }
+
+// SecondaryKeyHash returns hash of the secondary key to be used for filtering.
+func SecondaryKeyHash() string {
+	return defaultEncryptor.SecondaryKeyHash()
+}

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -50,7 +50,7 @@ type encryptor struct {
 	secondaryKey []byte
 	// primaryKeyHash is prepended to base64-encoded ciphertext with `separator`.
 	primaryKeyHash string
-	// secondaryKeyHash is the previously hash that was prepended to ciphertext with `seperator`
+	// secondaryKeyHash is the previous hash that was prepended to ciphertext with `separator`
 	secondaryKeyHash string
 }
 

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -54,7 +54,9 @@ type encryptor struct {
 	secondaryKeyHash string
 }
 
-// sliceKeyHash returns a string which is the first 6 bytes of given key's SHA256 checksum in hexadecimal.
+// sliceKeyHash returns a string which is the first 6 bytes of given key's SHA2-256 checksum in hexadecimal.
+// This checksum was chosen due to the (current) lack of SHA2 collisions, and is used to
+// indicate without leaking, how something has encrypted. The inspiration for this is /etc/shadow.
 func sliceKeyHash(k []byte) string {
 	if k == nil {
 		return ""

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	validKeyLength = 32 // 32 bytes is the required length for AES-256.
+	validKeyLength = 32  // 32 bytes is the required length for AES-256.
 	separator      = "$" // used specifically because $ is not part of base64
 )
 

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -61,7 +61,7 @@ func sliceKeyHash(k []byte) string {
 	}
 
 	h := sha256.New()
-	h.Write(k)
+	_, _ = h.Write(k)
 	return hex.EncodeToString(h.Sum(nil))[:6]
 }
 

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	validKeyLength = 32  // 32 bytes is the required length for AES-256.
-	separator      = "$" // used specifically because $ is not part of base64
+	requiredKeyLength = 32  // 32 bytes is the required length for AES-256.
+	separator         = "$" // used specifically because $ is not part of base64
 )
 
 // EncryptionError is an error about encryption or decryption.
@@ -135,19 +135,19 @@ func (e encryptor) SecondaryKeyHash() string {
 // ConfiguredToEncrypt returns the status of our encryptor, whether or not
 // it has a key specified, and can thus encrypt.
 func (e encryptor) ConfiguredToEncrypt() bool {
-	return len(e.primaryKey) == validKeyLength
+	return len(e.primaryKey) == requiredKeyLength
 }
 
 // ConfiguredToRotate returns the status of our encryptor. If it contains two keys it
 // is configured to rotate.
 func (e encryptor) ConfiguredToRotate() bool {
-	return len(e.primaryKey) == validKeyLength && len(e.secondaryKey) == validKeyLength
+	return len(e.primaryKey) == requiredKeyLength && len(e.secondaryKey) == requiredKeyLength
 }
 
 // Encrypt encrypts the plaintext using the primaryKey of the encryptor. This
 // relies on the AES-GCM encryption defined in encrypt, within this package.
 func (e encryptor) Encrypt(plaintext string) (ciphertext string, err error) {
-	if len(e.primaryKey) < validKeyLength {
+	if len(e.primaryKey) < requiredKeyLength {
 		return "", &EncryptionError{errors.New("primary key is unavailable")}
 	}
 
@@ -164,7 +164,7 @@ func (e encryptor) Encrypt(plaintext string) (ciphertext string, err error) {
 // This relies on AES-GCM. The `failed` indicates if attempts have been made
 // to decrypt but failed with both primary and secondary keys.
 func (e encryptor) Decrypt(ciphertext string) (plaintext string, failed bool, err error) {
-	if len(e.primaryKey) < validKeyLength && len(e.secondaryKey) < validKeyLength {
+	if len(e.primaryKey) < requiredKeyLength && len(e.secondaryKey) < requiredKeyLength {
 		return "", false, &EncryptionError{errors.New("no valid keys available")}
 	}
 

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -160,7 +160,7 @@ func (e encryptor) Encrypt(plaintext string) (ciphertext string, err error) {
 	return e.PrimaryKeyHash() + separator + ciphertext, nil
 }
 
-// Decrypt decrypts the plaintext using the primaryKey of the encryptor.
+// Decrypt decrypts base64 encoded ciphertext using the primaryKey of the encryptor
 // This relies on AES-GCM. The `failed` indicates if attempts have been made
 // to decrypt but failed with both primary and secondary keys.
 func (e encryptor) Decrypt(ciphertext string) (plaintext string, failed bool, err error) {

--- a/internal/secrets/encryptor_test.go
+++ b/internal/secrets/encryptor_test.go
@@ -2,13 +2,10 @@ package secrets
 
 import (
 	"bytes"
-	"crypto/rand"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
-
-var messageToEncrypt = "I Madam. I made radio, So I dared. Am I mad? Am I?"
 
 func TestGenerateRandomAESKey(t *testing.T) {
 	key, err := generateRandomAESKey()
@@ -20,7 +17,9 @@ func TestGenerateRandomAESKey(t *testing.T) {
 	}
 }
 
-func TestEncryptingAndDecrypting(t *testing.T) {
+var messageToEncrypt = "I Madam. I made radio, So I dared. Am I mad? Am I?"
+
+func TestAESGCMEncodedEncrytor(t *testing.T) {
 	primaryKey, err := generateRandomAESKey()
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +30,7 @@ func TestEncryptingAndDecrypting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("using primary key", func(t *testing.T) {
+	t.Run("use primary key to encrypt", func(t *testing.T) {
 		e := newAESGCMEncodedEncryptor(primaryKey, nil)
 
 		encrypted, err := e.Encrypt(messageToEncrypt)
@@ -39,7 +38,7 @@ func TestEncryptingAndDecrypting(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		decrypted, _, err := e.Decrypt(encrypted)
+		decrypted, err := e.Decrypt(encrypted)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -49,7 +48,7 @@ func TestEncryptingAndDecrypting(t *testing.T) {
 		}
 	})
 
-	t.Run("using secondary key", func(t *testing.T) {
+	t.Run("use secondary key to encrypt", func(t *testing.T) {
 		// Only load secondary key to encrypt
 		e := newAESGCMEncodedEncryptor(secondaryKey, nil)
 		encrypted, err := e.Encrypt(messageToEncrypt)
@@ -59,7 +58,7 @@ func TestEncryptingAndDecrypting(t *testing.T) {
 
 		// Then load both keys to decrypt
 		e = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
-		decrypted, _, err := e.Decrypt(encrypted)
+		decrypted, err := e.Decrypt(encrypted)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -68,9 +67,66 @@ func TestEncryptingAndDecrypting(t *testing.T) {
 			t.Fatal("unable to decrypt and get the original bytes")
 		}
 	})
+
+	isInSliceOnce := func(item string, slice []string) bool {
+		found := 0
+		for _, s := range slice {
+			if item == s {
+				found++
+			}
+		}
+
+		return found == 1
+	}
+
+	t.Run("different messages should generate different outputs", func(t *testing.T) {
+		e := newAESGCMEncodedEncryptor(primaryKey, nil)
+
+		messages := []string{
+			"This may or may",
+			"This is not the same as that",
+			"The end of that",
+			"Plants and animals",
+			"Snow, igloos, sunshine, unicords",
+		}
+
+		var crypts []string
+		for _, m := range messages {
+			encrypted, err := e.Encrypt(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			crypts = append(crypts, string(encrypted))
+		}
+
+		for _, c := range crypts {
+			if !isInSliceOnce(c, crypts) {
+				t.Fatalf("Duplicate encryption string: %v", c)
+			}
+		}
+	})
+
+	t.Run("same message generates different outputs every time", func(t *testing.T) {
+		e := newAESGCMEncodedEncryptor(primaryKey, nil)
+
+		var crypts []string
+		for i := 0; i < 1000; i++ {
+			encrypted, err := e.Encrypt(messageToEncrypt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			crypts = append(crypts, encrypted)
+		}
+
+		for _, item := range crypts {
+			if isInSliceOnce(item, crypts) == false {
+				t.Fatalf("Duplicate encrypted string found")
+			}
+		}
+	})
 }
 
-func TestKeyHash(t *testing.T) {
+func TestAESGCMEncodedEncrytor_KeyHash(t *testing.T) {
 	primaryKey, err := generateRandomAESKey()
 	if err != nil {
 		t.Fatal(err)
@@ -97,49 +153,8 @@ func TestKeyHash(t *testing.T) {
 		t.Errorf("expected PrimaryKeyHash() %q == PrimaryKeyHash() %q", encryptorHash, primaryKeyHash)
 	}
 }
-func TestNoopEncryptor(t *testing.T) {
 
-	// now test when we cannot Encrypt
-	t.Run("test no-op encryptor", func(t *testing.T) {
-		e := noOpEncryptor{}
-		encString, err := e.Encrypt(messageToEncrypt)
-		if err != nil {
-			t.Fatalf("Received error when code path should be nil, but got %v", err)
-		}
-		if encString != messageToEncrypt {
-			t.Fatalf("Received encrypted string, expected unencrypted")
-		}
-		decString, _, err := e.Decrypt(encString)
-		if err != nil {
-			t.Fatalf("Received error when code path should be nil, but got %v", err)
-		}
-		if decString != messageToEncrypt {
-			t.Fatalf("Received encrypted string, expected unencrypted")
-		}
-	})
-
-}
-func TestNoOpEncryptor_KeyHash(t *testing.T) {
-	e := noOpEncryptor{}
-	if e.PrimaryKeyHash() != "" && e.SecondaryKeyHash() != "" {
-		t.Fatal("noop encryptor shouldn't have key hashes")
-	}
-}
-
-func TestNoOpEncryptor_Encrypt(t *testing.T) {
-	e := noOpEncryptor{}
-
-	encrypted, err := e.Encrypt(messageToEncrypt)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if encrypted != messageToEncrypt {
-		t.Fatal("encrypted bytes is not same as the original")
-	}
-}
-
-func TestBadKeysFailToDecrypt(t *testing.T) {
+func TestAESGCMEncodedEncrytor_BadKeysFailToDecrypt(t *testing.T) {
 	key, err := generateRandomAESKey()
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +167,7 @@ func TestBadKeysFailToDecrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	decrypted, _, err := e.Decrypt(encrypted)
+	decrypted, err := e.Decrypt(encrypted)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,115 +178,17 @@ func TestBadKeysFailToDecrypt(t *testing.T) {
 	}
 	e2 := newAESGCMEncodedEncryptor(notTheSameKey, nil)
 
-	decryptedAgain, failed, err := e2.Decrypt(encrypted)
+	decryptedAgain, err := e2.Decrypt(encrypted)
 	// Not the same key will have different keyHash and effectively makes the decryption no-op.
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !failed {
-		t.Fatal("!failed")
+	if err != ErrDecryptAttemptedButFailed {
+		t.Fatalf("err: want %v but got %v", ErrDecryptAttemptedButFailed, err)
 	}
 	if decrypted == decryptedAgain {
 		t.Fatal("Should not have been able to Decrypt string with an invalid secret key")
 	}
 }
 
-// Test that different strings EncryptBytes to different outputs
-func TestDifferentOutputs(t *testing.T) {
-	key, err := generateRandomAESKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	e := newAESGCMEncodedEncryptor(key, nil)
-	messages := []string{
-		"This may or may",
-		"This is not the same as that",
-		"The end of that",
-		"Plants and animals",
-		"Snow, igloos, sunshine, unicords",
-	}
-
-	var crypts []string
-	for _, m := range messages {
-		encrypted, err := e.Encrypt(m)
-		if err != nil {
-			t.Fatal(err)
-		}
-		crypts = append(crypts, string(encrypted))
-	}
-
-	for _, c := range crypts {
-		if !isInSliceOnce(c, crypts) {
-			t.Fatalf("Duplicate encryption string: %v", c)
-		}
-	}
-}
-
-func isInSliceOnce(item string, slice []string) bool {
-	found := 0
-	for _, s := range slice {
-		if item == s {
-			found++
-		}
-	}
-
-	return found == 1
-}
-
-func TestSampleNoRepeats(t *testing.T) {
-	key, err := generateRandomAESKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	e := newAESGCMEncodedEncryptor(key, nil)
-
-	var crypts []string
-	for i := 0; i < 10000; i++ {
-		encrypted, err := e.Encrypt(messageToEncrypt)
-		if err != nil {
-			t.Fatal(err)
-		}
-		crypts = append(crypts, encrypted)
-	}
-
-	for _, item := range crypts {
-		if isInSliceOnce(item, crypts) == false {
-			t.Fatalf("Duplicate encrypted string found")
-		}
-	}
-}
-
-func TestKeyMigration(t *testing.T) {
-	keyA, err := generateRandomAESKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	keyB, err := generateRandomAESKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	encryptorA := newAESGCMEncodedEncryptor(keyA, nil)
-
-	message := "encrypted with Key A"
-	encryptedMessage, err := encryptorA.Encrypt(message)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// now rotate keys to use Key B
-	encryptorB := newAESGCMEncodedEncryptor(keyB, keyA)
-	decryptedMessage, _, err := encryptorB.Decrypt(encryptedMessage)
-	if err != nil {
-		t.Fatalf("unable to Decrypt string: %v", err)
-	}
-
-	if decryptedMessage != message {
-		t.Fatalf("messages do not match")
-	}
-}
-
-func Test_gatherKeys(t *testing.T) {
+func TestGatherKeys(t *testing.T) {
 	tests := []struct {
 		name             string
 		data             []byte
@@ -280,25 +197,25 @@ func Test_gatherKeys(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			"base-case",
-			[]byte("key123,key345"),
-			[]byte("key123"),
-			[]byte("key345"),
-			false,
+			name:             "base-case",
+			data:             []byte("key123,key345"),
+			wantPrimaryKey:   []byte("key123"),
+			wantSecondaryKey: []byte("key345"),
+			wantErr:          false,
 		},
 		{
-			"no key set",
-			[]byte("key123"),
-			[]byte("key123"),
-			nil,
-			false,
+			name:             "no key set",
+			data:             []byte("key123"),
+			wantPrimaryKey:   []byte("key123"),
+			wantSecondaryKey: nil,
+			wantErr:          false,
 		},
 		{
-			"3 key err case",
-			[]byte("look mom, I am a key, me too"),
-			nil,
-			nil,
-			true,
+			name:             "3 key err case",
+			data:             []byte("look mom, I am a key, me too"),
+			wantPrimaryKey:   nil,
+			wantSecondaryKey: nil,
+			wantErr:          true,
 		},
 	}
 	for _, tt := range tests {
@@ -318,34 +235,47 @@ func Test_gatherKeys(t *testing.T) {
 	}
 }
 
-func Test_encryptor_RotateEncryption(t *testing.T) {
+func TestAESGCMEncodedEncrytor_RotateEncryption(t *testing.T) {
 	tests := []struct {
-		name         string
-		primaryKey   []byte
-		secondaryKey []byte
-		plaintext    string
-		wantErr      bool
+		name           string
+		primaryKey     []byte
+		secondaryKey   []byte
+		mockCiphertext string
+		wantPlaintext  string
+		wantErr        bool
 	}{
 		{
-			"base",
-			mockGenRandomKey(),
-			mockGenRandomKey(),
-			"this is a special string",
-			false,
+			name:          "base",
+			primaryKey:    mustGenerateRandomAESKey(),
+			secondaryKey:  mustGenerateRandomAESKey(),
+			wantPlaintext: "this is a special string",
+			wantErr:       false,
+		},
+		{
+			name:           "failed_case",
+			primaryKey:     mustGenerateRandomAESKey(),
+			secondaryKey:   mustGenerateRandomAESKey(),
+			mockCiphertext: "jdklasjdklsa$",
+			wantPlaintext:  "",
+			wantErr:        true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := newAESGCMEncodedEncryptor(tt.primaryKey, tt.secondaryKey)
 
 			// pretend we originally use secondaryKey
 			e2 := newAESGCMEncodedEncryptor(tt.secondaryKey, nil)
-			ciphertext, err := e2.Encrypt(tt.plaintext)
+			ciphertext, err := e2.Encrypt(tt.wantPlaintext)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			if tt.mockCiphertext != "" {
+				ciphertext = tt.mockCiphertext
+			}
+
 			// rotate to use new primary key
+			e := newAESGCMEncodedEncryptor(tt.primaryKey, tt.secondaryKey)
 			got, err := e.RotateEncryption(ciphertext)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("RotateEncryption() error = %v, wantErr %v", err, tt.wantErr)
@@ -353,30 +283,28 @@ func Test_encryptor_RotateEncryption(t *testing.T) {
 
 			// we should always Encrypt with the primary key
 			e3 := newAESGCMEncodedEncryptor(tt.primaryKey, nil)
-			got, _, err = e3.Decrypt(got)
+			got, err = e3.Decrypt(got)
 			if err != nil {
 				t.Fatalf("RotateEncryption() unable to Decrypt with primary key %v", err)
 			}
 
-			if diff := cmp.Diff(tt.plaintext, got); diff != "" {
+			if diff := cmp.Diff(tt.wantPlaintext, got); diff != "" {
 				t.Fatalf("Mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-// mockGenRandomKey does not return an error
-func mockGenRandomKey() []byte {
-	b := make([]byte, requiredKeyLength)
-	_, err := rand.Read(b)
+// mustGenerateRandomAESKey generates a random AES key and panics for any error.
+func mustGenerateRandomAESKey() []byte {
+	key, err := generateRandomAESKey()
 	if err != nil {
 		panic(err)
 	}
-	return b
+	return key
 }
 
-func Test_Decrypt_Plaintext(t *testing.T) {
-
+func TestAESGCMEncodedEncrytor_Decrypt_Plaintext(t *testing.T) {
 	tests := []struct {
 		name          string
 		primaryKey    []byte
@@ -384,56 +312,50 @@ func Test_Decrypt_Plaintext(t *testing.T) {
 		encryptInTest bool
 		ciphertext    string
 		wantPlaintext string
-		wantFailed    bool
 		wantErr       bool
 	}{
 
 		{
-			"base",
-			mockGenRandomKey(),
-			mockGenRandomKey(),
-			true,
-			"VerySpecialString",
-			"VerySpecialString",
-			false,
-			false,
+			name:          "base",
+			primaryKey:    mustGenerateRandomAESKey(),
+			secondaryKey:  mustGenerateRandomAESKey(),
+			encryptInTest: true,
+			ciphertext:    "VerySpecialString",
+			wantPlaintext: "VerySpecialString",
+			wantErr:       false,
 		},
 		{
-			"unencrypted ciphertext",
-			mockGenRandomKey(),
-			mockGenRandomKey(),
-			false,
-			"Non-encrypted string",
-			"Non-encrypted string",
-			false,
-			false,
+			name:          "unencrypted ciphertext",
+			primaryKey:    mustGenerateRandomAESKey(),
+			secondaryKey:  mustGenerateRandomAESKey(),
+			encryptInTest: false,
+			ciphertext:    "Non-encrypted string",
+			wantPlaintext: "Non-encrypted string",
+			wantErr:       false,
 		},
 		{
 			// this occurs when a token contains the `separator`
-			"unencrypted ciphertext with separator",
-			mockGenRandomKey(),
-			mockGenRandomKey(),
-			false,
-			"VeryBadString" + separator,
-			"VeryBadString" + separator,
-			true,
-			false,
+			name:          "unencrypted ciphertext with separator",
+			primaryKey:    mustGenerateRandomAESKey(),
+			secondaryKey:  mustGenerateRandomAESKey(),
+			encryptInTest: false,
+			ciphertext:    "VeryBadString" + separator,
+			wantPlaintext: "",
+			wantErr:       true,
 		},
 		{
-			"single key",
-			mockGenRandomKey(),
-			nil,
-			false,
-			messageToEncrypt,
-			messageToEncrypt,
-			false,
-			false,
+			name:          "single key",
+			primaryKey:    mustGenerateRandomAESKey(),
+			secondaryKey:  nil,
+			encryptInTest: false,
+			ciphertext:    messageToEncrypt,
+			wantPlaintext: messageToEncrypt,
+			wantErr:       false,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			var e encryptor
 			if tt.primaryKey != nil && tt.secondaryKey != nil {
 				e = newAESGCMEncodedEncryptor(tt.primaryKey, tt.secondaryKey)
@@ -453,7 +375,7 @@ func Test_Decrypt_Plaintext(t *testing.T) {
 				}
 			}
 
-			gotPlaintext, gotFailed, err := e.Decrypt(tt.ciphertext)
+			gotPlaintext, err := e.Decrypt(tt.ciphertext)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Decrypt() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -461,9 +383,33 @@ func Test_Decrypt_Plaintext(t *testing.T) {
 			if gotPlaintext != tt.wantPlaintext {
 				t.Errorf("Decrypt() gotPlaintext = %q, want %q", gotPlaintext, tt.wantPlaintext)
 			}
-			if gotFailed != tt.wantFailed {
-				t.Errorf("Decrypt() gotFailed = %v, want %v", gotFailed, tt.wantFailed)
-			}
 		})
 	}
+}
+
+func TestNoOpEncryptor(t *testing.T) {
+	t.Run("should do nothing when encrypt and decrypt", func(t *testing.T) {
+		e := noOpEncryptor{}
+		encString, err := e.Encrypt(messageToEncrypt)
+		if err != nil {
+			t.Fatalf("Received error when code path should be nil, but got %v", err)
+		}
+		if encString != messageToEncrypt {
+			t.Fatalf("Received encrypted string, expected unencrypted")
+		}
+		decString, err := e.Decrypt(encString)
+		if err != nil {
+			t.Fatalf("Received error when code path should be nil, but got %v", err)
+		}
+		if decString != messageToEncrypt {
+			t.Fatalf("Received encrypted string, expected unencrypted")
+		}
+	})
+
+	t.Run("shouldn't have key hashes", func(t *testing.T) {
+		e := noOpEncryptor{}
+		if e.PrimaryKeyHash() != "" && e.SecondaryKeyHash() != "" {
+			t.Fatal("noop encryptor shouldn't have key hashes")
+		}
+	})
 }

--- a/internal/secrets/encryptor_test.go
+++ b/internal/secrets/encryptor_test.go
@@ -375,7 +375,6 @@ func mockGenRandomKey() []byte {
 	return b
 }
 
-//
 func Test_Decrypt_Plaintext(t *testing.T) {
 
 	tests := []struct {
@@ -389,7 +388,6 @@ func Test_Decrypt_Plaintext(t *testing.T) {
 		wantErr       bool
 	}{
 
-		// TODO: Add test cases.
 		{
 			"base",
 			mockGenRandomKey(),

--- a/internal/secrets/encryptor_test.go
+++ b/internal/secrets/encryptor_test.go
@@ -15,8 +15,8 @@ func TestGenerateRandomAESKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(key) != validKeyLength {
-		t.Fatalf("Exepected key length of %d received %d", validKeyLength, len(key))
+	if len(key) != requiredKeyLength {
+		t.Fatalf("Exepected key length of %d received %d", requiredKeyLength, len(key))
 	}
 }
 
@@ -367,7 +367,7 @@ func Test_encryptor_RotateEncryption(t *testing.T) {
 
 // mockGenRandomKey does not return an error
 func mockGenRandomKey() []byte {
-	b := make([]byte, validKeyLength)
+	b := make([]byte, requiredKeyLength)
 	_, err := rand.Read(b)
 	if err != nil {
 		panic(err)

--- a/internal/secrets/init.go
+++ b/internal/secrets/init.go
@@ -47,7 +47,7 @@ func Init() error {
 }
 
 // defaultEncryptor is configured during init, if no keys are provided it will implement noOpEncryptor
-var defaultEncryptor Encryptor
+var defaultEncryptor encryptorInterface
 
 func initDefaultEncryptor() error {
 	var encryptionKey []byte

--- a/internal/secrets/init.go
+++ b/internal/secrets/init.go
@@ -71,8 +71,8 @@ func initDefaultEncryptor() error {
 		if readErr != nil {
 			return errors.Wrapf(readErr, "couldn't read file %s", sourcegraphSecretfileEnvvar)
 		}
-		if len(contents) < validKeyLength {
-			return errors.Errorf("key length of %d characters is required", validKeyLength)
+		if len(contents) < requiredKeyLength {
+			return errors.Errorf("key length of %d characters is required", requiredKeyLength)
 		}
 		encryptionKey = contents
 
@@ -88,8 +88,8 @@ func initDefaultEncryptor() error {
 	envCryptKey, cryptOK := os.LookupEnv(sourcegraphCryptEnvvar)
 	// environment is second order
 	if cryptOK {
-		if len(envCryptKey) != validKeyLength {
-			return errors.Errorf("encryption key must be %d characters", validKeyLength)
+		if len(envCryptKey) != requiredKeyLength {
+			return errors.Errorf("encryption key must be %d characters", requiredKeyLength)
 		}
 		primaryKey, secondaryKey, err := gatherKeys(encryptionKey)
 		if err != nil {
@@ -150,7 +150,7 @@ func initDefaultEncryptor() error {
 
 // generateRandomAESKey generates a random key that can be used for AES-256 encryption.
 func generateRandomAESKey() ([]byte, error) {
-	b := make([]byte, validKeyLength)
+	b := make([]byte, requiredKeyLength)
 	_, err := rand.Read(b)
 	if err != nil {
 		return nil, err

--- a/internal/secrets/init.go
+++ b/internal/secrets/init.go
@@ -47,7 +47,7 @@ func Init() error {
 }
 
 // defaultEncryptor is configured during init, if no keys are provided it will implement noOpEncryptor
-var defaultEncryptor encryptorInterface
+var defaultEncryptor encryptor
 
 func initDefaultEncryptor() error {
 	var encryptionKey []byte
@@ -81,7 +81,7 @@ func initDefaultEncryptor() error {
 			return err
 		}
 
-		defaultEncryptor = newEncryptor(primaryKey, secondaryKey)
+		defaultEncryptor = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
 		return nil
 	}
 
@@ -96,7 +96,7 @@ func initDefaultEncryptor() error {
 			return err
 		}
 
-		defaultEncryptor = newEncryptor(primaryKey, secondaryKey)
+		defaultEncryptor = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
 		return nil
 	}
 
@@ -127,7 +127,7 @@ func initDefaultEncryptor() error {
 			return err
 		}
 
-		defaultEncryptor = newEncryptor(newKey, nil)
+		defaultEncryptor = newAESGCMEncodedEncryptor(newKey, nil)
 		return nil
 	}
 


### PR DESCRIPTION
This changeset is extracted from #13759 to make it easier to review.

1. Refactored `secrets` package to do base64 encoding/decoding.
2. Prepend encryption key hash to ciphertext for easier filtering by primary or secondary key.
3. Made encryptor interface to be private because application layer code should just use the exported package-level functions.
4. Changed separator to use `$` instead of `:` because it is going to fail with `https://xxx` (i.e. `external_service_repos.clone_url`) (the fact is whatever separator we choose, there is always a chance the plaintext string contains it).

Co-authored-by: Dax McDonald <31839142+daxmc99@users.noreply.github.com>