### PR TITLE
renovate-downstream: check for status context

### DIFF
--- a/.github/workflows/renovate-downstream.yml
+++ b/.github/workflows/renovate-downstream.yml
@@ -8,7 +8,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     # Run on commit status success on branch main, ignoring bot events
-    if: ${{ github.ref == 'refs/heads/main' && github.event.state == 'success' && github.event.sender.login != 'codecov[bot]' && github.event.sender.login != 'percy[bot]' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.event.state == 'success' && github.event.context == 'buildkite/sourcegraph' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
for #13842 - made a bit more of a systematic approach:

* set up https://webhook.site
* subscribe to webhooks via repo settings
* trigger buildkite run and look at what happens

Example success event:

```
{
  "id": 10777871439,
  "sha": "ae96a5a57a8b414ec59e64078addf5ac46a89b41",
  "name": "sourcegraph/sourcegraph",
  "target_url": "https://buildkite.com/sourcegraph/sourcegraph/builds/73542",
  "avatar_url": "https://avatars1.githubusercontent.com/oa/46194?v=4",
  "context": "buildkite/sourcegraph",
  "description": "Build #73542 passed (12 minutes, 42 seconds)",
  "state": "success",
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
