### PR TITLE
ci: do not wait for images to build before starting tests

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -297,24 +297,19 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 			for _, dockerImage := range allDockerImages {
 				addDockerImage(c, dockerImage, false)(pipeline)
 			}
-			pipeline.AddWait()
 		case c.releaseBranch:
 			addDockerImage(c, "server", false)(pipeline)
-			pipeline.AddWait()
 		case c.isMasterDryRun: // replicates `master` build but does not deploy
 			for _, dockerImage := range allDockerImages {
 				addDockerImage(c, dockerImage, false)(pipeline)
 			}
-			pipeline.AddWait()
 		case c.branch == "master" || c.branch == "main":
 			for _, dockerImage := range allDockerImages {
 				addDockerImage(c, dockerImage, true)(pipeline)
 			}
-			pipeline.AddWait()
 
 		case strings.HasPrefix(c.branch, "docker-images-patch/"):
 			addDockerImage(c, c.branch[20:], false)(pipeline)
-			pipeline.AddWait()
 		}
 	}
 }


### PR DESCRIPTION
From what I understand, the goal of https://github.com/sourcegraph/sourcegraph/pull/13689 is to *start* to build the images earlier, but it seems that what it does is cause tests to wait until images build. This PR is more or a proposal because I feel like we still want tests to *try* to grab an agent to start running on (while still prioritizing the images) - I think this change does the trick?

There is already a `wait` before the publish step, so this change should still wait for all images to build before publishing

Currently:

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/23356519/93306621-b65fb400-f832-11ea-8643-4a1f1bb1c6f2.png">

It seems that all the docker images must build before tests start

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
