### PR TITLE
renovate-downstream: check for branch in event instead of github.ref

### DIFF
--- a/.github/workflows/renovate-downstream.yml
+++ b/.github/workflows/renovate-downstream.yml
@@ -8,7 +8,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     # Run on commit status success on branch main, ignoring bot events
-    if: ${{ github.ref == 'refs/heads/main' && github.event.state == 'success' && github.event.context == 'buildkite/sourcegraph' }}
+    if: ${{ contains(github.event.branches.*.name, 'main') && github.event.state == 'success' && github.event.context == 'buildkite/sourcegraph' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
After the logs added in #13845 , it looks like `github.ref` does *not* refer to the branch of the event but of the workflow file itself! So _any_ buildkite success was triggering Renovate. Should close #13842 

This change looks at the branches in the event itself using the builtin function [`contains`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#example-using-an-array)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
