### PR TITLE
Fix global navbar crash

### DIFF
--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -112,7 +112,8 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                 onNavbarQueryChange({ query, cursorPosition: query.length })
             } else {
                 // If we have no component state, then we may have gotten unmounted during a route change.
-                const query = location.state ? location.state.query : ''
+                const query = location.state?.query || ''
+
                 onNavbarQueryChange({
                     query,
                     cursorPosition: query.length,

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -112,7 +112,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                 onNavbarQueryChange({ query, cursorPosition: query.length })
             } else {
                 // If we have no component state, then we may have gotten unmounted during a route change.
-                const query = location.state?.query || ''
+                const query = location.state?.query ?? ''
 
                 onNavbarQueryChange({
                     query,


### PR DESCRIPTION
Fix #13858

Previously used ternary that allowed undefined `query` to slip through.
@sqs are there any unintended side effects to my change?