### PR TITLE
search: add general search expressions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1026,14 +1026,6 @@ func (r *searchResolver) evaluateOperator(ctx context.Context, scopeParameters [
 	return result, nil
 }
 
-func prettyPrint(nodes []query.Node) string {
-	var resultStr []string
-	for _, node := range nodes {
-		resultStr = append(resultStr, node.String())
-	}
-	return strings.Join(resultStr, " ")
-}
-
 // setQuery sets a new query in the search resolver, for potentially repeated
 // calls in the search pipeline. The important part is it takes care of
 // invalidating cached repo info.
@@ -1041,7 +1033,6 @@ func (r *searchResolver) setQuery(q []query.Node) {
 	r.resolved.repoRevs = nil
 	r.resolved.missingRepoRevs = nil
 	r.repoErr = nil
-	log15.Info("q", prettyPrint(q))
 	r.query.(*query.AndOrQuery).Query = q
 }
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1232,11 +1232,11 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 		}
 	}
 
-	err = validate(query)
-	if err != nil {
-		return nil, err
+	for _, disjunct := range Dnf(query) {
+		err = validate(disjunct)
+		if err != nil {
+			return nil, err
+		}
 	}
-	query = concatRevFilters(query)
-
 	return &AndOrQuery{Query: query}, nil
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -414,7 +414,7 @@ func distribute(prefixes [][]Node, nodes []Node) [][]Node {
 	return prefixes
 }
 
-// dnf returns the Disjunctive Normal Form of a query (a flat sequence of
+// Dnf returns the Disjunctive Normal Form of a query (a flat sequence of
 // or-expressions) by applying the distributive property on (possibly nested)
 // or-expressions. For example, the query:
 //
@@ -427,7 +427,7 @@ func distribute(prefixes [][]Node, nodes []Node) [][]Node {
 // the results. Note that various optimizations are possible
 // during evaluation, but those are separate query pre- or postprocessing steps
 // separate from this general transformation.
-func dnf(query []Node) [][]Node {
+func Dnf(query []Node) [][]Node {
 	return distribute([][]Node{}, query)
 }
 
@@ -644,7 +644,7 @@ func FuzzifyRegexPatterns(nodes []Node) []Node {
 
 // concatRevFilters removes rev: filters from []Node and attaches their value as @rev to the repo: filters.
 // Invariant: Guaranteed to succeed on a validated and DNF query.
-func concatRevFilters(nodes []Node) []Node {
+func ConcatRevFilters(nodes []Node) []Node {
 	var revision string
 	nodes = MapField(nodes, FieldRev, func(value string, _ bool) Node {
 		revision = value

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -402,7 +402,7 @@ func TestExpandOr(t *testing.T) {
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			queries := dnf(query)
+			queries := Dnf(query)
 			var queriesStr []string
 			for _, q := range queries {
 				queriesStr = append(queriesStr, prettyPrint(q))
@@ -876,11 +876,11 @@ func TestConcatRevFilters(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			queries := dnf(query)
+			queries := Dnf(query)
 
 			var queriesStr []string
 			for _, q := range queries {
-				qConcat := concatRevFilters(q)
+				qConcat := ConcatRevFilters(q)
 				queriesStr = append(queriesStr, prettyPrint(qConcat))
 			}
 			got := "(" + strings.Join(queriesStr, ") OR (") + ")"
@@ -912,7 +912,7 @@ func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			qConcat := concatRevFilters(query)
+			qConcat := ConcatRevFilters(query)
 			if diff := cmp.Diff(c.want, prettyPrint(qConcat)); diff != "" {
 				t.Error(diff)
 			}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -56,6 +56,16 @@ func containsPattern(node Node) bool {
 	})
 }
 
+// containsField returns true if the field exists in the query.
+func containsField(nodes []Node, field string) bool {
+	return exists(nodes, func(node Node) bool {
+		if p, ok := node.(Parameter); ok && p.Field == field {
+			return true
+		}
+		return false
+	})
+}
+
 // ContainsAndOrKeyword returns true if this query contains or- or and-
 // keywords. It is a temporary signal to determine whether we can fallback to
 // the older existing search functionality.


### PR DESCRIPTION
Adds the ability to evaluate search expressions across different result types/scopes. Basically it recognizes and expands distributive properties of expressions. Examples:

[`repo:sourcegraph (newRouter OR file:router.go)`](https://sourcegraph.test:3443/search?q=repo:sourcegraph+%28newRouter+OR+file:router.go%29&patternType=literal)

[`repo:sourcegraph (type:diff or type:commit) author:keegan fast`](https://sourcegraph.test:3443/search?q=repo:sourcegraph+%28type:diff+or+type:commit%29+author:keegan+fast&patternType=literal)

[`(repo:^github\.com/sourcegraph/zoekt@master or repo:^github\.com/sourcegraph/sourcegraph$@3.18:3.17) indexed repos`](https://sourcegraph.test:3443/search?q=%28repo:%5Egithub%5C.com/sourcegraph/zoekt%40master+or+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%403.18:3.17%29+indexed+repos&patternType=literal)

[`repo:sourcegraph (file:schema.graphql hover(...) or file:codeintel.go (Line or Character))`](https://sourcegraph.test:3443/search?q=repo:sourcegraph+%28file:schema.graphql+hover%28...%29+or+file:codeintel.go+%28Line+or+Character%29%29&patternType=structural)

[`repo:^github\.com/sourcegraph/sourcegraph$ (rev:3.18 or rev:3.17 or rev:3.16 or rev:3.15) file:CHANGELOG.md`](https://sourcegraph.test:3443/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%28rev:3.18+or+rev:3.17+or+rev:3.16+or+rev:3.15%29+file:CHANGELOG.md&patternType=literal)

--- 

Overview of changes:

- Apply a transformation `Dnf` that expands queries like 
`(repo:foo (file:bar or baz))` => `(repo:foo file:bar) or (repo:foo baz)`

  This transformation ensures that we can can evaluate each disjunct as an independent and/or query. It means that the footprint of the change is small, we evaluate each disjunct, short-circuiting where possible. The downside is that in some cases we may give up the opportunity to optimize, e.g., for `(repo:foo (expression))`, we could theoretically see a speedup if we resolved `repo:foo` and then ran `expression` for all subexpressions. With the current method, we will potentially repeat the work of resolving `repo:foo`. It's currently too complex to rewrite how we evaluate queries so that we can benefit from this potential optimization.

- The search resolver caches certain result state, like repo results. Because this state is not necessarily valid for separate disjunct queries, the resolver cache data is reset per disjunct. See `setQuery`. 

- Note that none of the caching or query transformation code above affects current "traditional" queries, they only take effect for queries of the flavor in the examples above, that apply under distributive property. For this reason, I'm not adding a feature flag, but will just enable this behavior by default.

- There are some unresolved UI issues. To address this is straightforward: https://github.com/sourcegraph/sourcegraph/issues/13958#issuecomment-695087318 but I will do it separately. This PR does not yet document the feature or advertise its availability (no changelog entry).

- Due to the current query types, and in the interest of backwards-compatibility with old parser code, we (unfortunately) have to run the `Dnf` transformation twice: once for validation, and once for evaluation. This is avoidable in theory if I move the validation code into the evaluator, but that's not worth it. When the old parser code goes away (soon), I can remove the repeated `Dnf` call.

- All tests are via integration testing, other parts like the `Dnf` function already have unit tests.
