### PR TITLE
enterprise home: use larger page size when requesting searches in repo panel

### DIFF
--- a/web/src/search/panels/RepositoriesPanel.test.tsx
+++ b/web/src/search/panels/RepositoriesPanel.test.tsx
@@ -188,7 +188,7 @@ describe('RepositoriesPanel', () => {
             className: '',
             authenticatedUser: null,
             fetchRecentSearches: (_userId: string, first: number) =>
-                first === 20 ? of(recentSearches1) : of(recentSearches2),
+                first === 50 ? of(recentSearches1) : of(recentSearches2),
         }
 
         const component = mount(<RepositoriesPanel {...props} />)

--- a/web/src/search/panels/RepositoriesPanel.tsx
+++ b/web/src/search/panels/RepositoriesPanel.tsx
@@ -17,7 +17,9 @@ export const RepositoriesPanel: React.FunctionComponent<{
     fetchRecentSearches: (userId: string, first: number) => Observable<EventLogResult | null>
     className?: string
 }> = ({ authenticatedUser, fetchRecentSearches, className }) => {
-    const pageSize = 20
+    // Use a larger page size because not every search may have a `repo:` filter, and `repo:` filters could often
+    // be duplicated. Therefore, we fetch more searches to populate this panel.
+    const pageSize = 50
     const [itemsToLoad, setItemsToLoad] = useState(pageSize)
 
     const loadingDisplay = (


### PR DESCRIPTION
Addresses one bug in https://github.com/sourcegraph/sourcegraph/issues/13835. Sometimes the repo panel may not be populated fully because not every search has a `repo` filter, and we fetched only 20 recent searches at a time. Increasing the number of searches we fetch gives us better odds of filling up the panel with repo filter values.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
