### PR TITLE
Simplify syncSubset signature

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -66,7 +66,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/CountNotClonedRepos", testStoreCountNotClonedRepos},
 		{"DBStore/Syncer/Sync", testSyncerSync},
 		{"DBStore/Syncer/SyncWithErrors", testSyncerSyncWithErrors},
-		{"DBStore/Syncer/SyncSubset", testSyncSubset},
+		{"DBStore/Syncer/SyncSubset", testSyncSingleRepo},
 		{"DBStore/Syncer/SyncWorker", testSyncWorkerPlumbing(db)},
 		{"DBStore/Syncer/Run", testSyncRun(db)},
 		{"DBStore/Syncer/MultipleServices", testSyncer(db)},

--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -66,7 +66,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/CountNotClonedRepos", testStoreCountNotClonedRepos},
 		{"DBStore/Syncer/Sync", testSyncerSync},
 		{"DBStore/Syncer/SyncWithErrors", testSyncerSyncWithErrors},
-		{"DBStore/Syncer/SyncSubset", testSyncSingleRepo},
+		{"DBStore/Syncer/SyncRepo", testSyncRepo},
 		{"DBStore/Syncer/SyncWorker", testSyncWorkerPlumbing(db)},
 		{"DBStore/Syncer/Run", testSyncRun(db)},
 		{"DBStore/Syncer/MultipleServices", testSyncer(db)},

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -369,10 +369,8 @@ func calcSyncInterval(now time.Time, lastSync time.Time, minSyncInterval time.Du
 	return interval
 }
 
-// SyncSubset runs the syncer on a subset of the stored repositories. It will
-// only sync the repositories with the same name or external service spec as
-// sourcedSubset repositories.
-func (s *Syncer) SyncSubset(ctx context.Context, store Store, sourcedRepo *Repo) (err error) {
+// SyncSingleRepo runs the syncer on a single repository.
+func (s *Syncer) SyncSingleRepo(ctx context.Context, store Store, sourcedRepo *Repo) (err error) {
 	var diff Diff
 
 	ctx, save := s.observe(ctx, 0, "Syncer.SyncSubset", sourcedRepo.Name)
@@ -387,7 +385,7 @@ func (s *Syncer) SyncSubset(ctx context.Context, store Store, sourcedRepo *Repo)
 		store = txs
 	}
 
-	diff, err = s.syncSubset(ctx, store, false, sourcedRepo)
+	diff, err = s.syncSingleRepo(ctx, store, false, sourcedRepo)
 	return err
 }
 
@@ -399,11 +397,11 @@ func (s *Syncer) insertIfNew(ctx context.Context, store Store, sourcedRepo *Repo
 	ctx, save := s.observe(ctx, 0, "Syncer.InsertIfNew", sourcedRepo.Name)
 	defer save(&diff, &err)
 
-	diff, err = s.syncSubset(ctx, store, true, sourcedRepo)
+	diff, err = s.syncSingleRepo(ctx, store, true, sourcedRepo)
 	return err
 }
 
-func (s *Syncer) syncSubset(ctx context.Context, store Store, insertOnly bool, sourcedRepo *Repo) (diff Diff, err error) {
+func (s *Syncer) syncSingleRepo(ctx context.Context, store Store, insertOnly bool, sourcedRepo *Repo) (diff Diff, err error) {
 	var storedSubset Repos
 	args := StoreListReposArgs{
 		Names:         []string{sourcedRepo.Name},

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -635,7 +635,7 @@ func testSyncerSync(t *testing.T, s repos.Store) func(*testing.T) {
 	}
 }
 
-func testSyncSingleRepo(t *testing.T, s repos.Store) func(*testing.T) {
+func testSyncRepo(t *testing.T, s repos.Store) func(*testing.T) {
 	clock := repos.NewFakeClock(time.Now(), time.Second)
 
 	servicesPerKind := createExternalServices(t, s)
@@ -743,7 +743,7 @@ func testSyncSingleRepo(t *testing.T, s repos.Store) func(*testing.T) {
 				syncer := &repos.Syncer{
 					Now: clock.Now,
 				}
-				err := syncer.SyncSingleRepo(ctx, st, tc.sourced.Clone())
+				err := syncer.SyncRepo(ctx, st, tc.sourced.Clone())
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -635,7 +635,7 @@ func testSyncerSync(t *testing.T, s repos.Store) func(*testing.T) {
 	}
 }
 
-func testSyncSubset(t *testing.T, s repos.Store) func(*testing.T) {
+func testSyncSingleRepo(t *testing.T, s repos.Store) func(*testing.T) {
 	clock := repos.NewFakeClock(time.Now(), time.Second)
 
 	servicesPerKind := createExternalServices(t, s)
@@ -743,7 +743,7 @@ func testSyncSubset(t *testing.T, s repos.Store) func(*testing.T) {
 				syncer := &repos.Syncer{
 					Now: clock.Now,
 				}
-				err := syncer.SyncSubset(ctx, st, tc.sourced.Clone())
+				err := syncer.SyncSingleRepo(ctx, st, tc.sourced.Clone())
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -669,27 +669,23 @@ func testSyncSubset(t *testing.T, s repos.Store) func(*testing.T) {
 
 	testCases := []struct {
 		name    string
-		sourced repos.Repos
+		sourced *repos.Repo
 		stored  repos.Repos
 		assert  repos.ReposAssertion
 	}{{
-		name:   "no sourced",
-		stored: repos.Repos{repo.With(repos.Opt.RepoCreatedAt(clock.Time(2)))},
-		assert: repos.Assert.ReposEqual(repo.With(repos.Opt.RepoCreatedAt(clock.Time(2)))),
-	}, {
 		name:    "insert",
-		sourced: repos.Repos{repo},
+		sourced: repo,
 		assert:  repos.Assert.ReposEqual(repo.With(repos.Opt.RepoCreatedAt(clock.Time(2)))),
 	}, {
 		name:    "update",
-		sourced: repos.Repos{repo},
+		sourced: repo,
 		stored:  repos.Repos{repo.With(repos.Opt.RepoCreatedAt(clock.Time(2)))},
 		assert: repos.Assert.ReposEqual(repo.With(
 			repos.Opt.RepoModifiedAt(clock.Time(2)),
 			repos.Opt.RepoCreatedAt(clock.Time(2)))),
 	}, {
 		name:    "update name",
-		sourced: repos.Repos{repo},
+		sourced: repo,
 		stored: repos.Repos{repo.With(
 			repos.Opt.RepoName("old/name"),
 			repos.Opt.RepoCreatedAt(clock.Time(2)))},
@@ -698,7 +694,7 @@ func testSyncSubset(t *testing.T, s repos.Store) func(*testing.T) {
 			repos.Opt.RepoCreatedAt(clock.Time(2)))),
 	}, {
 		name:    "delete conflicting name",
-		sourced: repos.Repos{repo},
+		sourced: repo,
 		stored: repos.Repos{repo.With(
 			repos.Opt.RepoExternalID("old id"),
 			repos.Opt.RepoCreatedAt(clock.Time(2)))},
@@ -706,7 +702,7 @@ func testSyncSubset(t *testing.T, s repos.Store) func(*testing.T) {
 			repos.Opt.RepoCreatedAt(clock.Time(2)))),
 	}, {
 		name:    "rename and delete conflicting name",
-		sourced: repos.Repos{repo},
+		sourced: repo,
 		stored: repos.Repos{
 			repo.With(
 				repos.Opt.RepoExternalID("old id"),
@@ -747,7 +743,7 @@ func testSyncSubset(t *testing.T, s repos.Store) func(*testing.T) {
 				syncer := &repos.Syncer{
 					Now: clock.Now,
 				}
-				err := syncer.SyncSubset(ctx, st, tc.sourced.Clone()...)
+				err := syncer.SyncSubset(ctx, st, tc.sourced.Clone())
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -529,7 +529,7 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 		}, nil
 	}
 
-	err = s.Syncer.SyncSubset(ctx, s.Store, repo)
+	err = s.Syncer.SyncSingleRepo(ctx, s.Store, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -529,7 +529,7 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 		}, nil
 	}
 
-	err = s.Syncer.SyncSingleRepo(ctx, s.Store, repo)
+	err = s.Syncer.SyncRepo(ctx, s.Store, repo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[SyncSubset](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@sync_single_external_service/-/blob/cmd/repo-updater/repos/syncer.go#L375:18)'s signature allows calling it with a list of repositories but it's never called with more than one repository. This PR renames that function to `SyncSingleRepo` instead, to remain coherent with `SingleSingleExternalService` (though the `Single` seems redondant) and it now expects one repository instead of a variadic.
