### PR TITLE
codeintel: RFC 235: Add code intel postgres image

### DIFF
--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# This merely re-tags the image to match our official versioning scheme. The
+# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
+#
+# TODO: Move the image to this directory so it is open-source and built in CI automatically.
+docker pull index.docker.io/sourcegraph/postgres-11.4:20-04-07_56b20163@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+docker tag index.docker.io/sourcegraph/postgres-11.4:20-04-07_56b20163@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad "$IMAGE"

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -38,6 +38,7 @@ var allDockerImages = []string{
 	"syntax-highlighter",
 	"jaeger-agent",
 	"jaeger-all-in-one",
+	"codeintel-db",
 }
 
 // Verifies the docs formatting and builds the `docsite` command.


### PR DESCRIPTION
A step towards [RFC 235: Move LSIF data to Postgres](https://docs.google.com/document/u/1/d/1Y9p29hK8xrPUTvBdWqP9uAHDg3JLV-HCaxsbCo9-YHQ). Closes https://github.com/sourcegraph/sourcegraph/issues/13912.

This creates a new image that can be used as the code intel Postgres database. We're giving it a name instead of using the same postgres container in order to have a more consistent and less implementation-specific name.
