### PR TITLE
search: fix NOT erasing rest of query

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -893,7 +893,7 @@ loop:
 				parameter.Negated = true
 				parameter.Annotation.Range = newRange(start, p.pos)
 				nodes = append(nodes, parameter)
-				break loop
+				continue
 			}
 			pattern := p.ParsePatternLiteral()
 			pattern.Negated = true
@@ -997,7 +997,7 @@ loop:
 				parameter.Negated = true
 				parameter.Annotation.Range = newRange(start, p.pos)
 				nodes = append(nodes, parameter)
-				break loop
+				continue
 			}
 			pattern := p.ParsePatternRegexp()
 			pattern.Negated = true

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -1221,6 +1221,11 @@ func TestParseAndOrLiteral(t *testing.T) {
 			WantLabels: "Literal",
 		},
 		{
+			Input:      `not file:foo pattern`,
+			Want:       `(and "-file:foo" "pattern")`,
+			WantLabels: "Literal",
+		},
+		{
 			Input:      `not literal.*pattern`,
 			Want:       `"NOT literal.*pattern"`,
 			WantLabels: "Literal",


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/13756 I refactored this code and terminate parsing after a `not` keyword with `break loop` (wrong). It should have been `continue` to keep parsing. The previous change means any use of the `not` keyword on parameters like `not file:`, etc. erases the rest of the query.

Extra context for 3.20 release cc @davejrt : The changelog documents that 

> NOT is available as an alternative syntax of - on supported keywords repo, file, content, lang, and repohasfile. #12412

Without this commit, the above behavior is buggy. We should either cherrypick this change into the 3.20 release branch (preferred), or remove this entry from the changelog and then include this commit fix + changelog entry in a subsequent patch release.