### PR TITLE
Add script to produce source code zip of browser extension

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -20,7 +20,8 @@
     "clean": "rm -rf build/ dist/ *.zip *.xpi .checksum",
     "test": "jest --testPathIgnorePatterns end-to-end",
     "test-e2e": "mocha './src/end-to-end/**/*.test.ts'",
-    "bundlesize": "GITHUB_TOKEN= bundlesize"
+    "bundlesize": "GITHUB_TOKEN= bundlesize",
+    "create-source-zip": "node scripts/create-source-zip"
   },
   "browserslist": [
     "last 3 Chrome versions",

--- a/browser/scripts/create-source-zip.js
+++ b/browser/scripts/create-source-zip.js
@@ -1,0 +1,45 @@
+const shelljs = require('shelljs')
+const signale = require('signale')
+
+/**
+ * Purpose of this script: create a source code zip that can be used shared and
+ * used to produce a build of the browser extensions.
+ *
+ * This makes it possible to provide the complete source code to the maintainers of
+ * extension registries, in the cases where providing the source code is a
+ * pre-requisite to getting approval for publishing.
+ *
+ * This script fetches a fresh copy of the repository, identified by commit ID.
+ * This is done instead of using packaging the contents of the current working copy
+ * repository, and the reason is to avoid including any build artifacts that may
+ * be present. By pinning it to a commit, it become
+ *
+ */
+
+// Configuration
+const commitId = '350764282631014ea24ccd88fda459a4b19a5669'
+const includeCodeIntelExtensions = true
+const rootDirectoryNameForZip = 'sourcegraph-source'
+
+shelljs.rm('-f', 'sourcegraph.zip')
+signale.await(`Downloading sourcegraph/sourcegraph at revision ${commitId}`)
+shelljs.exec(
+  `curl -Ls https://github.com/sourcegraph/sourcegraph/archive/${commitId}.zip -o sourcegraph-downloaded.zip`
+)
+shelljs.rm('-rf', `sourcegraph-${commitId}/`)
+shelljs.exec('unzip -q sourcegraph-downloaded.zip')
+shelljs.rm('-f', 'sourcegraph-downloaded.zip')
+shelljs.mv(`sourcegraph-${commitId}`, rootDirectoryNameForZip)
+signale.success('Downloaded and unzipped sourcegraph/sourcegraph repository')
+
+if (includeCodeIntelExtensions) {
+  shelljs.pushd(rootDirectoryNameForZip)
+  shelljs.exec('yarn install')
+  shelljs.exec('yarn --cwd browser run fetch-code-intel-extensions')
+  shelljs.popd()
+}
+
+signale.await('Producing sourcegraph.zip')
+shelljs.exec(`zip -qr sourcegraph.zip ${rootDirectoryNameForZip} --exclude "${rootDirectoryNameForZip}/node_modules/*"`)
+shelljs.rm('-rf', rootDirectoryNameForZip)
+signale.success('Done producing sourcegraph.zip')

--- a/browser/scripts/create-source-zip.js
+++ b/browser/scripts/create-source-zip.js
@@ -5,14 +5,15 @@ const signale = require('signale')
  * Purpose of this script: create a source code zip that can be used shared and
  * used to produce a build of the browser extensions.
  *
- * This makes it possible to provide the complete source code to the maintainers of
- * extension registries, in the cases where providing the source code is a
+ * This makes it possible to provide the complete source code to the maintainers
+ * of extension registries, in the cases where providing the source code is a
  * pre-requisite to getting approval for publishing.
  *
  * This script fetches a fresh copy of the repository, identified by commit ID.
- * This is done instead of using packaging the contents of the current working copy
- * repository, and the reason is to avoid including any build artifacts that may
- * be present. By pinning it to a commit, it become
+ * This is done instead of using packaging the contents of the current working
+ * copy repository, and the reason is to avoid including any build artifacts
+ * that may be present. By pinning it to a commit, it's possible to use this
+ * script across any branch and commit.
  *
  */
 


### PR DESCRIPTION
**Background**

For publishing our extensions, we need to provide source code for review. The Firefox add-on registry requires this before publishing. An outline of these requirements is described in #12918 

Until now the process of producing a source code zip was manual.

**Implementation**

This introduces a script: `yarn run create-source-zip` which produces `sourcegraph.zip` as an output.

The script's configuration specifies the particular commit of `sourcegraph/sourcegraph` to use, which is fetched from the repository.

By default the script also fetches and includes `sourcegraph/code-intel-extensions` for bundling in the Firefox build.

**Related issues**

Closes #12918 because this PR implements most of the scope of that issue.

The only remaining scope is automating this process in CI, which has been previously filed under #11370.


