### PR TITLE
Attempt to fix browser extension e2e test possible race condition

### DIFF
--- a/browser/src/end-to-end/shared.ts
+++ b/browser/src/end-to-end/shared.ts
@@ -37,7 +37,7 @@ export function testSingleFilePage({
             await getDriver().page.waitForSelector('.code-view-toolbar .open-on-sourcegraph', { timeout: 10000 })
             expect(await getDriver().page.$$('.code-view-toolbar .open-on-sourcegraph')).toHaveLength(1)
             await Promise.all([
-                getDriver().page.waitForNavigation(),
+                getDriver().page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
                 getDriver().page.click('.code-view-toolbar .open-on-sourcegraph'),
             ])
             expect(getDriver().page.url()).toBe(


### PR DESCRIPTION
The "open in sourcegraph" button adds a `utm_source` param to the destination url. The [e2e tests check for the url with the param included](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/browser/src/end-to-end/shared.ts#L44), but we are seeing failures often, showing that the param is missing.

In fact, after the destination page loads, [the param is stripped from the URL.](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/web/src/tracking/analyticsUtils.tsx#L75) - thanks @dadlerj for pointing this out.

It's possible that by the time the assertion runs, the param may be already stripped from the URL. That would explain why this test doesn't behave consistently -- it might be a race condition.

By default `waitForNavigation` waits for the `load` event to take place on the destination page. This PR change relies on the assumption that if we assert as early as possible after the page navigates, the race condition might be avoided. The `domcontentloaded` event is the earliest event that's supported by the `waitUntil` option.

This change makes the tests succeed consistently when running locally; hopefully this will be the case in the nightly CI runs too.