### PR TITLE
Document token permissions required by campaigns

### DIFF
--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -15,7 +15,7 @@ Also consider installing the [Sourcegraph Bitbucket Server plugin](../../integra
 
 Sourcegraph requires a Bitbucket Server personal access token with **read** permissions to sync repositories.
 
-When using [campaigns](../../user/campaigns/index.md) the access token requires **write** permissions on the project and repository level. See "[Code host interactions in campaigns](../../user/campaigns/managing_access.md#code-host-interactions-in-campaigns)" for details.
+When using [campaigns](../../user/campaigns/index.md) the access token needs **write** permissions on the project and repository level. See "[Code host interactions in campaigns](../../user/campaigns/managing_access.md#code-host-interactions-in-campaigns)" for details.
 
 You can create a personal access token at `https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add`. Also set the corresponding `username` field.
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -11,6 +11,16 @@ To connect Bitbucket Server to Sourcegraph:
 
 Also consider installing the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) which enables native code intelligence for every Bitbucket user when browsing code and reviewing pull requests, allows for faster permission syncing between Sourcegraph and Bitbucket Server and adds support for webhooks to Bitbucket Server.
 
+## Access token permissions
+
+Sourcegraph requires a Bitbucket Server personal access token with **read** permissions to sync repositories.
+
+When using [campaigns](../../user/campaigns/index.md) the access token requires **write** permissions on the project and repository level. See "[Code host interactions in campaigns](../../user/campaigns/managing_access.md#code-host-interactions-in-campaigns)" for details.
+
+You can create a personal access token at `https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add`. Also set the corresponding `username` field.
+
+For Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the `username` and `password` fields.
+
 ## Repository syncing
 
 There are four fields for configuring which repositories are mirrored:

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -34,7 +34,7 @@ No token scopes are required if you only want to sync public repositories and do
 
 - `repo` to sync private repositories from GitHub to Sourcegraph.
 - `read:org` to use the `"allowOrgs"` setting [with a GitHub authentication provider](../auth/index.md#github).
-- `repo`, `read:org`, and `read:discussion` to use [campaigns](../../user/campaigns/index.md) with GitHub repositories.
+- `repo`, `read:org`, and `read:discussion` to use [campaigns](../../user/campaigns/index.md) with GitHub repositories. See "[Code host interactions in campaigns](../../user/campaigns/managing_access.md#code-host-interactions-in-campaigns)" for details.
 
 >NOTE: If you plan to use repository permissions with background syncing, an access token that has admin access to all private repositories is required. It is because only admin can list all collaborators of a repository.
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -83,7 +83,7 @@ We are actively collaborating with GitLab to improve our integration (e.g. the [
 | [`GET /users/:id`](https://docs.gitlab.com/ee/api/users.html#single-user) | `read_user` or `api` | If using GitLab OAuth, used to fetch user metadata during the OAuth sign in process. |
 | [`GET /projects/:id`](https://docs.gitlab.com/ee/api/projects.html#get-single-project) | `api` | (1) If using GitLab OAuth and repository permissions, used to determine if a user has access to a given _project_; (2) Used to query repository metadata (e.g. description) for display on Sourcegraph. |
 | [`GET /projects/:id/repository/tree`](https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree) | `api` | If using GitLab OAuth and repository permissions, used to verify a given user has access to the file contents of a repository within a project (i.e. does not merely have `Guest` permissions). |
-| (future) write access | `api` | graph site-admins (only) to perform large-scale code refactors, with Sourcegraph issuing and managing the merge requests on GitLab repositories, company-wide. |
+| Campaigns requests | `api`, `read_repository`, `write_repository` | [Campaigns](../../user/campaigns/index.md) require write access to push commits and create, update and close merge requests on GitLab repositories. See "[Code host interactions in campaigns](../../user/campaigns/managing_access.md#code-host-interactions-in-campaigns)" for details. |
 
 ## Webhooks
 

--- a/doc/user/campaigns/managing_access.md
+++ b/doc/user/campaigns/managing_access.md
@@ -51,6 +51,12 @@ All interactions with the code host are performed by Sourcegraph with the token 
 - Updating a changeset
 - Closing a changeset
 
+See these code host specific pages for which permissions and scopes the tokens require:
+
+- [GitHub](../../admin/external_service/github.md#github-api-token-and-access)
+- [GitLab](../../admin/external_service/gitlab.md#access-token-scopes)
+- [Bitbucket Server](../../admin/external_service/gitlab.md#access-token-permissions)
+
 In the future you'll be able to perform all code host interactions with a separate access token or your personal code host account.
 
 ## Repository permissions for campaigns

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -57,7 +57,7 @@
       "examples": ["https://bitbucket.example.com"]
     },
     "token": {
-      "description": "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
+      "description": "A Bitbucket Server personal access token with Read permissions. When using campaigns, the token needs Write permissions. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
       "type": "string",
       "minLength": 1
     },

--- a/schema/bitbucket_server_stringdata.go
+++ b/schema/bitbucket_server_stringdata.go
@@ -62,7 +62,7 @@ const BitbucketServerSchemaJSON = `{
       "examples": ["https://bitbucket.example.com"]
     },
     "token": {
-      "description": "A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
+      "description": "A Bitbucket Server personal access token with Read permissions. When using campaigns, the token needs Write permissions. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
       "type": "string",
       "minLength": 1
     },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -205,7 +205,7 @@ type BitbucketServerConnection struct {
 	//
 	// The special string "none" can be used as the only element to disable this feature. Repositories matched by multiple query strings are only imported once. Here's the official Bitbucket Server documentation about which query string parameters are valid: https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355
 	RepositoryQuery []string `json:"repositoryQuery,omitempty"`
-	// Token description: A Bitbucket Server personal access token with Read scope. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding "username" field.
+	// Token description: A Bitbucket Server personal access token with Read permissions. When using campaigns, the token needs Write permissions. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding "username" field.
 	//
 	// For Bitbucket Server instances that don't support personal access tokens (Bitbucket Server version 5.4 and older), specify user-password credentials in the "username" and "password" fields.
 	Token string `json:"token,omitempty"`


### PR DESCRIPTION
This fixes #12888 by:

- linking to the code host specific documentation from the campaigns docs
- updating the GitLab documentation to make clear which permissions are required by campaigns
- adding a section to the Bitbucket Server docs to mention which permissions are required in general and by campaigns (some of that is duplicated from the schema, but I think it's much more discoverable up there)
- extending the comment in the Bitbucket Server schema to mention Write access for campaigns
