### PR TITLE
Enable the new enterprise home page in dev mode

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -1,6 +1,7 @@
 {
   // This is set from an environment variable
   "experimentalFeatures": {
-    "showRepogroupHomepage": true
+    "showRepogroupHomepage": true,
+    "showEnterpriseHomePanels": true
   }
 }


### PR DESCRIPTION
@limitedmage @attfarhan @rrhyne any reason not to have enabled this by default in dev mode yet?