### PR TITLE
chore: Multiple database handles

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -87,7 +87,7 @@ func defaultExternalURL(nginxAddr, httpAddr string) *url.URL {
 // InitDB initializes the global database connection and sets the
 // version of the frontend in our versions table.
 func InitDB() error {
-	if err := dbconn.ConnectToDB(""); err != nil {
+	if err := dbconn.SetupGlobalConnection(""); err != nil {
 		return err
 	}
 

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -87,7 +87,7 @@ func mustInitializeStore() store.Store {
 		}
 	})
 
-	if err := dbconn.ConnectToDB(postgresDSN); err != nil {
+	if err := dbconn.SetupGlobalConnection(postgresDSN); err != nil {
 		log.Fatalf("failed to connect to database: %s", err)
 	}
 

--- a/internal/db/dbtesting/dbtesting.go
+++ b/internal/db/dbtesting/dbtesting.go
@@ -141,7 +141,7 @@ func initTest(nameSuffix string) error {
 		}
 	}
 
-	if err := dbconn.ConnectToDB("dbname=" + dbname); err != nil {
+	if err := dbconn.SetupGlobalConnection("dbname=" + dbname); err != nil {
 		return err
 	}
 

--- a/internal/db/schemadoc/main.go
+++ b/internal/db/schemadoc/main.go
@@ -94,8 +94,8 @@ func generate(log *log.Logger) (string, error) {
 		return "", fmt.Errorf("createdb: %s: %w", out, err)
 	}
 
-	if err := dbconn.ConnectToDB(dataSource); err != nil {
-		return "", fmt.Errorf("ConnectToDB: %w", err)
+	if err := dbconn.SetupGlobalConnection(dataSource); err != nil {
+		return "", fmt.Errorf("SetupGlobalConnection: %w", err)
 	}
 
 	if err := dbconn.MigrateDB(dbconn.Global, dataSource); err != nil {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/issues/13884 requires that we connect to multiple databases in an application. This PR renames `ConnectToDB` to `SetupGlobalConnection` and creates a new version of the method `dbutil.New` that returns a Postgres handler instead of storing it in a global variable.