### PR TITLE
ci: run backend integration tests first

### DIFF
--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -130,8 +130,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
 			triggerE2E(c, env),
-			addDockerImages(c, false),
 			addBackendIntegrationTests(c), // ~11m
+			addDockerImages(c, false),     // ~8m
 			addLint,                       // ~4.5m
 			addSharedTests(c),             // ~4.5m
 			addWebApp,                     // ~3m


### PR DESCRIPTION
It is our slowest step, so will benefit from running first.
