### PR TITLE
Fix query state getting erased on location changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.
 
+### Fixed
+
+- Fixed an issue causing the scoped query in the search field to be erased when viewing files. [#13954](https://github.com/sourcegraph/sourcegraph/pull/13954).
+
 ## 3.20.0
 
 ### Added

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -138,7 +138,14 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                 onFiltersInQueryChange(filtersInQuery)
             }
         }
-    }, [interactiveSearchMode, isSearchRelatedPage, location, onFiltersInQueryChange, onNavbarQueryChange, query])
+    }, [
+        interactiveSearchMode,
+        isSearchRelatedPage,
+        location.state?.query,
+        onFiltersInQueryChange,
+        onNavbarQueryChange,
+        query,
+    ])
 
     const logo = (
         <LinkOrSpan to={authRequired ? undefined : '/search'} className="global-navbar__logo-link">

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -106,16 +106,20 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
     const query = useMemo(() => parseSearchURLQuery(location.search || ''), [location.search])
 
     useEffect(() => {
+        // On a non-search related page or non-repo page, we clear the query in
+        // the main query input and interactive mode UI to avoid misleading users
+        // that the query is relevant in any way on those pages.
+        if (!isSearchRelatedPage) {
+            onNavbarQueryChange({ query: '', cursorPosition: 0 })
+            onFiltersInQueryChange({})
+            return
+        }
+        // Do nothing if there is no query in the URL
         if (!query) {
             return
         }
-        if (!isSearchRelatedPage) {
-            // On a non-search related page or non-repo page, we clear the query in
-            // the main query input and interactive mode UI to avoid misleading users
-            // that the query is relevant in any way on those pages.
-            onNavbarQueryChange({ query: '', cursorPosition: 0 })
-            onFiltersInQueryChange({})
-        } else if (interactiveSearchMode) {
+        // If the URL contains a query, update the query state to reflect it
+        if (interactiveSearchMode) {
             let filtersInQuery: FiltersToTypeAndValue = {}
             const { filtersInQuery: newFiltersInQuery, navbarQuery } = convertPlainTextToInteractiveQuery(query)
             filtersInQuery = { ...filtersInQuery, ...newFiltersInQuery }
@@ -124,7 +128,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         } else {
             onNavbarQueryChange({ query, cursorPosition: query.length })
         }
-    }, [interactiveSearchMode, isSearchRelatedPage, onFiltersInQueryChange, onNavbarQueryChange, query])
+    }, [interactiveSearchMode, isSearchRelatedPage, onFiltersInQueryChange, onNavbarQueryChange, query, location])
 
     const logo = (
         <LinkOrSpan to={authRequired ? undefined : '/search'} className="global-navbar__logo-link">

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -128,7 +128,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         } else {
             onNavbarQueryChange({ query, cursorPosition: query.length })
         }
-    }, [interactiveSearchMode, isSearchRelatedPage, onFiltersInQueryChange, onNavbarQueryChange, query, location])
+    }, [interactiveSearchMode, isSearchRelatedPage, location, onFiltersInQueryChange, onNavbarQueryChange, query])
 
     const logo = (
         <LinkOrSpan to={authRequired ? undefined : '/search'} className="global-navbar__logo-link">

--- a/web/src/nav/GlobalNavbar.tsx
+++ b/web/src/nav/GlobalNavbar.tsx
@@ -106,46 +106,25 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
     const query = useMemo(() => parseSearchURLQuery(location.search || ''), [location.search])
 
     useEffect(() => {
-        // In interactive search mode, the InteractiveModeInput component will handle updating the inputs.
-        if (!interactiveSearchMode) {
-            if (query) {
-                onNavbarQueryChange({ query, cursorPosition: query.length })
-            } else {
-                // If we have no component state, then we may have gotten unmounted during a route change.
-                const query = location.state?.query ?? ''
-
-                onNavbarQueryChange({
-                    query,
-                    cursorPosition: query.length,
-                })
-            }
+        if (!query) {
+            return
         }
-
-        if (query) {
-            if (!isSearchRelatedPage) {
-                // On a non-search related page or non-repo page, we clear the query in
-                // the main query input and interactive mode UI to avoid misleading users
-                // that the query is relevant in any way on those pages.
-                onNavbarQueryChange({ query: '', cursorPosition: 0 })
-                onFiltersInQueryChange({})
-            }
-
-            if (interactiveSearchMode) {
-                let filtersInQuery: FiltersToTypeAndValue = {}
-                const { filtersInQuery: newFiltersInQuery, navbarQuery } = convertPlainTextToInteractiveQuery(query)
-                filtersInQuery = { ...filtersInQuery, ...newFiltersInQuery }
-                onNavbarQueryChange({ query: navbarQuery, cursorPosition: navbarQuery.length })
-                onFiltersInQueryChange(filtersInQuery)
-            }
+        if (!isSearchRelatedPage) {
+            // On a non-search related page or non-repo page, we clear the query in
+            // the main query input and interactive mode UI to avoid misleading users
+            // that the query is relevant in any way on those pages.
+            onNavbarQueryChange({ query: '', cursorPosition: 0 })
+            onFiltersInQueryChange({})
+        } else if (interactiveSearchMode) {
+            let filtersInQuery: FiltersToTypeAndValue = {}
+            const { filtersInQuery: newFiltersInQuery, navbarQuery } = convertPlainTextToInteractiveQuery(query)
+            filtersInQuery = { ...filtersInQuery, ...newFiltersInQuery }
+            onNavbarQueryChange({ query: navbarQuery, cursorPosition: navbarQuery.length })
+            onFiltersInQueryChange(filtersInQuery)
+        } else {
+            onNavbarQueryChange({ query, cursorPosition: query.length })
         }
-    }, [
-        interactiveSearchMode,
-        isSearchRelatedPage,
-        location.state?.query,
-        onFiltersInQueryChange,
-        onNavbarQueryChange,
-        query,
-    ])
+    }, [interactiveSearchMode, isSearchRelatedPage, onFiltersInQueryChange, onNavbarQueryChange, query])
 
     const logo = (
         <LinkOrSpan to={authRequired ? undefined : '/search'} className="global-navbar__logo-link">


### PR DESCRIPTION
Fixes #13805

#13679 moved the logic that updates the navbar query from [`<GlobalNavbar/>`'s `constructor`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@62f73fa98a321bb0a78134dd837c93293692a068/-/blob/web/src/nav/GlobalNavbar.tsx?subtree=true#L91-107) (admittedly not a great place to have it) to a `useEffect()` block, with `location` as a dependency.

As a result, every time the `location` was updated, for example when clicking on tokens in a code view, any query state that wasn't persisted to the URL (a partially edited query, or the scoped query added automatically when navigating to a repo/file) would be erased.

~~The immediate fix I saw was to narrow the dependency array of the `useEffect()` block, to avoid running it on every `location` change. But I'm wondering if there isn't still an issue left: the scoped query randomly can get randomly erased on page load (race condition), depending on which of the `useEffect()` blocks in `<GlobalNavbar/>` and [`<RepoContainer/>`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a0d822fd03932f93423866784bfa0d5ea820ff3f/-/blob/web/src/repo/RepoContainer.tsx?subtree=true#L266-306) executes first.~~

I've simplified the `useEffect()` block in `<GlobalNavbar/>` (which could end up calling `onNavbarQueryChange()` multiple times, had some comments implying that it wouldn't update the query in interactive mode but still did it further down...), fixing the issue as a result, by restricting the cases in which we update the query state.