### PR TITLE
add GraphQL API field Query.namespaceByName for easy user/org lookup by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## Unreleased
 
+### Added
+
+- The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.
+
 ## 3.20.0
 
 ### Added

--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
 // Namespace is the interface for the GraphQL Namespace interface.
@@ -53,6 +55,30 @@ func UnmarshalNamespaceID(id graphql.ID, userID *int32, orgID *int32) (err error
 		err = InvalidNamespaceIDErr{id: id}
 	}
 	return err
+}
+
+func (r *schemaResolver) NamespaceByName(ctx context.Context, args *struct{ Name string }) (*NamespaceResolver, error) {
+	namespace, err := db.GetNamespaceByName(ctx, dbconn.Global, args.Name)
+	if err == db.ErrNamespaceNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var n Namespace
+	switch {
+	case namespace.User != 0:
+		n, err = UserByIDInt32(ctx, namespace.User)
+	case namespace.Organization != 0:
+		n, err = OrgByIDInt32(ctx, namespace.Organization)
+	default:
+		panic("invalid namespace (neither user nor organization)")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &NamespaceResolver{n}, nil
 }
 
 // NamespaceResolver resolves the GraphQL Namespace interface to a type.

--- a/cmd/frontend/graphqlbackend/namespaces_test.go
+++ b/cmd/frontend/graphqlbackend/namespaces_test.go
@@ -109,3 +109,111 @@ func TestNamespace(t *testing.T) {
 		})
 	})
 }
+
+func TestNamespaceByName(t *testing.T) {
+	t.Run("user", func(t *testing.T) {
+		resetMocks()
+		const (
+			wantName   = "alice"
+			wantUserID = 123
+		)
+		db.Mocks.GetNamespaceByName = func(name string) (*db.Namespace, error) {
+			if name != wantName {
+				t.Errorf("got %q, want %q", name, wantName)
+			}
+			return &db.Namespace{Name: "alice", User: wantUserID}, nil
+		}
+		db.Mocks.Users.GetByID = func(_ context.Context, id int32) (*types.User, error) {
+			if id != wantUserID {
+				t.Errorf("got %d, want %d", id, wantUserID)
+			}
+			return &types.User{ID: wantUserID, Username: wantName}, nil
+		}
+		gqltesting.RunTests(t, []*gqltesting.Test{
+			{
+				Schema: mustParseGraphQLSchema(t),
+				Query: `
+				{
+					namespaceByName(name: "alice") {
+						__typename
+						... on User { username }
+					}
+				}
+			`,
+				ExpectedResult: `
+				{
+					"namespaceByName": {
+						"__typename": "User",
+						"username": "alice"
+					}
+				}
+			`,
+			},
+		})
+	})
+
+	t.Run("organization", func(t *testing.T) {
+		resetMocks()
+		const (
+			wantName  = "acme"
+			wantOrgID = 3
+		)
+		db.Mocks.GetNamespaceByName = func(name string) (*db.Namespace, error) {
+			if name != wantName {
+				t.Errorf("got %q, want %q", name, wantName)
+			}
+			return &db.Namespace{Name: "alice", Organization: wantOrgID}, nil
+		}
+		db.Mocks.Orgs.GetByID = func(_ context.Context, id int32) (*types.Org, error) {
+			if id != wantOrgID {
+				t.Errorf("got %d, want %d", id, wantOrgID)
+			}
+			return &types.Org{ID: wantOrgID, Name: "acme"}, nil
+		}
+		gqltesting.RunTests(t, []*gqltesting.Test{
+			{
+				Schema: mustParseGraphQLSchema(t),
+				Query: `
+				{
+					namespaceByName(name: "acme") {
+						__typename
+						... on Org { name }
+					}
+				}
+			`,
+				ExpectedResult: `
+				{
+					"namespaceByName": {
+						"__typename": "Org",
+						"name": "acme"
+					}
+				}
+			`,
+			},
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		resetMocks()
+		db.Mocks.GetNamespaceByName = func(name string) (*db.Namespace, error) {
+			return nil, db.ErrNamespaceNotFound
+		}
+		gqltesting.RunTests(t, []*gqltesting.Test{
+			{
+				Schema: mustParseGraphQLSchema(t),
+				Query: `
+				{
+					namespaceByName(name: "doesntexist") {
+						__typename
+					}
+				}
+			`,
+				ExpectedResult: `
+				{
+					"namespaceByName": null
+				}
+			`,
+			},
+		})
+	})
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2281,6 +2281,16 @@ type Query {
     namespace(id: ID!): Namespace
 
     """
+    Look up a namespace by name, which is a username or organization name.
+    """
+    namespaceByName(
+        """
+        The name of the namespace.
+        """
+        name: String!
+    ): Namespace
+
+    """
     The repositories a user is authorized to access with the given permission.
     This isn’t defined in the User type because we store permissions for users
     that don’t yet exist (i.e. late binding). Only one of "username" or "email"

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2274,6 +2274,16 @@ type Query {
     namespace(id: ID!): Namespace
 
     """
+    Look up a namespace by name, which is a username or organization name.
+    """
+    namespaceByName(
+        """
+        The name of the namespace.
+        """
+        name: String!
+    ): Namespace
+
+    """
     The repositories a user is authorized to access with the given permission.
     This isn’t defined in the User type because we store permissions for users
     that don’t yet exist (i.e. late binding). Only one of "username" or "email"

--- a/internal/db/mockstores.go
+++ b/internal/db/mockstores.go
@@ -25,4 +25,6 @@ type MockStores struct {
 	Authz MockAuthz
 
 	Secrets MockSecrets
+
+	GetNamespaceByName func(name string) (*Namespace, error)
 }

--- a/internal/db/namespaces.go
+++ b/internal/db/namespaces.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+// A Namespace is a username or an organization name. No user may have a username that is equal to
+// an organization name, and vice versa. This property means that a username or organization name
+// serves as a namespace for other objects that are owned by the user or organization, such as
+// campaigns and extensions.
+type Namespace struct {
+	// Name is the canonical-case name of the namespace (which is unique among all namespace
+	// types). For a user, this is the username. For an organization, this is the organization name.
+	Name string
+
+	User, Organization int32 // exactly 1 is non-zero
+}
+
+var ErrNamespaceNotFound = errors.New("namespace not found")
+
+// GetNamespaceByName looks up the namespace by a name. The name is matched case-insensitively
+// against all namespaces, which is the set of usernames and organization names.
+//
+// If no namespace is found, ErrNamespaceNotFound is returned.
+func GetNamespaceByName(ctx context.Context, dbh interface {
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+}, name string) (*Namespace, error) {
+	if Mocks.GetNamespaceByName != nil {
+		return Mocks.GetNamespaceByName(name)
+	}
+
+	var n Namespace
+	err := dbh.QueryRowContext(ctx, `SELECT name, COALESCE(user_id, 0), COALESCE(org_id, 0) FROM names WHERE name=$1`, name).
+		Scan(&n.Name, &n.User, &n.Organization)
+	if err == sql.ErrNoRows {
+		return nil, ErrNamespaceNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &n, nil
+}

--- a/internal/db/namespaces_test.go
+++ b/internal/db/namespaces_test.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestGetNamespaceByName(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+	dbh := dbconn.Global
+
+	// Create user and organization to test lookups.
+	user, err := Users.Create(ctx, NewUser{Username: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	org, err := Orgs.Create(ctx, "Acme", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("user", func(t *testing.T) {
+		ns, err := GetNamespaceByName(ctx, dbh, "Alice")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := (&Namespace{Name: "alice", User: user.ID}); !reflect.DeepEqual(ns, want) {
+			t.Errorf("got %+v, want %+v", ns, want)
+		}
+	})
+	t.Run("organization", func(t *testing.T) {
+		ns, err := GetNamespaceByName(ctx, dbh, "acme")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := (&Namespace{Name: "Acme", Organization: org.ID}); !reflect.DeepEqual(ns, want) {
+			t.Errorf("got %+v, want %+v", ns, want)
+		}
+	})
+	t.Run("not found", func(t *testing.T) {
+		if _, err := GetNamespaceByName(ctx, dbh, "doesntexist"); err != ErrNamespaceNotFound {
+			t.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.

Namespaces are used by campaigns and extensions. For example, a campaign `alice/my-campaign` is in the `alice` namespace, which (presumably) refers to a user with username `alice`. A campaign named `acme-corp/foo` is owned by the `acme-corp` organization.

The `src campaign apply -namespace ...` CLI command will use the new `namespaceByName` field to simplify resolution of the given namespace name (such as `alice` or `acme-corp`) to the node ID (of the user or organization whose name was given). Without `namespaceByName`, it (and other callers) needed to look up both `user(name: "foo")` and `organization(name: "foo")` separately, which is repetitive, error-prone, and brittle (if we ever add another type of thing that can be a namespace).