### PR TITLE
use more explicit and consistent wording for site admin user "Log out"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The site configuration `search.limits`. This allows configuring the maximum timeout (defaults to 1 minute). Also allows configuring the maximum repositories to search in different scenarios. [#13448](https://github.com/sourcegraph/sourcegraph/pull/13448)
-- Site admins now have a button to log out users from the all users view. [#13647](https://github.com/sourcegraph/sourcegraph/pull/13647)
+- Site admins can now force a specific user to re-authenticate on their next request or visit. [#13647](https://github.com/sourcegraph/sourcegraph/pull/13647)
 - After changing their password, a user will be signed out from all devices, and will be required to sign in with the new password.
 - Sourcegraph watches the [advanced config files](https://docs.sourcegraph.com/admin/config/advanced_config_file) and automatically applies the changes to Sourcegraph's configuration when they change. For example this allows Sourcegraph to notice when Kubernetes updates ConfigMap for the configuration. [#13646](https://github.com/sourcegraph/sourcegraph/pull/13646)
 - The total size of all git repositories and the lines of code for indexed branches will be sent back in pings. [#13764](https://github.com/sourcegraph/sourcegraph/pull/13764)

--- a/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -119,9 +119,9 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 className="btn btn-sm btn-secondary"
                                 onClick={this.invalidateSessions}
                                 disabled={this.state.loading}
-                                data-tooltip="Log out user"
+                                data-tooltip="Force the user to re-authenticate on their next request"
                             >
-                                Log out
+                                Force sign-out
                             </button>
                         )}{' '}
                         {window.context.resetPasswordEnabled && (
@@ -256,7 +256,11 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
     }
 
     private invalidateSessions = (): void => {
-        if (!window.confirm(`Log ${this.props.node.username} out of Sourcegraph?`)) {
+        if (
+            !window.confirm(
+                `Revoke all active sessions for ${this.props.node.username}? The user will need to re-authenticate on their next request or visit to Sourcegraph.`
+            )
+        ) {
             return
         }
 


### PR DESCRIPTION
- Elsewhere, we use the term "sign out" instead of "log out".
- The tooltip and alert did not add (much) additional clarity. This commit's updated tooltip and alert makes it clearer what this action does.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->