### PR TITLE
move title to top

### DIFF
--- a/doc/user/search/structural.md
+++ b/doc/user/search/structural.md
@@ -1,3 +1,5 @@
+# Structural search
+
 <style>
 table td:first-child {
   width: 8em;
@@ -17,8 +19,6 @@ table tr:nth-child(2n) {
 }
 
 </style>
-
-# Structural search
 
 Structural search lets you match richer syntax patterns specifically in code
 and structured data formats like JSON. It can be awkward or difficult to match


### PR DESCRIPTION
The `docsite` Markdown parser expects the title to be at the top.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
