### PR TITLE
Add password reset duration to docs

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -46,6 +46,8 @@ external identity provider.
 
 The [`builtin` auth provider](../config/site_config.md#builtin-password-authentication) manages user accounts internally in its own database. It supports user signup, login, and password reset (via email if configured, or else via a site admin).
 
+Password reset links expire after 4 hours.
+
 Site configuration example:
 
 ```json


### PR DESCRIPTION
Question from https://app.hubspot.com/contacts/2762526/company/554338610:

>I would like to bring to your attention a problem that we are currently facing as we move into the trial. We sent password reset links to everyone, but a lot of them report failed/expired after people try to reset the password. I could not find any documentation about the timeline of validity of the password reset link, or how to increase the life of the reset link. Can you please let us know what can be done her? I would like to get your thoughts before resending reset links that fail again.


Unfortunately it appears as though this limit is hardcoded: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/db/users_builtin_auth.go#L63:126. Not urgent, but this should be made configurable.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
