### PR TITLE
codeintel: Resolve abbreviated OID

### DIFF
--- a/enterprise/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler.go
@@ -43,16 +43,24 @@ func NewUploadHandler(store store.Store, bundleManagerClient bundles.BundleManag
 func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var repositoryID int
-	if !hasQuery(r, "uploadId") {
-		repoName := getQuery(r, "repository")
-		commit := getQuery(r, "commit")
+	repoName := getQuery(r, "repository")
+	commit := getQuery(r, "commit")
+	root := sanitizeRoot(getQuery(r, "root"))
+	indexer := getQuery(r, "indexerName")
 
-		repo, ok := ensureRepoAndCommitExist(ctx, w, repoName, commit)
+	uploadArgs := UploadArgs{
+		Commit:  commit,
+		Root:    root,
+		Indexer: indexer,
+	}
+
+	if !hasQuery(r, "uploadId") {
+		repo, commit, ok := ensureRepoAndCommitExist(ctx, w, repoName, commit)
 		if !ok {
 			return
 		}
-		repositoryID = int(repo.ID)
+		uploadArgs.RepositoryID = int(repo.ID)
+		uploadArgs.Commit = commit
 
 		// 🚨 SECURITY: Ensure we return before proxying to the precise-code-intel-api-server upload
 		// endpoint. This endpoint is unprotected, so we need to make sure the user provides a valid
@@ -62,7 +70,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	payload, err := h.handleEnqueueErr(w, r, repositoryID)
+	payload, err := h.handleEnqueueErr(w, r, uploadArgs)
 	if err != nil {
 		if cerr, ok := err.(*ClientError); ok {
 			http.Error(w, cerr.Error(), http.StatusBadRequest)
@@ -90,9 +98,9 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 // UploadArgs are common arguments required to enqueue an upload for both
 // single-payload and multipart uploads.
 type UploadArgs struct {
+	RepositoryID int
 	Commit       string
 	Root         string
-	RepositoryID int
 	Indexer      string
 }
 
@@ -119,15 +127,8 @@ type enqueuePayload struct {
 //   - handleEnqueueMultipartSetup
 //   - handleEnqueueMultipartUpload
 //   - handleEnqueueMultipartFinalize
-func (h *UploadHandler) handleEnqueueErr(w http.ResponseWriter, r *http.Request, repositoryID int) (interface{}, error) {
+func (h *UploadHandler) handleEnqueueErr(w http.ResponseWriter, r *http.Request, uploadArgs UploadArgs) (interface{}, error) {
 	ctx := r.Context()
-
-	uploadArgs := UploadArgs{
-		Commit:       getQuery(r, "commit"),
-		Root:         sanitizeRoot(getQuery(r, "root")),
-		RepositoryID: repositoryID,
-		Indexer:      getQuery(r, "indexerName"),
-	}
 
 	if !hasQuery(r, "multiPart") && !hasQuery(r, "uploadId") {
 		return h.handleEnqueueSinglePayload(r, uploadArgs)
@@ -325,22 +326,23 @@ func (h *UploadHandler) handleEnqueueMultipartFinalize(r *http.Request, upload s
 	return nil, nil
 }
 
-func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool) {
+func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, string, bool) {
 	repo, err := backend.Repos.GetByName(ctx, api.RepoName(repoName))
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
-			return nil, false
+			return nil, "", false
 		}
 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return nil, false
+		return nil, "", false
 	}
 
-	if _, err := backend.Repos.ResolveRev(ctx, repo, commit); err != nil {
+	commitID, err := backend.Repos.ResolveRev(ctx, repo, commit)
+	if err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
-			return nil, false
+			return nil, "", false
 		}
 
 		// If the repository is currently being cloned (which is most likely to happen on dotcom),
@@ -348,9 +350,9 @@ func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoNa
 		// the worker wait until the rev is resolvable before starting to process.
 		if !vcs.IsCloneInProgress(err) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return nil, false
+			return nil, "", false
 		}
 	}
 
-	return repo, true
+	return repo, string(commitID), true
 }

--- a/enterprise/internal/codeintel/httpapi/upload_handler_test.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler_test.go
@@ -424,6 +424,6 @@ func setupRepoMocks(t *testing.T) {
 		if rev != "deadbeef" {
 			t.Errorf("unexpected commit. want=%s have=%s", "deadbeef", rev)
 		}
-		return "", nil
+		return api.CommitID(rev), nil
 	}
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/13957.

This replaces the query string commit value with the one given back by gitserver when ensuring that commit exists. Using this value ensures that it's a 40-character revhash, which is what we require going into the database.