### PR TITLE
Revert "Update latest release to 3.20.0 (#13962)"

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -34,12 +34,12 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	//version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newBuild("3.20.0")
+	latestReleaseDockerServerImageBuild = newBuild("3.19.2")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("3.20.0")
+	latestReleaseKubernetesBuild = newBuild("3.19.2")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -9,7 +9,7 @@
 
 {{define "versionSelector"}}
     <div id="version-selector" class="dropdown version-dropdown ml-2">
-        {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.19.2"}} {{$previousReleaseVersion := "3.19"}} {{$currentReleaseRevspec := "v3.20.0"}} {{$currentReleaseVersion := "3.20"}} {{$nextReleaseVersion := "main"}}
+        {{/* Update these after each release. */}} {{$previousReleaseRevspec := "v3.18.0"}} {{$previousReleaseVersion := "3.18"}} {{$currentReleaseRevspec := "v3.19.2"}} {{$currentReleaseVersion := "3.19"}} {{$nextReleaseVersion := "main"}}
         <button class="btn btn-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           {{.ContentVersion}}{{/* If no version is specified we are on the currentReleaseVersion */}}{{if eq .ContentVersion ""}}{{$currentReleaseVersion}}{{end}}
         </button>

--- a/doc/admin/external_database.md
+++ b/doc/admin/external_database.md
@@ -22,7 +22,7 @@ Add the following to your `docker run` command:
   We want line breaks for readability, but backslashes to escape them do not work cross-platform.
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.20.0</code></pre>
+<pre class="pre-wrap start-sourcegraph-command"><code>docker run [...]<span class="virtual-br"></span> -e PGHOST=psql.mycompany.org<span class="virtual-br"></span> -e PGUSER=sourcegraph<span class="virtual-br"></span> -e PGPASSWORD=secret<span class="virtual-br"></span> -e PGDATABASE=sourcegraph<span class="virtual-br"></span> -e PGSSLMODE=require<span class="virtual-br"></span> sourcegraph/server:3.19.2</code></pre>
 
 ### Docker Compose
 
@@ -100,7 +100,7 @@ or follow the [IANA specification for Redis URLs](https://www.iana.org/assignmen
   We want line breaks for readability, but backslashes to escape them do not work cross-platform.
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
-<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.20.0</code></pre>
+<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.19.2</code></pre>
 
 > NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
 

--- a/doc/admin/install/docker-compose/migrate.md
+++ b/doc/admin/install/docker-compose/migrate.md
@@ -9,7 +9,7 @@ Sourcegraph's core data (including user accounts, configuration, repository-meta
 ### Version requirements
 
 * This migration can only be done with Sourcegraph v3.13.1+. If you are not currently on at least this version, please upgrade first.
-* Do NOT attempt to upgrade at the same time as migrating to docker-compose. Use the docker-compose version corresponding to your current version. For example, if you are running `sourcegraph/server:3.20.0` you must follow this guide using the Docker Compose deployment version `v3.19.2`.
+* Do NOT attempt to upgrade at the same time as migrating to docker-compose. Use the docker-compose version corresponding to your current version. For example, if you are running `sourcegraph/server:3.19.2` you must follow this guide using the Docker Compose deployment version `v3.19.2`.
 
 ### Storage location change
 

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -33,7 +33,7 @@ This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AW
    - usermod -a -G docker ec2-user
 
    # Install and run Sourcegraph. Restart the container upon subsequent reboots
-   - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7080 --publish 127.0.0.1:3370:3370 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.20.0' ]
+   - [ sh, -c, 'docker run -d --publish 80:7080 --publish 443:7080 --publish 127.0.0.1:3370:3370 --restart unless-stopped --volume /home/ec2-user/.sourcegraph/config:/etc/sourcegraph --volume /home/ec2-user/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.19.2' ]
    ```
 
 - Select **Next: ...** until you get to the **Configure Security Group** page. Then add the following rules:

--- a/doc/admin/install/docker/digitalocean.md
+++ b/doc/admin/install/docker/digitalocean.md
@@ -16,7 +16,7 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Di
 1. Run the Sourcegraph Docker image as a daemon:
 
    ```
-   docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.20.0
+   docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.19.2
    ```
 1. Navigate to the droplet's IP address to finish initializing Sourcegraph. If you have configured a
    DNS entry for the IP, configure `externalURL` to reflect that.

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -23,7 +23,7 @@ This tutorial shows you how to deploy Sourcegraph to a single node running on Go
   sudo apt-get install -y docker-ce
   mkdir -p /root/.sourcegraph/config
   mkdir -p /root/.sourcegraph/data
-  docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.20.0
+  docker run -d --publish 80:7080 --publish 443:7443 --restart unless-stopped --volume /root/.sourcegraph/config:/etc/sourcegraph --volume /root/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.19.2
   ```
 
 - Create your VM, then navigate to its public IP address.

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -12,7 +12,7 @@ It takes less than a minute to run and install Sourcegraph using Docker:
   This uses line breaks that are rendered but not copy-pasted to the clipboard.
 -->
 
-<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.20.0</code></pre>
+<pre class="pre-wrap start-sourcegraph-command"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.19.2</code></pre>
 
 Once the server is ready (logo is displayed in the terminal), navigate to the hostname or IP address on port `7080`.  Create the admin account, then you'll be guided through setting up Sourcegraph for code searching and navigation.
 
@@ -56,7 +56,7 @@ Sourcegraph can be **tested** on Windows 10 using roughly the same steps provide
 1. [Install Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
 2. Using a command prompt, follow the same [installation steps provided above](#install-sourcegraph-with-docker) but remove the `--volume` arguments. For example by pasting this:
 
-<pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.20.0</code></pre>
+<pre class="pre-wrap"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> sourcegraph/server:3.19.2</code></pre>
 
 ## Low resource environments
 

--- a/doc/admin/postgres.md
+++ b/doc/admin/postgres.md
@@ -39,7 +39,7 @@ docker run -p 7080:7080 -p 2633:2633 --rm \
   -v ~/.sourcegraph/config:/etc/sourcegraph \
   -v ~/.sourcegraph/data:/var/opt/sourcegraph \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
-  sourcegraph/server:3.20.0
+  sourcegraph/server:3.19.2
 ```
 
 **3.** When the upgrade has been completed, stop the Sourcegraph container, then run again using the original `docker run` command (without mounting the Docker socket).

--- a/doc/admin/pprof.md
+++ b/doc/admin/pprof.md
@@ -23,7 +23,7 @@ kubectl port-forward sourcegraph-frontend-xxxx 6060:6060
 The docker run command for the single-container server needs an additional publish flag to expose the debug port:
 
 ```bash script
-docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --publish 127.0.0.1:6060:6060 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.20.0
+docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --publish 127.0.0.1:6060:6060 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.19.2
 ```
 
 If Sourcegraph is deployed to a remote server, then access via an SSH tunnel using a tool

--- a/doc/admin/repo/custom_git_or_ssh_config.md
+++ b/doc/admin/repo/custom_git_or_ssh_config.md
@@ -11,7 +11,7 @@ For cluster environments, we have guides for configuring SSH cloning. These can 
 Upon the Sourcegraph Docker image container start, it copies all files from `/etc/sourcegraph/{ssh,gitconfig,netrc}` into its own `$HOME` directory. Alternatively you can create a new Docker image which inherits from Sourcegraph and then mutates the environment:
 
 ``` dockerfile
-FROM sourcegraph/server:3.20.0
+FROM sourcegraph/server:3.19.2
 
 COPY gitconfig /etc/gitconfig
 COPY ssh /root/.ssh

--- a/doc/admin/ssl_https_self_signed_cert_nginx.md
+++ b/doc/admin/ssl_https_self_signed_cert_nginx.md
@@ -91,7 +91,7 @@ docker container run \
   \
   --volume ~/.sourcegraph/config:/etc/sourcegraph  \
   --volume ~/.sourcegraph/data:/var/opt/sourcegraph  \
-  sourcegraph/server:3.20.0
+  sourcegraph/server:3.19.2
 ```
 
 > NOTE: We recommend removing `--publish 7080:7080` as it's not needed and traffic sent to that port is un-encrypted.

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -325,5 +325,5 @@ To manually test against a Kubernetes cluster, use https://k8s.sgdev.org.
 For testing with a single Docker image, run something like
 
 ```
-IMAGE=sourcegraph/server:3.20.0 ./dev/run-server-image.sh
+IMAGE=sourcegraph/server:3.19.2 ./dev/run-server-image.sh
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,7 +16,7 @@ It takes less than 5 minutes to run and install Sourcegraph using Docker:
 -->
 
 
-<pre class="pre-wrap start-sourcegraph-command" id="dockerInstall"  onclick="copyText(this)"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.20.0<span class="iconify copy-text" data-icon="mdi:clipboard-arrow-left-outline" data-inline="false"></span></code>
+<pre class="pre-wrap start-sourcegraph-command" id="dockerInstall"  onclick="copyText(this)"><code>docker run<span class="virtual-br"></span> --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm<span class="virtual-br"></span> --volume ~/.sourcegraph/config:/etc/sourcegraph<span class="virtual-br"></span> --volume ~/.sourcegraph/data:/var/opt/sourcegraph<span class="virtual-br"></span> sourcegraph/server:3.19.2<span class="iconify copy-text" data-icon="mdi:clipboard-arrow-left-outline" data-inline="false"></span></code>
 </pre>
 
 Once the server is ready (logo is displayed in the terminal), navigate to the hostname or IP address on port `7080`. Create the admin account, then you'll be guided through setting up Sourcegraph for code searching and navigation.
@@ -54,7 +54,7 @@ We actively maintain the two most recent monthly releases of Sourcegraph.
 Upgrades should happen across consecutive minor versions of Sourcegraph. For example, if you are
 running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 and then 3.3.
 
-> The Docker server image tags follow SemVer semantics, so version `3.20.0` can be found at `sourcegraph/server:3.20.0`. You can see the full list of tags on our [Docker Hub page](https://hub.docker.com/r/sourcegraph/server/tags).
+> The Docker server image tags follow SemVer semantics, so version `3.19.2` can be found at `sourcegraph/server:3.19.2`. You can see the full list of tags on our [Docker Hub page](https://hub.docker.com/r/sourcegraph/server/tags).
 
 ### Core documentation
 


### PR DESCRIPTION
This reverts commit 82b7370d6e909e502bd24c87d22fb8ecd5f70274.

I don't know for sure if this is the right call, but if the delay to the next release coming out will be >2 more hours or so (e.g. if it'll take until tomorrow) then I definitely think we should revert this. Admins are seeing alerts to upgrade.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
