### PR TITLE
campaigns: add backlink when creating changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.
+- Changesets created by campaigns will now include a link back to the campaign in their body text.[#14033](https://github.com/sourcegraph/sourcegraph/issues/14033)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.
-- Changesets created by campaigns will now include a link back to the campaign in their body text.[#14033](https://github.com/sourcegraph/sourcegraph/issues/14033)
+- Changesets created by campaigns will now include a link back to the campaign in their body text. [#14033](https://github.com/sourcegraph/sourcegraph/issues/14033)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -7,7 +7,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
 // Namespace is the interface for the GraphQL Namespace interface.
@@ -58,7 +57,7 @@ func UnmarshalNamespaceID(id graphql.ID, userID *int32, orgID *int32) (err error
 }
 
 func (r *schemaResolver) NamespaceByName(ctx context.Context, args *struct{ Name string }) (*NamespaceResolver, error) {
-	namespace, err := db.GetNamespaceByName(ctx, dbconn.Global, args.Name)
+	namespace, err := db.Namespaces.GetByName(ctx, args.Name)
 	if err == db.ErrNamespaceNotFound {
 		return nil, nil
 	}

--- a/cmd/frontend/graphqlbackend/namespaces_test.go
+++ b/cmd/frontend/graphqlbackend/namespaces_test.go
@@ -117,7 +117,7 @@ func TestNamespaceByName(t *testing.T) {
 			wantName   = "alice"
 			wantUserID = 123
 		)
-		db.Mocks.GetNamespaceByName = func(name string) (*db.Namespace, error) {
+		db.Mocks.Namespaces.GetByName = func(ctx context.Context, name string) (*db.Namespace, error) {
 			if name != wantName {
 				t.Errorf("got %q, want %q", name, wantName)
 			}
@@ -158,7 +158,7 @@ func TestNamespaceByName(t *testing.T) {
 			wantName  = "acme"
 			wantOrgID = 3
 		)
-		db.Mocks.GetNamespaceByName = func(name string) (*db.Namespace, error) {
+		db.Mocks.Namespaces.GetByName = func(ctx context.Context, name string) (*db.Namespace, error) {
 			if name != wantName {
 				t.Errorf("got %q, want %q", name, wantName)
 			}
@@ -195,7 +195,7 @@ func TestNamespaceByName(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		resetMocks()
-		db.Mocks.GetNamespaceByName = func(name string) (*db.Namespace, error) {
+		db.Mocks.Namespaces.GetByName = func(ctx context.Context, name string) (*db.Namespace, error) {
 			return nil, db.ErrNamespaceNotFound
 		}
 		gqltesting.RunTests(t, []*gqltesting.Test{

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -250,6 +250,12 @@ func (r *reconciler) updateChangeset(ctx context.Context, tx *Store, ch *campaig
 		Changeset: ch,
 	}
 
+	// Depending on the changeset, we may want to add to the body (for example,
+	// to add a backlink to Sourcegraph).
+	if err := decorateChangesetBody(ctx, tx, &cs); err != nil {
+		return errors.Wrapf(err, "decorating body for changeset %d", ch.ID)
+	}
+
 	if err := ccs.UpdateChangeset(ctx, &cs); err != nil {
 		return errors.Wrap(err, "updating changeset")
 	}

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -580,7 +580,7 @@ func loadCampaign(ctx context.Context, tx *Store, id int64) (*campaigns.Campaign
 	}
 
 	campaign, err := tx.GetCampaign(ctx, GetCampaignOpts{ID: id})
-	if err != nil {
+	if err != nil && err != ErrNoResults {
 		return nil, errors.Wrapf(err, "retrieving owning campaign: %d", id)
 	} else if campaign == nil {
 		return nil, errors.Errorf("campaign not found: %d", id)

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -106,7 +106,7 @@ var ErrPublishSameBranch = errors.New("cannot create changeset on the same branc
 
 // publishChangeset creates the given changeset on its code host.
 func (r *reconciler) publishChangeset(ctx context.Context, tx *Store, ch *campaigns.Changeset, spec *campaigns.ChangesetSpec) (err error) {
-	repo, extSvc, err := loadAssociations(ctx, tx, ch)
+	repo, extSvc, campaign, err := loadAssociations(ctx, tx, ch)
 	if err != nil {
 		return errors.Wrap(err, "failed to load associations")
 	}
@@ -152,7 +152,7 @@ func (r *reconciler) publishChangeset(ctx context.Context, tx *Store, ch *campai
 
 	// Depending on the changeset, we may want to add to the body (for example,
 	// to add a backlink to Sourcegraph).
-	if err := decorateChangesetBody(ctx, tx, cs); err != nil {
+	if err := decorateChangesetBody(ctx, tx, cs, campaign); err != nil {
 		return errors.Wrapf(err, "decorating body for changeset %d", ch.ID)
 	}
 
@@ -199,7 +199,7 @@ func (r *reconciler) publishChangeset(ctx context.Context, tx *Store, ch *campai
 // If the delta requires updates to the changeset on the code host, it will
 // update the changeset there.
 func (r *reconciler) updateChangeset(ctx context.Context, tx *Store, ch *campaigns.Changeset, spec *campaigns.ChangesetSpec, delta *changesetSpecDelta) (err error) {
-	repo, extSvc, err := loadAssociations(ctx, tx, ch)
+	repo, extSvc, campaign, err := loadAssociations(ctx, tx, ch)
 	if err != nil {
 		return errors.Wrap(err, "failed to load associations")
 	}
@@ -252,7 +252,7 @@ func (r *reconciler) updateChangeset(ctx context.Context, tx *Store, ch *campaig
 
 	// Depending on the changeset, we may want to add to the body (for example,
 	// to add a backlink to Sourcegraph).
-	if err := decorateChangesetBody(ctx, tx, &cs); err != nil {
+	if err := decorateChangesetBody(ctx, tx, &cs, campaign); err != nil {
 		return errors.Wrapf(err, "decorating body for changeset %d", ch.ID)
 	}
 
@@ -283,7 +283,7 @@ func (r *reconciler) closeChangeset(ctx context.Context, tx *Store, ch *campaign
 		return tx.UpdateChangeset(ctx, ch)
 	}
 
-	repo, extSvc, err := loadAssociations(ctx, tx, ch)
+	repo, extSvc, _, err := loadAssociations(ctx, tx, ch)
 	if err != nil {
 		return errors.Wrap(err, "failed to load associations")
 	}
@@ -499,20 +499,25 @@ func checkSpecAppliedToCampaign(ctx context.Context, tx *Store, spec *campaigns.
 	return nil
 }
 
-func loadAssociations(ctx context.Context, tx *Store, ch *campaigns.Changeset) (*repos.Repo, *repos.ExternalService, error) {
+func loadAssociations(ctx context.Context, tx *Store, ch *campaigns.Changeset) (*repos.Repo, *repos.ExternalService, *campaigns.Campaign, error) {
 	reposStore := repos.NewDBStore(tx.Handle().DB(), sql.TxOptions{})
 
 	repo, err := loadRepo(ctx, reposStore, ch.RepoID)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to load repository")
+		return nil, nil, nil, errors.Wrap(err, "failed to load repository")
 	}
 
 	extSvc, err := loadExternalService(ctx, reposStore, repo)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to load external service")
+		return nil, nil, nil, errors.Wrap(err, "failed to load external service")
 	}
 
-	return repo, extSvc, nil
+	campaign, err := loadCampaign(ctx, tx, ch.OwnedByCampaignID)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to load campaign")
+	}
+
+	return repo, extSvc, campaign, nil
 }
 
 func loadRepo(ctx context.Context, tx repos.Store, id api.RepoID) (*repos.Repo, error) {
@@ -569,32 +574,38 @@ func loadExternalService(ctx context.Context, reposStore repos.Store, repo *repo
 	return externalService, nil
 }
 
-func decorateChangesetBody(ctx context.Context, tx *Store, cs *repos.Changeset) error {
-	// If the changeset is owned by a campaign, then we want to add a backlink
-	// to the body so the user can easily return to Sourcegraph.
-	if cid := cs.OwnedByCampaignID; cid != 0 {
-		campaign, err := tx.GetCampaign(ctx, GetCampaignOpts{ID: cid})
-		if err != nil {
-			return errors.Wrapf(err, "retrieving owning campaign: %d", cid)
-		}
-
-		// We need to get the namespace, since external campaign URLs are
-		// namespaced.
-		ns, err := db.Namespaces.GetByID(ctx, campaign.NamespaceOrgID, campaign.NamespaceUserID)
-		if err != nil {
-			return errors.Wrap(err, "retrieving namespace")
-		}
-
-		url, err := campaignURL(ctx, ns, campaign)
-		if err != nil {
-			return errors.Wrap(err, "building URL")
-		}
-
-		cs.Body = fmt.Sprintf(
-			"%s\n\n[_Created by Sourcegraph campaign `%s/%s`._](%s)",
-			cs.Body, ns.Name, campaign.Name, url,
-		)
+func loadCampaign(ctx context.Context, tx *Store, id int64) (*campaigns.Campaign, error) {
+	if id == 0 {
+		return nil, errors.New("changeset has no owning campaign")
 	}
+
+	campaign, err := tx.GetCampaign(ctx, GetCampaignOpts{ID: id})
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving owning campaign: %d", id)
+	} else if campaign == nil {
+		return nil, errors.Errorf("campaign not found: %d", id)
+	}
+
+	return campaign, nil
+}
+
+func decorateChangesetBody(ctx context.Context, tx *Store, cs *repos.Changeset, campaign *campaigns.Campaign) error {
+	// We need to get the namespace, since external campaign URLs are
+	// namespaced.
+	ns, err := db.Namespaces.GetByID(ctx, campaign.NamespaceOrgID, campaign.NamespaceUserID)
+	if err != nil {
+		return errors.Wrap(err, "retrieving namespace")
+	}
+
+	url, err := campaignURL(ctx, ns, campaign)
+	if err != nil {
+		return errors.Wrap(err, "building URL")
+	}
+
+	cs.Body = fmt.Sprintf(
+		"%s\n\n[_Created by Sourcegraph campaign `%s/%s`._](%s)",
+		cs.Body, ns.Name, campaign.Name, url,
+	)
 
 	return nil
 }

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -755,7 +755,7 @@ func TestDecorateChangesetBody(t *testing.T) {
 	githubPR := buildGithubPR(clock(), "OPEN")
 	commonHeadRef := "refs/heads/main"
 
-	// Create a published changeset.
+	// Create an unpublished changeset.
 	campaignSpec := createCampaignSpec(t, ctx, store, "reconciler-test-campaign", admin.ID)
 	campaign := createCampaign(t, ctx, store, "reconciler-test-campaign", admin.ID, campaignSpec.ID)
 	changesetSpec := createChangesetSpec(t, ctx, store, testSpecOpts{

--- a/enterprise/internal/campaigns/resolvers/urls.go
+++ b/enterprise/internal/campaigns/resolvers/urls.go
@@ -9,5 +9,6 @@ func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignSpec
 }
 
 func campaignURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignResolver) string {
+	// This needs to be kept consistent with campaigns.campaignURL().
 	return n.URL() + "/campaigns/" + string(c.Name())
 }

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -40,6 +40,9 @@ type FakeChangesetSource struct {
 	// ClosedChangesets contains the changesets that were passed to CloseChangeset
 	ClosedChangesets []*repos.Changeset
 
+	// CreatedChangesets contains the changesets that were passed to CloseChangeset
+	CreatedChangesets []*repos.Changeset
+
 	// LoadedChangesets contains the changesets that were passed to LoadChangesets
 	LoadedChangesets []*repos.Changeset
 }
@@ -67,6 +70,7 @@ func (s *FakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Chan
 		return s.ChangesetExists, err
 	}
 
+	s.CreatedChangesets = append(s.CreatedChangesets, c)
 	return s.ChangesetExists, s.Err
 }
 

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -40,11 +40,16 @@ type FakeChangesetSource struct {
 	// ClosedChangesets contains the changesets that were passed to CloseChangeset
 	ClosedChangesets []*repos.Changeset
 
-	// CreatedChangesets contains the changesets that were passed to CloseChangeset
+	// CreatedChangesets contains the changesets that were passed to
+	// CreateChangeset
 	CreatedChangesets []*repos.Changeset
 
 	// LoadedChangesets contains the changesets that were passed to LoadChangesets
 	LoadedChangesets []*repos.Changeset
+
+	// UpdateChangesets contains the changesets that were passed to
+	// UpdateChangeset
+	UpdatedChangesets []*repos.Changeset
 }
 
 func (s *FakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
@@ -88,6 +93,7 @@ func (s *FakeChangesetSource) UpdateChangeset(ctx context.Context, c *repos.Chan
 		return fmt.Errorf("wrong BaseRef. want=%s, have=%s", s.WantBaseRef, c.BaseRef)
 	}
 
+	s.UpdatedChangesets = append(s.UpdatedChangesets, c)
 	return c.SetMetadata(s.FakeMetadata)
 }
 

--- a/internal/db/mockstores.go
+++ b/internal/db/mockstores.go
@@ -7,6 +7,7 @@ type MockStores struct {
 	AccessTokens MockAccessTokens
 
 	Repos         MockRepos
+	Namespaces    MockNamespaces
 	Orgs          MockOrgs
 	OrgMembers    MockOrgMembers
 	SavedSearches MockSavedSearches
@@ -25,6 +26,4 @@ type MockStores struct {
 	Authz MockAuthz
 
 	Secrets MockSecrets
-
-	GetNamespaceByName func(name string) (*Namespace, error)
 }

--- a/internal/db/namespaces.go
+++ b/internal/db/namespaces.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+
+	"github.com/keegancsmith/sqlf"
 )
 
 // A Namespace is a username or an organization name. No user may have a username that is equal to
@@ -21,25 +24,55 @@ type Namespace struct {
 
 var ErrNamespaceNotFound = errors.New("namespace not found")
 
-// GetNamespaceByName looks up the namespace by a name. The name is matched case-insensitively
-// against all namespaces, which is the set of usernames and organization names.
+type namespaces struct{}
+
+// GetByName looks up the namespace by a name. The name is matched
+// case-insensitively against all namespaces, which is the set of usernames and
+// organization names.
 //
 // If no namespace is found, ErrNamespaceNotFound is returned.
-func GetNamespaceByName(ctx context.Context, dbh interface {
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
-}, name string) (*Namespace, error) {
-	if Mocks.GetNamespaceByName != nil {
-		return Mocks.GetNamespaceByName(name)
+func (*namespaces) GetByName(
+	ctx context.Context,
+	name string,
+) (*Namespace, error) {
+	if Mocks.Namespaces.GetByName != nil {
+		return Mocks.Namespaces.GetByName(ctx, name)
 	}
 
 	var n Namespace
-	err := dbh.QueryRowContext(ctx, `SELECT name, COALESCE(user_id, 0), COALESCE(org_id, 0) FROM names WHERE name=$1`, name).
-		Scan(&n.Name, &n.User, &n.Organization)
-	if err == sql.ErrNoRows {
-		return nil, ErrNamespaceNotFound
-	}
-	if err != nil {
+	if err := getNamespace(ctx, &n, []*sqlf.Query{
+		sqlf.Sprintf("name = %s", name),
+	}); err != nil {
 		return nil, err
 	}
 	return &n, nil
 }
+
+func getNamespace(ctx context.Context, n *Namespace, preds []*sqlf.Query) error {
+	q := getNamespaceQuery(preds)
+	err := dbconn.Global.QueryRowContext(
+		ctx,
+		q.Query(sqlf.PostgresBindVar),
+		q.Args()...,
+	).Scan(&n.Name, &n.User, &n.Organization)
+
+	if err == sql.ErrNoRows {
+		return ErrNamespaceNotFound
+	}
+	return err
+}
+
+func getNamespaceQuery(preds []*sqlf.Query) *sqlf.Query {
+	return sqlf.Sprintf(namespaceQueryFmtstr, sqlf.Join(preds, "\n AND "))
+}
+
+var namespaceQueryFmtstr = `
+-- source: internal/db/namespaces.go:getNamespace
+SELECT
+	name,
+	COALESCE(user_id, 0) AS user_id,
+	COALESCE(org_id, 0) AS org_id
+FROM
+	names
+WHERE %s
+`

--- a/internal/db/namespaces_mock.go
+++ b/internal/db/namespaces_mock.go
@@ -3,5 +3,6 @@ package db
 import "context"
 
 type MockNamespaces struct {
+	GetByID   func(ctx context.Context, orgID, userID int32) (*Namespace, error)
 	GetByName func(ctx context.Context, name string) (*Namespace, error)
 }

--- a/internal/db/namespaces_mock.go
+++ b/internal/db/namespaces_mock.go
@@ -1,0 +1,7 @@
+package db
+
+import "context"
+
+type MockNamespaces struct {
+	GetByName func(ctx context.Context, name string) (*Namespace, error)
+}

--- a/internal/db/namespaces_test.go
+++ b/internal/db/namespaces_test.go
@@ -25,6 +25,68 @@ func TestNamespaces(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	t.Run("GetByID", func(t *testing.T) {
+		t.Run("no ID", func(t *testing.T) {
+			ns, err := Namespaces.GetByID(ctx, 0, 0)
+			if ns != nil {
+				t.Errorf("unexpected non-nil namespace: %v", ns)
+			}
+			if want := ErrNamespaceNoID; err != want {
+				t.Errorf("unexpected error: have=%v want=%v", err, want)
+			}
+		})
+
+		t.Run("multiple IDs", func(t *testing.T) {
+			ns, err := Namespaces.GetByID(ctx, 123, 456)
+			if ns != nil {
+				t.Errorf("unexpected non-nil namespace: %v", ns)
+			}
+			if want := ErrNamespaceMultipleIDs; err != want {
+				t.Errorf("unexpected error: have=%v want=%v", err, want)
+			}
+		})
+
+		t.Run("user not found", func(t *testing.T) {
+			ns, err := Namespaces.GetByID(ctx, user.ID+1, 0)
+			if ns != nil {
+				t.Errorf("unexpected non-nil namespace: %v", ns)
+			}
+			if want := ErrNamespaceNotFound; err != want {
+				t.Errorf("unexpected error: have=%v want=%v", err, want)
+			}
+		})
+
+		t.Run("organization not found", func(t *testing.T) {
+			ns, err := Namespaces.GetByID(ctx, 0, org.ID+1)
+			if ns != nil {
+				t.Errorf("unexpected non-nil namespace: %v", ns)
+			}
+			if want := ErrNamespaceNotFound; err != want {
+				t.Errorf("unexpected error: have=%v want=%v", err, want)
+			}
+		})
+
+		t.Run("user", func(t *testing.T) {
+			ns, err := Namespaces.GetByID(ctx, 0, user.ID)
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if want := (&Namespace{Name: "alice", User: user.ID}); !reflect.DeepEqual(ns, want) {
+				t.Errorf("unexpected namespace: have=%v want=%v", ns, want)
+			}
+		})
+
+		t.Run("organization", func(t *testing.T) {
+			ns, err := Namespaces.GetByID(ctx, org.ID, 0)
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if want := (&Namespace{Name: "Acme", Organization: org.ID}); !reflect.DeepEqual(ns, want) {
+				t.Errorf("unexpected namespace: have=%v want=%v", ns, want)
+			}
+		})
+	})
+
 	t.Run("GetByName", func(t *testing.T) {
 		t.Run("user", func(t *testing.T) {
 			ns, err := Namespaces.GetByName(ctx, "Alice")

--- a/internal/db/namespaces_test.go
+++ b/internal/db/namespaces_test.go
@@ -5,17 +5,15 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
-func TestGetNamespaceByName(t *testing.T) {
+func TestNamespaces(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	dbh := dbconn.Global
 
 	// Create user and organization to test lookups.
 	user, err := Users.Create(ctx, NewUser{Username: "alice"})
@@ -27,27 +25,29 @@ func TestGetNamespaceByName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("user", func(t *testing.T) {
-		ns, err := GetNamespaceByName(ctx, dbh, "Alice")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want := (&Namespace{Name: "alice", User: user.ID}); !reflect.DeepEqual(ns, want) {
-			t.Errorf("got %+v, want %+v", ns, want)
-		}
-	})
-	t.Run("organization", func(t *testing.T) {
-		ns, err := GetNamespaceByName(ctx, dbh, "acme")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want := (&Namespace{Name: "Acme", Organization: org.ID}); !reflect.DeepEqual(ns, want) {
-			t.Errorf("got %+v, want %+v", ns, want)
-		}
-	})
-	t.Run("not found", func(t *testing.T) {
-		if _, err := GetNamespaceByName(ctx, dbh, "doesntexist"); err != ErrNamespaceNotFound {
-			t.Fatal(err)
-		}
+	t.Run("GetByName", func(t *testing.T) {
+		t.Run("user", func(t *testing.T) {
+			ns, err := Namespaces.GetByName(ctx, "Alice")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := (&Namespace{Name: "alice", User: user.ID}); !reflect.DeepEqual(ns, want) {
+				t.Errorf("got %+v, want %+v", ns, want)
+			}
+		})
+		t.Run("organization", func(t *testing.T) {
+			ns, err := Namespaces.GetByName(ctx, "acme")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := (&Namespace{Name: "Acme", Organization: org.ID}); !reflect.DeepEqual(ns, want) {
+				t.Errorf("got %+v, want %+v", ns, want)
+			}
+		})
+		t.Run("not found", func(t *testing.T) {
+			if _, err := Namespaces.GetByName(ctx, "doesntexist"); err != ErrNamespaceNotFound {
+				t.Fatal(err)
+			}
+		})
 	})
 }

--- a/internal/db/stores.go
+++ b/internal/db/stores.go
@@ -7,6 +7,7 @@ var (
 	Repos            = &repos{}
 	Phabricator      = &phabricator{}
 	QueryRunnerState = &queryRunnerState{}
+	Namespaces       = &namespaces{}
 	Orgs             = &orgs{}
 	OrgMembers       = &orgMembers{}
 	SavedSearches    = &savedSearches{}


### PR DESCRIPTION
Here's how the backlinks look in GitLab, as an example:

![image](https://user-images.githubusercontent.com/229984/93837577-7c7c1c80-fc3b-11ea-8590-7f03aa05451a.png)

The styling is taken from [how GitHub styles the line added when an issue is created from a comment](https://docs.github.com/en/github/managing-your-work-on-github/opening-an-issue-from-a-comment).

There's also a bonus refactor in here: #13965 added `internal/db/namespaces.go`: I've expanded this out to add the functionality I need (resolving a namespace from an ID tuple) and also brought that file more into line with other files in `internal/db` by using `sqlf` and namespacing its methods with an empty struct like the other files. Those are in separate commits, so if people would prefer these to go into separate PRs, I'm happy to make that split.