### PR TITLE
web: initial search stream PoC

### DIFF
--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -37,7 +37,7 @@ import { RepoContainerRoute } from './repo/RepoContainer'
 import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
 import { LayoutRouteProps } from './routes'
-import { search, fetchSavedSearches, fetchRecentSearches, fetchRecentFileViews } from './search/backend'
+import { search, searchStream, fetchSavedSearches, fetchRecentSearches, fetchRecentFileViews } from './search/backend'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { ThemePreference } from './theme'
@@ -421,7 +421,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     navbarSearchQueryState={this.state.navbarSearchQueryState}
                                     onNavbarQueryChange={this.onNavbarQueryChange}
                                     fetchHighlightedFileLines={fetchHighlightedFileLines}
-                                    searchRequest={search}
+                                    searchRequest={this.state.searchStreaming ? searchStream : search}
                                     // Extensions
                                     platformContext={this.platformContext}
                                     extensionsController={this.extensionsController}

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -167,6 +167,11 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
      */
     previousVersionContext: string | null
 
+    /**
+     * Whether the experimental search streaming API should be used.
+     */
+    searchStreaming: boolean
+
     showRepogroupHomepage: boolean
 
     showOnboardingTour: boolean
@@ -255,6 +260,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             versionContext: resolvedVersionContext,
             availableVersionContexts,
             previousVersionContext,
+            searchStreaming: false,
             showRepogroupHomepage: false,
             showOnboardingTour: false,
             showEnterpriseHomePanels: false,

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -204,7 +204,7 @@ export function searchStream(
 
     return transformedQuery
         .pipe(switchMap(query => SearchStream.search(query, version, patternType, versionContext)))
-        .pipe(SearchStream.switchToGQLISearchResults())
+        .pipe(SearchStream.switchToGQLISearchResults)
 }
 
 /**

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -202,9 +202,13 @@ export function searchStream(
         switchMap(extensionHost => wrapRemoteObservable(extensionHost.transformSearchQuery(query)))
     )
 
-    return transformedQuery
-        .pipe(switchMap(query => SearchStream.search(query, version, patternType, versionContext)))
-        .pipe(SearchStream.switchToGQLISearchResults)
+    return transformedQuery.pipe(
+        switchMap(query =>
+            SearchStream.search(query, version, patternType, versionContext).pipe(
+                SearchStream.switchToGQLISearchResults
+            )
+        )
+    )
 }
 
 /**

--- a/web/src/search/backend.tsx
+++ b/web/src/search/backend.tsx
@@ -11,6 +11,7 @@ import { FlatExtHostAPI } from '../../../shared/src/api/contract'
 import { wrapRemoteObservable } from '../../../shared/src/api/client/api/common'
 import { DeployType } from '../jscontext'
 import { SearchPatternType, EventLogsDataResult, EventLogsDataVariables } from '../graphql-operations'
+import * as SearchStream from './stream'
 
 export function search(
     query: string,
@@ -188,6 +189,22 @@ export function search(
             )
         )
     )
+}
+
+export function searchStream(
+    query: string,
+    version: string,
+    patternType: SearchPatternType,
+    versionContext: string | undefined,
+    extensionHostPromise: Promise<Remote<FlatExtHostAPI>>
+): Observable<GQL.ISearchResults | ErrorLike> {
+    const transformedQuery = from(extensionHostPromise).pipe(
+        switchMap(extensionHost => wrapRemoteObservable(extensionHost.transformSearchQuery(query)))
+    )
+
+    return transformedQuery
+        .pipe(switchMap(query => SearchStream.search(query, version, patternType, versionContext)))
+        .pipe(SearchStream.switchToGQLISearchResults())
 }
 
 /**

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable id-length */
+import { Observable, fromEvent, Subscription, OperatorFunction } from 'rxjs'
+import { map } from 'rxjs/operators'
+import * as GQL from '../../../shared/src/graphql/schema'
+import { SearchPatternType } from '../graphql-operations'
+
+// This is an initial proof of concept implementation of search streaming.
+// The protocol and implementation is still in the design phase. Feel free to
+// change anything and everything here. We are iteratively improving this
+// until it is no longer a proof of concept and instead works well.
+
+type SearchEvent = FileMatch[]
+
+interface FileMatch {
+    name: string
+    repository: string
+    branches?: [string]
+    version?: string
+    lineMatches: [LineMatch]
+}
+
+interface LineMatch {
+    line: string
+    lineNumber: number
+    offsetAndLengths: [[number]]
+}
+
+const toGQLLineMatch = (line: LineMatch): GQL.ILineMatch => ({
+    __typename: 'LineMatch',
+    limitHit: false,
+    lineNumber: line.lineNumber,
+    offsetAndLengths: line.offsetAndLengths,
+    preview: line.line,
+})
+
+function toGQLFileMatch(fm: FileMatch): GQL.IFileMatch {
+    let revision = ''
+    if (fm.branches) {
+        const branch = fm.branches[0]
+        if (branch !== '') {
+            revision = '@' + branch
+        }
+    } else if (fm.version) {
+        revision = '@' + fm.version
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const file: GQL.IGitBlob = {
+        path: fm.name,
+        // /github.com/gorilla/mux@v1.7.2/-/blob/mux_test.go
+        // TODO return in response?
+        url: '/' + fm.repository + revision + '/-/blob/' + fm.name,
+        commit: {
+            oid: fm.version || '',
+        },
+    } as GQL.IGitBlob
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const repository: GQL.IRepository = {
+        name: fm.repository,
+    } as GQL.IRepository
+    return {
+        __typename: 'FileMatch',
+        file,
+        repository,
+        revSpec: null,
+        resource: fm.name,
+        symbols: [],
+        lineMatches: fm.lineMatches.map(toGQLLineMatch),
+        limitHit: false,
+    }
+}
+
+// TODO fill in the fields we actually care about
+const toGQLSearchResults = (results: GQL.SearchResult[]): GQL.ISearchResults => ({
+    __typename: 'SearchResults',
+    matchCount: 0,
+    resultCount: 0,
+    approximateResultCount: '',
+    limitHit: false,
+    sparkline: [],
+    repositories: [],
+    repositoriesCount: 0,
+    repositoriesSearched: [],
+    indexedRepositoriesSearched: [],
+    cloning: [],
+    missing: [],
+    timedout: [],
+    indexUnavailable: false,
+    alert: null,
+    elapsedMilliseconds: 0,
+    dynamicFilters: [],
+    results,
+    pageInfo: { __typename: 'PageInfo', endCursor: null, hasNextPage: false },
+})
+
+/**
+ * Converts a stream of SearchEvents into an aggregated GQL.ISearchResult
+ */
+export function switchToGQLISearchResults(): OperatorFunction<SearchEvent, GQL.ISearchResults> {
+    let allFileMatches: GQL.IFileMatch[] = []
+
+    return map<SearchEvent, GQL.ISearchResults>(fileMatches => {
+        allFileMatches = allFileMatches.concat(fileMatches.map(toGQLFileMatch))
+
+        return toGQLSearchResults(allFileMatches)
+    })
+}
+
+/**
+ * Initiates a streaming search. This is a type safe wrapper around Sourcegraph's streaming search API (using Server Sent Events).
+ * The observable will emit each event returned from the backend.
+ *
+ * @param query the search query to send to Sourcegraph's backend.
+ */
+export function search(
+    query: string,
+    version: string,
+    patternType: SearchPatternType,
+    versionContext: string | undefined
+): Observable<SearchEvent> {
+    return new Observable<SearchEvent>(observer => {
+        const parameters = [
+            ['q', query],
+            ['v', version],
+            ['t', patternType as string],
+        ]
+        if (versionContext) {
+            parameters.push(['vc', versionContext])
+        }
+        const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
+
+        const eventSource = new EventSource('/search/stream?' + parameterEncoded)
+        const subscriptions = new Subscription()
+        subscriptions.add(
+            fromEvent(eventSource, 'filematches').subscribe((event: Event) => {
+                if (!(event instanceof MessageEvent)) {
+                    throw new TypeError('internal error: expected MessageEvent in streaming search filematches')
+                }
+                observer.next(JSON.parse(event.data) as FileMatch[])
+            })
+        )
+        subscriptions.add(
+            fromEvent(eventSource, 'done').subscribe(() => {
+                observer.complete()
+                eventSource.close()
+            })
+        )
+        subscriptions.add(
+            fromEvent(eventSource, 'error').subscribe(error => {
+                observer.error(error)
+                eventSource.close()
+            })
+        )
+        return () => {
+            subscriptions.unsubscribe()
+            eventSource.close()
+        }
+    })
+}

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -96,15 +96,12 @@ const toGQLSearchResults = (results: GQL.SearchResult[]): GQL.ISearchResults => 
 /**
  * Converts a stream of SearchEvents into an aggregated GQL.ISearchResult
  */
-export function switchToGQLISearchResults(): OperatorFunction<SearchEvent, GQL.ISearchResults> {
-    let allFileMatches: GQL.IFileMatch[] = []
-
-    return map<SearchEvent, GQL.ISearchResults>(fileMatches => {
-        allFileMatches = allFileMatches.concat(fileMatches.map(toGQLFileMatch))
-
-        return toGQLSearchResults(allFileMatches)
-    })
-}
+export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearchResults> = searchEvents =>
+    searchEvents.pipe(
+        map(fileMatches => fileMatches.map(toGQLFileMatch)),
+        scan((allFileMatches, newFileMatches) => allFileMatches.concat(newFileMatches), []),
+        map(toGQLSearchResults)
+    )
 
 /**
  * Initiates a streaming search. This is a type safe wrapper around Sourcegraph's streaming search API (using Server Sent Events).

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable id-length */
-import { Observable, fromEvent, Subscription, OperatorFunction } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { Observable, fromEvent, Subscription, OperatorFunction, pipe } from 'rxjs'
+import { map, scan } from 'rxjs/operators'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SearchPatternType } from '../graphql-operations'
 
@@ -96,12 +96,11 @@ const toGQLSearchResults = (results: GQL.SearchResult[]): GQL.ISearchResults => 
 /**
  * Converts a stream of SearchEvents into an aggregated GQL.ISearchResult
  */
-export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearchResults> = searchEvents =>
-    searchEvents.pipe(
-        map(fileMatches => fileMatches.map(toGQLFileMatch)),
-        scan((allFileMatches, newFileMatches) => allFileMatches.concat(newFileMatches), []),
-        map(toGQLSearchResults)
-    )
+export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearchResults> = pipe(
+    map(fileMatches => fileMatches.map(toGQLFileMatch)),
+    scan((allFileMatches: GQL.IFileMatch[], newFileMatches) => allFileMatches.concat(newFileMatches), []),
+    map(toGQLSearchResults)
+)
 
 /**
  * Initiates a streaming search. This is a type safe wrapper around Sourcegraph's streaming search API (using Server Sent Events).

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable id-length */
 import { Observable, fromEvent, Subscription, OperatorFunction, pipe } from 'rxjs'
-import { map, scan } from 'rxjs/operators'
+import { defaultIfEmpty, map, scan } from 'rxjs/operators'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { SearchPatternType } from '../graphql-operations'
 
@@ -99,6 +99,7 @@ const toGQLSearchResults = (results: GQL.SearchResult[]): GQL.ISearchResults => 
 export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearchResults> = pipe(
     map(fileMatches => fileMatches.map(toGQLFileMatch)),
     scan((allFileMatches: GQL.IFileMatch[], newFileMatches) => allFileMatches.concat(newFileMatches), []),
+    defaultIfEmpty([] as GQL.IFileMatch[]),
     map(toGQLSearchResults)
 )
 

--- a/web/src/util/settings.ts
+++ b/web/src/util/settings.ts
@@ -49,6 +49,7 @@ export function experimentalFeaturesFromSettings(
 ): {
     splitSearchModes: boolean
     copyQueryButton: boolean
+    searchStreaming: boolean
     showRepogroupHomepage: boolean
     showOnboardingTour: boolean
     showEnterpriseHomePanels: boolean
@@ -60,10 +61,18 @@ export function experimentalFeaturesFromSettings(
     const {
         splitSearchModes = true,
         copyQueryButton = false,
+        searchStreaming = false,
         showRepogroupHomepage = false,
         showOnboardingTour = false,
         showEnterpriseHomePanels = false,
     } = experimentalFeatures
 
-    return { splitSearchModes, copyQueryButton, showRepogroupHomepage, showOnboardingTour, showEnterpriseHomePanels }
+    return {
+        splitSearchModes,
+        copyQueryButton,
+        searchStreaming,
+        showRepogroupHomepage,
+        showOnboardingTour,
+        showEnterpriseHomePanels,
+    }
 }


### PR DESCRIPTION
This is an initial implementation of streaming search results from the
backend. It is based on our proof of concept backend layer. From here we
can interatively improve and change the protocol to suit the frontend's
needs. This is not production ready and as such is hidden behind a
feature flag.

This implementation is a bit hacky. The GraphQL types are quite heavily
baked into our components. So this implementation converts the stream
into the graphql types.

Part of #13067 