### PR TITLE
gqltest: skip TestExternalService_{AWSCodeCommit,BitbucketServer}

### DIFF
--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -69,6 +69,8 @@ func TestExternalService(t *testing.T) {
 }
 
 func TestExternalService_AWSCodeCommit(t *testing.T) {
+	t.Skip("https://github.com/sourcegraph/sourcegraph/issues/14046")
+
 	if len(*awsAccessKeyID) == 0 || len(*awsSecretAccessKey) == 0 ||
 		len(*awsCodeCommitUsername) == 0 || len(*awsCodeCommitPassword) == 0 {
 		t.Skip("Environment variable AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_CODE_COMMIT_USERNAME or AWS_CODE_COMMIT_PASSWORD is not set")
@@ -125,6 +127,8 @@ func TestExternalService_AWSCodeCommit(t *testing.T) {
 }
 
 func TestExternalService_BitbucketServer(t *testing.T) {
+	t.Skip("https://github.com/sourcegraph/sourcegraph/issues/14046")
+
 	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
 		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
 	}


### PR DESCRIPTION
These are currently failing in master and blocking CI. I assume these
are credential issues (based on when it started to fail). So I am just
skipping for now to unblock prod.

Part of https://github.com/sourcegraph/sourcegraph/issues/14046