### PR TITLE
dev: allow specify start.sh only and except via envvar

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -166,8 +166,8 @@ build_ts_pid="$!"
 # Now launch the services in $PROCFILE
 export PROCFILE=${PROCFILE:-dev/Procfile}
 
-only=""
-except=""
+only="${SRC_DEV_ONLY}"
+except="${SRC_DEV_EXCEPT}"
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     -e | --except)


### PR DESCRIPTION
This allows me to always run with the same environment via direnv. For
example this is my setup to do docker free development :)

```sh
# Kill docker in dev with fire
export CTAGS_COMMAND=/Users/keegan/src/github.com/universal-ctags/ctags/ctags
export USE_SYNTECT_SERVER_FROM_PATH=t
export SRC_DEV_EXCEPT=grafana,prometheus,postgres_exporter
```