### PR TITLE
use default values for new SRC_DEV_ONLY, SRC_DEV_EXCEPT bash vars

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -166,8 +166,8 @@ build_ts_pid="$!"
 # Now launch the services in $PROCFILE
 export PROCFILE=${PROCFILE:-dev/Procfile}
 
-only="${SRC_DEV_ONLY}"
-except="${SRC_DEV_EXCEPT}"
+only="${SRC_DEV_ONLY:-}"
+except="${SRC_DEV_EXCEPT:-}"
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     -e | --except)


### PR DESCRIPTION
fixes #14054 by supplying default values for the bash variables introduced by https://github.com/sourcegraph/sourcegraph/pull/14049
