### PR TITLE
codenotify: Configure efritz's subscriptions

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/CODENOTIFY
+++ b/enterprise/cmd/frontend/internal/codeintel/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/cmd/precise-code-intel-bundle-manager/CODENOTIFY
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/cmd/precise-code-intel-indexer-vm/CODENOTIFY
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/cmd/precise-code-intel-indexer/CODENOTIFY
+++ b/enterprise/cmd/precise-code-intel-indexer/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/cmd/precise-code-intel-worker/CODENOTIFY
+++ b/enterprise/cmd/precise-code-intel-worker/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/internal/codeintel/CODENOTIFY
+++ b/enterprise/internal/codeintel/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/internal/cmd/precise-code-intel-tester/CODENOTIFY
+++ b/internal/cmd/precise-code-intel-tester/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/internal/db/CODENOTIFY
+++ b/internal/db/CODENOTIFY
@@ -1,0 +1,7 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+basestore/** @efritz
+dbconn/** @efritz
+dbtest/** @efritz
+dbtesting/** @efritz
+dbutil/** @efritz

--- a/internal/workerutil/CODENOTIFY
+++ b/internal/workerutil/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz


### PR DESCRIPTION
I see @eseliger has added stuff into the root file. Should we standardize on a way to configure this (prefer subdirectory configuration over root-directory configuration)?