### PR TITLE
db: Add sql.TxOptions to basestore

### DIFF
--- a/cmd/repo-updater/repos/sync_worker.go
+++ b/cmd/repo-updater/repos/sync_worker.go
@@ -23,7 +23,7 @@ import (
 
 // NewSyncWorker creates a new external service sync worker.
 func NewSyncWorker(ctx context.Context, db dbutil.DB, handler dbworker.Handler, numHandlers int) *workerutil.Worker {
-	dbHandle := basestore.NewHandleWithDB(db)
+	dbHandle := basestore.NewHandleWithDB(db, sql.TxOptions{})
 
 	syncJobColumns := append(store.DefaultColumnExpressions(), []*sqlf.Query{
 		sqlf.Sprintf("external_service_id"),

--- a/dev/reconciler-test-script/main.go
+++ b/dev/reconciler-test-script/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -308,7 +309,7 @@ func deleteEverything() {
 
 func getRepositoryID(name string) string {
 	dsn := dbutil.PostgresDSN("sourcegraph", os.Getenv)
-	s, err := basestore.New(dsn, "campaigns-reconciler")
+	s, err := basestore.New(dsn, "campaigns-reconciler", sql.TxOptions{})
 	if err != nil {
 		log.Fatalf("failed to initialize db store: %v", err)
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -19,7 +19,6 @@ import (
 	codeintelresolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/resolvers"
 	codeintelgqlresolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/resolvers/graphql"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
-	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -45,7 +44,7 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	store := store.NewObserved(store.NewWithHandle(basestore.NewHandleWithDB(dbconn.Global)), observationContext)
+	store := store.NewObserved(store.NewWithDB(dbconn.Global), observationContext)
 	bundleManagerClient := bundles.New(bundleManagerURL)
 	commitUpdater := commits.NewUpdater(store, codeintelgitserver.DefaultClient)
 	api := codeintelapi.NewObserved(codeintelapi.New(store, bundleManagerClient, codeintelgitserver.DefaultClient, commitUpdater), observationContext)

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -91,5 +90,5 @@ func mustInitializeStore() store.Store {
 		log.Fatalf("failed to connect to database: %s", err)
 	}
 
-	return store.NewWithHandle(basestore.NewHandleWithDB(dbconn.Global))
+	return store.NewWithDB(dbconn.Global)
 }

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -38,8 +38,7 @@ func NewStore(db dbutil.DB) *Store {
 // NewStoreWithClock returns a new Store backed by the given db and
 // clock for timestamps.
 func NewStoreWithClock(db dbutil.DB, clock func() time.Time) *Store {
-	handle := basestore.NewHandleWithDB(db)
-	return &Store{Store: basestore.NewWithHandle(handle), now: clock}
+	return &Store{Store: basestore.NewWithDB(db, sql.TxOptions{}), now: clock}
 }
 
 // Clock returns the clock used by the Store.

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/bundles/types"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 // Store is the interface to Postgres for precise-code-intel features.
@@ -216,12 +217,16 @@ var _ Store = &store{}
 
 // New creates a new instance of store connected to the given Postgres DSN.
 func New(postgresDSN string) (Store, error) {
-	base, err := basestore.New(postgresDSN, "codeintel")
+	base, err := basestore.New(postgresDSN, "codeintel", sql.TxOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	return &store{Store: base}, nil
+}
+
+func NewWithDB(db dbutil.DB) Store {
+	return &store{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 func NewWithHandle(handle *basestore.TransactableHandle) Store {

--- a/enterprise/internal/codeintel/store/store_test.go
+++ b/enterprise/internal/codeintel/store/store_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"database/sql"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
@@ -13,5 +15,5 @@ func init() {
 
 func testStore() Store {
 	// Wrap in observed, as that's how it's used in production
-	return NewObserved(&store{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(dbconn.Global))}, &observation.TestContext)
+	return NewObserved(&store{Store: basestore.NewWithDB(dbconn.Global, sql.TxOptions{})}, &observation.TestContext)
 }

--- a/internal/db/basestore/store_test.go
+++ b/internal/db/basestore/store_test.go
@@ -2,6 +2,7 @@ package basestore
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -116,7 +117,7 @@ func recurSavepoints(t *testing.T, store *Store, index, rollbackAt int) {
 }
 
 func testStore() *Store {
-	return NewWithHandle(NewHandleWithDB(dbconn.Global))
+	return NewWithDB(dbconn.Global, sql.TxOptions{})
 }
 
 func assertCounts(t *testing.T, db dbutil.DB, expectedCounts map[int]int) {

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -21,7 +21,7 @@ func (r TestWorkRecord) RecordID() int {
 }
 
 func testStore(options StoreOptions) *store {
-	return newStore(basestore.NewHandleWithDB(dbconn.Global), options)
+	return newStore(basestore.NewHandleWithDB(dbconn.Global, sql.TxOptions{}), options)
 }
 
 type TestRecord struct {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/14044.

**Updated**:

Previously this PR added sql options at the time the transaction is opened. Instead, we should be supplying them at the time the database handle is created. This seems like a more appropriate solution and should enable @asdine to choose the correct transaction options when the store powering the worker is created.