### PR TITLE
Small adjustment to home panel header size

### DIFF
--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -13,7 +13,7 @@
     }
 
     &__action-button-group {
-        margin-bottom: .25rem;
+        margin-bottom: 0.25rem;
     }
 
     &__empty-container {

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -2,6 +2,8 @@
     margin-bottom: 1rem;
 
     &__header {
+        position:relative;
+        
         &-text {
             margin-bottom: 0.25rem;
             flex-grow: 1;
@@ -11,8 +13,11 @@
     }
 
     &__action-button-group {
-        margin-bottom: 0.125rem;
         font-size: 12px;
+        float: right;
+        position: absolute;
+        bottom: .25rem;
+        right: 0;
     }
 
     &__action-button {

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -2,10 +2,10 @@
     margin-bottom: 1rem;
 
     &__header {
-        position:relative;
-        
+        min-height: 2rem;
+
         &-text {
-            margin-bottom: 0.25rem;
+            margin-bottom: 0.125rem;
             flex-grow: 1;
             align-self: flex-end;
             font-weight: 400;
@@ -13,16 +13,7 @@
     }
 
     &__action-button-group {
-        font-size: 12px;
-        float: right;
-        position: absolute;
-        bottom: .25rem;
-        right: 0;
-    }
-
-    &__action-button {
-        font-size: 12px;
-        line-height: 16px !important;
+        margin-bottom: .25rem;
     }
 
     &__empty-container {

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -6,6 +6,7 @@
             margin-bottom: 0.25rem;
             flex-grow: 1;
             align-self: flex-end;
+            font-weight: 400;
         }
     }
 

--- a/web/src/search/panels/PanelContainer.tsx
+++ b/web/src/search/panels/PanelContainer.tsx
@@ -25,7 +25,7 @@ export const PanelContainer: React.FunctionComponent<Props> = ({
 }) => (
     <div className={classNames(className, 'panel-container', 'd-flex', 'flex-column')}>
         <div className="panel-container__header d-flex border-bottom">
-            <h3 className="panel-container__header-text">{title}</h3>
+            <h4 className="panel-container__header-text">{title}</h4>
             {actionButtons}
         </div>
 

--- a/web/src/search/panels/__snapshots__/PanelContainer.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/PanelContainer.test.tsx.snap
@@ -26,11 +26,11 @@ exports[`PanelContainer content state 1`] = `
     <div
       className="panel-container__header d-flex border-bottom"
     >
-      <h3
+      <h4
         className="panel-container__header-text"
       >
         Test Panel
-      </h3>
+      </h4>
     </div>
     <div
       className="panel-container__content h-100"
@@ -69,11 +69,11 @@ exports[`PanelContainer empty state 1`] = `
     <div
       className="panel-container__header d-flex border-bottom"
     >
-      <h3
+      <h4
         className="panel-container__header-text"
       >
         Test Panel
-      </h3>
+      </h4>
     </div>
     <div
       className="panel-container__content h-100"
@@ -112,11 +112,11 @@ exports[`PanelContainer loading state 1`] = `
     <div
       className="panel-container__header d-flex border-bottom"
     >
-      <h3
+      <h4
         className="panel-container__header-text"
       >
         Test Panel
-      </h3>
+      </h4>
     </div>
     <div
       className="panel-container__content h-100"
@@ -162,11 +162,11 @@ exports[`PanelContainer with action buttons 1`] = `
     <div
       className="panel-container__header d-flex border-bottom"
     >
-      <h3
+      <h4
         className="panel-container__header-text"
       >
         Test Panel
-      </h3>
+      </h4>
       <button
         type="button"
       >

--- a/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
@@ -26,9 +26,9 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
               className="text-monospace"
               to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
             >
-              lang:c if(:[eval_match]) 
+              lang:c if(:[eval_match])
               {
-               :[statement_match] 
+               :[statement_match]
               }
             </AnchorLink>
           </li>
@@ -166,11 +166,11 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Recent searches
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"
@@ -339,9 +339,9 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
               className="text-monospace"
               to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
             >
-              lang:c if(:[eval_match]) 
+              lang:c if(:[eval_match])
               {
-               :[statement_match] 
+               :[statement_match]
               }
             </AnchorLink>
           </li>
@@ -535,11 +535,11 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Recent searches
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"
@@ -777,9 +777,9 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
               className="text-monospace"
               to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
             >
-              lang:c if(:[eval_match]) 
+              lang:c if(:[eval_match])
               {
-               :[statement_match] 
+               :[statement_match]
               }
             </AnchorLink>
           </li>
@@ -913,11 +913,11 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Recent searches
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"

--- a/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
@@ -26,9 +26,9 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
               className="text-monospace"
               to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
             >
-              lang:c if(:[eval_match])
+              lang:c if(:[eval_match]) 
               {
-               :[statement_match]
+               :[statement_match] 
               }
             </AnchorLink>
           </li>
@@ -339,9 +339,9 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
               className="text-monospace"
               to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
             >
-              lang:c if(:[eval_match])
+              lang:c if(:[eval_match]) 
               {
-               :[statement_match]
+               :[statement_match] 
               }
             </AnchorLink>
           </li>
@@ -777,9 +777,9 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
               className="text-monospace"
               to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
             >
-              lang:c if(:[eval_match])
+              lang:c if(:[eval_match]) 
               {
-               :[statement_match]
+               :[statement_match] 
               }
             </AnchorLink>
           </li>

--- a/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
           <p
             className="mb-1"
           >
-            Search in repositories with the 
+            Search in repositories with the
             <strong>
               repo:
             </strong>
@@ -119,11 +119,11 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Repositories
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"
@@ -213,7 +213,7 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
           <p
             className="mb-1"
           >
-            Search in repositories with the 
+            Search in repositories with the
             <strong>
               repo:
             </strong>
@@ -332,11 +332,11 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Repositories
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"
@@ -466,7 +466,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
           <p
             className="mb-1"
           >
-            Search in repositories with the 
+            Search in repositories with the
             <strong>
               repo:
             </strong>
@@ -635,11 +635,11 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Repositories
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"
@@ -821,7 +821,7 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
           <p
             className="mb-1"
           >
-            Search in repositories with the 
+            Search in repositories with the
             <strong>
               repo:
             </strong>
@@ -918,11 +918,11 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
       <div
         className="panel-container__header d-flex border-bottom"
       >
-        <h3
+        <h4
           className="panel-container__header-text"
         >
           Repositories
-        </h3>
+        </h4>
       </div>
       <div
         className="panel-container__content h-100"

--- a/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
           <p
             className="mb-1"
           >
-            Search in repositories with the
+            Search in repositories with the 
             <strong>
               repo:
             </strong>
@@ -213,7 +213,7 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
           <p
             className="mb-1"
           >
-            Search in repositories with the
+            Search in repositories with the 
             <strong>
               repo:
             </strong>
@@ -466,7 +466,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
           <p
             className="mb-1"
           >
-            Search in repositories with the
+            Search in repositories with the 
             <strong>
               repo:
             </strong>
@@ -821,7 +821,7 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
           <p
             className="mb-1"
           >
-            Search in repositories with the
+            Search in repositories with the 
             <strong>
               repo:
             </strong>


### PR DESCRIPTION
My designs specified an H3 for these panels that is just too large. This pull request reduces them to h4 and overrides the standard 600 weight to 400. 

Left is before, right is after:

![image](https://user-images.githubusercontent.com/539268/93927806-4045cc00-fcce-11ea-918f-b359ffaa0ced.png)
