### PR TITLE
prometheus: only override Slack username if it is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Usernames set in Slack `observability.alerts` now apply correctly. [#14079](https://github.com/sourcegraph/sourcegraph/pull/14079)
+
 ## 3.20.1
 
 ### Fixed

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers.go
@@ -206,7 +206,9 @@ For more details, please refer to the service dashboard: %s`, firingBodyTemplate
 				newProblem(fmt.Errorf("failed to apply notifier %d: %w", i, err))
 				continue
 			}
-			if notifier.Slack.Username != "" {
+
+			// set a default username if none is provided
+			if notifier.Slack.Username == "" {
 				notifier.Slack.Username = "Sourcegraph Alerts"
 			}
 


### PR DESCRIPTION
Previously, usernames being set in Slack alerts were being overridden if they were set.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
