### PR TITLE
indent and highlight JSON campaign specs

### DIFF
--- a/web/src/enterprise/campaigns/detail/CampaignSpecTab.test.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignSpecTab.test.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import { CampaignFields } from '../../../graphql-operations'
 
 jest.mock('mdi-react/FileDownloadIcon', () => 'FileDownloadIcon')
-jest.mock('../../../../../shared/src/util/markdown', () => ({ highlightCodeSafe: () => 'code' }))
+jest.mock('../../../../../shared/src/util/markdown', () => ({ highlightCodeSafe: (input: string) => input }))
 
 const ALICE: CampaignFields['initialApplier'] | CampaignFields['lastApplier'] = {
     username: 'alice',
@@ -39,6 +39,22 @@ describe('CampaignSpecTab', () => {
                         lastApplier: ALICE,
                     }}
                     originalInput="x"
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    test('input spec is JSON', () => {
+        expect(
+            mount(
+                <CampaignSpecTab
+                    campaign={{
+                        name: 'c',
+                        createdAt: '2020-01-01T15:00:00Z',
+                        lastAppliedAt: '2020-01-01T15:00:00Z',
+                        lastApplier: ALICE,
+                    }}
+                    originalInput='{"foo":"bar"}'
                 />
             )
         ).toMatchSnapshot()

--- a/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
+++ b/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
@@ -10,6 +10,16 @@ export interface CampaignSpecTabProps {
     originalInput: CampaignFields['currentSpec']['originalInput']
 }
 
+/** Reports whether str is a valid JSON document. */
+const isJSON = (string: string): boolean => {
+    try {
+        JSON.parse(string)
+        return true
+    } catch {
+        return false
+    }
+}
+
 export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({
     campaign: { name: campaignName, createdAt, lastApplier, lastAppliedAt },
     originalInput,
@@ -17,7 +27,20 @@ export const CampaignSpecTab: React.FunctionComponent<CampaignSpecTabProps> = ({
     const downloadUrl = useMemo(() => 'data:text/plain;charset=utf-8,' + encodeURIComponent(originalInput), [
         originalInput,
     ])
-    const highlightedInput = useMemo(() => ({ __html: highlightCodeSafe(originalInput, 'yaml') }), [originalInput])
+
+    // JSON is valid YAML, so the input might be JSON. In that case, we'll highlight and indent it
+    // as JSON. This is especially nice when the input is a "minified" (no extraneous whitespace)
+    // JSON document that's difficult to read unless indented.
+    const inputIsJSON = isJSON(originalInput)
+    const input = useMemo(() => (inputIsJSON ? JSON.stringify(JSON.parse(originalInput), null, 2) : originalInput), [
+        inputIsJSON,
+        originalInput,
+    ])
+
+    const highlightedInput = useMemo(() => ({ __html: highlightCodeSafe(input, inputIsJSON ? 'json' : 'yaml') }), [
+        inputIsJSON,
+        input,
+    ])
     return (
         <div className="mt-4">
             <div className="d-flex justify-content-between align-items-center mb-2 test-campaigns-spec">

--- a/web/src/enterprise/campaigns/detail/__snapshots__/CampaignSpecTab.test.tsx.snap
+++ b/web/src/enterprise/campaigns/detail/__snapshots__/CampaignSpecTab.test.tsx.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CampaignSpecTab input spec is JSON 1`] = `
+<CampaignSpecTab
+  campaign={
+    Object {
+      "createdAt": "2020-01-01T15:00:00Z",
+      "lastAppliedAt": "2020-01-01T15:00:00Z",
+      "lastApplier": Object {
+        "url": "https://example.com/alice",
+        "username": "alice",
+      },
+      "name": "c",
+    }
+  }
+  originalInput="{\\"foo\\":\\"bar\\"}"
+>
+  <div
+    className="mt-4"
+  >
+    <div
+      className="d-flex justify-content-between align-items-center mb-2 test-campaigns-spec"
+    >
+      <p
+        className="m-0"
+      >
+        <AnchorLink
+          to="https://example.com/alice"
+        >
+          <a
+            href="https://example.com/alice"
+          >
+            alice
+          </a>
+        </AnchorLink>
+         
+        created
+         this campaign
+         
+        <Timestamp
+          date="2020-01-01T15:00:00Z"
+        >
+          <span
+            className="timestamp"
+            data-tooltip="2020-01-01T15:00:00Z"
+          >
+            in almost 14 years
+          </span>
+        </Timestamp>
+         by applying the following campaign spec:
+      </p>
+      <a
+        className="text-right btn btn-secondary text-nowrap"
+        data-tooltip="Download c.campaign.yaml"
+        download="c.campaign.yaml"
+        href="data:text/plain;charset=utf-8,%7B%22foo%22%3A%22bar%22%7D"
+      >
+        <FileDownloadIcon
+          className="icon-inline"
+        />
+         Download YAML
+      </a>
+    </div>
+    <div
+      className="mb-3"
+    >
+      <div
+        className="campaign-spec-tab__specfile rounded p-3"
+      >
+        <pre
+          className="m-0"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "{
+  \\"foo\\": \\"bar\\"
+}",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</CampaignSpecTab>
+`;
+
 exports[`CampaignSpecTab last apply was an update (after creation) 1`] = `
 <CampaignSpecTab
   campaign={
@@ -71,7 +154,7 @@ exports[`CampaignSpecTab last apply was an update (after creation) 1`] = `
           className="m-0"
           dangerouslySetInnerHTML={
             Object {
-              "__html": "code",
+              "__html": "x",
             }
           }
         />
@@ -152,7 +235,7 @@ exports[`CampaignSpecTab last apply was the (initial) creation 1`] = `
           className="m-0"
           dangerouslySetInnerHTML={
             Object {
-              "__html": "code",
+              "__html": "x",
             }
           }
         />


### PR DESCRIPTION
A campaign spec is a YAML document. YAML is a superset of JSON. If a campaign spec is pure-JSON, then it's nice to indent it (in case it's all on one line, for example) and highlight it using the JSON highlighter.

The button is still "Download YAML" and the filename is still "whatever.yaml", but that's OK because YAML is a superset of JSON, so those are correct.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->