### PR TITLE
simplify extension API context impl

### DIFF
--- a/shared/src/actions/ActionsContainer.tsx
+++ b/shared/src/actions/ActionsContainer.tsx
@@ -16,7 +16,7 @@ export interface ActionsProps
         PlatformContextProps<'forceUpdateTooltip' | 'settings'> {
     menu: ContributableMenu
     scope?: ContributionScope
-    extraContext?: Context<any>
+    extraContext?: Context
     listClass?: string
     location: H.Location
 }
@@ -39,7 +39,7 @@ export class ActionsContainer extends React.PureComponent<Props, ActionsState> {
     public state: ActionsState = {}
 
     private scopeChanges = new Subject<ContributionScope | undefined>()
-    private extraContextChanges = new Subject<Context<any> | undefined>()
+    private extraContextChanges = new Subject<Context | undefined>()
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {

--- a/shared/src/actions/ActionsNavItems.tsx
+++ b/shared/src/actions/ActionsNavItems.tsx
@@ -54,7 +54,7 @@ export class ActionsNavItems extends React.PureComponent<ActionsNavItemsProps, A
     public state: ActionsState = {}
 
     private scopeChanges = new Subject<ContributionScope | undefined>()
-    private extraContextChanges = new Subject<Context<any> | undefined>()
+    private extraContextChanges = new Subject<Context | undefined>()
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {

--- a/shared/src/api/client/context/context.test.ts
+++ b/shared/src/api/client/context/context.test.ts
@@ -157,11 +157,6 @@ describe('getComputedContextProperty', () => {
             test('returns null when there is no component', () => {
                 assertNoSelection()
             })
-
-            test('returns undefined for out-of-bounds selection', () =>
-                expect(
-                    getComputedContextProperty(editor, EMPTY_SETTINGS_CASCADE, {}, 'get(component.selections, 1)')
-                ).toBe(undefined))
         })
     })
 
@@ -190,6 +185,6 @@ describe('getComputedContextProperty', () => {
 
     test('falls back to the context entries', () => {
         expect(getComputedContextProperty(undefined, EMPTY_SETTINGS_CASCADE, { x: 1 }, 'x')).toBe(1)
-        expect(getComputedContextProperty(undefined, EMPTY_SETTINGS_CASCADE, {}, 'y')).toBe(undefined)
+        expect(getComputedContextProperty(undefined, EMPTY_SETTINGS_CASCADE, {}, 'y')).toBe(null)
     })
 })

--- a/shared/src/api/client/context/expr/evaluator.test.ts
+++ b/shared/src/api/client/context/expr/evaluator.test.ts
@@ -1,14 +1,14 @@
+import { Context } from '../context'
 import { parse, parseTemplate } from './evaluator'
 
-const FIXTURE_CONTEXT = new Map<string, any>(
-    Object.entries({
-        a: 1,
-        b: 1,
-        c: 2,
-        x: 'y',
-        o: { k: 'v' },
-    })
-)
+const FIXTURE_CONTEXT: Context = {
+    a: 1,
+    b: 1,
+    c: 2,
+    x: 'y',
+    o: { k: 'v' },
+    array: [7],
+}
 
 describe('Expression', () => {
     /* eslint-disable no-template-curly-in-string */
@@ -39,6 +39,8 @@ describe('Expression', () => {
         '`_${x}_${a}_${a+b}`': '_y_1_2',
         '`_${`-${x}-`}_`': '_-y-_',
         'a || isnotdefined': 1, // short-circuit (if not, the use of an undefined ident would cause an error)
+        'get(array, 0)': 7,
+        'get(array, 1)': undefined, // out-of-bounds array index is undefined
     }
     /* eslint-enable no-template-curly-in-string */
     for (const [expression, want] of Object.entries(TESTS)) {

--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -1,3 +1,4 @@
+import { Context } from '../context'
 import { TokenType } from './lexer'
 import { ExpressionNode, Parser, TemplateParser } from './parser'
 
@@ -7,7 +8,7 @@ import { ExpressionNode, Parser, TemplateParser } from './parser'
 export class Expression<T> {
     constructor(private root: ExpressionNode) {}
 
-    public exec(context: ComputedContext): T {
+    public exec(context: Context): T {
         return exec(this.root, context)
     }
 }
@@ -35,22 +36,12 @@ export function parseTemplate(template: string): TemplateExpression {
     return new TemplateExpression(new TemplateParser().parse(template))
 }
 
-/** A way to look up the value for an identifier. */
-export interface ComputedContext {
-    get(key: string): any
-}
-
-/** A computed context that returns undefined for every key. */
-export const EMPTY_COMPUTED_CONTEXT: ComputedContext = {
-    get: () => undefined,
-}
-
 const FUNCS: { [name: string]: (...args: any[]) => any } = {
     get: (object: any, key: string): any => object?.[key] ?? undefined,
     json: (object: any): string => JSON.stringify(object),
 }
 
-function exec(node: ExpressionNode, context: ComputedContext): any {
+function exec(node: ExpressionNode, context: Context): any {
     if ('Literal' in node) {
         switch (node.Literal.type) {
             case TokenType.String:
@@ -139,7 +130,7 @@ function exec(node: ExpressionNode, context: ComputedContext): any {
             case 'null':
                 return null
         }
-        return context.get(node.Identifier)
+        return context[node.Identifier]
     }
 
     if ('FunctionCall' in node) {

--- a/shared/src/api/client/context/expr/evaluator.ts
+++ b/shared/src/api/client/context/expr/evaluator.ts
@@ -8,8 +8,8 @@ import { ExpressionNode, Parser, TemplateParser } from './parser'
 export class Expression<T> {
     constructor(private root: ExpressionNode) {}
 
-    public exec(context: Context): T {
-        return exec(this.root, context)
+    public exec<C>(context: Context<C>): T {
+        return exec<C>(this.root, context)
     }
 }
 
@@ -41,7 +41,7 @@ const FUNCS: { [name: string]: (...args: any[]) => any } = {
     json: (object: any): string => JSON.stringify(object),
 }
 
-function exec(node: ExpressionNode, context: Context): any {
+function exec<C>(node: ExpressionNode, context: Context<C>): any {
     if ('Literal' in node) {
         switch (node.Literal.type) {
             case TokenType.String:

--- a/shared/src/api/client/services/contribution.test.ts
+++ b/shared/src/api/client/services/contribution.test.ts
@@ -4,7 +4,7 @@ import { TestScheduler } from 'rxjs/testing'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../../settings/settings'
 import { ContributableMenu, Contributions, Evaluated } from '../../protocol'
 import { Context, ContributionScope } from '../context/context'
-import { EMPTY_COMPUTED_CONTEXT, parse, parseTemplate } from '../context/expr/evaluator'
+import { parse, parseTemplate } from '../context/expr/evaluator'
 import {
     ContributionRegistry,
     ContributionsEntry,
@@ -357,13 +357,11 @@ describe('mergeContributions()', () => {
     })
 })
 
-const FIXTURE_CONTEXT = new Map<string, any>(
-    Object.entries({
-        a: true,
-        b: false,
-        replaceMe: 'x',
-    })
-)
+const FIXTURE_CONTEXT: Context = {
+    a: true,
+    b: false,
+    replaceMe: 'x',
+}
 
 describe('filterContributions()', () => {
     it('handles empty contributions', () => {
@@ -424,14 +422,14 @@ describe('filterContributions()', () => {
 describe('evaluateContributions()', () => {
     test('handles empty contributions', () => {
         const expected: Evaluated<Contributions> = {}
-        expect(evaluateContributions(EMPTY_COMPUTED_CONTEXT, {})).toEqual(expected)
+        expect(evaluateContributions({}, {})).toEqual(expected)
     })
 
     test('handles empty array of command contributions', () => {
         const expected: Evaluated<Contributions> = {
             actions: [],
         }
-        expect(evaluateContributions(EMPTY_COMPUTED_CONTEXT, { actions: [] })).toEqual(expected)
+        expect(evaluateContributions({}, { actions: [] })).toEqual(expected)
     })
 
     test('handles non-empty contributions', () => {

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -189,7 +189,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end">
                         <ActionsNavItems
                             {...props}
-                            extraContext={{ searchQuery: props.query }}
+                            extraContext={{ searchQuery: props.query || null }}
                             menu={ContributableMenu.SearchResultsToolbar}
                             wrapInList={false}
                             showLoadingSpinnerDuringExecution={true}


### PR DESCRIPTION
The getComputedContextProperty function is called to provide the values for extension context keys such as `resource.uri` (for extensions to define actions that, when invoked, call a function with the URI of the currently visible document).

Now, instead of getComputedContextProperty parsing the requested key (such as `resource.uri`) and running custom code to return each key's value, it constructs a JavaScript object with all possible keys and just indexes into that object.

Finally, the getComputedContextProperty is renamed to computeContext. It now always returns the entire computed context data as a map, instead of computing the value per-key. This is a simplification because it enforces that there must be no special per-key computation; the context can be treated as a map instead of as an interface with an arbitrary `{get(key:string): any}` function.

This is not expected to have any impact on extensions. It does slightly change the behavior, such as context expressions that used to return `null` now return `undefined`. I will search existing extension code for potential backcompat problems and will test it more before merging.