### PR TITLE
search: call zoekt early

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1120,11 +1120,9 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, err
 	}
 
-	rp := search.NewRepoPromise().Resolve(resolved.repoRevs)
-
 	args := search.TextParameters{
 		PatternInfo:     p,
-		RepoPromise:     rp,
+		RepoPromise:     search.NewRepoPromise().Resolve(resolved.repoRevs),
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1119,9 +1119,13 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 	if err != nil {
 		return nil, err
 	}
+
+	rp := search.NewRepoPromise()
+	rp.Resolve(resolved.repoRevs)
+
 	args := search.TextParameters{
 		PatternInfo:     p,
-		Repos:           resolved.repoRevs,
+		RepoPromise:     rp,
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1120,8 +1120,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, err
 	}
 
-	rp := search.NewRepoPromise()
-	rp.Resolve(resolved.repoRevs)
+	rp := search.NewRepoPromise().Resolve(resolved.repoRevs)
 
 	args := search.TextParameters{
 		PatternInfo:     p,

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1122,7 +1122,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 
 	args := search.TextParameters{
 		PatternInfo:     p,
-		RepoPromise:     search.NewRepoPromise().Resolve(resolved.repoRevs),
+		RepoPromise:     (&search.Promise{}).Resolve(resolved.repoRevs),
 		Query:           r.query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,
@@ -1294,4 +1294,18 @@ func handleRepoSearchResult(common *searchResultsCommon, repoRev *search.Reposit
 		return searchErr
 	}
 	return nil
+}
+
+// getRepos is a wrapper around p.Get. It returns an error if the promise
+// contains an underlying type other than []*search.RepositoryRevisions.
+func getRepos(ctx context.Context, p *search.Promise) ([]*search.RepositoryRevisions, error) {
+	v, err := p.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	repoRevs, ok := v.([]*search.RepositoryRevisions)
+	if !ok {
+		return nil, fmt.Errorf("unexpected underlying type (%T) of promise", v)
+	}
+	return repoRevs, nil
 }

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -60,7 +60,7 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 
 	// Filter args.Repos by matching their names against the query pattern.
 	common = &searchResultsCommon{}
-	resolved, err := args.RepoPromise.Get(ctx)
+	resolved, err := getRepos(ctx, args.RepoPromise)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,7 +118,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			newArgs.RepoPromise = search.NewRepoPromise().Resolve(repos)
+			newArgs.RepoPromise = (&search.Promise{}).Resolve(repos)
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
 			matches, _, err := searchFilesInRepos(ctx, &newArgs)
@@ -145,7 +145,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			rp := search.NewRepoPromise().Resolve(repos)
+			rp := (&search.Promise{}).Resolve(repos)
 			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -118,8 +118,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			rp := search.NewRepoPromise().Resolve(repos)
-			newArgs.RepoPromise = rp
+			newArgs.RepoPromise = search.NewRepoPromise().Resolve(repos)
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
 			matches, _, err := searchFilesInRepos(ctx, &newArgs)

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -60,9 +60,9 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 
 	// Filter args.Repos by matching their names against the query pattern.
 	common = &searchResultsCommon{}
-	common.repos = make([]*types.Repo, len(args.Repos))
+	common.repos = make([]*types.Repo, len(args.RepoPromise.Get()))
 	var repos []*search.RepositoryRevisions
-	for i, r := range args.Repos {
+	for i, r := range args.RepoPromise.Get() {
 		common.repos[i] = r.Repo
 		if pattern.MatchString(string(r.Repo.Name)) {
 			repos = append(repos, r)
@@ -114,7 +114,9 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			newArgs.Repos = repos
+			rp := search.NewRepoPromise()
+			rp.Resolve(repos)
+			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
 			matches, _, err := searchFilesInRepos(ctx, &newArgs)
@@ -141,7 +143,9 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			newArgs.Repos = repos
+			rp := search.NewRepoPromise()
+			rp.Resolve(repos)
+			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
 			matches, _, err := searchFilesInRepos(ctx, &newArgs)

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -60,9 +60,13 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 
 	// Filter args.Repos by matching their names against the query pattern.
 	common = &searchResultsCommon{}
-	common.repos = make([]*types.Repo, len(args.RepoPromise.Get()))
+	resolved, err := args.RepoPromise.Get(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	common.repos = make([]*types.Repo, len(resolved))
 	var repos []*search.RepositoryRevisions
-	for i, r := range args.RepoPromise.Get() {
+	for i, r := range resolved {
 		common.repos[i] = r.Repo
 		if pattern.MatchString(string(r.Repo.Name)) {
 			repos = append(repos, r)
@@ -114,8 +118,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			rp := search.NewRepoPromise()
-			rp.Resolve(repos)
+			rp := search.NewRepoPromise().Resolve(repos)
 			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
@@ -143,8 +146,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			}
 			newArgs := *args
 			newArgs.PatternInfo = &p
-			rp := search.NewRepoPromise()
-			rp.Resolve(repos)
+			rp := search.NewRepoPromise().Resolve(repos)
 			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -90,10 +90,9 @@ func TestSearchRepositories(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rp := search.NewRepoPromise().Resolve(repositories)
 			results, _, err := searchRepositories(context.Background(), &search.TextParameters{
 				PatternInfo: pattern,
-				RepoPromise: rp,
+				RepoPromise: search.NewRepoPromise().Resolve(repositories),
 				Query:       q,
 				Zoekt:       zoekt,
 			}, int32(100))

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -24,7 +24,7 @@ func TestSearchRepositories(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repoName := args.Repos[0].Repo.Name
+		repoName := args.RepoPromise.Get()[0].Repo.Name
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
@@ -89,9 +89,11 @@ func TestSearchRepositories(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			rp := search.NewRepoPromise()
+			rp.Resolve(repositories)
 			results, _, err := searchRepositories(context.Background(), &search.TextParameters{
 				PatternInfo: pattern,
-				Repos:       repositories,
+				RepoPromise: rp,
 				Query:       q,
 				Zoekt:       zoekt,
 			}, int32(100))
@@ -118,7 +120,7 @@ func TestSearchRepositories(t *testing.T) {
 
 func TestRepoShouldBeAdded(t *testing.T) {
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repoName := args.Repos[0].Repo.Name
+		repoName := args.RepoPromise.Get()[0].Repo.Name
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -24,7 +24,10 @@ func TestSearchRepositories(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repos, _ := getRepos(context.Background(), args.RepoPromise)
+		repos, err := getRepos(context.Background(), args.RepoPromise)
+		if err != nil {
+			return nil, nil, err
+		}
 		repoName := repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":
@@ -119,7 +122,10 @@ func TestSearchRepositories(t *testing.T) {
 
 func TestRepoShouldBeAdded(t *testing.T) {
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repos, _ := getRepos(context.Background(), args.RepoPromise)
+		repos, err := getRepos(context.Background(), args.RepoPromise)
+		if err != nil {
+			return nil, nil, err
+		}
 		repoName := repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -24,7 +24,7 @@ func TestSearchRepositories(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repos, _ := args.RepoPromise.Get(context.Background())
+		repos, _ := getRepos(context.Background(), args.RepoPromise)
 		repoName := repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":
@@ -92,7 +92,7 @@ func TestSearchRepositories(t *testing.T) {
 
 			results, _, err := searchRepositories(context.Background(), &search.TextParameters{
 				PatternInfo: pattern,
-				RepoPromise: search.NewRepoPromise().Resolve(repositories),
+				RepoPromise: (&search.Promise{}).Resolve(repositories),
 				Query:       q,
 				Zoekt:       zoekt,
 			}, int32(100))
@@ -119,7 +119,7 @@ func TestSearchRepositories(t *testing.T) {
 
 func TestRepoShouldBeAdded(t *testing.T) {
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repos, _ := args.RepoPromise.Get(context.Background())
+		repos, _ := getRepos(context.Background(), args.RepoPromise)
 		repoName := repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -24,7 +24,8 @@ func TestSearchRepositories(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repoName := args.RepoPromise.Get()[0].Repo.Name
+		repos, _ := args.RepoPromise.Get(context.Background())
+		repoName := repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
@@ -89,8 +90,7 @@ func TestSearchRepositories(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rp := search.NewRepoPromise()
-			rp.Resolve(repositories)
+			rp := search.NewRepoPromise().Resolve(repositories)
 			results, _, err := searchRepositories(context.Background(), &search.TextParameters{
 				PatternInfo: pattern,
 				RepoPromise: rp,
@@ -120,7 +120,8 @@ func TestSearchRepositories(t *testing.T) {
 
 func TestRepoShouldBeAdded(t *testing.T) {
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-		repoName := args.RepoPromise.Get()[0].Repo.Name
+		repos, _ := args.RepoPromise.Get(context.Background())
+		repoName := repos[0].Repo.Name
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1796,6 +1796,10 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
 	if r.isGlobalSearch() && isFileOrPath() {
+		// to protect us from regression, we explicitly create a child context which is
+		// canceled if we return from doResults
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		argsIndexed := args
 		argsIndexed.Mode = search.ZoektGlobalSearch
 		wg := waitGroup(true)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1752,6 +1752,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return nil, err
 	}
 
+	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
+	tr.LazyPrintf("resultTypes: %v", resultTypes)
 	var (
 		requiredWg sync.WaitGroup
 		optionalWg sync.WaitGroup
@@ -1796,13 +1798,10 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	if alertResult != nil {
 		return alertResult, nil
 	}
+	args.Repos = resolved.repoRevs
 	if r.isGlobalSearch() {
 		args.RepoPromise <- resolved.repoRevs
 	}
-	args.Repos = resolved.repoRevs
-
-	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
-	tr.LazyPrintf("resultTypes: %v", resultTypes)
 
 	agg.common.excluded = resolved.excludedRepos
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1697,7 +1697,6 @@ func (r *searchResolver) isGlobalSearch() bool {
 	if r.versionContext != nil && *r.versionContext != "" {
 		return false
 	}
-
 	return len(r.query.Values(query.FieldRepo)) == 0 && len(r.query.Values(query.FieldRepoGroup)) == 0
 }
 
@@ -1788,7 +1787,16 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		fileMatches: make(map[string]*FileMatchResolver),
 	}
 
-	if r.isGlobalSearch() {
+	isFileOrPath := func() bool {
+		for _, rt := range resultTypes {
+			if rt == "file" || rt == "path" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if r.isGlobalSearch() && isFileOrPath() {
 		// call zoekt early
 		argsIndexed := args
 		argsIndexed.Mode = search.ZoektGlobalSearch

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1618,8 +1618,7 @@ func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters
 	}
 	repos, err := tp.RepoPromise.Get(ctx)
 	if err != nil {
-		log15.Error("doDiffSearch: context error while getting repos. This should never happen.")
-		return
+		log15.Info("doDiffSearch: context error while getting repos.")
 	}
 	args := search.TextParametersForCommitParameters{
 		PatternInfo: patternInfo,
@@ -1659,8 +1658,7 @@ func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParamete
 	}
 	repos, err := tp.RepoPromise.Get(ctx)
 	if err != nil {
-		log15.Error("doCommitSearch: context error while getting repos. This should never happen.")
-		return
+		log15.Info("doCommitSearch: context error while getting repos.")
 	}
 
 	args := search.TextParametersForCommitParameters{
@@ -1751,7 +1749,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		SearcherURLs:    r.searcherURLs,
 		RepoPromise:     search.NewRepoPromise(),
 	}
-
 	if err := args.PatternInfo.Validate(); err != nil {
 		return nil, &badRequestError{err}
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1795,8 +1795,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	if alertResult != nil {
 		return alertResult, nil
 	}
-	args.RepoPromise <- resolved.repoRevs
-	args.Repos = resolved.repoRevs
+	args.RepoPromise <- resolved.repoRevs // global search
+	args.Repos = resolved.repoRevs        // everything else
 
 	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
 	tr.LazyPrintf("resultTypes: %v", resultTypes)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1676,8 +1676,9 @@ func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParamete
 	}
 }
 
-// isGlobalSearch returns true if r.query is not a structural query and if it
-// does not contain any of the following filters: repo, repogroup
+// isGlobalSearch returns true if the query contains the filters repo or
+// repogroup. For structural queries and queries with version context
+// isGlobalSearch always return false.
 func (r *searchResolver) isGlobalSearch() bool {
 	if r.patternType == query.SearchTypeStructural {
 		return false

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1796,8 +1796,10 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	if alertResult != nil {
 		return alertResult, nil
 	}
-	args.RepoPromise <- resolved.repoRevs // global search
-	args.Repos = resolved.repoRevs        // everything else
+	if r.isGlobalSearch() {
+		args.RepoPromise <- resolved.repoRevs
+	}
+	args.Repos = resolved.repoRevs
 
 	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
 	tr.LazyPrintf("resultTypes: %v", resultTypes)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1793,8 +1793,9 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return false
 	}
 
+	// performance optimization: call zoekt early, resolve repos concurrently, filter
+	// search results with resolved repos.
 	if r.isGlobalSearch() && isFileOrPath() {
-		// call zoekt early
 		argsIndexed := args
 		argsIndexed.Mode = search.ZoektGlobalSearch
 		wg := waitGroup(true)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1082,9 +1082,8 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			}
 		}
 
-		rp := (&search.Promise{}).Resolve(repoRevs)
 		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
-			RepoPromise: rp,
+			RepoPromise: (&search.Promise{}).Resolve(repoRevs),
 			Query:       &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},
 		})
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1082,7 +1082,7 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			}
 		}
 
-		rp := search.NewRepoPromise().Resolve(repoRevs)
+		rp := (&search.Promise{}).Resolve(repoRevs)
 		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
 			RepoPromise: rp,
 			Query:       &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1082,8 +1082,7 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			}
 		}
 
-		rp := search.NewRepoPromise()
-		rp.Resolve(repoRevs)
+		rp := search.NewRepoPromise().Resolve(repoRevs)
 		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
 			RepoPromise: rp,
 			Query:       &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1082,9 +1082,11 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			}
 		}
 
+		rp := search.NewRepoPromise()
+		rp.Resolve(repoRevs)
 		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
-			Repos: repoRevs,
-			Query: &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},
+			RepoPromise: rp,
+			Query:       &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},
 		})
 
 		haveAlertDescription := ""

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -217,10 +217,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		rp := search.NewRepoPromise().Resolve(resolved.repoRevs)
 		fileMatches, _, err := searchSymbols(ctx, &search.TextParameters{
 			PatternInfo:  p,
-			RepoPromise:  rp,
+			RepoPromise:  search.NewRepoPromise().Resolve(resolved.repoRevs),
 			Query:        r.query,
 			Zoekt:        r.zoekt,
 			SearcherURLs: r.searcherURLs,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -219,7 +219,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 
 		fileMatches, _, err := searchSymbols(ctx, &search.TextParameters{
 			PatternInfo:  p,
-			RepoPromise:  search.NewRepoPromise().Resolve(resolved.repoRevs),
+			RepoPromise:  (&search.Promise{}).Resolve(resolved.repoRevs),
 			Query:        r.query,
 			Zoekt:        r.zoekt,
 			SearcherURLs: r.searcherURLs,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -217,8 +217,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		rp := search.NewRepoPromise()
-		rp.Resolve(resolved.repoRevs)
+		rp := search.NewRepoPromise().Resolve(resolved.repoRevs)
 		fileMatches, _, err := searchSymbols(ctx, &search.TextParameters{
 			PatternInfo:  p,
 			RepoPromise:  rp,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -217,9 +217,11 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
+		rp := search.NewRepoPromise()
+		rp.Resolve(resolved.repoRevs)
 		fileMatches, _, err := searchSymbols(ctx, &search.TextParameters{
 			PatternInfo:  p,
-			Repos:        resolved.repoRevs,
+			RepoPromise:  rp,
 			Query:        r.query,
 			Zoekt:        r.zoekt,
 			SearcherURLs: r.searcherURLs,

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -244,8 +244,8 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			if want := "foo-repo"; len(args.Repos) != 1 || string(args.Repos[0].Repo.Name) != want {
-				t.Errorf("got %q, want %q", args.Repos, want)
+			if want := "foo-repo"; len(args.RepoPromise.Get()) != 1 || string(args.RepoPromise.Get()[0].Repo.Name) != want {
+				t.Errorf("got %q, want %q", args.RepoPromise.Get(), want)
 			}
 			return []*FileMatchResolver{
 				mkFileMatch(&types.Repo{Name: "foo-repo"}, "dir/file"),
@@ -346,8 +346,8 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			if want := "foo-repo"; len(args.Repos) != 1 || string(args.Repos[0].Repo.Name) != want {
-				t.Errorf("got %q, want %q", args.Repos, want)
+			if want := "foo-repo"; len(args.RepoPromise.Get()) != 1 || string(args.RepoPromise.Get()[0].Repo.Name) != want {
+				t.Errorf("got %q, want %q", args.RepoPromise.Get(), want)
 			}
 			return []*FileMatchResolver{
 				mkFileMatch(&types.Repo{Name: "foo-repo"}, "dir/bar-file"),

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -244,7 +244,10 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			repos, _ := getRepos(context.Background(), args.RepoPromise)
+			repos, err := getRepos(context.Background(), args.RepoPromise)
+			if err != nil {
+				t.Error(err)
+			}
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
@@ -347,7 +350,10 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			repos, _ := getRepos(context.Background(), args.RepoPromise)
+			repos, err := getRepos(context.Background(), args.RepoPromise)
+			if err != nil {
+				t.Error(err)
+			}
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -244,7 +244,7 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			repos, _ := args.RepoPromise.Get(context.Background())
+			repos, _ := getRepos(context.Background(), args.RepoPromise)
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
@@ -347,7 +347,7 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			repos, _ := args.RepoPromise.Get(context.Background())
+			repos, _ := getRepos(context.Background(), args.RepoPromise)
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -244,8 +244,9 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			if want := "foo-repo"; len(args.RepoPromise.Get()) != 1 || string(args.RepoPromise.Get()[0].Repo.Name) != want {
-				t.Errorf("got %q, want %q", args.RepoPromise.Get(), want)
+			repos, _ := args.RepoPromise.Get(context.Background())
+			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
+				t.Errorf("got %q, want %q", repos, want)
 			}
 			return []*FileMatchResolver{
 				mkFileMatch(&types.Repo{Name: "foo-repo"}, "dir/file"),
@@ -346,8 +347,9 @@ func TestSearchSuggestions(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos = true
-			if want := "foo-repo"; len(args.RepoPromise.Get()) != 1 || string(args.RepoPromise.Get()[0].Repo.Name) != want {
-				t.Errorf("got %q, want %q", args.RepoPromise.Get(), want)
+			repos, _ := args.RepoPromise.Get(context.Background())
+			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
+				t.Errorf("got %q, want %q", repos, want)
 			}
 			return []*FileMatchResolver{
 				mkFileMatch(&types.Repo{Name: "foo-repo"}, "dir/bar-file"),

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -51,7 +51,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return mockSearchSymbols(ctx, args, limit)
 	}
 
-	repos, err := args.RepoPromise.Get(ctx)
+	repos, err := getRepos(ctx, args.RepoPromise)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -55,6 +55,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 	if err != nil {
 		return nil, nil, err
 	}
+
 	tr, ctx := trace.New(ctx, "Search symbols", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(repos)))
 	defer func() {
 		tr.SetError(err)

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -51,7 +51,11 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return mockSearchSymbols(ctx, args, limit)
 	}
 
-	tr, ctx := trace.New(ctx, "Search symbols", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.RepoPromise.Get())))
+	repos, err := args.RepoPromise.Get(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	tr, ctx := trace.New(ctx, "Search symbols", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(repos)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -71,8 +75,8 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return nil, nil, err
 	}
 
-	common.repos = make([]*types.Repo, len(args.RepoPromise.Get()))
-	for i, repo := range args.RepoPromise.Get() {
+	common.repos = make([]*types.Repo, len(repos))
+	for i, repo := range repos {
 		common.repos[i] = repo.Repo
 	}
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -51,7 +51,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return mockSearchSymbols(ctx, args, limit)
 	}
 
-	tr, ctx := trace.New(ctx, "Search symbols", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
+	tr, ctx := trace.New(ctx, "Search symbols", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.RepoPromise.Get())))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -71,8 +71,8 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return nil, nil, err
 	}
 
-	common.repos = make([]*types.Repo, len(args.Repos))
-	for i, repo := range args.Repos {
+	common.repos = make([]*types.Repo, len(args.RepoPromise.Get()))
+	for i, repo := range args.RepoPromise.Get() {
 		common.repos[i] = repo.Repo
 	}
 

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -972,3 +972,33 @@ func TestRepoGroupValuesToRegexp(t *testing.T) {
 		})
 	}
 }
+
+func repoRev(revSpec string) *search.RepositoryRevisions {
+	return &search.RepositoryRevisions{
+		Repo: &types.Repo{ID: api.RepoID(0), Name: "test/repo"},
+		Revs: []search.RevisionSpecifier{
+			{RevSpec: revSpec},
+		},
+	}
+}
+
+func TestGetRepos(t *testing.T) {
+	in := []*search.RepositoryRevisions{repoRev("HEAD")}
+	rp := (&search.Promise{}).Resolve(in)
+	out, err := getRepos(context.Background(), rp)
+	if err != nil {
+		t.Error(err)
+	}
+	if ok := reflect.DeepEqual(in, out); !ok {
+		t.Errorf("got %+v, expected %+v", out, in)
+	}
+}
+
+func TestGetReposWrongUnderlyingType(t *testing.T) {
+	in := "anything"
+	rp := (&search.Promise{}).Resolve(in)
+	_, err := getRepos(context.Background(), rp)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -293,7 +293,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return mockSearchFilesInRepos(args)
 	}
 
-	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s, numRepoRevs: %d", args.PatternInfo.Pattern, len(args.Repos)))
+	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s", args.PatternInfo.Pattern))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -334,11 +334,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	// query, there will be no results. Raise a friendly alert.
 	if args.PatternInfo.IsStructuralPat && len(indexed.Repos()) == 0 {
 		return nil, nil, errors.New("no indexed repositories for structural search")
-	}
-
-	common.repos = make([]*types.Repo, len(args.Repos))
-	for i, repo := range args.Repos {
-		common.repos[i] = repo.Repo
 	}
 
 	if args.PatternInfo.IsEmpty() {
@@ -598,6 +593,11 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	wg.Wait()
 	if searchErr != nil {
 		return nil, common, searchErr
+	}
+
+	common.repos = make([]*types.Repo, len(args.RepoPromise.Get()))
+	for i, repo := range args.RepoPromise.Get() {
+		common.repos[i] = repo.Repo
 	}
 
 	flattened := flattenFileMatches(unflattened, int(args.PatternInfo.FileMatchLimit))

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -595,7 +595,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return nil, common, searchErr
 	}
 
-	repos, err := args.RepoPromise.Get(ctx)
+	repos, err := getRepos(ctx, args.RepoPromise)
 	if err != nil {
 		return nil, common, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -595,8 +595,12 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return nil, common, searchErr
 	}
 
-	common.repos = make([]*types.Repo, len(args.RepoPromise.Get()))
-	for i, repo := range args.RepoPromise.Get() {
+	repos, err := args.RepoPromise.Get(ctx)
+	if err != nil {
+		return nil, common, err
+	}
+	common.repos = make([]*types.Repo, len(repos))
+	for i, repo := range repos {
 		common.repos[i] = repo.Repo
 	}
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -316,9 +316,18 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		indexedTyp = fileRequest
 	}
 
-	indexed, err := newIndexedSearchRequest(ctx, args, indexedTyp)
-	if err != nil {
-		return nil, nil, err
+	var indexed *indexedSearchRequest
+	if args.Mode == search.ZoektGlobalSearch {
+		indexed = &indexedSearchRequest{
+			args:  args,
+			typ:   indexedTyp,
+			repos: &indexedRepoRevs{},
+		}
+	} else {
+		indexed, err = newIndexedSearchRequest(ctx, args, indexedTyp)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	// if there are no indexed repos and this is a structural search
@@ -499,79 +508,81 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return nil
 	} // ends callSearcherOverRepos
 
-	wg.Add(1)
-	go func() {
-		// TODO limitHit, handleRepoSearchResult
-		defer wg.Done()
-		matches, limitHit, reposLimitHit, err := indexed.Search(ctx)
-		mu.Lock()
-		defer mu.Unlock()
-		if ctx.Err() == nil {
-			for _, repo := range indexed.Repos() {
-				common.searched = append(common.searched, repo.Repo)
-				common.indexed = append(common.indexed, repo.Repo)
-			}
-			for repo := range reposLimitHit {
-				// Repos that aren't included in the result set due to exceeded limits are partially searched
-				// for dynamic filter purposes. Note, reposLimitHit may include repos that did not have any results
-				// returned in the original result set, because indexed search has `limitHit` for the
-				// entire search rather than per repo as in non-indexed search.
-				common.partial[api.RepoName(repo)] = struct{}{}
-			}
-		}
-		if limitHit {
-			common.limitHit = true
-		}
-		if err == errNoResultsInTimeout {
-			// Effectively, all repositories have timed out.
-			for _, repo := range indexed.Repos() {
-				common.timedout = append(common.timedout, repo.Repo)
-			}
-		}
-		tr.LogFields(otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
-		if err != nil && err != errNoResultsInTimeout && searchErr == nil && !overLimitCanceled {
-			searchErr = err
-			tr.LazyPrintf("cancel indexed search due to error: %v", err)
-			cancel()
-		}
-
-		if args.PatternInfo.IsStructuralPat {
-			// A partition of {repo name => file list} that we will build from Zoekt matches
-			partition := make(map[string][]string)
-			var repos []*search.RepositoryRevisions
-
-			for _, m := range matches {
-				name := string(m.Repo.Name())
-				partition[name] = append(partition[name], m.JPath)
-			}
-
-			// Filter Zoekt repos that didn't contain matches
-			for _, repo := range indexed.Repos() {
-				for key := range partition {
-					if string(repo.Repo.Name) == key {
-						repos = append(repos, repo)
-					}
+	if args.Mode != search.SearcherOnly {
+		wg.Add(1)
+		go func() {
+			// TODO limitHit, handleRepoSearchResult
+			defer wg.Done()
+			matches, limitHit, reposLimitHit, err := indexed.Search(ctx)
+			mu.Lock()
+			defer mu.Unlock()
+			if ctx.Err() == nil {
+				for _, repo := range indexed.Repos() {
+					common.searched = append(common.searched, repo.Repo)
+					common.indexed = append(common.indexed, repo.Repo)
+				}
+				for repo := range reposLimitHit {
+					// Repos that aren't included in the result set due to exceeded limits are partially searched
+					// for dynamic filter purposes. Note, reposLimitHit may include repos that did not have any results
+					// returned in the original result set, because indexed search has `limitHit` for the
+					// entire search rather than per repo as in non-indexed search.
+					common.partial[api.RepoName(repo)] = struct{}{}
 				}
 			}
-
-			// For structural search, we run callSearcherOverRepos
-			// over the set of repos and files known to contain
-			// parts of the pattern as determined by Zoekt.
-			// callSearcherOverRepos must acquire the lock, so we
-			// must release the lock held by Zoekt at this point.
-			// The Zoekt part of the search is done here as far as
-			// structural search is concerned, so the lock can be
-			// freely released.
-			mu.Unlock()
-			err := callSearcherOverRepos(repos, partition)
-			mu.Lock()
-			if err != nil {
-				searchErr = err
+			if limitHit {
+				common.limitHit = true
 			}
-		} else {
-			addMatches(matches)
-		}
-	}()
+			if err == errNoResultsInTimeout {
+				// Effectively, all repositories have timed out.
+				for _, repo := range indexed.Repos() {
+					common.timedout = append(common.timedout, repo.Repo)
+				}
+			}
+			tr.LogFields(otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
+			if err != nil && err != errNoResultsInTimeout && searchErr == nil && !overLimitCanceled {
+				searchErr = err
+				tr.LazyPrintf("cancel indexed search due to error: %v", err)
+				cancel()
+			}
+
+			if args.PatternInfo.IsStructuralPat {
+				// A partition of {repo name => file list} that we will build from Zoekt matches
+				partition := make(map[string][]string)
+				var repos []*search.RepositoryRevisions
+
+				for _, m := range matches {
+					name := string(m.Repo.Name())
+					partition[name] = append(partition[name], m.JPath)
+				}
+
+				// Filter Zoekt repos that didn't contain matches
+				for _, repo := range indexed.Repos() {
+					for key := range partition {
+						if string(repo.Repo.Name) == key {
+							repos = append(repos, repo)
+						}
+					}
+				}
+
+				// For structural search, we run callSearcherOverRepos
+				// over the set of repos and files known to contain
+				// parts of the pattern as determined by Zoekt.
+				// callSearcherOverRepos must acquire the lock, so we
+				// must release the lock held by Zoekt at this point.
+				// The Zoekt part of the search is done here as far as
+				// structural search is concerned, so the lock can be
+				// freely released.
+				mu.Unlock()
+				err := callSearcherOverRepos(repos, partition)
+				mu.Lock()
+				if err != nil {
+					searchErr = err
+				}
+			} else {
+				addMatches(matches)
+			}
+		}()
+	}
 
 	// This guard disables
 	// - unindexed structural search

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -65,13 +65,12 @@ func TestSearchFilesInRepos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rp := search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev"))
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  rp,
+		RepoPromise:  search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -96,13 +95,12 @@ func TestSearchFilesInRepos(t *testing.T) {
 
 	// If we specify a rev and it isn't found, we fail the whole search since
 	// that should be checked earlier.
-	rp = search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/no-rev@dev"))
 	args = &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  rp,
+		RepoPromise:  search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/no-rev@dev")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -142,13 +140,12 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rp := search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/"))
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  rp,
+		RepoPromise:  search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -65,8 +65,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rp := search.NewRepoPromise()
-	rp.Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev"))
+	rp := search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev"))
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
@@ -97,8 +96,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 
 	// If we specify a rev and it isn't found, we fail the whole search since
 	// that should be checked earlier.
-	rp = search.NewRepoPromise()
-	rp.Resolve(makeRepositoryRevisions("foo/no-rev@dev"))
+	rp = search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/no-rev@dev"))
 	args = &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
@@ -144,8 +142,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rp := search.NewRepoPromise()
-	rp.Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/"))
+	rp := search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/"))
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
 			FileMatchLimit: defaultMaxSearchResults,
@@ -156,7 +153,8 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
 	}
-	args.RepoPromise.Get()[0].ListRefs = func(context.Context, gitserver.Repo) ([]git.Ref, error) {
+	repos, _ := args.RepoPromise.Get(context.Background())
+	repos[0].ListRefs = func(context.Context, gitserver.Repo) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}
 	results, _, err := searchFilesInRepos(context.Background(), args)

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -70,7 +70,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev")),
+		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-db", "foo/timedout", "foo/no-rev")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -100,7 +100,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo/no-rev@dev")),
+		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo/no-rev@dev")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
@@ -145,12 +145,12 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 			FileMatchLimit: defaultMaxSearchResults,
 			Pattern:        "foo",
 		},
-		RepoPromise:  search.NewRepoPromise().Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")),
+		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")),
 		Query:        q,
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
 	}
-	repos, _ := args.RepoPromise.Get(context.Background())
+	repos, _ := getRepos(context.Background(), args.RepoPromise)
 	repos[0].ListRefs = func(context.Context, gitserver.Repo) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -90,7 +90,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	repos, err := args.RepoPromise.Get(ctx)
+	repos, err := getRepos(ctx, args.RepoPromise)
 	if err != nil {
 		return nil, err
 	}
@@ -394,10 +394,11 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		for _, file := range resp.Files {
 			m[file.Repository] = nil
 		}
-		repos, err := args.RepoPromise.Get(ctx)
+		repos, err := getRepos(ctx, args.RepoPromise)
 		if err != nil {
 			return nil, false, nil, err
 		}
+
 		for _, repo := range repos {
 			if _, ok := m[string(repo.Repo.Name)]; !ok {
 				continue

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -309,6 +309,10 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	if err != nil {
 		return nil, false, nil, err
 	}
+	// Performance optimization: For queries without repo: filters, it is not
+	// necessary to send the list of all repoBranches to zoekt. Zoekt can simply
+	// search all its shards and we filter the results later against the list of
+	// repos we resolve concurrently.
 	var finalQuery zoektquery.Q
 	if args.Mode == search.ZoektGlobalSearch {
 		finalQuery = zoektquery.NewAnd(&zoektquery.Branch{Pattern: "HEAD", Exact: true}, queryExceptRepos)

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -199,10 +199,11 @@ func (s *indexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
 }
 
 func (s *indexedSearchRequest) Search(ctx context.Context) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
-	if len(s.Repos()) == 0 {
-		if s.args == nil || s.args.Mode != search.ZoektGlobalSearch {
-			return nil, false, nil, nil
-		}
+	if s.args == nil {
+		return nil, false, nil, nil
+	}
+	if len(s.Repos()) == 0 && s.args.Mode != search.ZoektGlobalSearch {
+		return nil, false, nil, nil
 	}
 
 	since := time.Since
@@ -297,10 +298,11 @@ var errNoResultsInTimeout = errors.New("no results found in specified timeout")
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
 func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
-	if len(repos.repoRevs) == 0 {
-		if args == nil || args.Mode != search.ZoektGlobalSearch {
-			return nil, false, nil, nil
-		}
+	if args == nil {
+		return nil, false, nil, nil
+	}
+	if len(repos.repoRevs) == 0 && args.Mode != search.ZoektGlobalSearch {
+		return nil, false, nil, nil
 	}
 
 	queryExceptRepos, err := queryToZoektQuery(args.PatternInfo, typ)

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -314,7 +314,7 @@ func TestIndexedSearch(t *testing.T) {
 			}
 
 			args.RepoPromise <- args.Repos
-			defer close(args.RepoPromise)
+			close(args.RepoPromise)
 
 			indexed, err := newIndexedSearchRequest(context.Background(), args, textRequest)
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -297,11 +297,11 @@ func TestIndexedSearch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			rp := search.NewRepoPromise().Resolve(tt.args.repos)
+
 			args := &search.TextParameters{
 				Query:           q,
 				PatternInfo:     tt.args.patternInfo,
-				RepoPromise:     rp,
+				RepoPromise:     search.NewRepoPromise().Resolve(tt.args.repos),
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt: &searchbackend.Zoekt{
 					Client: &fakeSearcher{

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -302,6 +302,7 @@ func TestIndexedSearch(t *testing.T) {
 				Query:           q,
 				PatternInfo:     tt.args.patternInfo,
 				Repos:           tt.args.repos,
+				RepoPromise:     make(chan []*search.RepositoryRevisions, 1),
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt: &searchbackend.Zoekt{
 					Client: &fakeSearcher{
@@ -311,6 +312,9 @@ func TestIndexedSearch(t *testing.T) {
 					DisableCache: true,
 				},
 			}
+
+			args.RepoPromise <- args.Repos
+			defer close(args.RepoPromise)
 
 			indexed, err := newIndexedSearchRequest(context.Background(), args, textRequest)
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -297,12 +297,12 @@ func TestIndexedSearch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
+			rp := search.NewRepoPromise()
+			rp.Resolve(tt.args.repos)
 			args := &search.TextParameters{
 				Query:           q,
 				PatternInfo:     tt.args.patternInfo,
-				Repos:           tt.args.repos,
-				RepoPromise:     make(chan []*search.RepositoryRevisions, 1),
+				RepoPromise:     rp,
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt: &searchbackend.Zoekt{
 					Client: &fakeSearcher{
@@ -312,9 +312,6 @@ func TestIndexedSearch(t *testing.T) {
 					DisableCache: true,
 				},
 			}
-
-			args.RepoPromise <- args.Repos
-			close(args.RepoPromise)
 
 			indexed, err := newIndexedSearchRequest(context.Background(), args, textRequest)
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -297,8 +297,7 @@ func TestIndexedSearch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			rp := search.NewRepoPromise()
-			rp.Resolve(tt.args.repos)
+			rp := search.NewRepoPromise().Resolve(tt.args.repos)
 			args := &search.TextParameters{
 				Query:           q,
 				PatternInfo:     tt.args.patternInfo,

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -301,7 +301,7 @@ func TestIndexedSearch(t *testing.T) {
 			args := &search.TextParameters{
 				Query:           q,
 				PatternInfo:     tt.args.patternInfo,
-				RepoPromise:     search.NewRepoPromise().Resolve(tt.args.repos),
+				RepoPromise:     (&search.Promise{}).Resolve(tt.args.repos),
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt: &searchbackend.Zoekt{
 					Client: &fakeSearcher{

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -68,11 +68,11 @@ type SymbolsParameters struct {
 	First int
 }
 
-type GlobalSearchMode string
+type GlobalSearchMode int
 
-var (
-	ZoektGlobalSearch = GlobalSearchMode("globalIndex")
-	SearcherOnly      = GlobalSearchMode("searcherOnly")
+const (
+	ZoektGlobalSearch GlobalSearchMode = iota + 1
+	SearcherOnly
 )
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -68,6 +68,13 @@ type SymbolsParameters struct {
 	First int
 }
 
+type Mode string
+
+var (
+	ZoektGlobalSearch = Mode("globalIndex")
+	SearcherOnly      = Mode("searcherOnly")
+)
+
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to
 // search. It defines behavior for text search on repository names, file names, and file content.
@@ -79,6 +86,10 @@ type TextParameters struct {
 	// instead, but Query is useful for checking extra fields that are set and
 	// ignored by Pattern, such as index:no
 	Query query.QueryInfo
+
+	Mode Mode
+
+	RepoPromise chan []*RepositoryRevisions
 
 	// UseFullDeadline indicates that the search should try do as much work as
 	// it can within context.Deadline. If false the search should try and be

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -68,11 +68,11 @@ type SymbolsParameters struct {
 	First int
 }
 
-type Mode string
+type GlobalSearchMode string
 
 var (
-	ZoektGlobalSearch = Mode("globalIndex")
-	SearcherOnly      = Mode("searcherOnly")
+	ZoektGlobalSearch = GlobalSearchMode("globalIndex")
+	SearcherOnly      = GlobalSearchMode("searcherOnly")
 )
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
@@ -82,14 +82,17 @@ type TextParameters struct {
 	PatternInfo *TextPatternInfo
 	Repos       []*RepositoryRevisions
 
+	// Performance optimization.
+	//
+	// For global queries, resolving repositories and querying zoekt happens
+	// concurrently. Eventually RepoPromise and Repos will be identical.
+	RepoPromise chan []*RepositoryRevisions
+	Mode        GlobalSearchMode
+
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and
 	// ignored by Pattern, such as index:no
 	Query query.QueryInfo
-
-	Mode Mode
-
-	RepoPromise chan []*RepositoryRevisions
 
 	// UseFullDeadline indicates that the search should try do as much work as
 	// it can within context.Deadline. If false the search should try and be

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -105,7 +105,8 @@ func (p *Promise) Resolve(v interface{}) *Promise {
 // Get returns the value. It blocks until the promise resolves or the context is
 // canceled. Further calls to Get will always return the original results, IE err
 // will stay nil even if the context expired between the first and the second
-// call.
+// call. Vice versa, if ctx finishes while resolving, then we will always return
+// ctx.Err()
 func (p *Promise) Get(ctx context.Context) (interface{}, error) {
 	p.getOnce.Do(func() {
 		p.init()

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -20,7 +20,7 @@ func repoRev(revSpec string) *RepositoryRevisions {
 
 func TestRepoPromise(t *testing.T) {
 	in := []*RepositoryRevisions{repoRev("HEAD")}
-	rp := NewRepoPromise().Resolve(in)
+	rp := (&Promise{}).Resolve(in)
 	out, err := rp.Get(context.Background())
 	if err != nil {
 		t.Fatal("error should have been nil, because we supplied a context.Background()")
@@ -31,7 +31,7 @@ func TestRepoPromise(t *testing.T) {
 }
 
 func TestRepoPromiseWithCancel(t *testing.T) {
-	rp := NewRepoPromise()
+	rp := Promise{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := rp.Get(ctx)
@@ -43,7 +43,7 @@ func TestRepoPromiseWithCancel(t *testing.T) {
 func TestRepoPromiseConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	in := []*RepositoryRevisions{repoRev("HEAD")}
-	rp := NewRepoPromise()
+	rp := Promise{}
 	go func() {
 		rp.Resolve(in)
 	}()

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -1,0 +1,67 @@
+package search
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func repoRev(revSpec string) *RepositoryRevisions {
+	return &RepositoryRevisions{
+		Repo: &types.Repo{ID: api.RepoID(0), Name: "test/repo"},
+		Revs: []RevisionSpecifier{
+			{RevSpec: revSpec},
+		},
+	}
+}
+
+func TestRepoPromise(t *testing.T) {
+	in := []*RepositoryRevisions{repoRev("HEAD")}
+	rp := NewRepoPromise().Resolve(in)
+	out, err := rp.Get(context.Background())
+	if err != nil {
+		t.Fatal("error should have been nil, because we supplied a context.Background()")
+	}
+	if ok := reflect.DeepEqual(in, out); !ok {
+		t.Fatalf("got %+v, expected %+v", out, in)
+	}
+}
+
+func TestRepoPromiseWithCancel(t *testing.T) {
+	rp := NewRepoPromise()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := rp.Get(ctx)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRepoPromiseConcurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	in := []*RepositoryRevisions{repoRev("HEAD")}
+	rp := NewRepoPromise()
+	go func() {
+		rp.Resolve(in)
+	}()
+	out, err := rp.Get(ctx)
+	if err != nil {
+		t.Fatal("error should have been nil, because we didn't cancel the context")
+	}
+	if ok := reflect.DeepEqual(in, out); !ok {
+		t.Fatalf("got %+v, expected %+v", out, in)
+	}
+
+	cancel()
+
+	out, err = rp.Get(ctx)
+	if err != nil {
+		t.Fatal("error should have been nil, because we canceled the context after the first call to get")
+	}
+	if ok := reflect.DeepEqual(in, out); !ok {
+		t.Fatalf("got %+v, expected %+v", out, in)
+	}
+}

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -4,24 +4,12 @@ import (
 	"context"
 	"reflect"
 	"testing"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-func repoRev(revSpec string) *RepositoryRevisions {
-	return &RepositoryRevisions{
-		Repo: &types.Repo{ID: api.RepoID(0), Name: "test/repo"},
-		Revs: []RevisionSpecifier{
-			{RevSpec: revSpec},
-		},
-	}
-}
-
-func TestRepoPromise(t *testing.T) {
-	in := []*RepositoryRevisions{repoRev("HEAD")}
-	rp := (&Promise{}).Resolve(in)
-	out, err := rp.Get(context.Background())
+func TestPromiseGet(t *testing.T) {
+	in := "anything"
+	p := (&Promise{}).Resolve(in)
+	out, err := p.Get(context.Background())
 	if err != nil {
 		t.Fatal("error should have been nil, because we supplied a context.Background()")
 	}
@@ -30,7 +18,7 @@ func TestRepoPromise(t *testing.T) {
 	}
 }
 
-func TestRepoPromiseWithCancel(t *testing.T) {
+func TestPromiseGetWithCancel(t *testing.T) {
 	rp := Promise{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -40,14 +28,14 @@ func TestRepoPromiseWithCancel(t *testing.T) {
 	}
 }
 
-func TestRepoPromiseConcurrent(t *testing.T) {
+func TestPromiseGetConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	in := []*RepositoryRevisions{repoRev("HEAD")}
-	rp := Promise{}
+	in := "anything"
+	p := Promise{}
 	go func() {
-		rp.Resolve(in)
+		p.Resolve(in)
 	}()
-	out, err := rp.Get(ctx)
+	out, err := p.Get(ctx)
 	if err != nil {
 		t.Fatal("error should have been nil, because we didn't cancel the context")
 	}
@@ -57,7 +45,7 @@ func TestRepoPromiseConcurrent(t *testing.T) {
 
 	cancel()
 
-	out, err = rp.Get(ctx)
+	out, err = p.Get(ctx)
 	if err != nil {
 		t.Fatal("error should have been nil, because we canceled the context after the first call to get")
 	}


### PR DESCRIPTION
For global queries, we call zoekt before resolving and splitting repositories. The scope of this PR is limited to `file` and `path` results for literal search without version contexts.

**Why?**
traces of global queries shows that a significant amount of time is spent on handling large lists of repository references. Specifically, we spent a lot of time on: 
- resolving
- splitting
- serializing

For global queries, we can save time, because zoekt can simply search all shards without having to match them against a list of indexed repositories. 

We still have to filter the results coming from zoekt to make sure the user sees only repositories she has access to.  