### PR TITLE
Properly truncate path breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Usernames set in Slack `observability.alerts` now apply correctly. [#14079](https://github.com/sourcegraph/sourcegraph/pull/14079)
+- Path segments in breadcrumbs get truncated correctly again on small screen sizes instead of inflating the header bar. [#14097](https://github.com/sourcegraph/sourcegraph/pull/14097)
 
 ## 3.20.1
 

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -24,10 +24,8 @@ interface BaseBreadcrumb {
 }
 
 interface ElementBreadcrumb extends BaseBreadcrumb {
-
     /** The breadcrumb element being displayed. */
     element: React.ReactNode
-
 }
 
 interface LinkBreadcrumb extends BaseBreadcrumb {
@@ -165,7 +163,13 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location:
                 // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
                 // render link breadcrumbs as plain text
                 return (
-                    <span key={breadcrumb.key} className={classNames('text-muted d-flex align-items-center test-breadcrumb', breadcrumb.className)}>
+                    <span
+                        key={breadcrumb.key}
+                        className={classNames(
+                            'text-muted d-flex align-items-center test-breadcrumb',
+                            breadcrumb.className
+                        )}
+                    >
                         <span className="font-weight-semibold">{divider}</span>
                         {isElementBreadcrumb(breadcrumb) ? (
                             breadcrumb.element

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -5,15 +5,16 @@ import { sortBy } from 'lodash'
 import { Unsubscribable } from 'sourcegraph'
 import { isDefined } from '../../../shared/src/util/types'
 import * as H from 'history'
+import classNames from 'classnames'
 
 export type Breadcrumb = ElementBreadcrumb | LinkBreadcrumb
 
-interface ElementBreadcrumb {
+interface BaseBreadcrumb {
     /** A unique key for the breadcrumb. */
     key: string
 
-    /** The breadcrumb element being displayed. */
-    element: React.ReactNode
+    /** A CSS class name to apply to the container of the breadcrumb element. */
+    className?: string
 
     /**
      * Optionally a custom divider displayed before the element.
@@ -22,21 +23,19 @@ interface ElementBreadcrumb {
     divider?: React.ReactNode
 }
 
-interface LinkBreadcrumb {
-    /** A unique key for the breadcrumb. */
-    key: string
+interface ElementBreadcrumb extends BaseBreadcrumb {
 
+    /** The breadcrumb element being displayed. */
+    element: React.ReactNode
+
+}
+
+interface LinkBreadcrumb extends BaseBreadcrumb {
     /**
      * Specification for links. When this breadcrumb is the last breadcrumb and
      * the URL hash is empty, the label is rendered as plain text instead of a link.
      */
     link: { label: string; to: string }
-
-    /**
-     * Optionally a custom divider displayed before the element.
-     * By default a chevron icon `>` is used.
-     */
-    divider?: React.ReactNode
 }
 
 /** Type guard to differentiate arbitrary elements and links */
@@ -156,7 +155,7 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location:
     breadcrumbs,
     location,
 }) => (
-    <nav className="d-flex p-2" aria-label="Breadcrumbs">
+    <nav className="d-flex p-2 flex-shrink-past-contents" aria-label="Breadcrumbs">
         {sortBy(breadcrumbs, 'depth')
             .map(({ breadcrumb }) => breadcrumb)
             .filter(isDefined)
@@ -166,7 +165,7 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location:
                 // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
                 // render link breadcrumbs as plain text
                 return (
-                    <span key={breadcrumb.key} className="text-muted d-flex align-items-center test-breadcrumb">
+                    <span key={breadcrumb.key} className={classNames('text-muted d-flex align-items-center test-breadcrumb', breadcrumb.className)}>
                         <span className="font-weight-semibold">{divider}</span>
                         {isElementBreadcrumb(breadcrumb) ? (
                             breadcrumb.element

--- a/web/src/repo/FilePathBreadcrumbs.scss
+++ b/web/src/repo/FilePathBreadcrumbs.scss
@@ -11,6 +11,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         text-align: center;
+        white-space: nowrap;
     }
 
     .part-last {

--- a/web/src/repo/FilePathBreadcrumbs.scss
+++ b/web/src/repo/FilePathBreadcrumbs.scss
@@ -1,9 +1,12 @@
 .file-path-breadcrumbs {
     display: flex;
+    min-width: 0;
+    overflow: hidden;
     align-items: center;
 
     .part-directory {
         flex: 1 1 1em;
+        min-width: 1em;
         max-width: fit-content;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/web/src/repo/FilePathBreadcrumbs.scss
+++ b/web/src/repo/FilePathBreadcrumbs.scss
@@ -3,6 +3,7 @@
     min-width: 0;
     overflow: hidden;
     align-items: center;
+    white-space: nowrap;
 
     .part-directory {
         flex: 1 1 1em;
@@ -11,7 +12,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
         text-align: center;
-        white-space: nowrap;
     }
 
     .part-last {

--- a/web/src/repo/RepoHeader.tsx
+++ b/web/src/repo/RepoHeader.tsx
@@ -180,7 +180,7 @@ export const RepoHeader: React.FunctionComponent<Props> = ({ onLifecyclePropsCha
     const rightActions = repoHeaderContributions.filter(({ position }) => position === 'right')
     return (
         <nav className="repo-header navbar navbar-expand">
-            <div className="d-flex align-items-center">
+            <div className="d-flex align-items-center flex-shrink-past-contents">
                 {/* Breadcrumb for the nav elements */}
                 <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
             </div>

--- a/web/src/repo/blob/BlobPage.tsx
+++ b/web/src/repo/blob/BlobPage.tsx
@@ -122,6 +122,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
 
             return {
                 key: 'filePath',
+                className: 'flex-shrink-past-contents',
                 element: (
                     // TODO should these be "flattened" all using setBreadcrumb()?
                     <FilePathBreadcrumbs

--- a/web/src/repo/tree/TreePage.tsx
+++ b/web/src/repo/tree/TreePage.tsx
@@ -147,6 +147,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
             }
             return {
                 key: 'treePath',
+                className: 'flex-shrink-past-contents',
                 element: (
                     <FilePathBreadcrumbs
                         key="path"


### PR DESCRIPTION
Restores the ellipsis truncation behavior. All ancestors need to have a `min-width` to shrink and truncate.

![image](https://user-images.githubusercontent.com/10532611/94017081-4495e600-fdaf-11ea-814e-a3c68cd18977.png)

Fixes #13535