### PR TITLE
Add background job for deleting completed external service sync jobs

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -83,6 +83,7 @@ func (s *Syncer) Run(pctx context.Context, db *sql.DB, store Store, opts RunOpti
 		WorkerInterval:       opts.DequeueInterval,
 		NumHandlers:          3,
 		PrometheusRegisterer: s.Registerer,
+		CleanupOldJobs:       true,
 	})
 
 	go worker.Start()


### PR DESCRIPTION
This PR adds a ~trigger~ background job that deletes completed or errored jobs from the `external_service_sync_jobs` table. This table can potentially grow a lot with the number of user-added external services, this change makes sure it remains small.
All the `completed` and `errored` jobs finished since more than one day are deleted automatically.
~The function is triggered whenever a job is marked as `completed` or `errored` which shouldn't happen a lot (a few times per second at most).~
The function is run every hour by default.
Fixes #14048 
