### PR TITLE
Re-attach changesets to campaign that were owned by campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Path segments in breadcrumbs get truncated correctly again on small screen sizes instead of inflating the header bar. [#14097](https://github.com/sourcegraph/sourcegraph/pull/14097)
 - GitLab pipelines are now parsed correctly and show their current status in campaign changesets. [#14129](https://github.com/sourcegraph/sourcegraph/pull/14129)
 - Fixed an issue where specifying any repogroups would effectively search all repositories for all repogroups. [#14190](https://github.com/sourcegraph/sourcegraph/pull/14190)
+- Changesets that were previously closed after being detached from a campaign are now reopened when being reattached. [#14099](https://github.com/sourcegraph/sourcegraph/pull/14099)
 
 ### Removed
 

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -229,6 +229,17 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 	return nil
 }
 
+// ReopenChangeset reopens the *Changeset on the code host and updates the
+// Metadata column in the *campaigns.Changeset.
+func (s BitbucketServerSource) ReopenChangeset(ctx context.Context, c *Changeset) error {
+	_, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
+	if !ok {
+		return errors.New("Changeset is not a Bitbucket Server pull request")
+	}
+
+	return errors.New("TODO: not implemented!")
+}
+
 // ExternalServices returns a singleton slice containing the external service.
 func (s BitbucketServerSource) ExternalServices() ExternalServices {
 	return ExternalServices{s.svc}

--- a/cmd/repo-updater/repos/bitbucketserver.go
+++ b/cmd/repo-updater/repos/bitbucketserver.go
@@ -232,12 +232,18 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 // ReopenChangeset reopens the *Changeset on the code host and updates the
 // Metadata column in the *campaigns.Changeset.
 func (s BitbucketServerSource) ReopenChangeset(ctx context.Context, c *Changeset) error {
-	_, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
+	pr, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
 	if !ok {
 		return errors.New("Changeset is not a Bitbucket Server pull request")
 	}
 
-	return errors.New("TODO: not implemented!")
+	if err := s.client.ReopenPullRequest(ctx, pr); err != nil {
+		return err
+	}
+
+	c.Changeset.Metadata = pr
+
+	return nil
 }
 
 // ExternalServices returns a singleton slice containing the external service.

--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -423,6 +423,75 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 	}
 }
 
+func TestBitbucketServerSource_ReopenChangeset(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		// The test fixtures and golden files were generated with
+		// this config pointed to bitbucket.sgdev.org
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	pr := &bitbucketserver.PullRequest{ID: 95, Version: 1}
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs:   &Changeset{Changeset: &campaigns.Changeset{Metadata: pr}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "BitbucketServerSource_ReopenChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+
+		t.Run(tc.name, func(t *testing.T) {
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &ExternalService{
+				Kind: extsvc.KindBitbucketServer,
+				Config: marshalJSON(t, &schema.BitbucketServerConnection{
+					Url:   instanceURL,
+					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				}),
+			}
+
+			bbsSrc, err := NewBitbucketServerSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			err = bbsSrc.ReopenChangeset(ctx, tc.cs)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
+		})
+	}
+}
+
 func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
 	if instanceURL == "" {

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -259,6 +259,23 @@ func (s GithubSource) UpdateChangeset(ctx context.Context, c *Changeset) error {
 	return nil
 }
 
+// ReopenChangeset reopens the given *Changeset on the code host.
+func (s GithubSource) ReopenChangeset(ctx context.Context, c *Changeset) error {
+	pr, ok := c.Changeset.Metadata.(*github.PullRequest)
+	if !ok {
+		return errors.New("Changeset is not a GitHub pull request")
+	}
+
+	err := s.client.ReopenPullRequest(ctx, pr)
+	if err != nil {
+		return err
+	}
+
+	c.Changeset.Metadata = pr
+
+	return nil
+}
+
 // GetRepo returns the Github repository with the given name and owner
 // ("org/repo-name")
 func (s GithubSource) GetRepo(ctx context.Context, nameWithOwner string) (*Repo, error) {

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -201,6 +201,74 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 	}
 }
 
+func TestGithubSource_ReopenChangeset(t *testing.T) {
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs: &Changeset{
+				Changeset: &campaigns.Changeset{
+					Metadata: &github.PullRequest{
+						// https://github.com/sourcegraph/automation-testing/pull/353
+						ID: "MDExOlB1bGxSZXF1ZXN0NDg4MDI2OTk5",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "GithubSource_ReopenChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+
+		t.Run(tc.name, func(t *testing.T) {
+			// The GithubSource uses the github.Client under the hood, which
+			// uses rcache, a caching layer that uses Redis.
+			// We need to clear the cache before we run the tests
+			rcache.SetupForTest(t)
+
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &ExternalService{
+				Kind: extsvc.KindGitHub,
+				Config: marshalJSON(t, &schema.GitHubConnection{
+					Url:   "https://github.com",
+					Token: os.Getenv("GITHUB_TOKEN"),
+				}),
+			}
+
+			githubSrc, err := NewGithubSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			err = githubSrc.ReopenChangeset(ctx, tc.cs)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			pr := tc.cs.Changeset.Metadata.(*github.PullRequest)
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
+		})
+	}
+}
+
 func TestGithubSource_UpdateChangeset(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -302,6 +302,8 @@ func projectQueryToURL(projectQuery string, perPage int) (string, error) {
 	return u.String(), nil
 }
 
+var _ ChangesetSource = &GitLabSource{}
+
 // CreateChangeset creates a GitLab merge request. If it already exists,
 // *Changeset will be populated and the return value will be true.
 func (s *GitLabSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error) {
@@ -390,6 +392,16 @@ func (s *GitLabSource) LoadChangesets(ctx context.Context, cs ...*Changeset) err
 	}
 
 	return nil
+}
+
+// ReopenChangeset closes the merge request on GitLab, leaving it unlocked.
+func (s *GitLabSource) ReopenChangeset(ctx context.Context, c *Changeset) error {
+	_, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
+	if !ok {
+		return errors.New("Changeset is not a GitLab merge request")
+	}
+
+	return errors.New("TODO: not implemented yet")
 }
 
 func (s *GitLabSource) decorateMergeRequestData(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) error {

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -116,6 +116,16 @@ type ChangesetSource interface {
 	UpdateChangeset(context.Context, *Changeset) error
 }
 
+// A ChangesetReopener is a ChangesetSource that can reopen Changesets.
+// We can remove this once all ChangesetSources can reopen changtesets.
+type ChangesetReopener interface {
+	ChangesetSource
+
+	// ReopenChangeset will reopen the Changeset on the source, if it's closed.
+	// If not, it's a noop.
+	ReopenChangeset(context.Context, *Changeset) error
+}
+
 // ChangesetsNotFoundError is returned by LoadChangesets if any of the passed
 // Changesets could not be found on the codehost.
 type ChangesetsNotFoundError struct {

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -117,7 +117,7 @@ type ChangesetSource interface {
 }
 
 // A ChangesetReopener is a ChangesetSource that can reopen Changesets.
-// We can remove this once all ChangesetSources can reopen changtesets.
+// We can remove this once all ChangesetSources can reopen changesets.
 type ChangesetReopener interface {
 	ChangesetSource
 

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -114,13 +114,6 @@ type ChangesetSource interface {
 	CloseChangeset(context.Context, *Changeset) error
 	// UpdateChangeset can update Changesets.
 	UpdateChangeset(context.Context, *Changeset) error
-}
-
-// A ChangesetReopener is a ChangesetSource that can reopen Changesets.
-// We can remove this once all ChangesetSources can reopen changesets.
-type ChangesetReopener interface {
-	ChangesetSource
-
 	// ReopenChangeset will reopen the Changeset on the source, if it's closed.
 	// If not, it's a noop.
 	ReopenChangeset(context.Context, *Changeset) error

--- a/cmd/repo-updater/repos/testdata/golden/BitbucketServerSource_ReopenChangeset_success
+++ b/cmd/repo-updater/repos/testdata/golden/BitbucketServerSource_ReopenChangeset_success
@@ -1,0 +1,55 @@
+{
+  "id": 95,
+  "version": 2,
+  "title": "Replace fmt.Sprintf with equivalent strconv.Itoa",
+  "description": "This campaign replaces `fmt.Sprintf` with `strconv.Itoa`",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1600256487945,
+  "updatedDate": 1600950914772,
+  "fromRef": {
+   "id": "refs/heads/campaigns-demo/sprintf-to-itoa",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "thorsten",
+    "emailAddress": "thorsten@sourcegraph.com",
+    "id": 104,
+    "displayName": "thorsten",
+    "active": true,
+    "slug": "thorsten",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/95"
+    }
+   ]
+  }
+ }

--- a/cmd/repo-updater/repos/testdata/golden/GithubSource_ReopenChangeset_success
+++ b/cmd/repo-updater/repos/testdata/golden/GithubSource_ReopenChangeset_success
@@ -1,0 +1,113 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0NDg4MDI2OTk5",
+  "Title": "Replace fmt.Sprintf with equivalent strconv.Itoa",
+  "Body": "This campaign replaces `fmt.Sprintf` with `strconv.Itoa`",
+  "State": "OPEN",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/353",
+  "HeadRefOid": "d965153c0b869943e935878d23a576928cc8c951",
+  "BaseRefOid": "6274d04b734de9f057bb5f196a5046a9e86ba992",
+  "HeadRefName": "campaigns-screenshare/sprintf-to-itoa",
+  "BaseRefName": "master",
+  "Number": 353,
+  "Author": {
+   "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+   "Login": "mrnugget",
+   "URL": "https://github.com/mrnugget"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "Labels": {
+   "Nodes": []
+  },
+  "TimelineItems": [
+   {
+    "Type": "PullRequestCommit",
+    "Item": {
+     "Commit": {
+      "OID": "d965153c0b869943e935878d23a576928cc8c951",
+      "Message": "Replacing fmt.Sprintf with strconv.Iota",
+      "MessageHeadline": "Replacing fmt.Sprintf with strconv.Iota",
+      "URL": "https://github.com/sourcegraph/automation-testing/commit/d965153c0b869943e935878d23a576928cc8c951",
+      "Committer": {
+       "AvatarURL": "https://avatars3.githubusercontent.com/u/1185253?v=4",
+       "Email": "thorsten@sourcegraph.com",
+       "Name": "Thorsten Ball",
+       "User": {
+        "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+        "Login": "mrnugget",
+        "URL": "https://github.com/mrnugget"
+       }
+      },
+      "CommittedDate": "2020-09-16T14:23:01Z",
+      "PushedDate": "2020-09-16T14:23:07Z"
+     }
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "CreatedAt": "2020-09-24T08:23:38Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/353#event-3801996724"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "CreatedAt": "2020-09-24T08:27:54Z"
+    }
+   }
+  ],
+  "Commits": {
+   "Nodes": [
+    {
+     "Commit": {
+      "OID": "d965153c0b869943e935878d23a576928cc8c951",
+      "CheckSuites": {
+       "Nodes": [
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUxMjAxMzM0OTIz",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUxMjAxMzM0OTI2",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        }
+       ]
+      },
+      "Status": {
+       "State": "",
+       "Contexts": null
+      },
+      "CommittedDate": "2020-09-16T14:23:01Z"
+     }
+    }
+   ]
+  },
+  "CreatedAt": "2020-09-16T14:23:08Z",
+  "UpdatedAt": "2020-09-24T08:27:54Z"
+ }

--- a/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_ReopenChangeset_success.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/BitbucketServerSource_ReopenChangeset_success.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/95/reopen?version=1
+    method: POST
+  response:
+    body: '{"id":95,"version":2,"title":"Replace fmt.Sprintf with equivalent strconv.Itoa","description":"This campaign replaces `fmt.Sprintf` with `strconv.Itoa`","state":"OPEN","open":true,"closed":false,"createdDate":1600256487945,"updatedDate":1600950914772,"fromRef":{"id":"refs/heads/campaigns-demo/sprintf-to-itoa","displayId":"campaigns-demo/sprintf-to-itoa","latestCommit":"a5d1ee5e1b025220137e05fe69f495dba324ad00","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"1e256a405ec07c904f0a4e681c8136cc9fca3b87","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/95"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 5d7c8b4e8d8f1786-FRA
+      Cf-Request-Id:
+      - 0561b56516000017866203d200000001
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 24 Sep 2020 12:35:14 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Vary:
+      - X-AUSERNAME,Accept-Encoding
+      X-Arequestid:
+      - '@PXMM0Qx755x755770x0'
+      X-Asen:
+      - SEN-11363689
+      X-Asessionid:
+      - smlip
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/cmd/repo-updater/repos/testdata/sources/GithubSource_ReopenChangeset_success.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GithubSource_ReopenChangeset_success.yaml
@@ -1,0 +1,58 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label {\n  name\n  color\n  description\n  id\n}\n\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment commitWithChecks on Commit {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last: 20){\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last: 20){\n        nodes{\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  author {\n    ...actor\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first: 100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT, CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW, PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT, REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT]) {\n    nodes {\n      __typename\n      ... on AssignedEvent {\n        actor {\n          ...actor\n        }\n        assignee {\n          ...actor\n        }\n        createdAt\n      }\n      ... on ClosedEvent {\n        actor {\n          ...actor\n        }\n        createdAt\n        url\n      }\n      ... on IssueComment {\n        databaseId\n        author {\n          ...actor\n        }\n        authorAssociation\n        body\n        createdAt\n        editor {\n          ...actor\n        }\n        url\n        updatedAt\n        includesCreatedEdit\n        publishedAt\n      }\n      ... on RenamedTitleEvent {\n        actor {\n          ...actor\n        }\n        previousTitle\n        currentTitle\n        createdAt\n      }\n      ... on MergedEvent {\n        actor {\n          ...actor\n        }\n        mergeRefName\n        url\n        commit {\n          ...commit\n        }\n        createdAt\n      }\n      ... on PullRequestReview {\n        ...review\n      }\n      ... on PullRequestReviewThread {\n        comments(last: 100) {\n          nodes {\n            databaseId\n            author {\n              ...actor\n            }\n            authorAssociation\n            editor {\n              ...actor\n            }\n            commit {\n              ...commit\n            }\n            body\n            state\n            url\n            createdAt\n            updatedAt\n            includesCreatedEdit\n          }\n        }\n      }\n      ... on ReopenedEvent {\n        actor {\n          ...actor\n        }\n        createdAt\n      }\n      ... on ReviewDismissedEvent {\n        actor {\n          ...actor\n        }\n        review {\n          ...review\n        }\n        dismissalMessage\n        createdAt\n      }\n      ... on ReviewRequestRemovedEvent {\n        actor {\n          ...actor\n        }\n        requestedReviewer {\n          ...actor\n        }\n        requestedTeam: requestedReviewer {\n          ... on Team {\n            name\n            url\n            avatarUrl\n          }\n        }\n        createdAt\n      }\n      ... on ReviewRequestedEvent {\n        actor {\n          ...actor\n        }\n        requestedReviewer {\n          ...actor\n        }\n        requestedTeam: requestedReviewer {\n          ... on Team {\n            name\n            url\n            avatarUrl\n          }\n        }\n        createdAt\n      }\n      ... on UnassignedEvent {\n        actor {\n          ...actor\n        }\n        assignee {\n          ...actor\n        }\n        createdAt\n      }\n      ... on LabeledEvent {\n        actor {\n          ...actor\n        }\n        label {\n          ...label\n        }\n        createdAt\n      }\n      ... on UnlabeledEvent {\n        actor {\n          ...actor\n        }\n        label {\n          ...label\n        }\n        createdAt\n      }\n      ... on PullRequestCommit {\n        commit {\n          ...commit\n        }\n      }\n    }\n  }\n}\nmutation\tReopenPullRequest($input:ReopenPullRequestInput!) {\n  reopenPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"pullRequestId":"MDExOlB1bGxSZXF1ZXN0NDg4MDI2OTk5"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"reopenPullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0NDg4MDI2OTk5","title":"Replace fmt.Sprintf with equivalent strconv.Itoa","body":"This campaign replaces `fmt.Sprintf` with `strconv.Itoa`","state":"OPEN","url":"https://github.com/sourcegraph/automation-testing/pull/353","number":353,"createdAt":"2020-09-16T14:23:08Z","updatedAt":"2020-09-24T08:27:54Z","headRefOid":"d965153c0b869943e935878d23a576928cc8c951","baseRefOid":"6274d04b734de9f057bb5f196a5046a9e86ba992","headRefName":"campaigns-screenshare/sprintf-to-itoa","baseRefName":"master","author":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"participants":{"nodes":[{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"labels":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"d965153c0b869943e935878d23a576928cc8c951","status":null,"checkSuites":{"nodes":[{"id":"MDEwOkNoZWNrU3VpdGUxMjAxMzM0OTIz","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"MDEwOkNoZWNrU3VpdGUxMjAxMzM0OTI2","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}}]},"committedDate":"2020-09-16T14:23:01Z"}}]},"timelineItems":{"nodes":[{"__typename":"PullRequestCommit","commit":{"oid":"d965153c0b869943e935878d23a576928cc8c951","message":"Replacing fmt.Sprintf with strconv.Iota","messageHeadline":"Replacing fmt.Sprintf with strconv.Iota","committedDate":"2020-09-16T14:23:01Z","pushedDate":"2020-09-16T14:23:07Z","url":"https://github.com/sourcegraph/automation-testing/commit/d965153c0b869943e935878d23a576928cc8c951","committer":{"avatarUrl":"https://avatars3.githubusercontent.com/u/1185253?v=4","email":"thorsten@sourcegraph.com","name":"Thorsten Ball","user":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"}}}},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"createdAt":"2020-09-24T08:23:38Z","url":"https://github.com/sourcegraph/automation-testing/pull/353#event-3801996724"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"createdAt":"2020-09-24T08:27:54Z"}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Sep 2020 08:27:54 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.antiope-preview; format=json
+      X-Github-Request-Id:
+      - F0A4:A4E1:E7E1445:11644DA7:5F6C5889
+      X-Oauth-Scopes:
+      - read:org, repo
+      X-Ratelimit-Used:
+      - "38"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -296,7 +296,7 @@ func (r *reconciler) updateChangeset(ctx context.Context, tx *Store, ch *campaig
 
 // reopenChangeset reopens the given changeset attribute on the code host.
 func (r *reconciler) reopenChangeset(ctx context.Context, tx *Store, ch *campaigns.Changeset) (err error) {
-	repo, extSvc, err := loadAssociations(ctx, tx, ch)
+	repo, extSvc, _, err := loadAssociations(ctx, tx, ch)
 	if err != nil {
 		return errors.Wrap(err, "failed to load associations")
 	}

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -319,7 +319,7 @@ func (r *reconciler) reopenChangeset(ctx context.Context, tx *Store, ch *campaig
 	}
 
 	// We extract the events, compute derived state and upsert events because
-	// the reopening has updated changeset on the code host.
+	// the reopening has updated the changeset on the code host.
 	events := ch.Events()
 	SetDerivedState(ctx, ch, events)
 	if err := tx.UpsertChangesetEvents(ctx, events...); err != nil {

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -487,6 +487,7 @@ func TestReconcilerProcess(t *testing.T) {
 				externalBranch:    githubPR.HeadRefName,
 				externalState:     campaigns.ChangesetExternalStateClosed,
 				createdByCampaign: true,
+				closing:           false,
 			},
 			// We return the open GitHub PR here
 			sourcerMetadata: githubPR,
@@ -530,6 +531,7 @@ func TestReconcilerProcess(t *testing.T) {
 				externalBranch:    githubPR.HeadRefName,
 				externalState:     campaigns.ChangesetExternalStateClosed,
 				createdByCampaign: true,
+				closing:           false,
 			},
 			sourcerMetadata: githubPR,
 

--- a/enterprise/internal/campaigns/service_apply_campaign.go
+++ b/enterprise/internal/campaigns/service_apply_campaign.go
@@ -399,10 +399,8 @@ func (r *changesetRewirer) loadAssociations() (err error) {
 		return err
 	}
 
-	// Load all Changesets attached to this Campaign.
-	r.changesets, _, err = r.tx.ListChangesets(r.ctx, ListChangesetsOpts{
-		CampaignID: r.campaign.ID,
-	})
+	// Load all Changesets attached to this campaign, or owned by this campaign but detached.
+	r.changesets, err = r.tx.ListChangesetsAttachedOrOwnedByCampaign(r.ctx, r.campaign.ID)
 	if err != nil {
 		return err
 	}
@@ -457,6 +455,7 @@ func (r *changesetRewirer) indexAssociations() (err error) {
 			r.changesetsByRepoHeadRef[k] = c
 		}
 	}
+
 	return nil
 }
 

--- a/enterprise/internal/campaigns/service_apply_campaign.go
+++ b/enterprise/internal/campaigns/service_apply_campaign.go
@@ -297,7 +297,8 @@ func (r *changesetRewirer) Rewire() (err error) {
 			}
 		} else {
 			// But if we already have a changeset in the given repository with
-			// the given branch, we need to update it to have the new spec:
+			// the given branch, we need to update it to have the new spec
+			// and possibly re-attach it to the campaign:
 			if err = r.updateChangesetToNewSpec(c, spec); err != nil {
 				return err
 			}
@@ -377,6 +378,9 @@ func (r *changesetRewirer) createChangesetForSpec(repo *types.Repo, spec *campai
 func (r *changesetRewirer) updateChangesetToNewSpec(c *campaigns.Changeset, spec *campaigns.ChangesetSpec) error {
 	c.PreviousSpecID = c.CurrentSpecID
 	c.CurrentSpecID = spec.ID
+
+	// Ensure that the changeset is attached to the campaign
+	c.CampaignIDs = append(c.CampaignIDs, r.campaign.ID)
 
 	// Copy over diff stat from the new spec.
 	diffStat := spec.DiffStat()

--- a/enterprise/internal/campaigns/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service_apply_campaign_test.go
@@ -587,6 +587,67 @@ func TestServiceApplyCampaign(t *testing.T) {
 				numFailures:     0,
 			})
 		})
+
+		t.Run("campaign with changeset that is detached and reattached", func(t *testing.T) {
+			campaignSpec1 := createCampaignSpec(t, ctx, store, "detach-reattach-changeset", admin.ID)
+
+			specOpts := testSpecOpts{
+				user:         admin.ID,
+				repo:         repos[0].ID,
+				campaignSpec: campaignSpec1.ID,
+				headRef:      "refs/heads/detached-reattached",
+			}
+			spec1 := createChangesetSpec(t, ctx, store, specOpts)
+
+			// STEP 1: We apply the spec and expect 1 changeset.
+			campaign, changesets := applyAndListChangesets(adminCtx, t, svc, campaignSpec1.RandID, 1)
+
+			// Now we update the changeset so it looks like it's been published
+			// on the code host.
+			c := changesets[0]
+			setChangesetPublished(t, ctx, store, c, specOpts.headRef, "995544")
+
+			assertions := changesetAssertions{
+				repo:             c.RepoID,
+				currentSpec:      spec1.ID,
+				externalID:       c.ExternalID,
+				externalBranch:   c.ExternalBranch,
+				ownedByCampaign:  campaign.ID,
+				reconcilerState:  campaigns.ReconcilerStateCompleted,
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				diffStat:         testChangsetSpecDiffStat,
+			}
+			reloadAndAssertChangeset(t, ctx, store, c, assertions)
+
+			// STEP 2: Now we apply a new spec without any changesets.
+			campaignSpec2 := createCampaignSpec(t, ctx, store, "detach-reattach-changeset", admin.ID)
+			applyAndListChangesets(adminCtx, t, svc, campaignSpec2.RandID, 0)
+
+			// Our previously published changeset should be marked as "to be closed"
+			assertions.closing = true
+			assertions.reconcilerState = campaigns.ReconcilerStateQueued
+			reloadAndAssertChangeset(t, ctx, store, c, assertions)
+
+			// Now we update the changeset to make it look closed.
+			// TODO: What if we do the next step without it being closed by reconciler?
+			setChangesetClosed(t, ctx, store, c)
+			assertions.closing = false
+			assertions.reconcilerState = campaigns.ReconcilerStateCompleted
+			assertions.externalState = campaigns.ChangesetExternalStateClosed
+			reloadAndAssertChangeset(t, ctx, store, c, assertions)
+
+			// STEP 3: We apply the spec and expect _the same changeset_ to be re-attached.
+			campaignSpec3 := createCampaignSpec(t, ctx, store, "detach-reattach-changeset", admin.ID)
+			specOpts.campaignSpec = campaignSpec3.ID
+			createChangesetSpec(t, ctx, store, specOpts)
+
+			campaign, changesets = applyAndListChangesets(adminCtx, t, svc, campaignSpec3.RandID, 1)
+
+			attachedChangeset := changesets[0]
+			if have, want := attachedChangeset.ID, c.ID; have != want {
+				t.Fatalf("attached changeset has wrong ID. want=%d, have=%d", want, have)
+			}
+		})
 	})
 
 	t.Run("applying to closed campaign", func(t *testing.T) {
@@ -784,6 +845,19 @@ func setChangesetFailed(t *testing.T, ctx context.Context, s *Store, c *campaign
 	c.ReconcilerState = campaigns.ReconcilerStateErrored
 	c.FailureMessage = &canceledChangesetFailureMessage
 	c.NumFailures = 5
+
+	if err := s.UpdateChangeset(ctx, c); err != nil {
+		t.Fatalf("failed to update changeset: %s", err)
+	}
+}
+
+func setChangesetClosed(t *testing.T, ctx context.Context, s *Store, c *campaigns.Changeset) {
+	t.Helper()
+
+	c.PublicationState = campaigns.ChangesetPublicationStatePublished
+	c.ReconcilerState = campaigns.ReconcilerStateCompleted
+	c.Closing = false
+	c.ExternalState = campaigns.ChangesetExternalStateClosed
 
 	if err := s.UpdateChangeset(ctx, c); err != nil {
 		t.Fatalf("failed to update changeset: %s", err)

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -481,6 +481,34 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	)
 }
 
+// ListChangesetsAttachedOrOwnedByCampaign lists Changesets that are either
+// attached to the given Campaign or their OwnedByCampaignID points to the
+// campaign.
+func (s *Store) ListChangesetsAttachedOrOwnedByCampaign(ctx context.Context, campaign int64) (cs campaigns.Changesets, err error) {
+	q := sqlf.Sprintf(`
+-- source: enterprise/internal/campaigns/store.go:ListChangesetsAttachedOrOwnedByCampaign
+SELECT %s FROM changesets
+INNER JOIN repo ON repo.id = changesets.repo_id
+WHERE (changesets.campaign_ids ? %s) OR changesets.owned_by_campaign_id = %s
+ORDER BY id ASC
+`,
+		sqlf.Join(changesetColumns, ", "),
+		campaign,
+		campaign,
+	)
+
+	err = s.query(ctx, q, func(sc scanner) (err error) {
+		var c campaigns.Changeset
+		if err = scanChangeset(&c, sc); err != nil {
+			return err
+		}
+		cs = append(cs, &c)
+		return nil
+	})
+
+	return cs, err
+}
+
 // UpdateChangeset updates the given Changeset.
 func (s *Store) UpdateChangeset(ctx context.Context, cs *campaigns.Changeset) error {
 	cs.UpdatedAt = s.now()

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -489,7 +489,10 @@ func (s *Store) ListChangesetsAttachedOrOwnedByCampaign(ctx context.Context, cam
 -- source: enterprise/internal/campaigns/store.go:ListChangesetsAttachedOrOwnedByCampaign
 SELECT %s FROM changesets
 INNER JOIN repo ON repo.id = changesets.repo_id
-WHERE (changesets.campaign_ids ? %s) OR changesets.owned_by_campaign_id = %s
+WHERE
+  ((changesets.campaign_ids ? %s) OR changesets.owned_by_campaign_id = %s)
+AND
+  repo.deleted_at IS NULL
 ORDER BY id ASC
 `,
 		sqlf.Join(changesetColumns, ", "),

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -952,6 +952,38 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 			reloadAndAssertChangeset(t, ctx, s, changeset, want)
 		}
 	})
+
+	t.Run("ListChangesetsAttachedOrOwnedByCampaign", func(t *testing.T) {
+		var campaignID int64 = 191918
+
+		baseOpts := testChangesetOpts{repo: repo.ID}
+
+		opts1 := baseOpts
+		opts1.campaign = campaignID
+		opts1.ownedByCampaign = campaignID
+		c1 := createChangeset(t, ctx, s, opts1)
+
+		opts2 := baseOpts
+		opts2.campaign = campaignID
+		opts2.ownedByCampaign = 0
+		c2 := createChangeset(t, ctx, s, opts2)
+
+		opts3 := baseOpts
+		opts3.campaign = campaignID + 999
+		opts3.ownedByCampaign = campaignID + 999
+		createChangeset(t, ctx, s, opts3)
+
+		cs, err := s.ListChangesetsAttachedOrOwnedByCampaign(ctx, campaignID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantIDs := []int64{c1.ID, c2.ID}
+		haveIDs := cs.IDs()
+		if diff := cmp.Diff(wantIDs, haveIDs); diff != "" {
+			t.Fatalf("wrong changesets returned. diff=%s", diff)
+		}
+	})
 }
 
 func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store, reposStore repos.Store, clock clock) {

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -973,6 +973,12 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		opts3.ownedByCampaign = campaignID + 999
 		createChangeset(t, ctx, s, opts3)
 
+		opts4 := baseOpts
+		opts4.repo = deletedRepo.ID
+		opts4.campaign = campaignID
+		opts4.ownedByCampaign = 0
+		createChangeset(t, ctx, s, opts4)
+
 		cs, err := s.ListChangesetsAttachedOrOwnedByCampaign(ctx, campaignID)
 		if err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -20,6 +20,7 @@ type FakeChangesetSource struct {
 	ExternalServicesCalled bool
 	LoadChangesetsCalled   bool
 	CloseChangesetCalled   bool
+	ReopenChangesetCalled  bool
 
 	// The Changeset.HeadRef to be expected in CreateChangeset/UpdateChangeset calls.
 	WantHeadRef string
@@ -50,6 +51,9 @@ type FakeChangesetSource struct {
 	// UpdateChangesets contains the changesets that were passed to
 	// UpdateChangeset
 	UpdatedChangesets []*repos.Changeset
+
+	// ReopenedChangesets contains the changesets that were passed to ReopenedChangeset
+	ReopenedChangesets []*repos.Changeset
 }
 
 func (s *FakeChangesetSource) CreateChangeset(ctx context.Context, c *repos.Changeset) (bool, error) {
@@ -145,7 +149,24 @@ func (s *FakeChangesetSource) CloseChangeset(ctx context.Context, c *repos.Chang
 	}
 
 	s.ClosedChangesets = append(s.ClosedChangesets, c)
-	return nil
+
+	return c.SetMetadata(s.FakeMetadata)
+}
+
+func (s *FakeChangesetSource) ReopenChangeset(ctx context.Context, c *repos.Changeset) error {
+	s.ReopenChangesetCalled = true
+
+	if s.Err != nil {
+		return s.Err
+	}
+
+	if c.Repo == nil {
+		return NoReposErr
+	}
+
+	s.ReopenedChangesets = append(s.ReopenedChangesets, c)
+
+	return c.SetMetadata(s.FakeMetadata)
 }
 
 // FakeGitserverClient is a test implementation of the GitserverClient

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -550,6 +550,29 @@ func (c *Client) DeclinePullRequest(ctx context.Context, pr *PullRequest) error 
 	return c.send(ctx, "POST", path, qry, nil, pr)
 }
 
+// ReopenPullRequest reopens a previously declined & closed PullRequest,
+// returning an error in case of failure.
+func (c *Client) ReopenPullRequest(ctx context.Context, pr *PullRequest) error {
+	if pr.ToRef.Repository.Slug == "" {
+		return errors.New("repository slug empty")
+	}
+
+	if pr.ToRef.Repository.Project.Key == "" {
+		return errors.New("project key empty")
+	}
+
+	path := fmt.Sprintf(
+		"rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/reopen",
+		pr.ToRef.Repository.Project.Key,
+		pr.ToRef.Repository.Slug,
+		pr.ID,
+	)
+
+	qry := url.Values{"version": {strconv.Itoa(pr.Version)}}
+
+	return c.send(ctx, "POST", path, qry, nil, pr)
+}
+
 // LoadPullRequestActivities loads the given PullRequest's timeline of activities,
 // returning an error in case of failure.
 func (c *Client) LoadPullRequestActivities(ctx context.Context, pr *PullRequest) (err error) {

--- a/internal/extsvc/github/testdata/golden/ReopenPullRequest-0
+++ b/internal/extsvc/github/testdata/golden/ReopenPullRequest-0
@@ -1,0 +1,144 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0NDg4NjEzODA3",
+  "Title": "Test reopening 1",
+  "Body": "This is just one of _many_ pull requests. Is it useless? Yes. But is it cool? Yes.",
+  "State": "OPEN",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/356",
+  "HeadRefOid": "4fc28c316ec75bd1c6f71938a7b285f41cd3ef96",
+  "BaseRefOid": "6274d04b734de9f057bb5f196a5046a9e86ba992",
+  "HeadRefName": "demo/267-in-2",
+  "BaseRefName": "master",
+  "Number": 356,
+  "Author": {
+   "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+   "Login": "mrnugget",
+   "URL": "https://github.com/mrnugget"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "Labels": {
+   "Nodes": []
+  },
+  "TimelineItems": [
+   {
+    "Type": "PullRequestCommit",
+    "Item": {
+     "Commit": {
+      "OID": "4fc28c316ec75bd1c6f71938a7b285f41cd3ef96",
+      "Message": "Append Hello World to all README.md files",
+      "MessageHeadline": "Append Hello World to all README.md files",
+      "URL": "https://github.com/sourcegraph/automation-testing/commit/4fc28c316ec75bd1c6f71938a7b285f41cd3ef96",
+      "Committer": {
+       "AvatarURL": "https://camo.githubusercontent.com/33d4c509ae479643c65ba8967c16b869c1558e90/68747470733a2f2f322e67726176617461722e636f6d2f6176617461722f34366333653536396163366530356264326136366339313661396666343934633f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67",
+       "Email": "campaigns@sourcegraph.com",
+       "Name": "Sourcegraph"
+      },
+      "CommittedDate": "2020-09-17T11:50:07Z",
+      "PushedDate": "2020-09-17T11:53:51Z"
+     }
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "CreatedAt": "2020-09-24T08:12:22Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/356#event-3801951041"
+    }
+   },
+   {
+    "Type": "RenamedTitleEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "PreviousTitle": "Hello Viewers!",
+     "CurrentTitle": "Test reopening 1",
+     "CreatedAt": "2020-09-24T08:12:32Z"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "CreatedAt": "2020-09-24T08:16:19Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "CreatedAt": "2020-09-24T08:18:04Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/356#event-3801974500"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+      "Login": "mrnugget",
+      "URL": "https://github.com/mrnugget"
+     },
+     "CreatedAt": "2020-09-24T08:18:30Z"
+    }
+   }
+  ],
+  "Commits": {
+   "Nodes": [
+    {
+     "Commit": {
+      "OID": "4fc28c316ec75bd1c6f71938a7b285f41cd3ef96",
+      "CheckSuites": {
+       "Nodes": [
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUxMjA2MzA3OTU4",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUxMjA2MzA3OTYx",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        }
+       ]
+      },
+      "Status": {
+       "State": "",
+       "Contexts": null
+      },
+      "CommittedDate": "2020-09-17T11:50:07Z"
+     }
+    }
+   ]
+  },
+  "CreatedAt": "2020-09-17T11:53:51Z",
+  "UpdatedAt": "2020-09-24T08:18:30Z"
+ }

--- a/internal/extsvc/github/testdata/golden/ReopenPullRequest-1
+++ b/internal/extsvc/github/testdata/golden/ReopenPullRequest-1
@@ -1,0 +1,85 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0NDg4NjA0NTQ5",
+  "Title": "Hello Viewers!",
+  "Body": "This is just one of _many_ pull requests. Is it useless? Yes. But is it cool? Yes.",
+  "State": "OPEN",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/355",
+  "HeadRefOid": "55dc5cf08fad39e41973cd384ffe0ea5d5e958d3",
+  "BaseRefOid": "6274d04b734de9f057bb5f196a5046a9e86ba992",
+  "HeadRefName": "demo/200-in-2",
+  "BaseRefName": "master",
+  "Number": 355,
+  "Author": {
+   "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+   "Login": "mrnugget",
+   "URL": "https://github.com/mrnugget"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "Labels": {
+   "Nodes": []
+  },
+  "TimelineItems": [
+   {
+    "Type": "PullRequestCommit",
+    "Item": {
+     "Commit": {
+      "OID": "55dc5cf08fad39e41973cd384ffe0ea5d5e958d3",
+      "Message": "Append Hello World to all README.md files",
+      "MessageHeadline": "Append Hello World to all README.md files",
+      "URL": "https://github.com/sourcegraph/automation-testing/commit/55dc5cf08fad39e41973cd384ffe0ea5d5e958d3",
+      "Committer": {
+       "AvatarURL": "https://camo.githubusercontent.com/33d4c509ae479643c65ba8967c16b869c1558e90/68747470733a2f2f322e67726176617461722e636f6d2f6176617461722f34366333653536396163366530356264326136366339313661396666343934633f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67",
+       "Email": "campaigns@sourcegraph.com",
+       "Name": "Sourcegraph"
+      },
+      "CommittedDate": "2020-09-17T11:35:44Z",
+      "PushedDate": "2020-09-17T11:37:38Z"
+     }
+    }
+   }
+  ],
+  "Commits": {
+   "Nodes": [
+    {
+     "Commit": {
+      "OID": "55dc5cf08fad39e41973cd384ffe0ea5d5e958d3",
+      "CheckSuites": {
+       "Nodes": [
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUxMjA2MjM5ODg1",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUxMjA2MjM5ODg3",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        }
+       ]
+      },
+      "Status": {
+       "State": "",
+       "Contexts": null
+      },
+      "CommittedDate": "2020-09-17T11:35:44Z"
+     }
+    }
+   ]
+  },
+  "CreatedAt": "2020-09-17T11:37:38Z",
+  "UpdatedAt": "2020-09-17T11:37:38Z"
+ }

--- a/internal/extsvc/github/testdata/vcr/ReopenPullRequest.yaml
+++ b/internal/extsvc/github/testdata/vcr/ReopenPullRequest.yaml
@@ -1,0 +1,125 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label {\n  name\n  color\n  description\n  id\n}\n\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment commitWithChecks on Commit {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last: 20){\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last: 20){\n        nodes{\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  author {\n    ...actor\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first: 100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT, CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW, PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT, REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT]) {\n    nodes {\n      __typename\n      ... on AssignedEvent {\n        actor {\n          ...actor\n        }\n        assignee {\n          ...actor\n        }\n        createdAt\n      }\n      ... on ClosedEvent {\n        actor {\n          ...actor\n        }\n        createdAt\n        url\n      }\n      ... on IssueComment {\n        databaseId\n        author {\n          ...actor\n        }\n        authorAssociation\n        body\n        createdAt\n        editor {\n          ...actor\n        }\n        url\n        updatedAt\n        includesCreatedEdit\n        publishedAt\n      }\n      ... on RenamedTitleEvent {\n        actor {\n          ...actor\n        }\n        previousTitle\n        currentTitle\n        createdAt\n      }\n      ... on MergedEvent {\n        actor {\n          ...actor\n        }\n        mergeRefName\n        url\n        commit {\n          ...commit\n        }\n        createdAt\n      }\n      ... on PullRequestReview {\n        ...review\n      }\n      ... on PullRequestReviewThread {\n        comments(last: 100) {\n          nodes {\n            databaseId\n            author {\n              ...actor\n            }\n            authorAssociation\n            editor {\n              ...actor\n            }\n            commit {\n              ...commit\n            }\n            body\n            state\n            url\n            createdAt\n            updatedAt\n            includesCreatedEdit\n          }\n        }\n      }\n      ... on ReopenedEvent {\n        actor {\n          ...actor\n        }\n        createdAt\n      }\n      ... on ReviewDismissedEvent {\n        actor {\n          ...actor\n        }\n        review {\n          ...review\n        }\n        dismissalMessage\n        createdAt\n      }\n      ... on ReviewRequestRemovedEvent {\n        actor {\n          ...actor\n        }\n        requestedReviewer {\n          ...actor\n        }\n        requestedTeam: requestedReviewer {\n          ... on Team {\n            name\n            url\n            avatarUrl\n          }\n        }\n        createdAt\n      }\n      ... on ReviewRequestedEvent {\n        actor {\n          ...actor\n        }\n        requestedReviewer {\n          ...actor\n        }\n        requestedTeam: requestedReviewer {\n          ... on Team {\n            name\n            url\n            avatarUrl\n          }\n        }\n        createdAt\n      }\n      ... on UnassignedEvent {\n        actor {\n          ...actor\n        }\n        assignee {\n          ...actor\n        }\n        createdAt\n      }\n      ... on LabeledEvent {\n        actor {\n          ...actor\n        }\n        label {\n          ...label\n        }\n        createdAt\n      }\n      ... on UnlabeledEvent {\n        actor {\n          ...actor\n        }\n        label {\n          ...label\n        }\n        createdAt\n      }\n      ... on PullRequestCommit {\n        commit {\n          ...commit\n        }\n      }\n    }\n  }\n}\nmutation\tReopenPullRequest($input:ReopenPullRequestInput!) {\n  reopenPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"pullRequestId":"MDExOlB1bGxSZXF1ZXN0NDg4NjEzODA3"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"reopenPullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0NDg4NjEzODA3","title":"Test reopening 1","body":"This is just one of _many_ pull requests. Is it useless? Yes. But is it cool? Yes.","state":"OPEN","url":"https://github.com/sourcegraph/automation-testing/pull/356","number":356,"createdAt":"2020-09-17T11:53:51Z","updatedAt":"2020-09-24T08:18:30Z","headRefOid":"4fc28c316ec75bd1c6f71938a7b285f41cd3ef96","baseRefOid":"6274d04b734de9f057bb5f196a5046a9e86ba992","headRefName":"demo/267-in-2","baseRefName":"master","author":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"participants":{"nodes":[{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"labels":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"4fc28c316ec75bd1c6f71938a7b285f41cd3ef96","status":null,"checkSuites":{"nodes":[{"id":"MDEwOkNoZWNrU3VpdGUxMjA2MzA3OTU4","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"MDEwOkNoZWNrU3VpdGUxMjA2MzA3OTYx","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}}]},"committedDate":"2020-09-17T11:50:07Z"}}]},"timelineItems":{"nodes":[{"__typename":"PullRequestCommit","commit":{"oid":"4fc28c316ec75bd1c6f71938a7b285f41cd3ef96","message":"Append Hello World to all README.md files","messageHeadline":"Append Hello World to all README.md files","committedDate":"2020-09-17T11:50:07Z","pushedDate":"2020-09-17T11:53:51Z","url":"https://github.com/sourcegraph/automation-testing/commit/4fc28c316ec75bd1c6f71938a7b285f41cd3ef96","committer":{"avatarUrl":"https://camo.githubusercontent.com/33d4c509ae479643c65ba8967c16b869c1558e90/68747470733a2f2f322e67726176617461722e636f6d2f6176617461722f34366333653536396163366530356264326136366339313661396666343934633f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67","email":"campaigns@sourcegraph.com","name":"Sourcegraph","user":null}}},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"createdAt":"2020-09-24T08:12:22Z","url":"https://github.com/sourcegraph/automation-testing/pull/356#event-3801951041"},{"__typename":"RenamedTitleEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"previousTitle":"Hello Viewers!","currentTitle":"Test reopening 1","createdAt":"2020-09-24T08:12:32Z"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"createdAt":"2020-09-24T08:16:19Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"createdAt":"2020-09-24T08:18:04Z","url":"https://github.com/sourcegraph/automation-testing/pull/356#event-3801974500"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"createdAt":"2020-09-24T08:18:30Z"}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Sep 2020 08:18:31 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.antiope-preview; format=json
+      X-Github-Request-Id:
+      - F07D:C7EE:EC752F2:11B68573:5F6C5656
+      X-Oauth-Scopes:
+      - read:org, repo
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4975"
+      X-Ratelimit-Reset:
+      - "1600937339"
+      X-Ratelimit-Used:
+      - "25"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label {\n  name\n  color\n  description\n  id\n}\n\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment commitWithChecks on Commit {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last: 20){\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last: 20){\n        nodes{\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  author {\n    ...actor\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first: 100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT, CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW, PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT, REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT]) {\n    nodes {\n      __typename\n      ... on AssignedEvent {\n        actor {\n          ...actor\n        }\n        assignee {\n          ...actor\n        }\n        createdAt\n      }\n      ... on ClosedEvent {\n        actor {\n          ...actor\n        }\n        createdAt\n        url\n      }\n      ... on IssueComment {\n        databaseId\n        author {\n          ...actor\n        }\n        authorAssociation\n        body\n        createdAt\n        editor {\n          ...actor\n        }\n        url\n        updatedAt\n        includesCreatedEdit\n        publishedAt\n      }\n      ... on RenamedTitleEvent {\n        actor {\n          ...actor\n        }\n        previousTitle\n        currentTitle\n        createdAt\n      }\n      ... on MergedEvent {\n        actor {\n          ...actor\n        }\n        mergeRefName\n        url\n        commit {\n          ...commit\n        }\n        createdAt\n      }\n      ... on PullRequestReview {\n        ...review\n      }\n      ... on PullRequestReviewThread {\n        comments(last: 100) {\n          nodes {\n            databaseId\n            author {\n              ...actor\n            }\n            authorAssociation\n            editor {\n              ...actor\n            }\n            commit {\n              ...commit\n            }\n            body\n            state\n            url\n            createdAt\n            updatedAt\n            includesCreatedEdit\n          }\n        }\n      }\n      ... on ReopenedEvent {\n        actor {\n          ...actor\n        }\n        createdAt\n      }\n      ... on ReviewDismissedEvent {\n        actor {\n          ...actor\n        }\n        review {\n          ...review\n        }\n        dismissalMessage\n        createdAt\n      }\n      ... on ReviewRequestRemovedEvent {\n        actor {\n          ...actor\n        }\n        requestedReviewer {\n          ...actor\n        }\n        requestedTeam: requestedReviewer {\n          ... on Team {\n            name\n            url\n            avatarUrl\n          }\n        }\n        createdAt\n      }\n      ... on ReviewRequestedEvent {\n        actor {\n          ...actor\n        }\n        requestedReviewer {\n          ...actor\n        }\n        requestedTeam: requestedReviewer {\n          ... on Team {\n            name\n            url\n            avatarUrl\n          }\n        }\n        createdAt\n      }\n      ... on UnassignedEvent {\n        actor {\n          ...actor\n        }\n        assignee {\n          ...actor\n        }\n        createdAt\n      }\n      ... on LabeledEvent {\n        actor {\n          ...actor\n        }\n        label {\n          ...label\n        }\n        createdAt\n      }\n      ... on UnlabeledEvent {\n        actor {\n          ...actor\n        }\n        label {\n          ...label\n        }\n        createdAt\n      }\n      ... on PullRequestCommit {\n        commit {\n          ...commit\n        }\n      }\n    }\n  }\n}\nmutation\tReopenPullRequest($input:ReopenPullRequestInput!) {\n  reopenPullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"pullRequestId":"MDExOlB1bGxSZXF1ZXN0NDg4NjA0NTQ5"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"reopenPullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0NDg4NjA0NTQ5","title":"Hello Viewers!","body":"This is just one of _many_ pull requests. Is it useless? Yes. But is it cool? Yes.","state":"OPEN","url":"https://github.com/sourcegraph/automation-testing/pull/355","number":355,"createdAt":"2020-09-17T11:37:38Z","updatedAt":"2020-09-17T11:37:38Z","headRefOid":"55dc5cf08fad39e41973cd384ffe0ea5d5e958d3","baseRefOid":"6274d04b734de9f057bb5f196a5046a9e86ba992","headRefName":"demo/200-in-2","baseRefName":"master","author":{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"},"participants":{"nodes":[{"avatarUrl":"https://avatars1.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"labels":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"55dc5cf08fad39e41973cd384ffe0ea5d5e958d3","status":null,"checkSuites":{"nodes":[{"id":"MDEwOkNoZWNrU3VpdGUxMjA2MjM5ODg1","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"MDEwOkNoZWNrU3VpdGUxMjA2MjM5ODg3","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}}]},"committedDate":"2020-09-17T11:35:44Z"}}]},"timelineItems":{"nodes":[{"__typename":"PullRequestCommit","commit":{"oid":"55dc5cf08fad39e41973cd384ffe0ea5d5e958d3","message":"Append Hello World to all README.md files","messageHeadline":"Append Hello World to all README.md files","committedDate":"2020-09-17T11:35:44Z","pushedDate":"2020-09-17T11:37:38Z","url":"https://github.com/sourcegraph/automation-testing/commit/55dc5cf08fad39e41973cd384ffe0ea5d5e958d3","committer":{"avatarUrl":"https://camo.githubusercontent.com/33d4c509ae479643c65ba8967c16b869c1558e90/68747470733a2f2f322e67726176617461722e636f6d2f6176617461722f34366333653536396163366530356264326136366339313661396666343934633f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67","email":"campaigns@sourcegraph.com","name":"Sourcegraph","user":null}}}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Sep 2020 08:18:31 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.antiope-preview; format=json
+      X-Github-Request-Id:
+      - F07D:C7EE:EC75490:11B68751:5F6C5657
+      X-Oauth-Scopes:
+      - read:org, repo
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4972"
+      X-Ratelimit-Reset:
+      - "1600937339"
+      X-Ratelimit-Used:
+      - "28"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/13849 by re-opening changesets that were previously detached from the campaign.

See [this Slack thread for a demo video that I recorded to show off this bug fix and what it fixes](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1600957705006800).

### Thoughts on design

I'm not 100% happy with the code in the reconciler yet. I have the feeling that there's some design that makes the distinction between `applyCampaign`-directed state transitions (e.g. closing a changeset when detaching it from a campaign, or, like here, re-opening a detached one) and user-directed updates (e.g. update title and commit of a PR) clearer and easier to handle.

At its heart this problem revolves around the fact that a subset of the desired changeset state is included in the changeset spec and another set is not (since we don't allow closing in the spec). If we include our internal-state-directives in the changeset specs, they'd need to be in the schema _and_ we'd need to create new changeset specs every time we want to make a change. That seems odd.

What we could do is to make this idea of internal-state-directives clearer by bundling them in a single column, for example, or treating all of them the same way. Not sure yet.

**However, I think the code is fine to merge as it is.** It's just something I keep thinking about.

### Caveat

As it stands, this implementation _could_ lead to changesets being re-opened after the user closed them on the code host. In practice, though, this won't _currently_ happen, since the reconciler is only kicked off on user action, in which case we _do_ want to reopen the changesets.

In order to avoid that, we could add _another_ boolean on the changesets, `reopening bool`, that, just like `closing`, would cause the reconciler to reopen the changeset only on `applyCampaign`.