### PR TITLE
Make command palette keyboard navigable

### DIFF
--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -5,7 +5,7 @@ import { sortBy, uniq, uniqueId } from 'lodash'
 import MenuDownIcon from 'mdi-react/MenuDownIcon'
 import ConsoleIcon from 'mdi-react/ConsoleIcon'
 import MenuUpIcon from 'mdi-react/MenuUpIcon'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import TooltipPopoverWrapper from 'reactstrap/lib/TooltipPopoverWrapper'
@@ -353,12 +353,30 @@ export const CommandListPopoverButton: React.FunctionComponent<CommandListPopove
 
     const id = useMemo(() => uniqueId('command-list-popover-button-'), [])
 
+    const buttonReference = useRef<HTMLAnchorElement | null>(null)
+
+    const onKeyDown: React.KeyboardEventHandler<HTMLAnchorElement> = useCallback(event => {
+        switch (event.key) {
+            case Key.Escape: {
+                buttonReference.current?.focus()
+                break
+            }
+            case Key.Enter: {
+                toggleIsOpen()
+                break
+            }
+        }
+    }, [toggleIsOpen])
+
     return (
         <ButtonElement
             role="button"
             className={`command-list__popover-button ${buttonClassName} ${isOpen ? buttonOpenClassName : ''}`}
             id={id}
             onClick={toggleIsOpen}
+            onKeyDown={onKeyDown}
+            tabIndex={0}
+            ref={buttonReference}
         >
             <ConsoleIcon className="icon-inline" />
             {showCaret && (isOpen ? <MenuUpIcon className="icon-inline" /> : <MenuDownIcon className="icon-inline" />)}

--- a/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
+++ b/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-7"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -491,6 +492,7 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-8"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -842,6 +844,7 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-5"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -1160,6 +1163,7 @@ exports[`NavLinks authed self-hosted /search 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-6"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -1430,6 +1434,7 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-3"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -1540,6 +1545,7 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-4"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -1669,6 +1675,7 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-1"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"
@@ -1788,6 +1795,7 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
       class="command-list__popover-button btn btn-link "
       id="command-list-popover-button-2"
       role="button"
+      tabindex="0"
     >
       <svg
         class="mdi-icon icon-inline"


### PR DESCRIPTION
I've been learning about accessibility today, which reminded me of the poor state of command palette keyboard navigation. 

<details>
<summary>Works on Sourcegraph</summary>
<img src="https://user-images.githubusercontent.com/37420160/94032313-d5f46080-fd8d-11ea-8b4b-5287c7b8ca1b.gif" />
</details>

<details>
<summary>Works on GitHub</summary>
<img src="https://user-images.githubusercontent.com/37420160/94032298-cf65e900-fd8d-11ea-8325-1363e1d83689.gif" />
</details>

Did I miss anything? Could this be simplified?