### PR TITLE
codeintel: Refactor command runner in indexer

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/command.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/command.go
@@ -13,13 +13,25 @@ import (
 )
 
 // runCommand invokes the given command on the host machine.
-func runCommand(ctx context.Context, command string, args ...string) error {
-	cmd, stdout, stderr, err := makeCommand(ctx, command, args...)
+func runCommand(ctx context.Context, command ...string) error {
+	if len(command) == 0 {
+		return fmt.Errorf("no command supplied")
+	}
+
+	switch command[0] {
+	case "git":
+	case "docker":
+	case "ignite":
+	default:
+		fmt.Errorf("illegal command: %s", strings.Join(command, " "))
+	}
+
+	cmd, stdout, stderr, err := makeCommand(ctx, command...)
 	if err != nil {
 		return err
 	}
 
-	log15.Debug(fmt.Sprintf("Running command: %s %s", command, strings.Join(args, " ")))
+	log15.Debug(fmt.Sprintf("Running command: %s", strings.Join(command, " ")))
 
 	wg := parallel(
 		func() { processStream("stdout", stdout) },
@@ -40,8 +52,8 @@ func runCommand(ctx context.Context, command string, args ...string) error {
 }
 
 // makeCommand returns a new exec.Cmd and pipes to its stdout/stderr streams.
-func makeCommand(ctx context.Context, command string, args ...string) (_ *exec.Cmd, stdout, stderr io.Reader, err error) {
-	cmd := exec.CommandContext(ctx, command, args...)
+func makeCommand(ctx context.Context, command ...string) (_ *exec.Cmd, stdout, stderr io.Reader, err error) {
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
 	stdout, err = cmd.StdoutPipe()
 	if err != nil {

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/command.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/command.go
@@ -23,7 +23,7 @@ func runCommand(ctx context.Context, command ...string) error {
 	case "docker":
 	case "ignite":
 	default:
-		fmt.Errorf("illegal command: %s", strings.Join(command, " "))
+		return fmt.Errorf("illegal command: %s", strings.Join(command, " "))
 	}
 
 	cmd, stdout, stderr, err := makeCommand(ctx, command...)

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/commander.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/commander.go
@@ -5,15 +5,15 @@ import "context"
 // Commander abstracts running processes on the host machine.
 type Commander interface {
 	// Run invokes the given command on the host machine.
-	Run(ctx context.Context, command string, args ...string) error
+	Run(ctx context.Context, command ...string) error
 }
 
 // CommanderFunc is a function version of the Commander interface.
-type CommanderFunc func(ctx context.Context, command string, args ...string) error
+type CommanderFunc func(ctx context.Context, command ...string) error
 
 // Run invokes the given command on the host machine. See the Commander interface for additional details.
-func (f CommanderFunc) Run(ctx context.Context, command string, args ...string) error {
-	return f(ctx, command, args...)
+func (f CommanderFunc) Run(ctx context.Context, command ...string) error {
+	return f(ctx, command...)
 }
 
 // DefaultCommander is a commander that uses exec.Cmd to invoke commands on the host machine.

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -110,7 +110,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 			"--name", name.String(),
 			sanitizeImage(h.options.FirecrackerImage),
 		)
-		if err := h.commander.Run(ctx, args[0], args[1:]...); err != nil {
+		if err := h.commander.Run(ctx, args...); err != nil {
 			return errors.Wrap(err, "failed to start firecracker vm")
 		}
 		defer func() {
@@ -120,7 +120,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 				"--network-plugin", "docker-bridge",
 				name.String(),
 			}
-			if err := h.commander.Run(ctx, stopArgs[0], stopArgs[1:]...); err != nil {
+			if err := h.commander.Run(ctx, stopArgs...); err != nil {
 				log15.Warn("failed to stop firecracker vm", "name", name.String(), "err", err)
 			}
 
@@ -130,7 +130,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 				"--network-plugin", "docker-bridge",
 				name.String(),
 			}
-			if err := h.commander.Run(ctx, removeArgs[0], removeArgs[1:]...); err != nil {
+			if err := h.commander.Run(ctx, removeArgs...); err != nil {
 				log15.Warn("failed to remove firecracker vm", "name", name.String(), "err", err)
 			}
 		}()
@@ -155,7 +155,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 	if h.options.UseFirecracker {
 		indexArgs = append([]string{"ignite", "exec", name.String(), "--"}, indexArgs...)
 	}
-	if err := h.commander.Run(ctx, indexArgs[0], indexArgs[1:]...); err != nil {
+	if err := h.commander.Run(ctx, indexArgs...); err != nil {
 		return errors.Wrap(err, "failed to index repository")
 	}
 
@@ -176,7 +176,7 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 	if h.options.UseFirecracker {
 		uploadArgs = append([]string{"ignite", "exec", name.String(), "--"}, uploadArgs...)
 	}
-	if err := h.commander.Run(ctx, uploadArgs[0], uploadArgs[1:]...); err != nil {
+	if err := h.commander.Run(ctx, uploadArgs...); err != nil {
 		return errors.Wrap(err, "failed to upload index")
 	}
 
@@ -216,13 +216,13 @@ func (h *Handler) fetchRepository(ctx context.Context, repositoryName, commit st
 	}
 
 	commands := [][]string{
-		{"-C", tempDir, "init"},
-		{"-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit},
-		{"-C", tempDir, "checkout", commit},
+		{"git", "-C", tempDir, "init"},
+		{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit},
+		{"git", "-C", tempDir, "checkout", commit},
 	}
 
 	for _, args := range commands {
-		if err := h.commander.Run(ctx, "git", args...); err != nil {
+		if err := h.commander.Run(ctx, args...); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("failed `git %s`", strings.Join(args, " ")))
 		}
 	}

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -87,15 +87,22 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 				return err
 			}
 
-			if err := h.commander.Run(ctx, "docker", "pull", fmt.Sprintf("sourcegraph/%s:latest", image)); err != nil {
+			pullCommand := []string{
+				"docker", "pull", fmt.Sprintf("sourcegraph/%s:latest", image),
+			}
+			if err := h.commander.Run(ctx, pullCommand...); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to pull sourcegraph/%s:latest", image))
 			}
-			if err := h.commander.Run(ctx, "docker", "save", "-o", tarfile, fmt.Sprintf("sourcegraph/%s:latest", image)); err != nil {
+
+			saveCommand := []string{
+				"docker", "save", "-o", tarfile, fmt.Sprintf("sourcegraph/%s:latest", image),
+			}
+			if err := h.commander.Run(ctx, saveCommand...); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to save sourcegraph/%s:latest", image))
 			}
 		}
 
-		args := []string{
+		startCommand := []string{
 			"ignite", "run",
 			"--runtime", "docker",
 			"--network-plugin", "docker-bridge",
@@ -103,46 +110,51 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 			"--memory", h.options.FirecrackerMemory,
 			"--copy-files", fmt.Sprintf("%s:%s", repoDir, mountPoint),
 		}
-		args = append(args, copyfiles...)
-		args = append(
-			args,
+		startCommand = append(startCommand, copyfiles...)
+		startCommand = append(
+			startCommand,
 			"--ssh",
 			"--name", name.String(),
 			sanitizeImage(h.options.FirecrackerImage),
 		)
-		if err := h.commander.Run(ctx, args...); err != nil {
+		if err := h.commander.Run(ctx, startCommand...); err != nil {
 			return errors.Wrap(err, "failed to start firecracker vm")
 		}
 		defer func() {
-			stopArgs := []string{
+			stopCommand := []string{
 				"ignite", "stop",
 				"--runtime", "docker",
 				"--network-plugin", "docker-bridge",
 				name.String(),
 			}
-			if err := h.commander.Run(ctx, stopArgs...); err != nil {
+			if err := h.commander.Run(ctx, stopCommand...); err != nil {
 				log15.Warn("failed to stop firecracker vm", "name", name.String(), "err", err)
 			}
 
-			removeArgs := []string{
+			removeCommand := []string{
 				"ignite", "rm", "-f",
 				"--runtime", "docker",
 				"--network-plugin", "docker-bridge",
 				name.String(),
 			}
-			if err := h.commander.Run(ctx, removeArgs...); err != nil {
+			if err := h.commander.Run(ctx, removeCommand...); err != nil {
 				log15.Warn("failed to remove firecracker vm", "name", name.String(), "err", err)
 			}
 		}()
 
 		for _, image := range images {
-			if err := h.commander.Run(ctx, "ignite", "exec", name.String(), "--", "docker", "load", "-i", fmt.Sprintf("/%s.tar", image)); err != nil {
+			loadCommand := []string{
+				"ignite", "exec", name.String(), "--",
+				"docker", "load",
+				"-i", fmt.Sprintf("/%s.tar", image),
+			}
+			if err := h.commander.Run(ctx, loadCommand...); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to load sourcegraph/%s:latest", image))
 			}
 		}
 	}
 
-	indexArgs := []string{
+	indexCommand := []string{
 		"docker", "run", "--rm",
 		"--cpus", strconv.Itoa(h.options.FirecrackerNumCPUs),
 		"--memory", h.options.FirecrackerMemory,
@@ -153,13 +165,13 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 		"--no-animation",
 	}
 	if h.options.UseFirecracker {
-		indexArgs = append([]string{"ignite", "exec", name.String(), "--"}, indexArgs...)
+		indexCommand = append([]string{"ignite", "exec", name.String(), "--"}, indexCommand...)
 	}
-	if err := h.commander.Run(ctx, indexArgs...); err != nil {
+	if err := h.commander.Run(ctx, indexCommand...); err != nil {
 		return errors.Wrap(err, "failed to index repository")
 	}
 
-	uploadArgs := []string{
+	uploadCommand := []string{
 		"docker", "run", "--rm",
 		"--cpus", strconv.Itoa(h.options.FirecrackerNumCPUs),
 		"--memory", h.options.FirecrackerMemory,
@@ -174,9 +186,9 @@ func (h *Handler) Handle(ctx context.Context, _ workerutil.Store, record workeru
 		"-upload-route", "/.internal-code-intel/lsif/upload",
 	}
 	if h.options.UseFirecracker {
-		uploadArgs = append([]string{"ignite", "exec", name.String(), "--"}, uploadArgs...)
+		uploadCommand = append([]string{"ignite", "exec", name.String(), "--"}, uploadCommand...)
 	}
-	if err := h.commander.Run(ctx, uploadArgs...); err != nil {
+	if err := h.commander.Run(ctx, uploadCommand...); err != nil {
 		return errors.Wrap(err, "failed to upload index")
 	}
 
@@ -215,15 +227,14 @@ func (h *Handler) fetchRepository(ctx context.Context, repositoryName, commit st
 		return "", err
 	}
 
-	commands := [][]string{
+	gitCommands := [][]string{
 		{"git", "-C", tempDir, "init"},
 		{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit},
 		{"git", "-C", tempDir, "checkout", commit},
 	}
-
-	for _, args := range commands {
-		if err := h.commander.Run(ctx, args...); err != nil {
-			return "", errors.Wrap(err, fmt.Sprintf("failed `git %s`", strings.Join(args, " ")))
+	for _, gitCommand := range gitCommands {
+		if err := h.commander.Run(ctx, gitCommand...); err != nil {
+			return "", errors.Wrap(err, fmt.Sprintf("failed `git %s`", strings.Join(gitCommand, " ")))
 		}
 	}
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -60,7 +59,7 @@ func TestHandleWithDocker(t *testing.T) {
 		calls := commander.RunFunc.History()
 
 		for i, expectedCall := range expectedCalls {
-			if diff := cmp.Diff(expectedCall, fmt.Sprintf("%s %s", calls[i].Arg1, strings.Join(calls[i].Arg2, " "))); diff != "" {
+			if diff := cmp.Diff(expectedCall, strings.Join(calls[i].Arg1, " ")); diff != "" {
 				t.Errorf("unexpected command (-want +got):\n%s", diff)
 			}
 		}
@@ -124,7 +123,7 @@ func TestHandleWithFirecracker(t *testing.T) {
 		calls := commander.RunFunc.History()
 
 		for i, expectedCall := range expectedCalls {
-			if diff := cmp.Diff(expectedCall, fmt.Sprintf("%s %s", calls[i].Arg1, strings.Join(calls[i].Arg2, " "))); diff != "" {
+			if diff := cmp.Diff(expectedCall, strings.Join(calls[i].Arg1, " ")); diff != "" {
 				t.Errorf("unexpected command (-want +got):\n%s", diff)
 			}
 		}


### PR DESCRIPTION
This changes the signature of `Commander` which used to take a command and a series of arguments to take only a series of arguments. This also validates the initial command to prevent against arbitrary execution.