### PR TITLE
tracking-issue: Fix strikethrough on closed (un-merged) PRs

### DIFF
--- a/internal/cmd/tracking-issue/issue.go
+++ b/internal/cmd/tracking-issue/issue.go
@@ -30,10 +30,14 @@ type Issue struct {
 	Parents       []*Issue       `json:"-"`
 }
 
+func (issue *Issue) Closed() bool {
+	return strings.EqualFold(issue.State, "closed")
+}
+
 func (issue *Issue) Markdown(labelAllowlist []string) string {
 	state := " "
 	prefixSuffix := ""
-	if strings.EqualFold(issue.State, "closed") {
+	if issue.Closed() {
 		state = "x"
 		prefixSuffix = "~"
 	}

--- a/internal/cmd/tracking-issue/pull_request.go
+++ b/internal/cmd/tracking-issue/pull_request.go
@@ -27,9 +27,21 @@ type PullRequest struct {
 	LinkedIssues []*Issue `json:"-"`
 }
 
+func (pr *PullRequest) Closed() bool {
+	return strings.EqualFold(pr.State, "closed")
+}
+
+func (pr *PullRequest) Merged() bool {
+	return strings.EqualFold(pr.State, "merged")
+}
+
+func (pr *PullRequest) Done() bool {
+	return pr.Merged() || pr.Closed()
+}
+
 func (pr *PullRequest) Summary() string {
 	prefixSuffix := ""
-	if strings.EqualFold(pr.State, "merged") {
+	if pr.Done() {
 		prefixSuffix = "~"
 	}
 
@@ -38,7 +50,7 @@ func (pr *PullRequest) Summary() string {
 
 func (pr *PullRequest) Markdown() string {
 	state := " "
-	if strings.EqualFold(pr.State, "merged") {
+	if pr.Done() {
 		state = "x"
 	}
 
@@ -66,7 +78,7 @@ func (pr *PullRequest) title() string {
 		title = pr.Title
 	}
 
-	if strings.EqualFold(pr.State, "closed") {
+	if pr.Closed() {
 		title = "~" + strings.TrimSpace(title) + "~"
 	}
 

--- a/internal/cmd/tracking-issue/tracking_issue.go
+++ b/internal/cmd/tracking-issue/tracking_issue.go
@@ -88,7 +88,7 @@ func (t *TrackingIssue) Workloads() Workloads {
 				estimate := Estimate(issue.Labels)
 				w.Days += Days(estimate)
 
-				if strings.EqualFold(issue.State, "closed") {
+				if issue.Closed() {
 					w.CompletedDays += Days(estimate)
 				}
 			} else {

--- a/internal/cmd/tracking-issue/workload.go
+++ b/internal/cmd/tracking-issue/workload.go
@@ -44,7 +44,7 @@ func (wl *Workload) Markdown(labelAllowlist []string) string {
 		// Render any issue that belongs to zero or more than one
 		// tracking issue (excluding the team tracking issue).
 		if len(issue.Parents) != 1 {
-			if !strings.EqualFold(issue.State, "closed") {
+			if !issue.Closed() {
 				renderIssue(&b, labelAllowlist, issue, 0)
 			} else {
 				hasCompletedIssueOrPullRequest = true
@@ -55,7 +55,7 @@ func (wl *Workload) Markdown(labelAllowlist []string) string {
 	// Put all PRs that aren't linked to issues top-level
 	for _, pr := range wl.PullRequests {
 		if len(pr.LinkedIssues) == 0 {
-			if !strings.EqualFold(pr.State, "merged") {
+			if !pr.Done() {
 				b.WriteString(pr.Markdown())
 			} else {
 				hasCompletedIssueOrPullRequest = true
@@ -79,7 +79,7 @@ func (wl *Workload) Markdown(labelAllowlist []string) string {
 		for _, issue := range wl.Issues {
 			// Render any issue that belongs to zero or more than one
 			// tracking issue (excluding the team tracking issue).
-			if strings.EqualFold(issue.State, "closed") {
+			if issue.Closed() {
 				b.WriteString(indent(0))
 				b.WriteString(issue.Markdown(labelAllowlist))
 			}
@@ -87,7 +87,7 @@ func (wl *Workload) Markdown(labelAllowlist []string) string {
 
 		// Put all PRs that aren't linked to issues top-level
 		for _, pr := range wl.PullRequests {
-			if strings.EqualFold(pr.State, "merged") {
+			if pr.Done() {
 				b.WriteString(pr.Markdown())
 			}
 		}


### PR DESCRIPTION
Display a strikethrough on the title of closed (but un-merged) PRs.