### PR TITLE
show command palette immediately, don't wait for fade-in

### DIFF
--- a/shared/src/commandPalette/CommandList.tsx
+++ b/shared/src/commandPalette/CommandList.tsx
@@ -366,12 +366,13 @@ export const CommandListPopoverButton: React.FunctionComponent<CommandListPopove
             <TooltipPopoverWrapper
                 isOpen={isOpen}
                 toggle={toggleIsOpen}
-                popperClassName={classNames('show', popoverClassName)}
+                popperClassName={popoverClassName}
                 innerClassName={classNames('popover-inner', popoverInnerClassName)}
                 placement="bottom-end"
                 target={id}
                 trigger="legacy"
                 delay={0}
+                fade={false}
                 hideArrow={true}
             >
                 <CommandList {...props} onSelect={close} />


### PR DESCRIPTION
This improves UI responsiveness and is consistent with other similar menus in the UI (that immediately appear without a fade-in).




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->