### PR TITLE
Don't skip pipelines and notes already seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Usernames set in Slack `observability.alerts` now apply correctly. [#14079](https://github.com/sourcegraph/sourcegraph/pull/14079)
 - Path segments in breadcrumbs get truncated correctly again on small screen sizes instead of inflating the header bar. [#14097](https://github.com/sourcegraph/sourcegraph/pull/14097)
+- GitLab pipelines are now parsed correctly and show their current status in campaign changesets. [#14129](https://github.com/sourcegraph/sourcegraph/pull/14129)
 
 ## 3.20.1
 

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -478,9 +478,7 @@ func readPipelines(it func() ([]*gitlab.Pipeline, error)) ([]*gitlab.Pipeline, e
 			return pipelines, nil
 		}
 
-		for _, pipeline := range page {
-			pipelines = append(pipelines, pipeline)
-		}
+		pipelines = append(pipelines, page...)
 	}
 }
 

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -366,7 +366,6 @@ func (s *GitLabSource) LoadChangesets(ctx context.Context, cs ...*Changeset) err
 	// When we require GitLab 12.0+, we should migrate to the GraphQL API, which
 	// will allow us to query multiple MRs at once.
 	for _, c := range cs {
-		old := c.Changeset.Metadata.(*gitlab.MergeRequest)
 		project := c.Repo.Metadata.(*gitlab.Project)
 
 		iid, err := strconv.ParseInt(c.ExternalID, 10, 64)
@@ -381,7 +380,7 @@ func (s *GitLabSource) LoadChangesets(ctx context.Context, cs ...*Changeset) err
 
 		// As above, these additional API calls can go away once we can use
 		// GraphQL.
-		if err := s.decorateMergeRequestData(ctx, project, mr, old); err != nil {
+		if err := s.decorateMergeRequestData(ctx, project, mr); err != nil {
 			return errors.Wrapf(err, "retrieving additional data for merge request %d", iid)
 		}
 
@@ -393,13 +392,13 @@ func (s *GitLabSource) LoadChangesets(ctx context.Context, cs ...*Changeset) err
 	return nil
 }
 
-func (s *GitLabSource) decorateMergeRequestData(ctx context.Context, project *gitlab.Project, mr, old *gitlab.MergeRequest) error {
-	notes, err := s.getMergeRequestNotes(ctx, project, mr, old)
+func (s *GitLabSource) decorateMergeRequestData(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) error {
+	notes, err := s.getMergeRequestNotes(ctx, project, mr)
 	if err != nil {
 		return errors.Wrap(err, "retrieving notes")
 	}
 
-	pipelines, err := s.getMergeRequestPipelines(ctx, project, mr, old)
+	pipelines, err := s.getMergeRequestPipelines(ctx, project, mr)
 	if err != nil {
 		return errors.Wrap(err, "retrieving pipelines")
 	}
@@ -409,47 +408,23 @@ func (s *GitLabSource) decorateMergeRequestData(ctx context.Context, project *gi
 	return nil
 }
 
-type idSet map[gitlab.ID]struct{}
-
-func (s idSet) add(id gitlab.ID) { s[id] = struct{}{} }
-
-func (s idSet) has(id gitlab.ID) bool {
-	_, ok := s[id]
-	return ok
-}
-
 // getMergeRequestNotes retrieves the notes attached to a merge request in
-// descending time order. The old merge request is used to prevent retrieving
-// notes that have already been seen.
-func (s *GitLabSource) getMergeRequestNotes(ctx context.Context, project *gitlab.Project, mr, old *gitlab.MergeRequest) ([]*gitlab.Note, error) {
-	// Firstly, we'll set up a set containing the old note IDs so that we know
-	// where we can stop iterating: on a MR with lots of notes, this will mean
-	// we shouldn't need to load all pages on every sync.
-	extant := make(idSet)
-	for _, note := range old.Notes {
-		extant.add(note.ID)
-	}
-
-	// Secondly, we'll get the forward iterator that gives us a note page at a
-	// time.
+// descending time order.
+func (s *GitLabSource) getMergeRequestNotes(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) ([]*gitlab.Note, error) {
+	// Get the forward iterator that gives us a note page at a time.
 	it := s.client.GetMergeRequestNotes(ctx, project, mr.IID)
 
 	// Now we can iterate over the pages of notes and fill in the slice to be
 	// returned.
-	notes, err := readNotesUntilSeen(it, extant)
+	notes, err := readSystemNotes(it)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading note pages")
 	}
 
-	// Finally, we should append the old notes to the new notes. Doing so after
-	// handling the new notes means that all the notes should be in descending
-	// order without needing to explicitly sort.
-	notes = append(notes, old.Notes...)
-
 	return notes, nil
 }
 
-func readNotesUntilSeen(it func() ([]*gitlab.Note, error), extant idSet) ([]*gitlab.Note, error) {
+func readSystemNotes(it func() ([]*gitlab.Note, error)) ([]*gitlab.Note, error) {
 	var notes []*gitlab.Note
 
 	for {
@@ -468,11 +443,6 @@ func readNotesUntilSeen(it func() ([]*gitlab.Note, error), extant idSet) ([]*git
 			// include the review state changes we need; let's not even bother
 			// storing the non-system ones.
 			if note.System {
-				if extant.has(note.ID) {
-					// We've seen this note before, which means that nothing
-					// after this point should be new.
-					return notes, nil
-				}
 				notes = append(notes, note)
 			}
 		}
@@ -480,37 +450,21 @@ func readNotesUntilSeen(it func() ([]*gitlab.Note, error), extant idSet) ([]*git
 }
 
 // getMergeRequestPipelines retrieves the pipelines attached to a merge request
-// in descending time order. The old merge request is used to prevent
-// retrieving pipelines that have already been seen.
-func (s *GitLabSource) getMergeRequestPipelines(ctx context.Context, project *gitlab.Project, mr, old *gitlab.MergeRequest) ([]*gitlab.Pipeline, error) {
-	// Firstly, we'll set up a set containing the old pipeline IDs so that we
-	// know where we can stop iterating: on a MR with lots of pipelines, this
-	// will mean we shouldn't need to load all pages on every sync.
-	extant := make(idSet)
-	for _, pipeline := range old.Pipelines {
-		extant.add(pipeline.ID)
-	}
-
-	// Secondly, we'll get the forward iterator that gives us a pipeline page at
-	// a time.
+// in descending time order.
+func (s *GitLabSource) getMergeRequestPipelines(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) ([]*gitlab.Pipeline, error) {
+	// Get the forward iterator that gives us a pipeline page at a time.
 	it := s.client.GetMergeRequestPipelines(ctx, project, mr.IID)
 
 	// Now we can iterate over the pages of pipelines and fill in the slice to
 	// be returned.
-	pipelines, err := readPipelinesUntilSeen(it, extant)
+	pipelines, err := readPipelines(it)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading pipeline pages")
 	}
-
-	// Finally, we should append the old pipelines to the new pipelines. Doing
-	// so after handling the new pipelines means that all the pipelines should
-	// be in descending order without needing to explicitly sort.
-	pipelines = append(pipelines, old.Pipelines...)
-
 	return pipelines, nil
 }
 
-func readPipelinesUntilSeen(it func() ([]*gitlab.Pipeline, error), extant idSet) ([]*gitlab.Pipeline, error) {
+func readPipelines(it func() ([]*gitlab.Pipeline, error)) ([]*gitlab.Pipeline, error) {
 	var pipelines []*gitlab.Pipeline
 
 	for {
@@ -525,11 +479,6 @@ func readPipelinesUntilSeen(it func() ([]*gitlab.Pipeline, error), extant idSet)
 		}
 
 		for _, pipeline := range page {
-			if extant.has(pipeline.ID) {
-				// We've seen this pipeline before, which means that nothing
-				// after this point should be new.
-				return pipelines, nil
-			}
 			pipelines = append(pipelines, pipeline)
 		}
 	}

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -583,11 +583,21 @@ func TestReadNotesUntilSeen(t *testing.T) {
 		{ID: 4, System: true},
 	}
 
+	t.Run("reads all notes", func(t *testing.T) {
+		notes, err := readSystemNotes(paginatedNoteIterator(commonNotes, 2))
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %+v", err)
+		}
+		if diff := cmp.Diff(notes, commonNotes); diff != "" {
+			t.Errorf("unexpected notes: %s", diff)
+		}
+	})
+
 	t.Run("error from iterator", func(t *testing.T) {
 		want := errors.New("foo")
-		notes, err := readNotesUntilSeen(func() ([]*gitlab.Note, error) {
+		notes, err := readSystemNotes(func() ([]*gitlab.Note, error) {
 			return nil, want
-		}, make(idSet))
+		})
 		if notes != nil {
 			t.Errorf("unexpected non-nil notes: %+v", notes)
 		}
@@ -597,65 +607,27 @@ func TestReadNotesUntilSeen(t *testing.T) {
 	})
 
 	t.Run("no system notes", func(t *testing.T) {
-		notes, err := readNotesUntilSeen(paginatedNoteIterator([]*gitlab.Note{
+		notes, err := readSystemNotes(paginatedNoteIterator([]*gitlab.Note{
 			{ID: 1, System: false},
 			{ID: 2, System: false},
 			{ID: 3, System: false},
 			{ID: 4, System: false},
-		}, 2), make(idSet))
+		}, 2))
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %+v", err)
 		}
 		if len(notes) > 0 {
 			t.Errorf("unexpected notes: %+v", notes)
-		}
-	})
-
-	t.Run("empty extant notes", func(t *testing.T) {
-		notes, err := readNotesUntilSeen(paginatedNoteIterator(commonNotes, 2), make(idSet))
-		if err != nil {
-			t.Errorf("unexpected non-nil error: %+v", err)
-		}
-		if diff := cmp.Diff(notes, commonNotes); diff != "" {
-			t.Errorf("unexpected notes: %s", diff)
-		}
-	})
-
-	t.Run("no overlap with extant notes", func(t *testing.T) {
-		set := make(idSet)
-		set.add(5)
-		set.add(6)
-
-		notes, err := readNotesUntilSeen(paginatedNoteIterator(commonNotes, 2), set)
-		if err != nil {
-			t.Errorf("unexpected non-nil error: %+v", err)
-		}
-		if diff := cmp.Diff(notes, commonNotes); diff != "" {
-			t.Errorf("unexpected notes: %s", diff)
 		}
 	})
 
 	t.Run("no pages", func(t *testing.T) {
-		notes, err := readNotesUntilSeen(paginatedNoteIterator([]*gitlab.Note{}, 2), make(idSet))
+		notes, err := readSystemNotes(paginatedNoteIterator([]*gitlab.Note{}, 2))
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %+v", err)
 		}
 		if len(notes) > 0 {
 			t.Errorf("unexpected notes: %+v", notes)
-		}
-	})
-
-	t.Run("early end", func(t *testing.T) {
-		set := make(idSet)
-		set.add(3)
-		set.add(4)
-
-		notes, err := readNotesUntilSeen(paginatedNoteIterator(commonNotes, 2), set)
-		if err != nil {
-			t.Errorf("unexpected non-nil error: %+v", err)
-		}
-		if diff := cmp.Diff(notes, commonNotes[0:2]); diff != "" {
-			t.Errorf("unexpected notes: %s", diff)
 		}
 	})
 }
@@ -668,11 +640,21 @@ func TestReadPipelinesUntilSeen(t *testing.T) {
 		{ID: 4},
 	}
 
+	t.Run("reads all pipelines", func(t *testing.T) {
+		notes, err := readPipelines(paginatedPipelineIterator(commonPipelines, 2))
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %+v", err)
+		}
+		if diff := cmp.Diff(notes, commonPipelines); diff != "" {
+			t.Errorf("unexpected notes: %s", diff)
+		}
+	})
+
 	t.Run("error from iterator", func(t *testing.T) {
 		want := errors.New("foo")
-		pipelines, err := readPipelinesUntilSeen(func() ([]*gitlab.Pipeline, error) {
+		pipelines, err := readPipelines(func() ([]*gitlab.Pipeline, error) {
 			return nil, want
-		}, make(idSet))
+		})
 		if pipelines != nil {
 			t.Errorf("unexpected non-nil pipelines: %+v", pipelines)
 		}
@@ -681,51 +663,13 @@ func TestReadPipelinesUntilSeen(t *testing.T) {
 		}
 	})
 
-	t.Run("empty extant pipelines", func(t *testing.T) {
-		pipelines, err := readPipelinesUntilSeen(paginatedPipelineIterator(commonPipelines, 2), make(idSet))
-		if err != nil {
-			t.Errorf("unexpected non-nil error: %+v", err)
-		}
-		if diff := cmp.Diff(pipelines, commonPipelines); diff != "" {
-			t.Errorf("unexpected pipelines: %s", diff)
-		}
-	})
-
-	t.Run("no overlap with extant pipelines", func(t *testing.T) {
-		set := make(idSet)
-		set.add(5)
-		set.add(6)
-
-		pipelines, err := readPipelinesUntilSeen(paginatedPipelineIterator(commonPipelines, 2), set)
-		if err != nil {
-			t.Errorf("unexpected non-nil error: %+v", err)
-		}
-		if diff := cmp.Diff(pipelines, commonPipelines); diff != "" {
-			t.Errorf("unexpected pipelines: %s", diff)
-		}
-	})
-
 	t.Run("no pages", func(t *testing.T) {
-		pipelines, err := readPipelinesUntilSeen(paginatedPipelineIterator([]*gitlab.Pipeline{}, 2), make(idSet))
+		pipelines, err := readPipelines(paginatedPipelineIterator([]*gitlab.Pipeline{}, 2))
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %+v", err)
 		}
 		if len(pipelines) > 0 {
 			t.Errorf("unexpected pipelines: %+v", pipelines)
-		}
-	})
-
-	t.Run("early end", func(t *testing.T) {
-		set := make(idSet)
-		set.add(3)
-		set.add(4)
-
-		pipelines, err := readPipelinesUntilSeen(paginatedPipelineIterator(commonPipelines, 2), set)
-		if err != nil {
-			t.Errorf("unexpected non-nil error: %+v", err)
-		}
-		if diff := cmp.Diff(pipelines, commonPipelines[0:2]); diff != "" {
-			t.Errorf("unexpected pipelines: %s", diff)
 		}
 	})
 }

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -405,9 +405,9 @@ func parseGitLabPipelineStatus(status gitlab.PipelineStatus) campaigns.Changeset
 	switch status {
 	case gitlab.PipelineStatusSuccess:
 		return campaigns.ChangesetCheckStatePassed
-	case gitlab.PipelineStatusFailed:
+	case gitlab.PipelineStatusFailed, gitlab.PipelineStatusCanceled:
 		return campaigns.ChangesetCheckStateFailed
-	case gitlab.PipelineStatusPending:
+	case gitlab.PipelineStatusPending, gitlab.PipelineStatusRunning, gitlab.PipelineStatusCreated:
 		return campaigns.ChangesetCheckStatePending
 	default:
 		return campaigns.ChangesetCheckStateUnknown


### PR DESCRIPTION
This optimization caused problems, because we cannot ensure that resources beyond that timestamp never get updated,
and in fact, they do. Hence the Pipelines would never get into their final state, because a refetch would not happen.
Also, there were some state mappings missing in the GitlabPipelineState -> ChangesetCheckstate conversion.

Closes https://github.com/sourcegraph/sourcegraph/issues/12667
