### PR TITLE
Make breadcrumbs properly align with containers

### DIFF
--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -153,7 +153,7 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location:
     breadcrumbs,
     location,
 }) => (
-    <nav className="d-flex p-2 flex-shrink-past-contents" aria-label="Breadcrumbs">
+    <nav className="d-flex py-2 container-fluid flex-shrink-past-contents" aria-label="Breadcrumbs">
         {sortBy(breadcrumbs, 'depth')
             .map(({ breadcrumb }) => breadcrumb)
             .filter(isDefined)


### PR DESCRIPTION
As discussed, using container-fluid will properly align the breadcrumbs container with containerized content on smaller screens.