### PR TITLE
codeintel: Validate input commit

### DIFF
--- a/enterprise/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler.go
@@ -43,24 +43,16 @@ func NewUploadHandler(store store.Store, bundleManagerClient bundles.BundleManag
 func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	repoName := getQuery(r, "repository")
-	commit := getQuery(r, "commit")
-	root := sanitizeRoot(getQuery(r, "root"))
-	indexer := getQuery(r, "indexerName")
-
-	uploadArgs := UploadArgs{
-		Commit:  commit,
-		Root:    root,
-		Indexer: indexer,
-	}
-
+	var repositoryID int
 	if !hasQuery(r, "uploadId") {
-		repo, commit, ok := ensureRepoAndCommitExist(ctx, w, repoName, commit)
+		repoName := getQuery(r, "repository")
+		commit := getQuery(r, "commit")
+
+		repo, ok := ensureRepoAndCommitExist(ctx, w, repoName, commit)
 		if !ok {
 			return
 		}
-		uploadArgs.RepositoryID = int(repo.ID)
-		uploadArgs.Commit = commit
+		repositoryID = int(repo.ID)
 
 		// 🚨 SECURITY: Ensure we return before proxying to the precise-code-intel-api-server upload
 		// endpoint. This endpoint is unprotected, so we need to make sure the user provides a valid
@@ -70,7 +62,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	payload, err := h.handleEnqueueErr(w, r, uploadArgs)
+	payload, err := h.handleEnqueueErr(w, r, repositoryID)
 	if err != nil {
 		if cerr, ok := err.(*ClientError); ok {
 			http.Error(w, cerr.Error(), http.StatusBadRequest)
@@ -98,9 +90,9 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 // UploadArgs are common arguments required to enqueue an upload for both
 // single-payload and multipart uploads.
 type UploadArgs struct {
-	RepositoryID int
 	Commit       string
 	Root         string
+	RepositoryID int
 	Indexer      string
 }
 
@@ -127,8 +119,15 @@ type enqueuePayload struct {
 //   - handleEnqueueMultipartSetup
 //   - handleEnqueueMultipartUpload
 //   - handleEnqueueMultipartFinalize
-func (h *UploadHandler) handleEnqueueErr(w http.ResponseWriter, r *http.Request, uploadArgs UploadArgs) (interface{}, error) {
+func (h *UploadHandler) handleEnqueueErr(w http.ResponseWriter, r *http.Request, repositoryID int) (interface{}, error) {
 	ctx := r.Context()
+
+	uploadArgs := UploadArgs{
+		Commit:       getQuery(r, "commit"),
+		Root:         sanitizeRoot(getQuery(r, "root")),
+		RepositoryID: repositoryID,
+		Indexer:      getQuery(r, "indexerName"),
+	}
 
 	if !hasQuery(r, "multiPart") && !hasQuery(r, "uploadId") {
 		return h.handleEnqueueSinglePayload(r, uploadArgs)
@@ -326,23 +325,22 @@ func (h *UploadHandler) handleEnqueueMultipartFinalize(r *http.Request, upload s
 	return nil, nil
 }
 
-func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, string, bool) {
+func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool) {
 	repo, err := backend.Repos.GetByName(ctx, api.RepoName(repoName))
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
-			return nil, "", false
+			return nil, false
 		}
 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return nil, "", false
+		return nil, false
 	}
 
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, commit)
-	if err != nil {
+	if _, err := backend.Repos.ResolveRev(ctx, repo, commit); err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
-			return nil, "", false
+			return nil, false
 		}
 
 		// If the repository is currently being cloned (which is most likely to happen on dotcom),
@@ -350,9 +348,9 @@ func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoNa
 		// the worker wait until the rev is resolvable before starting to process.
 		if !vcs.IsCloneInProgress(err) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return nil, "", false
+			return nil, false
 		}
 	}
 
-	return repo, string(commitID), true
+	return repo, true
 }

--- a/enterprise/internal/codeintel/httpapi/upload_handler_test.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler_test.go
@@ -32,6 +32,8 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+const testCommit = "deadbeef01deadbeef02deadbeef03deadbeef04"
+
 func TestHandleEnqueueSinglePayload(t *testing.T) {
 	setupRepoMocks(t)
 
@@ -46,7 +48,7 @@ func TestHandleEnqueueSinglePayload(t *testing.T) {
 		t.Fatalf("unexpected error constructing url: %s", err)
 	}
 	testURL.RawQuery = (url.Values{
-		"commit":      []string{"deadbeef"},
+		"commit":      []string{testCommit},
 		"root":        []string{"proj/"},
 		"repository":  []string{"github.com/test/test"},
 		"indexerName": []string{"lsif-go"},
@@ -80,8 +82,8 @@ func TestHandleEnqueueSinglePayload(t *testing.T) {
 		t.Errorf("unexpected number of InsertUploadFunc calls. want=%d have=%d", 1, len(mockStore.InsertUploadFunc.History()))
 	} else {
 		call := mockStore.InsertUploadFunc.History()[0]
-		if call.Arg1.Commit != "deadbeef" {
-			t.Errorf("unexpected commit. want=%q have=%q", "deadbeef", call.Arg1.Commit)
+		if call.Arg1.Commit != testCommit {
+			t.Errorf("unexpected commit. want=%q have=%q", testCommit, call.Arg1.Commit)
 		}
 		if call.Arg1.Root != "proj/" {
 			t.Errorf("unexpected root. want=%q have=%q", "proj/", call.Arg1.Root)
@@ -127,7 +129,7 @@ func TestHandleEnqueueSinglePayloadNoIndexerName(t *testing.T) {
 		t.Fatalf("unexpected error constructing url: %s", err)
 	}
 	testURL.RawQuery = (url.Values{
-		"commit":     []string{"deadbeef"},
+		"commit":     []string{testCommit},
 		"root":       []string{"proj/"},
 		"repository": []string{"github.com/test/test"},
 	}).Encode()
@@ -193,7 +195,7 @@ func TestHandleEnqueueMultipartSetup(t *testing.T) {
 		t.Fatalf("unexpected error constructing url: %s", err)
 	}
 	testURL.RawQuery = (url.Values{
-		"commit":      []string{"deadbeef"},
+		"commit":      []string{testCommit},
 		"root":        []string{"proj/"},
 		"repository":  []string{"github.com/test/test"},
 		"indexerName": []string{"lsif-go"},
@@ -224,8 +226,8 @@ func TestHandleEnqueueMultipartSetup(t *testing.T) {
 		t.Errorf("unexpected number of InsertUploadFunc calls. want=%d have=%d", 1, len(mockStore.InsertUploadFunc.History()))
 	} else {
 		call := mockStore.InsertUploadFunc.History()[0]
-		if call.Arg1.Commit != "deadbeef" {
-			t.Errorf("unexpected commit. want=%q have=%q", "deadbeef", call.Arg1.Commit)
+		if call.Arg1.Commit != testCommit {
+			t.Errorf("unexpected commit. want=%q have=%q", testCommit, call.Arg1.Commit)
 		}
 		if call.Arg1.Root != "proj/" {
 			t.Errorf("unexpected root. want=%q have=%q", "proj/", call.Arg1.Root)
@@ -421,8 +423,8 @@ func setupRepoMocks(t *testing.T) {
 	}
 
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
-		if rev != "deadbeef" {
-			t.Errorf("unexpected commit. want=%s have=%s", "deadbeef", rev)
+		if rev != testCommit {
+			t.Errorf("unexpected commit. want=%s have=%s", testCommit, rev)
 		}
 		return "", nil
 	}

--- a/enterprise/internal/codeintel/httpapi/upload_handler_test.go
+++ b/enterprise/internal/codeintel/httpapi/upload_handler_test.go
@@ -424,6 +424,6 @@ func setupRepoMocks(t *testing.T) {
 		if rev != "deadbeef" {
 			t.Errorf("unexpected commit. want=%s have=%s", "deadbeef", rev)
 		}
-		return api.CommitID(rev), nil
+		return "", nil
 	}
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/14052.

This reverts the change in https://github.com/sourcegraph/sourcegraph/pull/14005, then strengthens the validation on the input commit.

In short, we pass the repo name and commit to gitserver for resolution. If gitserver is currently cloning the repo, we can't determine what the correct commit is. If this happens to be a symbolic name, it will fail to be put into the database. This error message helps with this case.

**Note to reviewer**: This is weenie hut junior mode if reviewed by commit.