### PR TITLE
disable interactive search (splitSearchModes) by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to Sourcegraph are documented in this file.
 - The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.
 - Changesets created by campaigns will now include a link back to the campaign in their body text. [#14033](https://github.com/sourcegraph/sourcegraph/issues/14033)
 
+### Changed
+
+- Interactive search mode is now disabled by default because the new plain text search input is smarter. To reenable it, add `{ "experimentalFeatures": { "splitSearchModes": true } }` in user settings.
+
 ### Fixed
 
 - Usernames set in Slack `observability.alerts` now apply correctly. [#14079](https://github.com/sourcegraph/sourcegraph/pull/14079)

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -15,7 +15,7 @@
         "splitSearchModes": {
           "description": "Enables toggling between the current omni search mode, and experimental interactive search mode.",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "!go": { "pointer": true }
         },
         "codeInsights": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -20,7 +20,7 @@ const SettingsSchemaJSON = `{
         "splitSearchModes": {
           "description": "Enables toggling between the current omni search mode, and experimental interactive search mode.",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "!go": { "pointer": true }
         },
         "codeInsights": {

--- a/web/src/SourcegraphWebApp.tsx
+++ b/web/src/SourcegraphWebApp.tsx
@@ -252,7 +252,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             searchPatternType: urlPatternType,
             searchCaseSensitivity: urlCase,
             filtersInQuery: {},
-            splitSearchModes: true,
+            splitSearchModes: false,
             interactiveSearchMode: currentSearchMode ? currentSearchMode === 'interactive' : false,
             copyQueryButton: false,
             versionContext: resolvedVersionContext,

--- a/web/src/repogroups/RepogroupPage.story.tsx
+++ b/web/src/repogroups/RepogroupPage.story.tsx
@@ -82,7 +82,7 @@ const commonProps = subtypeOf<Partial<RepogroupPageProps>>()({
     keyboardShortcuts: [],
     onFiltersInQueryChange: action('onFiltersInQueryChange'),
     setCaseSensitivity: action('setCaseSensitivity'),
-    splitSearchModes: true,
+    splitSearchModes: false,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     toggleSearchMode: action('toggleSearchMode'),
     versionContext: undefined,

--- a/web/src/search/input/MonacoQueryInput.tsx
+++ b/web/src/search/input/MonacoQueryInput.tsx
@@ -247,6 +247,7 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
                             options={options}
                             border={false}
                             keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
+                            className="test-query-input"
                         />
                     </div>
                     <Toggles

--- a/web/src/util/settings.ts
+++ b/web/src/util/settings.ts
@@ -59,7 +59,7 @@ export function experimentalFeaturesFromSettings(
         {}
 
     const {
-        splitSearchModes = true,
+        splitSearchModes = false,
         copyQueryButton = false,
         searchStreaming = false,
         showRepogroupHomepage = false,


### PR DESCRIPTION
Switches the default back to interactive search mode being disabled. The plain text search input (using Monaco) has gotten a lot smarter since we introduced interactive search mode, and interactive search mode has seen fairly low usage as a % of all searches.

See https://sourcegraph.slack.com/archives/CHEKCRWKV/p1600450926015300?thread_ts=1600443200.010300 for discussion about potentially completely removing interactive search mode in the future. For now, it's still there, but it's disabled by default.