### PR TITLE
ignore https errors when running e2e/integration tests

### DIFF
--- a/shared/src/testing/driver.ts
+++ b/shared/src/testing/driver.ts
@@ -688,6 +688,7 @@ export async function createDriverForTest(options?: DriverOptions): Promise<Driv
     const { loadExtension, sourcegraphBaseUrl, logBrowserConsole, keepBrowser } = options
     const args: string[] = []
     const launchOptions: puppeteer.LaunchOptions = {
+        ignoreHTTPSErrors: true,
         ...options,
         args,
         defaultViewport: null,


### PR DESCRIPTION
We use https for local dev, but our self-signed certificates aren't trusted by all systems reliably (despite Caddy's best efforts at making this smooth). A common case is where you're developing in Chrome and you've manually accepted the cert, but your system doesn't trust it systemwide. In that case, the e2e and integration tests will fail because the vendored Chromium/Firefox doesn't trust your cert. This ignoreHTTPSErrors setting is necessary to run the tests in that case (and bypass the `Error: net::ERR_CERT_AUTHORITY_INVALID at https://sourcegraph.test:3443` error in the test output)

I can't think of a realistic downside to setting this, and it will probably save people many minutes here and there.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->