### PR TITLE
tracking-issue: Do not show completed PRs if the owning image is also complete

### DIFF
--- a/internal/cmd/tracking-issue/testdata/issue.md
+++ b/internal/cmd/tracking-issue/testdata/issue.md
@@ -35,7 +35,7 @@ Completed
   - [ ] RFC 235: Configure connection to codeintel database ([#13884](https://github.com/sourcegraph/sourcegraph/issues/13884); PRs: ~[#13952](https://github.com/sourcegraph/sourcegraph/pull/13952)~, [#13864](https://github.com/sourcegraph/sourcegraph/pull/13864)) __0.5d__ 
   - [ ] RFC 235: Add code intel postgres container ([#13883](https://github.com/sourcegraph/sourcegraph/issues/13883); PRs: [#13924](https://github.com/sourcegraph/sourcegraph/pull/13924), [#13904](https://github.com/sourcegraph/sourcegraph/pull/13904), [#13864](https://github.com/sourcegraph/sourcegraph/pull/13864)) __1d__ 
   - [x] (🏁 5 days ago) chore: Set exec bit on docker-images/codeintel-db/build.sh ([#13955](https://github.com/sourcegraph/sourcegraph/pull/13955)) :shipit:
-  - [x] (🏁 5 days ago) chore: Co-locate dev scripts to interact with postgres ([#13942](https://github.com/sourcegraph/sourcegraph/pull/13942)) :shipit:
+  - [x] (🏁 6 days ago) chore: Co-locate dev scripts to interact with postgres ([#13942](https://github.com/sourcegraph/sourcegraph/pull/13942)) :shipit:
   - [ ] codeintel: RFC 235: Soft delete upload records ([#13822](https://github.com/sourcegraph/sourcegraph/pull/13822)) :shipit:
 - [ ] RFC 201: Tracking issue ([#13891](https://github.com/sourcegraph/sourcegraph/issues/13891)) 
   - [ ] RFC 201: Use auto-configurator ([#13898](https://github.com/sourcegraph/sourcegraph/issues/13898)) 
@@ -57,28 +57,25 @@ Completed
 - [ ] codeintel: Remove some wrappers from a previous abstraction ([#14142](https://github.com/sourcegraph/sourcegraph/pull/14142)) :shipit:
 
 Completed: __1.00d__
-- [x] (🏁 5 days ago) chore: Co-locate dev scripts to interact with postgres ([#13942](https://github.com/sourcegraph/sourcegraph/pull/13942)) :shipit:
+- [x] (🏁 6 days ago) chore: Co-locate dev scripts to interact with postgres ([#13942](https://github.com/sourcegraph/sourcegraph/pull/13942)) :shipit:
 - [x] (🏁 5 days ago) chore: Multiple database handles ([#13952](https://github.com/sourcegraph/sourcegraph/pull/13952)) :shipit:
 - [x] (🏁 5 days ago) RFC 235: Add code intel postgres image ([~#13912~](https://github.com/sourcegraph/sourcegraph/issues/13912); PRs: ~[#13913](https://github.com/sourcegraph/sourcegraph/pull/13913)~) __0.5d__ 
-- [x] (🏁 5 days ago) codeintel: RFC 235: Add code intel postgres image ([#13913](https://github.com/sourcegraph/sourcegraph/pull/13913)) :shipit:
 - [x] (🏁 5 days ago) chore: Set exec bit on docker-images/codeintel-db/build.sh ([#13955](https://github.com/sourcegraph/sourcegraph/pull/13955)) :shipit:
 - [x] (🏁 5 days ago) chore: Relocate frontend migrations ([#13943](https://github.com/sourcegraph/sourcegraph/pull/13943)) :shipit:
 - [x] (🏁 2 days ago) tracking-issue: Fix timeout ([#13986](https://github.com/sourcegraph/sourcegraph/pull/13986)) :shipit:
 - [x] (🏁 2 days ago) tracking-issue: Fix long-form linked issues ([#13989](https://github.com/sourcegraph/sourcegraph/pull/13989)) :shipit:
 - [x] (🏁 2 days ago) 504 Gateway Timeouts when mousing over after the page has loaded for a while ([~#12930~](https://github.com/sourcegraph/sourcegraph/issues/12930)) 🐛
-- [x] (🏁 2 days ago) codeintel: Resolve abbreviated OID ([#14005](https://github.com/sourcegraph/sourcegraph/pull/14005)) :shipit:
 - [x] (🏁 2 days ago) LSIF uploads fail with abbreviated OID ([~#13957~](https://github.com/sourcegraph/sourcegraph/issues/13957); PRs: ~[#14005](https://github.com/sourcegraph/sourcegraph/pull/14005)~) __0.5d__ 
 - [x] (🏁 2 days ago) tracking-issue: Nested tracking issues ([#13998](https://github.com/sourcegraph/sourcegraph/pull/13998)) :shipit:
 - [x] (🏁 2 days ago) Fix retries in src-cli lsif upload ([~#14008~](https://github.com/sourcegraph/sourcegraph/issues/14008)) 
 - [x] (🏁 2 days ago) tracking-issue: Parallelize writes ([#14006](https://github.com/sourcegraph/sourcegraph/pull/14006)) :shipit:
-- [x] (🏁 1 day ago) tracking-issue: Break code up into files according to type/action ([#14013](https://github.com/sourcegraph/sourcegraph/pull/14013)) :shipit:
-- [x] (🏁 1 day ago) tracking-issue: List PRs for an issue inline ([#14018](https://github.com/sourcegraph/sourcegraph/pull/14018)) :shipit:
+- [x] (🏁 2 days ago) tracking-issue: Break code up into files according to type/action ([#14013](https://github.com/sourcegraph/sourcegraph/pull/14013)) :shipit:
+- [x] (🏁 2 days ago) tracking-issue: List PRs for an issue inline ([#14018](https://github.com/sourcegraph/sourcegraph/pull/14018)) :shipit:
 - [x] (🏁 1 day ago) tracking-issue: Separate complete/incomplete work ([#14034](https://github.com/sourcegraph/sourcegraph/pull/14034)) :shipit:
 - [x] (🏁 1 day ago) tracking-issue: Better nested tracking issue estimates ([#14035](https://github.com/sourcegraph/sourcegraph/pull/14035)) :shipit:
 - [x] (🏁 today) codenotify: Configure efritz's subscriptions ([#14060](https://github.com/sourcegraph/sourcegraph/pull/14060)) :shipit:
 - [x] (🏁 today) codeintel: Refactor command runner in indexer ([#14102](https://github.com/sourcegraph/sourcegraph/pull/14102)) :shipit:
 - [x] (🏁 today) codeintel: Lower indexer output to debug level ([#14103](https://github.com/sourcegraph/sourcegraph/pull/14103)) :shipit:
-- [x] (🏁 today) ~workerutil: Add isolation level option to store~ ([#14063](https://github.com/sourcegraph/sourcegraph/pull/14063)) :shipit:
 - [x] (🏁 today) tracking-issue: Fix strikethrough on closed (un-merged) PRs ([#14107](https://github.com/sourcegraph/sourcegraph/pull/14107)) :shipit:
 - [x] (🏁 today) codeintel: Refactor index command construction ([#14105](https://github.com/sourcegraph/sourcegraph/pull/14105)) :shipit:
 - [x] (🏁 today) codeintel: Move away from hardcoding image names ([#14114](https://github.com/sourcegraph/sourcegraph/pull/14114)) :shipit:
@@ -86,7 +83,6 @@ Completed: __1.00d__
 - [x] (🏁 today) codeintel: Add orderedKeys to indexer ([#14117](https://github.com/sourcegraph/sourcegraph/pull/14117)) :shipit:
 - [x] (🏁 today) tracking-issue: Nest unlinked PRs under the closest tracking issue ([#14108](https://github.com/sourcegraph/sourcegraph/pull/14108)) :shipit:
 - [x] (🏁 today) dbworker: Pass sql options to TransactableHandle ([~#14044~](https://github.com/sourcegraph/sourcegraph/issues/14044); PRs: ~[#14063](https://github.com/sourcegraph/sourcegraph/pull/14063)~, ~[#14061](https://github.com/sourcegraph/sourcegraph/pull/14061)~) 
-- [x] (🏁 today) db: Add sql.TxOptions to basestore ([#14061](https://github.com/sourcegraph/sourcegraph/pull/14061)) :shipit:
 - [x] (🏁 today) tracking-issue: Order finished work chronologically ([#14124](https://github.com/sourcegraph/sourcegraph/pull/14124)) :shipit:
 <!-- END ASSIGNEE -->
 

--- a/internal/cmd/tracking-issue/workload.go
+++ b/internal/cmd/tracking-issue/workload.go
@@ -92,9 +92,17 @@ func (wl *Workload) Markdown(labelAllowlist []string) string {
 			}
 		}
 
-		// Put all PRs that aren't linked to issues top-level
+	outer:
 		for _, pr := range wl.PullRequests {
 			if pr.Done() {
+				// Put all closed PRs that have at least one linked issue that
+				// has not been completed at the top level of the finished work.
+				for _, issue := range pr.LinkedIssues {
+					if issue.Closed() {
+						continue outer
+					}
+				}
+
 				completedWork = append(completedWork, renderedCompletedWork{
 					Markdown: pr.Markdown(),
 					ClosedAt: pr.ClosedAt,


### PR DESCRIPTION
By popular demand, we de-duplicate the list of finished work by hiding PRs that are tracked by a completed issue.