### PR TITLE
Simplify git commit node styling

### DIFF
--- a/web/src/end-to-end/end-to-end.test.ts
+++ b/web/src/end-to-end/end-to-end.test.ts
@@ -862,7 +862,7 @@ describe('e2e test suite', () => {
                 await retry(async () =>
                     expect(
                         await driver.page.evaluate(() =>
-                            document.querySelectorAll('.git-commit-node-byline')[3].textContent!.trim()
+                            document.querySelectorAll('.test-git-commit-node-byline')[3].textContent!.trim()
                         )
                     ).toContain('Dmitri Shuralyov')
                 )

--- a/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -18,18 +18,20 @@ import {
     GitCommitFields,
     Scalars,
 } from '../graphql-operations'
+import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 
-interface CommitNodeProps {
+interface CommitNodeProps extends TelemetryProps {
     node: GitCommitFields
     location: H.Location
 }
 
-const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, location }) => (
+const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, location, telemetryService }) => (
     <li className="list-group-item p-0">
         <GitCommitNode
             compact={true}
             node={node}
             hideExpandCommitMessageBody={true}
+            telemetryService={telemetryService}
             afterElement={
                 <Link
                     to={replaceRevisionInURL(location.pathname + location.search + location.hash, node.oid)}
@@ -43,7 +45,7 @@ const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, location }
     </li>
 )
 
-interface Props extends Partial<RevisionSpec>, FileSpec {
+interface Props extends Partial<RevisionSpec>, FileSpec, TelemetryProps {
     repoID: Scalars['ID']
     history: H.History
     location: H.Location
@@ -52,14 +54,14 @@ interface Props extends Partial<RevisionSpec>, FileSpec {
 export class RepoRevisionSidebarCommits extends React.PureComponent<Props> {
     public render(): JSX.Element | null {
         return (
-            <FilteredConnection<GitCommitFields, Pick<CommitNodeProps, 'location'>, CommitAncestorsConnectionFields>
+            <FilteredConnection<GitCommitFields, Omit<CommitNodeProps, 'node'>, CommitAncestorsConnectionFields>
                 className="list-group list-group-flush"
                 compact={true}
                 noun="commit"
                 pluralNoun="commits"
                 queryConnection={this.fetchCommits}
                 nodeComponent={CommitNode}
-                nodeComponentProps={{ location: this.props.location }}
+                nodeComponentProps={{ location: this.props.location, telemetryService: this.props.telemetryService }}
                 defaultFirst={100}
                 hideSearch={true}
                 useURLQuery={false}

--- a/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/web/src/repo/blob/panel/BlobPanel.tsx
@@ -21,6 +21,7 @@ import { RepoHeaderContributionsLifecycleProps } from '../../RepoHeader'
 import { RepoRevisionSidebarCommits } from '../../RepoRevisionSidebarCommits'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { AuthenticatedUser } from '../../../auth'
+import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 
 interface Props
     extends AbsoluteRepoFile,
@@ -31,7 +32,8 @@ interface Props
         PlatformContextProps,
         ExtensionsControllerProps,
         ThemeProps,
-        ActivationProps {
+        ActivationProps,
+        TelemetryProps {
     location: H.Location
     history: H.History
     repoID: GQL.ID
@@ -176,6 +178,7 @@ export class BlobPanel extends React.PureComponent<Props> {
                                     filePath={subject.filePath}
                                     history={this.props.history}
                                     location={this.props.location}
+                                    telemetryService={this.props.telemetryService}
                                 />
                             ),
                         }))

--- a/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -237,6 +237,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                                     node={this.state.commitOrError}
                                     expandCommitMessageBody={true}
                                     showSHAAndParentsRow={true}
+                                    telemetryService={this.props.telemetryService}
                                 />
                             </div>
                         </div>

--- a/web/src/repo/commits/GitCommitNode.scss
+++ b/web/src/repo/commits/GitCommitNode.scss
@@ -1,5 +1,4 @@
 .git-commit-node {
-    padding: 0.75rem 0.5rem 0.5rem;
     &--compact {
         padding-top: 0.5rem;
     }
@@ -15,17 +14,9 @@
         &-subject {
             flex: 0 1 auto;
             font-weight: bold;
-            padding-right: 0.5rem;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
-            color: $color-text-2;
-        }
-        &-toggle {
-            flex: none;
-            font-size: 9px;
-            padding: 0 0.175rem;
-            margin-right: 0.5rem;
         }
         &-timestamp {
             flex: none;
@@ -105,15 +96,5 @@
     }
     &--compact &__oid {
         flex: 0 0 auto;
-    }
-}
-
-.theme-light {
-    .git-commit-node {
-        &__message {
-            &-subject {
-                color: $color-light-text-1;
-            }
-        }
     }
 }

--- a/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/web/src/repo/commits/GitCommitNode.story.tsx
@@ -5,6 +5,7 @@ import { GitCommitNode } from './GitCommitNode'
 import { subDays } from 'date-fns'
 import { GitCommitFields } from '../../graphql-operations'
 import { WebStory } from '../../components/WebStory'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../shared/src/telemetry/telemetryService'
 
 const { add } = storiesOf('web/GitCommitNode', module).addDecorator(story => (
     <div className="p-3 container web-content">{story()}</div>
@@ -68,6 +69,7 @@ add('Full customizable', () => (
             <div className="card">
                 <GitCommitNode
                     node={gitCommitNode}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                     compact={boolean('compact', false)}
                     expandCommitMessageBody={boolean('expandCommitMessageBody', false)}
                     showSHAAndParentsRow={boolean('showSHAAndParentsRow', false)}
@@ -83,6 +85,7 @@ add('Compact', () => (
             <div className="card">
                 <GitCommitNode
                     node={gitCommitNode}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                     compact={true}
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={false}
@@ -98,6 +101,7 @@ add('Commit message expanded', () => (
             <div className="card">
                 <GitCommitNode
                     node={gitCommitNode}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                     compact={false}
                     expandCommitMessageBody={true}
                     showSHAAndParentsRow={false}
@@ -113,6 +117,7 @@ add('SHA and parent shown', () => (
             <div className="card">
                 <GitCommitNode
                     node={gitCommitNode}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                     compact={false}
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={true}
@@ -128,6 +133,7 @@ add('Expand commit message btn hidden', () => (
             <div className="card">
                 <GitCommitNode
                     node={gitCommitNode}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                     compact={false}
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={false}

--- a/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -3,6 +3,7 @@ import { Timestamp } from '../../components/time/Timestamp'
 import { UserAvatar } from '../../user/UserAvatar'
 import { formatPersonName, PersonLink } from '../../person/PersonLink'
 import { SignatureFields } from '../../graphql-operations'
+import classNames from 'classnames'
 
 interface Props {
     author: SignatureFields
@@ -28,7 +29,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, co
     ) {
         // The author and committer both exist and are different people.
         return (
-            <small className={`git-commit-node-byline git-commit-node-byline--has-committer ${className}`}>
+            <small className={classNames('test-git-commit-node-byline', className)}>
                 <UserAvatar
                     className="icon-inline"
                     user={author.person}
@@ -51,7 +52,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, co
     }
 
     return (
-        <small className={`git-commit-node-byline git-commit-node-byline--no-committer ${className}`}>
+        <small className={classNames('test-git-commit-node-byline', className)}>
             <UserAvatar
                 className="icon-inline mr-1"
                 user={author.person}

--- a/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -15,6 +15,7 @@ import { RevisionSpec, ResolvedRevisionSpec } from '../../../../shared/src/util/
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { GitCommitFields } from '../../graphql-operations'
 import { externalLinkFieldsFragment } from '../backend'
+import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 
 export const gitCommitFragment = gql`
     fragment GitCommitFields on GitCommit {
@@ -108,7 +109,8 @@ interface Props
     extends RepoHeaderContributionsLifecycleProps,
         Partial<RevisionSpec>,
         ResolvedRevisionSpec,
-        BreadcrumbSetters {
+        BreadcrumbSetters,
+        TelemetryProps {
     repo: GQL.IRepository
 
     history: H.History
@@ -132,14 +134,14 @@ export const RepositoryCommitsPage: React.FunctionComponent<Props> = ({ useBread
     return (
         <div className="repository-commits-page">
             <PageTitle title="Commits" />
-            <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact'>>
+            <FilteredConnection<GitCommitFields, Omit<GitCommitNodeProps, 'node'>>
                 className="repository-commits-page__content"
                 listClassName="list-group list-group-flush"
                 noun="commit"
                 pluralNoun="commits"
                 queryConnection={queryCommits}
                 nodeComponent={GitCommitNode}
-                nodeComponentProps={{ className: 'list-group-item' }}
+                nodeComponentProps={{ className: 'list-group-item', telemetryService: props.telemetryService }}
                 defaultFirst={20}
                 autoFocus={true}
                 history={props.history}

--- a/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GitCommitNodeByline author (compact) 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className="test-git-commit-node-byline"
 >
   <img
     className="user-avatar icon-inline mr-1"
@@ -29,7 +29,7 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
 
 exports[`GitCommitNodeByline author 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className="test-git-commit-node-byline"
 >
   <img
     className="user-avatar icon-inline mr-1"
@@ -56,7 +56,7 @@ exports[`GitCommitNodeByline author 1`] = `
 
 exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--has-committer "
+  className="test-git-commit-node-byline"
 >
   <img
     className="user-avatar icon-inline"
@@ -100,7 +100,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
 
 exports[`GitCommitNodeByline different author and committer 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--has-committer "
+  className="test-git-commit-node-byline"
 >
   <img
     className="user-avatar icon-inline"
@@ -144,7 +144,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
 
 exports[`GitCommitNodeByline omit GitHub committer 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className="test-git-commit-node-byline"
 >
   <img
     className="user-avatar icon-inline mr-1"
@@ -171,7 +171,7 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
 
 exports[`GitCommitNodeByline same author and committer 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className="test-git-commit-node-byline"
 >
   <img
     className="user-avatar icon-inline mr-1"

--- a/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -63,7 +63,7 @@ interface State extends HoverState<HoverContext, HoverMerged, ActionItemAction> 
 /**
  * Properties passed to all page components in the repository compare area.
  */
-export interface RepositoryCompareAreaPageProps extends PlatformContextProps {
+export interface RepositoryCompareAreaPageProps extends PlatformContextProps, TelemetryProps {
     /** The repository being compared. */
     repo: GQL.IRepository
 
@@ -185,6 +185,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
             head: { repoID: this.props.repo.id, repoName: this.props.repo.name, revision: spec?.head },
             routePrefix: this.props.match.url,
             platformContext: this.props.platformContext,
+            telemetryService: this.props.telemetryService,
         }
 
         return (

--- a/web/src/repo/compare/RepositoryCompareCommitsPage.tsx
+++ b/web/src/repo/compare/RepositoryCompareCommitsPage.tsx
@@ -90,7 +90,7 @@ export class RepositoryCompareCommitsPage extends React.PureComponent<Props> {
             <div className="repository-compare-page">
                 <div className="card">
                     <div className="card-header">Commits</div>
-                    <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact'>>
+                    <FilteredConnection<GitCommitFields, Omit<GitCommitNodeProps, 'node'>>
                         listClassName="list-group list-group-flush"
                         noun="commit"
                         pluralNoun="commits"
@@ -100,6 +100,7 @@ export class RepositoryCompareCommitsPage extends React.PureComponent<Props> {
                         nodeComponentProps={{
                             className: 'list-group-item',
                             compact: true,
+                            telemetryService: this.props.telemetryService,
                         }}
                         defaultFirst={50}
                         hideSearch={true}

--- a/web/src/repo/tree/TreePage.tsx
+++ b/web/src/repo/tree/TreePage.tsx
@@ -130,15 +130,16 @@ export const TreePage: React.FunctionComponent<Props> = ({
     caseSensitive,
     settingsCascade,
     useBreadcrumb,
+    telemetryService,
     ...props
 }) => {
     useEffect(() => {
         if (filePath === '') {
-            props.telemetryService.logViewEvent('Repository')
+            telemetryService.logViewEvent('Repository')
         } else {
-            props.telemetryService.logViewEvent('Tree')
+            telemetryService.logViewEvent('Tree')
         }
-    }, [filePath, props.telemetryService])
+    }, [filePath, telemetryService])
 
     useBreadcrumb(
         useMemo(() => {
@@ -355,6 +356,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                     {/* eslint-disable react/jsx-no-bind */}
                     <ActionsContainer
                         {...props}
+                        telemetryService={telemetryService}
                         menu={ContributableMenu.DirectoryPage}
                         render={items => (
                             <section className="tree-page__section">
@@ -362,6 +364,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                 {items.map(item => (
                                     <ActionItem
                                         {...props}
+                                        telemetryService={telemetryService}
                                         key={item.action.id}
                                         {...item}
                                         className="btn btn-secondary mr-1 mb-1"
@@ -374,7 +377,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                     {/* eslint-enable react/jsx-no-bind */}
                     <div className="tree-page__section">
                         <h3 className="tree-page__section-header">Changes</h3>
-                        <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact'>>
+                        <FilteredConnection<GitCommitFields, Omit<GitCommitNodeProps, 'node'>>
                             location={props.location}
                             className="mt-2 tree-page__section--commits"
                             listClassName="list-group list-group-flush"
@@ -385,6 +388,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                             nodeComponentProps={{
                                 className: 'list-group-item',
                                 compact: true,
+                                telemetryService,
                             }}
                             updateOnChange={`${repoName}:${revision}:${filePath}:${String(showOlderCommits)}`}
                             defaultFirst={7}


### PR DESCRIPTION
Also migrates to using an injected telemetryService, so no http errors are logged in the storybook.
