### PR TITLE
Update codeql.yml to reference main, not master

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "Code Scanning - Action"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
Looks like this got missed during our updates to the branch name - figured it'd be a quick security win to get this re-enabled!