### PR TITLE
search: fix repogroups and introduce types for repogroup values

### DIFF
--- a/cmd/frontend/graphqlbackend/repo_groups.go
+++ b/cmd/frontend/graphqlbackend/repo_groups.go
@@ -21,16 +21,29 @@ func (r *schemaResolver) RepoGroups(ctx context.Context) ([]*repoGroup, error) {
 		return nil, err
 	}
 
-	groupsByName, _, err := resolveRepoGroups(settings)
+	groupsByName, err := resolveRepoGroups(settings)
 	if err != nil {
 		return nil, err
 	}
 
 	groups := make([]*repoGroup, 0, len(groupsByName))
-	for name, repos := range groupsByName {
-		repoPaths := make([]api.RepoName, len(repos))
-		for i, repo := range repos {
-			repoPaths[i] = repo.Name
+	for name, values := range groupsByName {
+		var repoPaths []api.RepoName
+		for _, value := range values {
+			switch v := value.(type) {
+			case RepoPath:
+				repoPaths = append(repoPaths, api.RepoName(v.String()))
+			case RepoRegexpPattern:
+				// TODO(@sourcegraph/search): decide how to handle
+				// regexp patterns associated with repogroups.
+				// Currently they are skipped. They either need to
+				// resolve to a set of api.RepoNames or return the
+				// pattern as a string.
+				continue
+			default:
+				panic("unreachable")
+
+			}
 		}
 		groups = append(groups, &repoGroup{
 			name:         name,

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -342,35 +342,54 @@ func decodedViewerFinalSettings(ctx context.Context) (*schema.Settings, error) {
 	return &settings, nil
 }
 
-var mockResolveRepoGroups func() (map[string][]*types.Repo, []string, error)
+// A repogroup value is either a exact repo path RepoPath, or a regular
+// expression pattern RepoRegexpPattern.
+type RepoGroupValue interface {
+	value()
+	String() string
+}
 
-func resolveRepoGroups(settings *schema.Settings) (groups map[string][]*types.Repo, patterns []string, err error) {
+type RepoPath string
+type RepoRegexpPattern string
+
+func (RepoPath) value() {}
+func (r RepoPath) String() string {
+	return string(r)
+}
+
+func (RepoRegexpPattern) value() {}
+func (r RepoRegexpPattern) String() string {
+	return string(r)
+}
+
+var mockResolveRepoGroups func() (map[string][]RepoGroupValue, error)
+
+func resolveRepoGroups(settings *schema.Settings) (groups map[string][]RepoGroupValue, err error) {
 	if mockResolveRepoGroups != nil {
 		return mockResolveRepoGroups()
 	}
-	groups = map[string][]*types.Repo{}
+	groups = map[string][]RepoGroupValue{}
 
-	for name, repoSpecs := range settings.SearchRepositoryGroups {
-		repos := make([]*types.Repo, 0, len(repoSpecs))
+	for name, values := range settings.SearchRepositoryGroups {
+		repos := make([]RepoGroupValue, 0, len(values))
 
-		for _, repoSpec := range repoSpecs {
-			switch path := repoSpec.(type) {
+		for _, value := range values {
+			switch path := value.(type) {
 			case string:
-				patterns = append(patterns, "^"+regexp.QuoteMeta(path)+"$")
-				repos = append(repos, &types.Repo{Name: api.RepoName(path)})
+				repos = append(repos, RepoPath(path))
 			case map[string]interface{}:
 				if stringRegex, ok := path["regex"].(string); ok {
-					patterns = append(patterns, stringRegex)
+					repos = append(repos, RepoRegexpPattern(stringRegex))
 				} else {
-					log15.Warn("ignoring repo group object because regex not specfied", "regex-string", path["regex"])
+					log15.Warn("ignoring repo group value because regex not specfied", "regex-string", path["regex"])
 				}
 			default:
-				log15.Warn("ignoring repo group object of unrecognized type", "object", repoSpec, "type", fmt.Sprintf("%T", repoSpec))
+				log15.Warn("ignoring repo group value of unrecognized type", "value", value, "type", fmt.Sprintf("%T", value))
 			}
 		}
 		groups[name] = repos
 	}
-	return groups, patterns, nil
+	return groups, nil
 }
 
 // NOTE: This function is not called if the version context is not used
@@ -769,9 +788,22 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 	// groups and the set of repos specified with repo:. (If none are specified
 	// with repo:, then include all from the group.)
 	if groupNames := op.repoGroupFilters; len(groupNames) > 0 {
-		_, patterns, err := resolveRepoGroups(op.userSettings)
+		groups, err := resolveRepoGroups(op.userSettings)
 		if err != nil {
 			return resolvedRepositories{}, err
+		}
+		var patterns []string
+		for _, groupName := range groupNames {
+			for _, value := range groups[groupName] {
+				switch v := value.(type) {
+				case RepoPath:
+					patterns = append(patterns, "^"+regexp.QuoteMeta(v.String())+"$")
+				case RepoRegexpPattern:
+					patterns = append(patterns, v.String())
+				default:
+					panic("unreachable")
+				}
+			}
 		}
 		tr.LazyPrintf("repogroups: adding %d repos to include pattern", len(patterns))
 		includePatterns = append(includePatterns, unionRegExps(patterns))

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -15,7 +15,7 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 		return nil, err
 	}
 
-	groupsByName, _, err := resolveRepoGroups(settings)
+	groupsByName, err := resolveRepoGroups(settings)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestSearchFilterSuggestions(t *testing.T) {
-	mockResolveRepoGroups = func() (map[string][]*types.Repo, []string, error) {
-		return map[string][]*types.Repo{
+	mockResolveRepoGroups = func() (map[string][]RepoGroupValue, error) {
+		return map[string][]RepoGroupValue{
 			"repogroup1": {},
 			"repogroup2": {},
-		}, nil, nil
+		}, nil
 	}
 	defer func() { mockResolveRepoGroups = nil }()
 

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -181,16 +181,16 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockSearchFilesInRepos = nil }()
 
 		calledResolveRepoGroups := false
-		mockResolveRepoGroups = func() (map[string][]*types.Repo, []string, error) {
+		mockResolveRepoGroups = func() (map[string][]RepoGroupValue, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledResolveRepoGroups = true
-			return map[string][]*types.Repo{
+			return map[string][]RepoGroupValue{
 				"baz": {
-					&types.Repo{Name: "foo-repo1"},
-					&types.Repo{Name: "repo3"},
+					RepoPath("foo-repo1"),
+					RepoPath("repo3"),
 				},
-			}, nil, nil
+			}, nil
 		}
 		defer func() { mockResolveRepoGroups = nil }()
 		for _, v := range searchVersions {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -933,11 +933,11 @@ func TestRevisionValidation(t *testing.T) {
 
 func TestRepoGroupValuesToRegexp(t *testing.T) {
 	groups := map[string][]RepoGroupValue{
-		"go": []RepoGroupValue{
+		"go": {
 			RepoPath("github.com/saucegraph/saucegraph"),
 			RepoRegexpPattern(`github\.com/golang/.*`),
 		},
-		"typescript": []RepoGroupValue{
+		"typescript": {
 			RepoPath("github.com/eslint/eslint"),
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -930,3 +930,45 @@ func TestRevisionValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestRepoGroupValuesToRegexp(t *testing.T) {
+	groups := map[string][]RepoGroupValue{
+		"go": []RepoGroupValue{
+			RepoPath("github.com/saucegraph/saucegraph"),
+			RepoRegexpPattern(`github\.com/golang/.*`),
+		},
+		"typescript": []RepoGroupValue{
+			RepoPath("github.com/eslint/eslint"),
+		},
+	}
+
+	cases := []struct {
+		LookupGroupNames []string
+		Want             []string
+	}{
+		{
+			LookupGroupNames: []string{"go"},
+			Want: []string{
+				`^github\.com/saucegraph/saucegraph$`,
+				`github\.com/golang/.*`,
+			},
+		},
+		{
+			LookupGroupNames: []string{"go", "typescript"},
+			Want: []string{
+				`^github\.com/saucegraph/saucegraph$`,
+				`github\.com/golang/.*`,
+				`^github\.com/eslint/eslint$`,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("repogroup values to regexp", func(t *testing.T) {
+			got := repoGroupValuesToRegexp(c.LookupGroupNames, groups)
+			if diff := cmp.Diff(c.Want, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/13947. https://github.com/sourcegraph/sourcegraph/pull/13730 removed the part where we use a repogroup label to get the list of repo values. Part of the problem there is that the repogroup map of `label -> value` was separated from regex patterns, so that regex patterns were not considered a proper value of the `repogroup` map. This has janky implicit effects that are alleviated by introducing a variant type for the `value` in the `label -> value` mapping:

- our RepoGroups resolver returns repo names associated with a repogroup mapping. Since it doesn't support returning regex patterns associated with a repogroup, this was just implicitly ignored. We should decide on what an acceptable contract is here, either of: (1) returning the set of values, whether repo path _or_ regex patterns associated with a repogroup, or (2) resolving repos associated with regex patterns and returning the set of repo paths. If (1), the return type of the RepoGroups resolver needs to change. If (2), we need to add logic that resolves the regular expressions to valid repo names. Again, this was implicitly ignored in the previous PR, so I will not attempt to address it here. But, the new `RepoGroupValue` type alleviates this and makes the issue explicit, forcing the code to consider how to handle regex-pattern values in this resolver code (see the TODO comment).

- needing to handle a tuple of return values and ignores these based on context. With the the value type, we keep one return value and case out on the map values based on context.

- we previously wrapped the values in a `*types.Repo` struct but only ever populated (and used) the `Name` string entry for this data type. This seems unnecessary. Now we use the `RepoGroupValue` with string variants.