### PR TITLE
secrets: add scanners for transparent encryption and decryption

### DIFF
--- a/internal/secrets/encryptor_test.go
+++ b/internal/secrets/encryptor_test.go
@@ -295,15 +295,6 @@ func TestAESGCMEncodedEncrytor_RotateEncryption(t *testing.T) {
 	}
 }
 
-// mustGenerateRandomAESKey generates a random AES key and panics for any error.
-func mustGenerateRandomAESKey() []byte {
-	key, err := generateRandomAESKey()
-	if err != nil {
-		panic(err)
-	}
-	return key
-}
-
 func TestAESGCMEncodedEncrytor_Decrypt_Plaintext(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/secrets/init.go
+++ b/internal/secrets/init.go
@@ -46,8 +46,14 @@ func Init() error {
 	return initErr
 }
 
-// defaultEncryptor is configured during init, if no keys are provided it will implement noOpEncryptor
-var defaultEncryptor encryptor
+// defaultEncryptor is configured during init, if no keys are provided it will implement noOpEncryptor.
+var defaultEncryptor encryptor = noOpEncryptor{}
+
+// NOTE: MockDefaultEncryptor should only be called in tests where a random encryptor is
+// needed to test transparent encryption and decryption.
+func MockDefaultEncryptor() {
+	defaultEncryptor = newAESGCMEncodedEncryptor(mustGenerateRandomAESKey(), nil)
+}
 
 func initDefaultEncryptor() error {
 	var encryptionKey []byte
@@ -138,7 +144,6 @@ func initDefaultEncryptor() error {
 	}
 
 	log15.Warn("no encryption option enabled")
-	defaultEncryptor = noOpEncryptor{}
 	return nil
 
 	// TODO: Enable this once docs are in place for
@@ -156,4 +161,13 @@ func generateRandomAESKey() ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+// mustGenerateRandomAESKey generates a random AES key and panics for any error.
+func mustGenerateRandomAESKey() []byte {
+	key, err := generateRandomAESKey()
+	if err != nil {
+		panic(err)
+	}
+	return key
 }

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -1,0 +1,78 @@
+package secrets
+
+import (
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	_ driver.Valuer = StringValue{}
+	_ sql.Scanner   = (*StringValue)(nil)
+)
+
+// StringValue implements driver.Valuer and sql.Scanner for string type secret.
+type StringValue struct {
+	S *string
+}
+
+func (v StringValue) Value() (driver.Value, error) {
+	if v.S == nil {
+		return nil, errors.New("unable to encrypt a nil string pointer")
+	}
+	return Encrypt(*v.S)
+}
+
+func (v *StringValue) Scan(src interface{}) (err error) {
+	if v.S == nil {
+		return errors.New("unable to decrypt to a nil string pointer")
+	}
+
+	var plaintext string
+	switch src := src.(type) {
+	case string: // expect a base64 encoded string
+		plaintext, err = Decrypt(src)
+		if err != nil {
+			return err
+		}
+
+	default:
+		return errors.Errorf("incompatible type %T for StringValue", src)
+	}
+
+	*v.S = plaintext
+	return nil
+}
+
+var (
+	_ driver.Valuer = NullStringValue{}
+	_ sql.Scanner   = (*NullStringValue)(nil)
+)
+
+// NullStringValue implements driver.Valuer and sql.Scanner for NULLABLE string type secret.
+type NullStringValue struct {
+	S     *string
+	Valid bool // Valid is true if String is not NULL
+}
+
+func (nv *NullStringValue) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case string:
+		es := StringValue{S: nv.S}
+		err := es.Scan(v)
+		if err != nil {
+			return err
+		}
+		nv.Valid = true
+	}
+	return nil
+}
+
+func (nv NullStringValue) Value() (driver.Value, error) {
+	if nv.S == nil {
+		return nil, nil
+	}
+
+	return StringValue{S: nv.S}.Value()
+}

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -1,0 +1,91 @@
+package secrets
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
+	}
+	dbtesting.DBNameSuffix = "secret"
+	os.Exit(m.Run())
+}
+
+func TestScanner(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+
+	dbtesting.SetupGlobalTestDB(t)
+	defaultEncryptor = newAESGCMEncodedEncryptor(mustGenerateRandomAESKey(), nil)
+
+	t.Run("base", func(t *testing.T) {
+		message := "Able was I ere I saw Elba"
+		esMessage := StringValue{S: &message}
+
+		_, err := dbconn.Global.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS secret_scanner_test(name text, message text)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = dbconn.Global.ExecContext(ctx, `INSERT INTO secret_scanner_test(name,message) VALUES ($1,$2)`, t.Name(), esMessage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var gotName string
+		var gotMessage string
+		err = dbconn.Global.QueryRowContext(ctx, `SELECT name,message FROM secret_scanner_test`).
+			Scan(&gotName, &StringValue{S: &gotMessage})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if gotName != t.Name() {
+			t.Fatalf("expected %q, got %q for name", t.Name(), gotName)
+		}
+		if gotMessage != message {
+			t.Fatalf("expected %q, got %q", message, gotMessage)
+		}
+	})
+
+	t.Run("null example", func(t *testing.T) {
+		_, err := dbconn.Global.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS secret_null_test(name text, message text)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = dbconn.Global.ExecContext(ctx, `INSERT INTO secret_null_test(name, message) VALUES ($1, $2)`, t.Name(), NullStringValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var gotName string
+		var gotMessage string
+		esMessage := NullStringValue{S: &gotMessage}
+		err = dbconn.Global.QueryRowContext(ctx, `SELECT name,message FROM secret_null_test`).
+			Scan(&gotName, &esMessage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if gotName != t.Name() {
+			t.Fatalf("expected %q, got %q for name", t.Name(), gotName)
+		}
+		if esMessage.Valid {
+			t.Fatal("expected not valid, got valid")
+		}
+	})
+}


### PR DESCRIPTION
Add two types in `secrets` package: `StringValue` and `NullStringValue`, both implements `sql.Scanner` and `driver.Valuer` for "automatic" encryption and decryption during DB scan and write time.

This is a subset of #13759 and extracted here to have much smaller diff to review.