### PR TITLE
VersionContext does not implement GraphQL Node

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -499,11 +499,6 @@ func (r *NodeResolver) ToLSIFIndex() (LSIFIndexResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToVersionContext() (*versionContextResolver, bool) {
-	n, ok := r.Node.(*versionContextResolver)
-	return n, ok
-}
-
 // schemaResolver handles all GraphQL queries for Sourcegraph. To do this, it
 // uses subresolvers which are globals. Enterprise-only resolvers are assigned
 // to a field of EnterpriseResolvers.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3502,12 +3502,7 @@ type ExternalRepository {
 (experimental) A version context. Used to change the set of default repository and revisions searched.
 Note: We do not expose the list of repositories and revisions in the version context. This is intentional. However, if a need arises we can add it in.
 """
-type VersionContext implements Node {
-    """
-    The version context ID is its name.
-    """
-    id: ID!
-
+type VersionContext {
     """
     The name of the version context.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3495,12 +3495,7 @@ type ExternalRepository {
 (experimental) A version context. Used to change the set of default repository and revisions searched.
 Note: We do not expose the list of repositories and revisions in the version context. This is intentional. However, if a need arises we can add it in.
 """
-type VersionContext implements Node {
-    """
-    The version context ID is its name.
-    """
-    id: ID!
-
+type VersionContext {
     """
     The name of the version context.
     """

--- a/cmd/frontend/graphqlbackend/version_context.go
+++ b/cmd/frontend/graphqlbackend/version_context.go
@@ -3,17 +3,12 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type versionContextResolver struct {
 	vc *schema.VersionContext
-}
-
-func (v *versionContextResolver) ID() graphql.ID {
-	return graphql.ID(v.vc.Name)
 }
 
 func (v *versionContextResolver) Name() string {


### PR DESCRIPTION
The GraphQL Node ID needs to be able to be looked up globally. But the VersionContext ID was just the string name of the version context, which is not globally addressable. Plus, there is no switch-clause in the `Node` resolver impl to look up a version context anyway.

There are no places in the frontend code that attempted to look up a VersionContext by its node ID. If there were any, they would not have worked anyway. So, this is safe to remove.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->