### PR TITLE
add Campaigns nav item to user/org header in central place

### DIFF
--- a/web/src/enterprise/namespaces/navitems.ts
+++ b/web/src/enterprise/namespaces/navitems.ts
@@ -1,6 +1,12 @@
-import { NavItemWithIconDescriptor } from '../../util/contributions'
+import { NamespaceAreaNavItem } from '../../namespaces/NamespaceArea'
+import { CampaignsIcon } from '../campaigns/icons'
 
-export const enterpriseNamespaceAreaHeaderNavItems: readonly Pick<
-    NavItemWithIconDescriptor,
-    Exclude<keyof NavItemWithIconDescriptor, 'condition'>
->[] = []
+export const enterpriseNamespaceAreaHeaderNavItems: readonly NamespaceAreaNavItem[] = [
+    {
+        to: '/campaigns',
+        label: 'Campaigns',
+        icon: CampaignsIcon,
+        condition: ({ isSourcegraphDotCom }: { isSourcegraphDotCom: boolean }): boolean =>
+            !isSourcegraphDotCom && window.context.campaignsEnabled,
+    },
+]

--- a/web/src/enterprise/organizations/navitems.ts
+++ b/web/src/enterprise/organizations/navitems.ts
@@ -1,15 +1,8 @@
 import { orgAreaHeaderNavItems } from '../../org/area/navitems'
 import { OrgAreaHeaderNavItem } from '../../org/area/OrgHeader'
 import { enterpriseNamespaceAreaHeaderNavItems } from '../namespaces/navitems'
-import { CampaignsIcon } from '../campaigns/icons'
 
 export const enterpriseOrgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[] = [
     ...orgAreaHeaderNavItems,
     ...enterpriseNamespaceAreaHeaderNavItems,
-    {
-        to: '/campaigns',
-        label: 'Campaigns',
-        icon: CampaignsIcon,
-        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom && window.context.campaignsEnabled,
-    },
 ]

--- a/web/src/enterprise/user/navitems.ts
+++ b/web/src/enterprise/user/navitems.ts
@@ -1,13 +1,8 @@
 import { userAreaHeaderNavItems } from '../../user/area/navitems'
 import { UserAreaHeaderNavItem } from '../../user/area/UserAreaHeader'
-import { CampaignsIcon } from '../campaigns/icons'
+import { enterpriseNamespaceAreaHeaderNavItems } from '../namespaces/navitems'
 
 export const enterpriseUserAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
     ...userAreaHeaderNavItems,
-    {
-        to: '/campaigns',
-        label: 'Campaigns',
-        icon: CampaignsIcon,
-        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom && window.context.campaignsEnabled,
-    },
+    ...enterpriseNamespaceAreaHeaderNavItems,
 ]

--- a/web/src/namespaces/NamespaceArea.tsx
+++ b/web/src/namespaces/NamespaceArea.tsx
@@ -1,6 +1,6 @@
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { RouteDescriptor } from '../util/contributions'
+import { NavItemWithIconDescriptor, RouteDescriptor } from '../util/contributions'
 import { PatternTypeProps } from '../search'
 import { ThemeProps } from '../../../shared/src/theme'
 import { AuthenticatedUser } from '../auth'
@@ -18,3 +18,8 @@ export interface NamespaceAreaContext
 }
 
 export interface NamespaceAreaRoute extends RouteDescriptor<NamespaceAreaContext> {}
+
+export interface NamespaceAreaNavItem
+    extends NavItemWithIconDescriptor<{
+        isSourcegraphDotCom: boolean
+    }> {}

--- a/web/src/user/area/navitems.ts
+++ b/web/src/user/area/navitems.ts
@@ -1,6 +1,7 @@
 import FeatureSearchOutlineIcon from 'mdi-react/FeatureSearchOutlineIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
 import TimelineTextOutlineIcon from 'mdi-react/TimelineTextOutlineIcon'
+import { namespaceAreaHeaderNavItems } from '../../namespaces/navitems'
 import { UserAreaHeaderNavItem } from './UserAreaHeader'
 
 export const userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
@@ -21,6 +22,7 @@ export const userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
         icon: FeatureSearchOutlineIcon,
         condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
     },
+    ...namespaceAreaHeaderNavItems,
     {
         to: '/event-log',
         label: 'Event log',


### PR DESCRIPTION
There is already a list of common nav items for namespaces. We can define the campaign nav item there, and then it will be reused for both users and organizations.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->