### PR TITLE
incorporate graphql-go patch to fix union/interface inline fragments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -205,7 +205,7 @@ replace (
 
 	// We need our fork until https://github.com/graph-gophers/graphql-go/pull/400 is merged upstream
 	// Our change limits the number of goroutines spawned by resolvers which was causing memory spikes on our frontend
-	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484
+	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20200925042138-03da4e7f938c
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 
 	// prom-wrapper needs to be able to write alertmanager configuration with secrets, etc, which

--- a/go.sum
+++ b/go.sum
@@ -1251,6 +1251,8 @@ github.com/sourcegraph/gosyntect v0.0.0-20200429204402-842ed26129d0 h1:AEImdu3+4
 github.com/sourcegraph/gosyntect v0.0.0-20200429204402-842ed26129d0/go.mod h1:WiNJKgKTnR3psOIGzVZQjLqZjJZuoL3F8tCh25Uk8dU=
 github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484 h1:oMnbwXPJDRDfUjEuFHlO6u1MY6O64G2TrDBOXTgVX58=
 github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
+github.com/sourcegraph/graphql-go v0.0.0-20200925042138-03da4e7f938c h1:FK6V3LUPvx57QBpeXVa2G9Ye5BzQQ7gW9emBl/HEPUI=
+github.com/sourcegraph/graphql-go v0.0.0-20200925042138-03da4e7f938c/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=


### PR DESCRIPTION
Incorporates https://github.com/graph-gophers/graphql-go/pull/409.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->