### PR TITLE
server: Add parameter to start only PosgreSQL

### DIFF
--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -153,7 +153,7 @@ func postgresProcfile() (string, error) {
 			}
 		}
 	}
-
+	l("Finished initializing the internal database.")
 	return "postgres: su-exec postgres sh -c 'postgres -c listen_addresses=127.0.0.1 -D " + path + "' 2>&1 | grep -v 'database system was shut down' | grep -v 'MultiXact member wraparound' | grep -v 'database system is ready' | grep -v 'autovacuum launcher started' | grep -v 'the database system is starting up' | grep -v 'listening on IPv4 address'", nil
 }
 

--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -58,7 +58,7 @@ func postgresProcfile() (string, error) {
 	e.Command("mkdir", "-p", "/run/postgresql")
 	e.Command("chown", "-R", "postgres", "/run/postgresql")
 	if err := e.Error(); err != nil {
-		l("Setting up postgres failed:\n%s", output.String())
+		pgPrintf("Setting up postgres failed:\n%s", output.String())
 		return "", err
 	}
 
@@ -75,7 +75,7 @@ func postgresProcfile() (string, error) {
 		e.Command("touch", filepath.Join(markersPath, "sourcegraph"))
 
 		if err := e.Error(); err != nil {
-			l("Failed to set up postgres database marker files:\n%s", output.String())
+			pgPrintf("Failed to set up postgres database marker files:\n%s", output.String())
 			os.RemoveAll(path)
 			return "", err
 		}
@@ -85,9 +85,9 @@ func postgresProcfile() (string, error) {
 		return "", err
 	} else if !ok {
 		if verbose {
-			l("Setting up PostgreSQL at %s", path)
+			pgPrintf("Setting up PostgreSQL at %s", path)
 		}
-		l("Sourcegraph is initializing the internal database... (may take 15-20 seconds)")
+		pgPrintf("Sourcegraph is initializing the internal database... (may take 15-20 seconds)")
 
 		var output bytes.Buffer
 		e := execer{Out: &output}
@@ -103,7 +103,7 @@ func postgresProcfile() (string, error) {
 		}
 		e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-m", "fast", "-l", "/tmp/pgsql.log", "-w", "stop")
 		if err := e.Error(); err != nil {
-			l("Setting up postgres failed:\n%s", output.String())
+			pgPrintf("Setting up postgres failed:\n%s", output.String())
 			os.RemoveAll(path)
 			return "", err
 		}
@@ -114,7 +114,7 @@ func postgresProcfile() (string, error) {
 		e := execer{Out: &output}
 		e.Command("chown", "-R", "postgres", path)
 		if err := e.Error(); err != nil {
-			l("Adjusting fs owners for postgres failed:\n%s", output.String())
+			pgPrintf("Adjusting fs owners for postgres failed:\n%s", output.String())
 			return "", err
 		}
 
@@ -128,7 +128,7 @@ func postgresProcfile() (string, error) {
 			}
 		}
 		if len(missingDatabases) > 0 {
-			l("Sourcegraph is creating missing databases %s... (may take 15-20 seconds)", strings.Join(missingDatabases, ", "))
+			pgPrintf("Sourcegraph is creating missing databases %s... (may take 15-20 seconds)", strings.Join(missingDatabases, ", "))
 
 			e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-o -c listen_addresses=127.0.0.1", "-l", "/tmp/pgsql.log", "-w", "start")
 			for _, database := range missingDatabases {
@@ -148,12 +148,12 @@ func postgresProcfile() (string, error) {
 			}
 			e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-m", "fast", "-l", "/tmp/pgsql.log", "-w", "stop")
 			if err := e.Error(); err != nil {
-				l("Setting up postgres failed:\n%s", output.String())
+				pgPrintf("Setting up postgres failed:\n%s", output.String())
 				return "", err
 			}
 		}
 	}
-	l("Finished initializing the internal database.")
+	pgPrintf("Finished initializing the internal database.")
 	return "postgres: su-exec postgres sh -c 'postgres -c listen_addresses=127.0.0.1 -D " + path + "' 2>&1 | grep -v 'database system was shut down' | grep -v 'MultiXact member wraparound' | grep -v 'database system is ready' | grep -v 'autovacuum launcher started' | grep -v 'the database system is starting up' | grep -v 'listening on IPv4 address'", nil
 }
 
@@ -173,7 +173,7 @@ func isPostgresConfigured(prefix string) bool {
 	return os.Getenv(prefix+"PGHOST") != "" || os.Getenv(prefix+"PGDATASOURCE") != ""
 }
 
-func l(format string, args ...interface{}) {
+func pgPrintf(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, "✱ "+format+"\n", args...)
 }
 

--- a/cmd/server/shared/redis.go
+++ b/cmd/server/shared/redis.go
@@ -114,16 +114,16 @@ func redisFixAOF(rootDataDir string, c redisProcfileConfig) {
 		cmd.Stdin = &yesReader{Expletive: []byte("y\n")}
 		e.Run(cmd)
 		if err := e.Error(); err != nil {
-			l("Repairing %s appendonly.aof failed:\n%s", c.name, output.String())
+			pgPrintf("Repairing %s appendonly.aof failed:\n%s", c.name, output.String())
 		}
 		close(done)
 	}()
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		l("Running redis-check-aof --fix %q...", aofPath)
+		pgPrintf("Running redis-check-aof --fix %q...", aofPath)
 		<-done
-		l("Finished running redis-check-aof")
+		pgPrintf("Finished running redis-check-aof")
 	}
 }
 

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -170,10 +170,12 @@ func Main() {
 		procfile = append(procfile, redisCacheLine)
 	}
 
-	if line, err := maybePostgresProcFile(); err != nil {
+	postgresLine, err := maybePostgresProcFile()
+	if err != nil {
 		log.Fatal(err)
-	} else if line != "" {
-		procfile = append(procfile, line)
+	}
+	if postgresLine != "" {
+		procfile = append(procfile, postgresLine)
 	}
 
 	procfile = append(procfile, maybeZoektProcFile()...)
@@ -186,6 +188,12 @@ func Main() {
 		// example use case is connecting to postgres even though frontend is
 		// dying due to a bad migration.
 		procDiedAction = goreman.Ignore
+	}
+
+	// If in restore mode, only run PostgreSQL
+	if restore, _ := strconv.ParseBool(os.Getenv("PGRESTORE")); restore {
+		procfile = []string{}
+		procfile = append(procfile, postgresLine)
 	}
 
 	err = goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -64,6 +64,15 @@ To test sourcegraph in a low resource environment you may want to disable some o
 
 Add `-e DISABLE_OBSERVABILITY=true` to your docker run command
 
+## Starting in Postgres restore mode
+
+In order to restore a Postgres backup, you need to start on an empty database and prevent all other Sourcegraph services from starting.
+You can do this by adding `-e PGRESTORE=true` to your `docker run` command. This will start only the Postgres system and allow you to perform a restore, once it is done, simply remove that parameter from your docker command.
+
+The database is only accessible from within the container, to perform a restore you will need to copy the required files to the container and then execute the restore commands from within the container using `docker exec`.
+
+You can find examples of this procedure for `docker-compose` in our [docker-compose migration docs](../docker-compose/migrate.md).
+
 ## Insiders build
 
 To test new development builds of Sourcegraph (triggered by commits to `main`), change the tag to `insiders` in the `docker run` command.


### PR DESCRIPTION
Related to: https://github.com/sourcegraph/sourcegraph/issues/12229

When restoring a deployment DB to a new deployment, we need to start the DB service only to ensure we can restore on a clean database.