### PR TITLE
doc: add tutorial for adding LSIF to many repos

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -98,6 +98,7 @@
                                     <li><a href="/user/code_intelligence/adding_lsif_to_workflows">Adding LSIF to workflows</a></li>
                                     <li><a href="/user/code_intelligence/languages">Language-specific guides</a></li>
                                     <li><a href="/user/code_intelligence/writing_an_indexer">Writing an indexer</a></li>
+                                    <li><a href="/user/code_intelligence/adding_lsif_to_many_repos">Tutorial: Adding LSIF to many repositories</a></li>
                                 </ul>
                             </li>
                             <li><a href="/user/search">Code Search</a></li>

--- a/doc/user/code_intelligence/adding_lsif_to_many_repos.md
+++ b/doc/user/code_intelligence/adding_lsif_to_many_repos.md
@@ -1,0 +1,69 @@
+# Tutorial: Adding LSIF to many repositories
+
+## Prerequisites
+
+* You have a private Sourcegraph instance (i.e., you're not using
+  Sourcegraph.com), and the repositories you wish to explore have been added to
+  that instance.
+* You have admin access on your Sourcegraph instance.
+* You have installed [`src-cli`](https://github.com/sourcegraph/src-cli) to your local machine.
+* You have the ability to create org-level secrets in your GitHub organization.
+* Your Sourcegraph instance is accessible from your GitHub instance. If you are
+  using GitHub.com, this means your Sourcegraph instance is accessible on the
+  public Internet.
+
+## Directions
+
+1. Generate an access token for your Sourcegraph instance. The access token does
+   NOT need `sudo` privileges, but should have permission to read every
+   repository for which LSIF should be enabled.
+  1. Create the following secrets in each GitHub organization represented in the
+     set of repositories. Follow the [GitHub
+     documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization)
+     for doing this.
+     1. `srcEndpoint`: the URL of the Sourcegraph instance, from the perspective
+        of the GitHub instance. If using GitHub.com, this is just the URL you use
+        to access Sourcegraph.
+     1. `srcAccessToken`: the Sourcegraph access token you just created.
+
+1. Download
+   [`lsif-go.campaign.yaml`](https://raw.githubusercontent.com/sourcegraph/snippets/main/lsif/lsif-go.campaign.yaml)
+   to your local machine.
+
+1. Verify the list of repositories for which you wish to enable LSIF:
+   ```
+   # Use the values you set in your GitHub secrets for SRC_ENDPOINT and SRC_ACCESS_TOKEN
+   SRC_ENDPOINT= SRC_ACCESS_TOKEN= src campaigns repos -f lsif-go.campaign.yaml
+   ```
+   If the set of repositories displayed is not the set of repositories for which you want to enable LSIF, modify the `repositoriesMatchingQuery` line in `lsif-go.campaign.yaml` to specify the Sourcegraph search query that selects the desired repository set.
+1. Run the campaign to generate a list of all pull requests that will be created:
+   ```
+   # Use the values you set in your GitHub secrets for SRC_ENDPOINT and SRC_ACCESS_TOKEN.
+   # Pass your Sourcegraph username to the -namespace flag.
+   SRC_ENDPOINT= SRC_ACCESS_TOKEN= src campaigns preview -f lsif-go.campaign.yaml -namespace=$USERNAME
+   ```
+   This will create a campaign preview in Sourcegraph. Navigate to the URL printed in the
+     terminal to preview all the pull requests that will be created.
+
+1. Once you've verified the preview looks correct, change `published: false` to `published: true` in `lsif-go.campaign.yaml` and run the following:
+  ```
+   # Use the values you set in your GitHub secrets for SRC_ENDPOINT and SRC_ACCESS_TOKEN.
+   # Pass your Sourcegraph username to the -namespace flag.
+  SRC_ENDPOINT= SRC_ACCESS_TOKEN= src campaigns apply -f lsif-go.campaign.yaml -namespace=$USERNAME
+  ```
+  Now, go back to the campaign page and verify the pull requests have been
+  created.
+  1. If there are errors creating any pull request, check to make sure the GitHub token in the
+     Sourcegraph code host configuration (Site admin > Manage repositories) has the
+     necessary scopes (`repo` and (`read:discussion` or `read:org`)).
+  1. Verify that the GitHub action has run successfully in the repositories on GitHub.
+  1. Verify that the LSIF data has been successfully uploaded to Sourcegraph by
+     navigating to any repository page on Sourcegraph > Settings > Code
+     intelligence: Uploads. You should also be able to explore the code at that
+     revision with precise code navigation.
+
+1. Enable LSIF in [global settings](../../admin/config/settings.md): `"codeIntel.lsif": true`.
+
+1. Merge the pull requests created by the campaign and close the campaign. The
+   GitHub action should now run on each push, generating LSIF data for the
+   pushed revision and uploading this data to your Sourcegraph instance.


### PR DESCRIPTION
Based on the [Google doc @efritz wrote](https://docs.google.com/document/d/1NmsEY7PgZLY-kJ-D5viF9oBloZZ3yG_GA1GPimy0I0I/edit), I created a tutorial doc page for creating a campaign to bulk-add lsif-go to a bunch of repositories. This doc page makes some slight modifications to the original instructions, based on friction points I encountered following the original doc.