### PR TITLE
migrations: update go generate command

### DIFF
--- a/migrations/frontend/README.md
+++ b/migrations/frontend/README.md
@@ -39,7 +39,7 @@ After adding SQL statements to those files, embed them into the Go code and upda
 or, to only run the DB generate scripts (subset of the command above):
 
 ```
-go generate ./migrations/
+go generate ./migrations/frontend/
 go generate ./internal/db/
 ```
 


### PR DESCRIPTION
Alternative is to run `go generate ./migrations/...` but since it is the README of the `frontend/` directory, I think this is more accurate.