### PR TITLE
secret: rename from secrets to avoid conflict with db.secrets

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -35,7 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/processrestart"
-	"github.com/sourcegraph/sourcegraph/internal/secrets"
+	"github.com/sourcegraph/sourcegraph/internal/secret"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -208,7 +208,7 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 		return errors.New("dbconn.Global is nil when trying to parse GraphQL schema")
 	}
 
-	err := secrets.Init()
+	err := secret.Init()
 	if err != nil {
 		return err
 	}

--- a/internal/secret/doc.go
+++ b/internal/secret/doc.go
@@ -11,4 +11,4 @@ being used for encryption
 The secondaryKey is only required when key rotation is desired and is not required to perform encryption.
 
 */
-package secrets
+package secret

--- a/internal/secret/encryptor.go
+++ b/internal/secret/encryptor.go
@@ -1,4 +1,4 @@
-package secrets
+package secret
 
 import (
 	"crypto/aes"

--- a/internal/secret/encryptor_test.go
+++ b/internal/secret/encryptor_test.go
@@ -1,4 +1,4 @@
-package secrets
+package secret
 
 import (
 	"bytes"

--- a/internal/secret/init.go
+++ b/internal/secret/init.go
@@ -1,4 +1,4 @@
-package secrets
+package secret
 
 import (
 	"bytes"

--- a/internal/secret/scanner.go
+++ b/internal/secret/scanner.go
@@ -1,4 +1,4 @@
-package secrets
+package secret
 
 import (
 	"database/sql"

--- a/internal/secret/scanner_test.go
+++ b/internal/secret/scanner_test.go
@@ -1,4 +1,4 @@
-package secrets
+package secret
 
 import (
 	"context"


### PR DESCRIPTION
Simply rename `internal/secrets` to `internal/secret` to avoid import path rename in every single place because it conflicts with `db.secrets` variable.

This is a subset of #13759 and extracted here to have much smaller diff to review.