### PR TITLE
doc: add 1rem padding above each doc page title

### DIFF
--- a/doc/_resources/assets/content.css
+++ b/doc/_resources/assets/content.css
@@ -28,6 +28,7 @@
     text-overflow: ellipsis;
 }
 .markdown-body {
+    padding-top: 1rem;
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
     line-height: 1.5;


### PR DESCRIPTION
# Before: 
![image](https://user-images.githubusercontent.com/1646931/94348667-fa9d4200-fff2-11ea-9381-368c12ce95e8.png)


# After:
![image](https://user-images.githubusercontent.com/1646931/94348630-b1e58900-fff2-11ea-91f3-7d775c8eb330.png)

