### PR TITLE
Add code host icons for go to code host action

### DIFF
--- a/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -14,6 +14,7 @@ import { fetchFileExternalLinks } from '../backend'
 import { RevisionSpec, FileSpec } from '../../../../shared/src/util/url'
 import { ExternalLinkFields } from '../../graphql-operations'
 import GitlabIcon from 'mdi-react/GitlabIcon'
+import { eventLogger } from '../../tracking/eventLogger'
 
 interface Props extends RevisionSpec, Partial<FileSpec> {
     repo?: GQL.IRepository | null
@@ -136,12 +137,17 @@ export class GoToCodeHostAction extends React.PureComponent<Props, State> {
             }
         }
 
+        function logEvent(): void {
+            eventLogger.log('GoToCodeHostClicked', { codeHost: displayName })
+        }
+
         return (
             <LinkOrButton
                 className="nav-link test-go-to-code-host"
                 to={url}
                 target="_self"
                 data-tooltip={`View on ${displayName}`}
+                onSelect={logEvent}
             >
                 <Icon className="icon-inline" />
             </LinkOrButton>

--- a/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -13,6 +13,7 @@ import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/err
 import { fetchFileExternalLinks } from '../backend'
 import { RevisionSpec, FileSpec } from '../../../../shared/src/util/url'
 import { ExternalLinkFields } from '../../graphql-operations'
+import GitlabIcon from 'mdi-react/GitlabIcon'
 
 interface Props extends RevisionSpec, Partial<FileSpec> {
     repo?: GQL.IRepository | null
@@ -155,7 +156,7 @@ function serviceTypeDisplayNameAndIcon(
         case 'github':
             return { displayName: 'GitHub', icon: GithubIcon }
         case 'gitlab':
-            return { displayName: 'GitLab' }
+            return { displayName: 'GitLab', icon: GitlabIcon }
         case 'bitbucketServer':
             // TODO: Why is bitbucketServer (correctly) camelCase but
             // awscodecommit is (correctly) lowercase? Why is serviceType


### PR DESCRIPTION
Closes #14200.

We already specified GitHub, Phabricator, and Bitbucket icons, so I just added the GitLab icon.

#### Phabricator
![Screenshot from 2020-09-28 13-13-17](https://user-images.githubusercontent.com/37420160/94464845-03c21680-018d-11eb-94ba-3f4a133e1d85.png)

#### GitLab
![Screenshot from 2020-09-28 13-13-48](https://user-images.githubusercontent.com/37420160/94464847-045aad00-018d-11eb-8a26-fe9c180889b6.png)

#### Bitbucket
![Screenshot from 2020-09-28 13-14-34](https://user-images.githubusercontent.com/37420160/94464849-045aad00-018d-11eb-9514-2dc7f3d9a289.png)

- [x] - Add all icons
- [x] - Track clicks for go to code host action

Note: Aux clicks don't seem to fire for `LinkOrButton`