### PR TITLE
disable shellcheck error when running locally

### DIFF
--- a/test/e2e/smoke-test.sh
+++ b/test/e2e/smoke-test.sh
@@ -3,6 +3,7 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -exo pipefail
 
+# shellcheck disable=SC1091
 source /root/.profile
 Xvfb "$DISPLAY" -screen 0 1280x1024x24 &
 x11vnc -display "$DISPLAY" -forever -rfbport 5900 >/x11vnc.log 2>&1 &


### PR DESCRIPTION
Otherwise, `dev/check/shellcheck.sh` returns an error (permission denied on `/root/.profile`) when running in local dev.