### PR TITLE
Add "Browser extension" to user nav

### DIFF
--- a/web/src/nav/UserNavItem.tsx
+++ b/web/src/nav/UserNavItem.tsx
@@ -128,19 +128,25 @@ export class UserNavItem extends React.PureComponent<UserNavItemProps, State> {
                             Sign out
                         </a>
                     )}
+                    <DropdownItem divider={true} />
                     {this.props.showDotComMarketing && (
-                        <>
-                            <DropdownItem divider={true} />
-                            <a
-                                href="https://about.sourcegraph.com"
-                                target="_blank"
-                                rel="noopener"
-                                className="dropdown-item"
-                            >
-                                About Sourcegraph <OpenInNewIcon className="icon-inline" />
-                            </a>
-                        </>
+                        <a
+                            href="https://about.sourcegraph.com"
+                            target="_blank"
+                            rel="noopener"
+                            className="dropdown-item"
+                        >
+                            About Sourcegraph <OpenInNewIcon className="icon-inline" />
+                        </a>
                     )}
+                    <a
+                        href="https://docs.sourcegraph.com/integration/browser_extension"
+                        target="_blank"
+                        rel="noopener"
+                        className="dropdown-item"
+                    >
+                        Browser extension <OpenInNewIcon className="icon-inline" />
+                    </a>
                 </DropdownMenu>
             </ButtonDropdown>
         )

--- a/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
+++ b/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
@@ -361,6 +361,25 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
             />
           </svg>
         </a>
+        <a
+          class="dropdown-item"
+          href="https://docs.sourcegraph.com/integration/browser_extension"
+          rel="noopener"
+          target="_blank"
+        >
+          Browser extension 
+          <svg
+            class="mdi-icon icon-inline"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+            />
+          </svg>
+        </a>
       </div>
     </div>
   </li>
@@ -718,6 +737,25 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
             />
           </svg>
         </a>
+        <a
+          class="dropdown-item"
+          href="https://docs.sourcegraph.com/integration/browser_extension"
+          rel="noopener"
+          target="_blank"
+        >
+          Browser extension 
+          <svg
+            class="mdi-icon icon-inline"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+            />
+          </svg>
+        </a>
       </div>
     </div>
   </li>
@@ -1062,6 +1100,29 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
         >
           Sign out
         </a>
+        <div
+          class="dropdown-divider"
+          tabindex="-1"
+        />
+        <a
+          class="dropdown-item"
+          href="https://docs.sourcegraph.com/integration/browser_extension"
+          rel="noopener"
+          target="_blank"
+        >
+          Browser extension 
+          <svg
+            class="mdi-icon icon-inline"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+            />
+          </svg>
+        </a>
       </div>
     </div>
   </li>
@@ -1395,6 +1456,29 @@ exports[`NavLinks authed self-hosted /search 1`] = `
           href="/-/sign-out"
         >
           Sign out
+        </a>
+        <div
+          class="dropdown-divider"
+          tabindex="-1"
+        />
+        <a
+          class="dropdown-item"
+          href="https://docs.sourcegraph.com/integration/browser_extension"
+          rel="noopener"
+          target="_blank"
+        >
+          Browser extension 
+          <svg
+            class="mdi-icon icon-inline"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+            />
+          </svg>
         </a>
       </div>
     </div>

--- a/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
+++ b/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
@@ -375,6 +375,17 @@ exports[`UserNavItem simple 1`] = `
                       className="icon-inline"
                     />
                   </a>
+                  <a
+                    className="dropdown-item"
+                    href="https://docs.sourcegraph.com/integration/browser_extension"
+                    rel="noopener"
+                    target="_blank"
+                  >
+                    Browser extension 
+                    <Memo(OpenInNewIcon)
+                      className="icon-inline"
+                    />
+                  </a>
                 </div>
               </DropdownMenu>
             </div>


### PR DESCRIPTION
Adds "Browser extension" as an entry to the dropdown.

Based on the [discussion about the icon](https://www.figma.com/file/V5t7KOzC6PIX75L4dz8IFc/RFC-221---Browser-extension----improve-discoverability-and-awareness-%5BApproved%5D) the conclusion was to use the "external link" icon (`OpenInNewIcon`)

![image](https://user-images.githubusercontent.com/602886/94491944-31bc5080-01b7-11eb-88c0-da6f3ecbc51c.png)

Note that the screenshot shows an instance where the "About Sourcegraph" item is not displayed.

Closes #14167