### PR TITLE
Update docs and scripts to replace -endpoint

### DIFF
--- a/doc/user/code_intelligence/languages/go.md
+++ b/doc/user/code_intelligence/languages/go.md
@@ -26,7 +26,7 @@ This guide is meant to provide specific instructions to get you producing index 
 
    ```
    # for private instances
-   src -endpoint=<your sourcegraph endpoint> lsif upload
+   SRC_ENDPOINT=<your sourcegraph endpoint> src lsif upload
    # for public instances
    src lsif upload -github-token=<your github token>
    ```

--- a/doc/user/code_intelligence/languages/typescript_and_javascript.md
+++ b/doc/user/code_intelligence/languages/typescript_and_javascript.md
@@ -31,7 +31,7 @@ This guide is meant to provide specific instructions to get you producing index 
 
    ```
    # for private instances
-   src -endpoint=<your sourcegraph endpoint> lsif upload
+   SRC_ENDPOINT=<your sourcegraph endpoint> src lsif upload
    # for public instances
    src lsif upload -github-token=<your github token>
    ```

--- a/doc/user/code_intelligence/lsif_quickstart.md
+++ b/doc/user/code_intelligence/lsif_quickstart.md
@@ -45,7 +45,7 @@ The upload step is the same for all languages. Make sure the current working dir
 
 #### To a private Sourcegraph instance (on prem)
 ```
-$ src -endpoint=<your sourcegraph endpoint> lsif upload -file=<LSIF file (e.g. dump.lsif)>
+$ SRC_ENDPOINT=<your sourcegraph endpoint> src lsif upload -file=<LSIF file (e.g. dump.lsif)>
 ```
 
 #### To cloud based Sourcegraph.com
@@ -92,7 +92,7 @@ To view LSIF indexer processing failures go to **Repository settings > Code inte
 Possible errors that can happen during upload include:
 
 - Clone in progress: the instance doesn't have the necessary data to process your upload yet, retry in a few minutes
-- Unknown repository (404): check your `-endpoint` and make sure you can view the repository on your Sourcegraph instance
+- Unknown repository (404): check your `SRC_ENDPOINT` and make sure you can view the repository on your Sourcegraph instance
 - Invalid commit (404): try visiting the repository at that commit on your Sourcegraph instance to trigger an update
 - Invalid auth when using Sourcegraph.com or when [`lsifEnforceAuth`](https://docs.sourcegraph.com/admin/config/site_config#lsifEnforceAuth) is `true` (401 for an invalid token or 404 if the repository cannot be found on GitHub.com): make sure your GitHub token is valid and that the repository is correct
 - Unexpected errors (500s): [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new)

--- a/internal/cmd/precise-code-intel-tester/upload.go
+++ b/internal/cmd/precise-code-intel-tester/upload.go
@@ -270,7 +270,7 @@ func upload(ctx context.Context, name, rev string, limiter *util.Limiter) (strin
 	defer limiter.Release()
 
 	args := []string{
-		fmt.Sprintf("-endpoint=%s", endpoint),
+		"-e", fmt.Sprintf("SRC_ENDPOINT=%s", endpoint),
 		"lsif",
 		"upload",
 		"-root=/",

--- a/internal/cmd/precise-code-intel-tester/upload.go
+++ b/internal/cmd/precise-code-intel-tester/upload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -270,7 +271,6 @@ func upload(ctx context.Context, name, rev string, limiter *util.Limiter) (strin
 	defer limiter.Release()
 
 	args := []string{
-		"-e", fmt.Sprintf("SRC_ENDPOINT=%s", endpoint),
 		"lsif",
 		"upload",
 		"-root=/",
@@ -280,6 +280,7 @@ func upload(ctx context.Context, name, rev string, limiter *util.Limiter) (strin
 	}
 
 	cmd := exec.CommandContext(ctx, "src", args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("SRC_ENDPOINT=%s", endpoint))
 	cmd.Dir = indexDir
 
 	output, err := cmd.CombinedOutput()

--- a/web/src/regression/codeintel.test.ts
+++ b/web/src/regression/codeintel.test.ts
@@ -754,7 +754,8 @@ async function performUpload(
     try {
         // Upload data
         const uploadCommand = [
-            `src -endpoint ${config.sourcegraphBaseUrl}`,
+            `SRC_ENDPOINT=${config.sourcegraphBaseUrl}`,
+            `src`,
             'lsif upload',
             `-repo ${repository}`,
             `-commit ${commit}`,


### PR DESCRIPTION
-endpoint flag has been deprecated, updating docs and scripts to use SRC_ENDPOINT



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
