### PR TITLE
make repo name more prominent in repo breadcrumb

### DIFF
--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -21,6 +21,11 @@ interface BaseBreadcrumb {
      * By default a chevron icon `>` is used.
      */
     divider?: React.ReactNode
+
+    /**
+     * Hide the "Home >" prefix from the breadcrumb.
+     */
+    noHome?: boolean
 }
 
 interface ElementBreadcrumb extends BaseBreadcrumb {
@@ -157,6 +162,7 @@ export const Breadcrumbs: React.FC<{ breadcrumbs: BreadcrumbAtDepth[]; location:
         {sortBy(breadcrumbs, 'depth')
             .map(({ breadcrumb }) => breadcrumb)
             .filter(isDefined)
+            .filter((_breadcrumb, index) => index > 0 || !breadcrumbs.some(breadcrumb => breadcrumb.breadcrumb?.noHome))
             .map((breadcrumb, index, validBreadcrumbs) => {
                 const divider =
                     breadcrumb.divider === undefined ? <ChevronRightIcon className="icon-inline" /> : breadcrumb.divider

--- a/web/src/integration/repository.test.ts
+++ b/web/src/integration/repository.test.ts
@@ -381,17 +381,11 @@ describe('Repository', () => {
             const breadcrumbTexts = await driver.page.evaluate(() =>
                 [...document.querySelectorAll('.test-breadcrumb')].map(breadcrumb => breadcrumb.textContent)
             )
-            assert.deepStrictEqual(breadcrumbTexts, [
-                'Home',
-                'Repositories',
-                shortRepositoryName,
-                '@master',
-                clickedFileName,
-            ])
+            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', clickedFileName])
 
             // Return to repo page
-            await driver.page.waitForSelector('a.repo-header__repo')
-            await driver.page.click('a.repo-header__repo')
+            await driver.page.waitForSelector('a.test-repo-breadcrumb__repo')
+            await driver.page.click('a.test-repo-breadcrumb__repo')
             await driver.page.waitForSelector('h2.tree-page__title')
             await assertSelectorHasText('h2.tree-page__title', ' ' + shortRepositoryName)
             await driver.assertWindowLocation(repositorySourcegraphUrl)
@@ -462,7 +456,7 @@ describe('Repository', () => {
             const breadcrumbTexts = await driver.page.evaluate(() =>
                 [...document.querySelectorAll('.test-breadcrumb')].map(breadcrumb => breadcrumb.textContent)
             )
-            assert.deepStrictEqual(breadcrumbTexts, ['Home', 'Repositories', shortRepositoryName, '@master', filePath])
+            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', filePath])
 
             // TODO, broken: https://github.com/sourcegraph/sourcegraph/issues/12296
             // await driver.page.waitForSelector('#monaco-query-input .view-lines')

--- a/web/src/repo/RepoContainer.tsx
+++ b/web/src/repo/RepoContainer.tsx
@@ -55,6 +55,7 @@ import { displayRepoName, splitPath } from '../../../shared/src/components/RepoF
 import { AuthenticatedUser } from '../auth'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { ExternalLinkFields } from '../graphql-operations'
+import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -188,17 +189,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         RepoHeaderContributionsLifecycleProps
     >()
 
-    const repositoryBreadcrumbSetters = props.useBreadcrumb(
-        useMemo(
-            () => ({
-                key: 'repositories',
-                element: <>Repositories</>,
-            }),
-            []
-        )
-    )
-
-    const childBreadcrumbSetters = repositoryBreadcrumbSetters.useBreadcrumb(
+    const childBreadcrumbSetters = props.useBreadcrumb(
         useMemo(() => {
             if (isErrorLike(repoOrError) || !repoOrError) {
                 return
@@ -208,6 +199,8 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
 
             return {
                 key: 'repository',
+                divider: null,
+                noHome: true,
                 element: (
                     <>
                         <Link
@@ -216,8 +209,9 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                                     ? resolvedRevisionOrError.rootTreeURL
                                     : repoOrError.url
                             }
-                            className="repo-header__repo"
+                            className="h5 mb-0 d-inline-flex align-items-center test-repo-breadcrumb__repo"
                         >
+                            <SourceRepositoryIcon className="icon-inline mr-1" />
                             {repoDirectory ? `${repoDirectory}/` : ''}
                             <span className="font-weight-semibold">{repoBase}</span>
                         </Link>


### PR DESCRIPTION
The repo name is bigger and now has an icon. The "Home > Repositories >" prefix is removed. This makes it easier to quickly scan the repo name.

See discussion at https://sourcegraph.slack.com/archives/C0HMGV90V/p1601315825028400?thread_ts=1601314236.026900&cid=C0HMGV90V. Maybe this isn't the global best solution for the repo breadcrumb, but I propose we try it and see how people like it! If we come up with a way to make the repo breadcrumb consistent with the other breadcrumbs (and still have nice properties of not wasting precious space there, etc.), then we can always switch in the future.

## Light theme

![image](https://user-images.githubusercontent.com/1976/94493504-a84e5380-01a1-11eb-89c1-bc72b3d51f07.png)

## Dark theme

![image](https://user-images.githubusercontent.com/1976/94493515-aedccb00-01a1-11eb-893b-f57b2598e850.png)
