### PR TITLE
logging: introduce new json log format with automatic severity field

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -29,7 +29,7 @@ var (
 	// MyName represents the name of the current process.
 	MyName, envVarName = findName()
 	LogLevel           = Get("SRC_LOG_LEVEL", "dbug", "upper log level to restrict log output to (dbug, info, warn, error, crit)")
-	LogFormat          = Get("SRC_LOG_FORMAT", "logfmt", "log format (logfmt, condensed)")
+	LogFormat          = Get("SRC_LOG_FORMAT", "logfmt", "log format (logfmt, condensed, json)")
 	InsecureDev, _     = strconv.ParseBool(Get("INSECURE_DEV", "false", "Running in insecure dev (local laptop) mode"))
 )
 

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -88,7 +88,7 @@ func LogEntryLevelString(l log15.Lvl) string {
 	case log15.LvlCrit:
 		return "CRITICAL"
 	default:
-		panic("bad level")
+		return "INVALID"
 	}
 }
 

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -74,6 +74,24 @@ func init() {
 	color.NoColor = env.Get("NO_COLOR", "", "Disable colored output") != ""
 }
 
+// For severity field, see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+func LogEntryLevelString(l log15.Lvl) string {
+	switch l {
+	case log15.LvlDebug:
+		return "DEBUG"
+	case log15.LvlInfo:
+		return "INFO"
+	case log15.LvlWarn:
+		return "WARNING"
+	case log15.LvlError:
+		return "ERROR"
+	case log15.LvlCrit:
+		return "CRITICAL"
+	default:
+		panic("bad level")
+	}
+}
+
 func Init(options ...Option) {
 	opts := &Options{}
 	for _, setter := range options {
@@ -86,6 +104,13 @@ func Init(options ...Option) {
 	switch env.LogFormat {
 	case "condensed":
 		handler = log15.StreamHandler(os.Stderr, log15.FormatFunc(condensedFormat))
+	case "json":
+		// for these uses: https://cloud.google.com/run/docs/logging#log-resource
+		jsonFormatHandler := log15.StreamHandler(os.Stderr, log15.JsonFormat())
+		handler = log15.FuncHandler(func(r *log15.Record) error {
+			r.Ctx = append(r.Ctx, "severity", LogEntryLevelString(r.Lvl))
+			return jsonFormatHandler.Log(r)
+		})
 	case "logfmt":
 		fallthrough
 	default:


### PR DESCRIPTION
addresses some aspects of issue https://github.com/sourcegraph/sourcegraph/issues/13191

allows to specify a log format with the env var `SRC_LOG_FORMAT=json` which makes it log in json and automatically adds a severity field. this allows for filtering and redirecting according to severity (for example in stackdriver)
