### PR TITLE
show BrowserExtensionToast after more days of activity

### DIFF
--- a/web/src/marketing/BrowserExtensionToast.tsx
+++ b/web/src/marketing/BrowserExtensionToast.tsx
@@ -39,7 +39,7 @@ abstract class BrowserExtensionToast extends React.Component<Props, State> {
                     !isInstalled &&
                     showDotComMarketing &&
                     localStorage.getItem(HAS_DISMISSED_TOAST_KEY) !== 'true' &&
-                    daysActiveCount === 1
+                    daysActiveCount === 3
                 this.setState({ visible })
                 if (visible) {
                     eventLogger.log('BrowserExtReminderViewed')


### PR DESCRIPTION
Currently, the "Get Sourcegraph on GitHub" toast shows up on the first day of being active. That means that a brand new user who just visits Sourcegraph for the first time will see it. This is not effective because it's (1) annoying and (2) before they have had time to (hopefully) enjoy using Sourcegraph.