### PR TITLE
monitoring: update trace log format in db hook

### DIFF
--- a/internal/db/dbconn/dbconn.go
+++ b/internal/db/dbconn/dbconn.go
@@ -176,7 +176,7 @@ func (h *hook) Before(ctx context.Context, query string, args ...interface{}) (c
 	)
 	tr.LogFields(otlog.Lazy(func(fv otlog.Encoder) {
 		for i, arg := range args {
-			fv.EmitString(strconv.Itoa(i+1), fmt.Sprintf("%q", arg))
+			fv.EmitString(strconv.Itoa(i+1), fmt.Sprintf("%v", arg))
 		}
 	}))
 


### PR DESCRIPTION
Integers like user IDs are currently interpreted as code points. Changing `%q` to `%v` should fix that.


![image](https://user-images.githubusercontent.com/26413131/94534141-54df1280-0240-11eb-88d1-a9e3c801b1b0.png)





<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
