### PR TITLE
gomod: zoekt always respects search.largeFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - GitLab pipelines are now parsed correctly and show their current status in campaign changesets. [#14129](https://github.com/sourcegraph/sourcegraph/pull/14129)
 - Fixed an issue where specifying any repogroups would effectively search all repositories for all repogroups. [#14190](https://github.com/sourcegraph/sourcegraph/pull/14190)
 - Changesets that were previously closed after being detached from a campaign are now reopened when being reattached. [#14099](https://github.com/sourcegraph/sourcegraph/pull/14099)
+- Previously large files that match the site configuration [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) would not be indexed if they contained a large number of unique trigrams. We now index those files as well. Note: files matching the glob still need to be valid utf-8. [#12443](https://github.com/sourcegraph/sourcegraph/issues/12443)
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200922223456-ae29571c327d
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200929094455-d0d95b84fe01
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1263,6 +1263,8 @@ github.com/sourcegraph/zoekt v0.0.0-20200922213257-67a0830742b9 h1:1wIrBgAJaOavX
 github.com/sourcegraph/zoekt v0.0.0-20200922213257-67a0830742b9/go.mod h1:wKw27qflqCRl3jee8T3Q60r50n3GGYe9iuRQD5ZZJgE=
 github.com/sourcegraph/zoekt v0.0.0-20200922223456-ae29571c327d h1:YiP7Zy08Z/OYi6xBIUBlomFvsqbsKGpmX8BI/rP6BU0=
 github.com/sourcegraph/zoekt v0.0.0-20200922223456-ae29571c327d/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
+github.com/sourcegraph/zoekt v0.0.0-20200929094455-d0d95b84fe01 h1:VTFPthjlbk4Rql+rhbM/omTWQADnz+QrTXJkEJlJNow=
+github.com/sourcegraph/zoekt v0.0.0-20200929094455-d0d95b84fe01/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1223,7 +1223,7 @@ type SiteConfiguration struct {
 	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.
 	SearchIndexSymbolsEnabled *bool `json:"search.index.symbols.enabled,omitempty"`
-	// SearchLargeFiles description: A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.
+	// SearchLargeFiles description: A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.
 	SearchLargeFiles []string `json:"search.largeFiles,omitempty"`
 	// SearchLimits description: Limits that search applies for number of repositories searched and timeouts.
 	SearchLimits *SearchLimits `json:"search.limits,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -30,7 +30,7 @@
       "group": "Search"
     },
     "search.largeFiles": {
-      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.",
+      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.",
       "type": "array",
       "items": {
         "type": "string"

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -35,7 +35,7 @@ const SiteSchemaJSON = `{
       "group": "Search"
     },
     "search.largeFiles": {
-      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.",
+      "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://golang.org/pkg/path/filepath/#Match.",
       "type": "array",
       "items": {
         "type": "string"


### PR DESCRIPTION
Updates zoekt to include changes around search.largeFiles. Previously we
would exclude files which contained too many trigrams. We now increase
the trigram limit in the case of files that match search.largeFiles.

Includes commits from zoekt:

- https://github.com/sourcegraph/zoekt/commit/d0d95b8 build: always run checktext
- https://github.com/sourcegraph/zoekt/commit/db2988b build: ignore size max includes binary

Fixes https://github.com/sourcegraph/sourcegraph/issues/12443