### PR TITLE
frontend: instrument failures in config file override watcher

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -50,6 +50,10 @@ var (
 		Name: "src_frontend_config_file_watcher_running",
 		Help: "1 if the configuration file overrides watcher is running.",
 	})
+	metricConfigOverrideUpdates = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "src_frontend_config_file_watcher_updates",
+		Help: "Incremented each time the config file is updated.",
+	}, []string{"status"})
 )
 
 // handleConfigOverrides allows environments to forcibly override the
@@ -61,6 +65,7 @@ var (
 // the configuration server is started but after PostgreSQL is connected.
 func handleConfigOverrides() error {
 	ctx := context.Background()
+	log := log15.Root().New("svc", "config.file")
 
 	overrideSiteConfig := os.Getenv("SITE_CONFIG_FILE")
 	overrideExtSvcConfig := os.Getenv("EXTSVC_CONFIG_FILE")
@@ -127,7 +132,7 @@ func handleConfigOverrides() error {
 			return errors.Wrap(err, "parsing EXTSVC_CONFIG_FILE")
 		}
 		if len(rawConfigs) == 0 {
-			log15.Warn("EXTSVC_CONFIG_FILE contains zero external service configurations")
+			log.Warn("EXTSVC_CONFIG_FILE contains zero external service configurations")
 		}
 
 		existing, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{
@@ -190,14 +195,14 @@ func handleConfigOverrides() error {
 
 		// Apply the delta update.
 		for extSvc := range toRemove {
-			log15.Debug("Deleting external service", "id", extSvc.ID, "displayName", extSvc.DisplayName)
+			log.Debug("Deleting external service", "id", extSvc.ID, "displayName", extSvc.DisplayName)
 			err := db.ExternalServices.Delete(ctx, extSvc.ID)
 			if err != nil {
 				return errors.Wrap(err, "ExternalServices.Delete")
 			}
 		}
 		for extSvc := range toAdd {
-			log15.Debug("Adding external service", "displayName", extSvc.DisplayName)
+			log.Debug("Adding external service", "displayName", extSvc.DisplayName)
 			if err := db.ExternalServices.Create(ctx, confGet, extSvc); err != nil {
 				return errors.Wrap(err, "ExternalServices.Create")
 			}
@@ -205,7 +210,7 @@ func handleConfigOverrides() error {
 
 		ps := confGet().AuthProviders
 		for id, extSvc := range toUpdate {
-			log15.Debug("Updating external service", "id", id, "displayName", extSvc.DisplayName)
+			log.Debug("Updating external service", "id", id, "displayName", extSvc.DisplayName)
 
 			update := &db.ExternalServiceUpdate{DisplayName: &extSvc.DisplayName, Config: &extSvc.Config}
 			if err := db.ExternalServices.Update(ctx, ps, id, update); err != nil {
@@ -221,20 +226,23 @@ func handleConfigOverrides() error {
 
 		events, err := watchPaths(ctx, overrideSiteConfig, overrideExtSvcConfig, overrideGlobalSettings)
 		if err != nil {
-			log15.Error("failed to watch config override files", "error", err)
+			log.Error("failed to watch config override files", "error", err)
 			return
 		}
 
 		for err := range events {
 			if err != nil {
-				log15.Warn("error while watching config override files", "error", err)
+				log.Warn("error while watching config override files", "error", err)
+				metricConfigOverrideUpdates.WithLabelValues("watch_failed").Inc()
 				continue
 			}
 
 			if err := handleConfigOverrides(); err != nil {
-				log15.Error("failed to update configuration from modified config override file", "error", err)
+				log.Error("failed to update configuration from modified config override file", "error", err)
+				metricConfigOverrideUpdates.WithLabelValues("update_failed").Inc()
 			} else {
-				log15.Info("updated configuration from modified config overrides files")
+				log.Info("updated configuration from modified config override files")
+				metricConfigOverrideUpdates.WithLabelValues("success").Inc()
 			}
 		}
 	})


### PR DESCRIPTION
This commit makes two changes. Firstly we introduce a new prometheus
metric which is incremented everytime we try to update configuration
while watching the files. Secondly we include a consistent key in logs
related to config overrides so we can search for it.

Part of https://github.com/sourcegraph/sourcegraph/issues/14019