### PR TITLE
repo-updater: Instrument the size of the scheduler heap

### DIFF
--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -65,6 +65,10 @@ var (
 		Name: "src_repoupdater_sched_known_repos",
 		Help: "The number of repositories that are managed by the scheduler.",
 	})
+	schedHeapCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "src_repoupdater_sched_heap_count",
+		Help: "The number of repositories currently in the scheduler heap.",
+	})
 )
 
 func MustRegisterMetrics(db dbutil.DB) {

--- a/cmd/repo-updater/repos/scheduler.go
+++ b/cmd/repo-updater/repos/scheduler.go
@@ -350,7 +350,7 @@ func (s *updateScheduler) DebugDump() interface{} {
 	}
 	for i, update := range s.schedule.heap {
 		// Copy the scheduledRepoUpdate as a value so that
-		// poping off the heap here won't update the index value of the real heap, and
+		// popping off the heap here won't update the index value of the real heap, and
 		// we don't do a racy read on the repo pointer which may change concurrently in the real heap.
 		updateCopy := *update
 		schedule.heap[i] = &updateCopy
@@ -743,6 +743,7 @@ func (s *schedule) reset() {
 		s.timer.Stop()
 		s.timer = nil
 	}
+	schedHeapCount.Set(0)
 }
 
 // The following methods implement heap.Interface based on the priority queue example:
@@ -768,6 +769,7 @@ func (s *schedule) Push(x interface{}) {
 	item.Index = n
 	s.heap = append(s.heap, item)
 	s.index[item.Repo.ID] = item
+	schedHeapCount.Inc()
 }
 
 func (s *schedule) Pop() interface{} {
@@ -776,6 +778,7 @@ func (s *schedule) Pop() interface{} {
 	item.Index = -1 // for safety
 	s.heap = s.heap[0 : n-1]
 	delete(s.index, item.Repo.ID)
+	schedHeapCount.Dec()
 	return item
 }
 


### PR DESCRIPTION
This will help us debug repo-updater schedule state.