### PR TITLE
use commands directly in vagrant shell

### DIFF
--- a/test/servers.yaml
+++ b/test/servers.yaml
@@ -10,5 +10,17 @@
   ssh_key_path: "~/.ssh/id_rsa"
   shell_commands:
     - |
-       cd /sourcegraph/test/e2e
-       ./smoke-test.sh
+       cd /sourcegraph
+
+       Xvfb "$DISPLAY" -screen 0 1280x1024x24 &
+       x11vnc -display "$DISPLAY" -forever -rfbport 5900 >/x11vnc.log 2>&1 &
+
+       asdf install
+       yarn upgrade
+
+       pushd enterprise
+       ./cmd/server/pre-build.sh
+       ./cmd/server/build.sh
+       popd
+       ./dev/ci/e2e.sh
+       docker image rm -f "${IMAGE}"


### PR DESCRIPTION
For some reason when running these commands in a script, the `pre-build.sh` script errors out. I've tried sourcing env vars and exporting them in a script to no avail. Related to #12339 