### PR TITLE
search: enable enterprise home panels by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The new GraphQL API query field `namespaceByName(name: String!)` makes it easier to look up the user or organization with the given name. Previously callers needed to try looking up the user and organization separately.
 - Changesets created by campaigns will now include a link back to the campaign in their body text. [#14033](https://github.com/sourcegraph/sourcegraph/issues/14033)
 - Users can now preview commits that are going to be created in their repositories in the campaign preview UI. [#14181](https://github.com/sourcegraph/sourcegraph/pull/14181)
+- Homepage panels are now enabled by default on Sourcegraph Server. [#14287](https://github.com/sourcegraph/sourcegraph/issues/14287)
 
 ### Changed
 

--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -2,7 +2,6 @@
   // This is set from an environment variable
   "experimentalFeatures": {
     "showRepogroupHomepage": true,
-    "showEnterpriseHomePanels": true,
     "showMultilineSearchConsole": true
   },
   "search.repositoryGroups": {

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -63,7 +63,7 @@
         "showEnterpriseHomePanels": {
           "description": "Enabled the homepage panels in the Enterprise homepage",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": { "pointer": true }
         },
         "showMultilineSearchConsole": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -68,7 +68,7 @@ const SettingsSchemaJSON = `{
         "showEnterpriseHomePanels": {
           "description": "Enabled the homepage panels in the Enterprise homepage",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": { "pointer": true }
         },
         "showMultilineSearchConsole": {

--- a/web/src/integration/graphQlResults.ts
+++ b/web/src/integration/graphQlResults.ts
@@ -113,6 +113,21 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
             },
         },
     }),
+    EventLogsData: () => ({
+        node: {
+            eventLogs: {
+                nodes: [],
+                totalCount: 0,
+                pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                },
+            },
+        },
+    }),
+    savedSearches: () => ({
+        savedSearches: [],
+    }),
     logEvent: () => ({
         logEvent: {
             alwaysNil: null,

--- a/web/src/util/settings.ts
+++ b/web/src/util/settings.ts
@@ -65,7 +65,7 @@ export function experimentalFeaturesFromSettings(
         searchStreaming = false,
         showRepogroupHomepage = false,
         showOnboardingTour = false,
-        showEnterpriseHomePanels = false,
+        showEnterpriseHomePanels = true, // Default to true if not set
         showMultilineSearchConsole = false,
     } = experimentalFeatures
 


### PR DESCRIPTION
Fixes #14287

Requires https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3518 to be completed first