### PR TITLE
Re-render extension card when theme changes

### DIFF
--- a/web/src/extensions/ExtensionCard.tsx
+++ b/web/src/extensions/ExtensionCard.tsx
@@ -271,5 +271,5 @@ areEqual)
 
 /** Custom compareFunction for ExtensionCard */
 function areEqual(oldProps: Props, newProps: Props): boolean {
-    return oldProps.enabled === newProps.enabled
+    return oldProps.enabled === newProps.enabled && oldProps.isLightTheme === newProps.isLightTheme
 }


### PR DESCRIPTION
#13666. Extension card for extensions with `iconDark` currently looks broken when user changes theme.