### PR TITLE
dep: use our fork of golang.org/x/oauth2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -221,6 +221,7 @@ replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-202009222
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 
 replace github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
+replace golang.org/x/oauth2 => github.com/sourcegraph/oauth2 v1.0.0
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 

--- a/go.sum
+++ b/go.sum
@@ -1255,6 +1255,8 @@ github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484 h1:oMnbwXPJ
 github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
+github.com/sourcegraph/oauth2 v1.0.0 h1:8E8mWmiX8so+Lq0RDLKwDJAffUliM4K1nCINqCtXuvI=
+github.com/sourcegraph/oauth2 v1.0.0/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=


### PR DESCRIPTION
Quoted from https://github.com/sourcegraph/oauth2/commit/6a800d6a8d193c79bffb607e9eacb6860bbe0e0c:

>GitHub returns 200 status code for invalid client ID and/or client secret, and we have to rely on the response body for error checking.
>
>The error `oauth2: server response missing access_token` is imprecise and misleading.
>
>See https://docs.github.com/en/free-pro-team@latest/developers/apps/troubleshooting-oauth-app-access-token-request-errors
>
>Tested end-to-end:
>
><img width="391" alt="Screen Shot 2020-09-30 at 2 39 48 PM" src="https://user-images.githubusercontent.com/2946214/94651284-ce532f80-032a-11eb-96c0-8a5f7dd078d1.png">
>

Related: https://github.com/sourcegraph/customer/issues/105