### PR TITLE
search: add tracing to NewSearchImplementer

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -60,8 +60,7 @@ type SearchImplementer interface {
 }
 
 // NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
-func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplementer, error) {
-	var err error
+func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplementer, err error) {
 	tr, ctx := trace.New(ctx, "NewSearchImplementer", args.Query)
 	defer func() {
 		tr.SetError(err)

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
@@ -60,12 +61,19 @@ type SearchImplementer interface {
 
 // NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
 func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplementer, error) {
+	var err error
+	tr, ctx := trace.New(ctx, "NewSearchImplementer", args.Query)
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	settings, err := decodedViewerFinalSettings(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	useNewParser := getBoolPtr(settings.SearchMigrateParser, true)
+	tr.LogFields(otlog.Bool("useNewParser", useNewParser))
 
 	searchType, err := detectSearchType(args.Version, args.PatternType)
 	if err != nil {
@@ -80,6 +88,7 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 	var queryInfo query.QueryInfo
 	if useNewParser {
 		globbing := getBoolPtr(settings.SearchGlobbing, false)
+		tr.LogFields(otlog.Bool("globbing", globbing))
 		queryInfo, err = query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
 		if err != nil {
 			return alertForQuery(args.Query, err), nil
@@ -100,6 +109,7 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (SearchImplemen
 			return alertForQuery(queryString, err), nil
 		}
 	}
+	tr.LazyPrintf("parsing done")
 
 	// If stable:truthy is specified, make the query return a stable result ordering.
 	if queryInfo.BoolValue(query.FieldStable) {


### PR DESCRIPTION
Adds tracing to `NewSearchImplementer`. Currently, the traces show several trips to the DB but I wasn't sure which part of the code is responsible. Now, the traces make it very explicit that 

- Within `NewSearchImplementer`. we call the DB 4 times just to get the user settings
- the parser is not the bottleneck

![image](https://user-images.githubusercontent.com/26413131/94654251-165b5d80-02fd-11eb-8e25-e0d0cc67e8b0.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
