### PR TITLE
doc: mount volume for config file overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The extension registry has been redesigned to make it easier to find non-default Sourcegraph extensions.
 - Tokens and similar sensitive information included in the userinfo portion of remote repository URLs will no longer be visible on the Mirroring settings page. [#14153](https://github.com/sourcegraph/sourcegraph/pull/14153)
 - The sign in and sign up forms have been redesigned with better input validation.
+- Kubernetes admins mounting [configuration files](https://docs.sourcegraph.com/admin/config/advanced_config_file#kubernetes-configmap) are encouraged to change how the ConfigMap is mounted. See the new documentation. Previously our documentation suggested using subPath. However, this lead to Kubernetes not automatically updating the files on configuration change. [#14297](https://github.com/sourcegraph/sourcegraph/pull/14297)
 
 ### Fixed
 

--- a/doc/admin/config/advanced_config_file.md
+++ b/doc/admin/config/advanced_config_file.md
@@ -169,26 +169,19 @@ To have Sourcegraph use this new ConfigMap, add the following environment variab
 
 ```
         - name: SITE_CONFIG_FILE
-          value: /mnt/site.json
+          value: /etc/sourcegraph/site.json
         - name : GLOBAL_SETTINGS_FILE
-          value: /mnt/global-settings.json
+          value: /etc/sourcegraph/global-settings.json
         - name : EXTSVC_CONFIG_FILE
-          value: /mnt/extsvc.json
+          value: /etc/sourcegraph/extsvc.json
 ```
 
-And instruct Kubernetes to mount the ConfigMap file we created under `/mnt/` by adding the following in your `sourcegraph-frontend.Deployment.yaml` `volumeMounts` section:
+And instruct Kubernetes to mount the ConfigMap file we created under `/etc/sourcegraph/` by adding the following in your `sourcegraph-frontend.Deployment.yaml` `volumeMounts` section:
 
 ```
         volumeMounts:
-        - mountPath: /mnt/site.json
+        - mountPath: /etc/sourcegraph
           name: config-volume
-          subPath: site.json
-        - mountPath: /mnt/global-settings.json
-          name: config-volume
-          subPath: global-settings.json
-        - mountPath: /mnt/extsvc.json
-          name: config-volume
-          subPath: extsvc.json
 ```
 
 And similarly under the `volume` section:


### PR DESCRIPTION
Rather than using subpath we mount the full volume. This allows
kubernetes to update the configmap when it changes. It requires the full
volume since it does updates via symlinks. For example here is the ls
output on sourcegraph.com once we use this approach:

``` shellsession
# ls -la /etc/sourcegraph
total 12
drwxrwxrwx    3 root     root          4096 Sep 30 08:17 .
drwxr-xr-x    1 root     root          4096 Sep 30 08:17 ..
drwxr-xr-x    2 root     root          4096 Sep 30 08:17 ..2020_09_30_08_17_45.768252600
lrwxrwxrwx    1 root     root            31 Sep 30 08:17 ..data -> ..2020_09_30_08_17_45.768252600
lrwxrwxrwx    1 root     root            18 Sep 30 08:17 extsvc.json -> ..data/extsvc.json
lrwxrwxrwx    1 root     root            27 Sep 30 08:17 global-settings.json -> ..data/global-settings.json
lrwxrwxrwx    1 root     root            16 Sep 30 08:17 site.json -> ..data/site.json
```

When a new configmap update goes out kubernetes writes the data into a
directory like "..2020_09_30_08_17_45.768252600" and then can atomically
update symlinks.

We also suggest users mount to /etc/sourcegraph. This is a more natural
path for this configuration data than under /mnt which should just
contain volume mounts. Additionally /mnt has other mounts in it, so we
require an empty directory as the target.

Part of https://github.com/sourcegraph/sourcegraph/issues/14019