### PR TITLE
Enable multiline search console in dev

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -2,7 +2,8 @@
   // This is set from an environment variable
   "experimentalFeatures": {
     "showRepogroupHomepage": true,
-    "showEnterpriseHomePanels": true
+    "showEnterpriseHomePanels": true,
+    "showMultilineSearchConsole": true
   },
   "search.repositoryGroups": {
     "test": ["github.com/gorilla/mux", "github.com/gorilla/pat"]


### PR DESCRIPTION
This simply makes it possible to access `/search/console` in dev without having to explicitly flip a feature flag every time.