### PR TITLE
search: stream out repository matches

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -257,6 +257,10 @@ func (r *RepositoryResolver) Icon() string {
 	return r.icon
 }
 
+func (r *RepositoryResolver) Rev() string {
+	return r.rev
+}
+
 func (r *RepositoryResolver) Label() (*markdownResolver, error) {
 	var label string
 	if r.rev != "" {

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -106,7 +106,6 @@ function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
         matches: [],
     }
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return gqlRepo as GQL.IRepository
 }
 

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -9,14 +9,24 @@ import { SearchPatternType } from '../graphql-operations'
 // change anything and everything here. We are iteratively improving this
 // until it is no longer a proof of concept and instead works well.
 
-type SearchEvent = { type: 'filematches'; matches: FileMatch[] } | { type: 'filters'; filters: Filter[] }
+type SearchEvent =
+    | { type: 'filematches'; matches: FileMatch[] }
+    | { type: 'repomatches'; matches: RepositoryMatch[] }
+    | { type: 'filters'; filters: Filter[] }
+
+// TODO Notice that this is a subset of FileMatch. This is what Zoekt does. We explicitly call it out as a seperate type since that is more powerful.
+// This requires to add a RepositoryMatch event. We could however model FileMatch's as a generic type? What do you think is better?
+interface RepositoryMatch {
+    repository: string
+    branches?: string[]
+}
 
 interface FileMatch {
     name: string
     repository: string
-    branches?: [string]
+    branches?: string[]
     version?: string
-    lineMatches: [LineMatch]
+    lineMatches: LineMatch[]
 }
 
 interface LineMatch {
@@ -78,6 +88,35 @@ function toGQLFileMatch(fm: FileMatch): GQL.IFileMatch {
     }
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const md = (text: string): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
+
+function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
+    let revision = ''
+    if (repo.branches) {
+        const branch = repo.branches[0]
+        if (branch !== '') {
+            revision = '@' + branch
+        }
+    }
+    const label = repo.repository + revision
+
+    // We only need to return the subset defined in IGenericSearchResultInterface
+    const gqlRepo: unknown = {
+        __typename: 'Repository',
+        // copy-pasta from repositories.go :'(
+        icon:
+            'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K',
+        label: md('[' + label + '](/' + label + ')'),
+        url: '/' + label,
+        detail: md('Repository name match'),
+        matches: [],
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return gqlRepo as GQL.IRepository
+}
+
 const toGQLSearchFilter = (filter: Omit<Filter, 'type'>): GQL.ISearchFilter => ({
     __typename: 'SearchFilter',
     ...filter,
@@ -116,6 +155,13 @@ export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearc
                     ...results,
                     // File matches are additive
                     results: results.results.concat(newEvent.matches.map(toGQLFileMatch)),
+                }
+
+            case 'repomatches':
+                return {
+                    ...results,
+                    // File matches are additive
+                    results: results.results.concat(newEvent.matches.map(toGQLRepositoryMatch)),
                 }
 
             case 'filters':
@@ -160,6 +206,14 @@ export function search(
                     throw new TypeError('internal error: expected MessageEvent in streaming search filematches')
                 }
                 observer.next({ type: 'filematches', matches: JSON.parse(event.data) as FileMatch[] })
+            })
+        )
+        subscriptions.add(
+            fromEvent(eventSource, 'repomatches').subscribe((event: Event) => {
+                if (!(event instanceof MessageEvent)) {
+                    throw new TypeError('internal error: expected MessageEvent in streaming search filematches')
+                }
+                observer.next({ type: 'repomatches', matches: JSON.parse(event.data) as RepositoryMatch[] })
             })
         )
         subscriptions.add(

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -90,13 +90,8 @@ function toGQLFileMatch(fm: FileMatch): GQL.IFileMatch {
 const md = (text: string): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
 
 function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
-    let revision = ''
-    if (repo.branches) {
-        const branch = repo.branches[0]
-        if (branch !== '') {
-            revision = '@' + branch
-        }
-    }
+    const branch = repo?.branches?.[0]
+    const revision = branch ? `@${branch}` : ''
     const label = repo.repository + revision
 
     // We only need to return the subset defined in IGenericSearchResultInterface
@@ -105,7 +100,7 @@ function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
         // copy-pasta from repositories.go :'(
         icon:
             'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K',
-        label: md('[' + label + '](/' + label + ')'),
+        label: md('[$label](/$label)'),
         url: '/' + label,
         detail: md('Repository name match'),
         matches: [],

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -14,15 +14,10 @@ type SearchEvent =
     | { type: 'repomatches'; matches: RepositoryMatch[] }
     | { type: 'filters'; filters: Filter[] }
 
-// TODO Notice that this is a subset of FileMatch. This is what Zoekt does. We explicitly call it out as a seperate type since that is more powerful.
-// This requires to add a RepositoryMatch event. We could however model FileMatch's as a generic type? What do you think is better?
-interface RepositoryMatch {
-    repository: string
-    branches?: string[]
-}
-
 interface FileMatch extends RepositoryMatch {
     name: string
+    repository: string
+    branches?: string[]
     version?: string
     lineMatches: LineMatch[]
 }
@@ -32,6 +27,8 @@ interface LineMatch {
     lineNumber: number
     offsetAndLengths: [[number]]
 }
+
+type RepositoryMatch = Pick<FileMatch, 'repository' | 'branches'>
 
 interface Filter {
     value: string

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -87,7 +87,7 @@ function toGQLFileMatch(fm: FileMatch): GQL.IFileMatch {
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const md = (text: string): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
+const toMarkdown = (text: string): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
 
 function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     const branch = repo?.branches?.[0]
@@ -100,9 +100,9 @@ function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
         // copy-pasta from repositories.go :'(
         icon:
             'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K',
-        label: md('[$label](/$label)'),
+        label: toMarkdown('[$label](/$label)'),
         url: '/' + label,
-        detail: md('Repository name match'),
+        detail: toMarkdown('Repository name match'),
         matches: [],
     }
 

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -100,7 +100,7 @@ function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
         // copy-pasta from repositories.go :'(
         icon:
             'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K',
-        label: toMarkdown('[$label](/$label)'),
+        label: toMarkdown(`[${label}](/${label})`),
         url: '/' + label,
         detail: toMarkdown('Repository name match'),
         matches: [],
@@ -153,7 +153,7 @@ export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearc
             case 'repomatches':
                 return {
                     ...results,
-                    // File matches are additive
+                    // Repository matches are additive
                     results: results.results.concat(newEvent.matches.map(toGQLRepositoryMatch)),
                 }
 

--- a/web/src/search/stream.tsx
+++ b/web/src/search/stream.tsx
@@ -21,10 +21,8 @@ interface RepositoryMatch {
     branches?: string[]
 }
 
-interface FileMatch {
+interface FileMatch extends RepositoryMatch {
     name: string
-    repository: string
-    branches?: string[]
     version?: string
     lineMatches: LineMatch[]
 }


### PR DESCRIPTION
This streams out repository matches. The adapter in stream.tsx sets the
fields to the same values that our graphql backend computed.

Part of #13067