### PR TITLE
search: preserve patterntype in search console queries

### DIFF
--- a/web/src/search/SearchConsolePage.tsx
+++ b/web/src/search/SearchConsolePage.tsx
@@ -15,7 +15,7 @@ import { search } from './backend'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { Omit } from 'utility-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { parseSearchURL, parseSearchURLQuery, parseSearchURLPatternType } from '.'
+import { parseSearchURLQuery, parseSearchURLPatternType } from '.'
 import { SearchPatternType } from '../graphql-operations'
 
 interface SearchConsolePageProps

--- a/web/src/search/SearchConsolePage.tsx
+++ b/web/src/search/SearchConsolePage.tsx
@@ -35,6 +35,28 @@ interface SearchConsolePageProps
     location: H.Location
 }
 
+const options: Monaco.editor.IEditorOptions = {
+    readOnly: false,
+    minimap: {
+        enabled: false,
+    },
+    lineNumbers: 'off',
+    fontSize: 14,
+    glyphMargin: false,
+    overviewRulerBorder: false,
+    rulers: [],
+    overviewRulerLanes: 0,
+    wordBasedSuggestions: false,
+    quickSuggestions: false,
+    fixedOverflowWidgets: true,
+    renderLineHighlight: 'none',
+    contextmenu: false,
+    links: false,
+    // Display the cursor as a 1px line.
+    cursorStyle: 'line',
+    cursorWidth: 1,
+}
+
 export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> = props => {
     const searchQuery = useMemo(() => new BehaviorSubject<string>(parseSearchURL(location.search).query || ''), [])
     const [nextSearch, resultsOrError] = useEventObservable<'loading' | GQL.ISearchResults | ErrorLike>(
@@ -55,27 +77,6 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
     )
     const [allExpanded, setAllExpanded] = useState(false)
 
-    const options: Monaco.editor.IEditorOptions = {
-        readOnly: false,
-        minimap: {
-            enabled: false,
-        },
-        lineNumbers: 'off',
-        fontSize: 14,
-        glyphMargin: false,
-        overviewRulerBorder: false,
-        rulers: [],
-        overviewRulerLanes: 0,
-        wordBasedSuggestions: false,
-        quickSuggestions: false,
-        fixedOverflowWidgets: true,
-        renderLineHighlight: 'none',
-        contextmenu: false,
-        links: false,
-        // Display the cursor as a 1px line.
-        cursorStyle: 'line',
-        cursorWidth: 1,
-    }
     const [monacoInstance, setMonacoInstance] = useState<typeof Monaco>()
     useEffect(() => {
         if (!monacoInstance) {

--- a/web/src/search/SearchConsolePage.tsx
+++ b/web/src/search/SearchConsolePage.tsx
@@ -15,7 +15,8 @@ import { search } from './backend'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { Omit } from 'utility-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { parseSearchURL } from '.'
+import { parseSearchURL, parseSearchURLQuery, parseSearchURLPatternType } from '.'
+import { SearchPatternType } from '../graphql-operations'
 
 interface SearchConsolePageProps
     extends ThemeProps,
@@ -58,7 +59,8 @@ const options: Monaco.editor.IEditorOptions = {
 }
 
 export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> = props => {
-    const searchQuery = useMemo(() => new BehaviorSubject<string>(parseSearchURL(location.search).query || ''), [])
+    const searchQuery = useMemo(() => new BehaviorSubject<string>(parseSearchURLQuery(location.search) || ''), [])
+    const patternType = useMemo(() => parseSearchURLPatternType(location.search) || SearchPatternType.structural, [])
     const [nextSearch, resultsOrError] = useEventObservable<'loading' | GQL.ISearchResults | ErrorLike>(
         useCallback(
             searchRequests =>
@@ -68,11 +70,11 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                     switchMap(query =>
                         concat(
                             of('loading' as const),
-                            search(query, 'V2', props.patternType, undefined, props.extensionsController.extHostAPI)
+                            search(query, 'V2', patternType, undefined, props.extensionsController.extHostAPI)
                         )
                     )
                 ),
-            [searchQuery, props.patternType, props.extensionsController, props.history]
+            [searchQuery, patternType, props.extensionsController, props.history]
         )
     )
     const [allExpanded, setAllExpanded] = useState(false)


### PR DESCRIPTION
When clicking `Search`, `patterntype:foo` would be erased from the query, but not update the URL. Also if the URL contained a param for patterntype, it was ignored. Now we default to structural patterntype and can change it explicitly with `patterntype:` in the query. First two commits are cosmetic, the third adds these changes.
