### PR TITLE
Bump src-cli MinimumVersion to 3.21.0

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.20.0"
+const MinimumVersion = "3.21.0"


### PR DESCRIPTION
When downloading the latest version of src-cli from sourcegraph.com this
version here is used. And `3.20.0` is not the latest one.

We should default to immediately updating this when doing a release in
`src-cli`. I'll add it to the `src-cli` docs.

(Issue in which a user ran into this: https://github.com/sourcegraph/src-cli/issues/332)