### PR TITLE
Highlight code snippets in docs

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -115,6 +115,12 @@ pre, code, kbd {
     font-family: var(--monospace-font-family);
 }
 
+code {
+    background-color: rgba(200,200,200,0.2);
+    padding: 0.2em;
+    border-radius: 0.2em;
+}
+
 /* LAYOUT */
 body {
     display: flex;


### PR DESCRIPTION
This adds a little background color to `<code>` snippets in docs. It's
hard to spot the monospace font in some of the prose.

I'm probably breaking 18 CSS conventions by using `rgba`, `em`, etc. Happy to change anything here, but I mainly care about the background and if somebody wants to implement this properly: pleeease!

Compare left (without background color) and right:
<img width="2068" alt="screenshot_2020-10-01_08 47 44@2x" src="https://user-images.githubusercontent.com/1185253/94777071-1e7dd080-03c3-11eb-96a5-8b28cd8bfd5a.png">
