### PR TITLE
fix result type of Mutation.publishExtension

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -6901,7 +6901,7 @@ type ExtensionRegistryMutation {
         Force publish even if there are warnings (such as invalid JSON warnings).
         """
         force: Boolean = false
-    ): ExtensionRegistryCreateExtensionResult!
+    ): ExtensionRegistryPublishExtensionResult!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6894,7 +6894,7 @@ type ExtensionRegistryMutation {
         Force publish even if there are warnings (such as invalid JSON warnings).
         """
         force: Boolean = false
-    ): ExtensionRegistryCreateExtensionResult!
+    ): ExtensionRegistryPublishExtensionResult!
 }
 
 """

--- a/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -27,7 +27,7 @@ import { AuthenticatedUser } from '../../../auth'
 
 const publishExtension = (
     args: Pick<GQL.IPublishExtensionOnExtensionRegistryMutationArguments, 'extensionID' | 'manifest' | 'bundle'>
-): Promise<GQL.IExtensionRegistryCreateExtensionResult> =>
+): Promise<GQL.IExtensionRegistryPublishExtensionResult> =>
     mutateGraphQL(
         gql`
             mutation PublishRegistryExtension($extensionID: String!, $manifest: String!, $bundle: String!) {


### PR DESCRIPTION
It was a mistake that the createExtension result type was used for this as well. No callers (that I'm aware of, or that are likely to exist otherwise) rely on the previous type name, and the types currently have the same shape, so the risk of breakage is extremely low.

Found by @keegancsmith in #14326.

This result type pattern is probably not necessary now (we haven't added any new or diverging fields in the last ~2y), but I guess it's good to keep in.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->