### PR TITLE
graphqlbackend: remove DiffSearchResult and DeploymentConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - User-defined search scopes are no longer shown below the search bar on the homepage. Use the [`quicklinks`](https://docs.sourcegraph.com/user/quick_links) setting instead to display links there.
 - The explore page (`/explore`) was removed.
 - The sign out page was removed.
+- The unused GraphQL types `DiffSearchResult` and `DeploymentConfiguration` were removed.
 
 ## 3.20.1
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2879,20 +2879,6 @@ type CommitSearchResult implements GenericSearchResultInterface {
 }
 
 """
-A search result that is a diff between two diffable Git objects.
-"""
-type DiffSearchResult {
-    """
-    The diff that matched the search query.
-    """
-    diff: Diff!
-    """
-    The matching portion of the diff.
-    """
-    preview: HighlightedString!
-}
-
-"""
 A string that has highlights (e.g, query matches).
 """
 type HighlightedString {
@@ -6559,20 +6545,6 @@ type SiteUsageStages {
     The number of users using automation stage features.
     """
     automate: Int!
-}
-
-"""
-A deployment configuration.
-"""
-type DeploymentConfiguration {
-    """
-    The email.
-    """
-    email: String
-    """
-    The site ID.
-    """
-    siteID: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2872,20 +2872,6 @@ type CommitSearchResult implements GenericSearchResultInterface {
 }
 
 """
-A search result that is a diff between two diffable Git objects.
-"""
-type DiffSearchResult {
-    """
-    The diff that matched the search query.
-    """
-    diff: Diff!
-    """
-    The matching portion of the diff.
-    """
-    preview: HighlightedString!
-}
-
-"""
 A string that has highlights (e.g, query matches).
 """
 type HighlightedString {
@@ -6552,20 +6538,6 @@ type SiteUsageStages {
     The number of users using automation stage features.
     """
     automate: Int!
-}
-
-"""
-A deployment configuration.
-"""
-type DeploymentConfiguration {
-    """
-    The email.
-    """
-    email: String
-    """
-    The site ID.
-    """
-    siteID: String
 }
 
 """


### PR DESCRIPTION
Both types are unused. They aren't the child of any other type, there
are no resolvers implemented for them and there are no references to
them in the sourcegraph repos outside of the schema. The last point was
validated with a query like

  repo:github.com/sourcegraph \bVirtualFile\b

on sourcegraph.com.

Subset of https://github.com/sourcegraph/sourcegraph/pull/14326