### PR TITLE
search: add more traces

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -336,7 +336,12 @@ func (r *searchResolver) maxResults() int32 {
 
 var mockDecodedViewerFinalSettings *schema.Settings
 
-func decodedViewerFinalSettings(ctx context.Context) (*schema.Settings, error) {
+func decodedViewerFinalSettings(ctx context.Context) (_ *schema.Settings, err error) {
+	tr, ctx := trace.New(ctx, "decodedViewerFinalSettings", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	if mockDecodedViewerFinalSettings != nil {
 		return mockDecodedViewerFinalSettings, nil
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	otlog "github.com/opentracing/opentracing-go/log"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
@@ -1517,6 +1519,12 @@ type aggregator struct {
 }
 
 func (a *aggregator) doRepoSearch(ctx context.Context, args *search.TextParameters, limit int32) {
+	var err error
+	tr, ctx := trace.New(ctx, "doRepoSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	repoResults, repoCommon, err := searchRepositories(ctx, args, limit)
 	// Timeouts are reported through searchResultsCommon so don't report an error for them
 	if err != nil && !isContextError(ctx, err) {
@@ -1536,6 +1544,12 @@ func (a *aggregator) doRepoSearch(ctx context.Context, args *search.TextParamete
 	}
 }
 func (a *aggregator) doSymbolSearch(ctx context.Context, args *search.TextParameters, limit int) {
+	var err error
+	tr, ctx := trace.New(ctx, "doSymbolSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	symbolFileMatches, symbolsCommon, err := searchSymbols(ctx, args, limit)
 	// Timeouts are reported through searchResultsCommon so don't report an error for them
 	if err != nil && !isContextError(ctx, err) {
@@ -1563,6 +1577,12 @@ func (a *aggregator) doSymbolSearch(ctx context.Context, args *search.TextParame
 	}
 }
 func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextParameters) {
+	var err error
+	tr, ctx := trace.New(ctx, "doFilePathSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	fileResults, fileCommon, err := searchFilesInRepos(ctx, args)
 	// Timeouts are reported through searchResultsCommon so don't report an error for them
 	if err != nil && !isContextError(ctx, err) {
@@ -1608,6 +1628,12 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 }
 
 func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters) {
+	var err error
+	tr, ctx := trace.New(ctx, "doDiffSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	old := tp.PatternInfo
 	patternInfo := &search.CommitPatternInfo{
 		Pattern:                      old.Pattern,
@@ -1650,6 +1676,12 @@ func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters
 }
 
 func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParameters) {
+	var err error
+	tr, ctx := trace.New(ctx, "doCommitSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	old := tp.PatternInfo
 	patternInfo := &search.CommitPatternInfo{
 		Pattern:                      old.Pattern,
@@ -1710,13 +1742,13 @@ func (r *searchResolver) isGlobalSearch() bool {
 // regardless of what `type:` is specified in the query string.
 //
 // Partial results AND an error may be returned.
-func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType string) (*SearchResultsResolver, error) {
-	var err error
-	tr, ctx := trace.New(ctx, "graphql.SearchResults", r.rawQuery())
+func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType string) (_ *SearchResultsResolver, err error) {
+	tr, ctx := trace.New(ctx, "doResults", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
+	tr.LogFields(otlog.String("query", r.rawQuery()))
 
 	start := time.Now()
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
@@ -226,10 +224,8 @@ var commonFileFilters = []struct {
 }
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
-	var err error
 	tr, ctx := trace.New(ctx, "DynamicFilters", "", trace.Tag{Key: "resolver", Value: "SearchResultsResolver"})
 	defer func() {
-		tr.SetError(err)
 		tr.Finish()
 	}()
 
@@ -1739,12 +1735,11 @@ func (r *searchResolver) isGlobalSearch() bool {
 //
 // Partial results AND an error may be returned.
 func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType string) (_ *SearchResultsResolver, err error) {
-	tr, ctx := trace.New(ctx, "doResults", "")
+	tr, ctx := trace.New(ctx, "doResults", r.rawQuery())
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	tr.LogFields(otlog.String("query", r.rawQuery()))
 
 	start := time.Now()
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1525,10 +1525,8 @@ type aggregator struct {
 }
 
 func (a *aggregator) doRepoSearch(ctx context.Context, args *search.TextParameters, limit int32) {
-	var err error
 	tr, ctx := trace.New(ctx, "doRepoSearch", "")
 	defer func() {
-		tr.SetError(err)
 		tr.Finish()
 	}()
 	repoResults, repoCommon, err := searchRepositories(ctx, args, limit)
@@ -1550,10 +1548,8 @@ func (a *aggregator) doRepoSearch(ctx context.Context, args *search.TextParamete
 	}
 }
 func (a *aggregator) doSymbolSearch(ctx context.Context, args *search.TextParameters, limit int) {
-	var err error
 	tr, ctx := trace.New(ctx, "doSymbolSearch", "")
 	defer func() {
-		tr.SetError(err)
 		tr.Finish()
 	}()
 	symbolFileMatches, symbolsCommon, err := searchSymbols(ctx, args, limit)
@@ -1583,10 +1579,8 @@ func (a *aggregator) doSymbolSearch(ctx context.Context, args *search.TextParame
 	}
 }
 func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextParameters) {
-	var err error
 	tr, ctx := trace.New(ctx, "doFilePathSearch", "")
 	defer func() {
-		tr.SetError(err)
 		tr.Finish()
 	}()
 	fileResults, fileCommon, err := searchFilesInRepos(ctx, args)
@@ -1634,10 +1628,8 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 }
 
 func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters) {
-	var err error
 	tr, ctx := trace.New(ctx, "doDiffSearch", "")
 	defer func() {
-		tr.SetError(err)
 		tr.Finish()
 	}()
 	old := tp.PatternInfo
@@ -1682,10 +1674,8 @@ func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters
 }
 
 func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParameters) {
-	var err error
 	tr, ctx := trace.New(ctx, "doCommitSearch", "")
 	defer func() {
-		tr.SetError(err)
 		tr.Finish()
 	}()
 	old := tp.PatternInfo

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -226,6 +226,12 @@ var commonFileFilters = []struct {
 }
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
+	var err error
+	tr, ctx := trace.New(ctx, "DynamicFilters", "", trace.Tag{Key: "resolver", Value: "SearchResultsResolver"})
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 
 	globbing := false
 	if settings, err := decodedViewerFinalSettings(ctx); err == nil {

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 // settingsCascade implements the GraphQL type SettingsCascade (and the deprecated type ConfigurationCascade).
@@ -96,7 +97,12 @@ func (r *settingsCascade) Final(ctx context.Context) (string, error) {
 }
 
 // Deprecated: in the GraphQL API
-func (r *settingsCascade) Merged(ctx context.Context) (*configurationResolver, error) {
+func (r *settingsCascade) Merged(ctx context.Context) (_ *configurationResolver, err error) {
+	tr, ctx := trace.New(ctx, "Merged", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
 	var messages []string
 	s, err := r.Final(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently, we only trace file/path searches. This PR adds traces for all results types, at least on the highest level. We also increase the granularity of traces for getting user settings.

Learnings from this change:
* we access user settings twice, before and after search (fix costs, marked in orange)
* repository search (default result-type, marked in red) might be a bottleneck for larger index sizes because repo resolution is on its critical path. Streaming will probably mask this problem though.

There is still a gap after the end of `doResults`. I will look at this next.

![image](https://user-images.githubusercontent.com/26413131/94799323-39f8d380-03e3-11eb-873c-4a686ad059ab.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
