### PR TITLE
CNCF: Explicitly list CNCF repositories for auto-indexing

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer/env.go
@@ -13,7 +13,7 @@ var (
 	rawIndexabilityUpdaterInterval      = env.Get("PRECISE_CODE_INTEL_INDEXABILITY_UPDATER_INTERVAL", "30m", "Interval between scheduled indexability updates.")
 	rawSchedulerInterval                = env.Get("PRECISE_CODE_INTEL_SCHEDULER_INTERVAL", "30m", "Interval between scheduled index updates.")
 	rawJanitorInterval                  = env.Get("PRECISE_CODE_INTEL_JANITOR_INTERVAL", "1m", "Interval between cleanup runs.")
-	rawIndexBatchSize                   = env.Get("PRECISE_CODE_INTEL_INDEX_BATCH_SIZE", "25", "Number of indexable repos to consider on each index scheduler update.")
+	rawIndexBatchSize                   = env.Get("PRECISE_CODE_INTEL_INDEX_BATCH_SIZE", "100", "Number of indexable repos to consider on each index scheduler update.")
 	rawIndexMinimumTimeSinceLastEnqueue = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_TIME_SINCE_LAST_ENQUEUE", "24h", "Interval between indexing runs of the same repo.")
 	rawIndexMinimumSearchCount          = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_COUNT", "50", "Minimum number of search events to trigger indexing for a repo.")
 	rawIndexMinimumSearchRatio          = env.Get("PRECISE_CODE_INTEL_INDEX_MINIMUM_SEARCH_RATIO", "50", "Minimum ratio of search events to total events to trigger indexing for a repo.")

--- a/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
@@ -16,10 +16,14 @@ import (
 const MaxGitserverRequestsPerSecond = 20
 
 type Updater struct {
-	store           store.Store
-	gitserverClient gitserver.Client
-	metrics         UpdaterMetrics
-	limiter         *rate.Limiter
+	store               store.Store
+	gitserverClient     gitserver.Client
+	metrics             UpdaterMetrics
+	minimumSearchCount  int
+	minimumSearchRatio  float64
+	minimumPreciseCount int
+	enableIndexingCNCF  bool
+	limiter             *rate.Limiter
 }
 
 var _ goroutine.Handler = &Updater{}
@@ -29,12 +33,19 @@ func NewUpdater(
 	gitserverClient gitserver.Client,
 	interval time.Duration,
 	metrics UpdaterMetrics,
+	minimumSearchCount int,
+	minimumSearchRatio float64,
+	minimumPreciseCount int,
 ) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(context.Background(), interval, &Updater{
-		store:           store,
-		gitserverClient: gitserverClient,
-		metrics:         metrics,
-		limiter:         rate.NewLimiter(MaxGitserverRequestsPerSecond, 1),
+		store:               store,
+		gitserverClient:     gitserverClient,
+		metrics:             metrics,
+		minimumSearchCount:  minimumSearchCount,
+		minimumSearchRatio:  minimumSearchRatio,
+		minimumPreciseCount: minimumPreciseCount,
+		enableIndexingCNCF:  true,
+		limiter:             rate.NewLimiter(MaxGitserverRequestsPerSecond, 1),
 	})
 }
 
@@ -44,6 +55,10 @@ func (u *Updater) Handle(ctx context.Context) error {
 	stats, err := u.store.RepoUsageStatistics(ctx)
 	if err != nil {
 		return errors.Wrap(err, "store.RepoUsageStatistics")
+	}
+
+	if u.enableIndexingCNCF {
+		stats = append(u.cncfStats(), stats...)
 	}
 
 	for _, stat := range stats {
@@ -112,4 +127,116 @@ func isRepoNotExist(err error) bool {
 	}
 
 	return false
+}
+
+// Below we enable indexing CNCF repositories automatically as a work around for
+// not having finished implementation of RFC 201 before having an opportunity where
+// it would be the perfect solution T_T
+//
+// Each of these repositories will be the first in the list to try to be indexed. We
+// artificially create a repo stats object for each one that will trick the scheduler
+// into thinking the repo is "hot" enough to index, regardless of its actual use.
+//
+// Below is a list of repository IDs marked with the name of the repo:
+// see https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/5d7dce1a56e799c6b8167ee58c2c68ac25c67ee1/base/frontend/sourcegraph-frontend.ConfigMap.yaml#L4957
+//
+// Follow-up issue: https://github.com/sourcegraph/sourcegraph/issues/14343
+
+var cncfRepositoryIDs = []int{
+	480,      // github.com/prometheus/prometheus
+	30214,    // github.com/helm/helm
+	45657,    // github.com/kubernetes/kubernetes
+	45756,    // github.com/nats-io/nats-server
+	50798,    // github.com/opentracing/opentracing-go
+	50912,    // github.com/grpc/grpc
+	54472,    // github.com/containernetworking/cni
+	60368,    // github.com/fluent/fluentd
+	82186,    // github.com/theupdateframework/tuf
+	87511,    // github.com/fluxcd/flux
+	204428,   // github.com/openebs/openebs
+	459734,   // github.com/open-policy-agent/opa
+	490140,   // github.com/rook/rook
+	615667,   // github.com/kubevirt/kubevirt
+	749288,   // github.com/coredns/coredns
+	1107281,  // github.com/containerd/containerd
+	1244892,  // github.com/OpenObservability/OpenMetrics
+	1252983,  // github.com/in-toto/in-toto
+	1382850,  // github.com/argoproj/argo
+	1452554,  // github.com/envoyproxy/envoy
+	1481540,  // github.com/jaegertracing/jaeger
+	1513627,  // github.com/spiffe/spire
+	35581042, // github.com/brigadecore/brigade
+	35595017, // github.com/theupdateframework/notary
+	35613504, // github.com/projectcontour/contour
+	35654543, // github.com/thanos-io/thanos
+	35683453, // github.com/dragonflyoss/Dragonfly
+	35733223, // github.com/linkerd/linkerd2
+	35736704, // github.com/virtual-kubelet/virtual-kubelet
+	35965026, // github.com/vitessio/vitess
+	36096026, // github.com/litmuschaos/litmus
+	36168644, // github.com/operator-framework/operator-sdk
+	36239375, // github.com/telepresenceio/telepresence
+	36305039, // github.com/strimzi/strimzi-kafka-operator
+	36583472, // github.com/tikv/tikv
+	36589859, // github.com/goharbor/harbor
+	36645706, // github.com/buildpacks/pack
+	36664934, // github.com/etcd-io/etcd
+	36683122, // github.com/dexidp/dex
+	36708822, // github.com/cri-o/cri-o
+	36764924, // github.com/cortexproject/cortex
+	36827876, // github.com/falcosecurity/falco
+	37069094, // github.com/kubeedge/kubeedge
+	37249424, // github.com/cloud-custodian/cloud-custodian
+	37252548, // github.com/crossplane/crossplane
+	37519923, // github.com/networkservicemesh/networkservicemesh
+	37612302, // github.com/kudobuilder/kudo
+	37650592, // github.com/cni-genie/CNI-Genie
+	37700634, // github.com/rancher/k3s
+	37764298, // github.com/chubaofs/chubaofs
+	37779257, // github.com/longhorn/longhorn
+	38195917, // github.com/kedacore/keda
+	38697647, // github.com/servicemeshinterface/smi-spec
+	38766483, // github.com/volcano-sh/volcano
+	39017834, // github.com/bfenetworks/bfe
+	39194379, // github.com/kumahq/kuma
+	39299029, // github.com/spiffe/spiffe
+	39322847, // github.com/parallaxsecond/parsec
+	39738895, // github.com/chaos-mesh/chaos-mesh
+	39957286, // github.com/cloudevents/spec
+	39966375, // github.com/open-telemetry/opentelemetry-specification
+	39969558, // github.com/keptn/keptn
+	40014856, // github.com/tremor-rs/tremor-runtime
+	40243107, // github.com/artifacthub/hub
+	40313715, // github.com/spotify/backstage
+	41224626, // github.com/serverlessworkflow/specification
+	41696876, // github.com/openservicemesh/osm
+}
+
+func (u *Updater) cncfStats() (stats []store.RepoUsageStatistics) {
+	// p  = precise count
+	// mp = minimum precise count
+	// s  = search count
+	// ms = minimum search count
+	// r  = minimum precise/search ratio
+	//
+	//    p / s >= r (WHERE p >= mp AND s >= ms)
+	// => p * r >= s
+	// => p * r >= ms
+	// => p >= ms / r
+
+	searchCount := u.minimumSearchCount
+	preciseCount := int(float64(u.minimumSearchCount) / u.minimumSearchRatio)
+	if preciseCount < u.minimumPreciseCount {
+		preciseCount = u.minimumPreciseCount
+	}
+
+	for _, repositoryID := range cncfRepositoryIDs {
+		stats = append(stats, store.RepoUsageStatistics{
+			RepositoryID: repositoryID,
+			SearchCount:  searchCount,
+			PreciseCount: preciseCount,
+		})
+	}
+
+	return stats
 }

--- a/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater_test.go
@@ -43,10 +43,11 @@ func TestUpdate(t *testing.T) {
 	})
 
 	updater := &Updater{
-		store:           mockStore,
-		gitserverClient: mockGitserverClient,
-		metrics:         NewUpdaterMetrics(metrics.TestRegisterer),
-		limiter:         rate.NewLimiter(MaxGitserverRequestsPerSecond, 1),
+		store:              mockStore,
+		gitserverClient:    mockGitserverClient,
+		metrics:            NewUpdaterMetrics(metrics.TestRegisterer),
+		limiter:            rate.NewLimiter(MaxGitserverRequestsPerSecond, 1),
+		enableIndexingCNCF: false,
 	}
 
 	if err := updater.Handle(context.Background()); err != nil {

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -75,6 +75,9 @@ func main() {
 		gitserver.DefaultClient,
 		indexabilityUpdaterInterval,
 		indexabilityUpdaterMetrics,
+		indexMinimumSearchCount,
+		float64(indexMinimumSearchRatio)/100,
+		indexMinimumPreciseCount,
 	)
 
 	scheduler := scheduler.NewScheduler(


### PR DESCRIPTION
This adds a hardcoded list of CNCF repos that we'd like to automatically index. Some of these will likely fail, at which point we need to evaluate the additional effort of maintaining an out-of-band manual process, or additional hard-coded conditions for particular repositories.

The effort of RFC 201 will subsume this effort (we will be able to configure the index process in the UI). I will follow up with a permanent solution, tracked in https://github.com/sourcegraph/sourcegraph/issues/14343.
