### PR TITLE
doc: use the body font for theme buttons

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -279,6 +279,8 @@ body > #sidebar #theme div {
 body > #sidebar #theme button {
     border: 0;
     background-color: transparent;
+    font-family: var(--base-font-family);
+    font-size: 1rem;
 }
 body > #sidebar #theme button:not(.active) {
     color: var(--text-muted);


### PR DESCRIPTION
Since we style away the normal things that mark the theme buttons as buttons, we should also have them match the body font instead of falling back to the system font.

Before and after on my Linux desktop (and, yes, the descender on the `g` was really clipped for me):

![image](https://user-images.githubusercontent.com/229984/94845500-a02a2a00-03d4-11eb-847b-6dd22404d261.png)
