### PR TITLE
Signin page failing to display error

### DIFF
--- a/web/src/auth/SignInPage.tsx
+++ b/web/src/auth/SignInPage.tsx
@@ -43,7 +43,7 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
         ) : (
             <div className="mb-4 signin-page__container pb-5">
                 {error && (
-                    <ErrorAlert className="mt-4 mb-0 text-left" error={setError} icon={false} history={props.history} />
+                    <ErrorAlert className="mt-4 mb-0 text-left" error={error} icon={false} history={props.history} />
                 )}
                 <div
                     className={classNames(


### PR DESCRIPTION
Posting as a bug report just to give context

- **Sourcegraph version:** Sourcegraph.com
- **Platform information:** Firefox, Chrome, Safari

#### Steps to reproduce:

1. Attempt to sign in with an invalid username or passphrase

#### Expected behavior:
Error box stating "User or password was incorrect"


#### Actual behavior:
Error box stating

Function() {
[native code]
}

Firefox:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/40177171/94846251-aff63e00-03d5-11eb-8112-fac91748fe5d.png">

Chrome:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/40177171/94846312-c8665880-03d5-11eb-8039-6e7ee6fefd76.png">

Safari:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/40177171/94846351-db792880-03d5-11eb-8f35-ea66ffa5bd7c.png">

This error is caused by line 46 of `SignInPage.tsx`, where error is incorrectly assigned to a function, not an error.
