### PR TITLE
search: set up independent state for racy test

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -287,6 +287,10 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 		db.Mocks.Repos.Count = mockCount
 		defer func() { db.Mocks.Repos.List = nil }()
+		git.Mocks.ResolveRevision = func(rev string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+			return api.CommitID("deadbeef"), nil
+		}
+		defer git.ResetMocks()
 
 		calledReposGetInventory := false
 		backend.Mocks.Repos.GetInventory = func(_ context.Context, _ *types.Repo, _ api.CommitID) (*inventory.Inventory, error) {


### PR DESCRIPTION
A racy test affects some PRs and builds:

```

FAIL: TestSearchSuggestions (0.03s) | 1m 26s
-- | --
  | --- FAIL: TestSearchSuggestions/single_term (0.01s)
  | testing.go:906: race detected during execution of test
  | testing.go:906: race detected during execution of test
```

I attempted to disable it with a `t.Skip`, but then the tests fails, because: 

```
panic: unexpected state: no gitserver addresses
```

Turns out one of the tests didn't set up a gitserver mock state. This is probably what caused it to be racy, so this is an attempted fix. If this test _still_ flakes, I will add a `t.Skip` next (and it's possible to skip it now, unlike before this PR).
