### PR TITLE
codeintel: Fix values in fake repo usage stats for CNCF repos

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
@@ -213,28 +213,16 @@ var cncfRepositoryIDs = []int{
 }
 
 func (u *Updater) cncfStats() (stats []store.RepoUsageStatistics) {
-	// p  = precise count
-	// mp = minimum precise count
-	// s  = search count
-	// ms = minimum search count
-	// r  = minimum precise/search ratio
-	//
-	//    p / s >= r (WHERE p >= mp AND s >= ms)
-	// => p * r >= s
-	// => p * r >= ms
-	// => p >= ms / r
-
-	searchCount := u.minimumSearchCount
-	preciseCount := int(float64(u.minimumSearchCount) / u.minimumSearchRatio)
-	if preciseCount < u.minimumPreciseCount {
-		preciseCount = u.minimumPreciseCount
+	max := u.minimumSearchCount
+	if max < u.minimumPreciseCount {
+		max = u.minimumPreciseCount
 	}
 
 	for _, repositoryID := range cncfRepositoryIDs {
 		stats = append(stats, store.RepoUsageStatistics{
 			RepositoryID: repositoryID,
-			SearchCount:  searchCount,
-			PreciseCount: preciseCount,
+			SearchCount:  max,
+			PreciseCount: max,
 		})
 	}
 


### PR DESCRIPTION
Ratio, search counts, and precise counts are all min thresholds. If we set both search and precise to the max, then we pass both count minimums and the ratio minimum (as the ratio is 1).