### PR TITLE
codeintel: Ensure CNCF values override real values

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
@@ -58,7 +58,7 @@ func (u *Updater) Handle(ctx context.Context) error {
 	}
 
 	if u.enableIndexingCNCF {
-		stats = append(u.cncfStats(), stats...)
+		stats = append(stats, u.cncfStats()...)
 	}
 
 	for _, stat := range stats {


### PR DESCRIPTION
We lose our values when we actually pull the usage stats from the db. This will ensure the last write is our fake one.