### PR TITLE
codeintel: Add index config types

### DIFF
--- a/enterprise/internal/codeintel/index/json.go
+++ b/enterprise/internal/codeintel/index/json.go
@@ -1,0 +1,68 @@
+package index
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+)
+
+type jsonIndexConfiguration struct {
+	SharedSteps []jsonDockerStep `json:"shared_steps"`
+	IndexJobs   []jsonIndexJob   `json:"index_jobs"`
+}
+
+type jsonIndexJob struct {
+	Steps       []jsonDockerStep `json:"steps"`
+	Root        string           `json:"root"`
+	Indexer     string           `json:"indexer"`
+	IndexerArgs []string         `json:"indexer_args"`
+	Outfile     string           `json:"outfile"`
+}
+
+type jsonDockerStep struct {
+	Root     string   `json:"root"`
+	Image    string   `json:"image"`
+	Commands []string `json:"commands"`
+}
+
+func UnmarshalJSON(data []byte) (IndexConfiguration, error) {
+	jsonData, err := jsonc.Parse(string(data))
+	if err != nil {
+		return IndexConfiguration{}, fmt.Errorf("invalid JSON: %v", err)
+	}
+
+	configuration := jsonIndexConfiguration{}
+	if err := json.Unmarshal(jsonData, &configuration); err != nil {
+		return IndexConfiguration{}, fmt.Errorf("invalid JSON: %v", err)
+	}
+
+	var indexJobs []IndexJob
+	for _, value := range configuration.IndexJobs {
+		indexJobs = append(indexJobs, IndexJob{
+			Steps:       convertJSONDockerSteps(value.Steps),
+			Root:        value.Root,
+			Indexer:     value.Indexer,
+			IndexerArgs: value.IndexerArgs,
+			Outfile:     value.Outfile,
+		})
+	}
+
+	return IndexConfiguration{
+		SharedSteps: convertJSONDockerSteps(configuration.SharedSteps),
+		IndexJobs:   indexJobs,
+	}, nil
+}
+
+func convertJSONDockerSteps(raw []jsonDockerStep) []DockerStep {
+	steps := []DockerStep{}
+	for _, val := range raw {
+		steps = append(steps, DockerStep{
+			Root:     val.Root,
+			Image:    val.Image,
+			Commands: val.Commands,
+		})
+	}
+
+	return steps
+}

--- a/enterprise/internal/codeintel/index/json_test.go
+++ b/enterprise/internal/codeintel/index/json_test.go
@@ -1,0 +1,80 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const jsonTestInput = `
+{
+	"shared_steps": [
+		{
+			"root": "/",
+			"image": "node:12",
+			"commands": [
+				"yarn install --frozen-lockfile --non-interactive",
+			],
+		}
+	],
+	"index_jobs": [
+		{
+			"steps": [
+				{
+					// Comments are the future
+					"image": "go:latest",
+					"commands": ["go mod vendor"],
+				}
+			],
+			"indexer": "lsif-go",
+			"indexer_args": ["--no-animation"],
+		},
+		{
+			"root": "web/",
+			"indexer": "lsif-tsc",
+			"indexer_args": ["-p", "."],
+			"outfile": "lsif.dump",
+		},
+	]
+}
+`
+
+func TestUnmarshalJSON(t *testing.T) {
+	actual, err := UnmarshalJSON([]byte(jsonTestInput))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	expected := IndexConfiguration{
+		SharedSteps: []DockerStep{
+			{
+				Root:     "/",
+				Image:    "node:12",
+				Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
+			},
+		},
+		IndexJobs: []IndexJob{
+			{
+				Steps: []DockerStep{
+					{
+						Root:     "",
+						Image:    "go:latest",
+						Commands: []string{"go mod vendor"},
+					},
+				},
+				Indexer:     "lsif-go",
+				IndexerArgs: []string{"--no-animation"},
+			},
+			{
+				Steps:       []DockerStep{},
+				Root:        "web/",
+				Indexer:     "lsif-tsc",
+				IndexerArgs: []string{"-p", "."},
+				Outfile:     "lsif.dump",
+			},
+		},
+	}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("unexpected configuration (-want +got):\n%s", diff)
+	}
+}

--- a/enterprise/internal/codeintel/index/types.go
+++ b/enterprise/internal/codeintel/index/types.go
@@ -1,0 +1,20 @@
+package index
+
+type IndexConfiguration struct {
+	SharedSteps []DockerStep
+	IndexJobs   []IndexJob
+}
+
+type IndexJob struct {
+	Steps       []DockerStep
+	Root        string
+	Indexer     string
+	IndexerArgs []string
+	Outfile     string
+}
+
+type DockerStep struct {
+	Root     string
+	Image    string
+	Commands []string
+}

--- a/enterprise/internal/codeintel/index/yaml.go
+++ b/enterprise/internal/codeintel/index/yaml.go
@@ -1,0 +1,69 @@
+package index
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+type yamlIndexConfiguration struct {
+	SharedSteps []yamlDockerStep `yaml:"shared_steps"`
+	IndexJobs   []yamlIndexJob   `yaml:"index_jobs"`
+}
+
+type yamlIndexJob struct {
+	Steps       []yamlDockerStep `yaml:"steps"`
+	Root        string           `yaml:"root"`
+	Indexer     string           `yaml:"indexer"`
+	IndexerArgs []string         `yaml:"indexer_args"`
+	Outfile     string           `yaml:"outfile"`
+}
+
+type yamlDockerStep struct {
+	Root     string   `yaml:"root"`
+	Image    string   `yaml:"image"`
+	Commands []string `yaml:"commands"`
+}
+
+func UnmarshalYAML(data []byte) (IndexConfiguration, error) {
+	configuration := yamlIndexConfiguration{}
+	if err := yaml.Unmarshal(data, &configuration); err != nil {
+		return IndexConfiguration{}, fmt.Errorf("invalid YAML: %v", err)
+	}
+
+	var indexJobs []IndexJob
+	for _, value := range configuration.IndexJobs {
+		indexJobs = append(indexJobs, IndexJob{
+			Steps:       convertYAMLDockerSteps(value.Steps),
+			Root:        value.Root,
+			Indexer:     value.Indexer,
+			IndexerArgs: sliceize(value.IndexerArgs),
+			Outfile:     value.Outfile,
+		})
+	}
+
+	return IndexConfiguration{
+		SharedSteps: convertYAMLDockerSteps(configuration.SharedSteps),
+		IndexJobs:   indexJobs,
+	}, nil
+}
+
+func convertYAMLDockerSteps(raw []yamlDockerStep) []DockerStep {
+	steps := []DockerStep{}
+	for _, val := range raw {
+		steps = append(steps, DockerStep{
+			Root:     val.Root,
+			Image:    val.Image,
+			Commands: sliceize(val.Commands),
+		})
+	}
+
+	return steps
+}
+
+func sliceize(v []string) []string {
+	if v == nil {
+		return []string{}
+	}
+	return v
+}

--- a/enterprise/internal/codeintel/index/yaml_test.go
+++ b/enterprise/internal/codeintel/index/yaml_test.go
@@ -1,0 +1,70 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const yamlTestInput = `
+shared_steps:
+  - root: /
+    image: node:12
+    commands:
+      - yarn install --frozen-lockfile --non-interactive
+
+index_jobs:
+  -
+    steps:
+      - image: go:latest
+        commands:
+          - go mod vendor
+    indexer: lsif-go
+    indexer_args:
+      - --no-animation
+  -
+    root: web/
+    indexer: lsif-tsc
+    indexer_args: ['-p', '.']
+    outfile: lsif.dump
+`
+
+func TestUnmarshalYAML(t *testing.T) {
+	actual, err := UnmarshalYAML([]byte(yamlTestInput))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	expected := IndexConfiguration{
+		SharedSteps: []DockerStep{
+			{
+				Root:     "/",
+				Image:    "node:12",
+				Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
+			},
+		},
+		IndexJobs: []IndexJob{
+			{
+				Steps: []DockerStep{
+					{
+						Root:     "",
+						Image:    "go:latest",
+						Commands: []string{"go mod vendor"},
+					},
+				},
+				Indexer:     "lsif-go",
+				IndexerArgs: []string{"--no-animation"},
+			},
+			{
+				Steps:       []DockerStep{},
+				Root:        "web/",
+				Indexer:     "lsif-tsc",
+				IndexerArgs: []string{"-p", "."},
+				Outfile:     "lsif.dump",
+			},
+		},
+	}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("unexpected configuration (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/13892.

This adds a set of shared types that will be able to configure index jobs. This also has a jsonx and yaml-compatible set of unmarshallers so we'll be able to read from both config stores and files in-repo.