### PR TITLE
codeintel: Update lsif_index records to hold their own configuration

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
@@ -104,6 +104,11 @@ func (s *Scheduler) queueIndex(ctx context.Context, indexableRepository store.In
 		Commit:       commit,
 		RepositoryID: indexableRepository.RepositoryID,
 		State:        "queued",
+		DockerSteps:  []store.DockerStep{},
+		Root:         "",
+		Indexer:      "sourcegraph/lsif-go:latest",
+		IndexerArgs:  []string{},
+		Outfile:      "",
 	})
 	if err != nil {
 		return errors.Wrap(err, "store.QueueIndex")

--- a/enterprise/internal/codeintel/store/docker_step.go
+++ b/enterprise/internal/codeintel/store/docker_step.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+type DockerStep struct {
+	Root     string   `json:"root"`
+	Image    string   `json:"image"`
+	Commands []string `json:"commands"`
+}
+
+func (n *DockerStep) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return fmt.Errorf("value is not []byte: %T", value)
+	}
+
+	return json.Unmarshal(b, &n)
+}
+
+func (n DockerStep) Value() (driver.Value, error) {
+	return json.Marshal(n)
+}

--- a/enterprise/internal/codeintel/store/helpers_test.go
+++ b/enterprise/internal/codeintel/store/helpers_test.go
@@ -117,6 +117,12 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 		if index.RepositoryID == 0 {
 			index.RepositoryID = 50
 		}
+		if index.DockerSteps == nil {
+			index.DockerSteps = []DockerStep{}
+		}
+		if index.IndexerArgs == nil {
+			index.IndexerArgs = []string{}
+		}
 
 		// Ensure we have a repo for the inner join in select queries
 		insertRepo(t, db, index.RepositoryID, index.RepositoryName)
@@ -133,8 +139,13 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 				process_after,
 				num_resets,
 				num_failures,
-				repository_id
-			) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+				repository_id,
+				docker_steps,
+				root,
+				indexer,
+				indexer_args,
+				outfile
+			) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 		`,
 			index.ID,
 			index.Commit,
@@ -147,6 +158,11 @@ func insertIndexes(t *testing.T, db *sql.DB, indexes ...Index) {
 			index.NumResets,
 			index.NumFailures,
 			index.RepositoryID,
+			pq.Array(index.DockerSteps),
+			index.Root,
+			index.Indexer,
+			pq.Array(index.IndexerArgs),
+			index.Outfile,
 		)
 
 		if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {

--- a/enterprise/internal/codeintel/store/indexes_test.go
+++ b/enterprise/internal/codeintel/store/indexes_test.go
@@ -40,7 +40,17 @@ func TestGetIndexByID(t *testing.T) {
 		FinishedAt:     nil,
 		RepositoryID:   123,
 		RepositoryName: "n-123",
-		Rank:           nil,
+		DockerSteps: []DockerStep{
+			{
+				Image:    "cimg/node:12.16",
+				Commands: []string{"yarn install --frozen-lockfile --no-progress"},
+			},
+		},
+		Root:        "/foo/bar",
+		Indexer:     "sourcegraph/lsif-tsc:latest",
+		IndexerArgs: []string{"lib/**/*.js", "test/**/*.js", "--allowJs", "--checkJs"},
+		Outfile:     "dump.lsif",
+		Rank:        nil,
 	}
 
 	insertIndexes(t, dbconn.Global, expected)
@@ -275,9 +285,19 @@ func TestInsertIndex(t *testing.T) {
 	insertRepo(t, dbconn.Global, 50, "")
 
 	id, err := store.InsertIndex(context.Background(), Index{
-		Commit:       makeCommit(1),
 		State:        "queued",
+		Commit:       makeCommit(1),
 		RepositoryID: 50,
+		DockerSteps: []DockerStep{
+			{
+				Image:    "cimg/node:12.16",
+				Commands: []string{"yarn install --frozen-lockfile --no-progress"},
+			},
+		},
+		Root:        "/foo/bar",
+		Indexer:     "sourcegraph/lsif-tsc:latest",
+		IndexerArgs: []string{"lib/**/*.js", "test/**/*.js", "--allowJs", "--checkJs"},
+		Outfile:     "dump.lsif",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error enqueueing index: %s", err)
@@ -294,7 +314,17 @@ func TestInsertIndex(t *testing.T) {
 		FinishedAt:     nil,
 		RepositoryID:   50,
 		RepositoryName: "n-50",
-		Rank:           &rank,
+		DockerSteps: []DockerStep{
+			{
+				Image:    "cimg/node:12.16",
+				Commands: []string{"yarn install --frozen-lockfile --no-progress"},
+			},
+		},
+		Root:        "/foo/bar",
+		Indexer:     "sourcegraph/lsif-tsc:latest",
+		IndexerArgs: []string{"lib/**/*.js", "test/**/*.js", "--allowJs", "--checkJs"},
+		Outfile:     "dump.lsif",
+		Rank:        &rank,
 	}
 
 	if index, exists, err := store.GetIndexByID(context.Background(), id); err != nil {

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -521,6 +521,11 @@ Indexes:
  process_after   | timestamp with time zone | 
  num_resets      | integer                  | not null default 0
  num_failures    | integer                  | not null default 0
+ docker_steps    | jsonb[]                  | not null
+ root            | text                     | not null
+ indexer         | text                     | not null
+ indexer_args    | text[]                   | not null
+ outfile         | text                     | not null
 Indexes:
     "lsif_indexes_pkey" PRIMARY KEY, btree (id)
 Check constraints:

--- a/migrations/frontend/1528395725_indexer_configuration_fields.down.sql
+++ b/migrations/frontend/1528395725_indexer_configuration_fields.down.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+DROP VIEW lsif_indexes_with_repository_name;
+
+ALTER TABLE lsif_indexes
+    DROP COLUMN docker_steps,
+    DROP COLUMN root,
+    DROP COLUMN indexer,
+    DROP COLUMN indexer_args,
+    DROP COLUMN outfile;
+
+CREATE VIEW lsif_indexes_with_repository_name AS
+    SELECT u.*, r.name as repository_name FROM lsif_indexes u
+    JOIN repo r ON r.id = u.repository_id
+    WHERE r.deleted_at IS NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395725_indexer_configuration_fields.up.sql
+++ b/migrations/frontend/1528395725_indexer_configuration_fields.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+DROP VIEW lsif_indexes_with_repository_name;
+
+ALTER TABLE lsif_indexes
+    ADD COLUMN docker_steps jsonb[],  -- root, image, commands
+    ADD COLUMN root text,
+    ADD COLUMN indexer text,
+    ADD COLUMN indexer_args text[],
+    ADD COLUMN outfile text;
+
+UPDATE lsif_indexes SET
+    docker_steps = '{}',
+    root = '',
+    indexer = 'sourcegraph/lsif-go:latest',
+    indexer_args = '{}'::text[],
+    outfile = '';
+
+ALTER TABLE lsif_indexes
+    ALTER COLUMN root SET NOT NULL,
+    ALTER COLUMN indexer SET NOT NULL,
+    ALTER COLUMN indexer_args SET NOT NULL,
+    ALTER COLUMN outfile SET NOT NULL,
+    ALTER COLUMN docker_steps SET NOT NULL;
+
+CREATE VIEW lsif_indexes_with_repository_name AS
+    SELECT u.*, r.name as repository_name FROM lsif_indexes u
+    JOIN repo r ON r.id = u.repository_id
+    WHERE r.deleted_at IS NULL;
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -82,6 +82,8 @@
 // 1528395723_convert_secret_jsonb_to_text.up.sql (178B)
 // 1528395724_settings_org_id_idx.down.sql (59B)
 // 1528395724_settings_org_id_idx.up.sql (85B)
+// 1528395725_indexer_configuration_fields.down.sql (406B)
+// 1528395725_indexer_configuration_fields.up.sql (845B)
 
 package migrations
 
@@ -1790,6 +1792,46 @@ func _1528395724_settings_org_id_idxUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395725_indexer_configuration_fieldsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x8c\x8f\xc1\x4e\xc3\x30\x10\x44\xef\xfe\x8a\x39\xa3\x2a\x3f\x10\x71\x48\xc3\x02\x41\x4e\x8c\x1c\x97\x1e\xad\x08\xbb\x60\x11\xea\x6a\xed\x08\xf8\x7b\x54\x73\xa1\x14\x24\xae\x3b\x6f\x9e\x66\xd7\x74\xd3\x0d\xb5\x10\x57\x5a\xdd\xe3\xa1\xa3\x2d\xe6\x14\x76\x36\xec\x9d\x7f\xf7\xc9\xbe\x85\xfc\x6c\xd9\x1f\x62\x0a\x39\xf2\x87\xdd\x4f\xaf\xbe\x16\xa2\x91\x86\x34\x4c\xb3\x96\x74\xc2\x0b\x00\x28\xaa\x56\xc9\x4d\x3f\xc0\xc5\xc7\x17\xcf\x36\x65\x7f\x48\xab\xb3\x94\x63\xcc\xe7\xd7\x2f\x17\xff\x19\xd8\x89\x9f\x7e\x91\xc5\x25\xef\xc2\x7c\x5c\xd7\x6a\x6a\x0c\xfd\xf3\x1b\x34\x63\x51\x8d\x24\xa9\x35\x58\xaa\x8b\x15\xb8\x2a\xc9\x94\xf0\x13\xbe\xd6\xaa\x3f\x71\x62\x29\xed\x3b\xd5\x0d\x05\x06\x43\x0d\xe0\x2a\x38\x5c\x62\xa9\xbe\xf5\x83\x2b\xe4\xf6\x96\x34\x81\x2b\xe7\x67\x9f\xbd\xb3\x53\x46\x37\x62\xd8\x48\x79\x5c\xae\xfa\xbe\x33\xb5\xf8\x0c\x00\x00\xff\xff\x10\x4d\xb9\xf2\x96\x01\x00\x00")
+
+func _1528395725_indexer_configuration_fieldsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395725_indexer_configuration_fieldsDownSql,
+		"1528395725_indexer_configuration_fields.down.sql",
+	)
+}
+
+func _1528395725_indexer_configuration_fieldsDownSql() (*asset, error) {
+	bytes, err := _1528395725_indexer_configuration_fieldsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395725_indexer_configuration_fields.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x97, 0xd3, 0xb1, 0x40, 0x95, 0x1e, 0x80, 0x20, 0x49, 0xb0, 0xe8, 0xf2, 0x9, 0x86, 0xdb, 0xc8, 0x8a, 0x78, 0xb0, 0x2, 0xd4, 0x8, 0x72, 0x37, 0x82, 0xe, 0x59, 0x52, 0x38, 0xdb, 0x2b, 0x40}}
+	return a, nil
+}
+
+var __1528395725_indexer_configuration_fieldsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x8c\x92\xcd\x8e\x9b\x30\x14\x85\xf7\x7e\x8a\xb3\x8b\x54\x11\xba\x0f\xca\x82\x09\x6e\x4b\xc5\xcf\x08\x9c\xce\x62\x34\x42\x6e\xf0\x30\x6e\x01\x47\xb6\x51\xa7\xaa\xfa\xee\x15\xa6\x54\x30\x91\x9a\x2c\xd1\xf9\xee\xe1\xf3\xb5\xef\xe8\xc7\x38\x0b\x08\x89\x8a\xfc\x1e\x5f\x62\xfa\x80\xd6\xc8\xe7\x4a\xf6\xb5\x78\x15\xa6\xfa\x21\xed\x4b\xa5\xc5\x59\x19\x69\x95\xfe\x59\xf5\xbc\x13\x01\x21\x61\xc2\x68\x01\x16\xde\x25\x74\xc5\x13\x00\x08\xa3\x08\x87\x3c\x39\xa6\x19\x6a\x75\xfa\x2e\x74\x65\xac\x38\x1b\x7c\x33\xaa\xff\xfa\xf8\xe4\x01\xdb\x2d\xb4\x52\xd6\x83\xec\x78\x23\x3c\x9c\x54\xd7\xf1\xbe\xbe\x18\x1f\x21\x58\xf1\x6a\xbd\xb7\xc9\xf4\x3f\xfd\xdf\xb0\xe2\xba\x31\x8e\x78\x7c\xba\x60\xd4\x60\x9f\x65\x2b\x5c\x1c\x10\x72\xbc\x8f\x42\xb6\x3e\x0b\x4a\xca\xdc\xd4\xea\x10\x7b\x6c\x7e\xfd\xde\x4c\x75\x4e\x6f\x8f\xcd\xdf\xcf\xd9\x69\x8f\x8d\x51\x83\x3e\x89\x46\xf3\xf3\xcb\xfb\xb1\x73\xdb\xa8\x5d\xcb\xad\x30\x76\xcd\x4e\x8a\x53\xe7\x6e\xb7\x54\x9d\xfd\xc6\xfa\xab\x0b\x77\xe1\x72\x67\x25\x65\xc8\x72\x86\xec\x98\x24\xde\x25\x33\x9b\xde\x86\x4d\x92\x57\xd8\xd9\xf7\x0a\xb6\xda\xe5\x92\x0d\x08\x39\x14\x74\xbc\x83\xdb\x1e\x21\xc2\xd2\xb5\x97\x34\xa1\x07\x86\xc1\x7f\xe7\x41\xfb\x2e\xe1\x06\x6f\xe1\x0f\x45\x9e\xae\x2f\x77\x70\xd3\x9f\xf3\x38\x73\x30\x34\xf2\x0c\xda\x97\x35\xf6\x18\xfc\xc5\xbc\xac\x1d\xf9\xf0\x89\x16\x14\xda\xaf\x45\x2b\xac\xa8\x2b\x6e\x11\x97\xff\xcc\xf3\x34\x8d\x59\x40\xfe\x04\x00\x00\xff\xff\x48\xef\x9f\x4f\x4d\x03\x00\x00")
+
+func _1528395725_indexer_configuration_fieldsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395725_indexer_configuration_fieldsUpSql,
+		"1528395725_indexer_configuration_fields.up.sql",
+	)
+}
+
+func _1528395725_indexer_configuration_fieldsUpSql() (*asset, error) {
+	bytes, err := _1528395725_indexer_configuration_fieldsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395725_indexer_configuration_fields.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0x56, 0xf2, 0xae, 0x49, 0x55, 0x4d, 0xcd, 0xb9, 0xd, 0x30, 0xec, 0x62, 0xbb, 0x84, 0x3d, 0x80, 0x63, 0xd2, 0x9b, 0x77, 0x94, 0x87, 0xa, 0x56, 0x1, 0xf4, 0x91, 0x33, 0x7d, 0x26, 0x3b}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1963,6 +2005,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395723_convert_secret_jsonb_to_text.up.sql":                               _1528395723_convert_secret_jsonb_to_textUpSql,
 	"1528395724_settings_org_id_idx.down.sql":                                      _1528395724_settings_org_id_idxDownSql,
 	"1528395724_settings_org_id_idx.up.sql":                                        _1528395724_settings_org_id_idxUpSql,
+	"1528395725_indexer_configuration_fields.down.sql":                             _1528395725_indexer_configuration_fieldsDownSql,
+	"1528395725_indexer_configuration_fields.up.sql":                               _1528395725_indexer_configuration_fieldsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2091,6 +2135,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395723_convert_secret_jsonb_to_text.up.sql":                               {_1528395723_convert_secret_jsonb_to_textUpSql, map[string]*bintree{}},
 	"1528395724_settings_org_id_idx.down.sql":                                      {_1528395724_settings_org_id_idxDownSql, map[string]*bintree{}},
 	"1528395724_settings_org_id_idx.up.sql":                                        {_1528395724_settings_org_id_idxUpSql, map[string]*bintree{}},
+	"1528395725_indexer_configuration_fields.down.sql":                             {_1528395725_indexer_configuration_fieldsDownSql, map[string]*bintree{}},
+	"1528395725_indexer_configuration_fields.up.sql":                               {_1528395725_indexer_configuration_fieldsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This adds a one-job structure based on the types added in https://github.com/sourcegraph/sourcegraph/pull/14356 into the lsif_index table.

This will enable https://github.com/sourcegraph/sourcegraph/issues/13895 and https://github.com/sourcegraph/sourcegraph/issues/13896.