### PR TITLE
codeintel: Update indexer execution to reflect configured index jobs

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -173,35 +172,6 @@ func (h *Handler) fetchRepository(ctx context.Context, repositoryName, commit st
 	}
 
 	return tempDir, nil
-}
-
-func (h *Handler) saveDockerImage(ctx context.Context, key, image string) error {
-	pullCommand := flatten(
-		"docker", "pull",
-		image,
-	)
-	if err := h.commander.Run(ctx, pullCommand...); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to pull %s", image))
-	}
-
-	saveCommand := flatten(
-		"docker", "save",
-		"-o", h.tarfilePathOnHost(key),
-		image,
-	)
-	if err := h.commander.Run(ctx, saveCommand...); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to save %s", image))
-	}
-
-	return nil
-}
-
-func (h *Handler) tarfilePathOnHost(key string) string {
-	return filepath.Join(h.options.ImageArchivePath, fmt.Sprintf("%s.tar", key))
-}
-
-func (h *Handler) tarfilePathInVM(key string) string {
-	return fmt.Sprintf("/%s.tar", key)
 }
 
 func makeCloneURL(baseURL, authToken, repositoryName string) (*url.URL, error) {

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -64,12 +64,16 @@ func TestHandleWithDocker(t *testing.T) {
 		t.Errorf("unexpected run call count. want=%d have=%d", 7, callCount)
 	} else {
 		expectedCalls := []string{
+			// Git commands
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+			// Docker steps
 			"docker run --rm --cpus 8 --memory 32G -v /tmp/testing:/data -w /data/r1 install1 ls -liah",
 			"docker run --rm --cpus 8 --memory 32G -v /tmp/testing:/data -w /data/r2 install2 pwd",
+			// Index
 			"docker run --rm --cpus 8 --memory 32G -v /tmp/testing:/data -w /data/r3 sourcegraph/lsif-go:latest lsif-go --no-animation",
+			// Upload
 			"docker run --rm --cpus 8 --memory 32G -v /tmp/testing:/data -w /data/r3 -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -no-progress -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload -file nonstandard.lsif",
 		}
 
@@ -132,28 +136,38 @@ func TestHandleWithFirecracker(t *testing.T) {
 		t.Fatalf("unexpected error handling index: %s", err)
 	}
 
-	if callCount := len(commander.RunFunc.History()); callCount != 16 {
-		t.Errorf("unexpected run call count. want=%d have=%d", 16, callCount)
+	if callCount := len(commander.RunFunc.History()); callCount != 22 {
+		t.Errorf("unexpected run call count. want=%d have=%d", 22, callCount)
 	} else {
-		//
-		// TODO - update what images are pulled
-		//
-
 		expectedCalls := []string{
+			// Git commands
 			"git -C /tmp/testing init",
 			"git -C /tmp/testing -c protocol.version=2 fetch https://indexer:hunter2@sourcegraph.test:1234/.internal-code-intel/git/github.com/sourcegraph/sourcegraph e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
 			"git -C /tmp/testing checkout e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
-			"docker pull sourcegraph/lsif-go:latest",
-			"docker save -o /images/lsif-go.tar sourcegraph/lsif-go:latest",
+			// Stash docker images
 			"docker pull sourcegraph/src-cli:latest",
-			"docker save -o /images/src-cli.tar sourcegraph/src-cli:latest",
-			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --copy-files /images/lsif-go.tar:/lsif-go.tar --copy-files /images/src-cli.tar:/src-cli.tar --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
-			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /lsif-go.tar",
-			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /src-cli.tar",
+			"docker save -o /images/image0.tar sourcegraph/src-cli:latest",
+			"docker pull install1",
+			"docker save -o /images/image1.tar install1",
+			"docker pull install2",
+			"docker save -o /images/image2.tar install2",
+			"docker pull sourcegraph/lsif-go:latest",
+			"docker save -o /images/image3.tar sourcegraph/lsif-go:latest",
+			// VM setup
+			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --copy-files /images/image0.tar:/image0.tar --copy-files /images/image1.tar:/image1.tar --copy-files /images/image2.tar:/image2.tar --copy-files /images/image3.tar:/image3.tar --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			// Docker-inside-Vm` setup
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /image0.tar",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /image1.tar",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /image2.tar",
+			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /image3.tar",
+			// Docker steps
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data/r1 install1 ls -liah",
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data/r2 install2 pwd",
+			// Index
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data/r3 sourcegraph/lsif-go:latest lsif-go --no-animation",
+			// Upload
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker run --rm --cpus 8 --memory 32G -v /repo-dir:/data -w /data/r3 -e SRC_ENDPOINT=https://indexer:hunter2@sourcegraph.test:5432 sourcegraph/src-cli:latest lsif upload -no-progress -repo github.com/sourcegraph/sourcegraph -commit e2249f2173e8ca0c8c2541644847e7bf01aaef4a -upload-route /.internal-code-intel/lsif/upload -file nonstandard.lsif",
+			// Teardown
 			"ignite stop --runtime docker --network-plugin docker-bridge 97b45daf-53d1-48ad-b992-547469d8e438",
 			"ignite rm -f --runtime docker --network-plugin docker-bridge 97b45daf-53d1-48ad-b992-547469d8e438",
 		}

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -39,6 +39,9 @@ func TestHandleWithDocker(t *testing.T) {
 		ID:             42,
 		RepositoryName: "github.com/sourcegraph/sourcegraph",
 		Commit:         "e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+		// TODO - add steps
+		Indexer:     "sourcegraph/lsif-go:latest",
+		IndexerArgs: []string{"lsif-go", "--no-animation"},
 	}
 
 	if err := handler.Handle(context.Background(), nil, index); err != nil {
@@ -94,6 +97,9 @@ func TestHandleWithFirecracker(t *testing.T) {
 		ID:             42,
 		RepositoryName: "github.com/sourcegraph/sourcegraph",
 		Commit:         "e2249f2173e8ca0c8c2541644847e7bf01aaef4a",
+		// TODO - add steps
+		Indexer:     "sourcegraph/lsif-go:latest",
+		IndexerArgs: []string{"lsif-go", "--no-animation"},
 	}
 
 	if err := handler.Handle(context.Background(), nil, index); err != nil {


### PR DESCRIPTION
This updates the indexer machinery to read the details of indexing (images, commands, environments) from the index record rather than having it hard-coded. Closes https://github.com/sourcegraph/sourcegraph/issues/13894.