### PR TITLE
Fix e2e initialization

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -169,7 +169,7 @@ export class Driver {
             }
             await this.page.type('input[name=username]', username)
             await this.page.type('input[name=password]', password)
-            await this.page.waitForSelector('.test-signup-allowed')
+            await this.page.waitForSelector('button[type=submit]:not(:disabled)')
             await this.page.click('button[type=submit]')
             await this.page.waitForNavigation({ timeout: 3 * 10000 })
         } else if (url.pathname === '/sign-in') {

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -169,6 +169,7 @@ export class Driver {
             }
             await this.page.type('input[name=username]', username)
             await this.page.type('input[name=password]', password)
+            await this.page.waitForSelector('.test-signup-allowed')
             await this.page.click('button[type=submit]')
             await this.page.waitForNavigation({ timeout: 3 * 10000 })
         } else if (url.pathname === '/sign-in') {

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -252,9 +252,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ doSignUp,
                         label={buttonLabel || 'Register'}
                         type="submit"
                         disabled={disabled}
-                        className={classNames('btn btn-primary btn-block', {
-                            'test-signup-allowed': canRegister,
-                        })}
+                        className="btn btn-primary btn-block"
                     />
                 </div>
                 {window.context.sourcegraphDotComMode && (

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -74,7 +74,13 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ doSignUp,
         signUpFieldValidators.password
     )
 
-    const canRegister = emailState.kind === 'VALID' && usernameState.kind === 'VALID' && passwordState.kind === 'VALID'
+    const canRegister =
+        emailState.kind === 'VALID' &&
+        !emailState.loading &&
+        usernameState.kind === 'VALID' &&
+        !usernameState.loading &&
+        passwordState.kind === 'VALID' &&
+        !passwordState.loading
 
     const disabled = loading || !canRegister
 
@@ -246,7 +252,9 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ doSignUp,
                         label={buttonLabel || 'Register'}
                         type="submit"
                         disabled={disabled}
-                        className="btn btn-primary btn-block"
+                        className={classNames('btn btn-primary btn-block', {
+                            'test-signup-allowed': canRegister,
+                        })}
                     />
                 </div>
                 {window.context.sourcegraphDotComMode && (


### PR DESCRIPTION
Site init was broken in e2e now that sign up form input is debounced and asynchronously validated. This PR adds a 'test-signup-allowed' class to the submit button when it is enabled so we can wait for validation to click it.