### PR TITLE
search: get user settings once

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -230,9 +230,13 @@ var commonFileFilters = []struct {
 }
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
+	tr, ctx := trace.New(ctx, "DynamicFilters", "", trace.Tag{Key: "resolver", Value: "SearchResultsResolver"})
+	defer func() {
+		tr.Finish()
+	}()
 
 	// For search, sr.userSettings is set in (r *searchResolver) Results(ctx
-	// context.Context). However we might regres on that or call DynamicFilters
+	// context.Context). However we might regress on that or call DynamicFilters
 	// from other code paths.
 	if sr.userSettings == nil {
 		settings, err := decodedViewerFinalSettings(ctx)
@@ -242,19 +246,6 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 			sr.userSettings = settings
 		}
 	}
-}
-
-func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
-	tr, ctx := trace.New(ctx, "DynamicFilters", "", trace.Tag{Key: "resolver", Value: "SearchResultsResolver"})
-	defer func() {
-		tr.Finish()
-	}()
-
-	// For search, sr.userSettings is set in (r *searchResolver) Results(ctx
-	// context.Context). However we might call DynamicFilters from other code paths
-	// as well, so we cannot be certain that user settings have been cached before
-	// and that sr.userSettings is not nil.
-	sr.cacheUserSettings(ctx)
 
 	globbing := false
 	// userSettings could still be nil if decodedViewerFinalSettings returned with err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -241,7 +241,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	if sr.userSettings == nil {
 		settings, err := decodedViewerFinalSettings(ctx)
 		if err != nil {
-			log15.Warn("cacheUserSettings: could not get user settings from db")
+			log15.Warn("DynamicFilters: could not get user settings from db")
 		} else {
 			sr.userSettings = settings
 		}
@@ -1054,7 +1054,7 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 		tr.Finish()
 	}()
 	defer func() {
-		// hand-over the cached user settings from the searchResolver to the
+		// hand over the cached user settings from the searchResolver to the
 		// SearchResultsResolver
 		srr.userSettings = r.userSettings
 	}()

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1055,7 +1055,7 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 		tr.Finish()
 	}()
 	defer func() {
-		// hand over cached user settings from searchResolver to SearchResultsResolver
+		// copy the user settings from searchResolver to SearchResultsResolver
 		srr.userSettings = r.userSettings
 	}()
 	switch q := r.query.(type) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -235,7 +235,7 @@ func (sr *SearchResultsResolver) cacheUserSettings(ctx context.Context) {
 	if sr.userSettings == nil {
 		settings, err := decodedViewerFinalSettings(ctx)
 		if err != nil {
-			log15.Warn("DynamicFilters: could not get user settings from db")
+			log15.Warn("cacheUserSettings: could not get user settings from db")
 		} else {
 			sr.userSettings = settings
 		}
@@ -248,10 +248,10 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 		tr.Finish()
 	}()
 
-	// sr.userSettings is set in (r *searchResolver) Results(ctx context.Context).
-	// However we might call DynamicFilters from other code paths as well so we
-	// cannot be certain that sr.userSettings is not nil, in which case we get the
-	// user settings from the DB just like before.
+	// For search, sr.userSettings is set in (r *searchResolver) Results(ctx
+	// context.Context). However we might call DynamicFilters from other code paths
+	// as well, so we cannot be certain that user settings have been cached before
+	// and that sr.userSettings is not nil.
 	sr.cacheUserSettings(ctx)
 
 	globbing := false

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -14,13 +14,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/schema"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -41,6 +40,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/src-d/enry/v2"
 )
 
@@ -252,6 +252,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	if sr.userSettings != nil {
 		globbing = getBoolPtr(sr.userSettings.SearchGlobbing, false)
 	}
+	tr.LogFields(otlog.Bool("globbing", globbing))
 
 	filters := map[string]*searchFilterResolver{}
 	repoToMatchCount := make(map[string]int32)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -229,9 +229,11 @@ var commonFileFilters = []struct {
 	},
 }
 
-// cacheUserSettings gets the user settings from the DB and caches them in
-// sr.userSettings.
-func (sr *SearchResultsResolver) cacheUserSettings(ctx context.Context) {
+func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
+
+	// For search, sr.userSettings is set in (r *searchResolver) Results(ctx
+	// context.Context). However we might regres on that or call DynamicFilters
+	// from other code paths.
 	if sr.userSettings == nil {
 		settings, err := decodedViewerFinalSettings(ctx)
 		if err != nil {
@@ -255,6 +257,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	sr.cacheUserSettings(ctx)
 
 	globbing := false
+	// userSettings could still be nil if decodedViewerFinalSettings returned with err
 	if sr.userSettings != nil {
 		globbing = getBoolPtr(sr.userSettings.SearchGlobbing, false)
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1055,8 +1055,7 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 		tr.Finish()
 	}()
 	defer func() {
-		// hand over the cached user settings from the searchResolver to the
-		// SearchResultsResolver
+		// hand over cached user settings from searchResolver to SearchResultsResolver
 		srr.userSettings = r.userSettings
 	}()
 	switch q := r.query.(type) {


### PR DESCRIPTION
Tracing showed that we get user settings twice for each search query, once in the `searchResolver` and once in the `searchResultsResolver`. We can get rid of the second call by copying the user settings from the `searchResolver` to the `searchResultsResolver`. 

**Before**
<img width="2548" alt="Screenshot 2020-10-02 at 09 59 48" src="https://user-images.githubusercontent.com/26413131/94901740-60784680-0497-11eb-95b7-2b9b2f72bdac.png">

**After**
<img width="2556" alt="Screenshot 2020-10-02 at 09 58 20" src="https://user-images.githubusercontent.com/26413131/94901732-5d7d5600-0497-11eb-986c-389d80bf0b2c.png">
 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
