### PR TITLE
search: add more traces

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1029,7 +1029,7 @@ func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchR
 }
 
 func (r *searchResolver) Results(ctx context.Context) (_ *SearchResultsResolver, err error) {
-	tr, ctx := trace.New(ctx, "Results", "")
+	tr, ctx := trace.New(ctx, "Results", "", trace.Tag{Key: "resolver", Value: "searchResolver"})
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -526,7 +526,7 @@ var searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 // relies on the invariant that query and pattern error checking has already
 // been performed.
 func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32) {
-	tr, ctx := trace.New(ctx, "logSearchLatency", "", trace.Tag{Key: "resolver", Value: "searchResolver"})
+	tr, ctx := trace.New(ctx, "logSearchLatency", "")
 	defer func() {
 		tr.Finish()
 	}()
@@ -607,7 +607,7 @@ func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32)
 // evaluateLeaf performs a single search operation and corresponds to the
 // evaluation of leaf expression in a query.
 func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsResolver, err error) {
-	tr, ctx := trace.New(ctx, "evaluateLeaf", "", trace.Tag{Key: "resolver", Value: "searchResolver"})
+	tr, ctx := trace.New(ctx, "evaluateLeaf", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -1029,7 +1029,7 @@ func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchR
 }
 
 func (r *searchResolver) Results(ctx context.Context) (_ *SearchResultsResolver, err error) {
-	tr, ctx := trace.New(ctx, "Results", "", trace.Tag{Key: "resolver", Value: "searchResolver"})
+	tr, ctx := trace.New(ctx, "Results", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -526,7 +526,7 @@ var searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 // relies on the invariant that query and pattern error checking has already
 // been performed.
 func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32) {
-	tr, ctx := trace.New(ctx, "logSearchLatency", "")
+	tr, ctx := trace.New(ctx, "logSearchLatency", "", trace.Tag{Key: "resolver", Value: "searchResolver"})
 	defer func() {
 		tr.Finish()
 	}()
@@ -607,7 +607,7 @@ func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32)
 // evaluateLeaf performs a single search operation and corresponds to the
 // evaluation of leaf expression in a query.
 func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsResolver, err error) {
-	tr, ctx := trace.New(ctx, "evaluateLeaf", "")
+	tr, ctx := trace.New(ctx, "evaluateLeaf", "", trace.Tag{Key: "resolver", Value: "searchResolver"})
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()


### PR DESCRIPTION
This PR adds a couple of strategic spans which should help to explain the significant gap we see in our tracing. The size of the gap depends on the query. Here is an extreme example:

![image](https://user-images.githubusercontent.com/26413131/94921325-67638100-04b8-11eb-8603-37568a6e2899.png)

I suspect the culprit is `logSearchLatency`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
