### PR TITLE
repo-updater: Fix metrics

### DIFF
--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -110,6 +110,7 @@ func MustRegisterMetrics(db dbutil.DB) {
 -- source: cmd/repo-updater/repos/metrics.go:src_repoupdater_user_external_services_total
 SELECT COUNT(*) FROM external_services
 WHERE namespace_user_id IS NOT NULL
+AND deleted_at IS NOT NULL
 `)
 		if err != nil {
 			log15.Error("Failed to get total user external services", "err", err)
@@ -128,6 +129,7 @@ SELECT COUNT(*) FROM external_service_repos
 WHERE external_service_id IN (
 		SELECT DISTINCT(id) FROM external_services
 		WHERE namespace_user_id IS NOT NULL
+        AND deleted_at IS NOT NULL
 	)
 `)
 		if err != nil {
@@ -146,6 +148,7 @@ WHERE external_service_id IN (
 SELECT COUNT(DISTINCT(namespace_user_id)) AS total
 FROM external_services
 WHERE namespace_user_id IS NOT NULL
+AND deleted_at IS NOT NULL
 `)
 		if err != nil {
 			log15.Error("Failed to get total users with external services", "err", err)

--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -125,7 +125,7 @@ AND deleted_at IS NOT NULL
 	}, func() float64 {
 		count, err := scanCount(`
 -- source: cmd/repo-updater/repos/metrics.go:src_repoupdater_user_repos_total
-SELECT COUNT(*) FROM external_service_repos
+SELECT COUNT(DISTINCT(repo_id)) FROM external_service_repos
 WHERE external_service_id IN (
 		SELECT DISTINCT(id) FROM external_services
 		WHERE namespace_user_id IS NOT NULL


### PR DESCRIPTION
Don't count include deleted external services.
Don't double count repos when finding the total number of user added repos.