### PR TITLE
codeintel: Update default indexer args in index scheduler

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
@@ -107,7 +107,7 @@ func (s *Scheduler) queueIndex(ctx context.Context, indexableRepository store.In
 		DockerSteps:  []store.DockerStep{},
 		Root:         "",
 		Indexer:      "sourcegraph/lsif-go:latest",
-		IndexerArgs:  []string{},
+		IndexerArgs:  []string{"lsif-go", "--no-progress"},
 		Outfile:      "",
 	})
 	if err != nil {


### PR DESCRIPTION
We've updated the default arguments in the migration but we didn't update it here so I've got a few records to correct by hand 😬 .