### PR TITLE
fix: Ensure frontend connects to frontend database

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -108,7 +108,7 @@ func InitDB() error {
 			return nil
 		}
 
-		if err := dbconn.MigrateDB(dbconn.Global, ""); err != nil {
+		if err := dbconn.MigrateDB(dbconn.Global, "frontend"); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We now require naming the database as part of the connection/migration routine as we have two databases: `frontend` and `codeintel`. There was one path where the default `""` was passed from the frontend.

This should fix the current main build.