### PR TITLE
allow cookiebot to scan sourcegraph.com by disabling redirection

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -233,9 +233,10 @@ func serveHome(w http.ResponseWriter, r *http.Request) error {
 		return nil // request was handled
 	}
 
-	if envvar.SourcegraphDotComMode() && !actor.FromContext(r.Context()).IsAuthenticated() {
+	if envvar.SourcegraphDotComMode() && !actor.FromContext(r.Context()).IsAuthenticated() && !strings.Contains(r.UserAgent(), "Cookiebot") {
 		// The user is not signed in and tried to access Sourcegraph.com.  Redirect to
 		// about.sourcegraph.com so they see general info page.
+		// Don't redirect Cookiebot so it can scan the website without authentication.
 		http.Redirect(w, r, (&url.URL{Scheme: aboutRedirectScheme, Host: aboutRedirectHost}).String(), http.StatusTemporaryRedirect)
 		return nil
 	}

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -26,11 +26,12 @@ import (
 )
 
 func TestRedirects(t *testing.T) {
-	check := func(t *testing.T, path string, wantStatusCode int, wantRedirectLocation string) {
+	check := func(t *testing.T, path string, wantStatusCode int, wantRedirectLocation string, userAgent string) {
 		t.Helper()
 
 		rw := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", path, nil)
+		req.Header.Set("User-Agent", userAgent)
 		uirouter.Router.ServeHTTP(rw, req)
 		if rw.Code != wantStatusCode {
 			t.Errorf("got HTTP response code %d, want %d", rw.Code, wantStatusCode)
@@ -45,15 +46,25 @@ func TestRedirects(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(orig) // reset
 		t.Run("root", func(t *testing.T) {
-			check(t, "/", http.StatusTemporaryRedirect, "https://about.sourcegraph.com")
+			check(t, "/", http.StatusTemporaryRedirect, "https://about.sourcegraph.com", "Mozilla/5.0")
 		})
 	})
+
+	t.Run("on Sourcegraph.com from Cookiebot", func(t *testing.T) {
+		orig := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(true)
+		defer envvar.MockSourcegraphDotComMode(orig) // reset
+		t.Run("root", func(t *testing.T) {
+			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0 Cookiebot")
+		})
+	})
+
 	t.Run("non-Sourcegraph.com", func(t *testing.T) {
 		orig := envvar.SourcegraphDotComMode()
 		envvar.MockSourcegraphDotComMode(false)
 		defer envvar.MockSourcegraphDotComMode(orig) // reset
 		t.Run("root", func(t *testing.T) {
-			check(t, "/", http.StatusTemporaryRedirect, "/search")
+			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0")
 		})
 	})
 }


### PR DESCRIPTION
Currently, Cookiebot is not scanning sourcegraph.com at all, and instead is being redirected to about.sourcegraph.com. We need to allow Cookiebot to scan the main website so we can catalog which cookies we use. [Cookiebot recommends doing this by checking for the string `Cookiebot` in the user agent.](https://support.cookiebot.com/hc/en-us/articles/360003824153)
