### PR TITLE
Rr/server home ui tweaks

### DIFF
--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -38,6 +38,8 @@
         width: 49rem;
         max-width: 90%;
         position: relative;
+        padding-left: .5rem;
+        padding-right: .5rem;
 
         &:hover {
             .toggle-container__copy-query-button {

--- a/web/src/search/input/SearchPage.scss
+++ b/web/src/search/input/SearchPage.scss
@@ -38,8 +38,8 @@
         width: 49rem;
         max-width: 90%;
         position: relative;
-        padding-left: .5rem;
-        padding-right: .5rem;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
 
         &:hover {
             .toggle-container__copy-query-button {

--- a/web/src/search/panels/EnterpriseHomePanels.scss
+++ b/web/src/search/panels/EnterpriseHomePanels.scss
@@ -3,7 +3,7 @@
 @import './RepositoriesPanel.scss';
 
 .enterprise-home-panels {
-    margin-top: 2rem;
+    margin-top: 1rem;
     max-width: 90%;
 
     &__panel {

--- a/web/src/search/panels/EnterpriseHomePanels.scss
+++ b/web/src/search/panels/EnterpriseHomePanels.scss
@@ -3,7 +3,7 @@
 @import './RepositoriesPanel.scss';
 
 .enterprise-home-panels {
-    margin-top: 4rem;
+    margin-top: 2rem;
     max-width: 90%;
 
     &__panel {

--- a/web/src/search/panels/LoadingPanelView.tsx
+++ b/web/src/search/panels/LoadingPanelView.tsx
@@ -9,4 +9,3 @@ export const LoadingPanelView: React.FunctionComponent<{ text: string }> = ({ te
         <span className="text-muted">{text}</span>
     </div>
 )
-

--- a/web/src/search/panels/LoadingPanelView.tsx
+++ b/web/src/search/panels/LoadingPanelView.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
 export const LoadingPanelView: React.FunctionComponent<{ text: string }> = ({ text }) => (
-    <div className="d-flex justify-content-center align-items-center panel-container__empty-container">
+    <div className="d-flex justify-content-center align-items-center panel-container__empty-container panel-container__loading-container">
         <div className="icon-inline">
             <LoadingSpinner />
         </div>
         <span className="text-muted">{text}</span>
     </div>
 )
+

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -47,7 +47,11 @@
         }
 
         .footer {
-            background: rgba($color-light-bg-2, 0.4);
+            background: rgba($color-bg-2, 0.4);
+
+            .theme-light & {
+                background: rgba($color-light-bg-2, 0.4);
+            }
         }
     }
 }

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -12,7 +12,6 @@
         }
     }
 
-
     &__action-button-group {
         margin-bottom: 0.25rem;
     }
@@ -39,16 +38,16 @@
         overflow-y: auto;
         overflow-x: hidden;
 
-        .text-monospace{
+        .text-monospace {
             font-size: 0.75rem !important;
         }
 
-        .text-monospace .btn-link{
+        .text-monospace .btn-link {
             font-size: 0.75rem !important;
         }
 
         .footer {
-            background: rgba($color-light-bg-2,.4);
+            background: rgba($color-light-bg-2, 0.4);
         }
     }
 }

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -37,14 +37,6 @@
     &__content {
         overflow-y: auto;
         overflow-x: hidden;
-
-        .text-monospace {
-            font-size: 0.75rem !important;
-        }
-
-        .text-monospace .btn-link {
-            font-size: 0.75rem !important;
-        }
     }
 
     &__footer {

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -12,6 +12,7 @@
         }
     }
 
+
     &__action-button-group {
         margin-bottom: 0.25rem;
     }
@@ -44,6 +45,10 @@
 
         .text-monospace .btn-link{
             font-size: 0.75rem !important;
+        }
+
+        .footer {
+            background: rgba($color-light-bg-2,.4);
         }
     }
 }

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -46,7 +46,7 @@
             font-size: 0.75rem !important;
         }
 
-        .footer {
+        &__footer {
             background: rgba($color-bg-2, 0.4);
 
             .theme-light & {

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -45,13 +45,13 @@
         .text-monospace .btn-link {
             font-size: 0.75rem !important;
         }
+    }
 
-        &__footer {
-            background: rgba($color-bg-2, 0.4);
+    &__footer {
+        background: rgba($color-bg-2, 0.4);
 
-            .theme-light & {
-                background: rgba($color-light-bg-2, 0.4);
-            }
+        .theme-light & {
+            background: rgba($color-light-bg-2, 0.4);
         }
     }
 }

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -37,5 +37,13 @@
     &__content {
         overflow-y: auto;
         overflow-x: hidden;
+
+        .text-monospace{
+            font-size: 0.75rem !important;
+        }
+
+        .text-monospace .btn-link{
+            font-size: 0.75rem !important;
+        }
     }
 }

--- a/web/src/search/panels/PanelContainer.scss
+++ b/web/src/search/panels/PanelContainer.scss
@@ -30,6 +30,10 @@
         }
     }
 
+    &__loading-container {
+        background: none !important;
+    }
+
     &__content {
         overflow-y: auto;
         overflow-x: hidden;

--- a/web/src/search/panels/RecentFilesPanel.tsx
+++ b/web/src/search/panels/RecentFilesPanel.tsx
@@ -75,9 +75,11 @@ export const RecentFilesPanel: React.FunctionComponent<Props> = ({
             <dl className="list-group-flush">
                 {processedResults?.map((recentFile, index) => (
                     <dd key={index} className="text-monospace test-recent-files-item">
-                        <Link to={recentFile.url} onClick={logFileClicked}>
-                            {recentFile.repoName} › {recentFile.filePath}
-                        </Link>
+                        <small>
+                            <Link to={recentFile.url} onClick={logFileClicked}>
+                                {recentFile.repoName} › {recentFile.filePath}
+                            </Link>
+                        </small>
                     </dd>
                 ))}
             </dl>

--- a/web/src/search/panels/RecentSearchesPanel.tsx
+++ b/web/src/search/panels/RecentSearchesPanel.tsx
@@ -76,42 +76,48 @@ export const RecentSearchesPanel: React.FunctionComponent<Props> = ({
 
             <ul className="recent-searches-panel__examples-list">
                 <li className="recent-searches-panel__examples-list-item">
-                    <Link
-                        to={
-                            '/search?' +
-                            buildSearchURLQuery(
-                                'lang:c if(:[eval_match]) { :[statement_match] }',
-                                SearchPatternType.structural,
-                                false
-                            )
-                        }
-                        className="text-monospace"
-                    >
-                        lang:c if(:[eval_match]) {'{'} :[statement_match] {'}'}
-                    </Link>
+                    <small>
+                        <Link
+                            to={
+                                '/search?' +
+                                buildSearchURLQuery(
+                                    'lang:c if(:[eval_match]) { :[statement_match] }',
+                                    SearchPatternType.structural,
+                                    false
+                                )
+                            }
+                            className="text-monospace"
+                        >
+                            lang:c if(:[eval_match]) {'{'} :[statement_match] {'}'}
+                        </Link>
+                    </small>
                 </li>
                 <li className="recent-searches-panel__examples-list-item">
-                    <Link
-                        to={
-                            '/search?' +
-                            buildSearchURLQuery(
-                                'lang:java type:diff after:"1 week ago"',
-                                SearchPatternType.literal,
-                                false
-                            )
-                        }
-                        className="text-monospace"
-                    >
-                        lang:java type:diff after:"1 week ago"
-                    </Link>
+                    <small>
+                        <Link
+                            to={
+                                '/search?' +
+                                buildSearchURLQuery(
+                                    'lang:java type:diff after:"1 week ago"',
+                                    SearchPatternType.literal,
+                                    false
+                                )
+                            }
+                            className="text-monospace"
+                        >
+                            lang:java type:diff after:"1 week ago"
+                        </Link>
+                    </small>
                 </li>
                 <li className="recent-searches-panel__examples-list-item">
-                    <Link
-                        to={'/search?' + buildSearchURLQuery('lang:java', SearchPatternType.literal, false)}
-                        className="text-monospace"
-                    >
-                        lang:java
-                    </Link>
+                    <small>
+                        <Link
+                            to={'/search?' + buildSearchURLQuery('lang:java', SearchPatternType.literal, false)}
+                            className="text-monospace"
+                        >
+                            lang:java
+                        </Link>
+                    </small>
                 </li>
             </ul>
         </div>
@@ -147,9 +153,11 @@ export const RecentSearchesPanel: React.FunctionComponent<Props> = ({
                                 </span>
                             </td>
                             <td>
-                                <Link to={recentSearch.url} className="text-monospace" onClick={logSearchClicked}>
-                                    {recentSearch.searchText}
-                                </Link>
+                                <small>
+                                    <Link to={recentSearch.url} className="text-monospace" onClick={logSearchClicked}>
+                                        {recentSearch.searchText}
+                                    </Link>
+                                </small>
                             </td>
                             <td className="recent-searches-panel__results-table-date-col">
                                 <Timestamp noAbout={true} date={recentSearch.timestamp} now={now} strict={true} />

--- a/web/src/search/panels/RepositoriesPanel.tsx
+++ b/web/src/search/panels/RepositoriesPanel.tsx
@@ -91,10 +91,12 @@ export const RepositoriesPanel: React.FunctionComponent<Props> = ({
             </div>
             {repoFilterValues?.map((repoFilterValue, index) => (
                 <dd key={`${repoFilterValue}-${index}`} className="text-monospace text-break">
-                    <Link to={`/search?q=repo:${repoFilterValue}`} onClick={logRepoClicked}>
-                        <span className="search-keyword">repo:</span>
-                        <span className="repositories-panel__search-value">{repoFilterValue}</span>
-                    </Link>
+                    <small>
+                        <Link to={`/search?q=repo:${repoFilterValue}`} onClick={logRepoClicked}>
+                            <span className="search-keyword">repo:</span>
+                            <span className="repositories-panel__search-value">{repoFilterValue}</span>
+                        </Link>
+                    </small>
                 </dd>
             ))}
             {searchEventLogs?.pageInfo.hasNextPage && (

--- a/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/web/src/search/panels/SavedSearchesPanel.tsx
@@ -99,7 +99,7 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                     ))}
             </dl>
             {authenticatedUser && (
-                <div className="footer p-1">
+                <div className="panel-container__content__footer p-1">
                     <small>
                         <Link
                             to={`/users/${authenticatedUser.username}/searches`}

--- a/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/web/src/search/panels/SavedSearchesPanel.tsx
@@ -71,13 +71,15 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                     .map(search => (
                         <dd key={search.id} className="text-monospace test-saved-search-entry">
                             <div className="d-flex justify-content-between">
-                                <Link
-                                    to={'/search?' + buildSearchURLQuery(search.query, patternType, false)}
-                                    className="btn btn-link p-0"
-                                    onClick={logEvent('SavedSearchesPanelSearchClicked')}
-                                >
-                                    {search.description}
-                                </Link>
+                                <small>
+                                    <Link
+                                        to={'/search?' + buildSearchURLQuery(search.query, patternType, false)}
+                                        className=" p-0"
+                                        onClick={logEvent('SavedSearchesPanelSearchClicked')}
+                                    >
+                                        {search.description}
+                                    </Link>
+                                </small>
                                 {authenticatedUser &&
                                     (search.namespace.__typename === 'User' ? (
                                         <Link

--- a/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/web/src/search/panels/SavedSearchesPanel.tsx
@@ -99,7 +99,7 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                     ))}
             </dl>
             {authenticatedUser && (
-                <div className="panel-container__content__footer p-1">
+                <div className="panel-container__footer p-1">
                     <small>
                         <Link
                             to={`/users/${authenticatedUser.username}/searches`}

--- a/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/web/src/search/panels/SavedSearchesPanel.tsx
@@ -99,13 +99,17 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                     ))}
             </dl>
             {authenticatedUser && (
-                <Link
-                    to={`/users/${authenticatedUser.username}/searches`}
-                    className="btn btn-secondary w-100 text-left"
-                    onClick={logEvent('SavedSearchesPanelViewAllClicked')}
-                >
-                    View saved searches
-                </Link>
+                <div className="footer p-1">
+                    <small>
+                        <Link
+                            to={`/users/${authenticatedUser.username}/searches`}
+                            className=" text-left"
+                            onClick={logEvent('SavedSearchesPanelViewAllClicked')}
+                        >
+                            View saved searches
+                        </Link>
+                    </small>
+                </div>
             )}
         </div>
     )

--- a/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
@@ -28,35 +28,41 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
-            >
-              lang:c if(:[eval_match]) 
-              {
-               :[statement_match] 
-              }
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
+              >
+                lang:c if(:[eval_match]) 
+                {
+                 :[statement_match] 
+                }
+              </AnchorLink>
+            </small>
           </li>
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:java+type:diff+after:%221+week+ago%22&patternType=literal"
-            >
-              lang:java type:diff after:"1 week ago"
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:java+type:diff+after:%221+week+ago%22&patternType=literal"
+              >
+                lang:java type:diff after:"1 week ago"
+              </AnchorLink>
+            </small>
           </li>
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:java&patternType=literal"
-            >
-              lang:java
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:java&patternType=literal"
+              >
+                lang:java
+              </AnchorLink>
+            </small>
           </li>
         </ul>
       </div>
@@ -108,13 +114,15 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  test
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
+                  >
+                    test
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -139,13 +147,15 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  r:sourcegraph
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
+                  >
+                    r:sourcegraph
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -224,19 +234,21 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=test&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
                   >
-                    test
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=test&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      test
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -269,19 +281,21 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=r:sourcegraph&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
                   >
-                    r:sourcegraph
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=r:sourcegraph&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      r:sourcegraph
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -353,35 +367,41 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
-            >
-              lang:c if(:[eval_match]) 
-              {
-               :[statement_match] 
-              }
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
+              >
+                lang:c if(:[eval_match]) 
+                {
+                 :[statement_match] 
+                }
+              </AnchorLink>
+            </small>
           </li>
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:java+type:diff+after:%221+week+ago%22&patternType=literal"
-            >
-              lang:java type:diff after:"1 week ago"
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:java+type:diff+after:%221+week+ago%22&patternType=literal"
+              >
+                lang:java type:diff after:"1 week ago"
+              </AnchorLink>
+            </small>
           </li>
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:java&patternType=literal"
-            >
-              lang:java
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:java&patternType=literal"
+              >
+                lang:java
+              </AnchorLink>
+            </small>
           </li>
         </ul>
       </div>
@@ -433,13 +453,15 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  test
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
+                  >
+                    test
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -464,13 +486,15 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  r:sourcegraph
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
+                  >
+                    r:sourcegraph
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -495,13 +519,15 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  test
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
+                  >
+                    test
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -526,13 +552,15 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  r:sourcegraph
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
+                  >
+                    r:sourcegraph
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -607,19 +635,21 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=test&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
                   >
-                    test
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=test&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      test
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -652,19 +682,21 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=r:sourcegraph&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
                   >
-                    r:sourcegraph
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=r:sourcegraph&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      r:sourcegraph
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -697,19 +729,21 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=test&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
                   >
-                    test
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=test&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      test
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -742,19 +776,21 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=r:sourcegraph&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
                   >
-                    r:sourcegraph
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=r:sourcegraph&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      r:sourcegraph
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -809,35 +845,41 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
-            >
-              lang:c if(:[eval_match]) 
-              {
-               :[statement_match] 
-              }
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:c+if%28:%5Beval_match%5D%29+%7B+:%5Bstatement_match%5D+%7D&patternType=structural"
+              >
+                lang:c if(:[eval_match]) 
+                {
+                 :[statement_match] 
+                }
+              </AnchorLink>
+            </small>
           </li>
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:java+type:diff+after:%221+week+ago%22&patternType=literal"
-            >
-              lang:java type:diff after:"1 week ago"
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:java+type:diff+after:%221+week+ago%22&patternType=literal"
+              >
+                lang:java type:diff after:"1 week ago"
+              </AnchorLink>
+            </small>
           </li>
           <li
             className="recent-searches-panel__examples-list-item"
           >
-            <AnchorLink
-              className="text-monospace"
-              to="/search?q=lang:java&patternType=literal"
-            >
-              lang:java
-            </AnchorLink>
+            <small>
+              <AnchorLink
+                className="text-monospace"
+                to="/search?q=lang:java&patternType=literal"
+              >
+                lang:java
+              </AnchorLink>
+            </small>
           </li>
         </ul>
       </div>
@@ -889,13 +931,15 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  test
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
+                  >
+                    test
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -920,13 +964,15 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  r:sourcegraph
-                </AnchorLink>
+                <small>
+                  <AnchorLink
+                    className="text-monospace"
+                    onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
+                  >
+                    r:sourcegraph
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -1001,19 +1047,21 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=test&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=test&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=test&patternType=literal"
                   >
-                    test
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=test&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      test
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"
@@ -1046,19 +1094,21 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                 </span>
               </td>
               <td>
-                <AnchorLink
-                  className="text-monospace"
-                  onClick={[Function]}
-                  to="/search?q=r:sourcegraph&patternType=literal"
-                >
-                  <a
+                <small>
+                  <AnchorLink
                     className="text-monospace"
-                    href="/search?q=r:sourcegraph&patternType=literal"
                     onClick={[Function]}
+                    to="/search?q=r:sourcegraph&patternType=literal"
                   >
-                    r:sourcegraph
-                  </a>
-                </AnchorLink>
+                    <a
+                      className="text-monospace"
+                      href="/search?q=r:sourcegraph&patternType=literal"
+                      onClick={[Function]}
+                    >
+                      r:sourcegraph
+                    </a>
+                  </AnchorLink>
+                </small>
               </td>
               <td
                 className="recent-searches-panel__results-table-date-col"

--- a/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
+++ b/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
@@ -81,40 +81,44 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:sourcegraph"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:sourcegraph"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              sourcegraph
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                sourcegraph
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
       </div>
     }
@@ -150,51 +154,55 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
             className="text-monospace text-break"
             key="sourcegraph-0"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:sourcegraph"
-            >
-              <a
-                href="/search?q=repo:sourcegraph"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:sourcegraph"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:sourcegraph"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  sourcegraph
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    sourcegraph
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="test-1"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test"
-            >
-              <a
-                href="/search?q=repo:test"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
         </div>
       </div>
@@ -284,59 +292,65 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:sourcegraph"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:sourcegraph"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              sourcegraph
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                sourcegraph
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test-two"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test-two"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test-two
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test-two
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <ShowMoreButton
           className="test-repositories-panel-show-more"
@@ -376,76 +390,82 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
             className="text-monospace text-break"
             key="test-0"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test"
-            >
-              <a
-                href="/search?q=repo:test"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="sourcegraph-1"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:sourcegraph"
-            >
-              <a
-                href="/search?q=repo:sourcegraph"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:sourcegraph"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:sourcegraph"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  sourcegraph
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    sourcegraph
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="test-two-2"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test-two"
-            >
-              <a
-                href="/search?q=repo:test-two"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test-two"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test-two"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test-two
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test-two
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <ShowMoreButton
             className="test-repositories-panel-show-more"
@@ -552,116 +572,128 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:sourcegraph"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:sourcegraph"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              sourcegraph
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                sourcegraph
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test-two"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test-two"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test-two
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test-two
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test-three"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test-three"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test-three
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test-three
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:r:test-four"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:r:test-four"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              r:test-four
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                r:test-four
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test-five"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test-five"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test-five
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test-five
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
       </div>
     }
@@ -697,151 +729,163 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
             className="text-monospace text-break"
             key="test-0"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test"
-            >
-              <a
-                href="/search?q=repo:test"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="sourcegraph-1"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:sourcegraph"
-            >
-              <a
-                href="/search?q=repo:sourcegraph"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:sourcegraph"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:sourcegraph"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  sourcegraph
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    sourcegraph
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="test-two-2"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test-two"
-            >
-              <a
-                href="/search?q=repo:test-two"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test-two"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test-two"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test-two
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test-two
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="test-three-3"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test-three"
-            >
-              <a
-                href="/search?q=repo:test-three"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test-three"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test-three"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test-three
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test-three
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="r:test-four-4"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:r:test-four"
-            >
-              <a
-                href="/search?q=repo:r:test-four"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:r:test-four"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:r:test-four"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  r:test-four
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    r:test-four
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="test-five-5"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test-five"
-            >
-              <a
-                href="/search?q=repo:test-five"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test-five"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test-five"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test-five
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test-five
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
         </div>
       </div>
@@ -931,40 +975,44 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:test"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:test"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              test
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                test
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
         <dd
           className="text-monospace text-break"
         >
-          <AnchorLink
-            onClick={[Function]}
-            to="/search?q=repo:sourcegraph"
-          >
-            <span
-              className="search-keyword"
+          <small>
+            <AnchorLink
+              onClick={[Function]}
+              to="/search?q=repo:sourcegraph"
             >
-              repo:
-            </span>
-            <span
-              className="repositories-panel__search-value"
-            >
-              sourcegraph
-            </span>
-          </AnchorLink>
+              <span
+                className="search-keyword"
+              >
+                repo:
+              </span>
+              <span
+                className="repositories-panel__search-value"
+              >
+                sourcegraph
+              </span>
+            </AnchorLink>
+          </small>
         </dd>
       </div>
     }
@@ -1000,51 +1048,55 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
             className="text-monospace text-break"
             key="test-0"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:test"
-            >
-              <a
-                href="/search?q=repo:test"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:test"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:test"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  test
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    test
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
           <dd
             className="text-monospace text-break"
             key="sourcegraph-1"
           >
-            <AnchorLink
-              onClick={[Function]}
-              to="/search?q=repo:sourcegraph"
-            >
-              <a
-                href="/search?q=repo:sourcegraph"
+            <small>
+              <AnchorLink
                 onClick={[Function]}
+                to="/search?q=repo:sourcegraph"
               >
-                <span
-                  className="search-keyword"
+                <a
+                  href="/search?q=repo:sourcegraph"
+                  onClick={[Function]}
                 >
-                  repo:
-                </span>
-                <span
-                  className="repositories-panel__search-value"
-                >
-                  sourcegraph
-                </span>
-              </a>
-            </AnchorLink>
+                  <span
+                    className="search-keyword"
+                  >
+                    repo:
+                  </span>
+                  <span
+                    className="repositories-panel__search-value"
+                  >
+                    sourcegraph
+                  </span>
+                </a>
+              </AnchorLink>
+            </small>
           </dd>
         </div>
       </div>


### PR DESCRIPTION
Small tweaks to the home page to fix a few design nits:

* panels at small sizes were not aligned with search UI because search UI did not have padding
* text size was larger than specified and did not match search box text size
* footer panels were a button instead of a div with a text link
* top margin was too large
* background color on panels was a poor design, causing a 'flash' when loading content


![image](https://user-images.githubusercontent.com/539268/94954134-8274c780-049d-11eb-8134-62ed72cd5991.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
