### PR TITLE
Fix useless recurring Percy reviews

### DIFF
--- a/web/src/components/time/Timestamp.tsx
+++ b/web/src/components/time/Timestamp.tsx
@@ -39,13 +39,13 @@ export class Timestamp extends React.PureComponent<Props> {
     public render(): JSX.Element {
         let label = formatDistance(
             typeof this.props.date === 'string' ? parseISO(this.props.date) : this.props.date,
-            this.props.now ? this.props.now() : new Date(),
+            this.props.now ? this.props.now() : Date.now(),
             { addSuffix: true, includeSeconds: true }
         )
         if (this.props.strict) {
             label = formatDistanceStrict(
                 typeof this.props.date === 'string' ? parseISO(this.props.date) : this.props.date,
-                this.props.now ? this.props.now() : new Date(),
+                this.props.now ? this.props.now() : Date.now(),
                 { addSuffix: true }
             )
         }

--- a/web/src/integration/repository.test.ts
+++ b/web/src/integration/repository.test.ts
@@ -365,7 +365,6 @@ describe('Repository', () => {
 
             // Assert that the directory listing displays properly
             await driver.page.waitForSelector('.test-tree-entries')
-            await new Promise(() => {})
             await percySnapshot(driver.page, 'Repository index page')
 
             const numberOfFileEntries = await driver.page.evaluate(

--- a/web/src/integration/repository.test.ts
+++ b/web/src/integration/repository.test.ts
@@ -352,12 +352,20 @@ describe('Repository', () => {
                 }),
             })
 
+            // Mock `Date.now` to stabilize timestamps
+            await driver.page.evaluateOnNewDocument(() => {
+                // Number of ms between Unix epoch and July 1, 2020 (arbitrary)
+                const mockMs = new Date('July 1, 2020 00:00:00 UTC').getTime()
+                Date.now = () => mockMs
+            })
+
             await driver.page.goto(driver.sourcegraphBaseUrl + repositorySourcegraphUrl)
+
             await driver.page.waitForSelector('h2.tree-page__title')
 
             // Assert that the directory listing displays properly
             await driver.page.waitForSelector('.test-tree-entries')
-
+            await new Promise(() => {})
             await percySnapshot(driver.page, 'Repository index page')
 
             const numberOfFileEntries = await driver.page.evaluate(


### PR DESCRIPTION
#### Problem

Percy requests visual review every month for `GitCommitNode`. The only thing that changes is the timestamp.

#### Solution

Mock `Date.now` before running scripts in the flaky integration test, use `Date.now` in `Timestamp`.

#### Possible alternatives

We could mock the entire Date object, either ourselves or with mockdate. There are several other instances in our application in which we construct a new Date with no arguments to get the current time, as opposed to calling `Date.now`.