### PR TITLE
codeintel: Fix bad default lsif-go arguments

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
@@ -107,7 +107,7 @@ func (s *Scheduler) queueIndex(ctx context.Context, indexableRepository store.In
 		DockerSteps:  []store.DockerStep{},
 		Root:         "",
 		Indexer:      "sourcegraph/lsif-go:latest",
-		IndexerArgs:  []string{"lsif-go", "--no-progress"},
+		IndexerArgs:  []string{"lsif-go", "--no-animation"},
 		Outfile:      "",
 	})
 	if err != nil {


### PR DESCRIPTION
How many times can I get this wrong 😬 