### PR TITLE
handle gzipped graphql requests

### DIFF
--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -31,12 +31,14 @@ func serveGraphQL(schema *graphql.Schema) func(w http.ResponseWriter, r *http.Re
 		r = r.WithContext(trace.WithRequestSource(r.Context(), guessSource(r)))
 
 		if r.Header.Get("Content-Encoding") == "gzip" {
-			reader, err := gzip.NewReader(r.Body)
+			gzipReader, err := gzip.NewReader(r.Body)
 			if err != nil {
 				return err
 			}
 
-			r.Body = reader
+			r.Body = gzipReader
+
+			defer gzipReader.Close()
 		}
 
 		relayHandler.ServeHTTP(w, r)

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -1,10 +1,8 @@
 package httpapi
 
 import (
-	"bytes"
 	"compress/gzip"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -37,13 +35,8 @@ func serveGraphQL(schema *graphql.Schema) func(w http.ResponseWriter, r *http.Re
 			if err != nil {
 				return err
 			}
-			defer reader.Close()
 
-			body, err := ioutil.ReadAll(reader)
-			if err != nil {
-				return err
-			}
-			r.Body = ioutil.NopCloser(bytes.NewReader(body))
+			r.Body = reader
 		}
 
 		relayHandler.ServeHTTP(w, r)

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
 	"github.com/graph-gophers/graphql-go"
@@ -59,7 +60,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, gitlabWebh
 		m.Path("/updates").Methods("GET", "POST").Name("updatecheck").Handler(trace.TraceRoute(http.HandlerFunc(updatecheck.Handler)))
 	}
 
-	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
+	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(gziphandler.GzipHandler(handler(serveGraphQL(schema)))))
 
 	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(http.HandlerFunc(frontendsearch.ServeStream)))
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/NYTimes/gziphandler"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
 	"github.com/graph-gophers/graphql-go"
@@ -60,7 +59,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook, gitlabWebh
 		m.Path("/updates").Methods("GET", "POST").Name("updatecheck").Handler(trace.TraceRoute(http.HandlerFunc(updatecheck.Handler)))
 	}
 
-	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(gziphandler.GzipHandler(handler(serveGraphQL(schema)))))
+	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
 
 	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(http.HandlerFunc(frontendsearch.ServeStream)))
 


### PR DESCRIPTION
This allows the backend to handle gzipped GraphQL requests. But perhaps this is not the right place to do this? I'm curious to know your thoughts.

This partially fixes #12840.