### PR TITLE
campaigns: support per-user tokens when interacting with code hosts

### DIFF
--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -43,15 +43,15 @@ type GithubSource struct {
 }
 
 // NewGithubSource returns a new GithubSource from the given external service.
-func NewGithubSource(svc *ExternalService, cf *httpcli.Factory) (*GithubSource, error) {
+func NewGithubSource(svc *ExternalService, token *string, cf *httpcli.Factory) (*GithubSource, error) {
 	var c schema.GitHubConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	return newGithubSource(svc, &c, cf)
+	return newGithubSource(svc, &c, token, cf)
 }
 
-func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error) {
+func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, token *string, cf *httpcli.Factory) (*GithubSource, error) {
 	baseURL, err := url.Parse(c.Url)
 	if err != nil {
 		return nil, err
@@ -105,6 +105,10 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 		return nil, err
 	}
 
+	if token == nil {
+		token = &c.Token
+	}
+
 	return &GithubSource{
 		svc:              svc,
 		config:           c,
@@ -113,8 +117,8 @@ func newGithubSource(svc *ExternalService, c *schema.GitHubConnection, cf *httpc
 		excludeForks:     excludeForks,
 		baseURL:          baseURL,
 		githubDotCom:     githubDotCom,
-		client:           github.NewClient(apiURL, c.Token, cli),
-		searchClient:     github.NewClient(apiURL, c.Token, cli),
+		client:           github.NewClient(apiURL, *token, cli),
+		searchClient:     github.NewClient(apiURL, *token, cli),
 		originalHostname: originalHostname,
 	}, nil
 }

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -721,7 +721,12 @@ func merge(o, n *Repo) {
 }
 
 func (s *Syncer) sourced(ctx context.Context, svcs []*ExternalService, observe ...func(*Repo)) ([]*Repo, error) {
-	srcs, err := s.Sourcer(svcs...)
+	sts := make([]SourceTuple, len(svcs))
+	for i, svc := range svcs {
+		sts[i].ExternalService = svc
+	}
+
+	srcs, err := s.Sourcer(sts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/repo-updater/repos/testing.go
+++ b/cmd/repo-updater/repos/testing.go
@@ -15,14 +15,14 @@ import (
 // NewFakeSourcer returns a Sourcer which always returns the given error and sources,
 // ignoring the given external services.
 func NewFakeSourcer(err error, srcs ...Source) Sourcer {
-	return func(svcs ...*ExternalService) (Sources, error) {
+	return func(tuples ...SourceTuple) (Sources, error) {
 		var errs *multierror.Error
 
 		if err != nil {
-			for _, svc := range svcs {
-				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: svc})
+			for _, st := range tuples {
+				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: st.ExternalService})
 			}
-			if len(svcs) == 0 {
+			if len(tuples) == 0 {
 				errs = multierror.Append(errs, &SourceError{Err: err, ExtSvc: nil})
 			}
 		}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -375,7 +375,7 @@ func externalServiceValidate(ctx context.Context, req *protocol.ExternalServiceS
 		Kind:        req.ExternalService.Kind,
 		DisplayName: req.ExternalService.DisplayName,
 		Config:      req.ExternalService.Config,
-	}, httpcli.NewExternalHTTPClientFactory())
+	}, nil, httpcli.NewExternalHTTPClientFactory())
 	if err != nil {
 		return err
 	}

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -148,11 +148,11 @@ func Main(enterpriseInit EnterpriseInit) {
 			switch c := cfg.(type) {
 			case *schema.GitHubConnection:
 				if strings.HasPrefix(c.Url, "https://github.com") && c.Token != "" {
-					server.GithubDotComSource, err = repos.NewGithubSource(e, cf)
+					server.GithubDotComSource, err = repos.NewGithubSource(e, nil, cf)
 				}
 			case *schema.GitLabConnection:
 				if strings.HasPrefix(c.Url, "https://gitlab.com") && c.Token != "" {
-					server.GitLabDotComSource, err = repos.NewGitLabSource(e, cf)
+					server.GitLabDotComSource, err = repos.NewGitLabSource(e, nil, cf)
 				}
 			}
 

--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -1,12 +1,15 @@
 package campaigns
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"strings"
 	"testing"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
@@ -20,7 +23,7 @@ func TestIntegration(t *testing.T) {
 
 	db := dbtest.NewDB(t, *dsn)
 
-	userID := insertTestUser(t, db)
+	userID := insertTestUser(t, context.Background(), db, "bbs-admin")
 
 	t.Run("Store", func(t *testing.T) {
 		t.Run("Campaigns", storeTest(db, testStoreCampaigns))
@@ -29,6 +32,7 @@ func TestIntegration(t *testing.T) {
 		t.Run("ListChangesetSyncData", storeTest(db, testStoreListChangesetSyncData))
 		t.Run("CampaignSpecs", storeTest(db, testStoreCampaignSpecs))
 		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
+		t.Run("UserToken", storeTest(db, testStoreUserTokens))
 	})
 
 	t.Run("GitHubWebhook", testGitHubWebhook(db, userID))
@@ -56,10 +60,15 @@ func insertTestOrg(t *testing.T, db *sql.DB) (orgID int32) {
 	return orgID
 }
 
-func insertTestUser(t *testing.T, db *sql.DB) (userID int32) {
+func insertTestUser(t *testing.T, ctx context.Context, db dbutil.DB, name string) (userID int32) {
 	t.Helper()
 
-	err := db.QueryRow("INSERT INTO users (username) VALUES ('bbs-admin') RETURNING id").Scan(&userID)
+	q := sqlf.Sprintf(
+		"INSERT INTO users (username) VALUES (%s) RETURNING id",
+		name,
+	)
+
+	err := db.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), name).Scan(&userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -506,9 +506,10 @@ func TestUserDeleteCascades(t *testing.T) {
 		t.Skip()
 	}
 
+	ctx := context.Background()
 	db := dbtest.NewDB(t, *dsn)
 	orgID := insertTestOrg(t, db)
-	userID := insertTestUser(t, db)
+	userID := insertTestUser(t, ctx, db, "bbs-admin")
 
 	t.Run("user delete", storeTest(db, func(t *testing.T, ctx context.Context, store *Store, rs repos.Store, clock clock) {
 		// Set up two campaigns and specs: one in the user's namespace (which

--- a/enterprise/internal/campaigns/store_user_tokens.go
+++ b/enterprise/internal/campaigns/store_user_tokens.go
@@ -1,0 +1,175 @@
+package campaigns
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/secret"
+)
+
+var userTokenColumns = []*sqlf.Query{
+	sqlf.Sprintf("user_id"),
+	sqlf.Sprintf("external_service_id"),
+	sqlf.Sprintf("token"),
+	sqlf.Sprintf("created_at"),
+	sqlf.Sprintf("updated_at"),
+}
+
+func (s *Store) UpsertUserToken(ctx context.Context, token *campaigns.UserToken) error {
+	if token.CreatedAt.IsZero() {
+		token.CreatedAt = s.now()
+	}
+
+	if token.UpdatedAt.IsZero() {
+		token.UpdatedAt = token.CreatedAt
+	}
+
+	columns := sqlf.Join(userTokenColumns, ", ")
+	q := sqlf.Sprintf(
+		upsertUserTokenQueryFmtstr,
+		columns,
+		token.UserID,
+		token.ExternalServiceID,
+		token.Token,
+		token.CreatedAt,
+		token.UpdatedAt,
+		columns,
+	)
+
+	return s.query(ctx, q, func(sc scanner) error {
+		return scanUserToken(token, sc)
+	})
+}
+
+const upsertUserTokenQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_user_tokens.go:CreateUserToken
+INSERT INTO campaign_user_tokens (%s) VALUES (%s, %s, %s, %s, %s)
+ON CONFLICT (user_id, external_service_id) DO UPDATE SET
+	token = excluded.token,
+	created_at = excluded.created_at,
+	updated_at = excluded.updated_at
+RETURNING %s
+`
+
+func (s *Store) DeleteUserToken(ctx context.Context, userID int32, externalServiceID int64) error {
+	return s.Store.Exec(ctx, sqlf.Sprintf(deleteUserTokenQueryFmtstr, userID, externalServiceID))
+}
+
+const deleteUserTokenQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_user_tokens.go:DeleteUserToken
+DELETE FROM campaign_user_tokens WHERE user_id = %s AND external_service_id = %d
+`
+
+func (s *Store) GetUserToken(ctx context.Context, userID int32, externalServiceID int64) (*campaigns.UserToken, error) {
+	q := sqlf.Sprintf(
+		getUserTokenQueryFmtstr,
+		sqlf.Join(userTokenColumns, ", "),
+		userID,
+		externalServiceID,
+	)
+
+	var token campaigns.UserToken
+	if err := s.query(ctx, q, func(sc scanner) error {
+		return scanUserToken(&token, sc)
+	}); err != nil {
+		return nil, err
+	}
+
+	if token.UserID == 0 {
+		return nil, ErrNoResults
+	}
+
+	return &token, nil
+}
+
+const getUserTokenQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_user_tokens.go:GetUserToken
+SELECT %s
+FROM campaign_user_tokens
+WHERE user_id = %s AND external_service_id = %s
+LIMIT 1
+`
+
+type ListUserTokensOpts struct {
+	*db.LimitOffset
+	UserID            int32
+	ExternalServiceID int64
+}
+
+// sql overrides LimitOffset.SQL() to give a LIMIT clause with one extra value
+// so we can populate the next cursor.
+func (opts *ListUserTokensOpts) sql() *sqlf.Query {
+	if opts.LimitOffset == nil || opts.Limit == 0 {
+		return &sqlf.Query{}
+	}
+
+	return (&db.LimitOffset{Limit: opts.Limit + 1, Offset: opts.Offset}).SQL()
+}
+
+func (s *Store) ListUserTokens(ctx context.Context, opts ListUserTokensOpts) (tokens []*campaigns.UserToken, next int, err error) {
+	q := listUserTokensQuery(&opts)
+
+	tokens = make([]*campaigns.UserToken, 0)
+	err = s.query(ctx, q, func(sc scanner) error {
+		var token campaigns.UserToken
+		if err := scanUserToken(&token, sc); err != nil {
+			return err
+		}
+		tokens = append(tokens, &token)
+		return nil
+	})
+
+	// There are more results, since the extra value is populated, so we need
+	// to set the return cursor and lop off the last tokens entry.
+	if opts.LimitOffset != nil && opts.Limit != 0 && len(tokens) == opts.Limit+1 {
+		next = opts.Offset + opts.Limit
+		tokens = tokens[:len(tokens)-1]
+	}
+
+	return tokens, next, err
+}
+
+func listUserTokensQuery(opts *ListUserTokensOpts) *sqlf.Query {
+	preds := []*sqlf.Query{}
+
+	if opts.UserID != 0 {
+		preds = append(preds, sqlf.Sprintf("user_id = %s", opts.UserID))
+	}
+	if opts.ExternalServiceID != 0 {
+		preds = append(preds, sqlf.Sprintf("external_service_id = %s", opts.ExternalServiceID))
+	}
+
+	return sqlf.Sprintf(
+		listUserTokensQueryFmtstr,
+		sqlf.Join(userTokenColumns, ", "),
+		sqlf.Join(preds, "\n AND "),
+		opts.sql(),
+	)
+}
+
+const listUserTokensQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store_user_tokens.go:ListUserTokens
+SELECT %s
+FROM campaign_user_tokens
+WHERE %s
+ORDER BY created_at ASC, user_id ASC, external_service_id ASC
+%s
+`
+
+func scanUserToken(token *campaigns.UserToken, s scanner) error {
+	// secret.StringValue can't Scan if it doesn't have a concrete string
+	// within it, so we'll put something in place, knowing it'll get
+	// overwritten by Scan() anyway.
+	st := ""
+	token.Token = secret.StringValue{S: &st}
+
+	return s.Scan(
+		&token.UserID,
+		&token.ExternalServiceID,
+		&token.Token,
+		&token.CreatedAt,
+		&token.UpdatedAt,
+	)
+}

--- a/enterprise/internal/campaigns/store_user_tokens_test.go
+++ b/enterprise/internal/campaigns/store_user_tokens_test.go
@@ -1,0 +1,265 @@
+package campaigns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/secret"
+)
+
+func testStoreUserTokens(t *testing.T, ctx context.Context, s *Store, rs repos.Store, clock clock) {
+	// All of our tests require an external service. We'll actually create two,
+	// so we can perform meaningful list tests.
+	svcA := createExternalService(t, ctx, rs, extsvc.KindGitHub)
+	svcB := createExternalService(t, ctx, rs, extsvc.KindGitLab)
+
+	// Similarly, we need users.
+	uidA := insertTestUser(t, ctx, s.DB(), "a")
+	uidB := insertTestUser(t, ctx, s.DB(), "b")
+
+	// We also need to be able to refer to the tokens in multiple places, so
+	// let's define our token placeholders here, along with other state we need
+	// to track across subtests.
+	var (
+		tokenAA *campaigns.UserToken
+		tokenAB *campaigns.UserToken
+
+		createdAt = time.Date(2020, 10, 2, 23, 56, 0, 0, time.UTC)
+		updatedAt = time.Date(2020, 10, 2, 23, 57, 0, 0, time.UTC)
+	)
+
+	// UpsertUserToken is going to serve a double purpose: it's both going to
+	// test the eponymous function, and also set up the state we're going to
+	// use in the other subtests, at least as far as user A's tokens go.
+	t.Run("UpsertUserToken insert", func(t *testing.T) {
+		// Create a user token with implicit created and updated times.
+		tokenAA = &campaigns.UserToken{
+			UserID:            uidA,
+			ExternalServiceID: svcA.ID,
+			Token:             createSecretString("foo"),
+		}
+		if err := s.UpsertUserToken(ctx, tokenAA); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+
+		// Create a user token with explicit created and updated times.
+		tokenAB = &campaigns.UserToken{
+			UserID:            uidA,
+			ExternalServiceID: svcB.ID,
+			Token:             createSecretString("bar"),
+			CreatedAt:         createdAt,
+			UpdatedAt:         updatedAt,
+		}
+		if err := s.UpsertUserToken(ctx, tokenAB); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+	})
+
+	t.Run("GetUserToken", func(t *testing.T) {
+		// Let's get those tokens that we just created back and see what we
+		// have.
+		if have, err := s.GetUserToken(ctx, uidA, svcA.ID); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if diff := cmp.Diff(have, tokenAA); diff != "" {
+			t.Errorf("unexpected token:\n%s", diff)
+		}
+
+		if have, err := s.GetUserToken(ctx, uidA, svcB.ID); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if diff := cmp.Diff(have, tokenAB); diff != "" {
+			t.Errorf("unexpected token:\n%s", diff)
+		}
+
+		// Now let's see what happens when we ask for a token that doesn't
+		// exist.
+		if _, err := s.GetUserToken(ctx, uidB, svcA.ID); err != ErrNoResults {
+			t.Errorf("unexpected error: have=%v want=%v", err, ErrNoResults)
+		}
+	})
+
+	t.Run("ListUserTokens", func(t *testing.T) {
+		// If we don't set any limits, then we should just get all the tokens
+		// for the user back.
+		if have, next, err := s.ListUserTokens(ctx, ListUserTokensOpts{
+			UserID: uidA,
+		}); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if next != 0 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 0)
+		} else if diff := cmp.Diff(have, []*campaigns.UserToken{
+			// The seeming reverse order here is because of the earlier
+			// createdAt that we used when upserting tokenAB.
+			tokenAB,
+			tokenAA,
+		}); diff != "" {
+			t.Errorf("unexpected tokens:\n%s", diff)
+		}
+
+		// If we ask for one token, then we should get a cursor indicating
+		// there are more records.
+		have, next, err := s.ListUserTokens(ctx, ListUserTokensOpts{
+			UserID:      uidA,
+			LimitOffset: &db.LimitOffset{Limit: 1},
+		})
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		if next != 1 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 1)
+		}
+		if diff := cmp.Diff(have, []*campaigns.UserToken{
+			tokenAB,
+		}); diff != "" {
+			t.Errorf("unexpected tokens:\n%s", diff)
+		}
+
+		// Now we should be able to get the other token by using the cursor.
+		have, next, err = s.ListUserTokens(ctx, ListUserTokensOpts{
+			UserID:      uidA,
+			LimitOffset: &db.LimitOffset{Limit: 1, Offset: next},
+		})
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		// This time, we shouldn't have a next cursor.
+		if next != 0 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 0)
+		}
+		if diff := cmp.Diff(have, []*campaigns.UserToken{
+			tokenAA,
+		}); diff != "" {
+			t.Errorf("unexpected tokens:\n%s", diff)
+		}
+
+		// Next, let's ensure that listing tokens for a user without tokens
+		// results in an empty slice.
+		if have, next, err := s.ListUserTokens(ctx, ListUserTokensOpts{
+			UserID: uidB,
+		}); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if next != 0 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 0)
+		} else if len(have) != 0 {
+			t.Errorf("unexpected non-empty slice: %v", have)
+		}
+
+		// We hope you enjoyed the user tests, because here are some
+		// suspiciously similar scenarios for external service searches.
+
+		// If we don't set any limits, then we should just get all the tokens
+		// for the external service back.
+		if have, next, err := s.ListUserTokens(ctx, ListUserTokensOpts{
+			ExternalServiceID: svcA.ID,
+		}); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if next != 0 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 0)
+		} else if diff := cmp.Diff(have, []*campaigns.UserToken{
+			tokenAA,
+		}); diff != "" {
+			t.Errorf("unexpected tokens:\n%s", diff)
+		}
+
+		// If we ask for one token, then we should get a cursor indicating
+		// there are no more records.
+		have, next, err = s.ListUserTokens(ctx, ListUserTokensOpts{
+			ExternalServiceID: svcA.ID,
+			LimitOffset:       &db.LimitOffset{Limit: 1},
+		})
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		if next != 0 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 0)
+		}
+		if diff := cmp.Diff(have, []*campaigns.UserToken{
+			tokenAA,
+		}); diff != "" {
+			t.Errorf("unexpected tokens:\n%s", diff)
+		}
+
+		// Using a bogus cursor should result in no user tokens.
+		have, next, err = s.ListUserTokens(ctx, ListUserTokensOpts{
+			ExternalServiceID: svcA.ID,
+			LimitOffset:       &db.LimitOffset{Limit: 1, Offset: 1},
+		})
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		if next != 0 {
+			t.Errorf("unexpected cursor: have=%d want=%d", next, 0)
+		}
+		if len(have) != 0 {
+			t.Errorf("unexpected non-empty slice: %v", have)
+		}
+
+		// Finally, let's validate that combining a user ID with an external
+		// service ID essentially has the same behaviour as GetUserToken().
+		want, err := s.GetUserToken(ctx, uidA, svcB.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if have, _, err := s.ListUserTokens(ctx, ListUserTokensOpts{
+			ExternalServiceID: svcB.ID,
+			UserID:            uidA,
+		}); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if diff := cmp.Diff(have[0], want); diff != "" {
+			t.Errorf("unexpected tokens:\n%s", diff)
+		}
+	})
+
+	// Now let's try updating one of the tokens we've already created.
+	t.Run("UpsertUserToken update", func(t *testing.T) {
+		tokenAB.Token = createSecretString("quux")
+		if err := s.UpsertUserToken(ctx, tokenAB); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+
+		if token, err := s.GetUserToken(ctx, tokenAB.UserID, tokenAB.ExternalServiceID); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		} else if have, want := *token.Token.S, "quux"; have != want {
+			t.Errorf("unexpected token value: have=%q want=%q", have, want)
+		}
+	})
+
+	// Finally, let's delete a token.
+	t.Run("DeleteUserToken", func(t *testing.T) {
+		if err := s.DeleteUserToken(ctx, uidA, svcB.ID); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+
+		// Let's ensure it really was deleted!
+		if _, err := s.GetUserToken(ctx, uidA, svcB.ID); err != ErrNoResults {
+			t.Errorf("unexpected error: have=%v want=%v", err, ErrNoResults)
+		}
+
+		// Validate that deleting a non-existent token behaves as expected.
+		if err := s.DeleteUserToken(ctx, uidB, svcB.ID); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+	})
+}
+
+func createExternalService(t *testing.T, ctx context.Context, rs repos.Store, kind string) *repos.ExternalService {
+	t.Helper()
+	es := repos.ExternalService{
+		Kind:   kind,
+		Config: "{}",
+	}
+
+	if err := rs.UpsertExternalServices(ctx, &es); err != nil {
+		t.Fatal(err)
+	}
+	return &es
+}
+
+func createSecretString(s string) secret.StringValue {
+	return secret.StringValue{S: &s}
+}

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -663,7 +663,7 @@ func groupChangesetsBySource(
 
 	bySource := make(map[int64]*SourceChangesets, len(es))
 	for _, e := range es {
-		sources, err := sourcer(e)
+		sources, err := sourcer(repos.SourceTuple{ExternalService: e})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/campaigns/user_token.go
+++ b/internal/campaigns/user_token.go
@@ -1,0 +1,15 @@
+package campaigns
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/secret"
+)
+
+type UserToken struct {
+	UserID            int32
+	ExternalServiceID int64
+	Token             secret.StringValue
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}

--- a/migrations/frontend/1528395728_campaign_user_tokens.down.sql
+++ b/migrations/frontend/1528395728_campaign_user_tokens.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS campaign_user_tokens;
+
+COMMIT;

--- a/migrations/frontend/1528395728_campaign_user_tokens.up.sql
+++ b/migrations/frontend/1528395728_campaign_user_tokens.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS campaign_user_tokens (
+    user_id INTEGER NOT NULL,
+    external_service_id BIGINT NOT NULL,
+    token TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- deleted_at is intentionally left out: given the secret nature of tokens,
+    -- users will likely want to be certain that tokens are deleted when
+    -- removed, even with encryption in place.
+
+    -- user_id is first because we'll need to be able to query all the tokens
+    -- for a user on a regular basis, and PostgreSQL can use the primary key
+    -- index for the first column of a composite key individually.
+    PRIMARY KEY (user_id, external_service_id),
+
+    -- Set up the foreign keys.
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE DEFERRABLE,
+    FOREIGN KEY (external_service_id) REFERENCES external_services (id) ON DELETE CASCADE DEFERRABLE
+);
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -88,6 +88,8 @@
 // 1528395726_lsif_index_defaults.up.sql (164B)
 // 1528395727_frontend.down.sql (139B)
 // 1528395727_frontend.up.sql (139B)
+// 1528395728_campaign_user_tokens.down.sql (60B)
+// 1528395728_campaign_user_tokens.up.sql (978B)
 
 package migrations
 
@@ -1916,6 +1918,46 @@ func _1528395727_frontendUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395728_campaign_user_tokensDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\x4e\xcc\x2d\x48\xcc\x4c\xcf\x8b\x2f\x2d\x4e\x2d\x8a\x2f\xc9\xcf\x4e\xcd\x2b\xb6\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x19\x15\xa9\x99\x3c\x00\x00\x00")
+
+func _1528395728_campaign_user_tokensDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395728_campaign_user_tokensDownSql,
+		"1528395728_campaign_user_tokens.down.sql",
+	)
+}
+
+func _1528395728_campaign_user_tokensDownSql() (*asset, error) {
+	bytes, err := _1528395728_campaign_user_tokensDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395728_campaign_user_tokens.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x42, 0x6, 0xf7, 0x55, 0xf8, 0xf0, 0xec, 0x8a, 0x5, 0x75, 0x4c, 0x1a, 0xc, 0xa8, 0xaa, 0x1b, 0x13, 0x28, 0x46, 0xe3, 0x13, 0xdd, 0x7, 0x2c, 0x9e, 0x7f, 0x23, 0xe9, 0x3c, 0x91, 0xa6, 0xc1}}
+	return a, nil
+}
+
+var __1528395728_campaign_user_tokensUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x93\xc1\x72\xda\x3c\x14\x85\xf7\x7e\x8a\xb3\xfb\xc9\x8c\x93\x07\xf8\xb3\x32\x20\xa8\xa7\xc6\x50\x5b\x99\x24\xdd\x30\xc2\xbe\x80\x06\x21\xb9\x92\x0c\xf1\xdb\x77\x64\x43\x87\xd2\x2c\x3a\xdd\xd9\xd2\x39\xdf\x3d\x57\x57\x1a\xb3\x79\x9a\x3f\x47\xd1\xa4\x60\x09\x67\xe0\xc9\x38\x63\x48\x67\xc8\x97\x1c\xec\x2d\x2d\x79\x89\x4a\x1c\x1b\x21\x77\x7a\xdd\x3a\xb2\x6b\x6f\x0e\xa4\x1d\x46\x11\x00\xf4\x2b\xb2\x46\x9a\x73\x36\x67\x45\xef\xca\x5f\xb2\x2c\xee\x77\xe9\xc3\x93\xd5\x42\xad\x1d\xd9\x93\xac\x28\x28\xc7\xe9\x3c\xcd\xf9\x9d\xb0\x67\x82\xb3\xb7\xfb\x8d\xca\x92\xf0\x54\xaf\x85\x07\x4f\x17\xac\xe4\xc9\x62\x85\xd7\x94\x7f\xe9\x7f\xf1\x7d\x99\xb3\x5f\x0e\x4c\xd9\x2c\x79\xc9\x02\xe2\x75\xf4\x30\xf8\xdb\xa6\xfe\x67\x7f\x0f\x78\x7c\x44\x4d\x8a\x2e\x0c\xe9\x20\xb5\x27\xed\xa5\xd1\x42\xa9\x0e\x8a\xb6\x1e\xa6\xf5\xff\x63\x27\x4f\xa4\xe1\xf7\x04\x47\x95\x25\x0f\x2d\x7c\x6b\x09\x66\x3b\x74\xe7\xe2\x2b\x2f\x9c\x99\xc3\x59\x2a\x05\x25\x0f\xa4\x3a\x9c\x85\xf6\xf0\x06\x1b\x42\x45\xd6\x0b\x19\x40\xc2\x5f\x8c\x10\x96\xae\x21\x70\xde\x93\xbe\x82\x2c\x1d\xcd\x89\xea\x18\x14\x4a\x9f\xa5\xdf\x83\x74\x65\xbb\x26\xc4\x83\xd4\x68\x94\xa8\xe8\x29\xba\x2d\x1c\x46\x20\x1d\xb6\xd2\x3a\x8f\x0d\x55\xa2\x75\x84\x33\xfd\xa7\x14\x34\x51\x7d\x49\x21\x36\x8a\xc2\xe7\x8f\x96\x6c\x07\xa1\x54\xdf\xd8\x10\xe7\x4a\xdb\x1a\x0b\xd1\x33\x61\x34\x04\x2c\xed\x5a\x25\x2c\x36\xc2\x49\x17\x43\xe8\x1a\x2b\xe3\xfc\xce\x52\xf9\x2d\x43\x25\x74\xd0\xf6\x9c\xc6\xca\xa3\xb0\x1d\x0e\xd4\x5d\x61\x52\xd7\xf4\xd1\x23\x83\x60\x48\x57\x19\xd5\x1e\x75\x38\x40\x81\xca\x1c\x1b\xe3\xa4\xa7\x60\x0a\x6a\x79\x92\x75\x1b\x46\xf0\xd4\x23\x56\x45\xba\x48\x8a\x77\x7c\x65\xef\x18\x5d\xfa\x8c\x3f\xbb\x7f\x37\x73\x2d\xc9\xa3\x6d\x86\x82\xc6\x92\xdc\xe9\x00\x77\x03\x70\xb6\x2c\x58\x3a\xcf\x7f\x03\x3e\xa0\x60\x33\x56\xb0\x7c\xc2\xca\xcb\x14\x47\x61\x75\x99\x63\xca\x32\xc6\x19\x26\x49\x39\x49\xa6\x2c\xdc\x24\x56\x14\xe1\x29\xc5\x7f\xd2\x3e\x4b\x75\x4b\xbe\xdf\xff\x8b\x2a\xd1\x43\x78\xc1\xcb\xc5\x22\xe5\xcf\xd1\xcf\x00\x00\x00\xff\xff\xcb\x2a\x54\x51\xd2\x03\x00\x00")
+
+func _1528395728_campaign_user_tokensUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395728_campaign_user_tokensUpSql,
+		"1528395728_campaign_user_tokens.up.sql",
+	)
+}
+
+func _1528395728_campaign_user_tokensUpSql() (*asset, error) {
+	bytes, err := _1528395728_campaign_user_tokensUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395728_campaign_user_tokens.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xef, 0xa1, 0xba, 0x80, 0xec, 0x88, 0x5b, 0xca, 0x9e, 0xa7, 0xa0, 0x5d, 0x81, 0xef, 0xc, 0x6f, 0xc5, 0xf1, 0xc, 0x60, 0x8b, 0xa0, 0x73, 0xd0, 0xf1, 0x1c, 0x83, 0x3, 0xfe, 0x2d, 0x55, 0x36}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2095,6 +2137,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395726_lsif_index_defaults.up.sql":                                        _1528395726_lsif_index_defaultsUpSql,
 	"1528395727_frontend.down.sql":                                                 _1528395727_frontendDownSql,
 	"1528395727_frontend.up.sql":                                                   _1528395727_frontendUpSql,
+	"1528395728_campaign_user_tokens.down.sql":                                     _1528395728_campaign_user_tokensDownSql,
+	"1528395728_campaign_user_tokens.up.sql":                                       _1528395728_campaign_user_tokensUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2229,6 +2273,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395726_lsif_index_defaults.up.sql":                                        {_1528395726_lsif_index_defaultsUpSql, map[string]*bintree{}},
 	"1528395727_frontend.down.sql":                                                 {_1528395727_frontendDownSql, map[string]*bintree{}},
 	"1528395727_frontend.up.sql":                                                   {_1528395727_frontendUpSql, map[string]*bintree{}},
+	"1528395728_campaign_user_tokens.down.sql":                                     {_1528395728_campaign_user_tokensDownSql, map[string]*bintree{}},
+	"1528395728_campaign_user_tokens.up.sql":                                       {_1528395728_campaign_user_tokensUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This is nowhere near complete right now. It will eventually close #13862.

### Tasks

* [x] Add a database migration.
* [x] Add the new `UserToken` type and its store methods.
* [ ] Plumb the tokens through to the reconciler and syncer to ensure that the basic model works OK.
* [ ] Validate that tokens really are stored encrypted (since this is the first time I've used `secret`).
* [ ] Add GraphQL queries and mutations to manipulate tokens on a per-user basis, ensuring that the token is never returned in full.
* [ ] Build a user token setting UI.
* [ ] Add queries and mutations for admins to manage tokens on behalf of their users.
* [ ] Build an admin UI.