### PR TITLE
clean up UserArea, UserSettingsProfilePage, user header, updateUser mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to Sourcegraph are documented in this file.
 - `SRC_LOG_LEVEL=warn` is now the default in Docker Compose and Kubernetes deployments, reducing the amount of uninformative log spam. [#14458](https://github.com/sourcegraph/sourcegraph/pull/14458)
 - Permissions data that were stored in deprecated binary format are abandoned. Downgrade from 3.21 to 3.20 is OK, but to 3.19 or prior versions might experience missing/incomplete state of permissions for a short period of time. [#13740](https://github.com/sourcegraph/sourcegraph/issues/13740)
 - The query builder page is now disabled by default. To reenable it, add `{ "experimentalFeatures": { "showQueryBuilder": true } }` in user settings.
+- The GraphQL `updateUser` mutation now returns the updated user (instead of an empty response).
 
 ### Fixed
 

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -169,28 +169,28 @@ describe('e2e test suite', () => {
 
         test('Check allowed usernames', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/users/test/settings/profile')
-            await driver.page.waitForSelector('.test-user-settings-profile-page-username')
+            await driver.page.waitForSelector('.test-UserProfileFormFields-username')
 
             const name = 'alice.bob-chris-'
 
             await driver.replaceText({
-                selector: '.test-user-settings-profile-page-username',
+                selector: '.test-UserProfileFormFields-username',
                 newText: name,
                 selectMethod: 'selectall',
             })
 
-            await driver.page.click('.test-user-settings-profile-page-update-profile')
-            await driver.page.waitForSelector('.test-user-settings-profile-page-alert-success', { visible: true })
+            await driver.page.click('#test-EditUserProfileForm__save')
+            await driver.page.waitForSelector('.test-EditUserProfileForm__success', { visible: true })
 
             await driver.page.goto(sourcegraphBaseUrl + `/users/${name}/settings/profile`)
             await driver.replaceText({
-                selector: '.test-user-settings-profile-page-username',
+                selector: '.test-UserProfileFormFields-username',
                 newText: 'test',
                 selectMethod: 'selectall',
             })
 
-            await driver.page.click('.test-user-settings-profile-page-update-profile')
-            await driver.page.waitForSelector('.test-user-settings-profile-page-alert-success', { visible: true })
+            await driver.page.click('#test-EditUserProfileForm__save')
+            await driver.page.waitForSelector('.test-EditUserProfileForm__success', { visible: true })
         })
     })
 

--- a/client/web/src/enterprise/user/settings/routes.tsx
+++ b/client/web/src/enterprise/user/settings/routes.tsx
@@ -3,6 +3,9 @@ import { UserSettingsAreaRoute } from '../../../user/settings/UserSettingsArea'
 import { lazyComponent } from '../../../util/lazyComponent'
 import { SHOW_BUSINESS_FEATURES } from '../../dotcom/productSubscriptions/features'
 import { authExp } from '../../site-admin/SiteAdminAuthenticationProvidersPage'
+import React from 'react'
+
+const UserEventLogsPage = lazyComponent(() => import('../../../user/UserEventLogsPage'), 'UserEventLogsPage')
 
 export const enterpriseUserSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     ...userSettingsAreaRoutes,
@@ -11,6 +14,11 @@ export const enterpriseUserSettingsAreaRoutes: readonly UserSettingsAreaRoute[] 
         exact: true,
         render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
         condition: ({ authenticatedUser }) => authenticatedUser.siteAdmin,
+    },
+    {
+        path: '/event-log',
+        exact: true,
+        render: props => <UserEventLogsPage {...props} />,
     },
     {
         path: '/external-accounts',

--- a/client/web/src/enterprise/user/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/user/settings/sidebaritems.ts
@@ -25,5 +25,10 @@ export const enterpriseUserSettingsSideBarItems: UserSettingsSidebarItems = {
             exact: true,
             condition: ({ authenticatedUser }) => !!authenticatedUser.siteAdmin,
         },
+        {
+            to: '/event-log',
+            label: 'Event log',
+            condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
+        },
     ],
 }

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -224,7 +224,7 @@ function mockCommonGraphQLResponses(
                 viewerPendingInvitation: null,
             },
         }),
-        User: () => ({
+        UserArea: () => ({
             user: {
                 __typename: 'User',
                 id: 'user123',
@@ -234,6 +234,7 @@ function mockCommonGraphQLResponses(
                 settingsURL: `${namespaceURL}/settings`,
                 avatarURL: '',
                 viewerCanAdminister: true,
+                viewerCanChangeUsername: true,
                 siteAdmin: true,
                 builtinAuth: true,
                 createdAt: '2020-04-10T21:11:42Z',

--- a/client/web/src/integration/settings.test.ts
+++ b/client/web/src/integration/settings.test.ts
@@ -50,7 +50,7 @@ describe('Settings', () => {
                         },
                     },
                 }),
-                User: () => ({
+                UserArea: () => ({
                     user: {
                         __typename: 'User',
                         id: testUserID,
@@ -60,6 +60,7 @@ describe('Settings', () => {
                         settingsURL: '/users/test/settings',
                         avatarURL: null,
                         viewerCanAdminister: true,
+                        viewerCanChangeUsername: true,
                         siteAdmin: true,
                         builtinAuth: true,
                         createdAt: '2020-03-02T11:52:15Z',

--- a/client/web/src/regression/core.test.ts
+++ b/client/web/src/regression/core.test.ts
@@ -159,11 +159,11 @@ describe('Core functionality regression test suite', () => {
 
         await driver.page.goto(driver.sourcegraphBaseUrl + `/users/${testUsername}/settings/profile`)
         await driver.replaceText({
-            selector: '.test-user-settings-profile-page__display-name',
+            selector: '.test-UserProfileFormFields__displayName',
             newText: displayName,
         })
         await driver.replaceText({
-            selector: '.test-user-settings-profile-page__avatar_url',
+            selector: '.test-UserProfileFormFields__avatarURL',
             newText: aviURL,
             enterTextMethod: 'paste',
         })

--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
-import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 import { orgURL } from '../../org'
 import { OrgAvatar } from '../../org/OrgAvatar'
 import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { UserAvatar } from '../UserAvatar'
 import { UserAreaRouteContext } from './UserArea'
 
-interface Props extends UserAreaRouteContext, RouteComponentProps<{}> {
+interface Props extends UserAreaRouteContext {
     navItems: readonly UserAreaHeaderNavItem[]
     className?: string
 }

--- a/client/web/src/user/area/navitems.ts
+++ b/client/web/src/user/area/navitems.ts
@@ -1,6 +1,5 @@
 import FeatureSearchOutlineIcon from 'mdi-react/FeatureSearchOutlineIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
-import TimelineTextOutlineIcon from 'mdi-react/TimelineTextOutlineIcon'
 import { namespaceAreaHeaderNavItems } from '../../namespaces/navitems'
 import { UserAreaHeaderNavItem } from './UserAreaHeader'
 
@@ -23,10 +22,4 @@ export const userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
         condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
     },
     ...namespaceAreaHeaderNavItems,
-    {
-        to: '/event-log',
-        label: 'Event log',
-        icon: TimelineTextOutlineIcon,
-        condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
-    },
 ]

--- a/client/web/src/user/area/routes.tsx
+++ b/client/web/src/user/area/routes.tsx
@@ -5,7 +5,6 @@ import { lazyComponent } from '../../util/lazyComponent'
 import { UserAreaRoute } from './UserArea'
 
 const UserSettingsArea = lazyComponent(() => import('../settings/UserSettingsArea'), 'UserSettingsArea')
-const UserEventLogsPage = lazyComponent(() => import('../UserEventLogsPage'), 'UserEventLogsPage')
 
 export const userAreaRoutes: readonly UserAreaRoute[] = [
     {

--- a/client/web/src/user/area/routes.tsx
+++ b/client/web/src/user/area/routes.tsx
@@ -30,8 +30,4 @@ export const userAreaRoutes: readonly UserAreaRoute[] = [
         path: '/account',
         render: props => <Redirect to={`${props.url}/settings/profile`} />,
     },
-    {
-        path: '/event-log',
-        render: props => <UserEventLogsPage {...props} />,
-    },
 ]

--- a/client/web/src/user/settings/UserSettingsArea.scss
+++ b/client/web/src/user/settings/UserSettingsArea.scss
@@ -1,2 +1,2 @@
 @import './UserSettingsSidebar';
-@import './profile/UserSettingsProfilePage';
+@import './profile/UserProfileFormFields';

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -7,38 +7,6 @@ import { mutateGraphQL } from '../../backend/graphql'
 import { eventLogger } from '../../tracking/eventLogger'
 import { UserEvent, EventSource } from '../../../../shared/src/graphql-operations'
 
-interface UpdateUserOptions {
-    username: string | null
-    /** The user's display name */
-    displayName: string | null
-    /** The user's avatar URL */
-    avatarURL: string | null
-}
-
-/**
- * Sends a GraphQL mutation to update a user's profile
- */
-export function updateUser(user: GQL.ID, args: UpdateUserOptions): Observable<void> {
-    return mutateGraphQL(
-        gql`
-            mutation updateUser($user: ID!, $username: String, $displayName: String, $avatarURL: String) {
-                updateUser(user: $user, username: $username, displayName: $displayName, avatarURL: $avatarURL) {
-                    alwaysNil
-                }
-            }
-        `,
-        { ...args, user }
-    ).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.updateUser) {
-                eventLogger.log('UpdateUserFailed')
-                throw createAggregateError(errors)
-            }
-            eventLogger.log('UserProfileUpdated')
-        })
-    )
-}
-
 export function updatePassword(args: { oldPassword: string; newPassword: string }): Observable<void> {
     return mutateGraphQL(
         gql`

--- a/client/web/src/user/settings/profile/EditUserProfileForm.test.tsx
+++ b/client/web/src/user/settings/profile/EditUserProfileForm.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { EditUserProfileForm } from './EditUserProfileForm'
+
+jest.mock('./UserProfileFormFields', () => ({ UserProfileFormFields: 'mock-UserProfileFormFields' }))
+
+describe('EditUserProfileForm', () => {
+    test('simple', () =>
+        expect(
+            mount(
+                <EditUserProfileForm
+                    user={{ id: 'x', siteAdmin: false, viewerCanChangeUsername: true }}
+                    initialValue={{ username: 'u', displayName: 'd', avatarURL: 'https://example.com/image.jpg' }}
+                    onUpdate={() => {}}
+                    after="AFTER"
+                />
+            )
+        ).toMatchSnapshot())
+})

--- a/client/web/src/user/settings/profile/EditUserProfileForm.tsx
+++ b/client/web/src/user/settings/profile/EditUserProfileForm.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback, useState } from 'react'
+import { map } from 'rxjs/operators'
+import { dataOrThrowErrors, gql } from '../../../../../shared/src/graphql/graphql'
+import { isErrorLike } from '../../../../../shared/src/util/errors'
+import { requestGraphQL } from '../../../backend/graphql'
+import { UpdateUserResult, UpdateUserVariables, UserAreaUserFields } from '../../../graphql-operations'
+import { eventLogger } from '../../../tracking/eventLogger'
+import { UserProfileFormFields, UserProfileFormFieldsValue } from './UserProfileFormFields'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import { UserAreaGQLFragment } from '../../area/UserArea'
+import { Form } from '../../../../../branded/src/components/Form'
+
+interface Props {
+    user: Pick<GQL.IUser, 'id' | 'viewerCanChangeUsername' | 'siteAdmin'>
+
+    initialValue: UserProfileFormFieldsValue
+
+    /** Called when the user is successfully updated. */
+    onUpdate: (newValue: UserAreaUserFields) => void
+
+    after?: React.ReactFragment
+}
+
+/**
+ * A form to edit a user's profile.
+ */
+export const EditUserProfileForm: React.FunctionComponent<Props> = ({ user, initialValue, onUpdate, after }) => {
+    const [value, setValue] = useState<UserProfileFormFieldsValue>(initialValue)
+    const onChange = useCallback<React.ComponentProps<typeof UserProfileFormFields>['onChange']>(
+        newValue => setValue(previous => ({ ...previous, ...newValue })),
+        []
+    )
+
+    /** Operation state: false (initial state), true (loading), Error, or 'success'. */
+    const [opState, setOpState] = useState<boolean | Error | 'success'>(false)
+    const onSubmit = useCallback<React.FormEventHandler>(
+        async event => {
+            event.preventDefault()
+            setOpState(true)
+            eventLogger.log('UpdateUserClicked')
+            try {
+                const updatedUser = await requestGraphQL<UpdateUserResult, UpdateUserVariables>(
+                    gql`
+                        mutation UpdateUser(
+                            $user: ID!
+                            $username: String!
+                            $displayName: String
+                            $avatarURL: String
+                            $siteAdmin: Boolean!
+                        ) {
+                            updateUser(
+                                user: $user
+                                username: $username
+                                displayName: $displayName
+                                avatarURL: $avatarURL
+                            ) {
+                                ...UserAreaUserFields
+                            }
+                        }
+                        ${UserAreaGQLFragment}
+                    `,
+                    { ...value, user: user.id, siteAdmin: user.siteAdmin }
+                )
+                    .pipe(
+                        map(dataOrThrowErrors),
+                        map(data => data.updateUser)
+                    )
+                    .toPromise()
+                eventLogger.log('UserProfileUpdated')
+                setOpState('success')
+                onUpdate(updatedUser)
+            } catch (error) {
+                eventLogger.log('UpdateUserFailed')
+                setOpState(error)
+            }
+        },
+        [onUpdate, user.id, user.siteAdmin, value]
+    )
+
+    return (
+        <Form className="w-100" onSubmit={onSubmit}>
+            <UserProfileFormFields
+                value={value}
+                onChange={onChange}
+                usernameFieldDisabled={!user.viewerCanChangeUsername}
+                disabled={opState === true}
+            />
+            <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={opState === true}
+                id="test-EditUserProfileForm__save"
+            >
+                Save
+            </button>
+            {isErrorLike(opState) && <div className="mt-3 alert alert-danger">Error: {opState.message}</div>}
+            {opState === 'success' && (
+                <div className="mt-3 alert alert-success test-EditUserProfileForm__success">User profile updated.</div>
+            )}
+            {after && (
+                <>
+                    <hr className="my-4" />
+                    {after}
+                </>
+            )}
+        </Form>
+    )
+}

--- a/client/web/src/user/settings/profile/UserProfileFormFields.scss
+++ b/client/web/src/user/settings/profile/UserProfileFormFields.scss
@@ -1,0 +1,5 @@
+.user-profile-form-fields {
+    &__avatar {
+        max-width: 4.5rem;
+    }
+}

--- a/client/web/src/user/settings/profile/UserProfileFormFields.test.tsx
+++ b/client/web/src/user/settings/profile/UserProfileFormFields.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { UserProfileFormFields } from './UserProfileFormFields'
+
+describe('UserProfileFormFields', () => {
+    test('simple', () =>
+        expect(
+            mount(
+                <UserProfileFormFields
+                    value={{ username: 'u', displayName: 'd', avatarURL: 'https://example.com/image.jpg' }}
+                    onChange={() => {}}
+                />
+            )
+        ).toMatchSnapshot())
+})

--- a/client/web/src/user/settings/profile/UserProfileFormFields.tsx
+++ b/client/web/src/user/settings/profile/UserProfileFormFields.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react'
+import { UsernameInput } from '../../../auth/SignInSignUpCommon'
+import * as GQL from '../../../../../shared/src/graphql/schema'
+import { UserAvatar } from '../../UserAvatar'
+import { USER_DISPLAY_NAME_MAX_LENGTH } from '../..'
+
+export type UserProfileFormFieldsValue = Pick<GQL.IUser, 'username' | 'displayName' | 'avatarURL'>
+
+interface Props {
+    value: UserProfileFormFieldsValue
+    onChange: (newValue: UserProfileFormFieldsValue) => void
+    usernameFieldDisabled?: boolean
+    disabled?: boolean
+}
+
+export const UserProfileFormFields: React.FunctionComponent<Props> = ({
+    value,
+    onChange,
+    usernameFieldDisabled,
+    disabled,
+}) => {
+    const onUsernameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+        event => onChange({ ...value, username: event.target.value }),
+        [onChange, value]
+    )
+    const onDisplayNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+        event => onChange({ ...value, displayName: event.target.value }),
+        [onChange, value]
+    )
+    const onAvatarURLChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+        event => onChange({ ...value, avatarURL: event.target.value }),
+        [onChange, value]
+    )
+
+    return (
+        <div className="user-profile-form-fields">
+            <div className="form-group">
+                <label htmlFor="UserProfileFormFields__username">Username</label>
+                <UsernameInput
+                    id="UserProfileFormFields__username"
+                    className="test-UserProfileFormFields-username"
+                    value={value.username}
+                    onChange={onUsernameChange}
+                    required={true}
+                    disabled={usernameFieldDisabled || disabled}
+                    aria-describedby="UserProfileFormFields__username-help"
+                />
+                <small id="UserProfileFormFields__username-help" className="form-text text-muted">
+                    A username consists of letters, numbers, hyphens (-), dots (.) and may not begin or end with a dot,
+                    nor begin with a hyphen.
+                </small>
+            </div>
+            <div className="form-group">
+                <label htmlFor="UserProfileFormFields__displayName">Display name</label>
+                <input
+                    id="UserProfileFormFields__displayName"
+                    type="text"
+                    className="form-control test-UserProfileFormFields__displayName"
+                    value={value.displayName || ''}
+                    onChange={onDisplayNameChange}
+                    disabled={disabled}
+                    spellCheck={false}
+                    placeholder="Display name"
+                    maxLength={USER_DISPLAY_NAME_MAX_LENGTH}
+                />
+            </div>
+            <div className="d-flex align-items-center">
+                <div className="form-group w-100">
+                    <label htmlFor="UserProfileFormFields__avatarURL">Avatar URL</label>
+                    <input
+                        id="UserProfileFormFields__avatarURL"
+                        type="url"
+                        className="form-control test-UserProfileFormFields__avatarURL"
+                        value={value.avatarURL || ''}
+                        onChange={onAvatarURLChange}
+                        disabled={disabled}
+                        spellCheck={false}
+                        placeholder="URL to avatar photo"
+                    />
+                </div>
+                {value.avatarURL && <UserAvatar user={value} className="user-profile-form-fields__avatar ml-2" />}
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -1,300 +1,92 @@
-import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as React from 'react'
-import { RouteComponentProps } from 'react-router'
-import { combineLatest, concat, Observable, Subject, Subscription } from 'rxjs'
-import { catchError, distinctUntilChanged, filter, map, mergeMap, startWith, switchMap, tap } from 'rxjs/operators'
-import { USER_DISPLAY_NAME_MAX_LENGTH } from '../..'
+import React, { useCallback, useEffect } from 'react'
+import H from 'history'
 import { percentageDone } from '../../../../../shared/src/components/activation/Activation'
 import { ActivationChecklist } from '../../../../../shared/src/components/activation/ActivationChecklist'
 import { gql } from '../../../../../shared/src/graphql/graphql'
-import * as GQL from '../../../../../shared/src/graphql/schema'
-import { asError, createAggregateError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
+import { isErrorLike } from '../../../../../shared/src/util/errors'
 import { refreshAuthenticatedUser } from '../../../auth'
-import { UsernameInput } from '../../../auth/SignInSignUpCommon'
-import { queryGraphQL } from '../../../backend/graphql'
-import { Form } from '../../../../../branded/src/components/Form'
 import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserAreaRouteContext } from '../../area/UserArea'
-import { UserAvatar } from '../../UserAvatar'
-import { updateUser } from '../backend'
-import { ErrorAlert } from '../../../components/alerts'
+import { EditUserProfilePage as EditUserProfilePageFragment } from '../../../graphql-operations'
+import { EditUserProfileForm } from './EditUserProfileForm'
 
-function queryUser(user: GQL.ID): Observable<GQL.IUser> {
-    return queryGraphQL(
-        gql`
-            query UserForProfilePage($user: ID!) {
-                node(id: $user) {
-                    ... on User {
-                        id
-                        username
-                        displayName
-                        avatarURL
-                        viewerCanChangeUsername
-                    }
-                }
+export const EditUserProfilePageGQLFragment = gql`
+    fragment EditUserProfilePage on User {
+        id
+        username
+        displayName
+        avatarURL
+        viewerCanChangeUsername
+        siteAdmin
+    }
+`
+
+interface Props extends Pick<UserAreaRouteContext, 'onUserUpdate' | 'activation'> {
+    user: EditUserProfilePageFragment
+
+    history: H.History
+    location: H.Location
+}
+
+export const UserSettingsProfilePage: React.FunctionComponent<Props> = ({
+    user,
+    onUserUpdate: parentOnUpdate,
+    ...props
+}) => {
+    useEffect(() => eventLogger.logViewEvent('UserProfile'), [])
+
+    const onUpdate = useCallback<React.ComponentProps<typeof EditUserProfileForm>['onUpdate']>(
+        newValue => {
+            // Handle when username changes.
+            if (newValue.username !== user.username) {
+                props.history.push(`/users/${newValue.username}/settings/profile`)
             }
-        `,
-        { user }
-    ).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.node) {
-                throw createAggregateError(errors)
-            }
-            return data.node as GQL.IUser
-        })
+
+            parentOnUpdate(newValue)
+
+            // In case the edited user is the current user, immediately reflect the changes in the
+            // UI.
+            refreshAuthenticatedUser()
+                .toPromise()
+                .finally(() => {})
+        },
+        [parentOnUpdate, props.history, user.username]
     )
-}
 
-interface Props extends UserAreaRouteContext, RouteComponentProps<{}> {}
+    return (
+        <div className="user-settings-profile-page">
+            <PageTitle title="Profile" />
+            <h2>Profile</h2>
 
-interface State {
-    /** The user to edit, or an error, or undefined while loading. */
-    userOrError?: GQL.IUser | ErrorLike
-
-    loading: boolean
-    saved: boolean
-    error?: ErrorLike
-
-    /** undefined means unchanged from Props.user */
-    username?: string
-    displayName?: string
-    avatarURL?: string
-}
-
-export class UserSettingsProfilePage extends React.Component<Props, State> {
-    public state: State = { loading: false, saved: false }
-
-    private componentUpdates = new Subject<Props>()
-    private refreshRequests = new Subject<void>()
-    private submits = new Subject<React.FormEvent<HTMLFormElement>>()
-    private subscriptions = new Subscription()
-
-    public componentDidMount(): void {
-        eventLogger.logViewEvent('UserProfile')
-
-        const userChanges = this.componentUpdates.pipe(
-            distinctUntilChanged((a, b) => a.user.id === b.user.id),
-            map(({ user }) => user)
-        )
-
-        // Reset the fields upon navigation to a different user.
-        this.subscriptions.add(
-            userChanges.subscribe(() =>
-                this.setState({
-                    userOrError: undefined,
-                    loading: false,
-                    saved: false,
-                    username: undefined,
-                    displayName: undefined,
-                    avatarURL: undefined,
-                })
-            )
-        )
-
-        // Fetch the user with all of the fields we need (Props.user might not have them all).
-        this.subscriptions.add(
-            combineLatest([userChanges, this.refreshRequests.pipe(startWith<void>(undefined))])
-                .pipe(
-                    switchMap(([user]) =>
-                        queryUser(user.id).pipe(
-                            catchError(error => [asError(error)]),
-                            map((userOrError): Pick<State, 'userOrError'> => ({ userOrError }))
-                        )
-                    )
-                )
-                .subscribe(
-                    stateUpdate => this.setState(stateUpdate),
-                    error => console.error(error)
-                )
-        )
-
-        this.subscriptions.add(
-            this.submits
-                .pipe(
-                    tap(event => {
-                        event.preventDefault()
-                        eventLogger.log('UpdateUserClicked')
-                    }),
-                    filter(event => event.currentTarget.checkValidity()),
-                    tap(() => this.setState({ loading: true })),
-                    mergeMap(() =>
-                        updateUser(this.props.user.id, {
-                            username: this.state.username === undefined ? null : this.state.username,
-                            displayName: this.state.displayName === undefined ? null : this.state.displayName,
-                            avatarURL: this.state.avatarURL === undefined ? null : this.state.avatarURL,
-                        }).pipe(catchError(error => this.handleError(error)))
-                    ),
-                    tap(() => {
-                        this.setState({ loading: false, saved: true })
-                        this.props.onDidUpdateUser()
-
-                        // Handle when username changes.
-                        if (this.state.username !== undefined && this.state.username !== this.props.user.username) {
-                            this.props.history.push(`/users/${this.state.username}/settings/profile`)
-                            return
-                        }
-
-                        this.refreshRequests.next()
-                        setTimeout(() => this.setState({ saved: false }), 500)
-                    }),
-
-                    // In case the edited user is the current user, immediately reflect the changes in the UI.
-                    mergeMap(() => concat(refreshAuthenticatedUser(), [null]))
-                )
-                .subscribe({ error: error => this.handleError(error) })
-        )
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentDidUpdate(): void {
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public render(): JSX.Element | null {
-        return (
-            <div className="user-settings-profile-page">
-                <PageTitle title="Profile" />
-                <h2>Profile</h2>
-
-                {this.props.activation?.completed && percentageDone(this.props.activation.completed) < 100 && (
-                    <div className="card mb-3">
-                        <div className="card-body">
-                            <h3 className="mb-0">Almost there!</h3>
-                            <p className="mb-0">Complete the steps below to finish onboarding to Sourcegraph.</p>
-                        </div>
-                        <ActivationChecklist
-                            history={this.props.history}
-                            steps={this.props.activation.steps}
-                            completed={this.props.activation.completed}
-                        />
+            {props.activation?.completed && percentageDone(props.activation.completed) < 100 && (
+                <div className="card mb-3">
+                    <div className="card-body">
+                        <h3 className="mb-0">Almost there!</h3>
+                        <p className="mb-0">Complete the steps below to finish onboarding to Sourcegraph.</p>
                     </div>
-                )}
-
-                {isErrorLike(this.state.userOrError) && (
-                    <ErrorAlert error={this.state.userOrError.message} history={this.props.history} />
-                )}
-                {this.state.error && <ErrorAlert error={this.state.error.message} history={this.props.history} />}
-                {this.state.userOrError && !isErrorLike(this.state.userOrError) && (
-                    <Form className="user-settings-profile-page__form" onSubmit={this.handleSubmit}>
-                        <div className="form-group">
-                            <label htmlFor="user-settings-profile-page__form-username">Username</label>
-                            <UsernameInput
-                                id="user-settings-profile-page__form-username"
-                                className="test-user-settings-profile-page-username"
-                                value={
-                                    this.state.username === undefined
-                                        ? this.state.userOrError.username
-                                        : this.state.username
-                                }
-                                onChange={this.onUsernameFieldChange}
-                                required={true}
-                                disabled={
-                                    !this.state.userOrError ||
-                                    !this.state.userOrError.viewerCanChangeUsername ||
-                                    this.state.loading
-                                }
-                                aria-describedby="user-settings-profile-page__form-username-help"
-                            />
-                            <small className="form-text text-muted">
-                                A username consists of letters, numbers, hyphens (-), dots (.) and may not begin or end
-                                with a dot, nor begin with a hyphen.
-                            </small>
-                        </div>
-                        <div className="form-group">
-                            <label htmlFor="user-settings-profile-page__form-display-name">Display name</label>
-                            <input
-                                id="user-settings-profile-page__form-display-name"
-                                type="text"
-                                className="form-control test-user-settings-profile-page__display-name"
-                                value={
-                                    this.state.displayName === undefined
-                                        ? this.state.userOrError.displayName || ''
-                                        : this.state.displayName
-                                }
-                                onChange={this.onDisplayNameFieldChange}
-                                disabled={this.state.loading}
-                                spellCheck={false}
-                                placeholder="Display name"
-                                maxLength={USER_DISPLAY_NAME_MAX_LENGTH}
-                            />
-                        </div>
-                        <div className="user-settings-profile-page__avatar-row">
-                            <div className="form-group user-settings-profile-page__field-column">
-                                <label htmlFor="user-settings-profile-page__form-avatar-url">Avatar URL</label>
-                                <input
-                                    id="user-settings-profile-page__form-avatar-url"
-                                    type="url"
-                                    className="form-control test-user-settings-profile-page__avatar_url"
-                                    value={
-                                        this.state.avatarURL === undefined
-                                            ? this.state.userOrError.avatarURL || ''
-                                            : this.state.avatarURL
-                                    }
-                                    onChange={this.onAvatarURLFieldChange}
-                                    disabled={this.state.loading}
-                                    spellCheck={false}
-                                    placeholder="URL to avatar photo"
-                                />
-                            </div>
-                            {this.state.userOrError.avatarURL && (
-                                <div className="user-settings-profile-page__avatar-column">
-                                    <UserAvatar user={this.state.userOrError} />
-                                </div>
-                            )}
-                        </div>
-                        <button
-                            className="btn btn-primary user-settings-profile-page__button test-user-settings-profile-page-update-profile"
-                            type="submit"
-                            disabled={this.state.loading}
-                        >
-                            Update profile
-                        </button>
-                        {this.state.loading && (
-                            <div>
-                                <LoadingSpinner className="icon-inline" />
-                            </div>
-                        )}
-                        {this.state.saved && (
-                            <p className="alert alert-success user-settings-profile-page__alert test-user-settings-profile-page-alert-success">
-                                Profile saved!
-                            </p>
-                        )}
-                        {window.context.sourcegraphDotComMode && (
+                    <ActivationChecklist
+                        history={props.history}
+                        steps={props.activation.steps}
+                        completed={props.activation.completed}
+                    />
+                </div>
+            )}
+            {user && !isErrorLike(user) && (
+                <EditUserProfileForm
+                    user={user}
+                    initialValue={user}
+                    onUpdate={onUpdate}
+                    after={
+                        window.context.sourcegraphDotComMode && (
                             <p className="mt-4">
                                 <a href="https://about.sourcegraph.com/contact">Contact support</a> to delete your
                                 account.
                             </p>
-                        )}
-                    </Form>
-                )}
-            </div>
-        )
-    }
-
-    private onUsernameFieldChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        this.setState({ username: event.target.value })
-    }
-
-    private onDisplayNameFieldChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        this.setState({ displayName: event.target.value })
-    }
-
-    private onAvatarURLFieldChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        this.setState({ avatarURL: event.target.value })
-    }
-
-    private handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
-        this.submits.next(event)
-    }
-
-    private handleError = (error: Error): [] => {
-        console.error(error)
-        this.setState({ loading: false, saved: false, error })
-        return []
-    }
+                        )
+                    }
+                />
+            )}
+        </div>
+    )
 }

--- a/client/web/src/user/settings/profile/__snapshots__/EditUserProfileForm.test.tsx.snap
+++ b/client/web/src/user/settings/profile/__snapshots__/EditUserProfileForm.test.tsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditUserProfileForm simple 1`] = `
+<EditUserProfileForm
+  after="AFTER"
+  initialValue={
+    Object {
+      "avatarURL": "https://example.com/image.jpg",
+      "displayName": "d",
+      "username": "u",
+    }
+  }
+  onUpdate={[Function]}
+  user={
+    Object {
+      "id": "x",
+      "siteAdmin": false,
+      "viewerCanChangeUsername": true,
+    }
+  }
+>
+  <Form
+    className="w-100"
+    onSubmit={[Function]}
+  >
+    <form
+      className="w-100 "
+      onInvalid={[Function]}
+      onSubmit={[Function]}
+    >
+      <mock-UserProfileFormFields
+        disabled={false}
+        onChange={[Function]}
+        usernameFieldDisabled={false}
+        value={
+          Object {
+            "avatarURL": "https://example.com/image.jpg",
+            "displayName": "d",
+            "username": "u",
+          }
+        }
+      />
+      <button
+        className="btn btn-primary"
+        disabled={false}
+        id="test-EditUserProfileForm__save"
+        type="submit"
+      >
+        Save
+      </button>
+      <hr
+        className="my-4"
+      />
+      AFTER
+    </form>
+  </Form>
+</EditUserProfileForm>
+`;

--- a/client/web/src/user/settings/profile/__snapshots__/UserProfileFormFields.test.tsx.snap
+++ b/client/web/src/user/settings/profile/__snapshots__/UserProfileFormFields.test.tsx.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserProfileFormFields simple 1`] = `
+<UserProfileFormFields
+  onChange={[Function]}
+  value={
+    Object {
+      "avatarURL": "https://example.com/image.jpg",
+      "displayName": "d",
+      "username": "u",
+    }
+  }
+>
+  <div
+    className="user-profile-form-fields"
+  >
+    <div
+      className="form-group"
+    >
+      <label
+        htmlFor="UserProfileFormFields__username"
+      >
+        Username
+      </label>
+      <UsernameInput
+        aria-describedby="UserProfileFormFields__username-help"
+        className="test-UserProfileFormFields-username"
+        id="UserProfileFormFields__username"
+        onChange={[Function]}
+        required={true}
+        value="u"
+      >
+        <input
+          aria-describedby="UserProfileFormFields__username-help"
+          autoCapitalize="off"
+          autoComplete="username"
+          className="form-control test-UserProfileFormFields-username"
+          id="UserProfileFormFields__username"
+          maxLength={255}
+          name="username"
+          onChange={[Function]}
+          pattern="^[\\\\dA-Za-z](?:[\\\\dA-Za-z]|[.-](?=[\\\\dA-Za-z]))*-?$"
+          placeholder="Username"
+          required={true}
+          spellCheck={false}
+          type="text"
+          value="u"
+        />
+      </UsernameInput>
+      <small
+        className="form-text text-muted"
+        id="UserProfileFormFields__username-help"
+      >
+        A username consists of letters, numbers, hyphens (-), dots (.) and may not begin or end with a dot, nor begin with a hyphen.
+      </small>
+    </div>
+    <div
+      className="form-group"
+    >
+      <label
+        htmlFor="UserProfileFormFields__displayName"
+      >
+        Display name
+      </label>
+      <input
+        className="form-control test-UserProfileFormFields__displayName"
+        id="UserProfileFormFields__displayName"
+        maxLength={255}
+        onChange={[Function]}
+        placeholder="Display name"
+        spellCheck={false}
+        type="text"
+        value="d"
+      />
+    </div>
+    <div
+      className="d-flex align-items-center"
+    >
+      <div
+        className="form-group w-100"
+      >
+        <label
+          htmlFor="UserProfileFormFields__avatarURL"
+        >
+          Avatar URL
+        </label>
+        <input
+          className="form-control test-UserProfileFormFields__avatarURL"
+          id="UserProfileFormFields__avatarURL"
+          onChange={[Function]}
+          placeholder="URL to avatar photo"
+          spellCheck={false}
+          type="url"
+          value="https://example.com/image.jpg"
+        />
+      </div>
+      <UserAvatar
+        className="user-profile-form-fields__avatar ml-2"
+        user={
+          Object {
+            "avatarURL": "https://example.com/image.jpg",
+            "displayName": "d",
+            "username": "u",
+          }
+        }
+      >
+        <img
+          className="user-avatar user-profile-form-fields__avatar ml-2"
+          src="https://example.com/image.jpg"
+        />
+      </UserAvatar>
+    </div>
+  </div>
+</UserProfileFormFields>
+`;

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -55,7 +55,7 @@ type Mutation {
 
     Only the user and site admins may perform this mutation.
     """
-    updateUser(user: ID!, username: String, displayName: String, avatarURL: String): EmptyResponse!
+    updateUser(user: ID!, username: String, displayName: String, avatarURL: String): User!
     """
     Creates an organization. The caller is added as a member of the newly created organization.
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -48,7 +48,7 @@ type Mutation {
 
     Only the user and site admins may perform this mutation.
     """
-    updateUser(user: ID!, username: String, displayName: String, avatarURL: String): EmptyResponse!
+    updateUser(user: ID!, username: String, displayName: String, avatarURL: String): User!
     """
     Creates an organization. The caller is added as a member of the newly created organization.
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -185,7 +185,7 @@ type updateUserArgs struct {
 	AvatarURL   *string
 }
 
-func (*schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (*EmptyResponse, error) {
+func (*schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (*UserResolver, error) {
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (*schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (*E
 	if err := db.Users.Update(ctx, userID, update); err != nil {
 		return nil, err
 	}
-	return &EmptyResponse{}, nil
+	return UserByIDInt32(ctx, userID)
 }
 
 // CurrentUser returns the authenticated user if any. If there is no authenticated user, it returns

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -242,36 +242,41 @@ func TestUpdateUser(t *testing.T) {
 		}
 	})
 
-	db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
-		return &types.User{SiteAdmin: true}, nil
-	}
-	db.Mocks.Users.Update = func(userID int32, update db.UserUpdate) error {
-		return nil
-	}
-	t.Cleanup(func() {
-		db.Mocks.Users = db.MockUsers{}
-	})
+	t.Run("success", func(t *testing.T) {
+		db.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+			return &types.User{ID: id, Username: strconv.Itoa(int(id))}, nil
+		}
+		db.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{SiteAdmin: true}, nil
+		}
+		db.Mocks.Users.Update = func(userID int32, update db.UserUpdate) error {
+			return nil
+		}
+		t.Cleanup(func() {
+			db.Mocks.Users = db.MockUsers{}
+		})
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
-		{
-			Schema: mustParseGraphQLSchema(t),
-			Query: `
+		gqltesting.RunTests(t, []*gqltesting.Test{
+			{
+				Schema: mustParseGraphQLSchema(t),
+				Query: `
 			mutation {
 				updateUser(
 					user: "VXNlcjox",
 					username: "alice.bob-chris-"
 				) {
-					alwaysNil
+					username
 				}
 			}
 		`,
-			ExpectedResult: `
+				ExpectedResult: `
 			{
 				"updateUser": {
-					"alwaysNil": null
+					"username": "1"
 				}
 			}
 		`,
-		},
+			},
+		})
 	})
 }


### PR DESCRIPTION
This is mostly a cleanup of tech debt.

- Move the user event log tab into the user settings sidebar. Let's use the tabs (which are quite prominent) in the user area for things that users need in their usual workflow, not for site admin and audit stuff.
- Make the GraphQL mutation `updateUser` return a `User` instead of `EmptyResponse` so the caller can get the newly updated user in the same query. This is how most of our other mutations work.
- Clean up the UserArea code: make it a function component, remove needless props, etc.
- Clean up the page for editing a user's profile.

The GraphQL change is technically a breaking change, but I don't see any usage of the `updateUser` mutation outside of the app itself. The `src` CLI does not expose a command for `updateUser` either.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->