### PR TITLE
monitoring: allow page load latency to be NaN

### DIFF
--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -101,6 +101,7 @@ func Frontend() *Container {
 							Description:     "90th percentile page load latency over all routes over 10m",
 							Query:           `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route!="raw",route!="blob",route!~"graphql.*"}[10m])))`,
 							DataMayNotExist: true,
+							DataMayBeNaN:    true, // if all buckets are 0 (i.e. on low-traffic instances), histogram_quantile returns NaN
 							Critical:        Alert{GreaterOrEqual: 2},
 							PanelOptions:    PanelOptions().LegendFormat("latency").Unit(Seconds),
 							Owner:           ObservableOwnerCloud,


### PR DESCRIPTION
It seems histogram_quantile can return NaN if all buckets are 0, for example on low-traffic instances.

With this change:

<img width="1637" alt="Screen Shot 2020-10-05 at 5 54 13 PM" src="https://user-images.githubusercontent.com/23356519/95065734-0647e180-0734-11eb-880d-13e911c52e42.png">

Orange bar is the threshold, green is the metrics correctly not going above that threshold.

Just going with this solution because I was unable to find the "right way" to get around this. Closes https://github.com/sourcegraph/sourcegraph/issues/14401 (which has more details)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
