### PR TITLE
codeintel: Set size on index VMs

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer-vm/env.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/env.go
@@ -19,6 +19,7 @@ var (
 	rawUseFirecracker           = env.Get("PRECISE_CODE_INTEL_USE_FIRECRACKER", "true", "Whether to isolate index containers in virtual machines.")
 	rawFirecrackerNumCPUs       = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_NUM_CPUS", "4", "How many CPUs to allocate to each virtual machine or container.")
 	rawFirecrackerMemory        = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_MEMORY", "12G", "How much memory to allocate to each virtual machine or container.")
+	rawFirecrackerDiskSpace     = env.Get("PRECISE_CODE_INTEL_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine or container.")
 	rawImageArchivePath         = env.Get("PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH", "", "Where to store tar archives of docker images shared by virtual machines.")
 )
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/formatter.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/formatter.go
@@ -236,6 +236,7 @@ func (r *firecrackerCommandFormatter) resourceFlags() []string {
 	return []string{
 		"--cpus", strconv.Itoa(r.options.FirecrackerNumCPUs),
 		"--memory", r.options.FirecrackerMemory,
+		"--size", r.options.FirecrackerDiskSpace,
 	}
 }
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler.go
@@ -39,6 +39,7 @@ type HandlerOptions struct {
 	UseFirecracker        bool
 	FirecrackerNumCPUs    int
 	FirecrackerMemory     string
+	FirecrackerDiskSpace  string
 	ImageArchivePath      string
 }
 

--- a/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/internal/indexer/handler_test.go
@@ -31,6 +31,7 @@ func TestHandleWithDocker(t *testing.T) {
 			AuthToken:             "hunter2",
 			FirecrackerNumCPUs:    8,
 			FirecrackerMemory:     "32G",
+			FirecrackerDiskSpace:  "50G",
 		},
 		uuidGenerator: uuid.NewRandom,
 	}
@@ -104,6 +105,7 @@ func TestHandleWithFirecracker(t *testing.T) {
 			FirecrackerImage:      "sourcegraph/ignite-ubuntu:latest",
 			FirecrackerNumCPUs:    8,
 			FirecrackerMemory:     "32G",
+			FirecrackerDiskSpace:  "50G",
 			ImageArchivePath:      "/images",
 		},
 		uuidGenerator: func() (uuid.UUID, error) {
@@ -154,7 +156,7 @@ func TestHandleWithFirecracker(t *testing.T) {
 			"docker pull sourcegraph/lsif-go:latest",
 			"docker save -o /images/image3.tar sourcegraph/lsif-go:latest",
 			// VM setup
-			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --copy-files /tmp/testing:/repo-dir --copy-files /images/image0.tar:/image0.tar --copy-files /images/image1.tar:/image1.tar --copy-files /images/image2.tar:/image2.tar --copy-files /images/image3.tar:/image3.tar --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
+			"ignite run --runtime docker --network-plugin docker-bridge --cpus 8 --memory 32G --size 50G --copy-files /tmp/testing:/repo-dir --copy-files /images/image0.tar:/image0.tar --copy-files /images/image1.tar:/image1.tar --copy-files /images/image2.tar:/image2.tar --copy-files /images/image3.tar:/image3.tar --ssh --name 97b45daf-53d1-48ad-b992-547469d8e438 sourcegraph/ignite-ubuntu:latest",
 			// Docker-inside-Vm` setup
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /image0.tar",
 			"ignite exec 97b45daf-53d1-48ad-b992-547469d8e438 -- docker load -i /image1.tar",

--- a/enterprise/cmd/precise-code-intel-indexer-vm/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer-vm/main.go
@@ -37,6 +37,7 @@ func main() {
 		useFirecracker           = mustParseBool(rawUseFirecracker, "PRECISE_CODE_INTEL_USE_FIRECRACKER")
 		firecrackerNumCPUs       = mustParseInt(rawFirecrackerNumCPUs, "PRECISE_CODE_INTEL_FIRECRACKER_NUM_CPUS")
 		firecrackerMemory        = mustGet(rawFirecrackerMemory, "PRECISE_CODE_INTEL_FIRECRACKER_MEMORY")
+		firecrackerDiskSpace     = mustGet(rawFirecrackerDiskSpace, "PRECISE_CODE_INTEL_FIRECRACKER_DISK_SPACE")
 		imageArchivePath         = mustGet(rawImageArchivePath, "PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH")
 	)
 
@@ -75,6 +76,7 @@ func main() {
 			UseFirecracker:        useFirecracker,
 			FirecrackerNumCPUs:    firecrackerNumCPUs,
 			FirecrackerMemory:     firecrackerMemory,
+			FirecrackerDiskSpace:  firecrackerDiskSpace,
 			ImageArchivePath:      imageArchivePath,
 		},
 	})


### PR DESCRIPTION
This closes https://github.com/sourcegraph/sourcegraph/issues/14390.

The default firecracker FS size is 4GB, which is too low to index many projects. I believe this is the reason for the high failure rate (exit status 1 is often correlated with a disk quota error in the logs).