### PR TITLE
web: specify GenericSearchResult for SearchResult component

### DIFF
--- a/web/src/components/DecoratedTextLines.tsx
+++ b/web/src/components/DecoratedTextLines.tsx
@@ -3,7 +3,6 @@ import VisibilitySensor from 'react-visibility-sensor'
 import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { highlightNode } from '../../../shared/src/util/dom'
-import { HighlightRange } from './SearchResult'
 
 interface Props {
     /**
@@ -19,7 +18,7 @@ interface Props {
     /**
      * The highlights for the lines.
      */
-    highlights?: GQL.IHighlight[] | HighlightRange[]
+    highlights?: GQL.IHighlight[]
 
     /**
      * A list of classes to apply to 1-indexed line numbers.
@@ -34,7 +33,7 @@ interface Props {
 
 interface DecoratedLine {
     value: string
-    highlights?: (GQL.IHighlight | HighlightRange)[]
+    highlights?: GQL.IHighlight[]
     classNames?: string[]
     url?: string
 }

--- a/web/src/components/SearchResult.tsx
+++ b/web/src/components/SearchResult.tsx
@@ -9,38 +9,8 @@ import { ThemeProps } from '../../../shared/src/theme'
 import * as H from 'history'
 import { Markdown } from '../../../shared/src/components/Markdown'
 
-/**
- * This is a subset of GQL.GenericSearchResultInterface and GQL.IGenericSearchResultInterface that we use to render a SearchResult.
- */
-interface GenericSearchResult {
-    /**
-     * URL to an icon that is displayed with every search result.
-     */
-    icon: string
-
-    /**
-     * A markdown string that is rendered prominently.
-     */
-    label: GQL.IMarkdown
-
-    /**
-     * The URL of the result.
-     */
-    url: string
-
-    /**
-     * A markdown string that is rendered less prominently.
-     */
-    detail: GQL.IMarkdown
-
-    /**
-     * A list of matches in this search result.
-     */
-    matches: GQL.ISearchResultMatch[]
-}
-
 interface Props extends ThemeProps {
-    result: GenericSearchResult
+    result: Omit<GQL.IGenericSearchResultInterface, '__typename'>
     history: H.History
 }
 

--- a/web/src/components/SearchResult.tsx
+++ b/web/src/components/SearchResult.tsx
@@ -9,23 +9,38 @@ import { ThemeProps } from '../../../shared/src/theme'
 import * as H from 'history'
 import { Markdown } from '../../../shared/src/components/Markdown'
 
-export interface HighlightRange {
+/**
+ * This is a subset of GQL.GenericSearchResultInterface and GQL.IGenericSearchResultInterface that we use to render a SearchResult.
+ */
+interface GenericSearchResult {
     /**
-     * The 0-based line number that this highlight appears in
+     * URL to an icon that is displayed with every search result.
      */
-    line: number
+    icon: string
+
     /**
-     * The 0-based character offset to start highlighting at
+     * A markdown string that is rendered prominently.
      */
-    character: number
+    label: GQL.IMarkdown
+
     /**
-     * The number of characters to highlight
+     * The URL of the result.
      */
-    length: number
+    url: string
+
+    /**
+     * A markdown string that is rendered less prominently.
+     */
+    detail: GQL.IMarkdown
+
+    /**
+     * A list of matches in this search result.
+     */
+    matches: GQL.ISearchResultMatch[]
 }
 
 interface Props extends ThemeProps {
-    result: GQL.GenericSearchResultInterface
+    result: GenericSearchResult
     history: H.History
 }
 
@@ -59,26 +74,15 @@ export class SearchResult extends React.Component<Props> {
 
     private renderBody = (): JSX.Element => (
         <>
-            {this.props.result.matches.map(match => {
-                const highlightRanges: HighlightRange[] = []
-                match.highlights.map(highlight =>
-                    highlightRanges.push({
-                        line: highlight.line,
-                        character: highlight.character,
-                        length: highlight.length,
-                    })
-                )
-
-                return (
-                    <SearchResultMatch
-                        key={match.url}
-                        item={match}
-                        highlightRanges={highlightRanges}
-                        isLightTheme={this.props.isLightTheme}
-                        history={this.props.history}
-                    />
-                )
-            })}
+            {this.props.result.matches.map(match => (
+                <SearchResultMatch
+                    key={match.url}
+                    item={match}
+                    highlightRanges={match.highlights}
+                    isLightTheme={this.props.isLightTheme}
+                    history={this.props.history}
+                />
+            ))}
         </>
     )
 

--- a/web/src/components/SearchResultMatch.tsx
+++ b/web/src/components/SearchResultMatch.tsx
@@ -11,14 +11,13 @@ import { Markdown } from '../../../shared/src/components/Markdown'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { highlightNode } from '../../../shared/src/util/dom'
 import { highlightCode } from '../search/backend'
-import { HighlightRange } from './SearchResult'
 import { ThemeProps } from '../../../shared/src/theme'
 import * as H from 'history'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 
 interface SearchResultMatchProps extends ThemeProps {
     item: GQL.ISearchResultMatch
-    highlightRanges: HighlightRange[]
+    highlightRanges: GQL.IHighlight[]
     history: H.History
 }
 


### PR DESCRIPTION
We omit the __typename field so that repository and commit search match the
interface.  This is specified so we can use it in streaming search.

Additionally we remove the HighlightRange interface since
GQL.ISearchResultMatch.highlights has the same field names.