### PR TITLE
codeintel: Publish index configuration from database

### DIFF
--- a/dev/db/add_migration.sh
+++ b/dev/db/add_migration.sh
@@ -27,7 +27,7 @@ END {
 EOF
 )
 
-files=$(find . -type f -name '[0-9]*.sql' | sort | awk -v name="$1" "$awkcmd")
+files=$(find . -type f -name '[0-9]*.sql' | sort | awk -v name="$2" "$awkcmd")
 
 for f in $files; do
   cat >"$f" <<EOF

--- a/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/index"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -49,6 +50,11 @@ func NewScheduler(
 }
 
 func (s *Scheduler) Handle(ctx context.Context) error {
+	configuredRepositoryIDs, err := s.store.GetRepositoriesWithIndexConfiguration(ctx)
+	if err != nil {
+		return errors.Wrap(err, "store.GetRepositoriesWithIndexConfiguration")
+	}
+
 	indexableRepositories, err := s.store.IndexableRepositories(ctx, store.IndexableRepositoryQueryOptions{
 		Limit:                       s.batchSize,
 		MinimumTimeSinceLastEnqueue: s.minimumTimeSinceLastEnqueue,
@@ -60,8 +66,13 @@ func (s *Scheduler) Handle(ctx context.Context) error {
 		return errors.Wrap(err, "store.IndexableRepositories")
 	}
 
+	var indexableRepositoryIDs []int
 	for _, indexableRepository := range indexableRepositories {
-		if err := s.queueIndex(ctx, indexableRepository); err != nil {
+		indexableRepositoryIDs = append(indexableRepositoryIDs, indexableRepository.RepositoryID)
+	}
+
+	for _, repositoryID := range deduplicateRepositoryIDs(configuredRepositoryIDs, indexableRepositoryIDs) {
+		if err := s.queueIndex(ctx, repositoryID); err != nil {
 			if isRepoNotExist(err) {
 				continue
 			}
@@ -78,17 +89,25 @@ func (s *Scheduler) HandleError(err error) {
 	log15.Error("Failed to update indexable repositories", "err", err)
 }
 
-func (s *Scheduler) queueIndex(ctx context.Context, indexableRepository store.IndexableRepository) (err error) {
-	commit, err := s.gitserverClient.Head(ctx, s.store, indexableRepository.RepositoryID)
+func (s *Scheduler) queueIndex(ctx context.Context, repositoryID int) (err error) {
+	commit, err := s.gitserverClient.Head(ctx, s.store, repositoryID)
 	if err != nil {
 		return errors.Wrap(err, "gitserver.Head")
 	}
 
-	isQueued, err := s.store.IsQueued(ctx, indexableRepository.RepositoryID, commit)
+	isQueued, err := s.store.IsQueued(ctx, repositoryID, commit)
 	if err != nil {
 		return errors.Wrap(err, "store.IsQueued")
 	}
 	if isQueued {
+		return nil
+	}
+
+	indexes, err := s.inferIndexes(ctx, repositoryID, commit)
+	if err != nil {
+		return err
+	}
+	if len(indexes) == 0 {
 		return nil
 	}
 
@@ -100,38 +119,107 @@ func (s *Scheduler) queueIndex(ctx context.Context, indexableRepository store.In
 		err = tx.Done(err)
 	}()
 
-	id, err := tx.InsertIndex(ctx, store.Index{
+	for _, index := range indexes {
+		id, err := tx.InsertIndex(ctx, index)
+		if err != nil {
+			return errors.Wrap(err, "store.QueueIndex")
+		}
+
+		log15.Info(
+			"Enqueued index",
+			"id", id,
+			"repository_id", repositoryID,
+			"commit", commit,
+		)
+	}
+
+	now := time.Now().UTC()
+	update := store.UpdateableIndexableRepository{
+		RepositoryID:        repositoryID,
+		LastIndexEnqueuedAt: &now,
+	}
+
+	// TODO(efritz) - this may create records once a repository has an explicit
+	// index configuration. This shouldn't affect any indexing behavior at all.
+	if err := tx.UpdateIndexableRepository(ctx, update, now); err != nil {
+		return errors.Wrap(err, "store.UpdateIndexableRepository")
+	}
+
+	return nil
+}
+
+func (s *Scheduler) inferIndexes(ctx context.Context, repositoryID int, commit string) ([]store.Index, error) {
+	indexConfigurationRecord, ok, err := s.store.GetIndexConfigurationByRepositoryID(ctx, repositoryID)
+	if err != nil {
+		return nil, errors.Wrap(err, "store.GetIndexConfigurationByRepositoryID")
+	}
+	if ok {
+		indexConfiguration, err := index.UnmarshalJSON(indexConfigurationRecord.Data)
+		if err != nil {
+			log15.Warn("Failed to unmarshal index configuration", "repository_id", repositoryID)
+			return nil, nil
+		}
+
+		var indexes []store.Index
+		for _, indexJob := range indexConfiguration.IndexJobs {
+			var dockerSteps []store.DockerStep
+			for _, dockerStep := range indexConfiguration.SharedSteps {
+				dockerSteps = append(dockerSteps, store.DockerStep{
+					Root:     dockerStep.Root,
+					Image:    dockerStep.Image,
+					Commands: dockerStep.Commands,
+				})
+			}
+			for _, dockerStep := range indexJob.Steps {
+				dockerSteps = append(dockerSteps, store.DockerStep{
+					Root:     dockerStep.Root,
+					Image:    dockerStep.Image,
+					Commands: dockerStep.Commands,
+				})
+			}
+
+			indexes = append(indexes, store.Index{
+				Commit:       commit,
+				RepositoryID: repositoryID,
+				State:        "queued",
+				DockerSteps:  dockerSteps,
+				Root:         indexJob.Root,
+				Indexer:      indexJob.Indexer,
+				IndexerArgs:  indexJob.IndexerArgs,
+				Outfile:      indexJob.Outfile,
+			})
+		}
+
+		return indexes, nil
+	}
+
+	index := store.Index{
 		Commit:       commit,
-		RepositoryID: indexableRepository.RepositoryID,
+		RepositoryID: repositoryID,
 		State:        "queued",
 		DockerSteps:  []store.DockerStep{},
 		Root:         "",
 		Indexer:      "sourcegraph/lsif-go:latest",
 		IndexerArgs:  []string{"lsif-go", "--no-animation"},
 		Outfile:      "",
-	})
-	if err != nil {
-		return errors.Wrap(err, "store.QueueIndex")
 	}
 
-	now := time.Now().UTC()
-	update := store.UpdateableIndexableRepository{
-		RepositoryID:        indexableRepository.RepositoryID,
-		LastIndexEnqueuedAt: &now,
+	return []store.Index{index}, nil
+}
+
+func deduplicateRepositoryIDs(ids ...[]int) (repositoryIDs []int) {
+	repositoryIDMap := map[int]struct{}{}
+	for _, s := range ids {
+		for _, v := range s {
+			repositoryIDMap[v] = struct{}{}
+		}
 	}
 
-	if err := tx.UpdateIndexableRepository(ctx, update, now); err != nil {
-		return errors.Wrap(err, "store.UpdateIndexableRepository")
+	for repositoryID := range repositoryIDMap {
+		repositoryIDs = append(repositoryIDs, repositoryID)
 	}
 
-	log15.Info(
-		"Enqueued index",
-		"id", id,
-		"repository_id", indexableRepository.RepositoryID,
-		"commit", commit,
-	)
-
-	return nil
+	return repositoryIDs
 }
 
 func isRepoNotExist(err error) bool {

--- a/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler_test.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/scheduler/scheduler_test.go
@@ -28,10 +28,10 @@ func TestUpdate(t *testing.T) {
 	mockStore := storemocks.NewMockStore()
 	mockStore.TransactFunc.SetDefaultReturn(mockStore, nil)
 	mockStore.IndexableRepositoriesFunc.SetDefaultReturn([]store.IndexableRepository{
-		{RepositoryID: 1},
-		{RepositoryID: 2},
-		{RepositoryID: 3},
-		{RepositoryID: 4},
+		{RepositoryID: 41},
+		{RepositoryID: 42},
+		{RepositoryID: 43},
+		{RepositoryID: 44},
 	}, nil)
 	mockStore.IsQueuedFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string) (bool, error) {
 		return repositoryID%2 != 0, nil
@@ -61,7 +61,7 @@ func TestUpdate(t *testing.T) {
 		}
 		sort.Strings(commits)
 
-		if diff := cmp.Diff([]string{"c1", "c2", "c3", "c4"}, commits); diff != "" {
+		if diff := cmp.Diff([]string{"c41", "c42", "c43", "c44"}, commits); diff != "" {
 			t.Errorf("unexpected commits (-want +got):\n%s", diff)
 		}
 	}
@@ -75,8 +75,8 @@ func TestUpdate(t *testing.T) {
 		}
 
 		expectedIndexCommits := map[int]string{
-			2: "c2",
-			4: "c4",
+			42: "c42",
+			44: "c44",
 		}
 		if diff := cmp.Diff(expectedIndexCommits, indexCommits); diff != "" {
 			t.Errorf("unexpected indexes (-want +got):\n%s", diff)
@@ -85,5 +85,139 @@ func TestUpdate(t *testing.T) {
 
 	if len(mockStore.UpdateIndexableRepositoryFunc.History()) != 2 {
 		t.Errorf("unexpected number of calls to UpdateIndexableRepository. want=%d have=%d", 2, len(mockStore.UpdateIndexableRepositoryFunc.History()))
+	}
+}
+
+func TestUpdateExplicitIndexConfiguration(t *testing.T) {
+	indexConfiguration := store.IndexConfiguration{
+		ID:           1,
+		RepositoryID: 42,
+		Data: []byte(`{
+			"shared_steps": [
+				{
+					"root": "/",
+					"image": "node:12",
+					"commands": [
+						"yarn install --frozen-lockfile --non-interactive",
+					],
+				}
+			],
+			"index_jobs": [
+				{
+					"steps": [
+						{
+							// Comments are the future
+							"image": "go:latest",
+							"commands": ["go mod vendor"],
+						}
+					],
+					"indexer": "lsif-go",
+					"indexer_args": ["--no-animation"],
+				},
+				{
+					"root": "web/",
+					"indexer": "lsif-tsc",
+					"indexer_args": ["-p", "."],
+					"outfile": "lsif.dump",
+				},
+			]
+		}`),
+	}
+
+	mockStore := storemocks.NewMockStore()
+	mockStore.TransactFunc.SetDefaultReturn(mockStore, nil)
+	mockStore.GetRepositoriesWithIndexConfigurationFunc.SetDefaultReturn([]int{42}, nil)
+	mockStore.GetIndexConfigurationByRepositoryIDFunc.SetDefaultReturn(indexConfiguration, true, nil)
+
+	mockGitserverClient := gitservermocks.NewMockClient()
+	mockGitserverClient.HeadFunc.SetDefaultHook(func(ctx context.Context, store store.Store, repositoryID int) (string, error) {
+		return fmt.Sprintf("c%d", repositoryID), nil
+	})
+
+	scheduler := &Scheduler{
+		store:           mockStore,
+		gitserverClient: mockGitserverClient,
+		metrics:         NewSchedulerMetrics(metrics.TestRegisterer),
+	}
+
+	if err := scheduler.Handle(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing update: %s", err)
+	}
+
+	if len(mockStore.GetIndexConfigurationByRepositoryIDFunc.History()) != 1 {
+		t.Errorf("unexpected number of calls to GetIndexConfigurationByRepositoryID. want=%d have=%d", 1, len(mockStore.GetIndexConfigurationByRepositoryIDFunc.History()))
+	} else {
+		var repositoryIDs []int
+		for _, call := range mockStore.GetIndexConfigurationByRepositoryIDFunc.History() {
+			repositoryIDs = append(repositoryIDs, call.Arg1)
+		}
+		sort.Ints(repositoryIDs)
+
+		if diff := cmp.Diff([]int{42}, repositoryIDs); diff != "" {
+			t.Errorf("unexpected repository identifiers (-want +got):\n%s", diff)
+		}
+	}
+
+	if len(mockStore.IsQueuedFunc.History()) != 1 {
+		t.Errorf("unexpected number of calls to IsQueued. want=%d have=%d", 1, len(mockStore.IsQueuedFunc.History()))
+	} else {
+		var commits []string
+		for _, call := range mockStore.IsQueuedFunc.History() {
+			commits = append(commits, call.Arg2)
+		}
+		sort.Strings(commits)
+
+		if diff := cmp.Diff([]string{"c42"}, commits); diff != "" {
+			t.Errorf("unexpected commits (-want +got):\n%s", diff)
+		}
+	}
+
+	if len(mockStore.InsertIndexFunc.History()) != 2 {
+		t.Errorf("unexpected number of calls to InsertIndex. want=%d have=%d", 2, len(mockStore.InsertIndexFunc.History()))
+	} else {
+		var indexes []store.Index
+		for _, call := range mockStore.InsertIndexFunc.History() {
+			indexes = append(indexes, call.Arg1)
+		}
+
+		expectedIndexes := []store.Index{
+			{
+				RepositoryID: 42,
+				Commit:       "c42",
+				State:        "queued",
+				DockerSteps: []store.DockerStep{
+					{
+						Root:     "/",
+						Image:    "node:12",
+						Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
+					},
+					{
+						Image:    "go:latest",
+						Commands: []string{"go mod vendor"},
+					},
+				},
+				Indexer:     "lsif-go",
+				IndexerArgs: []string{"--no-animation"},
+			},
+			{
+				RepositoryID: 42,
+				Commit:       "c42",
+				State:        "queued",
+				DockerSteps: []store.DockerStep{
+					{
+						Root:     "/",
+						Image:    "node:12",
+						Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
+					},
+				},
+				Root:        "web/",
+				Indexer:     "lsif-tsc",
+				IndexerArgs: []string{"-p", "."},
+				Outfile:     "lsif.dump",
+			},
+		}
+		if diff := cmp.Diff(expectedIndexes, indexes); diff != "" {
+			t.Errorf("unexpected indexes (-want +got):\n%s", diff)
+		}
 	}
 }

--- a/enterprise/internal/codeintel/store/index_configuration.go
+++ b/enterprise/internal/codeintel/store/index_configuration.go
@@ -49,6 +49,11 @@ func scanFirstIndexConfiguration(rows *sql.Rows, err error) (IndexConfiguration,
 	return indexConfigurations[0], true, nil
 }
 
+// GetRepositoriesWithIndexConfiguration returns the ids of repositories explicit index configuration.
+func (s *store) GetRepositoriesWithIndexConfiguration(ctx context.Context) ([]int, error) {
+	return basestore.ScanInts(s.Store.Query(ctx, sqlf.Sprintf(`SELECT c.repository_id FROM lsif_index_configuration c`)))
+}
+
 // GetIndexConfigurationByRepositoryID returns the index configuration for a repository.
 func (s *store) GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (IndexConfiguration, bool, error) {
 	return scanFirstIndexConfiguration(s.Store.Query(ctx, sqlf.Sprintf(`

--- a/enterprise/internal/codeintel/store/index_configuration.go
+++ b/enterprise/internal/codeintel/store/index_configuration.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+)
+
+// IndexConfiguration stores the index configuration for a repository.
+type IndexConfiguration struct {
+	ID           int    `json:"id"`
+	RepositoryID int    `json:"repository_id"`
+	Data         []byte `json:"data"`
+}
+
+// scanIndexConfigurations scans a slice of index configurations from the return value of `*store.query`.
+func scanIndexConfigurations(rows *sql.Rows, queryErr error) (_ []IndexConfiguration, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	var indexConfigurations []IndexConfiguration
+	for rows.Next() {
+		var indexConfiguration IndexConfiguration
+		if err := rows.Scan(
+			&indexConfiguration.ID,
+			&indexConfiguration.RepositoryID,
+			&indexConfiguration.Data,
+		); err != nil {
+			return nil, err
+		}
+
+		indexConfigurations = append(indexConfigurations, indexConfiguration)
+	}
+
+	return indexConfigurations, nil
+}
+
+// scanFirstIndexConfiguration scans a slice of index configurations from the return value of `*store.query`
+// and returns the first.
+func scanFirstIndexConfiguration(rows *sql.Rows, err error) (IndexConfiguration, bool, error) {
+	indexConfigurations, err := scanIndexConfigurations(rows, err)
+	if err != nil || len(indexConfigurations) == 0 {
+		return IndexConfiguration{}, false, err
+	}
+	return indexConfigurations[0], true, nil
+}
+
+// GetIndexConfigurationByRepositoryID returns the index configuration for a repository.
+func (s *store) GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (IndexConfiguration, bool, error) {
+	return scanFirstIndexConfiguration(s.Store.Query(ctx, sqlf.Sprintf(`
+		SELECT
+			c.id,
+			c.repository_id,
+			c.data
+		FROM lsif_index_configuration c WHERE c.repository_id = %s
+	`, repositoryID)))
+}

--- a/enterprise/internal/codeintel/store/index_configuration_test.go
+++ b/enterprise/internal/codeintel/store/index_configuration_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +10,51 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
+
+func TestGetRepositoriesWithIndexConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	for _, repositoryID := range []int{42, 43, 44, 45, 46} {
+		query := sqlf.Sprintf(
+			`INSERT INTO repo (id, name) VALUES (%s, %s)`,
+			repositoryID,
+			fmt.Sprintf("github.com/baz/honk%2d", repositoryID),
+		)
+		if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+			t.Fatalf("unexpected error inserting repo: %s", err)
+		}
+	}
+
+	for i, repositoryID := range []int{42, 44, 45} {
+		query := sqlf.Sprintf(
+			`INSERT INTO lsif_index_configuration (id, repository_id, data) VALUES (%s, %s, %s)`,
+			i,
+			repositoryID,
+			[]byte(`test`),
+		)
+		if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+			t.Fatalf("unexpected error inserting repo: %s", err)
+		}
+	}
+
+	repositoryIDs, err := store.GetRepositoriesWithIndexConfiguration(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error while fetching repositories with index configuration: %s", err)
+	}
+
+	expectedRepositoryIDs := []int{
+		42,
+		44,
+		45,
+	}
+	if diff := cmp.Diff(expectedRepositoryIDs, repositoryIDs); diff != "" {
+		t.Errorf("unexpected repository identifiers (-want +got):\n%s", diff)
+	}
+}
 
 func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 	if testing.Short() {
@@ -23,9 +69,8 @@ func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 	}`)
 
 	query := sqlf.Sprintf(
-		`INSERT INTO repo (id, name, uri) VALUES (%s, %s, %s)`,
+		`INSERT INTO repo (id, name) VALUES (%s, %s)`,
 		42,
-		"github.com/baz/honk",
 		"github.com/baz/honk",
 	)
 	if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {

--- a/enterprise/internal/codeintel/store/index_configuration_test.go
+++ b/enterprise/internal/codeintel/store/index_configuration_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	expectedConfigurationData := []byte(`{
+		"foo": "bar",
+		"baz": "bonk",
+	}`)
+
+	query := sqlf.Sprintf(
+		`INSERT INTO repo (id, name, uri) VALUES (%s, %s, %s)`,
+		42,
+		"github.com/baz/honk",
+		"github.com/baz/honk",
+	)
+	if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		t.Fatalf("unexpected error inserting repo: %s", err)
+	}
+
+	query = sqlf.Sprintf(
+		`INSERT INTO lsif_index_configuration (id, repository_id, data) VALUES (%s, %s, %s)`,
+		1,
+		42,
+		expectedConfigurationData,
+	)
+	if _, err := dbconn.Global.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		t.Fatalf("unexpected error inserting repo: %s", err)
+	}
+
+	indexConfiguration, ok, err := store.GetIndexConfigurationByRepositoryID(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error while fetching index configuration: %s", err)
+	}
+	if !ok {
+		t.Fatalf("expected a configuration record")
+	}
+
+	if diff := cmp.Diff(expectedConfigurationData, indexConfiguration.Data); diff != "" {
+		t.Errorf("unexpected configuration payload (-want +got):\n%s", diff)
+	}
+}

--- a/enterprise/internal/codeintel/store/indexable_repos.go
+++ b/enterprise/internal/codeintel/store/indexable_repos.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 )
 
-// IndexableRepository marks a repository for eligibility to be index automatically.
+// IndexableRepository marks a repository for eligibility to be indexed automatically.
 type IndexableRepository struct {
 	RepositoryID        int
 	SearchCount         int

--- a/enterprise/internal/codeintel/store/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/store/mocks/mock_store.go
@@ -63,12 +63,20 @@ type MockStore struct {
 	// GetIndexByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexByID.
 	GetIndexByIDFunc *StoreGetIndexByIDFunc
+	// GetIndexConfigurationByRepositoryIDFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// GetIndexConfigurationByRepositoryID.
+	GetIndexConfigurationByRepositoryIDFunc *StoreGetIndexConfigurationByRepositoryIDFunc
 	// GetIndexesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexes.
 	GetIndexesFunc *StoreGetIndexesFunc
 	// GetPackageFunc is an instance of a mock function object controlling
 	// the behavior of the method GetPackage.
 	GetPackageFunc *StoreGetPackageFunc
+	// GetRepositoriesWithIndexConfigurationFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// GetRepositoriesWithIndexConfiguration.
+	GetRepositoriesWithIndexConfigurationFunc *StoreGetRepositoriesWithIndexConfigurationFunc
 	// GetStatesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetStates.
 	GetStatesFunc *StoreGetStatesFunc
@@ -254,6 +262,11 @@ func NewMockStore() *MockStore {
 				return store.Index{}, false, nil
 			},
 		},
+		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
+			defaultHook: func(context.Context, int) (store.IndexConfiguration, bool, error) {
+				return store.IndexConfiguration{}, false, nil
+			},
+		},
 		GetIndexesFunc: &StoreGetIndexesFunc{
 			defaultHook: func(context.Context, store.GetIndexesOptions) ([]store.Index, int, error) {
 				return nil, 0, nil
@@ -262,6 +275,11 @@ func NewMockStore() *MockStore {
 		GetPackageFunc: &StoreGetPackageFunc{
 			defaultHook: func(context.Context, string, string, string) (store.Dump, bool, error) {
 				return store.Dump{}, false, nil
+			},
+		},
+		GetRepositoriesWithIndexConfigurationFunc: &StoreGetRepositoriesWithIndexConfigurationFunc{
+			defaultHook: func(context.Context) ([]int, error) {
+				return nil, nil
 			},
 		},
 		GetStatesFunc: &StoreGetStatesFunc{
@@ -486,11 +504,17 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
 			defaultHook: i.GetIndexByID,
 		},
+		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
+			defaultHook: i.GetIndexConfigurationByRepositoryID,
+		},
 		GetIndexesFunc: &StoreGetIndexesFunc{
 			defaultHook: i.GetIndexes,
 		},
 		GetPackageFunc: &StoreGetPackageFunc{
 			defaultHook: i.GetPackage,
+		},
+		GetRepositoriesWithIndexConfigurationFunc: &StoreGetRepositoriesWithIndexConfigurationFunc{
+			defaultHook: i.GetRepositoriesWithIndexConfiguration,
 		},
 		GetStatesFunc: &StoreGetStatesFunc{
 			defaultHook: i.GetStates,
@@ -2264,6 +2288,123 @@ func (c StoreGetIndexByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// StoreGetIndexConfigurationByRepositoryIDFunc describes the behavior when
+// the GetIndexConfigurationByRepositoryID method of the parent MockStore
+// instance is invoked.
+type StoreGetIndexConfigurationByRepositoryIDFunc struct {
+	defaultHook func(context.Context, int) (store.IndexConfiguration, bool, error)
+	hooks       []func(context.Context, int) (store.IndexConfiguration, bool, error)
+	history     []StoreGetIndexConfigurationByRepositoryIDFuncCall
+	mutex       sync.Mutex
+}
+
+// GetIndexConfigurationByRepositoryID delegates to the next hook function
+// in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetIndexConfigurationByRepositoryID(v0 context.Context, v1 int) (store.IndexConfiguration, bool, error) {
+	r0, r1, r2 := m.GetIndexConfigurationByRepositoryIDFunc.nextHook()(v0, v1)
+	m.GetIndexConfigurationByRepositoryIDFunc.appendCall(StoreGetIndexConfigurationByRepositoryIDFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// GetIndexConfigurationByRepositoryID method of the parent MockStore
+// instance is invoked and the hook queue is empty.
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) SetDefaultHook(hook func(context.Context, int) (store.IndexConfiguration, bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetIndexConfigurationByRepositoryID method of the parent MockStore
+// instance inovkes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) PushHook(hook func(context.Context, int) (store.IndexConfiguration, bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) SetDefaultReturn(r0 store.IndexConfiguration, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, int) (store.IndexConfiguration, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) PushReturn(r0 store.IndexConfiguration, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, int) (store.IndexConfiguration, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) nextHook() func(context.Context, int) (store.IndexConfiguration, bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) appendCall(r0 StoreGetIndexConfigurationByRepositoryIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetIndexConfigurationByRepositoryIDFuncCall objects describing the
+// invocations of this function.
+func (f *StoreGetIndexConfigurationByRepositoryIDFunc) History() []StoreGetIndexConfigurationByRepositoryIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetIndexConfigurationByRepositoryIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetIndexConfigurationByRepositoryIDFuncCall is an object that
+// describes an invocation of method GetIndexConfigurationByRepositoryID on
+// an instance of MockStore.
+type StoreGetIndexConfigurationByRepositoryIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 store.IndexConfiguration
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 bool
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
 // StoreGetIndexesFunc describes the behavior when the GetIndexes method of
 // the parent MockStore instance is invoked.
 type StoreGetIndexesFunc struct {
@@ -2490,6 +2631,117 @@ func (c StoreGetPackageFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetPackageFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreGetRepositoriesWithIndexConfigurationFunc describes the behavior
+// when the GetRepositoriesWithIndexConfiguration method of the parent
+// MockStore instance is invoked.
+type StoreGetRepositoriesWithIndexConfigurationFunc struct {
+	defaultHook func(context.Context) ([]int, error)
+	hooks       []func(context.Context) ([]int, error)
+	history     []StoreGetRepositoriesWithIndexConfigurationFuncCall
+	mutex       sync.Mutex
+}
+
+// GetRepositoriesWithIndexConfiguration delegates to the next hook function
+// in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetRepositoriesWithIndexConfiguration(v0 context.Context) ([]int, error) {
+	r0, r1 := m.GetRepositoriesWithIndexConfigurationFunc.nextHook()(v0)
+	m.GetRepositoriesWithIndexConfigurationFunc.appendCall(StoreGetRepositoriesWithIndexConfigurationFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetRepositoriesWithIndexConfiguration method of the parent MockStore
+// instance is invoked and the hook queue is empty.
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) SetDefaultHook(hook func(context.Context) ([]int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetRepositoriesWithIndexConfiguration method of the parent MockStore
+// instance inovkes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) PushHook(hook func(context.Context) ([]int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) SetDefaultReturn(r0 []int, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) PushReturn(r0 []int, r1 error) {
+	f.PushHook(func(context.Context) ([]int, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) nextHook() func(context.Context) ([]int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) appendCall(r0 StoreGetRepositoriesWithIndexConfigurationFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetRepositoriesWithIndexConfigurationFuncCall objects describing the
+// invocations of this function.
+func (f *StoreGetRepositoriesWithIndexConfigurationFunc) History() []StoreGetRepositoriesWithIndexConfigurationFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetRepositoriesWithIndexConfigurationFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetRepositoriesWithIndexConfigurationFuncCall is an object that
+// describes an invocation of method GetRepositoriesWithIndexConfiguration
+// on an instance of MockStore.
+type StoreGetRepositoriesWithIndexConfigurationFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetStatesFunc describes the behavior when the GetStates method of

--- a/enterprise/internal/codeintel/store/observability.go
+++ b/enterprise/internal/codeintel/store/observability.go
@@ -12,55 +12,56 @@ import (
 
 // An ObservedStore wraps another store with error logging, Prometheus metrics, and tracing.
 type ObservedStore struct {
-	store                                   Store
-	doneOperation                           *observation.Operation
-	lockOperation                           *observation.Operation
-	getUploadByIDOperation                  *observation.Operation
-	getUploadsOperation                     *observation.Operation
-	queueSizeOperation                      *observation.Operation
-	insertUploadOperation                   *observation.Operation
-	addUploadPartOperation                  *observation.Operation
-	markQueuedOperation                     *observation.Operation
-	markCompleteOperation                   *observation.Operation
-	markErroredOperation                    *observation.Operation
-	dequeueOperation                        *observation.Operation
-	requeueOperation                        *observation.Operation
-	getStatesOperation                      *observation.Operation
-	deleteUploadByIDOperation               *observation.Operation
-	deleteUploadsWithoutRepositoryOperation *observation.Operation
-	hardDeleteUploadByIDOperation           *observation.Operation
-	resetStalledOperation                   *observation.Operation
-	getDumpByIDOperation                    *observation.Operation
-	findClosestDumpsOperation               *observation.Operation
-	deleteOldestDumpOperation               *observation.Operation
-	deleteOverlappingDumpsOperation         *observation.Operation
-	getPackageOperation                     *observation.Operation
-	updatePackagesOperation                 *observation.Operation
-	sameRepoPagerOperation                  *observation.Operation
-	updatePackageReferencesOperation        *observation.Operation
-	packageReferencePagerOperation          *observation.Operation
-	hasRepositoryOperation                  *observation.Operation
-	hasCommitOperation                      *observation.Operation
-	markRepositoryAsDirtyOperation          *observation.Operation
-	dirtyRepositoriesOperation              *observation.Operation
-	fixCommitsOperation                     *observation.Operation
-	indexableRepositoriesOperation          *observation.Operation
-	updateIndexableRepositoryOperation      *observation.Operation
-	resetIndexableRepositoriesOperation     *observation.Operation
-	getIndexByIDOperation                   *observation.Operation
-	getIndexesOperation                     *observation.Operation
-	indexQueueSizeOperation                 *observation.Operation
-	isQueuedOperation                       *observation.Operation
-	insertIndexOperation                    *observation.Operation
-	markIndexCompleteOperation              *observation.Operation
-	markIndexErroredOperation               *observation.Operation
-	dequeueIndexOperation                   *observation.Operation
-	requeueIndexOperation                   *observation.Operation
-	deleteIndexByIdOperation                *observation.Operation
-	deleteIndexesWithoutRepositoryOperation *observation.Operation
-	resetStalledIndexesOperation            *observation.Operation
-	repoUsageStatisticsOperation            *observation.Operation
-	repoNameOperation                       *observation.Operation
+	store                                        Store
+	doneOperation                                *observation.Operation
+	lockOperation                                *observation.Operation
+	getUploadByIDOperation                       *observation.Operation
+	getUploadsOperation                          *observation.Operation
+	queueSizeOperation                           *observation.Operation
+	insertUploadOperation                        *observation.Operation
+	addUploadPartOperation                       *observation.Operation
+	markQueuedOperation                          *observation.Operation
+	markCompleteOperation                        *observation.Operation
+	markErroredOperation                         *observation.Operation
+	dequeueOperation                             *observation.Operation
+	requeueOperation                             *observation.Operation
+	getStatesOperation                           *observation.Operation
+	deleteUploadByIDOperation                    *observation.Operation
+	deleteUploadsWithoutRepositoryOperation      *observation.Operation
+	hardDeleteUploadByIDOperation                *observation.Operation
+	resetStalledOperation                        *observation.Operation
+	getDumpByIDOperation                         *observation.Operation
+	findClosestDumpsOperation                    *observation.Operation
+	deleteOldestDumpOperation                    *observation.Operation
+	deleteOverlappingDumpsOperation              *observation.Operation
+	getPackageOperation                          *observation.Operation
+	updatePackagesOperation                      *observation.Operation
+	sameRepoPagerOperation                       *observation.Operation
+	updatePackageReferencesOperation             *observation.Operation
+	packageReferencePagerOperation               *observation.Operation
+	hasRepositoryOperation                       *observation.Operation
+	hasCommitOperation                           *observation.Operation
+	markRepositoryAsDirtyOperation               *observation.Operation
+	dirtyRepositoriesOperation                   *observation.Operation
+	fixCommitsOperation                          *observation.Operation
+	indexableRepositoriesOperation               *observation.Operation
+	updateIndexableRepositoryOperation           *observation.Operation
+	resetIndexableRepositoriesOperation          *observation.Operation
+	getIndexByIDOperation                        *observation.Operation
+	getIndexesOperation                          *observation.Operation
+	indexQueueSizeOperation                      *observation.Operation
+	isQueuedOperation                            *observation.Operation
+	insertIndexOperation                         *observation.Operation
+	markIndexCompleteOperation                   *observation.Operation
+	markIndexErroredOperation                    *observation.Operation
+	dequeueIndexOperation                        *observation.Operation
+	requeueIndexOperation                        *observation.Operation
+	deleteIndexByIdOperation                     *observation.Operation
+	deleteIndexesWithoutRepositoryOperation      *observation.Operation
+	resetStalledIndexesOperation                 *observation.Operation
+	repoUsageStatisticsOperation                 *observation.Operation
+	repoNameOperation                            *observation.Operation
+	getIndexConfigurationByRepositoryIDOperation *observation.Operation
 }
 
 var _ Store = &ObservedStore{}
@@ -316,6 +317,11 @@ func NewObserved(store Store, observationContext *observation.Context) Store {
 			MetricLabels: []string{"repo_name"},
 			Metrics:      metrics,
 		}),
+		getIndexConfigurationByRepositoryIDOperation: observationContext.Operation(observation.Op{
+			Name:         "store.GetIndexConfigurationByRepositoryID",
+			MetricLabels: []string{"get_index_configuration_by_repository_id"},
+			Metrics:      metrics,
+		}),
 	}
 }
 
@@ -326,55 +332,56 @@ func (s *ObservedStore) wrap(other Store) Store {
 	}
 
 	return &ObservedStore{
-		store:                                   other,
-		doneOperation:                           s.doneOperation,
-		lockOperation:                           s.lockOperation,
-		getUploadByIDOperation:                  s.getUploadByIDOperation,
-		deleteUploadsWithoutRepositoryOperation: s.deleteUploadsWithoutRepositoryOperation,
-		hardDeleteUploadByIDOperation:           s.hardDeleteUploadByIDOperation,
-		getUploadsOperation:                     s.getUploadsOperation,
-		queueSizeOperation:                      s.queueSizeOperation,
-		insertUploadOperation:                   s.insertUploadOperation,
-		addUploadPartOperation:                  s.addUploadPartOperation,
-		markQueuedOperation:                     s.markQueuedOperation,
-		markCompleteOperation:                   s.markCompleteOperation,
-		markErroredOperation:                    s.markErroredOperation,
-		dequeueOperation:                        s.dequeueOperation,
-		requeueOperation:                        s.requeueOperation,
-		getStatesOperation:                      s.getStatesOperation,
-		deleteUploadByIDOperation:               s.deleteUploadByIDOperation,
-		resetStalledOperation:                   s.resetStalledOperation,
-		getDumpByIDOperation:                    s.getDumpByIDOperation,
-		findClosestDumpsOperation:               s.findClosestDumpsOperation,
-		deleteOldestDumpOperation:               s.deleteOldestDumpOperation,
-		deleteOverlappingDumpsOperation:         s.deleteOverlappingDumpsOperation,
-		getPackageOperation:                     s.getPackageOperation,
-		updatePackagesOperation:                 s.updatePackagesOperation,
-		sameRepoPagerOperation:                  s.sameRepoPagerOperation,
-		updatePackageReferencesOperation:        s.updatePackageReferencesOperation,
-		packageReferencePagerOperation:          s.packageReferencePagerOperation,
-		hasRepositoryOperation:                  s.hasRepositoryOperation,
-		hasCommitOperation:                      s.hasCommitOperation,
-		markRepositoryAsDirtyOperation:          s.markRepositoryAsDirtyOperation,
-		dirtyRepositoriesOperation:              s.dirtyRepositoriesOperation,
-		fixCommitsOperation:                     s.fixCommitsOperation,
-		indexableRepositoriesOperation:          s.indexableRepositoriesOperation,
-		updateIndexableRepositoryOperation:      s.updateIndexableRepositoryOperation,
-		resetIndexableRepositoriesOperation:     s.resetIndexableRepositoriesOperation,
-		getIndexByIDOperation:                   s.getIndexByIDOperation,
-		getIndexesOperation:                     s.getIndexesOperation,
-		indexQueueSizeOperation:                 s.indexQueueSizeOperation,
-		isQueuedOperation:                       s.isQueuedOperation,
-		insertIndexOperation:                    s.insertIndexOperation,
-		markIndexCompleteOperation:              s.markIndexCompleteOperation,
-		markIndexErroredOperation:               s.markIndexErroredOperation,
-		dequeueIndexOperation:                   s.dequeueIndexOperation,
-		requeueIndexOperation:                   s.requeueIndexOperation,
-		deleteIndexByIdOperation:                s.deleteIndexByIdOperation,
-		deleteIndexesWithoutRepositoryOperation: s.deleteIndexesWithoutRepositoryOperation,
-		resetStalledIndexesOperation:            s.resetStalledIndexesOperation,
-		repoUsageStatisticsOperation:            s.repoUsageStatisticsOperation,
-		repoNameOperation:                       s.repoNameOperation,
+		store:                                        other,
+		doneOperation:                                s.doneOperation,
+		lockOperation:                                s.lockOperation,
+		getUploadByIDOperation:                       s.getUploadByIDOperation,
+		deleteUploadsWithoutRepositoryOperation:      s.deleteUploadsWithoutRepositoryOperation,
+		hardDeleteUploadByIDOperation:                s.hardDeleteUploadByIDOperation,
+		getUploadsOperation:                          s.getUploadsOperation,
+		queueSizeOperation:                           s.queueSizeOperation,
+		insertUploadOperation:                        s.insertUploadOperation,
+		addUploadPartOperation:                       s.addUploadPartOperation,
+		markQueuedOperation:                          s.markQueuedOperation,
+		markCompleteOperation:                        s.markCompleteOperation,
+		markErroredOperation:                         s.markErroredOperation,
+		dequeueOperation:                             s.dequeueOperation,
+		requeueOperation:                             s.requeueOperation,
+		getStatesOperation:                           s.getStatesOperation,
+		deleteUploadByIDOperation:                    s.deleteUploadByIDOperation,
+		resetStalledOperation:                        s.resetStalledOperation,
+		getDumpByIDOperation:                         s.getDumpByIDOperation,
+		findClosestDumpsOperation:                    s.findClosestDumpsOperation,
+		deleteOldestDumpOperation:                    s.deleteOldestDumpOperation,
+		deleteOverlappingDumpsOperation:              s.deleteOverlappingDumpsOperation,
+		getPackageOperation:                          s.getPackageOperation,
+		updatePackagesOperation:                      s.updatePackagesOperation,
+		sameRepoPagerOperation:                       s.sameRepoPagerOperation,
+		updatePackageReferencesOperation:             s.updatePackageReferencesOperation,
+		packageReferencePagerOperation:               s.packageReferencePagerOperation,
+		hasRepositoryOperation:                       s.hasRepositoryOperation,
+		hasCommitOperation:                           s.hasCommitOperation,
+		markRepositoryAsDirtyOperation:               s.markRepositoryAsDirtyOperation,
+		dirtyRepositoriesOperation:                   s.dirtyRepositoriesOperation,
+		fixCommitsOperation:                          s.fixCommitsOperation,
+		indexableRepositoriesOperation:               s.indexableRepositoriesOperation,
+		updateIndexableRepositoryOperation:           s.updateIndexableRepositoryOperation,
+		resetIndexableRepositoriesOperation:          s.resetIndexableRepositoriesOperation,
+		getIndexByIDOperation:                        s.getIndexByIDOperation,
+		getIndexesOperation:                          s.getIndexesOperation,
+		indexQueueSizeOperation:                      s.indexQueueSizeOperation,
+		isQueuedOperation:                            s.isQueuedOperation,
+		insertIndexOperation:                         s.insertIndexOperation,
+		markIndexCompleteOperation:                   s.markIndexCompleteOperation,
+		markIndexErroredOperation:                    s.markIndexErroredOperation,
+		dequeueIndexOperation:                        s.dequeueIndexOperation,
+		requeueIndexOperation:                        s.requeueIndexOperation,
+		deleteIndexByIdOperation:                     s.deleteIndexByIdOperation,
+		deleteIndexesWithoutRepositoryOperation:      s.deleteIndexesWithoutRepositoryOperation,
+		resetStalledIndexesOperation:                 s.resetStalledIndexesOperation,
+		repoUsageStatisticsOperation:                 s.repoUsageStatisticsOperation,
+		repoNameOperation:                            s.repoNameOperation,
+		getIndexConfigurationByRepositoryIDOperation: s.getIndexConfigurationByRepositoryIDOperation,
 	}
 }
 
@@ -755,4 +762,11 @@ func (s *ObservedStore) RepoName(ctx context.Context, repositoryID int) (_ strin
 	ctx, endObservation := s.repoNameOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 	return s.store.RepoName(ctx, repositoryID)
+}
+
+// GetIndexConfigurationByRepositoryID calls into the inner store and registers the observed results.
+func (s *ObservedStore) GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (_ IndexConfiguration, _ bool, err error) {
+	ctx, endObservation := s.getIndexConfigurationByRepositoryIDOperation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+	return s.store.GetIndexConfigurationByRepositoryID(ctx, repositoryID)
 }

--- a/enterprise/internal/codeintel/store/observability.go
+++ b/enterprise/internal/codeintel/store/observability.go
@@ -12,56 +12,57 @@ import (
 
 // An ObservedStore wraps another store with error logging, Prometheus metrics, and tracing.
 type ObservedStore struct {
-	store                                        Store
-	doneOperation                                *observation.Operation
-	lockOperation                                *observation.Operation
-	getUploadByIDOperation                       *observation.Operation
-	getUploadsOperation                          *observation.Operation
-	queueSizeOperation                           *observation.Operation
-	insertUploadOperation                        *observation.Operation
-	addUploadPartOperation                       *observation.Operation
-	markQueuedOperation                          *observation.Operation
-	markCompleteOperation                        *observation.Operation
-	markErroredOperation                         *observation.Operation
-	dequeueOperation                             *observation.Operation
-	requeueOperation                             *observation.Operation
-	getStatesOperation                           *observation.Operation
-	deleteUploadByIDOperation                    *observation.Operation
-	deleteUploadsWithoutRepositoryOperation      *observation.Operation
-	hardDeleteUploadByIDOperation                *observation.Operation
-	resetStalledOperation                        *observation.Operation
-	getDumpByIDOperation                         *observation.Operation
-	findClosestDumpsOperation                    *observation.Operation
-	deleteOldestDumpOperation                    *observation.Operation
-	deleteOverlappingDumpsOperation              *observation.Operation
-	getPackageOperation                          *observation.Operation
-	updatePackagesOperation                      *observation.Operation
-	sameRepoPagerOperation                       *observation.Operation
-	updatePackageReferencesOperation             *observation.Operation
-	packageReferencePagerOperation               *observation.Operation
-	hasRepositoryOperation                       *observation.Operation
-	hasCommitOperation                           *observation.Operation
-	markRepositoryAsDirtyOperation               *observation.Operation
-	dirtyRepositoriesOperation                   *observation.Operation
-	fixCommitsOperation                          *observation.Operation
-	indexableRepositoriesOperation               *observation.Operation
-	updateIndexableRepositoryOperation           *observation.Operation
-	resetIndexableRepositoriesOperation          *observation.Operation
-	getIndexByIDOperation                        *observation.Operation
-	getIndexesOperation                          *observation.Operation
-	indexQueueSizeOperation                      *observation.Operation
-	isQueuedOperation                            *observation.Operation
-	insertIndexOperation                         *observation.Operation
-	markIndexCompleteOperation                   *observation.Operation
-	markIndexErroredOperation                    *observation.Operation
-	dequeueIndexOperation                        *observation.Operation
-	requeueIndexOperation                        *observation.Operation
-	deleteIndexByIdOperation                     *observation.Operation
-	deleteIndexesWithoutRepositoryOperation      *observation.Operation
-	resetStalledIndexesOperation                 *observation.Operation
-	repoUsageStatisticsOperation                 *observation.Operation
-	repoNameOperation                            *observation.Operation
-	getIndexConfigurationByRepositoryIDOperation *observation.Operation
+	store                                          Store
+	doneOperation                                  *observation.Operation
+	lockOperation                                  *observation.Operation
+	getUploadByIDOperation                         *observation.Operation
+	getUploadsOperation                            *observation.Operation
+	queueSizeOperation                             *observation.Operation
+	insertUploadOperation                          *observation.Operation
+	addUploadPartOperation                         *observation.Operation
+	markQueuedOperation                            *observation.Operation
+	markCompleteOperation                          *observation.Operation
+	markErroredOperation                           *observation.Operation
+	dequeueOperation                               *observation.Operation
+	requeueOperation                               *observation.Operation
+	getStatesOperation                             *observation.Operation
+	deleteUploadByIDOperation                      *observation.Operation
+	deleteUploadsWithoutRepositoryOperation        *observation.Operation
+	hardDeleteUploadByIDOperation                  *observation.Operation
+	resetStalledOperation                          *observation.Operation
+	getDumpByIDOperation                           *observation.Operation
+	findClosestDumpsOperation                      *observation.Operation
+	deleteOldestDumpOperation                      *observation.Operation
+	deleteOverlappingDumpsOperation                *observation.Operation
+	getPackageOperation                            *observation.Operation
+	updatePackagesOperation                        *observation.Operation
+	sameRepoPagerOperation                         *observation.Operation
+	updatePackageReferencesOperation               *observation.Operation
+	packageReferencePagerOperation                 *observation.Operation
+	hasRepositoryOperation                         *observation.Operation
+	hasCommitOperation                             *observation.Operation
+	markRepositoryAsDirtyOperation                 *observation.Operation
+	dirtyRepositoriesOperation                     *observation.Operation
+	fixCommitsOperation                            *observation.Operation
+	indexableRepositoriesOperation                 *observation.Operation
+	updateIndexableRepositoryOperation             *observation.Operation
+	resetIndexableRepositoriesOperation            *observation.Operation
+	getIndexByIDOperation                          *observation.Operation
+	getIndexesOperation                            *observation.Operation
+	indexQueueSizeOperation                        *observation.Operation
+	isQueuedOperation                              *observation.Operation
+	insertIndexOperation                           *observation.Operation
+	markIndexCompleteOperation                     *observation.Operation
+	markIndexErroredOperation                      *observation.Operation
+	dequeueIndexOperation                          *observation.Operation
+	requeueIndexOperation                          *observation.Operation
+	deleteIndexByIdOperation                       *observation.Operation
+	deleteIndexesWithoutRepositoryOperation        *observation.Operation
+	resetStalledIndexesOperation                   *observation.Operation
+	repoUsageStatisticsOperation                   *observation.Operation
+	repoNameOperation                              *observation.Operation
+	getRepositoriesWithIndexConfigurationOperation *observation.Operation
+	getIndexConfigurationByRepositoryIDOperation   *observation.Operation
 }
 
 var _ Store = &ObservedStore{}
@@ -317,6 +318,11 @@ func NewObserved(store Store, observationContext *observation.Context) Store {
 			MetricLabels: []string{"repo_name"},
 			Metrics:      metrics,
 		}),
+		getRepositoriesWithIndexConfigurationOperation: observationContext.Operation(observation.Op{
+			Name:         "store.GetRepositoriesWithIndeConfiguration",
+			MetricLabels: []string{"get_repositories_with_index_configuration"},
+			Metrics:      metrics,
+		}),
 		getIndexConfigurationByRepositoryIDOperation: observationContext.Operation(observation.Op{
 			Name:         "store.GetIndexConfigurationByRepositoryID",
 			MetricLabels: []string{"get_index_configuration_by_repository_id"},
@@ -332,56 +338,57 @@ func (s *ObservedStore) wrap(other Store) Store {
 	}
 
 	return &ObservedStore{
-		store:                                        other,
-		doneOperation:                                s.doneOperation,
-		lockOperation:                                s.lockOperation,
-		getUploadByIDOperation:                       s.getUploadByIDOperation,
-		deleteUploadsWithoutRepositoryOperation:      s.deleteUploadsWithoutRepositoryOperation,
-		hardDeleteUploadByIDOperation:                s.hardDeleteUploadByIDOperation,
-		getUploadsOperation:                          s.getUploadsOperation,
-		queueSizeOperation:                           s.queueSizeOperation,
-		insertUploadOperation:                        s.insertUploadOperation,
-		addUploadPartOperation:                       s.addUploadPartOperation,
-		markQueuedOperation:                          s.markQueuedOperation,
-		markCompleteOperation:                        s.markCompleteOperation,
-		markErroredOperation:                         s.markErroredOperation,
-		dequeueOperation:                             s.dequeueOperation,
-		requeueOperation:                             s.requeueOperation,
-		getStatesOperation:                           s.getStatesOperation,
-		deleteUploadByIDOperation:                    s.deleteUploadByIDOperation,
-		resetStalledOperation:                        s.resetStalledOperation,
-		getDumpByIDOperation:                         s.getDumpByIDOperation,
-		findClosestDumpsOperation:                    s.findClosestDumpsOperation,
-		deleteOldestDumpOperation:                    s.deleteOldestDumpOperation,
-		deleteOverlappingDumpsOperation:              s.deleteOverlappingDumpsOperation,
-		getPackageOperation:                          s.getPackageOperation,
-		updatePackagesOperation:                      s.updatePackagesOperation,
-		sameRepoPagerOperation:                       s.sameRepoPagerOperation,
-		updatePackageReferencesOperation:             s.updatePackageReferencesOperation,
-		packageReferencePagerOperation:               s.packageReferencePagerOperation,
-		hasRepositoryOperation:                       s.hasRepositoryOperation,
-		hasCommitOperation:                           s.hasCommitOperation,
-		markRepositoryAsDirtyOperation:               s.markRepositoryAsDirtyOperation,
-		dirtyRepositoriesOperation:                   s.dirtyRepositoriesOperation,
-		fixCommitsOperation:                          s.fixCommitsOperation,
-		indexableRepositoriesOperation:               s.indexableRepositoriesOperation,
-		updateIndexableRepositoryOperation:           s.updateIndexableRepositoryOperation,
-		resetIndexableRepositoriesOperation:          s.resetIndexableRepositoriesOperation,
-		getIndexByIDOperation:                        s.getIndexByIDOperation,
-		getIndexesOperation:                          s.getIndexesOperation,
-		indexQueueSizeOperation:                      s.indexQueueSizeOperation,
-		isQueuedOperation:                            s.isQueuedOperation,
-		insertIndexOperation:                         s.insertIndexOperation,
-		markIndexCompleteOperation:                   s.markIndexCompleteOperation,
-		markIndexErroredOperation:                    s.markIndexErroredOperation,
-		dequeueIndexOperation:                        s.dequeueIndexOperation,
-		requeueIndexOperation:                        s.requeueIndexOperation,
-		deleteIndexByIdOperation:                     s.deleteIndexByIdOperation,
-		deleteIndexesWithoutRepositoryOperation:      s.deleteIndexesWithoutRepositoryOperation,
-		resetStalledIndexesOperation:                 s.resetStalledIndexesOperation,
-		repoUsageStatisticsOperation:                 s.repoUsageStatisticsOperation,
-		repoNameOperation:                            s.repoNameOperation,
-		getIndexConfigurationByRepositoryIDOperation: s.getIndexConfigurationByRepositoryIDOperation,
+		store:                                          other,
+		doneOperation:                                  s.doneOperation,
+		lockOperation:                                  s.lockOperation,
+		getUploadByIDOperation:                         s.getUploadByIDOperation,
+		deleteUploadsWithoutRepositoryOperation:        s.deleteUploadsWithoutRepositoryOperation,
+		hardDeleteUploadByIDOperation:                  s.hardDeleteUploadByIDOperation,
+		getUploadsOperation:                            s.getUploadsOperation,
+		queueSizeOperation:                             s.queueSizeOperation,
+		insertUploadOperation:                          s.insertUploadOperation,
+		addUploadPartOperation:                         s.addUploadPartOperation,
+		markQueuedOperation:                            s.markQueuedOperation,
+		markCompleteOperation:                          s.markCompleteOperation,
+		markErroredOperation:                           s.markErroredOperation,
+		dequeueOperation:                               s.dequeueOperation,
+		requeueOperation:                               s.requeueOperation,
+		getStatesOperation:                             s.getStatesOperation,
+		deleteUploadByIDOperation:                      s.deleteUploadByIDOperation,
+		resetStalledOperation:                          s.resetStalledOperation,
+		getDumpByIDOperation:                           s.getDumpByIDOperation,
+		findClosestDumpsOperation:                      s.findClosestDumpsOperation,
+		deleteOldestDumpOperation:                      s.deleteOldestDumpOperation,
+		deleteOverlappingDumpsOperation:                s.deleteOverlappingDumpsOperation,
+		getPackageOperation:                            s.getPackageOperation,
+		updatePackagesOperation:                        s.updatePackagesOperation,
+		sameRepoPagerOperation:                         s.sameRepoPagerOperation,
+		updatePackageReferencesOperation:               s.updatePackageReferencesOperation,
+		packageReferencePagerOperation:                 s.packageReferencePagerOperation,
+		hasRepositoryOperation:                         s.hasRepositoryOperation,
+		hasCommitOperation:                             s.hasCommitOperation,
+		markRepositoryAsDirtyOperation:                 s.markRepositoryAsDirtyOperation,
+		dirtyRepositoriesOperation:                     s.dirtyRepositoriesOperation,
+		fixCommitsOperation:                            s.fixCommitsOperation,
+		indexableRepositoriesOperation:                 s.indexableRepositoriesOperation,
+		updateIndexableRepositoryOperation:             s.updateIndexableRepositoryOperation,
+		resetIndexableRepositoriesOperation:            s.resetIndexableRepositoriesOperation,
+		getIndexByIDOperation:                          s.getIndexByIDOperation,
+		getIndexesOperation:                            s.getIndexesOperation,
+		indexQueueSizeOperation:                        s.indexQueueSizeOperation,
+		isQueuedOperation:                              s.isQueuedOperation,
+		insertIndexOperation:                           s.insertIndexOperation,
+		markIndexCompleteOperation:                     s.markIndexCompleteOperation,
+		markIndexErroredOperation:                      s.markIndexErroredOperation,
+		dequeueIndexOperation:                          s.dequeueIndexOperation,
+		requeueIndexOperation:                          s.requeueIndexOperation,
+		deleteIndexByIdOperation:                       s.deleteIndexByIdOperation,
+		deleteIndexesWithoutRepositoryOperation:        s.deleteIndexesWithoutRepositoryOperation,
+		resetStalledIndexesOperation:                   s.resetStalledIndexesOperation,
+		repoUsageStatisticsOperation:                   s.repoUsageStatisticsOperation,
+		repoNameOperation:                              s.repoNameOperation,
+		getRepositoriesWithIndexConfigurationOperation: s.getRepositoriesWithIndexConfigurationOperation,
+		getIndexConfigurationByRepositoryIDOperation:   s.getIndexConfigurationByRepositoryIDOperation,
 	}
 }
 
@@ -762,6 +769,13 @@ func (s *ObservedStore) RepoName(ctx context.Context, repositoryID int) (_ strin
 	ctx, endObservation := s.repoNameOperation.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 	return s.store.RepoName(ctx, repositoryID)
+}
+
+// GetRepositoriesWithIndexConfiguration calls into the inner store and registers the observed results.
+func (s *ObservedStore) GetRepositoriesWithIndexConfiguration(ctx context.Context) (_ []int, err error) {
+	ctx, endObservation := s.getRepositoriesWithIndexConfigurationOperation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+	return s.store.GetRepositoriesWithIndexConfiguration(ctx)
 }
 
 // GetIndexConfigurationByRepositoryID calls into the inner store and registers the observed results.

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -210,6 +210,9 @@ type Store interface {
 
 	// RepoName returns the name for the repo with the given identifier.
 	RepoName(ctx context.Context, repositoryID int) (string, error)
+
+	// GetIndexConfigurationByRepositoryID returns the index configuration for a repository.
+	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (IndexConfiguration, bool, error)
 }
 
 type store struct {

--- a/enterprise/internal/codeintel/store/store.go
+++ b/enterprise/internal/codeintel/store/store.go
@@ -211,6 +211,9 @@ type Store interface {
 	// RepoName returns the name for the repo with the given identifier.
 	RepoName(ctx context.Context, repositoryID int) (string, error)
 
+	// GetRepositoriesWithIndexConfiguration returns the ids of repositories explicit index configuration.
+	GetRepositoriesWithIndexConfiguration(ctx context.Context) ([]int, error)
+
 	// GetIndexConfigurationByRepositoryID returns the index configuration for a repository.
 	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (IndexConfiguration, bool, error)
 }

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -551,6 +551,21 @@ Indexes:
 
 ```
 
+# Table "public.lsif_index_configuration"
+```
+    Column     |  Type   |                               Modifiers                               
+---------------+---------+-----------------------------------------------------------------------
+ id            | bigint  | not null default nextval('lsif_index_configuration_id_seq'::regclass)
+ repository_id | integer | not null
+ data          | bytea   | not null
+Indexes:
+    "lsif_index_configuration_pkey" PRIMARY KEY, btree (id)
+    "lsif_index_configuration_repository_id_key" UNIQUE CONSTRAINT, btree (repository_id)
+Foreign-key constraints:
+    "lsif_index_configuration_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
+
+```
+
 # Table "public.lsif_indexable_repositories"
 ```
          Column         |           Type           |                                Modifiers                                 
@@ -949,6 +964,7 @@ Referenced by:
     TABLE "default_repos" CONSTRAINT "default_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "discussion_threads_target_repo" CONSTRAINT "discussion_threads_target_repo_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "lsif_index_configuration" CONSTRAINT "lsif_index_configuration_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
 Triggers:
     trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE PROCEDURE delete_repo_ref_on_external_service_repos()
 

--- a/migrations/frontend/1528395728_lsif_index_configuration.down.sql
+++ b/migrations/frontend/1528395728_lsif_index_configuration.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE lsif_index_configuration;
+
+COMMIT;

--- a/migrations/frontend/1528395728_lsif_index_configuration.up.sql
+++ b/migrations/frontend/1528395728_lsif_index_configuration.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE TABLE lsif_index_configuration (
+    id bigserial NOT NULL PRIMARY KEY,
+    repository_id integer UNIQUE NOT NULL REFERENCES repo(id) ON DELETE CASCADE,
+    data bytea NOT NULL
+);
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -88,6 +88,8 @@
 // 1528395726_lsif_index_defaults.up.sql (164B)
 // 1528395727_frontend.down.sql (139B)
 // 1528395727_frontend.up.sql (139B)
+// 1528395728_lsif_index_configuration.down.sql (54B)
+// 1528395728_lsif_index_configuration.up.sql (204B)
 
 package migrations
 
@@ -1916,6 +1918,46 @@ func _1528395727_frontendUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395728_lsif_index_configurationDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\xc8\x29\xce\x4c\x8b\xcf\xcc\x4b\x49\xad\x88\x4f\xce\xcf\x4b\xcb\x4c\x2f\x2d\x4a\x2c\xc9\xcc\xcf\xb3\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xb8\x04\xb7\xcd\x36\x00\x00\x00")
+
+func _1528395728_lsif_index_configurationDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395728_lsif_index_configurationDownSql,
+		"1528395728_lsif_index_configuration.down.sql",
+	)
+}
+
+func _1528395728_lsif_index_configurationDownSql() (*asset, error) {
+	bytes, err := _1528395728_lsif_index_configurationDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395728_lsif_index_configuration.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc9, 0x28, 0x6e, 0x4b, 0x63, 0xda, 0x29, 0x47, 0xaf, 0x48, 0xb2, 0xae, 0x44, 0x62, 0x19, 0x2d, 0x9d, 0xe6, 0x28, 0x71, 0x6b, 0x31, 0x61, 0x23, 0xc3, 0x50, 0xc, 0xb7, 0x66, 0x5a, 0xd7, 0xcb}}
+	return a, nil
+}
+
+var __1528395728_lsif_index_configurationUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x44\xce\xc1\x6a\xc4\x20\x14\x85\xe1\xbd\x4f\x71\x96\x33\xd0\x37\x98\x95\xe3\xdc\x16\xa9\x31\xad\x63\x16\xb3\x0a\x4e\x35\xe1\x42\xd0\x62\x2c\x34\x6f\x5f\x9a\x42\x67\x7f\xbe\xc3\x7f\xa6\x17\x6d\x4f\x42\x28\x47\xd2\x13\xbc\x3c\x1b\xc2\xb2\xf2\x34\x72\x8e\xe9\x7b\xfc\x28\x79\xe2\xf9\xab\x86\xc6\x25\xe3\x20\x00\x80\x23\xee\x3c\xaf\xa9\x72\x58\x60\x7b\x0f\x3b\x18\x83\x37\xa7\x3b\xe9\x6e\x78\xa5\xdb\xd3\x3e\xab\xe9\xb3\xac\xdc\x4a\xdd\x46\x8e\xe0\xdc\xd2\x9c\x2a\x06\xab\xdf\x07\x7a\x30\x47\xcf\xe4\xc8\x2a\xba\xee\xe0\xc0\xf1\x88\xde\xe2\x42\x86\x3c\x41\xc9\xab\x92\x17\xfa\x3b\x8c\xa1\x05\xdc\xb7\x96\xc2\x3f\x17\xc7\xdf\xf6\xbe\xeb\xb4\x3f\x89\x9f\x00\x00\x00\xff\xff\x69\xce\x75\x65\xcc\x00\x00\x00")
+
+func _1528395728_lsif_index_configurationUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395728_lsif_index_configurationUpSql,
+		"1528395728_lsif_index_configuration.up.sql",
+	)
+}
+
+func _1528395728_lsif_index_configurationUpSql() (*asset, error) {
+	bytes, err := _1528395728_lsif_index_configurationUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395728_lsif_index_configuration.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd6, 0x41, 0x4a, 0x57, 0x98, 0xc9, 0x8e, 0xbc, 0x2b, 0xe3, 0x49, 0x1e, 0x8e, 0xf5, 0x94, 0xdc, 0x56, 0x4b, 0x98, 0xe8, 0xc3, 0xe3, 0x5f, 0x74, 0x86, 0x9e, 0x9f, 0xe7, 0xef, 0x80, 0xdb, 0x98}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2095,6 +2137,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395726_lsif_index_defaults.up.sql":                                        _1528395726_lsif_index_defaultsUpSql,
 	"1528395727_frontend.down.sql":                                                 _1528395727_frontendDownSql,
 	"1528395727_frontend.up.sql":                                                   _1528395727_frontendUpSql,
+	"1528395728_lsif_index_configuration.down.sql":                                 _1528395728_lsif_index_configurationDownSql,
+	"1528395728_lsif_index_configuration.up.sql":                                   _1528395728_lsif_index_configurationUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2229,6 +2273,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395726_lsif_index_defaults.up.sql":                                        {_1528395726_lsif_index_defaultsUpSql, map[string]*bintree{}},
 	"1528395727_frontend.down.sql":                                                 {_1528395727_frontendDownSql, map[string]*bintree{}},
 	"1528395727_frontend.up.sql":                                                   {_1528395727_frontendUpSql, map[string]*bintree{}},
+	"1528395728_lsif_index_configuration.down.sql":                                 {_1528395728_lsif_index_configurationDownSql, map[string]*bintree{}},
+	"1528395728_lsif_index_configuration.up.sql":                                   {_1528395728_lsif_index_configurationUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This PR adds a table to the frontend Postgres instance that stores a configuration payload for index-configured repositories. We don't currently have a way to insert these records (so manual db access OR additional work on the UI/GraphQL API will be required to insert records for https://github.com/sourcegraph/sourcegraph/issues/14343).

This closes https://github.com/sourcegraph/sourcegraph/issues/14409.