### PR TITLE
repogroup: add icon styles, give cncf logo some margin

### DIFF
--- a/client/web/src/repogroups/RepogroupPage.scss
+++ b/client/web/src/repogroups/RepogroupPage.scss
@@ -10,6 +10,7 @@
     &__logo {
         width: 3rem;
         height: 3rem;
+        margin: 0.5rem;
     }
 
     &__logo-container {


### PR DESCRIPTION
This is really minor, but since the CNCF logo is a square and there's no margin, it feels ever so slightly too close to the text. This is a quick hack to add a bit of a margin to this logo, but feel free to close with a better implementation :)  

After and before:

![image](https://user-images.githubusercontent.com/23356519/95144187-9d4f8080-07aa-11eb-9ea8-06bab7ac3d93.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
