### PR TITLE
codeintel: Fix proper suffix for project root check

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/correlation/correlate.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/correlation/correlate.go
@@ -207,7 +207,7 @@ func correlateMetaData(state *wrappedState, element lsif.Element) error {
 		payload.ProjectRoot += "/"
 	}
 
-	if state.dumpRoot != "" && !strings.HasSuffix(payload.ProjectRoot, state.dumpRoot) {
+	if state.dumpRoot != "" && !strings.HasSuffix(payload.ProjectRoot, "/"+state.dumpRoot) {
 		payload.ProjectRoot += state.dumpRoot
 	}
 


### PR DESCRIPTION
The old substring matched partial segments which made files like `{root_name}.go` match incorrectly.