### PR TITLE
Enhancements

### DIFF
--- a/cmd/repo-updater/repoupdater/encrypt_tables.go
+++ b/cmd/repo-updater/repoupdater/encrypt_tables.go
@@ -1,0 +1,35 @@
+package repoupdater //TODO: Decide where this needs to live, we need the keys to perform rotation
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/sourcegraph/sourcegraph/internal/db"
+)
+
+func BackgroundEncryption(ctx context.Context, database *sql.DB) error {
+
+	// TODO: Consider dbworker pkg to run this in the background
+	err := db.TableRotateEncryption(ctx, database, "user_external_accounts",
+		db.SecretColumn{Name: "auth_data", Nullable: true},
+		db.SecretColumn{Name: "account_data", Nullable: true})
+	errlist := multierror.Append(err, err)
+
+	err = db.TableRotateEncryption(ctx, database,
+		"external_service", db.SecretColumn{Name: "config", Nullable: false})
+	errlist = multierror.Append(errlist, err)
+
+	err = db.TableRotateEncryption(ctx, database, "saved_searches",
+		db.SecretColumn{Name: "query", Nullable: false})
+	errlist = multierror.Append(errlist, err)
+
+	err = db.TableRotateEncryption(ctx, database,
+		"external_service_repo", db.SecretColumn{
+			Name:     "clone_url",
+			Nullable: false,
+		})
+
+	return err
+}

--- a/internal/db/encrypt_table_test.go
+++ b/internal/db/encrypt_table_test.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestTableRotateEncryption(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	db := dbconn.Global
+	ctx := context.Background()
+	err := insertTestData()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		table   string
+		cols    []SecretColumn
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			"bootstrap",
+			"external_service_repos",
+			[]SecretColumn{{
+				Name:     "clone_url",
+				Nullable: false,
+			}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := TableRotateEncryption(ctx, db, tt.table, tt.cols...); (err != nil) != tt.wantErr {
+				t.Errorf("TableRotateEncryption() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func insertTestData() error {
+	const testUser = `INSERT INTO users(id,username) VALUES (1,'test')`
+	_, err := dbconn.Global.Exec(testUser)
+	const testData = `INSERT INTO saved_searches(id,user_id,query,notify_owner,notify_slack,description) VALUES (1,1,'secretTokenString',false,false,false) `
+
+	_, err = dbconn.Global.Exec(testData)
+	return err
+}


### PR DESCRIPTION
Small changes to https://github.com/sourcegraph/sourcegraph/pull/14231 that adds tests and shows a possible way to run `TableRotateEncryption` in repo-updater

