### PR TITLE
search: don't split repos for global queries

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -1874,7 +1875,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			defer wg.Done()
 			agg.doFilePathSearch(ctx, &argsIndexed)
 		})
-		args.Mode = search.SearcherOnly
+		// On sourcegraph.com and for unscoped queries, determineRepos returns the subset
+		// of indexed default repositories. No need to call searcher, because
+		// len(searcherRepos) will always be 0.
+		if envvar.SourcegraphDotComMode() {
+			args.Mode = search.NoFilePath
+		} else {
+			args.Mode = search.SearcherOnly
+		}
 	}
 
 	resolved, alertResult, err := r.determineRepos(ctx, tr, start)
@@ -1918,7 +1926,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 				agg.doSymbolSearch(ctx, &args, int(r.maxResults()))
 			})
 		case "file", "path":
-			if searchedFileContentsOrPaths {
+			if searchedFileContentsOrPaths || args.Mode == search.NoFilePath {
 				// type:file and type:path use same searchFilesInRepos, so don't call 2x.
 				continue
 			}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -316,6 +316,8 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		indexedTyp = fileRequest
 	}
 
+	// performance: for global searches, we avoid calling newIndexedSearchRequest
+	// because zoekt will anyway have to search all its shards.
 	var indexed *indexedSearchRequest
 	if args.Mode == search.ZoektGlobalSearch {
 		indexed = &indexedSearchRequest{

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -75,6 +75,7 @@ type GlobalSearchMode int
 const (
 	ZoektGlobalSearch GlobalSearchMode = iota + 1
 	SearcherOnly
+	NoFilePath
 )
 
 type Promise struct {


### PR DESCRIPTION
For sourcegraph.com and global queries, we already limit our search to indexed
default repos. Hence there is no need to call searcher. This PR removes
searcher and `newIndexedSearchRequest` from the critical path of global queries.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
