### PR TITLE
search: LogBackendEvent asynchronously

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -613,10 +613,12 @@ func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32)
 		if actor.IsAuthenticated() {
 			value := fmt.Sprintf(`{"durationMs": %d}`, durationMs)
 			eventName := fmt.Sprintf("search.latencies.%s", types[0])
-			err := usagestats.LogBackendEvent(actor.UID, eventName, json.RawMessage(value))
-			if err != nil {
-				log15.Warn("Could not log search latency", "err", err)
-			}
+			go func() {
+				err := usagestats.LogBackendEvent(actor.UID, eventName, json.RawMessage(value))
+				if err != nil {
+					log15.Warn("Could not log search latency", "err", err)
+				}
+			}()
 		}
 	}
 }


### PR DESCRIPTION
This function takes 47ms on the critical path on Sourcegraph.com.