### PR TITLE
Add alert and metric for total queued jobs

### DIFF
--- a/cmd/repo-updater/repos/metrics.go
+++ b/cmd/repo-updater/repos/metrics.go
@@ -164,4 +164,19 @@ AND deleted_at IS NULL
 		}
 		return count
 	})
+
+	promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "src_repoupdater_queued_sync_jobs_total",
+		Help: "The total number of queued sync jobs",
+	}, func() float64 {
+		count, err := scanCount(`
+-- source: cmd/repo-updater/repos/metrics.go:src_repoupdater_queued_sync_jobs_total
+SELECT COUNT(*) FROM external_service_sync_jobs WHERE state = 'queued'
+`)
+		if err != nil {
+			log15.Error("Failed to get total queued sync jobs", "err", err)
+			return 0
+		}
+		return count
+	})
 }

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2997,6 +2997,24 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 ]
 ```
 
+## repo-updater: repoupdater_queued_sync_jobs_total
+
+**Descriptions:**
+
+- _repo-updater: 100+ the total number of queued sync jobs for 1h0m0s_
+
+**Possible solutions:**
+
+- **Check if jobs are failing to sync:** "SELECT * FROM external_service_sync_jobs WHERE state = `errored`";
+- **Increase the number of workers** using the `repoConcurrentExternalServiceSyncers` site config.
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_repo-updater_repoupdater_queued_sync_jobs_total"
+]
+```
+
 ## repo-updater: container_cpu_usage
 
 **Descriptions:**

--- a/monitoring/repo_updater.go
+++ b/monitoring/repo_updater.go
@@ -110,6 +110,27 @@ func RepoUpdater() *Container {
 				},
 			},
 			{
+				Title:  "External service synchronization",
+				Hidden: true,
+				Rows: []Row{
+					{
+						Observable{
+							Name:            "repoupdater_queued_sync_jobs_total",
+							Description:     "the total number of queued sync jobs",
+							Query:           `src_repoupdater_queued_sync_jobs_total`,
+							DataMayNotExist: true,
+							Warning:         Alert{GreaterOrEqual: 100, For: 1 * time.Hour},
+							PanelOptions:    PanelOptions().LegendFormat("{{type}}").Unit(Number),
+							Owner:           ObservableOwnerCloud,
+							PossibleSolutions: `
+								- **Check if jobs are failing to sync:** "SELECT * FROM external_service_sync_jobs WHERE state = 'errored'";
+								- **Increase the number of workers** using the 'repoConcurrentExternalServiceSyncers' site config.
+							`,
+						},
+					},
+				},
+			},
+			{
 				Title:  "Container monitoring (not available on server)",
 				Hidden: true,
 				Rows: []Row{


### PR DESCRIPTION
This adds a metric counting the number of jobs that are queued and an alert when their number is above 100 for a whole hour.
Fixes #14045 