### PR TITLE
default SRC_LOG_LEVEL=warn in production deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The sign in and sign up forms have been redesigned with better input validation.
 - Kubernetes admins mounting [configuration files](https://docs.sourcegraph.com/admin/config/advanced_config_file#kubernetes-configmap) are encouraged to change how the ConfigMap is mounted. See the new documentation. Previously our documentation suggested using subPath. However, this lead to Kubernetes not automatically updating the files on configuration change. [#14297](https://github.com/sourcegraph/sourcegraph/pull/14297)
 - The precise code intel bundle manager will now expire any converted LSIF data that is older than `PRECISE_CODE_INTEL_MAX_DATA_AGE` (30 days by default) that is also not visible from the tip of the default branch.
+- `SRC_LOG_LEVEL=warn` is now the default in Docker Compose and Kubernetes deployments, reducing the amount of uninformative log spam. [#14458](https://github.com/sourcegraph/sourcegraph/pull/14458)
 
 ### Fixed
 

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -54,7 +54,6 @@ var DefaultEnv = map[string]string{
 	"SRC_PROF_HTTP": "",
 
 	"LOGO":          "t",
-	"SRC_LOG_LEVEL": "warn",
 
 	// TODO other bits
 	// * DEBUG LOG_REQUESTS https://github.com/sourcegraph/sourcegraph/issues/8458

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -53,7 +53,7 @@ var DefaultEnv = map[string]string{
 	// enables the debug proxy (/-/debug)
 	"SRC_PROF_HTTP": "",
 
-	"LOGO":          "t",
+	"LOGO": "t",
 
 	// TODO other bits
 	// * DEBUG LOG_REQUESTS https://github.com/sourcegraph/sourcegraph/issues/8458

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -28,7 +28,7 @@ var locked = false
 var (
 	// MyName represents the name of the current process.
 	MyName, envVarName = findName()
-	LogLevel           = Get("SRC_LOG_LEVEL", "dbug", "upper log level to restrict log output to (dbug, info, warn, error, crit)")
+	LogLevel           = Get("SRC_LOG_LEVEL", "warn", "upper log level to restrict log output to (dbug, info, warn, error, crit)")
 	LogFormat          = Get("SRC_LOG_FORMAT", "logfmt", "log format (logfmt, condensed, json)")
 	InsecureDev, _     = strconv.ParseBool(Get("INSECURE_DEV", "false", "Running in insecure dev (local laptop) mode"))
 )


### PR DESCRIPTION
Prior to this change `SRC_LOG_LEVEL=dbug` was the default which meant
many customers would have several GB of logs for just a few days that
are mostly useless debug logs. e.g. https://github.com/sourcegraph/customer/issues/49

`sourcegraph/server` defaults to `SRC_LOG_LEVEL=warn`, in contrast to
Docker Compose and Kubernetes deployments that used the default `dbug`
level.

This PR changes the default `SRC_LOG_LEVEL=warn` except in dev
environments, which already specify `dbug` as the level explicitly.

Helps sourcegraph/customer#49



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
