### PR TITLE
search: implement fuzzy regex concatenation

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1214,20 +1214,20 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	query = Map(query, LowercaseFieldNames, SubstituteAliases)
 
 	switch options.SearchType {
 	case SearchTypeLiteral:
-		query = substituteConcat(query, " ")
+		query = substituteConcat(query, space)
 	case SearchTypeStructural:
 		if containsNegatedPattern(query) {
 			return nil, errors.New("the query contains a negated search pattern. Structural search does not support negated search patterns at the moment")
 		}
-		query = substituteConcat(query, " ")
+		query = substituteConcat(query, space)
 		query = ellipsesForHoles(query)
 	case SearchTypeRegex:
 		query = escapeParensHeuristic(query)
+		query = substituteConcat(query, fuzzyRegexp)
 	}
 
 	if options.Globbing {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -472,11 +472,11 @@ func substituteConcat(nodes []Node, separator string) []Node {
 		}
 		return false
 	}
-	new := []Node{}
+	newNode := []Node{}
 	for _, node := range nodes {
 		switch v := node.(type) {
 		case Parameter, Pattern:
-			new = append(new, node)
+			newNode = append(newNode, node)
 		case Operator:
 			if v.Kind == Concat {
 				// Merge consecutive patterns.
@@ -502,21 +502,21 @@ func substituteConcat(nodes []Node, separator string) []Node {
 						continue
 					}
 					if merged.Value != "" {
-						new = append(new, merged)
+						newNode = append(newNode, merged)
 						merged = Pattern{}
 					}
-					new = append(new, substituteConcat([]Node{node}, separator)...)
+					newNode = append(newNode, substituteConcat([]Node{node}, separator)...)
 				}
 				if merged.Value != "" {
-					new = append(new, merged)
+					newNode = append(newNode, merged)
 					merged = Pattern{}
 				}
 			} else {
-				new = append(new, newOperator(substituteConcat(v.Operands, separator), v.Kind)...)
+				newNode = append(newNode, newOperator(substituteConcat(v.Operands, separator), v.Kind)...)
 			}
 		}
 	}
-	return new
+	return newNode
 }
 
 // escapeParens is a heuristic used in the context of regular expression search.

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -477,7 +477,8 @@ func fuzzyRegexp(patterns []Pattern) Pattern {
 		}
 	}
 	return Pattern{
-		Value: "(" + strings.Join(values, ").*(") + ")",
+		Annotation: Annotation{Labels: Regexp},
+		Value:      "(" + strings.Join(values, ").*?(") + ")",
 	}
 }
 

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -232,30 +232,50 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 
 func TestSubstituteConcat(t *testing.T) {
 	cases := []struct {
-		input string
-		want  string
+		input  string
+		concat func([]Pattern) Pattern
+		want   string
 	}{
 		{
-			input: "a b c d e f",
-			want:  `"a b c d e f"`,
+			input:  "a b c d e f",
+			concat: space,
+			want:   `"a b c d e f"`,
 		},
 		{
-			input: "a (b and c) d",
-			want:  `"a" (and "b" "c") "d"`,
+			input:  "a (b and c) d",
+			concat: space,
+			want:   `"a" (and "b" "c") "d"`,
 		},
 		{
-			input: "a b (c and d) e f (g or h) (i j k)",
-			want:  `"a b" (and "c" "d") "e f" (or "g" "h") "(i j k)"`,
+			input:  "a b (c and d) e f (g or h) (i j k)",
+			concat: space,
+			want:   `"a b" (and "c" "d") "e f" (or "g" "h") "(i j k)"`,
 		},
 		{
-			input: "(((a b c))) and d",
-			want:  `(and "(((a b c)))" "d")`,
+			input:  "(((a b c))) and d",
+			concat: space,
+			want:   `(and "(((a b c)))" "d")`,
+		},
+		{
+			input:  `foo\d "bar*"`,
+			concat: fuzzyRegexp,
+			want:   `"(foo\\d).*(bar\\*)"`,
+		},
+		{
+			input:  `"bar*" foo\d "bar*" foo\d`,
+			concat: fuzzyRegexp,
+			want:   `"(bar\\*).*(foo\\d).*(bar\\*).*(foo\\d)"`,
+		},
+		{
+			input:  "a b (c and d) e f (g or h) (i j k)",
+			concat: fuzzyRegexp,
+			want:   `"(a).*(b)" (and "c" "d") "(e).*(f)" (or "g" "h") "(i j k)"`,
 		},
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			got := prettyPrint(substituteConcat(query, " "))
+			got := prettyPrint(substituteConcat(query, c.concat))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -259,17 +259,17 @@ func TestSubstituteConcat(t *testing.T) {
 		{
 			input:  `foo\d "bar*"`,
 			concat: fuzzyRegexp,
-			want:   `"(foo\\d).*(bar\\*)"`,
+			want:   `"(foo\\d).*?(bar\\*)"`,
 		},
 		{
 			input:  `"bar*" foo\d "bar*" foo\d`,
 			concat: fuzzyRegexp,
-			want:   `"(bar\\*).*(foo\\d).*(bar\\*).*(foo\\d)"`,
+			want:   `"(bar\\*).*?(foo\\d).*?(bar\\*).*?(foo\\d)"`,
 		},
 		{
 			input:  "a b (c and d) e f (g or h) (i j k)",
 			concat: fuzzyRegexp,
-			want:   `"(a).*(b)" (and "c" "d") "(e).*(f)" (or "g" "h") "(i j k)"`,
+			want:   `"(a).*?(b)" (and "c" "d") "(e).*?(f)" (or "g" "h") "(i j k)"`,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
We currently rely on query-manipulating code that turns a query like `foo bar` into `(foo).*(bar)`. This query-manipulating code is legacy/"old code" query processing [that's pretty convoluted](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1287-1355). We still run this logic though, even when the new parser is enabled.

This PR effectively implements all this logic in the new parser code, before it reaches the above processing. The changes effectively turn the above code into a no-op, and allows to delete all the legacy parser logic in `search_results.go` down the line. More urgently, I need this logic to preprocess things for search expressions. It is prep for https://github.com/sourcegraph/sourcegraph/pull/13907.

Commits 1 and 3: just refactors. Commit 2: the main change.