### PR TITLE
Revert syntect_server update (segfaulting) (#14456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
-- Syntax highlighting for GraphQL, INI, TOML, and Perforce files has been removed [due to incompatible/absent licenses](https://github.com/sourcegraph/sourcegraph/issues/13933). We plan to [add it back in the future](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+add+syntax+highlighting+for+develop+a+).
 - Search scope pages (`/search/scope/:id`) were removed.
 - User-defined search scopes are no longer shown below the search bar on the homepage. Use the [`quicklinks`](https://docs.sourcegraph.com/user/quick_links) setting instead to display links there.
 - The explore page (`/explore`) was removed.

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:9c1c9d7@sha256:c7a5d90ad995181ad520535c9b4d809576514933bbe60b625f821d78c31628cd /syntect_server /usr/local/bin/
+COPY --from=sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff /syntect_server /usr/local/bin/
 
 # install postgres 11
 # hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035

--- a/dev/syntect_server.sh
+++ b/dev/syntect_server.sh
@@ -23,4 +23,4 @@ if [[ "${INSECURE_DEV:-}" == '1' ]]; then
 fi
 
 docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server
-exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:9c1c9d7@sha256:c7a5d90ad995181ad520535c9b4d809576514933bbe60b625f821d78c31628cd
+exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:ff37f90@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff

--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/syntect_server:9c1c9d7@sha256:c7a5d90ad995181ad520535c9b4d809576514933bbe60b625f821d78c31628cd
-docker tag index.docker.io/sourcegraph/syntect_server:9c1c9d7@sha256:c7a5d90ad995181ad520535c9b4d809576514933bbe60b625f821d78c31628cd "$IMAGE"
+docker pull index.docker.io/sourcegraph/syntect_server:c22bde0@sha256:07b9f1ff4bd2c60299f9404144cd72897fa4de2308d1be65c35bcdcd10e5410d
+docker tag index.docker.io/sourcegraph/syntect_server:c22bde0@sha256:07b9f1ff4bd2c60299f9404144cd72897fa4de2308d1be65c35bcdcd10e5410d "$IMAGE"


### PR DESCRIPTION
This reverts commit 284ddb42b0b6b4ee15786104ef7556b2e5b57820.

Not sure why but the binary is segfaulting when copied into the `server` image and as such only failed on CI after merge: https://buildkite.com/sourcegraph/sourcegraph/builds/75505

Reverting while I investigate/fix.