### PR TITLE
monitoring: allow NaN values in alert queries by default

### DIFF
--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -17,10 +17,10 @@ func Frontend() *Container {
 							Description:     "99th percentile successful search request duration over 5m",
 							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name!="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 20},
-							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
-							Owner:           ObservableOwnerSearch,
+
+							Warning:      Alert{GreaterOrEqual: 20},
+							PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
+							Owner:        ObservableOwnerSearch,
 							PossibleSolutions: `
 								- **Get details on the exact queries that are slow** by configuring '"observability.logSlowSearches": 20,' in the site configuration and looking for 'frontend' warning logs prefixed with 'slow search request' for additional details.
 								- **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -33,10 +33,10 @@ func Frontend() *Container {
 							Description:     "90th percentile successful search request duration over 5m",
 							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",name!="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 15},
-							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
-							Owner:           ObservableOwnerSearch,
+
+							Warning:      Alert{GreaterOrEqual: 15},
+							PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
+							Owner:        ObservableOwnerSearch,
 							PossibleSolutions: `
 								- **Get details on the exact queries that are slow** by configuring '"observability.logSlowSearches": 15,' in the site configuration and looking for 'frontend' warning logs prefixed with 'slow search request' for additional details.
 								- **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -47,11 +47,11 @@ func Frontend() *Container {
 					},
 					{
 						{
-							Name:              "hard_timeout_search_responses",
-							Description:       "hard timeout search responses every 5m",
-							Query:             `(sum(increase(src_graphql_search_response{status="timeout",source="browser",name!="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",name!="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "hard_timeout_search_responses",
+							Description:     "hard timeout search responses every 5m",
+							Query:           `(sum(increase(src_graphql_search_response{status="timeout",source="browser",name!="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",name!="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard timeout").Unit(Percentage),
@@ -59,11 +59,11 @@ func Frontend() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "hard_error_search_responses",
-							Description:       "hard error search responses every 5m",
-							Query:             `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "hard_error_search_responses",
+							Description:     "hard error search responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{status}}").Unit(Percentage),
@@ -71,11 +71,11 @@ func Frontend() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "partial_timeout_search_responses",
-							Description:       "partial timeout search responses every 5m",
-							Query:             `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "partial_timeout_search_responses",
+							Description:     "partial timeout search responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{status}}").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,
@@ -86,10 +86,10 @@ func Frontend() *Container {
 							Description:     "search alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="browser",name!="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",name!="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // ratio denominator could be 0
-							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
-							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
-							Owner:           ObservableOwnerSearch,
+
+							Warning:      Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
+							PanelOptions: PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
+							Owner:        ObservableOwnerSearch,
 							PossibleSolutions: `
 								- This indicates your user's are making syntax errors or similar user errors.
 							`,
@@ -101,10 +101,10 @@ func Frontend() *Container {
 							Description:     "90th percentile page load latency over all routes over 10m",
 							Query:           `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route!="raw",route!="blob",route!~"graphql.*"}[10m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // if all buckets are 0 (i.e. on low-traffic instances), histogram_quantile returns NaN
-							Critical:        Alert{GreaterOrEqual: 2},
-							PanelOptions:    PanelOptions().LegendFormat("latency").Unit(Seconds),
-							Owner:           ObservableOwnerCloud,
+
+							Critical:     Alert{GreaterOrEqual: 2},
+							PanelOptions: PanelOptions().LegendFormat("latency").Unit(Seconds),
+							Owner:        ObservableOwnerCloud,
 							PossibleSolutions: `
 								- Confirm that the Sourcegraph frontend has enough CPU/memory using the provisioning panels.
 								- Trace a request to see what the slowest part is: https://docs.sourcegraph.com/admin/observability/tracing
@@ -137,9 +137,9 @@ func Frontend() *Container {
 							Owner:           ObservableOwnerCodeIntel,
 							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 20},
-							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
+
+							Warning:      Alert{GreaterOrEqual: 20},
+							PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
 							PossibleSolutions: `
 								- **Get details on the exact queries that are slow** by configuring '"observability.logSlowSearches": 20,' in the site configuration and looking for 'frontend' warning logs prefixed with 'slow search request' for additional details.
 								- **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -152,10 +152,10 @@ func Frontend() *Container {
 							Description:     "90th percentile code-intel successful search request duration over 5m",
 							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name="CodeIntelSearch"}[5m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 15},
-							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
-							Owner:           ObservableOwnerCodeIntel,
+
+							Warning:      Alert{GreaterOrEqual: 15},
+							PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
+							Owner:        ObservableOwnerCodeIntel,
 							PossibleSolutions: `
 								- **Get details on the exact queries that are slow** by configuring '"observability.logSlowSearches": 15,' in the site configuration and looking for 'frontend' warning logs prefixed with 'slow search request' for additional details.
 								- **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -166,11 +166,11 @@ func Frontend() *Container {
 					},
 					{
 						{
-							Name:              "hard_timeout_search_codeintel_responses",
-							Description:       "hard timeout search code-intel responses every 5m",
-							Query:             `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "hard_timeout_search_codeintel_responses",
+							Description:     "hard timeout search code-intel responses every 5m",
+							Query:           `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard timeout").Unit(Percentage),
@@ -178,11 +178,11 @@ func Frontend() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "hard_error_search_codeintel_responses",
-							Description:       "hard error search code-intel responses every 5m",
-							Query:             `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "hard_error_search_codeintel_responses",
+							Description:     "hard error search code-intel responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard error").Unit(Percentage),
@@ -190,11 +190,11 @@ func Frontend() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "partial_timeout_search_codeintel_responses",
-							Description:       "partial timeout search code-intel responses every 5m",
-							Query:             `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "partial_timeout_search_codeintel_responses",
+							Description:     "partial timeout search code-intel responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("partial timeout").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -205,10 +205,10 @@ func Frontend() *Container {
 							Description:     "search code-intel alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // ratio denominator could be 0
-							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
-							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
-							Owner:           ObservableOwnerCodeIntel,
+
+							Warning:      Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
+							PanelOptions: PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
+							Owner:        ObservableOwnerCodeIntel,
 							PossibleSolutions: `
 								- This indicates a bug in Sourcegraph, please [open an issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose).
 							`,
@@ -226,10 +226,10 @@ func Frontend() *Container {
 							Description:     "99th percentile successful search API request duration over 5m",
 							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 50},
-							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
-							Owner:           ObservableOwnerSearch,
+
+							Warning:      Alert{GreaterOrEqual: 50},
+							PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
+							Owner:        ObservableOwnerSearch,
 							PossibleSolutions: `
 								- **Get details on the exact queries that are slow** by configuring '"observability.logSlowSearches": 20,' in the site configuration and looking for 'frontend' warning logs prefixed with 'slow search request' for additional details.
 								- **If your users are requesting many results** with a large 'count:' parameter, consider using our [search pagination API](../../api/graphql/search.md).
@@ -243,10 +243,10 @@ func Frontend() *Container {
 							Description:     "90th percentile successful search API request duration over 5m",
 							Query:           `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // See https://github.com/sourcegraph/sourcegraph/issues/9834
-							Warning:         Alert{GreaterOrEqual: 40},
-							PanelOptions:    PanelOptions().LegendFormat("duration").Unit(Seconds),
-							Owner:           ObservableOwnerSearch,
+
+							Warning:      Alert{GreaterOrEqual: 40},
+							PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
+							Owner:        ObservableOwnerSearch,
 							PossibleSolutions: `
 								- **Get details on the exact queries that are slow** by configuring '"observability.logSlowSearches": 15,' in the site configuration and looking for 'frontend' warning logs prefixed with 'slow search request' for additional details.
 								- **If your users are requesting many results** with a large 'count:' parameter, consider using our [search pagination API](../../api/graphql/search.md).
@@ -258,11 +258,11 @@ func Frontend() *Container {
 					},
 					{
 						{
-							Name:              "hard_timeout_search_api_responses",
-							Description:       "hard timeout search API responses every 5m",
-							Query:             `(sum(increase(src_graphql_search_response{status="timeout",source="other"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="other"}[5m]))) / sum(increase(src_graphql_search_response{source="other"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "hard_timeout_search_api_responses",
+							Description:     "hard timeout search API responses every 5m",
+							Query:           `(sum(increase(src_graphql_search_response{status="timeout",source="other"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="other"}[5m]))) / sum(increase(src_graphql_search_response{source="other"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("hard timeout").Unit(Percentage),
@@ -270,11 +270,11 @@ func Frontend() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "hard_error_search_api_responses",
-							Description:       "hard error search API responses every 5m",
-							Query:             `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "hard_error_search_api_responses",
+							Description:     "hard error search API responses every 5m",
+							Query:           `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 2, For: 15 * time.Minute},
 							Critical:          Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{status}}").Unit(Percentage),
@@ -282,11 +282,11 @@ func Frontend() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "partial_timeout_search_api_responses",
-							Description:       "partial timeout search API responses every 5m",
-							Query:             `sum(increase(src_graphql_search_response{status="partial_timeout",source="other"}[5m])) / sum(increase(src_graphql_search_response{source="other"}[5m]))`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "partial_timeout_search_api_responses",
+							Description:     "partial timeout search API responses every 5m",
+							Query:           `sum(increase(src_graphql_search_response{status="partial_timeout",source="other"}[5m])) / sum(increase(src_graphql_search_response{source="other"}[5m]))`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("partial timeout").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,
@@ -297,10 +297,10 @@ func Frontend() *Container {
 							Description:     "search API alert user suggestions shown every 5m",
 							Query:           `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="other"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{status="alert",source="other"}[5m]))`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // ratio denominator could be 0
-							Warning:         Alert{GreaterOrEqual: 5},
-							PanelOptions:    PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
-							Owner:           ObservableOwnerSearch,
+
+							Warning:      Alert{GreaterOrEqual: 5},
+							PanelOptions: PanelOptions().LegendFormat("{{alert_type}}").Unit(Percentage),
+							Owner:        ObservableOwnerSearch,
 							PossibleSolutions: `
 								- This indicates your user's search API requests have syntax errors or a similar user error. Check the responses the API sends back for an explanation.
 							`,
@@ -317,20 +317,20 @@ func Frontend() *Container {
 							Name:        "99th_percentile_precise_code_intel_api_duration",
 							Description: "99th percentile successful precise code intel api query duration over 5m",
 							// TODO(efritz) - ensure these exclude error durations
-							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_api_duration_seconds_bucket[5m])))`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_api_duration_seconds_bucket[5m])))`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("api operation").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "precise_code_intel_api_errors",
-							Description:       "precise code intel api errors every 5m",
-							Query:             `sum(increase(src_code_intel_api_errors_total[5m])) / sum(increase(src_code_intel_api_total[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "precise_code_intel_api_errors",
+							Description:     "precise code intel api errors every 5m",
+							Query:           `sum(increase(src_code_intel_api_errors_total[5m])) / sum(increase(src_code_intel_api_total[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("api operations").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -342,20 +342,20 @@ func Frontend() *Container {
 							Name:        "99th_percentile_precise_code_intel_store_duration",
 							Description: "99th percentile successful precise code intel database query duration over 5m",
 							// TODO(efritz) - ensure these exclude error durations
-							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_store_duration_seconds_bucket{job="frontend"}[5m])))`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_store_duration_seconds_bucket{job="frontend"}[5m])))`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("store operation").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "precise_code_intel_store_errors",
-							Description:       "precise code intel database errors every 5m",
-							Query:             `sum(increase(src_code_intel_store_errors_total{job="frontend"}[5m])) / sum(increase(src_code_intel_store_total{job="frontend"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "precise_code_intel_store_errors",
+							Description:     "precise code intel database errors every 5m",
+							Query:           `sum(increase(src_code_intel_store_errors_total{job="frontend"}[5m])) / sum(increase(src_code_intel_store_total{job="frontend"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("store operations").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -374,7 +374,6 @@ func Frontend() *Container {
 							Description:     "internal indexed search error responses every 5m",
 							Query:           `sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{code}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -387,7 +386,6 @@ func Frontend() *Container {
 							Description:     "internal unindexed search error responses every 5m",
 							Query:           `sum by(code) (increase(searcher_service_request_total{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total[5m])) * 100`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{code}}").Unit(Percentage),
 							Owner:           ObservableOwnerSearch,
@@ -400,7 +398,6 @@ func Frontend() *Container {
 							Description:     "internal API error responses every 5m by route",
 							Query:           `sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_frontend_internal_request_duration_seconds_count[5m])) * 100`,
 							DataMayNotExist: true,
-							DataMayBeNaN:    true, // ratio denominator could be 0
 							Warning:         Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:    PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:           ObservableOwnerCloud,
@@ -415,7 +412,6 @@ func Frontend() *Container {
 							Description:       "99th percentile successful precise-code-intel-bundle-manager query duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_precise_code_intel_bundle_manager_request_duration_seconds_bucket{job="frontend",category!="transfer"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -426,7 +422,6 @@ func Frontend() *Container {
 							Description:       "99th percentile successful precise-code-intel-bundle-manager data transfer duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_precise_code_intel_bundle_manager_request_duration_seconds_bucket{job="frontend",category="transfer"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 300},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -437,7 +432,6 @@ func Frontend() *Container {
 							Description:       "precise-code-intel-bundle-manager error responses every 5m",
 							Query:             `sum by(category) (increase(src_precise_code_intel_bundle_manager_request_duration_seconds_count{job="frontend",code!~"2.."}[5m]))  / ignoring(code) group_left sum by(category) (increase(src_precise_code_intel_bundle_manager_request_duration_seconds_count{job="frontend"}[5m])) * 100`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,
@@ -450,7 +444,6 @@ func Frontend() *Container {
 							Description:       "99th percentile successful gitserver query duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_gitserver_request_duration_seconds_bucket{job="frontend"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
 							Owner:             ObservableOwnerCloud,
@@ -461,7 +454,6 @@ func Frontend() *Container {
 							Description:       "gitserver error responses every 5m",
 							Query:             `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="frontend",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="frontend"}[5m])) * 100`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerCloud,

--- a/monitoring/precise_code_intel_bundle_manager.go
+++ b/monitoring/precise_code_intel_bundle_manager.go
@@ -16,7 +16,6 @@ func PreciseCodeIntelBundleManager() *Container {
 							// TODO(efritz) - ensure these exclude error durations
 							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_bundle_database_duration_seconds_bucket[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("database operation").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -40,7 +39,6 @@ func PreciseCodeIntelBundleManager() *Container {
 							// TODO(efritz) - ensure these exclude error durations
 							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_bundle_reader_duration_seconds_bucket[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("reader operation").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,

--- a/monitoring/precise_code_intel_indexer.go
+++ b/monitoring/precise_code_intel_indexer.go
@@ -27,7 +27,6 @@ func PreciseCodeIntelIndexer() *Container {
 							Description:       "index queue growth rate every 5m",
 							Query:             `sum(increase(src_index_queue_indexes_total[30m])) / sum(increase(src_index_queue_processor_total[30m]))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // numerator and denominator could both be 0
 							Warning:           Alert{GreaterOrEqual: 5},
 							PanelOptions:      PanelOptions().LegendFormat("index queue growth rate"),
 							Owner:             ObservableOwnerCodeIntel,
@@ -52,7 +51,6 @@ func PreciseCodeIntelIndexer() *Container {
 							// TODO(efritz) - ensure these exclude error durations
 							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_store_duration_seconds_bucket{job="precise-code-intel-indexer"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("store operation").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -175,7 +173,6 @@ func PreciseCodeIntelIndexer() *Container {
 							Description:       "99th percentile successful gitserver query duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_gitserver_request_duration_seconds_bucket{job="precise-code-intel-indexer"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -186,7 +183,6 @@ func PreciseCodeIntelIndexer() *Container {
 							Description:       "gitserver error responses every 5m",
 							Query:             `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-indexer",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-indexer"}[5m])) * 100`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,

--- a/monitoring/precise_code_intel_worker.go
+++ b/monitoring/precise_code_intel_worker.go
@@ -23,11 +23,11 @@ func PreciseCodeIntelWorker() *Container {
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "upload_queue_growth_rate",
-							Description:       "upload queue growth rate every 5m",
-							Query:             `sum(increase(src_upload_queue_uploads_total[30m])) / sum(increase(src_upload_queue_processor_total[30m]))`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // numerator and denominator could both be 0
+							Name:            "upload_queue_growth_rate",
+							Description:     "upload queue growth rate every 5m",
+							Query:           `sum(increase(src_upload_queue_uploads_total[30m])) / sum(increase(src_upload_queue_processor_total[30m]))`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5},
 							PanelOptions:      PanelOptions().LegendFormat("upload queue growth rate"),
 							Owner:             ObservableOwnerCodeIntel,
@@ -50,9 +50,9 @@ func PreciseCodeIntelWorker() *Container {
 							Name:        "99th_percentile_store_duration",
 							Description: "99th percentile successful database query duration over 5m",
 							// TODO(efritz) - ensure these exclude error durations
-							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_store_duration_seconds_bucket{job="precise-code-intel-worker"}[5m])))`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
+							Query:           `histogram_quantile(0.99, sum by (le)(rate(src_code_intel_store_duration_seconds_bucket{job="precise-code-intel-worker"}[5m])))`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("store operation").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -119,7 +119,6 @@ func PreciseCodeIntelWorker() *Container {
 							Description:       "99th percentile successful bundle manager data transfer duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_precise_code_intel_bundle_manager_request_duration_seconds_bucket{job="precise-code-intel-worker",category="transfer"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 300},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
@@ -142,18 +141,17 @@ func PreciseCodeIntelWorker() *Container {
 							Description:       "99th percentile successful gitserver query duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_gitserver_request_duration_seconds_bucket{job="precise-code-intel-worker"}[5m])))`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true,
 							Warning:           Alert{GreaterOrEqual: 20},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
 							Owner:             ObservableOwnerCodeIntel,
 							PossibleSolutions: "none",
 						},
 						{
-							Name:              "gitserver_error_responses",
-							Description:       "gitserver error responses every 5m",
-							Query:             `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-worker",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-worker"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // ratio denominator could be 0
+							Name:            "gitserver_error_responses",
+							Description:     "gitserver error responses every 5m",
+							Query:           `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-worker",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job="precise-code-intel-worker"}[5m])) * 100`,
+							DataMayNotExist: true,
+
 							Warning:           Alert{GreaterOrEqual: 5, For: 15 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
 							Owner:             ObservableOwnerCodeIntel,

--- a/monitoring/searcher.go
+++ b/monitoring/searcher.go
@@ -17,7 +17,6 @@ func Searcher() *Container {
 							Description:       "unindexed search request errors every 5m by code",
 							Query:             `sum by (code)(increase(searcher_service_request_total{code!="200",code!="canceled"}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total[5m])) * 100`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // denominator may be zero
 							Warning:           Alert{GreaterOrEqual: 5, For: 5 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{code}}").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,

--- a/monitoring/zoekt_web_server.go
+++ b/monitoring/zoekt_web_server.go
@@ -20,7 +20,6 @@ func ZoektWebServer() *Container {
 							Description:       "indexed search request errors every 5m by code",
 							Query:             `sum by (code)(increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100`,
 							DataMayNotExist:   true,
-							DataMayBeNaN:      true, // denominator may be zero
 							Warning:           Alert{GreaterOrEqual: 5, For: 5 * time.Minute},
 							PanelOptions:      PanelOptions().LegendFormat("{{code}}").Unit(Percentage),
 							Owner:             ObservableOwnerSearch,


### PR DESCRIPTION
Many alert queries divide-by-0 in normal situations, such as low-traffic instances and scenarios, causing many alerts to require `DataMayBeNaN` to be true. This change switches our default to allow NaN values without triggering alerts.

There are currently [44 instances of alerts with `DataMayBeNan: true`](https://sourcegraph.com/search?q=DataMayBeNaN:+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+rev:7904337d9734a2f267a324c3298d79f42efa2a10&patternType=regexp) many of them [ratio alerts](https://github.com/sourcegraph/sourcegraph/pull/12869), and possibly more require it: https://github.com/sourcegraph/sourcegraph/issues/14401 was due to `histogram_quantile` returning NaN on no data, and it seems that all `histogram_quantile` alerts are susceptible to this ([1](https://sourcegraph.slack.com/archives/C01AS4GCA90/p1602005999000200), [2](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1602006353092500)) and require `DataMayBeNaN` (there are [23 alerts using `histogram_quantile`](https://sourcegraph.com/search?q=histogram_quantile+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+rev:7904337d9734a2f267a324c3298d79f42efa2a10+file:monitoring&patternType=regexp)), so at this point might as well switch the defaults around

Closes https://github.com/sourcegraph/sourcegraph/issues/10689

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
