### PR TITLE
Implement RFC 221 changes to ViewOnSourcegraphButton

### DIFF
--- a/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/browser/src/shared/code-hosts/github/codeHost.ts
@@ -290,8 +290,8 @@ export const githubCodeHost: CodeHost = {
     nativeTooltipResolvers: [nativeTooltipResolver],
     getContext: () => {
         const repoHeaderHasPrivateMarker =
-            !!document.querySelector('.repohead .private') ||
-            !!document.querySelector('#js-repo-pjax-container h1 .octicon-lock')
+            !!document.querySelector('main h1 .octicon-lock') ||
+            !![...document.querySelectorAll('main h1 span')].find(span => span.textContent?.toLowerCase() === 'private')
         const parsedURL = parseURL()
         return {
             ...parsedURL,

--- a/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/browser/src/shared/code-hosts/github/codeHost.ts
@@ -290,8 +290,14 @@ export const githubCodeHost: CodeHost = {
     nativeTooltipResolvers: [nativeTooltipResolver],
     getContext: () => {
         const repoHeaderHasPrivateMarker =
-            !!document.querySelector('main h1 .octicon-lock') ||
-            !![...document.querySelectorAll('main h1 span')].find(span => span.textContent?.toLowerCase() === 'private')
+            !!document.querySelector('.repohead .private') ||
+            !!document.querySelector('h1 .octicon-lock ~ [itemprop="author"] ~ [itemprop="name"]') ||
+            !!(
+                document
+                    .querySelector('h1 [itemprop="author"] ~ [itemprop="name"] ~ .Label')
+                    ?.textContent?.trim()
+                    .toLowerCase() === 'private'
+            )
         const parsedURL = parseURL()
         return {
             ...parsedURL,

--- a/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -47,8 +47,6 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     const commonProps: Partial<SourcegraphIconButtonProps> = {
         className,
         iconClassName,
-        target: '_blank',
-        rel: 'noopener noreferrer',
     }
 
     // Show nothing while loading

--- a/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -72,7 +72,6 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
 
         const commonErrorCaseProps: Partial<SourcegraphIconButtonProps> = {
             ...commonProps,
-            iconClassName: mutedIconClassName,
             // If we are not running in the browser extension where we can open the options menu,
             // open the documentation for how to configure the code host we are on.
             href: new URL(snakeCase(codeHostType), 'https://docs.sourcegraph.com/integration/').href,
@@ -103,6 +102,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         return (
             <SourcegraphIconButton
                 {...commonErrorCaseProps}
+                iconClassName={mutedIconClassName}
                 href={url}
                 label="Error"
                 title={repoExistsOrError.message}

--- a/browser/src/shared/code-hosts/shared/__snapshots__/ViewOnSourcegraphButton.test.tsx.snap
+++ b/browser/src/shared/code-hosts/shared/__snapshots__/ViewOnSourcegraphButton.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`<ViewOnSourcegraphButton /> existence could not be determined  because 
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true&utm_source=chrome-extension"
   onClick={[Function]}
+  rel="noopener noreferrer"
+  target="_blank"
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
   <svg
@@ -40,6 +42,8 @@ exports[`<ViewOnSourcegraphButton /> existence could not be determined  because 
   className="open-on-sourcegraph test"
   href="https://test.com/sign-in?close=true&utm_source=chrome-extension"
   onClick={[Function]}
+  rel="noopener noreferrer"
+  target="_blank"
   title="Sign into Sourcegraph to get hover tooltips, go to definition and more"
 >
   <svg

--- a/browser/src/shared/components/SourcegraphIconButton.tsx
+++ b/browser/src/shared/components/SourcegraphIconButton.tsx
@@ -25,8 +25,8 @@ export const SourcegraphIconButton: React.FunctionComponent<SourcegraphIconButto
     <a
         href={href}
         className={className}
-        target={target}
-        rel={rel}
+        target={target ?? '_blank'}
+        rel={rel ?? 'noopener noreferrer'}
         title={title}
         aria-label={ariaLabel}
         onClick={onClick}


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/security-issues/issues/81
Resolves #3669
Resolves #14225
(1 change/issue tackled per commit)

#### Private github.com repositories issue
Update selectors for `repoHeaderHasPrivateMarker` check.

#### Always open Sourcegraph in new tab
`target` and `rel` are set to `_blank` and `noopener norefferer` by default respectively.

#### Improve 'Configure on Sourcegraph' flow
1 ) Only apply `filter: grayscale(100%)` to `SourcegraphIconButton` for "real" errors, not for private repository errors.
2) Chrome does not implement `openPopup` for [security reasons](https://bugs.chromium.org/p/chromium/issues/detail?id=436489#c103), so we can't implement this change. (edit: Implementing in separate PR for working browsers)