### PR TITLE
Revert "incorporate graphql-go patch to fix union/interface inline fr…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ replace (
 
 	// We need our fork until https://github.com/graph-gophers/graphql-go/pull/400 is merged upstream
 	// Our change limits the number of goroutines spawned by resolvers which was causing memory spikes on our frontend
-	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20200925042138-03da4e7f938c
+	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 
 	// prom-wrapper needs to be able to write alertmanager configuration with secrets, etc, which

--- a/go.sum
+++ b/go.sum
@@ -1248,8 +1248,6 @@ github.com/sourcegraph/gosyntect v0.0.0-20200429204402-842ed26129d0 h1:AEImdu3+4
 github.com/sourcegraph/gosyntect v0.0.0-20200429204402-842ed26129d0/go.mod h1:WiNJKgKTnR3psOIGzVZQjLqZjJZuoL3F8tCh25Uk8dU=
 github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484 h1:oMnbwXPJDRDfUjEuFHlO6u1MY6O64G2TrDBOXTgVX58=
 github.com/sourcegraph/graphql-go v0.0.0-20200724075322-e542e8956484/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
-github.com/sourcegraph/graphql-go v0.0.0-20200925042138-03da4e7f938c h1:FK6V3LUPvx57QBpeXVa2G9Ye5BzQQ7gW9emBl/HEPUI=
-github.com/sourcegraph/graphql-go v0.0.0-20200925042138-03da4e7f938c/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
 github.com/sourcegraph/oauth2 v1.0.0 h1:8E8mWmiX8so+Lq0RDLKwDJAffUliM4K1nCINqCtXuvI=


### PR DESCRIPTION
…agments (#14195)"

There seems to be an issue with the current fix, so reverting as this broke the campaign detail page. This is not required for something to work, but was a nice to have fixed, so it should not break anything when we revert.

The error is the following:

```
03:25:48            frontend | graphql: panic occurred: {{"ExternalChangeset" {'-' '\x10'}}} does not implement "HiddenExternalChangeset"
03:25:48            frontend | goroutine 2640 [running]:
03:25:48            frontend | github.com/graph-gophers/graphql-go/log.(*DefaultLogger).LogPanic(0x3cf6538, 0x2d5e280, 0xc00218cb40, 0x254c560, 0xc001f3db10)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/log/log.go:21 +0x6f
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec.(*Request).handlePanic(0xc0005f8380, 0x2d5e280, 0xc00218cb40)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/exec.go:30 +0x8d
03:25:48            frontend | panic(0x254c560, 0xc001f3db10)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:969 +0x175
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyFragment(0xc0005f8380, 0xc0002f60e0, 0xc001f2a6c0, 0xc0004d8660, 0x0, 0x8, 0x1)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:181 +0x998
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applySelectionSet(0xc0005f8380, 0xc0002f60e0, 0xc001f2a6c0, 0xc0004890c0, 0x3, 0x4, 0x7, 0x0, 0xc0016fa118)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:159 +0x1c9
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyFragment(0xc0005f8380, 0xc0002f60e0, 0xc00045f3a0, 0xc000665480, 0xf, 0xc000665480, 0x140)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:199 +0x225
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applySelectionSet(0xc0005f8380, 0xc0002f60e0, 0xc00045f3a0, 0xc0021931a0, 0x1, 0x1, 0xc000519040, 0x84a1a98, 0xc0001e58e0)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:166 +0x17f1
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyField(0xc0005f8380, 0xc0002f60e0, 0x2d26f60, 0xc00045f3a0, 0xc0021931a0, 0x1, 0x1, 0x2765ca0, 0xc00066e5b8, 0xc000519040)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:214 +0x97
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyField(0xc0005f8380, 0xc0002f60e0, 0x2d26f40, 0xc001f306f0, 0xc0021931a0, 0x1, 0x1, 0x2, 0x2, 0x2)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:216 +0x13e
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applySelectionSet(0xc0005f8380, 0xc0002f60e0, 0xc00045f420, 0xc000489080, 0x3, 0x4, 0x2466940, 0xc00209ce00, 0xc002871cc0)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:143 +0xb1a
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyField(0xc0005f8380, 0xc0002f60e0, 0x2d26f60, 0xc00045f420, 0xc000489080, 0x3, 0x4, 0x0, 0x9802868, 0xc001fe9f00)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:214 +0x97
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applySelectionSet(0xc0005f8380, 0xc0002f60e0, 0xc00045fea0, 0xc0021931b0, 0x1, 0x1, 0x7, 0x0, 0x263f6e0)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:143 +0xb1a
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyFragment(0xc0005f8380, 0xc0002f60e0, 0xc00159a580, 0xc0004d8480, 0x0, 0xc001f3dab0, 0x0)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:186 +0x5be
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applySelectionSet(0xc0005f8380, 0xc0002f60e0, 0xc00159a580, 0xc001be7400, 0x2, 0x2, 0x258f820, 0xc001b19e20, 0xc001f3da80)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:159 +0x1c9
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applyField(0xc0005f8380, 0xc0002f60e0, 0x2d26f60, 0xc00159a580, 0xc001be7400, 0x2, 0x2, 0x0, 0xc0010ee0a0, 0x24a0100)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:214 +0x97
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.applySelectionSet(0xc0005f8380, 0xc0002f60e0, 0xc001dd9b60, 0xc0021931c0, 0x1, 0x1, 0xc001f6cdd8, 0xc8, 0xc8)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:143 +0xb1a
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec/selected.ApplyOperation(0xc0005f8380, 0xc0002f60e0, 0xc00237d560, 0x2d5e280, 0xe3292558a, 0xbfd764272fc9cf78)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/selected/selected.go:42 +0xa6
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec.(*Request).Execute.func1(0xc0005f8380, 0x2d5e280, 0xc00218cb40, 0xc0002f60e0, 0xc00237d560, 0xc0016fb068)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/exec.go:47 +0xa7
03:25:48            frontend | github.com/graph-gophers/graphql-go/internal/exec.(*Request).Execute(0xc0005f8380, 0x2d5e280, 0xc00218cb40, 0xc0002f60e0, 0xc00237d560, 0xc00314faa0, 0x12, 0xc00218cba0, 0xc00218cd50, 0x2d5e280, ...)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/internal/exec/exec.go:49 +0x94
03:25:48            frontend | github.com/graph-gophers/graphql-go.(*Schema).exec(0xc0001b4c60, 0x2d5e280, 0xc00218cb40, 0xc003450800, 0xb23, 0xc00314faa0, 0x12, 0xc00218cba0, 0xc0002f60e0, 0x0)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/graphql.go:231 +0x85c
03:25:48            frontend | github.com/graph-gophers/graphql-go.(*Schema).Exec(...)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/graphql.go:164
03:25:48            frontend | github.com/graph-gophers/graphql-go/relay.(*Handler).ServeHTTP(0xc00207b320, 0x2d554c0, 0xc0005c8230, 0xc0016fb358)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/sourcegraph/graphql-go@v0.0.0-20200925042138-03da4e7f938c/relay/relay.go:61 +0x17a
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi.serveGraphQL.func1(0x2d554c0, 0xc0005c8230, 0xc002478400, 0xc, 0xc0001e03f0)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/graphql.go:32 +0x34f
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi.jsonMiddleware.func1.1(0x2d554c0, 0xc0005c8230, 0xc002478400, 0x10054f0, 0x2cee718)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/httpapi.go:201 +0x122
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil.HandlerWithErrorReturn.ServeHTTP(0xc0020b2a20, 0xc0020b2a30, 0x24ddf00, 0x2d554c0, 0xc0005c8230, 0xc002478400)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil/handler.go:54 +0xbf
03:25:48            frontend | github.com/sourcegraph/sourcegraph/internal/trace.TraceRoute.func1(0x2d554c0, 0xc0005c8230, 0xc002478400)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/internal/trace/httptrace.go:269 +0xbf
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bbc0, 0x2d554c0, 0xc0005c8230, 0xc002478400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/gorilla/mux.(*Router).ServeHTTP(0xc0020a4d80, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/authz.Init.func3.1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/authz/authz.go:105 +0xdf
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bcc0, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/auth.glob..func1.1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/auth/non_public.go:35 +0x9e
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bce0, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/openidconnect.handleOpenIDConnectAuth(0x2d554c0, 0xc0005c8230, 0xc001ab0500, 0x2d2c2e0, 0xc00208bce0, 0x1657201)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/openidconnect/middleware.go:84 +0x347
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/openidconnect.glob..func1.1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/openidconnect/middleware.go:53 +0x56
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bd00, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/saml.authHandler(0x2d554c0, 0xc0005c8230, 0xc001ab0500, 0x2d2c2e0, 0xc00208bd00, 0x1)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/saml/middleware.go:53 +0x2df
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/saml.glob..func1.1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/saml/middleware.go:30 +0x56
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bd20, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/httpheader.middleware.func1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/httpheader/middleware.go:46 +0xae8
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bd40, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth.NewHandler.func1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth/middleware.go:31 +0x4ea
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0006d25c0, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth.NewHandler.func1(0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth/middleware.go:31 +0x4ea
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0006d2640, 0x2d554c0, 0xc0005c8230, 0xc001ab0500)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session.CookieMiddlewareWithCSRFSafety.func1(0x2d554c0, 0xc0005c8230, 0xc001ab0400)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/session/session.go:325 +0x1fa
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020b4c30, 0x2d554c0, 0xc0005c8230, 0xc001ab0400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi.AccessTokenAuthMiddleware.func1(0x2d554c0, 0xc0005c8230, 0xc001ab0400)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/auth.go:111 +0x1d8
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc00208bde0, 0x2d554c0, 0xc0005c8230, 0xc001ab0400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1(0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/!n!y!times/gziphandler@v1.1.1/gzip.go:336 +0x225
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020b4c90, 0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | net/http.(*ServeMux).ServeHTTP(0xc0006d2a40, 0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2417 +0x1ad
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth.OverrideAuthMiddleware.func1(0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/auth/override.go:74 +0xa2
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0ce0, 0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth.ForbidAllRequestsMiddleware.func1(0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/auth/forbid_all.go:19 +0xb5
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0d00, 0x2d56c80, 0xc001bc6500, 0xc001ab0400)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/felixge/httpsnoop.CaptureMetrics.func1(0x2d56c80, 0xc001bc6500)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.1/capture_metrics.go:30 +0x4c
03:25:48            frontend | github.com/felixge/httpsnoop.CaptureMetricsFn(0x2d55000, 0xc0003beb60, 0xc00246ee58, 0xc00071e9c0, 0xc00246ee78, 0x1010478)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.1/capture_metrics.go:81 +0x24b
03:25:48            frontend | github.com/felixge/httpsnoop.CaptureMetrics(0x2d2c2e0, 0xc0020c0d00, 0x2d55000, 0xc0003beb60, 0xc001ab0400, 0xc0016f2ef0, 0x2d5e280, 0xc00071e9c0)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.1/capture_metrics.go:29 +0x7d
03:25:48            frontend | github.com/sourcegraph/sourcegraph/internal/trace.HTTPTraceMiddleware.func1(0x2d55000, 0xc0003beb60, 0xc001ab0100)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/internal/trace/httptrace.go:192 +0x9a7
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0d20, 0x2d55000, 0xc0003beb60, 0xc001ab0100)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/getsentry/raven-go.Recoverer.func1(0x2d55000, 0xc0003beb60, 0xc001ab0100)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/getsentry/raven-go@v0.2.0/http.go:97 +0x83
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0d40, 0x2d55000, 0xc0003beb60, 0xc001ab0100)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5(0x2d55000, 0xc0003beb60, 0xc001ab0100)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/opentracing-contrib/go-stdlib@v1.0.0/nethttp/server.go:119 +0x83d
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0006d2ac0, 0x2d55000, 0xc0003beb60, 0xc001ab0100)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/internal/trace/ot.MiddlewareWithTracer.func2(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/internal/trace/ot/ot.go:70 +0x227
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0d80, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware.SourcegraphComGoGetHandler.func1(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware/goimportpath.go:48 +0xb0
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0da0, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware.BlackHole.func1(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware/blackhole.go:17 +0xc8
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0dc0, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli.secureHeadersMiddleware.func1(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/http.go:184 +0x5d2
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0de0, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli.healthCheckMiddleware.func1(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/http.go:101 +0xdd
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0e00, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/gorilla/context.ClearHandler.func1(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/go/pkg/mod/github.com/gorilla/context@v1.1.1/context.go:141 +0x74
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0e20, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware.Trace.func1(0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware/trace.go:27 +0x73
03:25:48            frontend | net/http.HandlerFunc.ServeHTTP(0xc0020c0e40, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042 +0x44
03:25:48            frontend | net/http.serverHandler.ServeHTTP(0xc0002f61c0, 0x2d55000, 0xc0003beb60, 0xc001ab0000)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2843 +0xa3
03:25:48            frontend | net/http.(*conn).serve(0xc000516000, 0x2d5e1c0, 0xc003103180)
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:1925 +0x8ad
03:25:48            frontend | created by net/http.(*Server).Serve
03:25:48            frontend |  /usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2969 +0x36c
03:25:48            frontend | context: context.Background.WithValue(type *http.contextKey, val <not Stringer>).WithValue(type *http.contextKey, val 127.0.0.1:3082).WithCancel.WithCancel.WithValue(type ot.key, val <not Stringer>).WithValue(type opentracing.contextKey, val <not Stringer>).WithValue(type opentracing.contextKey, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val unknown).WithValue(type sessions.contextKey, val <not Stringer>).WithValue(type actor.key, val Actor UID 1, internal false).WithValue(type mux.contextKey, val <not Stringer>).WithValue(type mux.contextKey, val <not Stringer>).WithValue(type trace.key, val CampaignChangesets).WithValue(type trace.key, val <not Stringer>)
```