### PR TITLE
prometheus: support regex silencing of alerts

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/silence.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/silence.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/prometheus/alertmanager/api/v2/models"
 )
 
@@ -12,12 +15,17 @@ func boolP(v bool) *bool {
 	return &v
 }
 
+const (
+	matcherRegexPrefix = "^("
+	matcherRegexSuffix = ")$"
+)
+
 // newMatchersFromSilence creates Alertmanager alert matchers from a configured silence
 func newMatchersFromSilence(silence string) models.Matchers {
 	return models.Matchers{{
 		Name:    stringP("alertname"),
-		Value:   stringP(silence),
-		IsRegex: boolP(false),
+		Value:   stringP(fmt.Sprintf("%s%s%s", matcherRegexPrefix, silence, matcherRegexSuffix)),
+		IsRegex: boolP(true),
 	}}
 }
 
@@ -25,7 +33,7 @@ func newMatchersFromSilence(silence string) models.Matchers {
 func newSilenceFromMatchers(matchers models.Matchers) string {
 	for _, m := range matchers {
 		if *m.Name == "alertname" {
-			return *m.Value
+			return strings.TrimSuffix(strings.TrimPrefix(*m.Value, matcherRegexPrefix), matcherRegexSuffix)
 		}
 	}
 	return ""

--- a/docker-images/prometheus/cmd/prom-wrapper/silence_test.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/silence_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestMatchersAndSilences(t *testing.T) {
+	tests := []struct {
+		name                  string
+		silence               string
+		wantMatcherAlertnames []string
+	}{
+		{
+			name:                  "add strict match",
+			silence:               "hello",
+			wantMatcherAlertnames: []string{"^(hello)$"},
+		},
+		{
+			name:                  "accept regex",
+			silence:               ".*hello.*",
+			wantMatcherAlertnames: []string{"^(.*hello.*)$"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matchers := newMatchersFromSilence(tt.silence)
+			for i, m := range matchers {
+				if *m.Name == "alertname" {
+					if *m.Value != tt.wantMatcherAlertnames[i] {
+						t.Errorf("newMatchersFromSilence got %s, want %s",
+							*m.Value, tt.wantMatcherAlertnames[i])
+					}
+				}
+			}
+			silence := newSilenceFromMatchers(matchers)
+			if silence != tt.silence {
+				t.Errorf("newSilenceFromMatchers() = %v, want %v", silence, tt.silence)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change allows us to perform regex silences in `observability.silenceAlerts`.

Pretty much every low-util alert is firing on k8s.sgdev.org: https://k8s.sgdev.org/-/debug/grafana/?viewPanel=11&orgId=1 so this would be useful for silencing those there (I don't think we want to scale down this particular deployment).

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
