### PR TITLE
search: add C-style comments to search console

### DIFF
--- a/client/shared/src/search/parser/parser.test.ts
+++ b/client/shared/src/search/parser/parser.test.ts
@@ -867,4 +867,154 @@ describe('parseSearchQuery()', () => {
             type: 'success',
         })
     })
+
+    test('interpret C-style comments', () => {
+        const query = `// saucegraph is best graph
+repo:sourcegraph
+// search for thing
+thing`
+        expect(parseSearchQuery(query, true)).toMatchObject({
+            range: {
+                end: 70,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            start: 0,
+                            end: 27,
+                        },
+                        token: {
+                            type: 'comment',
+                            value: '// saucegraph is best graph',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 27,
+                            end: 28,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 28,
+                            end: 44,
+                        },
+                        token: {
+                            filterType: {
+                                range: {
+                                    start: 28,
+                                    end: 32,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'repo',
+                                },
+                            },
+                            filterValue: {
+                                range: {
+                                    start: 33,
+                                    end: 44,
+                                },
+                                token: {
+                                    type: 'literal',
+                                    value: 'sourcegraph',
+                                },
+                                type: 'success',
+                            },
+                            type: 'filter',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 44,
+                            end: 45,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 45,
+                            end: 64,
+                        },
+                        token: {
+                            type: 'comment',
+                            value: '// search for thing',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 64,
+                            end: 65,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 65,
+                            end: 70,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'thing',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
+
+    test('do not interpret C-style comments', () => {
+        expect(parseSearchQuery('// thing')).toMatchObject({
+            range: {
+                end: 8,
+                start: 0,
+            },
+            token: {
+                members: [
+                    {
+                        range: {
+                            start: 0,
+                            end: 2,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: '//',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 2,
+                            end: 3,
+                        },
+                        token: {
+                            type: 'whitespace',
+                        },
+                    },
+                    {
+                        range: {
+                            start: 3,
+                            end: 8,
+                        },
+                        token: {
+                            type: 'literal',
+                            value: 'thing',
+                        },
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        })
+    })
 })

--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -1,5 +1,5 @@
 import * as Monaco from 'monaco-editor'
-import { Observable, fromEventPattern, of, combineLatest } from 'rxjs'
+import { Observable, fromEventPattern, of } from 'rxjs'
 import { parseSearchQuery } from './parser'
 import { map, first, takeUntil, publishReplay, refCount, switchMap, debounceTime, share } from 'rxjs/operators'
 import { getMonacoTokens } from './tokens'

--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -35,11 +35,12 @@ export function getProviders(
     searchQueries: Observable<string>,
     patternTypes: Observable<SearchPatternType>,
     fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>,
+    interpretComments: Observable<boolean>,
     globbing: Observable<boolean>
 ): SearchFieldProviders {
-    const parsedQueries = searchQueries.pipe(
-        map(rawQuery => {
-            const parsed = parseSearchQuery(rawQuery)
+    const parsedQueries = combineLatest([searchQueries, interpretComments]).pipe(
+        map(([rawQuery, interpretComments]) => {
+            const parsed = parseSearchQuery(rawQuery, interpretComments)
             return { rawQuery, parsed }
         }),
         publishReplay(1),

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -34,6 +34,12 @@ export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.
                     scopes: 'operator',
                 })
                 break
+            case 'comment':
+                tokens.push({
+                    startIndex: range.start,
+                    scopes: 'comment',
+                })
+                break
             default:
                 tokens.push({
                     startIndex: range.start,

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -34,6 +34,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'identifier', foreground: '#f2f4f8' },
         { token: 'keyword', foreground: '#569cd6' },
         { token: 'operator', foreground: '#da77f2' },
+        { token: 'comment', foreground: '#ffa94d' },
     ],
 })
 
@@ -59,6 +60,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'identifier', foreground: '#2b3750' },
         { token: 'keyword', foreground: '#268bd2' },
         { token: 'operator', foreground: '#ae3ec9' },
+        { token: 'comment', foreground: '#d9480f' },
     ],
 })
 

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -16,7 +16,6 @@ import { Omit } from 'utility-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { parseSearchURLQuery, parseSearchURLPatternType } from '.'
 import { SearchPatternType } from '../graphql-operations'
-import { replace } from 'lodash'
 
 interface SearchConsolePageProps
     extends ThemeProps,
@@ -89,19 +88,18 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
     )
     const [allExpanded, setAllExpanded] = useState(false)
     const [monacoInstance, setMonacoInstance] = useState<typeof Monaco>()
+    const { globbing } = props
     useEffect(() => {
         if (!monacoInstance) {
             return
         }
-        const subscription = addSourcegraphSearchCodeIntelligence(
-            monacoInstance,
-            searchQuery,
-            of(props.patternType),
-            of(true),
-            of(props.globbing)
-        )
+        const subscription = addSourcegraphSearchCodeIntelligence(monacoInstance, searchQuery, {
+            patternType,
+            globbing,
+            interpretComments: true,
+        })
         return () => subscription.unsubscribe()
-    }, [monacoInstance, searchQuery, props.patternType, props.globbing])
+    }, [monacoInstance, searchQuery, patternType, globbing])
     const [editorInstance, setEditorInstance] = useState<Monaco.editor.IStandaloneCodeEditor>()
     useEffect(() => {
         if (!editorInstance) {

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -16,6 +16,7 @@ import { Omit } from 'utility-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { parseSearchURLQuery, parseSearchURLPatternType } from '.'
 import { SearchPatternType } from '../graphql-operations'
+import { replace } from 'lodash'
 
 interface SearchConsolePageProps
     extends ThemeProps,
@@ -51,7 +52,7 @@ const options: Monaco.editor.IEditorOptions = {
     fixedOverflowWidgets: true,
     renderLineHighlight: 'none',
     contextmenu: false,
-    links: false,
+    links: true,
     // Display the cursor as a 1px line.
     cursorStyle: 'line',
     cursorWidth: 1,
@@ -75,7 +76,13 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
             return query
                 ? concat(
                       of('loading' as const),
-                      search(query, 'V2', patternType, undefined, props.extensionsController.extHostAPI)
+                      search(
+                          query.replace(/\/\/.*/g, ''),
+                          'V2',
+                          patternType,
+                          undefined,
+                          props.extensionsController.extHostAPI
+                      )
                   )
                 : NEVER
         }, [patternType, props.extensionsController, props.location.search])
@@ -90,6 +97,7 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
             monacoInstance,
             searchQuery,
             of(props.patternType),
+            of(true),
             of(props.globbing)
         )
         return () => subscription.unsubscribe()


### PR DESCRIPTION
I want it. C-style OK as a 'we go with that for now'? Needs tests, so still WIP, but please review my TS so far.

- `links: true` now, it's useful :-)
- see questions about TS

<img width="717" alt="Screen Shot 2020-10-07 at 12 27 52 AM" src="https://user-images.githubusercontent.com/888624/95301442-77bb8900-0835-11eb-919c-41b1a58f0db4.png">

<img width="716" alt="Screen Shot 2020-10-07 at 12 33 33 AM" src="https://user-images.githubusercontent.com/888624/95301445-79854c80-0835-11eb-84c4-fdf1956e7ecf.png">
