### PR TITLE
Hide 'show more' on search console page

### DIFF
--- a/web/src/search/SearchConsolePage.tsx
+++ b/web/src/search/SearchConsolePage.tsx
@@ -106,35 +106,6 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
         return () => disposable.dispose()
     }, [editorInstance, searchQuery, props.history])
 
-    const calculateCount = useCallback((): number => {
-        // This function can only get called if the results were successfully loaded,
-        // so casting is the right thing to do here
-        const results = resultsOrError as GQL.ISearchResults
-
-        const query = searchQuery.value
-        if (/count:(\d+)/.test(query)) {
-            return Math.max(results.matchCount * 2, 1000)
-        }
-        return Math.max(results.matchCount * 2 || 0, 1000)
-    }, [resultsOrError, searchQuery])
-
-    const showMoreResults = useCallback((): void => {
-        // Requery with an increased max result count.
-        if (!editorInstance) {
-            return
-        }
-        let query = editorInstance.getValue()
-
-        const count = calculateCount()
-        if (/count:(\d+)/.test(query)) {
-            query = query.replace(/count:\d+/g, '').trim() + ` count:${count}`
-        } else {
-            query = `${query} count:${count}`
-        }
-        searchQuery.next(query)
-        triggerSearch()
-    }, [calculateCount, editorInstance, searchQuery, triggerSearch])
-
     const onExpandAllResultsToggle = useCallback((): void => {
         setAllExpanded(allExpanded => {
             props.telemetryService.log(allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
@@ -178,7 +149,6 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                                 showSavedQueryButton={false}
                                 onDidCreateSavedQuery={voidCallback}
                                 onSavedQueryModalClose={voidCallback}
-                                onShowMoreResultsClick={showMoreResults}
                                 onSaveQueryClick={voidCallback}
                             />
                         ))}

--- a/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/web/src/search/results/SearchResultsInfoBar.tsx
@@ -33,7 +33,7 @@ interface SearchResultsInfoBarProps
     /** The loaded search results and metadata */
     query?: string
     results: GQL.ISearchResults
-    onShowMoreResultsClick: () => void
+    onShowMoreResultsClick?: () => void
 
     // Expand all feature
     allExpanded: boolean
@@ -108,7 +108,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                                 {props.results.limitHit && String.fromCharCode(160)}
                             </span>
 
-                            {props.results.limitHit && (
+                            {props.results.limitHit && props.onShowMoreResultsClick && (
                                 <button
                                     type="button"
                                     className="btn btn-link btn-sm p-0"

--- a/web/src/search/results/SearchResultsList.tsx
+++ b/web/src/search/results/SearchResultsList.tsx
@@ -58,7 +58,7 @@ export interface SearchResultsListProps
 
     // Result list
     resultsOrError?: GQL.ISearchResults | ErrorLike
-    onShowMoreResultsClick: () => void
+    onShowMoreResultsClick?: () => void
 
     // Expand all feature
     allExpanded: boolean
@@ -451,16 +451,18 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         results.length == 30 && resultsShown == 40 so we use >=
                                         comparison below.
                                     */}
-                                    {results.limitHit && this.state.resultsShown >= results.results.length && (
-                                        <button
-                                            type="button"
-                                            className="btn btn-secondary btn-block"
-                                            data-testid="search-show-more-button"
-                                            onClick={this.props.onShowMoreResultsClick}
-                                        >
-                                            Show more
-                                        </button>
-                                    )}
+                                    {results.limitHit &&
+                                        this.state.resultsShown >= results.results.length &&
+                                        this.props.onShowMoreResultsClick && (
+                                            <button
+                                                type="button"
+                                                className="btn btn-secondary btn-block"
+                                                data-testid="search-show-more-button"
+                                                onClick={this.props.onShowMoreResultsClick}
+                                            >
+                                                Show more
+                                            </button>
+                                        )}
 
                                     {results.matchCount === 0 && !results.alert && (
                                         <div className="alert alert-info d-flex m-2">


### PR DESCRIPTION
The primary use case for the search console page (showcasing complex structural search queries on Cloud) does not like `count:1000`. For simplicity's sake, we hide `Show more` altogether on the search console page.