### PR TITLE
Browser extension: open popup on 'Configure Sourcegraph' click

### DIFF
--- a/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -151,6 +151,15 @@ async function main(): Promise<void> {
             await browser.runtime.openOptionsPage()
         },
 
+        /** Tries to open popup, falls back to opening options page on error */
+        async openPopup(): Promise<void> {
+            try {
+                await browser.browserAction.openPopup()
+            } catch {
+                await this.openOptionsPage()
+            }
+        },
+
         async createBlobURL(bundleUrl: string): Promise<string> {
             return createBlobURLForBundle(bundleUrl)
         },

--- a/browser/src/browser-extension/web-extension-api/types.ts
+++ b/browser/src/browser-extension/web-extension-api/types.ts
@@ -74,6 +74,7 @@ export interface ManagedStorageItems extends SourcegraphURL {
  */
 export interface BackgroundMessageHandlers {
     openOptionsPage(): Promise<void>
+    openPopup(): Promise<void>
     createBlobURL(bundleUrl: string): Promise<string>
     requestGraphQL<T, V = object>(options: { request: string; variables: V }): Promise<GraphQLResult<T>>
 }

--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -700,7 +700,7 @@ export function handleCodeHost({
         )
         const onConfigureSourcegraphClick: React.MouseEventHandler<HTMLAnchorElement> = async event => {
             event.preventDefault()
-            await browser.runtime.sendMessage({ type: 'openOptionsPage' })
+            await browser.runtime.sendMessage({ type: 'openPopup' })
         }
 
         subscriptions.add(

--- a/browser/src/shared/code-hosts/shared/nativeTooltips.tsx
+++ b/browser/src/shared/code-hosts/shared/nativeTooltips.tsx
@@ -30,7 +30,7 @@ export function handleNativeTooltips(
     { nativeTooltipResolvers, name }: Pick<CodeHost, 'nativeTooltipResolvers' | 'name'>
 ): { nativeTooltipsAlert: Observable<HoverAlert>; subscription: Unsubscribable } {
     const nativeTooltips = mutations.pipe(trackViews(nativeTooltipResolvers || []))
-    const nativeTooltipsAlert = mutations.pipe(
+    const nativeTooltipsAlert = nativeTooltips.pipe(
         first(),
         mapTo({
             type: NATIVE_TOOLTIP_TYPE,

--- a/shared/src/hover/HoverOverlay.tsx
+++ b/shared/src/hover/HoverOverlay.tsx
@@ -169,7 +169,7 @@ export class HoverOverlay extends React.PureComponent<HoverOverlayProps, HoverOv
                         <div className={classNames('hover-overlay__hover-error', this.props.errorAlertClassName)}>
                             {upperFirst(hoverOrError.message)}
                         </div>
-                    ) : hoverOrError === null ? (
+                    ) : hoverOrError === null || (!hoverOrError?.contents.length && hoverOrError?.alerts?.length) ? (
                         // Show some content to give the close button space
                         // and communicate to the user we couldn't find a hover.
                         <em>No hover information available.</em>

--- a/shared/src/util/markdown.ts
+++ b/shared/src/util/markdown.ts
@@ -115,6 +115,8 @@ export const renderMarkdown = (
                     ...sanitize.defaults.allowedAttributes.a,
                     'title',
                     'data-tooltip', // TODO support fancy tooltips through native titles
+                    'class',
+                    'rel',
                 ],
                 img: [...sanitize.defaults.allowedAttributes.img, 'alt'],
                 // Support different images depending on media queries (e.g. color theme, reduced motion)


### PR DESCRIPTION
Part two of #14225.

This works for me on Chromium (Version 85.0.4183.121 (Official Build) snap (64-bit)), but falls back to opening the options page on  Firefox (81.0) (`browserAction.openPopup may only be called from a user input handler`)