### PR TITLE
Browser extension: open popup on 'Configure Sourcegraph' click

### DIFF
--- a/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -151,6 +151,15 @@ async function main(): Promise<void> {
             await browser.runtime.openOptionsPage()
         },
 
+        /** Tries to open popup, falls back to opening options page on error */
+        async openPopup(): Promise<void> {
+            try {
+                await browser.browserAction.openPopup()
+            } catch {
+                await this.openOptionsPage()
+            }
+        },
+
         async createBlobURL(bundleUrl: string): Promise<string> {
             return createBlobURLForBundle(bundleUrl)
         },

--- a/browser/src/browser-extension/web-extension-api/runtime.ts
+++ b/browser/src/browser-extension/web-extension-api/runtime.ts
@@ -18,6 +18,7 @@ const messageSender = <T extends keyof BackgroundMessageHandlers>(type: T): Back
  */
 export const background: BackgroundMessageHandlers = {
     createBlobURL: messageSender('createBlobURL'),
+    openPopup: messageSender('openPopup'),
     openOptionsPage: messageSender('openOptionsPage'),
     requestGraphQL: messageSender('requestGraphQL'),
 }

--- a/browser/src/browser-extension/web-extension-api/types.ts
+++ b/browser/src/browser-extension/web-extension-api/types.ts
@@ -74,6 +74,7 @@ export interface ManagedStorageItems extends SourcegraphURL {
  */
 export interface BackgroundMessageHandlers {
     openOptionsPage(): Promise<void>
+    openPopup(): Promise<void>
     createBlobURL(bundleUrl: string): Promise<string>
     requestGraphQL<T, V = object>(options: { request: string; variables: V }): Promise<GraphQLResult<T>>
 }

--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -680,7 +680,7 @@ export function handleCodeHost({
         )
         const onConfigureSourcegraphClick: React.MouseEventHandler<HTMLAnchorElement> = async event => {
             event.preventDefault()
-            await browser.runtime.sendMessage({ type: 'openOptionsPage' })
+            await browser.runtime.sendMessage({ type: 'openPopup' })
         }
 
         subscriptions.add(

--- a/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -110,6 +110,7 @@ import { wrapRemoteObservable } from '../../../../../shared/src/api/client/api/c
 import { HoverMerged } from '../../../../../shared/src/api/client/types/hover'
 import { isFirefox, observeSourcegraphURL } from '../../util/context'
 import { shouldOverrideSendTelemetry, observeOptionFlag } from '../../util/optionFlags'
+import { background } from '../../../browser-extension/web-extension-api/runtime'
 
 registerHighlightContributions()
 
@@ -680,7 +681,7 @@ export function handleCodeHost({
         )
         const onConfigureSourcegraphClick: React.MouseEventHandler<HTMLAnchorElement> = async event => {
             event.preventDefault()
-            await browser.runtime.sendMessage({ type: 'openPopup' })
+            await background.openPopup()
         }
 
         subscriptions.add(


### PR DESCRIPTION
Part two of #14225.

This works for me on Chromium (Version 85.0.4183.121 (Official Build) snap (64-bit)), but falls back to opening the options page on Firefox (81.0) (`browserAction.openPopup may only be called from a user input handler`)