### PR TITLE
search: condense query validation

### DIFF
--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -24,7 +24,7 @@ var allLabels = map[labels]string{
 	HeuristicParensAsPatterns: "HeuristicParensAsPatterns",
 	HeuristicDanglingParens:   "HeuristicDanglingParens",
 	HeuristicHoisted:          "HeuristicHoisted",
-	Structural:                "Strucutral",
+	Structural:                "Structural",
 }
 
 func (l *labels) isSet(label labels) bool {

--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -13,6 +13,7 @@ const (
 	HeuristicParensAsPatterns
 	HeuristicDanglingParens
 	HeuristicHoisted
+	Structural
 )
 
 var allLabels = map[labels]string{
@@ -23,6 +24,7 @@ var allLabels = map[labels]string{
 	HeuristicParensAsPatterns: "HeuristicParensAsPatterns",
 	HeuristicDanglingParens:   "HeuristicDanglingParens",
 	HeuristicHoisted:          "HeuristicHoisted",
+	Structural:                "Strucutral",
 }
 
 func (l *labels) isSet(label labels) bool {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1220,11 +1220,8 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	case SearchTypeLiteral:
 		query = substituteConcat(query, space)
 	case SearchTypeStructural:
-		if containsNegatedPattern(query) {
-			return nil, errors.New("the query contains a negated search pattern. Structural search does not support negated search patterns at the moment")
-		}
+		query = Map(query, labelStructural, ellipsesForHoles)
 		query = substituteConcat(query, space)
-		query = ellipsesForHoles(query)
 	case SearchTypeRegex:
 		query = escapeParensHeuristic(query)
 		query = substituteConcat(query, fuzzyRegexp)

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -661,6 +661,21 @@ func concatRevFilters(nodes []Node) []Node {
 	})
 }
 
+// labelStructural converts Literal labels to Structural labels. Structural
+// queries are parsed the same as literal queries, we just convert the labels as
+// a postprocessing step to keep the parser lean.
+func labelStructural(nodes []Node) []Node {
+	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
+		annotation.Labels.unset(Literal)
+		annotation.Labels.set(Structural)
+		return Pattern{
+			Value:      value,
+			Negated:    negated,
+			Annotation: annotation,
+		}
+	})
+}
+
 // ellipsesForHoles substitutes ellipses ... for :[_] holes in structural search queries.
 func ellipsesForHoles(nodes []Node) []Node {
 	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -64,18 +64,6 @@ func containsAndOrExpression(nodes []Node) bool {
 	})
 }
 
-// containsNegatedPattern returns true if any search pattern is negated in nodes.
-func containsNegatedPattern(nodes []Node) bool {
-	return exists(nodes, func(node Node) bool {
-		if p, ok := node.(Pattern); ok {
-			if p.Negated {
-				return true
-			}
-		}
-		return false
-	})
-}
-
 // ContainsAndOrKeyword returns true if this query contains or- or and-
 // keywords. It is a temporary signal to determine whether we can fallback to
 // the older existing search functionality.

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -401,12 +401,18 @@ func validate(nodes []Node) error {
 		err = validateField(field, value, negated, seen)
 		seen[field] = struct{}{}
 	})
-	VisitPattern(nodes, func(value string, _ bool, annotation Annotation) {
+	VisitPattern(nodes, func(value string, negated bool, annotation Annotation) {
 		if annotation.Labels.isSet(Regexp) {
 			if err != nil {
 				return
 			}
 			_, err = regexp.Compile(value)
+		}
+		if annotation.Labels.isSet(Structural) && negated {
+			if err != nil {
+				return
+			}
+			err = errors.New("the query contains a negated search pattern. Structural search does not support negated search patterns at the moment")
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
Tightens the toplevel parse function. This moves a structural search validation check out of the toplevel parse function and into the `validate` function.