### PR TITLE
search: abstract concat function to partial function

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1218,13 +1218,11 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 
 	switch options.SearchType {
 	case SearchTypeLiteral:
-		query = substituteConcat(query, space)
+		query = Map(query, substituteConcat(space))
 	case SearchTypeStructural:
-		query = Map(query, labelStructural, ellipsesForHoles)
-		query = substituteConcat(query, space)
+		query = Map(query, labelStructural, ellipsesForHoles, substituteConcat(space))
 	case SearchTypeRegex:
-		query = escapeParensHeuristic(query)
-		query = substituteConcat(query, fuzzyRegexp)
+		query = Map(query, escapeParensHeuristic, substituteConcat(fuzzyRegexp))
 	}
 
 	if options.Globbing {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -495,10 +495,11 @@ func space(patterns []Pattern) Pattern {
 	}
 }
 
-// substituteConcat calls the callback function for all contiguous patterns in
-// the tree, rooted by a concat operator. The return value of callback is
+// substituteConcat returns a function that concatenates all contiguous patterns
+// in the tree, rooted by a concat operator. The callback parameter defines how
+// the function concatenates patterns. The return value of callback is
 // substituted in-place in the tree.
-func substituteConcat(nodes []Node, callback func([]Pattern) Pattern) []Node {
+func substituteConcat(callback func([]Pattern) Pattern) func(nodes []Node) []Node {
 	isPattern := func(node Node) bool {
 		if pattern, ok := node.(Pattern); ok && !pattern.Negated {
 			return true
@@ -546,7 +547,7 @@ func substituteConcat(nodes []Node, callback func([]Pattern) Pattern) []Node {
 		}
 		return newNode
 	}
-	return substituteNodes(nodes)
+	return substituteNodes
 }
 
 // escapeParens is a heuristic used in the context of regular expression search.

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -275,7 +275,7 @@ func TestSubstituteConcat(t *testing.T) {
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			got := prettyPrint(substituteConcat(query, c.concat))
+			got := prettyPrint(Map(query, substituteConcat(c.concat)))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Stacked on #14494. Tightens the toplevel parse function so that we pipe query through `Map` for all transformer functions.