### PR TITLE
dev: Disable indexing cncf repositories locally

### DIFF
--- a/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
+++ b/enterprise/cmd/precise-code-intel-indexer/internal/indexability_updater/updater.go
@@ -2,6 +2,7 @@ package indexabilityupdater
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -45,7 +46,7 @@ func NewUpdater(
 		minimumSearchCount:  minimumSearchCount,
 		minimumSearchRatio:  minimumSearchRatio,
 		minimumPreciseCount: minimumPreciseCount,
-		enableIndexingCNCF:  true,
+		enableIndexingCNCF:  os.Getenv("DISABLE_CNCF") == "",
 		limiter:             rate.NewLimiter(MaxGitserverRequestsPerSecond, 1),
 	})
 }

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -45,6 +45,7 @@ export PRECISE_CODE_INTEL_INDEX_MANAGER_URL=http://localhost:3189
 export PRECISE_CODE_INTEL_INTERNAL_PROXY_AUTH_TOKEN=hunter2
 export PRECISE_CODE_INTEL_USE_FIRECRACKER=false
 export PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH=$HOME/.sourcegraph/images
+export DISABLE_CNCF=notonmybox
 
 export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"
 export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-indexer-vm precise-code-intel-worker "


### PR DESCRIPTION
Reduce developer spam when running the precise code intel indexer. There is a hard-coded list of repositories that work for the cloud deployment, but will not in dev. Just turn it off.