### PR TITLE
search: trigger search on cmd+enter in console

### DIFF
--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -105,12 +105,13 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
         if (!editorInstance) {
             return
         }
+        editorInstance.addCommand(Monaco.KeyMod.CtrlCmd | Monaco.KeyCode.Enter, triggerSearch)
         const disposable = editorInstance.onDidChangeModelContent(() => {
             const query = editorInstance.getValue()
             searchQuery.next(query)
         })
         return () => disposable.dispose()
-    }, [editorInstance, searchQuery, props.history])
+    }, [editorInstance, searchQuery, props.history, triggerSearch])
 
     const onExpandAllResultsToggle = useCallback((): void => {
         setAllExpanded(allExpanded => {

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -105,13 +105,24 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
         if (!editorInstance) {
             return
         }
-        editorInstance.addCommand(Monaco.KeyMod.CtrlCmd | Monaco.KeyCode.Enter, triggerSearch)
         const disposable = editorInstance.onDidChangeModelContent(() => {
             const query = editorInstance.getValue()
             searchQuery.next(query)
         })
         return () => disposable.dispose()
-    }, [editorInstance, searchQuery, props.history, triggerSearch])
+    }, [editorInstance, searchQuery, props.history])
+    useEffect(() => {
+        if (!editorInstance) {
+            return
+        }
+        const disposable = editorInstance.addAction({
+            id: 'submit-on-cmd-enter',
+            label: 'Submit search',
+            keybindings: [Monaco.KeyMod.CtrlCmd | Monaco.KeyCode.Enter],
+            run: () => triggerSearch(),
+        })
+        return () => disposable.dispose()
+    }, [editorInstance, triggerSearch])
 
     const onExpandAllResultsToggle = useCallback((): void => {
         setAllExpanded(allExpanded => {


### PR DESCRIPTION
> ![Screen Shot 2020-10-07 at 7 27 10 PM](https://user-images.githubusercontent.com/888624/95407892-1fd35f80-08d3-11eb-8d68-2be5c855a123.png)

---

Tested working manually. Question: Am I setting this in the right place? I'm not sure I grok `useEffect`. From docs:

> Accepts a function that contains imperative, possibly effectful code.
 @param effect — Imperative function that can return a cleanup function
 @param deps — If present, effect will only activate if the values in the list change.

I don't really care that this effect depends on whether `triggerSearch` _changes_, but `useEffect` seems to require me to add it to deps since `editorInstance` is effectful, and I'm looking for a place to add this key binding where `editorInstance` is defined. I.e., `editorInstance` is only guaranteed to be defined after the check inside this `useEffect` block, so it seems like the right place. The implication is that `triggerSearch` needs to be included in `deps`, which is weird to me.