### PR TITLE
Fix missing page title in search language docs

### DIFF
--- a/doc/user/search/language.md
+++ b/doc/user/search/language.md
@@ -1,3 +1,5 @@
+# Sourcegraph Search Query Language
+
 <style>
 
 ul.r {
@@ -167,7 +169,6 @@ img.r {
 
 </style>
 
-# Sourcegraph Search Query Language
 
 This page provides a visual breakdown of our Search Query Language and a handful
 of examples to get you started. It is complementary to our [syntax


### PR DESCRIPTION
I noticed this when shamelessly copying the custom-style-in-docs stuff from this page. With `<style>` being the first line, the page title is lost.

This fixes it by moving the `<style>` below the header.
