### PR TITLE
Fix crash on Gitlab external service configuration

### DIFF
--- a/enterprise/internal/db/external_services_test.go
+++ b/enterprise/internal/db/external_services_test.go
@@ -900,13 +900,13 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			kind:   extsvc.KindGitLab,
 			desc:   "invalid empty projects item",
 			config: `{"projects": [{}]}`,
-			assert: includes(`projects.0: Must validate at least one schema (anyOf)`),
+			assert: includes(`projects.0: Must validate one and only one schema (oneOf)`),
 		},
 		{
 			kind:   extsvc.KindGitLab,
 			desc:   "invalid projects item",
 			config: `{"projects": [{"foo": "bar"}]}`,
-			assert: includes(`projects.0: Must validate at least one schema (anyOf)`),
+			assert: includes(`projects.0: Must validate one and only one schema (oneOf)`),
 		},
 		{
 			kind:   extsvc.KindGitLab,
@@ -922,7 +922,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 		},
 		{
 			kind: extsvc.KindGitLab,
-			desc: "both name and id can be specified in projects",
+			desc: "both name and id cannot be specified in projects",
 			config: `
 			{
 				"url": "https://gitlab.corp.com",
@@ -932,7 +932,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 					{"name": "foo/bar", "id": 1234}
 				]
 			}`,
-			assert: equals(`<nil>`),
+			assert: includes(`projects.0: Must validate one and only one schema (oneOf)`),
 		},
 		{
 			kind:   extsvc.KindGitLab,

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -67,7 +67,7 @@
         "type": "object",
         "title": "GitLabProject",
         "additionalProperties": false,
-        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "oneOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {
           "name": {
             "description": "The name of a GitLab project (\"group/name\") to mirror.",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -72,7 +72,7 @@ const GitLabSchemaJSON = `{
         "type": "object",
         "title": "GitLabProject",
         "additionalProperties": false,
-        "anyOf": [{ "required": ["name"] }, { "required": ["id"] }],
+        "oneOf": [{ "required": ["name"] }, { "required": ["id"] }],
         "properties": {
           "name": {
             "description": "The name of a GitLab project (\"group/name\") to mirror.",


### PR DESCRIPTION
`OneOf` will prevent the schema from being saved and enforce choosing only one of the expected properties.

Fixes #13737 