### PR TITLE
codeintel: Lower number of goroutines during SQLite -> Postgres migration

### DIFF
--- a/enterprise/internal/codeintel/bundles/persistence/postgres/store.go
+++ b/enterprise/internal/codeintel/bundles/persistence/postgres/store.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"runtime"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
@@ -259,7 +258,7 @@ func (s *store) writeDefinitionReferences(ctx context.Context, tableName string,
 	return withBatchInserter(ctx, s.Handle().DB(), tableName, []string{"dump_id", "scheme", "identifier", "data"}, inserter)
 }
 
-var numWriterRoutines = runtime.GOMAXPROCS(0)
+var numWriterRoutines = 1 // runtime.GOMAXPROCS(0)
 
 func withBatchInserter(ctx context.Context, db dbutil.DB, tableName string, columns []string, f func(inserter *BatchInserter) error) error {
 	return util.InvokeN(numWriterRoutines, func() (err error) {


### PR DESCRIPTION
Migrations are really causing the bundle manager CPU to spike and performance to be suboptimal. This should help during the migration period (although it will take longer).