### PR TITLE
Only take reconciled changesets into consideration when calculating events

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -164,7 +164,7 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	resolvers := []graphqlbackend.ChangesetCountsResolver{}
 
 	publishedState := campaigns.ChangesetPublicationStatePublished
-	opts := ee.ListChangesetsOpts{CampaignID: r.Campaign.ID, PublicationState: &publishedState}
+	opts := ee.ListChangesetsOpts{CampaignID: r.Campaign.ID, PublicationState: &publishedState, ReconcilerStates: []campaigns.ReconcilerState{campaigns.ReconcilerStateCompleted}}
 	cs, _, err := r.store.ListChangesets(ctx, opts)
 	if err != nil {
 		return resolvers, err

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -164,7 +164,12 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	resolvers := []graphqlbackend.ChangesetCountsResolver{}
 
 	publishedState := campaigns.ChangesetPublicationStatePublished
-	opts := ee.ListChangesetsOpts{CampaignID: r.Campaign.ID, PublicationState: &publishedState, ReconcilerStates: []campaigns.ReconcilerState{campaigns.ReconcilerStateCompleted}}
+	opts := ee.ListChangesetsOpts{
+		CampaignID:       r.Campaign.ID,
+		PublicationState: &publishedState,
+		// Only request synced changesets, as we cannot be sure that we know all data required for computation for unsynced changesets.
+		OnlySynced: true,
+	}
 	cs, _, err := r.store.ListChangesets(ctx, opts)
 	if err != nil {
 		return resolvers, err

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -167,7 +167,7 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	opts := ee.ListChangesetsOpts{
 		CampaignID:       r.Campaign.ID,
 		PublicationState: &publishedState,
-		// Only request synced changesets, as we cannot be sure that we know all data required for computation for unsynced changesets.
+		// Only load fully-synced changesets, so that the data we use for computing the changeset counts is complete.
 		OnlySynced: true,
 	}
 	cs, _, err := r.store.ListChangesets(ctx, opts)

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -388,6 +388,8 @@ type ListChangesetsOpts struct {
 	ExternalCheckState   *campaigns.ChangesetCheckState
 	OwnedByCampaignID    int64
 	OnlyWithoutDiffStats bool
+	// OnlySynced adds a conditional on changeset.unsynced IS FALSE.
+	OnlySynced bool
 }
 
 // ListChangesets lists Changesets with the given filters.
@@ -469,6 +471,10 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 
 	if opts.OnlyWithoutDiffStats {
 		preds = append(preds, sqlf.Sprintf("(changesets.diff_stat_added IS NULL OR changesets.diff_stat_changed IS NULL OR changesets.diff_stat_deleted IS NULL)"))
+	}
+
+	if opts.OnlySynced {
+		preds = append(preds, sqlf.Sprintf("changesets.unsynced IS FALSE"))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -388,8 +388,7 @@ type ListChangesetsOpts struct {
 	ExternalCheckState   *campaigns.ChangesetCheckState
 	OwnedByCampaignID    int64
 	OnlyWithoutDiffStats bool
-	// OnlySynced adds a conditional on changeset.unsynced IS FALSE.
-	OnlySynced bool
+	OnlySynced           bool
 }
 
 // ListChangesets lists Changesets with the given filters.

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +95,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				NumResets:       18,
 				NumFailures:     25,
 
-				Unsynced: true,
+				Unsynced: i != 0,
 				Closing:  true,
 			}
 
@@ -540,10 +541,16 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				},
 				wantCount: 1,
 			},
+			{
+				opts: ListChangesetsOpts{
+					OnlySynced: true,
+				},
+				wantCount: 1,
+			},
 		}
 
-		for _, tc := range filterCases {
-			t.Run("", func(t *testing.T) {
+		for i, tc := range filterCases {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
 				have, _, err := s.ListChangesets(ctx, tc.opts)
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
This fixes a bug where calculation would fail because ExternalCreatedAt is null, because it could not be synced initially.
I think this makes sense, as we won't have consistent data before it's reconciled anyways, but please let's discuss!