### PR TITLE
Remove unnecessary check if campaigns are enabled

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -161,10 +161,6 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 	ctx context.Context,
 	args *graphqlbackend.ChangesetCountsArgs,
 ) ([]graphqlbackend.ChangesetCountsResolver, error) {
-	if err := campaignsEnabled(); err != nil {
-		return nil, err
-	}
-
 	resolvers := []graphqlbackend.ChangesetCountsResolver{}
 
 	publishedState := campaigns.ChangesetPublicationStatePublished


### PR DESCRIPTION
This can only be retrieved on a campaign, and when you cannot query a campaign node, this method will also not be exposed. .. or am I missing something?