### PR TITLE
Fix wrong state calculated for empty check suites

### DIFF
--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -215,7 +215,7 @@ func computeGitHubCheckState(lastSynced time.Time, pr *github.PullRequest, event
 			statusPerContext[c.Context] = parseGithubCheckState(c.State)
 		}
 		for _, c := range commit.Commit.CheckSuites.Nodes {
-			if c.Status == "QUEUED" && len(c.CheckRuns.Nodes) == 0 {
+			if (c.Status == "QUEUED" || c.Status == "COMPLETED") && len(c.CheckRuns.Nodes) == 0 {
 				// Ignore queued suites with no runs.
 				// It is common for suites to be created and then stay in the QUEUED state
 				// forever with zero runs.
@@ -246,7 +246,7 @@ func computeGitHubCheckState(lastSynced time.Time, pr *github.PullRequest, event
 				}
 			}
 		case *github.CheckSuite:
-			if m.Status == "QUEUED" && len(m.CheckRuns.Nodes) == 0 {
+			if (m.Status == "QUEUED" || m.Status == "COMPLETED") && len(m.CheckRuns.Nodes) == 0 {
 				// Ignore suites with no runs.
 				// See previous comment.
 				continue

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -133,12 +133,20 @@ func TestComputeGithubCheckState(t *testing.T) {
 			want: cmpgn.ChangesetCheckStatePassed,
 		},
 		{
-			name: "suites with zero runs should be ignored",
+			name: "queued suites with zero runs should be ignored",
 			events: []*cmpgn.ChangesetEvent{
 				commitEvent(1, "ctx1", "SUCCESS"),
 				checkSuiteEvent(1, "cs1", "QUEUED", ""),
 			},
 			want: cmpgn.ChangesetCheckStatePassed,
+		},
+		{
+			name: "completed suites with zero runs should be ignored",
+			events: []*cmpgn.ChangesetEvent{
+				commitEvent(1, "ctx1", "ERROR"),
+				checkSuiteEvent(1, "cs1", "COMPLETED", ""),
+			},
+			want: cmpgn.ChangesetCheckStateFailed,
 		},
 	}
 


### PR DESCRIPTION
Empty completed checksuites become stale at some point and then will be considered "UNKNOWN", but they don't contribute to the overall state displayed by GitHub, hence they should be ignored too.
