### PR TITLE
Add missing Close call to diff iterator

### DIFF
--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -536,6 +536,7 @@ func computeDiffStat(ctx context.Context, c *campaigns.Changeset, repo gitserver
 	if err != nil {
 		return nil, err
 	}
+	defer iter.Close()
 
 	stat := &diff.Stat{}
 	for {


### PR DESCRIPTION
The docs state this should always be done so it seems like this is missing.
