### PR TITLE
increase timeout for testing in vagrant box

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -170,13 +170,13 @@ export class Driver {
             await this.page.type('input[name=username]', username)
             await this.page.type('input[name=password]', password)
             await this.page.click('button[type=submit]')
-            await this.page.waitForNavigation({ timeout: 3 * 1000 })
+            await this.page.waitForNavigation({ timeout: 3 * 10000 })
         } else if (url.pathname === '/sign-in') {
             await this.page.waitForSelector('.test-signin-form')
             await this.page.type('input', username)
             await this.page.type('input[name=password]', password)
             await this.page.click('button[type=submit]')
-            await this.page.waitForNavigation({ timeout: 3 * 1000 })
+            await this.page.waitForNavigation({ timeout: 3 * 10000 })
         }
     }
 


### PR DESCRIPTION
increases the wait navigation timeout for e2e testing now that this occurs in a remote vagrant box, not directly on the buildkite agent. 