### PR TITLE
search: only show tour to new users

### DIFF
--- a/client/web/src/search/input/SearchPageInput.tsx
+++ b/client/web/src/search/input/SearchPageInput.tsx
@@ -40,6 +40,7 @@ import { useLocalStorage } from '../../util/useLocalStorage'
 import Shepherd from 'shepherd.js'
 import { AuthenticatedUser } from '../../auth'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
+import { daysActiveCount } from '../../marketing/util'
 
 interface Props
     extends SettingsCascadeProps<Settings>,
@@ -102,7 +103,8 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
         [props.location.pathname, props.location.search]
     )
 
-    const showOnboardingTour = props.showOnboardingTour && isHomepage && !hasSeenTour && !hasCancelledTour
+    const showOnboardingTour =
+        props.showOnboardingTour && isHomepage && daysActiveCount === 1 && !hasSeenTour && !hasCancelledTour
 
     const tour = useMemo(() => new Shepherd.Tour(defaultTourOptions), [])
 


### PR DESCRIPTION
I went back and forth with different ways this could be implemented (event log? data from homepage panels which already query the event log?), but eventually I decided on using the `daysActiveCount` we have available already in `localStorage` to show other toasts.

Pros:
- Available locally, no need to do a GraphQL query to get data
- Very easy to implement, no need to refactor
- Will show the tour to all new users, even if not logged in (huge win for Cloud)

Cons:
- Won't show the tour to existing users that have visited Sourcegraph before but have never done a search. Our hope is that the empty homepage panels will provide enough examples for these users.
- Will show the tour to existing users if they use a new browser/computer
