### PR TITLE
codeintel: Clean up bundle files after SQLite -> Postgres migration

### DIFF
--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/paths/paths.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/paths/paths.go
@@ -11,6 +11,7 @@ const uploadDir = "uploads"
 const uploadPartsDir = "upload-parts"
 const dbsDir = "dbs"
 const dbPartsDir = "db-parts"
+const dbBackupsDir = "db-backups"
 const migrationMarkersDir = "migration-markers"
 
 // PrepDirectories creates the root directories within the given bundle dir.
@@ -20,6 +21,7 @@ func PrepDirectories(bundleDir string) error {
 		uploadPartsDir,
 		dbsDir,
 		dbPartsDir,
+		dbBackupsDir,
 		migrationMarkersDir,
 	}
 
@@ -75,6 +77,16 @@ func DBPartsDir(bundleDir string) string {
 // DBPartFilename returns the path of the db with the given identifier and part index.
 func DBPartFilename(bundleDir string, id, index int64) string {
 	return filepath.Join(bundleDir, dbPartsDir, fmt.Sprintf("%d.%d.gz", id, index))
+}
+
+// DBBackupsDir returns the path of the directory containing db backup files.
+func DBBackupsDir(bundleDir string) string {
+	return filepath.Join(bundleDir, dbBackupsDir)
+}
+
+// DBBackupFilename returns the path of the backup SQLite db for the given bundle identifier.
+func DBBackupFilename(bundleDir string, id int64) string {
+	return filepath.Join(bundleDir, dbBackupsDir, strconv.FormatInt(id, 10)+".db")
 }
 
 // MigrationMarkerFilename returns the path to the file that marks a migration has been performed.

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/readers/migrate.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/readers/migrate.go
@@ -155,14 +155,13 @@ func noopHandler(store persistence.Store) error {
 }
 
 func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB) error {
-	paths, err := sqlitePaths(bundleDir)
+	bundleFilenames, err := sqlitePaths(bundleDir)
 	if err != nil {
 		return err
 	}
-	if len(paths) == 0 {
+	if len(bundleFilenames) == 0 {
 		return nil
 	}
-	bundleFilenames := paths
 
 	ctx := context.Background()
 
@@ -176,6 +175,19 @@ func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB
 		bundleIDMap[bundleID] = struct{}{}
 	}
 
+	moveFileToBackupDirectory := func(bundleID int64) {
+		filename := paths.SQLiteDBFilename(bundleDir, bundleID)
+
+		if err := os.Rename(filename, paths.DBBackupFilename(bundleDir, bundleID)); err != nil {
+			log15.Error("Failed to move bundle to backups directory", "err", err, "filename", filename)
+			return
+		}
+
+		if err := os.RemoveAll(filepath.Dir(filename)); err != nil {
+			log15.Error("Failed to remove outer directory", "err", err, "directory", filepath.Dir(filename))
+		}
+	}
+
 	updateIDs := map[string]int{}
 	for _, filename := range bundleFilenames {
 		bundleID, err := strconv.Atoi(filepath.Base(filepath.Dir(filename)))
@@ -185,6 +197,7 @@ func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB
 		}
 
 		if _, ok := bundleIDMap[bundleID]; ok {
+			moveFileToBackupDirectory(int64(bundleID))
 			continue
 		}
 
@@ -203,7 +216,10 @@ func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB
 	for filename, bundleID := range updateIDs {
 		if err := postgres.MigrateBundleToPostgres(ctx, bundleID, filename, db); err != nil {
 			log15.Error("Failed to migrate bundle", "err", err, "filename", filename)
+			continue
 		}
+
+		moveFileToBackupDirectory(int64(bundleID))
 	}
 
 	log15.Info("Finished migration to Postgres")


### PR DESCRIPTION
Once we have determined a bundle to be migrated into Postgres, we move it to a backup directory. I'm using this as a measure of completeness of the migration (once the dbs dir is empty we're good).