### PR TITLE
search: fix version context dropdown styles

### DIFF
--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -3,10 +3,18 @@
 .version-context-dropdown {
     width: max-content;
 
+    &:first-child &__button {
+        border-top-left-radius: 2px;
+        border-bottom-left-radius: 2px;
+    }
+
+    &:not(:first-child) .version-context-dropdown__button {
+        border-left: 1px solid $gray-17 !important;
+    }
+
     &__button {
         display: flex;
         border-radius: 0;
-        border-left: 1px solid $gray-17 !important;
 
         &-text {
             font-size: 10px;
@@ -32,13 +40,16 @@
     }
 
     &__popover {
-        padding: 0.5rem;
         color: var(--link-color);
         min-width: 30rem;
         max-width: 30rem;
         min-height: fit-content;
         max-height: 20rem;
         overflow-y: auto;
+
+        &:focus-within {
+            outline: none;
+        }
     }
 
     &__option {
@@ -81,7 +92,7 @@
             background-color: $color-light-bg-2;
         }
 
-        &__button {
+        &:not(:first-child) .version-context-dropdown__button {
             border-left: 1px solid $gray-07 !important;
         }
 

--- a/client/web/src/nav/VersionContextDropdown.story.tsx
+++ b/client/web/src/nav/VersionContextDropdown.story.tsx
@@ -2,16 +2,13 @@ import * as H from 'history'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { VersionContextDropdown, VersionContextDropdownProps } from './VersionContextDropdown'
-import webMainStyles from '../SourcegraphWebApp.scss'
 import { subtypeOf } from '../../../shared/src/util/types'
 import { action } from '@storybook/addon-actions'
 import { SearchPatternType } from '../graphql-operations'
+import { WebStory } from '../components/WebStory'
 
 const { add } = storiesOf('web/VersionContextDropdown', module).addDecorator(story => (
-    <>
-        <style>{webMainStyles}</style>
-        <div className="theme-light">{story()}</div>
-    </>
+    <WebStory>{webProps => story()}</WebStory>
 ))
 
 const setVersionContext = action('setVersionContext')
@@ -46,4 +43,10 @@ add('Context selected', () => <VersionContextDropdown {...commonProps} versionCo
 })
 add('Selected context appears at the top of the list', () => (
     <VersionContextDropdown {...commonProps} versionContext="test 3" />
+))
+add('Not first child', () => (
+    <>
+        <div />
+        <VersionContextDropdown {...commonProps} versionContext="test 4" />
+    </>
 ))


### PR DESCRIPTION
Fixes #14455

- Version context dropdown button now has rounded corners and no left border if it is a first child (when interactive search is disabled)
- Version context dropdown pane has been modified to remove focus outline and padding

## Interactive search enabled
![image](https://user-images.githubusercontent.com/206864/95512518-c8360200-096d-11eb-9630-f20ef963ccd3.png)

## Interactive search disabled
![image](https://user-images.githubusercontent.com/206864/95512594-e69bfd80-096d-11eb-80af-3f86d08e7e46.png)

## Pane
![image](https://user-images.githubusercontent.com/206864/95512668-04696280-096e-11eb-999a-97f3d2b0532a.png)
