### PR TITLE
Update browser extension icon with alert state

### DIFF
--- a/client/browser/src/browser-extension/browser-action-icon.ts
+++ b/client/browser/src/browser-extension/browser-action-icon.ts
@@ -9,7 +9,7 @@
 
 /** State of the Sourcegraph browser extension, as represented by the browser
  * action icon. */
-type BrowserActionIconState = 'active' | 'active-with-alert' | 'inactive'
+export type BrowserActionIconState = 'active' | 'active-with-alert' | 'inactive'
 interface BrowserActionIconPaths {
     '16': string
     '48': string

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -13,7 +13,6 @@ import {
     switchMap,
     take,
     concatMap,
-    tap,
     mapTo,
     catchError,
 } from 'rxjs/operators'
@@ -67,11 +66,6 @@ const configureOmnibox = (serverUrl: string): void => {
         description: `Search code on ${serverUrl}`,
     })
 }
-
-const doesUrlHavePermissions = (url: string): Promise<boolean> =>
-    browser.permissions.contains({
-        origins: [`${url}/*`],
-    })
 
 const requestGraphQL = <T, V = object>({
     request,

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -3,8 +3,20 @@ import '../../shared/polyfills'
 
 import { Endpoint } from 'comlink'
 import { without } from 'lodash'
-import { noop, Observable, Subscription } from 'rxjs'
-import { bufferCount, filter, groupBy, map, mergeMap, switchMap, take, concatMap } from 'rxjs/operators'
+import { combineLatest, Observable, Subscription, timer } from 'rxjs'
+import {
+    bufferCount,
+    filter,
+    groupBy,
+    map,
+    mergeMap,
+    switchMap,
+    take,
+    concatMap,
+    tap,
+    mapTo,
+    catchError,
+} from 'rxjs/operators'
 import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 import { createExtensionHostWorker } from '../../../../shared/src/api/extension/worker'
 import { GraphQLResult, requestGraphQL as requestGraphQLCommon } from '../../../../shared/src/graphql/graphql'
@@ -20,9 +32,14 @@ import { observeStorageKey, storage } from '../web-extension-api/storage'
 import { isDefined } from '../../../../shared/src/util/types'
 import { browserPortToMessagePort, findMessagePorts } from '../../shared/platform/ports'
 import { EndpointPair } from '../../../../shared/src/platform/context'
-import { setBrowserActionIconState } from '../browser-action-icon'
+import { BrowserActionIconState, setBrowserActionIconState } from '../browser-action-icon'
+import { fetchSite } from '../../shared/backend/server'
 
 const IS_EXTENSION = true
+
+// Interval to check if the Sourcegraph URL is valid
+// This polling allows to detect if Sourcegraph instance is invalid or needs authentication.
+const INTERVAL_FOR_SOURCEGRPAH_URL_CHECK = 5 /* minutes */ * 60 * 1000
 
 assertEnvironment('BACKGROUND')
 
@@ -50,6 +67,11 @@ const configureOmnibox = (serverUrl: string): void => {
         description: `Search code on ${serverUrl}`,
     })
 }
+
+const doesUrlHavePermissions = (url: string): Promise<boolean> =>
+    browser.permissions.contains({
+        origins: [`${url}/*`],
+    })
 
 const requestGraphQL = <T, V = object>({
     request,
@@ -94,12 +116,8 @@ async function main(): Promise<void> {
 
     // Update the browserAction icon based on the state of the extension
     subscriptions.add(
-        observeStorageKey('sync', 'disableExtension').subscribe(isDisabled => {
-            if (isDisabled) {
-                setBrowserActionIconState('inactive')
-            } else {
-                setBrowserActionIconState('active')
-            }
+        observeBrowserActionState().subscribe(state => {
+            setBrowserActionIconState(state)
         })
     )
 
@@ -177,8 +195,8 @@ async function main(): Promise<void> {
 
     await browser.runtime.setUninstallURL('https://about.sourcegraph.com/uninstall/')
 
-    browser.browserAction.onClicked.addListener(noop)
-    browser.browserAction.setBadgeText({ text: '' })
+    // The `popup=true` param is used by the options page to determine if it's
+    // loaded in the popup or in th standalone options page.
     browser.browserAction.setPopup({ popup: 'options.html?popup=true' })
 
     // Add "Enable Sourcegraph on this domain" context menu item
@@ -313,3 +331,30 @@ function handleBrowserPortPair(
 // Browsers log this unhandled Promise automatically (and with a better stack trace through console.error)
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 main()
+
+function validateSite(): Observable<boolean> {
+    return fetchSite(requestGraphQL).pipe(
+        mapTo(true),
+        catchError(error => [false])
+    )
+}
+
+function observeSourcegraphUrlValidation(): Observable<boolean> {
+    return timer(0, INTERVAL_FOR_SOURCEGRPAH_URL_CHECK).pipe(mergeMap(() => validateSite()))
+}
+
+function observeBrowserActionState(): Observable<BrowserActionIconState> {
+    return combineLatest([observeStorageKey('sync', 'disableExtension'), observeSourcegraphUrlValidation()]).pipe(
+        map(([isDisabled, isSourcegraphUrlValid]) => {
+            if (isDisabled) {
+                return 'inactive'
+            }
+
+            if (!isSourcegraphUrlValid) {
+                return 'active-with-alert'
+            }
+
+            return 'active'
+        })
+    )
+}


### PR DESCRIPTION
**Summary**

This PR adds a mechanism for the browser extension's icon to get updated based on the state of the extension.

**Implementation**

The idea behind this implementation is to have an observable that emits when the browser extension state changes between `active`, `inactive`, and `active-with-alert`. Then we subscribe to it to update the browse action icon.

This includes the change to the enabled/disabled state of the extension, and also changes to the validation state of the Sourcegraph URL, to show an alert if the instance is no longer valid (basically when the user is no longer logged into the instance or if the instance stops existing).

**Limitations**

The implementation doesn't include the changing of the icon based on the currently open tab. A problem I faced is that we would need to track the per-tab state of the icon and I haven't come up with an elegant solution for that. We would need to track which tabs are overriding the icon with an alert. That's because when we override a tab's icon, that icon is permanently set for the lifetime of the page even if the global state changes.

**Related**

Closes #14203 