### PR TITLE
Use code-bg for code tags in docs

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -116,7 +116,7 @@ pre, code, kbd {
 }
 
 code {
-    background-color: rgba(200,200,200,0.2);
+    background-color: var(--code-bg);
     padding: 0.2em;
     border-radius: 0.2em;
 }


### PR DESCRIPTION
This fixes two overlapping background colors when we have a `<pre><code> ... </code></pre>` block.

Screenshot:

![screenshot_2020-10-09_12 13 31@2x](https://user-images.githubusercontent.com/1185253/95571669-1956fc00-0a29-11eb-840f-a109470aab5a.png)

