### PR TITLE
search: indexed config API supports multiple repo query arguments

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -157,25 +157,33 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 // Additionally, it only cares about certain search specific settings so this
 // search specific endpoint is used rather than serving the entire site settings
 // from /.internal/configuration.
+//
+// This endpoint also supports batch requests to avoid managing concurrency in
+// zoekt. On vertically scaled instances we have observed zoekt requesting
+// this endpoint concurrently leading to socket starvation.
 func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
-	repo := r.URL.Query().Get("repo")
-	getVersion := func(branch string) (string, error) {
-		// Do not to trigger a repo-updater lookup since this is a batch job.
-		commitID, err := git.ResolveRevision(r.Context(), gitserver.Repo{Name: api.RepoName(repo)}, nil, branch, git.ResolveRevisionOptions{})
-		if err != nil && errcode.HTTP(err) == http.StatusNotFound {
-			// GetIndexOptions wants an empty rev for a missing rev or empty
-			// repo.
-			return "", nil
+	ctx := r.Context()
+	siteConfig := conf.Get().SiteConfiguration
+	getVersion := func(repo string) func(string) (string, error) {
+		return func(branch string) (string, error) {
+			// Do not to trigger a repo-updater lookup since this is a batch job.
+			commitID, err := git.ResolveRevision(ctx, gitserver.Repo{Name: api.RepoName(repo)}, nil, branch, git.ResolveRevisionOptions{})
+			if err != nil && errcode.HTTP(err) == http.StatusNotFound {
+				// GetIndexOptions wants an empty rev for a missing rev or empty
+				// repo.
+				return "", nil
+			}
+			return string(commitID), err
 		}
-		return string(commitID), err
 	}
 
-	b, err := searchbackend.GetIndexOptions(&conf.Get().SiteConfiguration, repo, getVersion)
-	if err != nil {
+	if err := r.ParseForm(); err != nil {
 		return err
 	}
-	_, err = w.Write(b)
-	return err
+
+	b := searchbackend.GetIndexOptions(&siteConfig, getVersion, r.Form["repo"]...)
+	_, _ = w.Write(b)
+	return nil
 }
 
 type reposListServer struct {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -123,7 +123,7 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/repos/list-enabled").Methods("POST").Name(ReposListEnabled)
 	base.Path("/repos/{RepoName:.*}").Methods("POST").Name(ReposGetByName)
 	base.Path("/configuration").Methods("POST").Name(Configuration)
-	base.Path("/search/configuration").Methods("GET").Name(SearchConfiguration)
+	base.Path("/search/configuration").Methods("GET", "POST").Name(SearchConfiguration)
 	base.Path("/telemetry").Methods("POST").Name(Telemetry)
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	addRegistryRoute(base)

--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -4,11 +4,14 @@ set -e
 
 export GO111MODULE=on
 
+# Can specify a SHA pushed to our fork instead of master
+version="${1:-master}"
+
 upstream=github.com/google/zoekt
 fork=github.com/sourcegraph/zoekt
 
 oldsha="$(go mod edit -print | grep "$fork" | grep -o '[a-f0-9]*$')"
-module="$(go get ${fork}@master 2>&1 | grep -E -o ${fork}'@v0.0.0-[0-9a-z-]+')"
+module="$(go get "${fork}@${version}" 2>&1 | grep -E -o ${fork}'@v0.0.0-[0-9a-z-]+')"
 newsha="$(echo "$module" | grep -o '[a-f0-9]*$')"
 
 echo "https://github.com/sourcegraph/zoekt/compare/$oldsha...$newsha"

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20200929094455-d0d95b84fe01
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201009114607-dae494155990
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1258,6 +1258,10 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20200929094455-d0d95b84fe01 h1:VTFPthjlbk4Rql+rhbM/omTWQADnz+QrTXJkEJlJNow=
 github.com/sourcegraph/zoekt v0.0.0-20200929094455-d0d95b84fe01/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
+github.com/sourcegraph/zoekt v0.0.0-20201009102516-82be173ea725 h1:KgqhInMxGkcVXhzr/ZLudF0ygWR6ZQoYq6lZXBTlwMg=
+github.com/sourcegraph/zoekt v0.0.0-20201009102516-82be173ea725/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
+github.com/sourcegraph/zoekt v0.0.0-20201009114607-dae494155990 h1:7ZDxlUJpYVm1cCfCt+z449b9NXiHZadJ9Am6kC/bRGc=
+github.com/sourcegraph/zoekt v0.0.0-20201009114607-dae494155990/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This converts the API into a batch API by writing a JSON blob per "repo"
query parameter in the order they are specified.

Each zoekt indexserver currently queries this endpoint with a hardcoded
concurrency of 32. This can cause many many HTTP requests, which on a
linux machine without tuning can lead to socket errors. By converting
this into a batch API we reduce the number of connections as well as
moving the responsbility of concurrency to the frontend which has more
knowledge of load/etc.

We also remove backwards compatibility support where repo wasn't
specified. Repo has been specified for multiple releases now.

Part of https://github.com/sourcegraph/customer/issues/111