### PR TITLE
Fix nyc include filter after renames

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       ".ts"
     ],
     "include": [
-      "@(web|shared|browser)/src/**/*.ts?(x)"
+      "client/*/src/**/*.ts?(x)"
     ],
     "exclude": [
       "node_modules",


### PR DESCRIPTION
This should fix coverage