### PR TITLE
search: preserve brackets in structural patterns

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -97,12 +97,14 @@ func templateToRegexp(buf []byte) []Term {
 		case '[':
 			if open > 0 {
 				inside++
+				currentHole = append(currentHole, '[')
 				continue
 			}
 			currentLiteral = append(currentLiteral, r)
 		case ']':
 			if open > 0 && inside > 0 {
 				inside--
+				currentHole = append(currentHole, ']')
 				continue
 			}
 			if open > 0 {

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -163,7 +163,7 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 		{
 			Name:    "Regex holes extracts regex",
 			Pattern: `:[x~[yo]]`,
-			Want:    `(yo)`,
+			Want:    `([yo])`,
 		},
 		{
 			Name:    "Regex holes with escaped space",
@@ -189,6 +189,11 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 			Name:    "Not well-formed is undefined",
 			Pattern: ":[[",
 			Want:    `(.|\s)*?`,
+		},
+		{
+			Name:    "Complex regex with character class",
+			Pattern: `:[chain~[^(){}\[\],]+\n( +\..*\n)+]`,
+			Want:    `([^(){}\[\],]+\n( +\..*\n)+)`,
 		},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
An expression like `:[~[a-z]]` would erase the brackets that refer to a character class and be parsed as `(a-z)` instead of `([a-z])`