### PR TITLE
repo-updater: Don't log when error is nil

### DIFF
--- a/cmd/repo-updater/repos/observability.go
+++ b/cmd/repo-updater/repos/observability.go
@@ -97,7 +97,9 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResul
 		}
 		count++
 	}
-	err = errs
+	if errs != nil {
+		err = errs.ErrorOrNil()
+	}
 }
 
 // NewObservedStore wraps the given Store with error logging,


### PR DESCRIPTION
Our logging.Log function doesn't handle multierror's which are empty.
Instead, we ensure that if it's empty we pass a nil error.
