### PR TITLE
fix regression in extension API to allow dynamic context key access

### DIFF
--- a/client/shared/src/api/client/context/expr/evaluator.test.ts
+++ b/client/shared/src/api/client/context/expr/evaluator.test.ts
@@ -41,6 +41,7 @@ describe('Expression', () => {
         'a || isnotdefined': 1, // short-circuit (if not, the use of an undefined ident would cause an error)
         'get(array, 0)': 7,
         'get(array, 1)': undefined, // out-of-bounds array index is undefined
+        'get(context, "c")': 2,
     }
     /* eslint-enable no-template-curly-in-string */
     for (const [expression, want] of Object.entries(TESTS)) {

--- a/client/shared/src/api/client/context/expr/evaluator.ts
+++ b/client/shared/src/api/client/context/expr/evaluator.ts
@@ -129,6 +129,8 @@ function exec<C>(node: ExpressionNode, context: Context<C>): any {
                 return undefined
             case 'null':
                 return null
+            case 'context':
+                return context
         }
         return context[node.Identifier]
     }


### PR DESCRIPTION
fix #14283

The Codecov extension checks the context (which is just a big key-value map) for a key like `codecov.coverageRatio.git://github.com/sourcegraph/sourcegraph?d947204f7b216004d94c9b504952a986e3685e46#cmd/frontend/registry/extensions.go` to determine whether there is coverage data for a file, which in turn determines whether the `Coverage: N%` button is shown. The key--that big long key in the previous sentence--is dynamic, based on the current repository, commit SHA, and file. The full condition for showing the button is (from [sourcegraph-codecov's package.json](https://sourcegraph.com/github.com/codecov/sourcegraph-codecov@f2f8581fda8bda2dc77bef98c7d36164332e494f/-/blob/package.json#L136)):

<code>resource && !config.codecov.hideCoverageButton && get(context, `codecov.coverageRatio.${resource.uri}`)</code>

That means: show the button if all of the following are true:

- there is a file being shown (`resource`)
- the user hasn't decided to always hide the button (`!config.codecov.hideCoverageButton`, which is the negation of the `codecov.hideCoverageButton` user setting)
- if there is a context key of the form `codecov.coverageRatio.${resource.uri}`, which is that big long key given above

In https://github.com/sourcegraph/sourcegraph/pull/14088 I simplified how the context was computed. But I broke support for <code>get(context, `some-dynamically-${interpolated}-string`)</code>; I accidentally removed the ability to reference `context` and index into the whole map, and there was no test case for that.

The fix here is to treat `context` as a special global, like `true` and `false`. An alternative fix would be to make the context map itself contain a key named `context` that was self-referential, but that leads to a cyclic data structure, which sounds like a bad idea.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->