### PR TITLE
Repro of buildkite CI script bug when commit msg contains vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ The `doc` directory has additional documentation for developing and understandin
 Sourcegraph OSS is available freely under the [Apache 2 license](LICENSE.apache). Sourcegraph OSS comprises all files in this repository except those in the `enterprise/` and `client/web/src/enterprise` directories.
 
 All files in the `enterprise/` and `client/web/src/enterprise/` directories are subject to the [Sourcegraph Enterprise license](LICENSE.enterprise).
+
+Foo


### PR DESCRIPTION
This commit message `interpolates a ${vari.able}` with a dot in it and causes buildkite CI to fail in the pipeline parsing step: https://buildkite.com/sourcegraph/sourcegraph/builds/76004#94723614-c602-4b41-812c-36d34f7954dc/50-54

```

2020-10-11 02:37:41 INFO   Reading pipeline config from STDIN
--
  | 2020-10-11 02:37:42 INFO   Updating BUILDKITE_COMMIT to "a2177c59a2cf3ba99153c5b1eef8691593c81255"
  | 2020-10-11 02:37:42 FATAL  Pipeline parsing of "" failed (Expected an operator, got .)

```


If you put a backslash before the dollar sign like `interpolating \${this.here}`, it works.