### PR TITLE
oauth2: debug logging toggled by INSECURE_OAUTH2_LOG_TRACES

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -105,6 +105,10 @@ The `allowOrgs` fields restricts logins to members of the specified GitHub organ
 
 Once you've configured GitHub as a sign-on provider, you may also want to [add GitHub repositories to Sourcegraph](../external_service/github.md#repository-syncing).
 
+### Troubleshooting
+
+Setting the env var `INSECURE_OAUTH2_LOG_TRACES=1` on the `sourcegraph/server` Docker container (or the `sourcegraph-frontend` deployment if you're using Kubernetes) causes all OAuth2 requests and responses to be logged.
+
 ## GitLab
 
 [Create a GitLab OAuth application](https://docs.gitlab.com/ee/integration/oauth_provider.html). Set
@@ -135,6 +139,10 @@ configuration.
 
 Once you've configured GitLab as a sign-on provider, you may also want to [add GitLab repositories
 to Sourcegraph](../external_service/gitlab.md#repository-syncing).
+
+### Troubleshooting
+
+Setting the env var `INSECURE_OAUTH2_LOG_TRACES=1` on the `sourcegraph/server` Docker container (or the `sourcegraph-frontend` deployment if you're using Kubernetes) causes all OAuth2 requests and responses to be logged.
 
 ## OpenID Connect
 

--- a/enterprise/cmd/frontend/auth/githuboauth/config_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config_test.go
@@ -36,8 +36,8 @@ func TestParseConfig(t *testing.T) {
 			args: args{cfg: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{
 				AuthProviders: []schema.AuthProviders{{
 					Github: &schema.GitHubAuthProvider{
-						ClientID:     "my-client-id",
-						ClientSecret: "my-client-secret",
+						ClientID:     "myclientid",
+						ClientSecret: "myclientsecret",
 						DisplayName:  "GitHub",
 						Type:         extsvc.TypeGitHub,
 						Url:          "https://github.com",
@@ -48,16 +48,16 @@ func TestParseConfig(t *testing.T) {
 			wantProviders: []Provider{
 				{
 					GitHubAuthProvider: &schema.GitHubAuthProvider{
-						ClientID:     "my-client-id",
-						ClientSecret: "my-client-secret",
+						ClientID:     "myclientid",
+						ClientSecret: "myclientsecret",
 						DisplayName:  "GitHub",
 						Type:         extsvc.TypeGitHub,
 						Url:          "https://github.com",
 						AllowOrgs:    []string{"myorg"},
 					},
 					Provider: provider("https://github.com/", oauth2.Config{
-						ClientID:     "my-client-id",
-						ClientSecret: "my-client-secret",
+						ClientID:     "myclientid",
+						ClientSecret: "myclientsecret",
 						Endpoint: oauth2.Endpoint{
 							AuthURL:  "https://github.com/login/oauth/authorize",
 							TokenURL: "https://github.com/login/oauth/access_token",
@@ -72,8 +72,8 @@ func TestParseConfig(t *testing.T) {
 			args: args{cfg: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{
 				AuthProviders: []schema.AuthProviders{{
 					Github: &schema.GitHubAuthProvider{
-						ClientID:     "my-client-id",
-						ClientSecret: "my-client-secret",
+						ClientID:     "myclientid",
+						ClientSecret: "myclientsecret",
 						DisplayName:  "GitHub",
 						Type:         extsvc.TypeGitHub,
 						Url:          "https://github.com",
@@ -81,8 +81,8 @@ func TestParseConfig(t *testing.T) {
 					},
 				}, {
 					Github: &schema.GitHubAuthProvider{
-						ClientID:     "my-client-id-2",
-						ClientSecret: "my-client-secret-2",
+						ClientID:     "myclientid2",
+						ClientSecret: "myclientsecret2",
 						DisplayName:  "GitHub Enterprise",
 						Type:         extsvc.TypeGitHub,
 						Url:          "https://mycompany.com",
@@ -92,16 +92,16 @@ func TestParseConfig(t *testing.T) {
 			wantProviders: []Provider{
 				{
 					GitHubAuthProvider: &schema.GitHubAuthProvider{
-						ClientID:     "my-client-id",
-						ClientSecret: "my-client-secret",
+						ClientID:     "myclientid",
+						ClientSecret: "myclientsecret",
 						DisplayName:  "GitHub",
 						Type:         extsvc.TypeGitHub,
 						Url:          "https://github.com",
 						AllowOrgs:    []string{"myorg"},
 					},
 					Provider: provider("https://github.com/", oauth2.Config{
-						ClientID:     "my-client-id",
-						ClientSecret: "my-client-secret",
+						ClientID:     "myclientid",
+						ClientSecret: "myclientsecret",
 						Endpoint: oauth2.Endpoint{
 							AuthURL:  "https://github.com/login/oauth/authorize",
 							TokenURL: "https://github.com/login/oauth/access_token",
@@ -111,15 +111,15 @@ func TestParseConfig(t *testing.T) {
 				},
 				{
 					GitHubAuthProvider: &schema.GitHubAuthProvider{
-						ClientID:     "my-client-id-2",
-						ClientSecret: "my-client-secret-2",
+						ClientID:     "myclientid2",
+						ClientSecret: "myclientsecret2",
 						DisplayName:  "GitHub Enterprise",
 						Type:         extsvc.TypeGitHub,
 						Url:          "https://mycompany.com",
 					},
 					Provider: provider("https://mycompany.com/", oauth2.Config{
-						ClientID:     "my-client-id-2",
-						ClientSecret: "my-client-secret-2",
+						ClientID:     "myclientid2",
+						ClientSecret: "myclientsecret2",
 						Endpoint: oauth2.Endpoint{
 							AuthURL:  "https://mycompany.com/login/oauth/authorize",
 							TokenURL: "https://mycompany.com/login/oauth/access_token",

--- a/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/middleware_test.go
@@ -34,8 +34,8 @@ func TestMiddleware(t *testing.T) {
 	authedHandler.Handle("/.api/", Middleware.API(h))
 	authedHandler.Handle("/", Middleware.App(h))
 
-	mockGitHubCom := newMockProvider(t, "github-com-client", "github-com-secret", "https://github.com/")
-	mockGHE := newMockProvider(t, "github-enterprise-client", "github-enterprise-secret", "https://mycompany.com/")
+	mockGitHubCom := newMockProvider(t, "githubcomclient", "githubcomsecret", "https://github.com/")
+	mockGHE := newMockProvider(t, "githubenterpriseclient", "githubenterprisesecret", "https://mycompany.com/")
 	providers.MockProviders = []providers.Provider{mockGitHubCom.Provider}
 	defer func() { providers.MockProviders = nil }()
 

--- a/enterprise/cmd/frontend/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider.go
@@ -62,7 +62,7 @@ func parseProvider(p *schema.GitHubAuthProvider, sourceCfg schema.AuthProviders)
 	}), messages
 }
 
-var clientIDSecretValidator = lazyregexp.MustCompile("^[a-z0-9]*$")
+var clientIDSecretValidator = lazyregexp.New("^[a-z0-9]*$")
 
 func validateClientIDAndSecret(clientIDOrSecret string) (valid bool) {
 	return clientIDSecretValidator.MatchString(clientIDOrSecret)

--- a/enterprise/cmd/frontend/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider.go
@@ -3,12 +3,12 @@ package githuboauth
 import (
 	"fmt"
 	"net/url"
-	"regexp"
 
 	"github.com/dghubble/gologin/github"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"golang.org/x/oauth2"
 )
@@ -62,7 +62,7 @@ func parseProvider(p *schema.GitHubAuthProvider, sourceCfg schema.AuthProviders)
 	}), messages
 }
 
-var clientIDSecretValidator = regexp.MustCompile("^[a-z0-9]*$")
+var clientIDSecretValidator = lazyregexp.MustCompile("^[a-z0-9]*$")
 
 func validateClientIDAndSecret(clientIDOrSecret string) (valid bool) {
 	return clientIDSecretValidator.MatchString(clientIDOrSecret)

--- a/enterprise/cmd/frontend/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/provider.go
@@ -51,7 +51,7 @@ func parseProvider(callbackURL string, p *schema.GitLabAuthProvider, sourceCfg s
 			}, sessionKey),
 			nil,
 		),
-	}), nil
+	}), messages
 }
 
 func getStateConfig() gologin.CookieConfig {

--- a/enterprise/cmd/frontend/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/auth/oauth/middleware.go
@@ -88,14 +88,9 @@ func newOAuthFlowHandler(serviceType string) http.Handler {
 func withOAuthExternalHTTPClient(r *http.Request) *http.Request {
 	client := httpcli.ExternalHTTPClient()
 	if traceLogEnabled {
-		if httpClient, ok := client.(*http.Client); ok {
-			loggingClient := *httpClient
-			loggingClient.Transport = &loggingRoundTripper{underlying: loggingClient.Transport}
-			ctx := context.WithValue(r.Context(), oauth2.HTTPClient, &loggingClient)
-			return r.WithContext(ctx)
-		} else {
-			log15.Warn("Could not initialize logging HTTP client, because external HTTP client was not an instance of *http.Client")
-		}
+		loggingClient := *client
+		loggingClient.Transport = &loggingRoundTripper{underlying: client.Transport}
+		client = &loggingClient
 	}
 	ctx := context.WithValue(r.Context(), oauth2.HTTPClient, client)
 	return r.WithContext(ctx)

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -118,7 +118,7 @@ func ExternalDoer() Doer {
 // NOTE: Use this for legacy code. New code should generally take in a
 // httpcli.Doer and at a high level NewExternalHTTPClientFactory() is called
 // and passed down.
-func ExternalHTTPClient() Doer {
+func ExternalHTTPClient() *http.Client {
 	externalInit()
 	return externalHTTPClient
 }


### PR DESCRIPTION
Logs will look like this, when `INSECURE_OAUTH2_LOG_TRACES=true` in the `frontend` environment:

```
18:06:37                          frontend | >>>>> HTTP Request: POST https://github.com/login/oauth/access_token                                                                                                                                                                                 
18:06:37                          frontend |       Header: map[Authorization:[Basic xxxxxxxxxxxxxxxxxxxxxx] Content-Type:[application/x-www-form-urlencoded]]                                                                       
18:06:37                          frontend |       Body: code=xxxxxxxxxxx&grant_type=authorization_code                                                                                                                                                                                                          
18:06:37                          frontend | >>>>> HTTP Request: POST https://github.com/login/oauth/access_token                                                                                                                                                                                                                                           
18:06:37                          frontend |       Header: map[Content-Type:[application/x-www-form-urlencoded]]                                                                                                                                                                                                                                            
18:06:37                          frontend |       Body: client_id=xxxxxxxxxxxxx&client_secret=xxxxxxxxxxxxxxxxxxxxxxx&code=xxxxxxxxxxxxxxxxxxxxxxx&grant_type=authorization_code                                                                                                                                                      

```

Also added validation for the GitHub client ID and secret to ensure no hidden or non-alphanumeric characters are used.