### PR TITLE
graphqlbackend: Markdown resolver is string

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -204,7 +204,7 @@ type LocationConnectionResolver interface {
 }
 
 type HoverResolver interface {
-	Markdown() MarkdownResolver
+	Markdown() Markdown
 	Range() RangeResolver
 }
 

--- a/cmd/frontend/graphqlbackend/markdown.go
+++ b/cmd/frontend/graphqlbackend/markdown.go
@@ -7,22 +7,18 @@ type MarkdownResolver interface {
 	HTML() string
 }
 
-type markdownResolver struct {
-	text string
-}
+type Markdown string
 
-var _ MarkdownResolver = &markdownResolver{}
+var _ MarkdownResolver = Markdown("")
 
 func NewMarkdownResolver(text string) MarkdownResolver {
-	return &markdownResolver{
-		text: text,
-	}
+	return Markdown(text)
 }
 
-func (m *markdownResolver) Text() string {
-	return m.text
+func (m Markdown) Text() string {
+	return string(m)
 }
 
-func (m *markdownResolver) HTML() string {
-	return markdown.Render(m.text)
+func (m Markdown) HTML() string {
+	return markdown.Render(string(m))
 }

--- a/cmd/frontend/graphqlbackend/markdown.go
+++ b/cmd/frontend/graphqlbackend/markdown.go
@@ -2,18 +2,7 @@ package graphqlbackend
 
 import "github.com/sourcegraph/sourcegraph/internal/markdown"
 
-type MarkdownResolver interface {
-	Text() string
-	HTML() string
-}
-
 type Markdown string
-
-var _ MarkdownResolver = Markdown("")
-
-func NewMarkdownResolver(text string) MarkdownResolver {
-	return Markdown(text)
-}
 
 func (m Markdown) Text() string {
 	return string(m)

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -261,7 +261,7 @@ func (r *RepositoryResolver) Rev() string {
 	return r.rev
 }
 
-func (r *RepositoryResolver) Label() (*markdownResolver, error) {
+func (r *RepositoryResolver) Label() (Markdown, error) {
 	var label string
 	if r.rev != "" {
 		label = string(r.repo.Name) + "@" + r.rev
@@ -269,11 +269,11 @@ func (r *RepositoryResolver) Label() (*markdownResolver, error) {
 		label = string(r.repo.Name)
 	}
 	text := "[" + label + "](/" + label + ")"
-	return &markdownResolver{text: text}, nil
+	return Markdown(text), nil
 }
 
-func (r *RepositoryResolver) Detail() *markdownResolver {
-	return &markdownResolver{text: "Repository name match"}
+func (r *RepositoryResolver) Detail() Markdown {
+	return Markdown("Repository name match")
 }
 
 func (r *RepositoryResolver) Matches() []*searchResultMatchResolver {

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -47,16 +47,16 @@ func (r *commitSearchResultResolver) Icon() string {
 	return r.icon
 }
 
-func (r *commitSearchResultResolver) Label() *markdownResolver {
-	return &markdownResolver{text: r.label}
+func (r *commitSearchResultResolver) Label() Markdown {
+	return Markdown(r.label)
 }
 
 func (r *commitSearchResultResolver) URL() string {
 	return r.url
 }
 
-func (r *commitSearchResultResolver) Detail() *markdownResolver {
-	return &markdownResolver{text: r.detail}
+func (r *commitSearchResultResolver) Detail() Markdown {
+	return Markdown(r.detail)
 }
 
 func (r *commitSearchResultResolver) Matches() []*searchResultMatchResolver {

--- a/cmd/frontend/graphqlbackend/search_result_match.go
+++ b/cmd/frontend/graphqlbackend/search_result_match.go
@@ -11,8 +11,8 @@ func (m *searchResultMatchResolver) URL() string {
 	return m.url
 }
 
-func (m *searchResultMatchResolver) Body() *markdownResolver {
-	return &markdownResolver{text: m.body}
+func (m *searchResultMatchResolver) Body() Markdown {
+	return Markdown(m.body)
 }
 
 func (m *searchResultMatchResolver) Highlights() []*highlightedRange {

--- a/enterprise/internal/codeintel/resolvers/graphql/hover.go
+++ b/enterprise/internal/codeintel/resolvers/graphql/hover.go
@@ -17,5 +17,5 @@ func NewHoverResolver(text string, lspRange lsp.Range) gql.HoverResolver {
 	}
 }
 
-func (r *HoverResolver) Markdown() gql.MarkdownResolver { return gql.NewMarkdownResolver(r.text) }
-func (r *HoverResolver) Range() gql.RangeResolver       { return gql.NewRangeResolver(r.lspRange) }
+func (r *HoverResolver) Markdown() gql.Markdown   { return gql.Markdown(r.text) }
+func (r *HoverResolver) Range() gql.RangeResolver { return gql.NewRangeResolver(r.lspRange) }


### PR DESCRIPTION
Our Markdown resolver can just be `type Markdown string`. This will
avoid some allocations and simplify interactions with the code. The next
few commits will remove the interface and the construction function.

Code in graphqlbackend pkg updated with comby:

```
comby -in-place '*markdownResolver' 'Markdown' 'go'
comby -in-place '&markdownResolver{text: :[a]}' 'Markdown(:[a])' 'go'
```