### PR TITLE
search: stream diff/commits and symbol in PoC

### DIFF
--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -12,6 +12,7 @@ import { SearchPatternType } from '../graphql-operations'
 type SearchEvent =
     | { type: 'filematches'; matches: FileMatch[] }
     | { type: 'repomatches'; matches: RepositoryMatch[] }
+    | { type: 'commitmatches'; matches: CommitMatch[] }
     | { type: 'filters'; filters: Filter[] }
 
 interface FileMatch extends RepositoryMatch {
@@ -25,7 +26,25 @@ interface FileMatch extends RepositoryMatch {
 interface LineMatch {
     line: string
     lineNumber: number
-    offsetAndLengths: [[number]]
+    offsetAndLengths: number[][]
+}
+
+type MarkdownText = string
+
+/**
+ * Our batch based client requests generic fields from GraphQL to represent repo and commit/diff matches.
+ * We currently are only using it for commit. To simplify the PoC we are keeping this interface for commits.
+ *
+ * @see GQL.IGenericSearchResultInterface
+ */
+interface CommitMatch {
+    icon: string
+    label: MarkdownText
+    url: string
+    detail: MarkdownText
+
+    content: MarkdownText
+    ranges: number[][]
 }
 
 type RepositoryMatch = Pick<FileMatch, 'repository' | 'branches'>
@@ -84,7 +103,11 @@ function toGQLFileMatch(fm: FileMatch): GQL.IFileMatch {
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const toMarkdown = (text: string): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
+const toMarkdown = (text: string | MarkdownText): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
+
+// copy-paste from search_repositories.go. When we move away from GQL types this shouldn't be part of the API.
+const repoIcon =
+    'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K'
 
 function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     const branch = repo?.branches?.[0]
@@ -94,9 +117,7 @@ function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     // We only need to return the subset defined in IGenericSearchResultInterface
     const gqlRepo: unknown = {
         __typename: 'Repository',
-        // copy-pasta from repositories.go :'(
-        icon:
-            'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K',
+        icon: repoIcon,
         label: toMarkdown(`[${label}](/${label})`),
         url: '/' + label,
         detail: toMarkdown('Repository name match'),
@@ -104,6 +125,34 @@ function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     }
 
     return gqlRepo as GQL.IRepository
+}
+
+//
+function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
+    const match = {
+        __typename: 'SearchResultMatch',
+        url: commit.url,
+        body: toMarkdown(commit.content),
+        highlights: commit.ranges.map(([line, character, length]) => ({
+            __typename: 'IHighlight',
+            line,
+            character,
+            length,
+        })),
+    }
+
+    // We only need to return the subset defined in IGenericSearchResultInterface
+    const gqlCommit: unknown = {
+        __typename: 'CommitSearchResult',
+        icon: commit.icon,
+        label: toMarkdown(commit.label),
+        url: commit.url,
+        detail: toMarkdown(commit.detail),
+        // TODO
+        matches: [match],
+    }
+
+    return gqlCommit as GQL.ICommitSearchResult
 }
 
 const toGQLSearchFilter = (filter: Omit<Filter, 'type'>): GQL.ISearchFilter => ({
@@ -151,6 +200,13 @@ export const switchToGQLISearchResults: OperatorFunction<SearchEvent, GQL.ISearc
                     ...results,
                     // Repository matches are additive
                     results: results.results.concat(newEvent.matches.map(toGQLRepositoryMatch)),
+                }
+
+            case 'commitmatches':
+                return {
+                    ...results,
+                    // Generic matches are additive
+                    results: results.results.concat(newEvent.matches.map(toGQLCommitMatch)),
                 }
 
             case 'filters':
@@ -212,6 +268,11 @@ export function search(
         subscriptions.add(
             observeMessages<RepositoryMatch[]>(eventSource, 'repomatches')
                 .pipe(map(matches => ({ type: 'repomatches' as const, matches })))
+                .subscribe(observer)
+        )
+        subscriptions.add(
+            observeMessages<CommitMatch[]>(eventSource, 'commitmatches')
+                .pipe(map(matches => ({ type: 'commitmatches' as const, matches })))
                 .subscribe(observer)
         )
         subscriptions.add(

--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -178,7 +178,6 @@ function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
         label: toMarkdown(commit.label),
         url: commit.url,
         detail: toMarkdown(commit.detail),
-        // TODO
         matches: [match],
     }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -71,7 +71,7 @@ func TestResolverTo(t *testing.T) {
 		&NamespaceResolver{},
 		&NodeResolver{},
 		&RepositoryResolver{},
-		&commitSearchResultResolver{},
+		&CommitSearchResultResolver{},
 		&gitRevSpec{},
 		&searchSuggestionResolver{},
 		&settingsSubject{},

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -282,7 +282,7 @@ func (r *RepositoryResolver) Matches() []*searchResultMatchResolver {
 
 func (r *RepositoryResolver) ToRepository() (*RepositoryResolver, bool) { return r, true }
 func (r *RepositoryResolver) ToFileMatch() (*FileMatchResolver, bool)   { return nil, false }
-func (r *RepositoryResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+func (r *RepositoryResolver) ToCommitSearchResult() (*CommitSearchResultResolver, bool) {
 	return nil, false
 }
 

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -24,8 +24,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-// commitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
-type commitSearchResultResolver struct {
+// CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
+type CommitSearchResultResolver struct {
 	commit         *GitCommitResolver
 	refs           []*GitRefResolver
 	sourceRefs     []*GitRefResolver
@@ -38,48 +38,48 @@ type commitSearchResultResolver struct {
 	matches        []*searchResultMatchResolver
 }
 
-func (r *commitSearchResultResolver) Commit() *GitCommitResolver         { return r.commit }
-func (r *commitSearchResultResolver) Refs() []*GitRefResolver            { return r.refs }
-func (r *commitSearchResultResolver) SourceRefs() []*GitRefResolver      { return r.sourceRefs }
-func (r *commitSearchResultResolver) MessagePreview() *highlightedString { return r.messagePreview }
-func (r *commitSearchResultResolver) DiffPreview() *highlightedString    { return r.diffPreview }
-func (r *commitSearchResultResolver) Icon() string {
+func (r *CommitSearchResultResolver) Commit() *GitCommitResolver         { return r.commit }
+func (r *CommitSearchResultResolver) Refs() []*GitRefResolver            { return r.refs }
+func (r *CommitSearchResultResolver) SourceRefs() []*GitRefResolver      { return r.sourceRefs }
+func (r *CommitSearchResultResolver) MessagePreview() *highlightedString { return r.messagePreview }
+func (r *CommitSearchResultResolver) DiffPreview() *highlightedString    { return r.diffPreview }
+func (r *CommitSearchResultResolver) Icon() string {
 	return r.icon
 }
 
-func (r *commitSearchResultResolver) Label() Markdown {
+func (r *CommitSearchResultResolver) Label() Markdown {
 	return Markdown(r.label)
 }
 
-func (r *commitSearchResultResolver) URL() string {
+func (r *CommitSearchResultResolver) URL() string {
 	return r.url
 }
 
-func (r *commitSearchResultResolver) Detail() Markdown {
+func (r *CommitSearchResultResolver) Detail() Markdown {
 	return Markdown(r.detail)
 }
 
-func (r *commitSearchResultResolver) Matches() []*searchResultMatchResolver {
+func (r *CommitSearchResultResolver) Matches() []*searchResultMatchResolver {
 	return r.matches
 }
 
-func (r *commitSearchResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
-func (r *commitSearchResultResolver) ToFileMatch() (*FileMatchResolver, bool)   { return nil, false }
-func (r *commitSearchResultResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+func (r *CommitSearchResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
+func (r *CommitSearchResultResolver) ToFileMatch() (*FileMatchResolver, bool)   { return nil, false }
+func (r *CommitSearchResultResolver) ToCommitSearchResult() (*CommitSearchResultResolver, bool) {
 	return r, true
 }
 
-func (r *commitSearchResultResolver) searchResultURIs() (string, string) {
+func (r *CommitSearchResultResolver) searchResultURIs() (string, string) {
 	// Diffs aren't going to be returned with other types of results
 	// and are already ordered in the desired order, so we'll just leave them in place.
 	return "~", "~" // lexicographically last in ASCII
 }
 
-func (r *commitSearchResultResolver) resultCount() int32 {
+func (r *CommitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query query.QueryInfo) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query query.QueryInfo) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
 	var terms []string
 	if info.Pattern != "" {
 		terms = append(terms, info.Pattern)
@@ -93,7 +93,7 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 	})
 }
 
-func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*commitSearchResultResolver, limitHit, timedOut bool, err error) {
+func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
 	tr, ctx := trace.New(ctx, "searchCommitsInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v", op.RepoRevs, op.PatternInfo))
 	defer func() {
 		tr.LazyPrintf("%d results, limitHit=%v, timedOut=%v", len(results), limitHit, timedOut)
@@ -239,11 +239,11 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 	}
 
 	repoResolver := &RepositoryResolver{repo: repo}
-	results = make([]*commitSearchResultResolver, len(rawResults))
+	results = make([]*CommitSearchResultResolver, len(rawResults))
 	for i, rawResult := range rawResults {
 		commit := rawResult.Commit
 		commitResolver := toGitCommitResolver(repoResolver, &commit)
-		results[i] = &commitSearchResultResolver{commit: commitResolver}
+		results[i] = &CommitSearchResultResolver{commit: commitResolver}
 
 		addRefs := func(dst *[]*GitRefResolver, src []string) {
 			for _, ref := range src {
@@ -429,7 +429,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 	var (
 		wg          sync.WaitGroup
 		mu          sync.Mutex
-		unflattened [][]*commitSearchResultResolver
+		unflattened [][]*CommitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
 	common.repos = make([]*types.Repo, len(args.Repos))
@@ -472,7 +472,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 		return nil, nil, err
 	}
 
-	var flattened []*commitSearchResultResolver
+	var flattened []*CommitSearchResultResolver
 	for _, results := range unflattened {
 		flattened = append(flattened, results...)
 	}
@@ -500,7 +500,7 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 	var (
 		wg          sync.WaitGroup
 		mu          sync.Mutex
-		unflattened [][]*commitSearchResultResolver
+		unflattened [][]*CommitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
 	common.repos = make([]*types.Repo, len(args.Repos))
@@ -537,14 +537,14 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 		return nil, nil, err
 	}
 
-	var flattened []*commitSearchResultResolver
+	var flattened []*CommitSearchResultResolver
 	for _, results := range unflattened {
 		flattened = append(flattened, results...)
 	}
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-func commitSearchResultsToSearchResults(results []*commitSearchResultResolver) []SearchResultResolver {
+func commitSearchResultsToSearchResults(results []*CommitSearchResultResolver) []SearchResultResolver {
 	// Show most recent commits first.
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].commit.author.Date() > results[j].commit.author.Date()

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -73,7 +73,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 	wantCommit.once.Do(func() {}) // mark as done
 
-	if want := []*commitSearchResultResolver{
+	if want := []*CommitSearchResultResolver{
 		{
 			commit:      &wantCommit,
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
@@ -97,7 +97,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 }
 
-func (r *commitSearchResultResolver) String() string {
+func (r *CommitSearchResultResolver) String() string {
 	return fmt.Sprintf("{commit: %+v diffPreview: %+v messagePreview: %+v}", r.commit, r.diffPreview, r.messagePreview)
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -498,7 +498,7 @@ loop:
 		case *RepositoryResolver:
 			// We don't care about repo results here.
 			continue
-		case *commitSearchResultResolver:
+		case *CommitSearchResultResolver:
 			// Diff searches are cheap, because we implicitly have author date info.
 			addPoint(m.commit.author.date)
 		case *FileMatchResolver:
@@ -2035,7 +2035,7 @@ type SearchResultResolver interface {
 
 	ToRepository() (*RepositoryResolver, bool)
 	ToFileMatch() (*FileMatchResolver, bool)
-	ToCommitSearchResult() (*commitSearchResultResolver, bool)
+	ToCommitSearchResult() (*CommitSearchResultResolver, bool)
 
 	resultCount() int32
 }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -109,7 +109,7 @@ func (fm *FileMatchResolver) LimitHit() bool {
 
 func (fm *FileMatchResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }
 func (fm *FileMatchResolver) ToFileMatch() (*FileMatchResolver, bool)   { return fm, true }
-func (fm *FileMatchResolver) ToCommitSearchResult() (*commitSearchResultResolver, bool) {
+func (fm *FileMatchResolver) ToCommitSearchResult() (*CommitSearchResultResolver, bool) {
 	return nil, false
 }
 


### PR DESCRIPTION
We stream the same interface used by our web client for commits. This is
just the generic search result interface. This change originally started
off trying to use a better API, but ran into two problems:

1. There is a lot of potential metadata used to create a commit
   result. Commit author name/time, message, etc.
2. The results we return are markdown files with highlights. Translating
   this from something more abstract (eg just offsetAndRange) would of been
   very complicated.

After this work, I realised we probably want to keep a generic interface
for better extensibility in the future. So commits will keep using our
generic interface for now.