### PR TITLE
Auto-retry integration tests as a bandaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",
-    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI ./client/web/src/integration/**/*.test.ts",
+    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 ./client/web/src/integration/**/*.test.ts",
     "cover-integration": "nyc --hook-require=false yarn test-integration",
     "test-e2e": "TS_NODE_PROJECT=client/web/src/end-to-end/tsconfig.json mocha ./client/web/src/end-to-end/end-to-end.test.ts",
     "cover-e2e": "nyc --hook-require=false yarn test-e2e",


### PR DESCRIPTION
This should prevent the flakiness of the integration tests (the symptom).
**This is a band-aid and we need to fix it asap**. It can cause us to merge changes that cause test failures in 50% of real-world cases because we will always grant it two tries. The only other alternative for a quickfix is disabling the integration tests completely though, and that would be  worse.