### PR TITLE
release: align issues query with tracking issue

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -313,11 +313,11 @@ Key dates:
                 )
             }
 
-            const blockingQuery = `is:open is:issue milestone:${config.majorVersion}.${config.minorVersion} label:release-blocker`
+            const blockingQuery = 'is:open org:sourcegraph label:release-blocker'
             const blockingIssues = await listIssues(githubClient, blockingQuery)
             const blockingIssuesURL = `https://github.com/issues?q=${encodeURIComponent(blockingQuery)}`
 
-            const openQuery = `is:open is:issue milestone:${config.majorVersion}.${config.minorVersion}`
+            const openQuery = `is:open org:sourcegraph is:issue milestone:${config.majorVersion}.${config.minorVersion}`
             const openIssues = await listIssues(githubClient, openQuery)
             const openIssuesURL = `https://github.com/issues?q=${encodeURIComponent(openQuery)}`
 


### PR DESCRIPTION
Also allows pull requests to be release blockers by removing `is:issue` from the blocking issues query (https://github.com/sourcegraph/about/pull/1751)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
