### PR TITLE
docs: Update upgrading docs

### DIFF
--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -1,10 +1,17 @@
 # Upgrading Sourcegraph
 
-For Kubernetes deployments, see "[Updating Sourcegraph](install/kubernetes/update.md)" on how to upgrade your Sourcegraph in general.
-See [the migration guide](updates/kubernetes.md) for exact steps (which may note required manual steps to perform).
+## Migrating to a new deployment type
 
-For other deployment types, follow the guide linked below.
+See [this page](install.md) to get advice on which deployment type you should be running.
 
-- [For single-image deployments](updates/server.md) (`sourcegraph/server`)
-- [For Docker Compose deployments](updates/docker_compose.md)
-- [For pure-Docker deployments](updates/pure_docker.md)
+- [Migrate to Docker Compose](install/docker-compose/migrate.md) for improved stability and performance if you are using a single-container `sourcegraph/server` deployment.
+- [Migrate to a Kubernetes cluster](https://docs.sourcegraph.com/admin/install/kubernetes) if you exceed the limits of a single machine Docker Compose deployment.
+
+## Updating to a new version of Sourcegraph
+
+Please see the instructions for your deployment type:
+
+- [Single-container `sourcegraph/server` deployments](updates/server.md)
+- [Docker Compose single-machine deployments](updates/docker_compose.md)
+- [Kubernetes cluster deployments](updates/kubernetes.md)
+- [pure-Docker custom deployments](updates/pure_docker.md)

--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -1,25 +1,10 @@
 # Upgrading Sourcegraph
 
-## For single-node deployments (`sourcegraph/server`)
+For Kubernetes deployments, see "[Updating Sourcegraph](install/kubernetes/update.md)" on how to upgrade your Sourcegraph in general.
+See [the migration guide](updates/kubernetes.md) for exact steps (which may note required manual steps to perform).
 
-A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates.
+For other deployment types, follow the guide linked below.
 
-To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
-
-You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
-
-- As a precaution, before updating, we recommend backing up the contents of the Docker volumes used by Sourcegraph.
-- If you need a HA deployment, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
-- There is currently no automated way to downgrade to an older version after you have updated. [Contact support](https://about.sourcegraph.com/contact) for help.
-
-## For Kubernetes cluster deployments
-
-See "[Updating Sourcegraph](install/kubernetes/update.md)" in the Kubernetes cluster administrator guide.
-
-## For Docker Compose deployments
-
-Please see: [updating a Docker Compose Sourcegraph instance](updates/docker_compose.md)
-
-## For pure-Docker cluster deployments
-
-Please see: [updating a pure-Docker Sourcegraph cluster](updates/pure_docker.md)
+- [For single-image deployments](updates/server.md) (`sourcegraph/server`)
+- [For Docker Compose deployments](updates/docker_compose.md)
+- [For pure-Docker deployments](updates/pure_docker.md)

--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -1,12 +1,5 @@
 # Upgrading Sourcegraph
 
-## Migrating to a new deployment type
-
-See [this page](install.md) to get advice on which deployment type you should be running.
-
-- [Migrate to Docker Compose](install/docker-compose/migrate.md) for improved stability and performance if you are using a single-container `sourcegraph/server` deployment.
-- [Migrate to a Kubernetes cluster](https://docs.sourcegraph.com/admin/install/kubernetes) if you exceed the limits of a single machine Docker Compose deployment.
-
 ## Updating to a new version of Sourcegraph
 
 Please see the instructions for your deployment type:
@@ -15,3 +8,10 @@ Please see the instructions for your deployment type:
 - [Docker Compose single-machine deployments](updates/docker_compose.md)
 - [Kubernetes cluster deployments](updates/kubernetes.md)
 - [pure-Docker custom deployments](updates/pure_docker.md)
+
+## Migrating to a new deployment type
+
+See [this page](install.md) to get advice on which deployment type you should be running.
+
+- [Migrate to Docker Compose](install/docker-compose/migrate.md) for improved stability and performance if you are using a single-container `sourcegraph/server` deployment.
+- [Migrate to a Kubernetes cluster](https://docs.sourcegraph.com/admin/install/kubernetes) if you exceed the limits of a single machine Docker Compose deployment.

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -9,11 +9,15 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 **Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
-## 3.20.1 -> 3.21.0
+## 3.20 -> 3.21
 
 Please upgrade to the [`v3.21.0` tag of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.21.0/docker-compose) by following the [standard upgrade procedure](#standard-upgrade-procedure).
 
 This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
+
+### If you wish to keep existing LSIF data
+
+> Warning: **Do not upgrade out of the 3.21.x release branch** until you have seen the log message indicating the completion of the LSIF data migration, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty. Otherwise, you risk data loss for precise code intelligence.
 
 If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db` upon upgrade. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
 
@@ -23,8 +27,7 @@ If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a backgroun
 
 ```sh
 docker exec -it precise-code-intel-bundle-manager sh -c 'rm -rf /lsif-storage/db-backups'
-
-> Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
+```
 
 ## 3.19.2 -> 3.20.1
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -19,7 +19,10 @@ If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a backgroun
 
 > Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
 
-Once this message has been printed, you are free to delete the bundle files moved into the `/lsif-storage/db-backups` directory on the bundle-manager volume.
+**Wait for the above message to be printed in `docker logs precise-code-intel-bundle-manager` before upgrading to the next Sourcegraph version**, then if everything is working you can free up disk space by deleting the backup bundle files using this command:
+
+```sh
+docker exec -it precise-code-intel-bundle-manager sh -c 'rm -rf /lsif-storage/db-backups'
 
 > Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -15,6 +15,14 @@ Please upgrade to the [`v3.21.0` tag of deploy-sourcegraph-docker](https://githu
 
 This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
+If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
+
+> Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
+
+Once this message has been printed, you are free to delete the bundle files moved into the `/lsif-storage/db-backups` directory on the bundle-manager volume.
+
+> Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
+
 ## 3.19.2 -> 3.20.1
 
 No manual migration required.

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -1,6 +1,6 @@
 # Updating a Docker Compose Sourcegraph instance
 
-This document describes the exact changes needed to update a [Docker Compose Sourcegraph instance](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/master/docker-compose).
+This document describes the exact changes needed to update a [Docker Compose Sourcegraph instance](../install/docker-compose.md).
 Each section comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
 A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates. We actively maintain the two most recent monthly releases of Sourcegraph.

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -15,7 +15,7 @@ Please upgrade to the [`v3.21.0` tag of deploy-sourcegraph-docker](https://githu
 
 This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
-If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
+If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db` upon upgrade. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
 
 > Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -1,8 +1,13 @@
 # Updating a Docker Compose Sourcegraph instance
 
-This document describes the exact changes needed to update a Docker Compose Sourcegraph instance.
-
+This document describes the exact changes needed to update a [Docker Compose Sourcegraph instance](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/master/docker-compose).
 Each section comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
+
+A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates. We actively maintain the two most recent monthly releases of Sourcegraph.
+
+Upgrades should happen across consecutive minor versions of Sourcegraph. For example, if you are running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 and then 3.3.
+
+**Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
 ## 3.20.1 -> 3.21.0
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -9,19 +9,21 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 **Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
-## 3.20 -> 3.21.0
+## 3.20 -> 3.21
 
 Follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your deployment.
 
 This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
-If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
+### If you wish to keep existing LSIF data
+
+> Warning: **Do not upgrade out of the 3.21.x release branch** until you have seen the log message indicating the completion of the LSIF data migration, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty. Otherwise, you risk data loss for precise code intelligence.
+
+If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db` upon upgrade. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
 
 > Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
 
-Once this message has been printed, you are free to delete the bundle files moved into the `/lsif-storage/db-backups` directory on the bundle-manager volume.
-
-> Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
+**Wait for the above message to be printed in `docker logs precise-code-intel-bundle-manager` before upgrading to the next Sourcegraph version**.
 
 ## 3.20
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -3,6 +3,10 @@
 This document describes the exact changes needed to update a Kubernetes Sourcegraph instance.
 Follow the [recommended method](../install/kubernetes/update.md) of upgrading a Kubernetes cluster.
 
+A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates. We actively maintain the two most recent monthly releases of Sourcegraph.
+
+Upgrades should happen across consecutive minor versions of Sourcegraph. For example, if you are running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 and then 3.3.
+
 **Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
 ## 3.20 -> 3.21.0

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -15,6 +15,14 @@ Follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade
 
 This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
+If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
+
+> Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
+
+Once this message has been printed, you are free to delete the bundle files moved into the `/lsif-storage/db-backups` directory on the bundle-manager volume.
+
+> Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
+
 ## 3.20
 
 No manual migration is required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your deployment.

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -1,8 +1,13 @@
 # Updating a pure-Docker Sourcegraph cluster
 
 This document describes the exact changes needed to update a [pure-Docker Sourcegraph cluster](https://github.com/sourcegraph/deploy-sourcegraph-docker).
-
 Each section comprehensively describes the changes needed in Docker images, environment variables, and added/removed services.
+
+A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates. We actively maintain the two most recent monthly releases of Sourcegraph.
+
+Upgrades should happen across consecutive minor versions of Sourcegraph. For example, if you are running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 and then 3.3.
+
+**Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
 ## 3.17.2 -> 3.18.0 changes
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -8,7 +8,7 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 **Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
-## 3.20 -> 3.21.0
+## 3.20 -> 3.21
 
 If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -1,0 +1,19 @@
+# Updating a single-image Sourcegraph instance (`sourcegraph/server`)
+
+This document describes the exact changes needed to update a single-node Sourcegraph instance.
+
+A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates. We actively maintain the two most recent monthly releases of Sourcegraph.
+
+Upgrades should happen across consecutive minor versions of Sourcegraph. For example, if you are running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 and then 3.3.
+
+**Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
+
+### Standard upgrade procedure
+
+To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
+
+You can always find the version number of the latest release at [docs.sourcegraph.com](https://docs.sourcegraph.com) in the `docker run` command's image tag.
+
+- As a precaution, before updating, we recommend backing up the contents of the Docker volumes used by Sourcegraph.
+- If you need a HA deployment, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph).
+- There is currently no automated way to downgrade to an older version after you have updated. [Contact support](https://about.sourcegraph.com/contact) for help.

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -10,13 +10,17 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 ## 3.20 -> 3.21
 
-If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
+This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
+
+### If you wish to keep existing LSIF data
+
+> Warning: **Do not upgrade out of the 3.21.x release branch** until you have seen the log message indicating the completion of the LSIF data migration, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty. Otherwise, you risk data loss for precise code intelligence.
+
+If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db` upon upgrade. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
 
 > Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
 
-Once this message has been printed, you are free to delete the bundle files moved into the `/lsif-storage/db-backups` directory on the bundle-manager volume.
-
-> Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
+**Wait for the above message to be printed in `docker logs precise-code-intel-bundle-manager` before upgrading to the next Sourcegraph version**.
 
 ### Standard upgrade procedure
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -8,6 +8,16 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 **Always refer to this page before upgrading Sourcegraph,** as it comprehensively describes the steps needed to upgrade, and any manual migration steps you must perform.
 
+## 3.20 -> 3.21.0
+
+If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a background migration that moves all existing LSIF data into the `codeintel-db`. Once this process completes, the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume should be empty, and the bundle manager should print the following log message:
+
+> Migration to Postgres has completed. All existing LSIF bundles have moved to the path /lsif-storage/db-backups and can be removed from the filesystem to reclaim space.
+
+Once this message has been printed, you are free to delete the bundle files moved into the `/lsif-storage/db-backups` directory on the bundle-manager volume.
+
+> Warning: In order to ensure there is no data loss, **do not upgrade out of the 3.21.x release branch** until you have seen this log message, or verified that the `/lsif-storage/dbs` directory on the precise-code-intel-bundle-manager volume is empty.
+
 ### Standard upgrade procedure
 
 To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.

--- a/enterprise/cmd/precise-code-intel-bundle-manager/internal/readers/migrate.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/internal/readers/migrate.go
@@ -155,11 +155,17 @@ func noopHandler(store persistence.Store) error {
 }
 
 func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB) error {
+	var migrationCompleteMessage = fmt.Sprintf(
+		"Migration to Postgres has completed. All existing LSIF bundles have moved to the path %s and can be removed from the filesystem to reclaim space.",
+		paths.DBBackupsDir(bundleDir),
+	)
+
 	bundleFilenames, err := sqlitePaths(bundleDir)
 	if err != nil {
 		return err
 	}
 	if len(bundleFilenames) == 0 {
+		log15.Info(migrationCompleteMessage)
 		return nil
 	}
 
@@ -205,6 +211,7 @@ func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB
 	}
 
 	if len(updateIDs) == 0 {
+		log15.Info(migrationCompleteMessage)
 		return nil
 	}
 
@@ -222,6 +229,6 @@ func migrateToPostgres(bundleDir string, storeCache cache.StoreCache, db *sql.DB
 		moveFileToBackupDirectory(int64(bundleID))
 	}
 
-	log15.Info("Finished migration to Postgres")
+	log15.Info(migrationCompleteMessage)
 	return nil
 }


### PR DESCRIPTION
This closes https://github.com/sourcegraph/sourcegraph/issues/14604.

This updates the admin docs for updating Sourcegraph. This moves some of the server-specific data from the index page into its page so that we don't muck up the flow for other environments.

The main change here is a note in the upgrade from 3.20 -> 3.21, which calls out that a background process is migrating data and you must see a migration complete message before moving on to 3.22 (which will assume that no more data exists on the bundle manager disk as part of our cleanup transition).

Once 3.22 is released, I will also update docs for the 3.21.? -> 3.22 migration which will re-iterate the same thing: if you hadn't seen this log or verified this property, you will lose data.

Other migration paths that do require some amount of time be spent in a particular version should follow this same pattern (unless someone on distribution has a rebuttal).

Note to @uwedeportivo that this is a bit more information you should add to https://github.com/sourcegraph/sourcegraph/issues/14347.