### PR TITLE
dbutil: Extract and reuse postgres batch inserter

### DIFF
--- a/enterprise/internal/codeintel/bundles/persistence/postgres/migrate.go
+++ b/enterprise/internal/codeintel/bundles/persistence/postgres/migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	sqlitestore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/bundles/persistence/sqlite/store"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/db/batch"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
@@ -52,9 +53,13 @@ func migrateMeta(ctx context.Context, from *sqlitestore.Store, to dbutil.DB, dum
 		return err
 	}
 
-	return withBatchInserter(ctx, to, "lsif_data_metadata", []string{"dump_id", "num_result_chunks"}, func(inserter *BatchInserter) error {
-		for _, value := range values {
-			if err := inserter.Insert(ctx, dumpID, value); err != nil {
+	ch := make(chan int, 1)
+	ch <- values[0]
+	close(ch)
+
+	return withBatchInserter(ctx, to, "lsif_data_metadata", []string{"dump_id", "num_result_chunks"}, func(inserter *batch.BatchInserter) error {
+		for v := range ch {
+			if err := inserter.Insert(ctx, dumpID, v); err != nil {
 				return err
 			}
 		}
@@ -89,7 +94,7 @@ func migrateDocuments(ctx context.Context, from *sqlitestore.Store, to dbutil.DB
 		}
 	}()
 
-	return withBatchInserter(ctx, to, "lsif_data_documents", []string{"dump_id", "path", "data"}, func(inserter *BatchInserter) error {
+	return withBatchInserter(ctx, to, "lsif_data_documents", []string{"dump_id", "path", "data"}, func(inserter *batch.BatchInserter) error {
 		for document := range ch {
 			if document.err != nil {
 				return document.err
@@ -130,7 +135,7 @@ func migrateResultChunks(ctx context.Context, from *sqlitestore.Store, to dbutil
 		}
 	}()
 
-	return withBatchInserter(ctx, to, "lsif_data_result_chunks", []string{"dump_id", "idx", "data"}, func(inserter *BatchInserter) error {
+	return withBatchInserter(ctx, to, "lsif_data_result_chunks", []string{"dump_id", "idx", "data"}, func(inserter *batch.BatchInserter) error {
 		for resultChunk := range ch {
 			if resultChunk.err != nil {
 				return resultChunk.err
@@ -180,7 +185,7 @@ func migrateDefinitionReferences(ctx context.Context, tableName string, from *sq
 		}
 	}()
 
-	return withBatchInserter(ctx, to, fmt.Sprintf("lsif_data_%s", tableName), []string{"dump_id", "scheme", "identifier", "data"}, func(inserter *BatchInserter) error {
+	return withBatchInserter(ctx, to, fmt.Sprintf("lsif_data_%s", tableName), []string{"dump_id", "scheme", "identifier", "data"}, func(inserter *batch.BatchInserter) error {
 		for location := range ch {
 			if location.err != nil {
 				return location.err

--- a/enterprise/internal/codeintel/store/commits.go
+++ b/enterprise/internal/codeintel/store/commits.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/db/batch"
 )
 
 // scanUploadMeta scans upload metadata grouped by commit from the return value of `*store.query`.
@@ -138,53 +139,30 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 		}
 	}
 
-	n := 0
-	for _, uploads := range visibleUploads {
-		n += len(uploads)
-	}
-	nearestUploadsRows := make([]*sqlf.Query, 0, n)
-
+	nearestUploadsInserter := batch.NewBatchInserter(ctx, s.Store.Handle().DB(), "lsif_nearest_uploads", "repository_id", "commit", "upload_id", "distance")
 	for commit, uploads := range visibleUploads {
 		for _, uploadMeta := range uploads {
-			nearestUploadsRows = append(nearestUploadsRows, sqlf.Sprintf(
-				"(%s, %s, %s, %s)",
-				repositoryID,
-				commit,
-				uploadMeta.UploadID,
-				uploadMeta.Distance,
-			))
+			if err := nearestUploadsInserter.Insert(ctx, repositoryID, commit, uploadMeta.UploadID, uploadMeta.Distance); err != nil {
+				return err
+			}
 		}
 	}
-
-	// Insert new data for this repository in batches - it's likely we'll exceed the maximum
-	// number of placeholders per query so we need to break it into several queries below this
-	// size.
-	for _, batch := range batchQueries(nearestUploadsRows, MaxPostgresNumParameters/4) {
-		if err := tx.Store.Exec(ctx, sqlf.Sprintf(
-			`INSERT INTO lsif_nearest_uploads (repository_id, "commit", upload_id, distance) VALUES %s`,
-			sqlf.Join(batch, ","),
-		)); err != nil {
-			return err
-		}
-	}
-
-	visibleAtTipRows := make([]*sqlf.Query, 0, len(visibleUploads[tipCommit]))
-	for _, uploadMeta := range visibleUploads[tipCommit] {
-		visibleAtTipRows = append(visibleAtTipRows, sqlf.Sprintf("(%s, %s)", repositoryID, uploadMeta.UploadID))
+	if err := nearestUploadsInserter.Flush(ctx); err != nil {
+		return err
 	}
 
 	// Update which repositories are visible from the tip of the default branch. This
 	// flag is used to determine which bundles for a repository we open during a global
 	// find references query.
-	if len(visibleAtTipRows) > 0 {
-		for _, batch := range batchQueries(visibleAtTipRows, MaxPostgresNumParameters/2) {
-			if err := tx.Store.Exec(ctx, sqlf.Sprintf(
-				`INSERT INTO lsif_uploads_visible_at_tip (repository_id, upload_id) VALUES %s`,
-				sqlf.Join(batch, ","),
-			)); err != nil {
-				return err
-			}
+	uploadsVisibleAtTipInserter := batch.NewBatchInserter(ctx, s.Store.Handle().DB(), "lsif_uploads_visible_at_tip", "repository_id", "upload_id")
+
+	for _, uploadMeta := range visibleUploads[tipCommit] {
+		if err := uploadsVisibleAtTipInserter.Insert(ctx, repositoryID, uploadMeta.UploadID); err != nil {
+			return err
 		}
+	}
+	if err := uploadsVisibleAtTipInserter.Flush(ctx); err != nil {
+		return err
 	}
 
 	if dirtyToken != 0 {
@@ -202,26 +180,4 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 	}
 
 	return nil
-}
-
-// MaxPostgresNumParameters is the maximum number of parameters per query that Postgres
-// will allow. Exceeding this number of parameters will cause the query to be rejected
-// by the server.
-const MaxPostgresNumParameters = 65535
-
-// batchQueries cuts the given query slice into batches of a maximum size. This function
-// will allocate only the outer array to hold each batch, and the data for each batch
-// will refer to the given slice.
-func batchQueries(queries []*sqlf.Query, batchSize int) (batches [][]*sqlf.Query) {
-	for len(queries) > 0 {
-		if len(queries) > batchSize {
-			batches = append(batches, queries[:batchSize])
-			queries = queries[batchSize:]
-		} else {
-			batches = append(batches, queries)
-			queries = nil
-		}
-	}
-
-	return batches
 }

--- a/internal/db/batch/batch.go
+++ b/internal/db/batch/batch.go
@@ -1,4 +1,4 @@
-package postgres
+package batch
 
 import (
 	"context"

--- a/internal/db/batch/batch_test.go
+++ b/internal/db/batch/batch_test.go
@@ -1,4 +1,4 @@
-package postgres
+package batch
 
 import (
 	"context"


### PR DESCRIPTION
This closes https://github.com/sourcegraph/sourcegraph/issues/14608.

This PR moves the Postgres batch inserter utility into the internal/db pacakge, then uses the inserter in a few places where a similar (but less sophisticated) process was being done in the code intel store.