### PR TITLE
crashfix: SendUserEmailOnFieldUpdate crashes on users without an email

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -187,12 +187,12 @@ Verify your email address {{printf "%q" .Email}} on Sourcegraph by following thi
 func (userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, id int32, change string) error {
 	email, _, err := db.UserEmails.GetPrimaryEmail(ctx, id)
 	if err != nil {
-		log15.Warn("Failed to get user email", "error", err, ctx)
+		log15.Warn("Failed to get user email", "error", err)
 		return err
 	}
 	usr, err := db.Users.GetByID(ctx, id)
 	if err != nil {
-		log15.Warn("Failed to get user from database", "error", err, ctx)
+		log15.Warn("Failed to get user from database", "error", err)
 		return err
 	}
 


### PR DESCRIPTION
`log15.Log` methods have the signature that expects a `message, key, value, key, value, ...`. Here, we're passing `ctx` where it expects a string, which causes the log line to crash the current goroutine.

This was preventing all e2e tests from running.

Fixes https://github.com/sourcegraph/sourcegraph/issues/14649