### PR TITLE
e2e: Fix negative string repeat in test runner

### DIFF
--- a/client/shared/src/testing/console.ts
+++ b/client/shared/src/testing/console.ts
@@ -31,12 +31,14 @@ export async function formatPuppeteerConsoleMessage(message: ConsoleMessage): Pr
                 .filter(Boolean)
                 .join(':')
         )
+
     // Right-align location, like in Chrome dev tools
     const locationLine = chalk.dim(
         formattedLocation &&
             '\n' +
                 (!process.env.CI
-                    ? ' '.repeat(terminalSize().columns - stringWidth(formattedLocation)) + formattedLocation
+                    ? ' '.repeat(Math.max(0, terminalSize().columns - stringWidth(formattedLocation))) +
+                      formattedLocation
                     : '\t' + formattedLocation)
     )
     return [


### PR DESCRIPTION
Fixes an uncaught exception when running e2e tests.

```
Uncaught RangeError: Invalid count value
```