### PR TITLE
repo-updater: init encryption and decrypt external service on read

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -1403,7 +1403,7 @@ func scanExternalService(svc *ExternalService, s scanner) error {
 		&svc.ID,
 		&svc.Kind,
 		&svc.DisplayName,
-		&svc.Config,
+		&secret.StringValue{S: &svc.Config},
 		&svc.CreatedAt,
 		&dbutil.NullTime{Time: &svc.UpdatedAt},
 		&dbutil.NullTime{Time: &svc.DeletedAt},

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/internal/secret"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -48,6 +49,11 @@ func Main(enterpriseInit EnterpriseInit) {
 	logging.Init()
 	tracer.Init()
 	trace.Init(true)
+
+	err := secret.Init()
+	if err != nil {
+		log.Fatalf("Failed to initialize encryption: %v", err)
+	}
 
 	clock := func() time.Time { return time.Now().UTC() }
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -52,7 +52,7 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	err := secret.Init()
 	if err != nil {
-		log.Fatalf("Failed to initialize encryption: %v", err)
+		log.Fatalf("Failed to initialize secrets encryption: %v", err)
 	}
 
 	clock := func() time.Time { return time.Now().UTC() }


### PR DESCRIPTION
Previously, we only init encryption on frontend (for read and write), which breaks all read paths for repo-updater.

Part of #14644