### PR TITLE
secret: clean up init logic

### DIFF
--- a/internal/secret/init.go
+++ b/internal/secret/init.go
@@ -81,7 +81,7 @@ func initDefaultEncryptor() error {
 	}
 
 	defaultEncryptor = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
-	log15.Info("Encryption initialized")
+	log15.Info("Database secrets encryption initialized")
 	return nil
 }
 

--- a/internal/secret/init.go
+++ b/internal/secret/init.go
@@ -5,19 +5,10 @@ import (
 	"crypto/rand"
 	"io/ioutil"
 	"os"
-	"path"
 	"sync"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
-
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-)
-
-const (
-	// #nosec G101
-	sourcegraphSecretfileEnvvar = "SOURCEGRAPH_SECRET_FILE"
-	sourcegraphCryptEnvvar      = "SOURCEGRAPH_CRYPT_KEY"
 )
 
 // gatherKeys splits the comma-separated encryption data into its potential two components:
@@ -55,102 +46,43 @@ func MockDefaultEncryptor() {
 	defaultEncryptor = newAESGCMEncodedEncryptor(mustGenerateRandomAESKey(), nil)
 }
 
-func initDefaultEncryptor() error {
-	var encryptionKey []byte
+const sourcegraphsSecretFile = "SOURCEGRAPH_SECRET_FILE"
 
-	// set the default location if none exists
-	secretFile := os.Getenv(sourcegraphSecretfileEnvvar)
+func initDefaultEncryptor() error {
+	// Set the default location if none exists
+	secretFile := os.Getenv(sourcegraphsSecretFile)
 	if secretFile == "" {
-		// #nosec G101
 		secretFile = "/var/lib/sourcegraph/token"
 	}
 
-	// reading from a file is first order
 	fileInfo, err := os.Stat(secretFile)
-	if err == nil {
-		perm := fileInfo.Mode().Perm()
-		if perm != os.FileMode(0400) {
-			return errors.New("key file permissions are not 0400")
-		}
-
-		contents, readErr := ioutil.ReadFile(secretFile)
-		if readErr != nil {
-			return errors.Wrapf(readErr, "couldn't read file %s", sourcegraphSecretfileEnvvar)
-		}
-		if len(contents) < requiredKeyLength {
-			return errors.Errorf("key length of %d characters is required", requiredKeyLength)
-		}
-		encryptionKey = contents
-
-		primaryKey, secondaryKey, err := gatherKeys(encryptionKey)
-		if err != nil {
-			return err
-		}
-
-		defaultEncryptor = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
-		return nil
-	}
-
-	envCryptKey, cryptOK := os.LookupEnv(sourcegraphCryptEnvvar)
-	// environment is second order
-	if cryptOK {
-		if len(envCryptKey) != requiredKeyLength {
-			return errors.Errorf("encryption key must be %d characters", requiredKeyLength)
-		}
-		primaryKey, secondaryKey, err := gatherKeys(encryptionKey)
-		if err != nil {
-			return err
-		}
-
-		defaultEncryptor = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
-		return nil
-	}
-
-	// for the single docker case, we generate the secret
-	deployType := conf.DeployType()
-	if conf.IsDeployTypeSingleDockerContainer(deployType) {
-		b, err := generateRandomAESKey()
-		if err != nil {
-			return errors.Wrap(err, "unable to generate random key")
-		}
-
-		err = os.MkdirAll(path.Dir(secretFile), os.ModePerm)
-		if err != nil {
-			return err
-		}
-
-		err = ioutil.WriteFile(secretFile, b, 0600)
-		if err != nil {
-			return err
-		}
-
-		err = os.Chmod(secretFile, 0400)
-		if err != nil {
-			return errors.Wrap(err, "unable to change key file permissions to 0400")
-		}
-		newKey, _, err := gatherKeys(b)
-		if err != nil {
-			return err
-		}
-
-		defaultEncryptor = newAESGCMEncodedEncryptor(newKey, nil)
-		return nil
-	}
-
-	// wrapping in deploytype check so that we can still compile and test locally
-	if os.Getenv("CI") != "" || conf.IsDev(deployType) {
+	if err != nil {
 		defaultEncryptor = noOpEncryptor{}
+		log15.Warn("No encryption initialized")
 		return nil
 	}
 
-	log15.Warn("no encryption option enabled")
-	return nil
+	perm := fileInfo.Mode().Perm()
+	if perm != os.FileMode(0400) {
+		return errors.New("key file permissions are not 0400")
+	}
 
-	// TODO: Enable this once docs are in place for
-	// for k8s & docker compose, expect a secret to be provided
-	//return errors.Errorf("Either specify environment variable %s or provide the secrets file %s",
-	//	sourcegraphCryptEnvvar,
-	//	sourcegraphSecretfileEnvvar)
+	encryptionKey, err := ioutil.ReadFile(secretFile)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't read file %s", sourcegraphsSecretFile)
+	}
+	if len(encryptionKey) < requiredKeyLength {
+		return errors.Errorf("key length of %d characters is required", requiredKeyLength)
+	}
+
+	primaryKey, secondaryKey, err := gatherKeys(encryptionKey)
+	if err != nil {
+		return errors.Wrap(err, "gather keys")
+	}
+
+	defaultEncryptor = newAESGCMEncodedEncryptor(primaryKey, secondaryKey)
+	log15.Info("Encryption initialized")
+	return nil
 }
 
 // generateRandomAESKey generates a random key that can be used for AES-256 encryption.


### PR DESCRIPTION
Notes:

1. We used to allow pass in the secret key via env var string `SOURCEGRAPH_CRYPT_KEY`, but the secret key we expect is an array of bytes not a string (so how is that possible? 🤔 ). Besides, the code logic for reading secret key from env var was actually not working, i.e. suppose to read `envCryptKey` but in fact we read `encryptionKey` (which by the time we read it, it is always an empty slice and guarantee to fail).
2. I realize the decision to automatically turn on encryption for single-docker-container was a mistake, the customer should explicitly chooses to do so (by specifying the `SOURCEGRAPH_SECRET_FILE`).

Part of #14644