### PR TITLE
Show form feedback on input

### DIFF
--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -109,7 +109,7 @@ export const OptionsPage: React.FunctionComponent<OptionsPageProps> = ({
                         className={classNames(deriveInputClassName(urlState))}
                     >
                         <input
-                            className="form-control"
+                            className={classNames('form-control', deriveInputClassName(urlState))}
                             id="sourcegraph-url"
                             type="url"
                             pattern="^https://.*"


### PR DESCRIPTION
The class was not assigned to the input which meant that the green and red outlines and checkmark/exclamation mark icons did not show.