### PR TITLE
search: store repo ID in zoekt shards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201009114607-dae494155990
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201013124050-0f9dde474446
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1264,6 +1264,8 @@ github.com/sourcegraph/zoekt v0.0.0-20201009102516-82be173ea725 h1:KgqhInMxGkcVX
 github.com/sourcegraph/zoekt v0.0.0-20201009102516-82be173ea725/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/sourcegraph/zoekt v0.0.0-20201009114607-dae494155990 h1:7ZDxlUJpYVm1cCfCt+z449b9NXiHZadJ9Am6kC/bRGc=
 github.com/sourcegraph/zoekt v0.0.0-20201009114607-dae494155990/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
+github.com/sourcegraph/zoekt v0.0.0-20201013124050-0f9dde474446 h1:gjd6ySuHTIaEp2HmT37LJBG6Y2ppxV8dWp3jL2PEL9E=
+github.com/sourcegraph/zoekt v0.0.0-20201013124050-0f9dde474446/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -15,6 +15,9 @@ import (
 //
 // We only specify a subset of the fields.
 type zoektIndexOptions struct {
+	// RepoID is the Sourcegraph Repository ID.
+	RepoID int32
+
 	// LargeFiles is a slice of glob patterns where matching file paths should
 	// be indexed regardless of their size. The pattern syntax can be found
 	// here: https://golang.org/pkg/path/filepath/#Match.
@@ -33,6 +36,9 @@ type zoektIndexOptions struct {
 // RepoIndexOptions are the options used by GetIndexOptions for a specific
 // repository.
 type RepoIndexOptions struct {
+	// RepoID is the Sourcegraph Repository ID.
+	RepoID int32
+
 	// GetVersion is used to resolve revisions for a repo. If it fails, the
 	// error is encoded in the body. If the revision is missing, an empty
 	// string should be returned rather than an error.
@@ -71,6 +77,7 @@ func getIndexOptions(c *schema.SiteConfiguration, repoName string, getRepoIndexO
 	}
 
 	o := &zoektIndexOptions{
+		RepoID:     opts.RepoID,
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
 	}

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -42,6 +42,7 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: schema.SiteConfiguration{},
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:  1,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -53,6 +54,7 @@ func TestGetIndexOptions(t *testing.T) {
 			SearchIndexSymbolsEnabled: boolPtr(false)},
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID: 1,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
 			},
@@ -64,6 +66,7 @@ func TestGetIndexOptions(t *testing.T) {
 		},
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:     1,
 			Symbols:    true,
 			LargeFiles: []string{"**/*.jar", "*.bin"},
 			Branches: []zoekt.RepositoryBranch{
@@ -75,6 +78,7 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: vcConf(vc("foo", "repo@b", "repo@a"), vc("bar", "repo@c", "repo@a", "other@d")),
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:  1,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -88,6 +92,7 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: vcConf(vc("foo", "repo@a")),
 		repo: "not_in_version_context",
 		want: zoektIndexOptions{
+			RepoID:  3,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{{
 				Name:    "HEAD",
@@ -99,6 +104,7 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: vcConf(vc("foo", "repo@HEAD", "repo@a")),
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:  1,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -111,6 +117,7 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: vcConf(vc("foo", "repo", "repo@a")),
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:  1,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -122,6 +129,7 @@ func TestGetIndexOptions(t *testing.T) {
 		conf: withBranches(schema.SiteConfiguration{}, map[string][]string{"repo": {"a"}}),
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:  1,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -135,6 +143,7 @@ func TestGetIndexOptions(t *testing.T) {
 			map[string][]string{"repo": {"b", "c"}}),
 		repo: "repo",
 		want: zoektIndexOptions{
+			RepoID:  1,
 			Symbols: true,
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
@@ -163,6 +172,7 @@ func TestGetIndexOptions(t *testing.T) {
 			conf: withBranches(schema.SiteConfiguration{}, map[string][]string{"repo": branches}),
 			repo: "repo",
 			want: zoektIndexOptions{
+				RepoID:   1,
 				Symbols:  true,
 				Branches: want,
 			},
@@ -170,7 +180,15 @@ func TestGetIndexOptions(t *testing.T) {
 	}
 
 	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
+		repoID := int32(1)
+		for _, r := range []string{"repo", "foo", "not_in_version_context"} {
+			if r == repo {
+				break
+			}
+			repoID++
+		}
 		return &RepoIndexOptions{
+			RepoID: repoID,
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil
 			},


### PR DESCRIPTION
This is information we have wanted access to for a long time. Main use
case is more efficient encoding of which repositories to search (int32
is much smaller than the name string). This won't be read, rather we
want to ship this so we start storing the information.

Right now if the repo ID is not set it won't trigger a re-index. IE it
does not affect "incremental" check. The intention is to not trigger a
reindex of all shards. The following release we can enforce it is set,
then the release after that assume it is available.

Zoekt Commits:

- https://github.com/sourcegraph/zoekt/commit/0f9dde4 indexserver: store sourcegraph repo ID in index
- https://github.com/sourcegraph/zoekt/commit/9ff81ec indexserver: Remove Error from IndexOptions

Best reviewed commit by commit.