### PR TITLE
RFC: abuse of api.RepoName

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -60,7 +60,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 	ctx, done := trace(ctx, "Repos", "GetByName", name, &err)
 	defer done()
 
-	switch repo, err := db.Repos.GetByName(ctx, name); {
+	switch repo, err := db.Repos.GetByName(ctx, string(name)); {
 	case err == nil:
 		return repo, nil
 	case !errcode.IsNotFound(err):
@@ -70,7 +70,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 		if err := s.Add(ctx, name); err != nil {
 			return nil, err
 		}
-		return db.Repos.GetByName(ctx, name)
+		return db.Repos.GetByName(ctx, string(name))
 	case shouldRedirect(name):
 		return nil, ErrRepoSeeOther{RedirectURL: (&url.URL{
 			Scheme:   "https",

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -381,7 +381,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 	Description *string
 	Date        *string
 }) (*GitCommitResolver, error) {
-	repo, err := db.Repos.GetByName(ctx, api.RepoName(args.RepoName))
+	repo, err := db.Repos.GetByName(ctx, args.RepoName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -69,9 +69,9 @@ func (s *repos) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
 // Name is the name for this repository (e.g., "github.com/user/repo"). It is
 // the same as URI, unless the user configures a non-default
 // repositoryPathPattern.
-func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.Repo, error) {
+func (s *repos) GetByName(ctx context.Context, nameOrURI string) (*types.Repo, error) {
 	if Mocks.Repos.GetByName != nil {
-		return Mocks.Repos.GetByName(ctx, nameOrURI)
+		return Mocks.Repos.GetByName(ctx, api.RepoName(nameOrURI))
 	}
 
 	repos, err := s.getBySQL(ctx, sqlf.Sprintf("name=%s LIMIT 1", nameOrURI))
@@ -92,7 +92,7 @@ func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.R
 	}
 
 	if len(repos) == 0 {
-		return nil, &RepoNotFoundErr{Name: nameOrURI}
+		return nil, &RepoNotFoundErr{Name: api.RepoName(nameOrURI)}
 	}
 
 	return repos[0], nil

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -54,7 +54,7 @@ func mustCreate(ctx context.Context, t *testing.T, repos ...*types.Repo) []*type
 	var createdRepos []*types.Repo
 	for _, repo := range repos {
 		createRepo(ctx, t, repo)
-		repo, err := Repos.GetByName(ctx, repo.Name)
+		repo, err := Repos.GetByName(ctx, string(repo.Name))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -145,7 +145,7 @@ func (s *repos) Upsert(ctx context.Context, op InsertRepoOp) error {
 	// upsert is logged as a modification to the DB, even if it is a no-op. So
 	// we do this check to avoid log spam if postgres is configured with
 	// log_statement='mod'.
-	r, err := s.GetByName(ctx, op.Name)
+	r, err := s.GetByName(ctx, string(op.Name))
 	if err != nil {
 		if _, ok := err.(*RepoNotFoundErr); !ok {
 			return err

--- a/internal/db/repos_test.go
+++ b/internal/db/repos_test.go
@@ -244,9 +244,9 @@ func TestRepos_UpsertForkAndArchivedFields(t *testing.T) {
 	for _, fork := range []bool{true, false} {
 		for _, archived := range []bool{true, false} {
 			i++
-			name := api.RepoName(fmt.Sprintf("myrepo-%d", i))
+			name := fmt.Sprintf("myrepo-%d", i)
 
-			if err := Repos.Upsert(ctx, InsertRepoOp{Name: name, Fork: fork, Archived: archived}); err != nil {
+			if err := Repos.Upsert(ctx, InsertRepoOp{Name: api.RepoName(name), Fork: fork, Archived: archived}); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
This PR is minimal and exists for discussion purposes only.

### Context

We have the `api.RepoName` type. Whenever we are refering to a Sourcegraph repository name, we expect it to be an `api.RepoName`. Both responses from our database as well as user input is cast to this type. This makes the type mostly useless, since it doesn't really tell us anything.

### Proposal

User input is never cast to `api.RepoName`. Only the database can create a `api.RepoName`, then if we see an `api.RepoName` we know it is a real repository name. All functions which looks like `GetRepoByName` take a string.

Alternatively get rid of the tiny type. It doesn't seem to prevent any mistakes nor make our code clearer.

WDYT?