### PR TITLE
fix issue preventing more than 1 theme cycle via keyboard shortcut

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -39,7 +39,7 @@ import { LayoutRouteProps } from './routes'
 import { search, searchStream, fetchSavedSearches, fetchRecentSearches, fetchRecentFileViews } from './search/backend'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
-import { ThemePreference } from './theme'
+import { ThemePreference, ThemePreferenceProps } from './theme'
 import { eventLogger } from './tracking/eventLogger'
 import { withActivation } from './tracking/withActivation'
 import { UserAreaRoute } from './user/area/UserArea'
@@ -469,8 +469,14 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         )
     }
 
-    private onThemePreferenceChange = (themePreference: ThemePreference): void => {
-        this.setState({ themePreference })
+    private onThemePreferenceChange: ThemePreferenceProps['onThemePreferenceChange'] = (
+        themePreferenceOrFunction
+    ): void => {
+        if (typeof themePreferenceOrFunction === 'function') {
+            this.setState(({ themePreference: previous }) => ({ themePreference: themePreferenceOrFunction(previous) }))
+        } else {
+            this.setState({ themePreference: themePreferenceOrFunction })
+        }
     }
 
     private onNavbarQueryChange = (navbarSearchQueryState: QueryState): void => {

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -58,16 +58,15 @@ export function useExtensionAlertAnimation(): ExtensionAlertAnimationProps & {
  * Displays the user's avatar and/or username in the navbar and exposes a dropdown menu with more options for
  * authenticated viewers.
  */
-export const UserNavItem: React.FunctionComponent<UserNavItemProps> = props => {
-    const {
-        location,
-        themePreference,
-        onThemePreferenceChange,
-        isExtensionAlertAnimating,
-        testIsOpen,
-        codeHostIntegrationMessaging,
-    } = props
-
+export const UserNavItem: React.FunctionComponent<UserNavItemProps> = ({
+    location,
+    themePreference,
+    onThemePreferenceChange,
+    isExtensionAlertAnimating,
+    testIsOpen,
+    codeHostIntegrationMessaging,
+    ...props
+}) => {
     const supportsSystemTheme = useMemo(
         () => Boolean(window.matchMedia?.('not all and (prefers-color-scheme), (prefers-color-scheme)').matches),
         []
@@ -91,8 +90,10 @@ export const UserNavItem: React.FunctionComponent<UserNavItemProps> = props => {
     )
 
     const onThemeCycle = useCallback((): void => {
-        onThemePreferenceChange(themePreference === ThemePreference.Dark ? ThemePreference.Light : ThemePreference.Dark)
-    }, [onThemePreferenceChange, themePreference])
+        onThemePreferenceChange(previous =>
+            previous === ThemePreference.Dark ? ThemePreference.Light : ThemePreference.Dark
+        )
+    }, [onThemePreferenceChange])
 
     // Target ID for tooltip
     const targetID = 'target-user-avatar'
@@ -149,14 +150,14 @@ export const UserNavItem: React.FunctionComponent<UserNavItemProps> = props => {
                         <select
                             className="custom-select custom-select-sm test-theme-toggle"
                             onChange={onThemeChange}
-                            value={props.themePreference}
+                            value={themePreference}
                         >
                             <option value={ThemePreference.Light}>Light</option>
                             <option value={ThemePreference.Dark}>Dark</option>
                             <option value={ThemePreference.System}>System</option>
                         </select>
                     </div>
-                    {props.themePreference === ThemePreference.System && !supportsSystemTheme && (
+                    {themePreference === ThemePreference.System && !supportsSystemTheme && (
                         <div className="text-wrap">
                             <small>
                                 <a

--- a/client/web/src/theme.ts
+++ b/client/web/src/theme.ts
@@ -13,5 +13,5 @@ export enum ThemePreference {
  */
 export interface ThemePreferenceProps {
     themePreference: ThemePreference
-    onThemePreferenceChange: (theme: ThemePreference) => void
+    onThemePreferenceChange: (theme: ThemePreference | ((previous: ThemePreference) => ThemePreference)) => void
 }


### PR DESCRIPTION
The keyboard shortcut Option+T/Alt+T/Meta+T cycles between the light and dark themes. It was broken: it worked the first time after the page load, but it did not work on subsequent times.

The issue is fixed by using a functional setter for the state value.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->