### PR TITLE
search: sync access `calledSearchFilesInRepos` mock

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchquerytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
 	"github.com/sourcegraph/sourcegraph/schema"
+	"go.uber.org/atomic"
 )
 
 var mockCount = func(_ context.Context, options db.ReposListOptions) (int, error) { return 0, nil }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -160,7 +160,7 @@ func TestSearchResults(t *testing.T) {
 		if !calledSearchRepositories {
 			t.Error("!calledSearchRepositories")
 		}
-		if !calledSearchFilesInRepos {
+		if !calledSearchFilesInRepos.Load() {
 			t.Error("!calledSearchFilesInRepos")
 		}
 		if calledSearchSymbols {
@@ -226,7 +226,7 @@ func TestSearchResults(t *testing.T) {
 		if !calledSearchRepositories {
 			t.Error("!calledSearchRepositories")
 		}
-		if !calledSearchFilesInRepos {
+		if !calledSearchFilesInRepos.Load() {
 			t.Error("!calledSearchFilesInRepos")
 		}
 		if calledSearchSymbols {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -140,7 +140,7 @@ func TestSearchResults(t *testing.T) {
 		}
 		defer func() { mockSearchSymbols = nil }()
 
-		calledSearchFilesInRepos := false
+		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
@@ -206,7 +206,7 @@ func TestSearchResults(t *testing.T) {
 		}
 		defer func() { mockSearchSymbols = nil }()
 
-		calledSearchFilesInRepos := false
+		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
 			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -143,7 +143,7 @@ func TestSearchResults(t *testing.T) {
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
-			calledSearchFilesInRepos = true
+			calledSearchFilesInRepos.Store(true)
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
@@ -209,7 +209,7 @@ func TestSearchResults(t *testing.T) {
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
-			calledSearchFilesInRepos = true
+			calledSearchFilesInRepos.Store(true)
 			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
+	"go.uber.org/atomic"
 )
 
 func TestSearchSuggestions(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -101,7 +101,7 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 		defer git.ResetMocks()
 
-		calledSearchFilesInRepos := false
+		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			calledSearchFilesInRepos = true
 			if want := "foo"; args.PatternInfo.Pattern != want {
@@ -158,7 +158,7 @@ func TestSearchSuggestions(t *testing.T) {
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
 		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
 
-		calledSearchFilesInRepos := false
+		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -239,7 +239,7 @@ func TestSearchSuggestions(t *testing.T) {
 		mockShowLangSuggestions = func() ([]*searchSuggestionResolver, error) { return nil, nil }
 		defer func() { mockShowLangSuggestions = nil }()
 
-		calledSearchFilesInRepos := false
+		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -349,7 +349,7 @@ func TestSearchSuggestions(t *testing.T) {
 		mockShowLangSuggestions = func() ([]*searchSuggestionResolver, error) { return nil, nil }
 		defer func() { mockShowLangSuggestions = nil }()
 
-		calledSearchFilesInRepos := false
+		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -122,7 +122,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if !calledReposListFoo {
 				t.Error("!calledReposListFoo")
 			}
-			if !calledSearchFilesInRepos {
+			if !calledSearchFilesInRepos.Load() {
 				t.Error("!calledSearchFilesInRepos")
 			}
 		}
@@ -202,7 +202,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if !calledReposListFooRepo3 {
 				t.Error("!calledReposListFooRepo3")
 			}
-			if !calledSearchFilesInRepos {
+			if !calledSearchFilesInRepos.Load() {
 				t.Error("!calledSearchFilesInRepos")
 			}
 			if !calledResolveRepoGroups {
@@ -263,7 +263,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if !calledReposList {
 				t.Error("!calledReposList")
 			}
-			if !calledSearchFilesInRepos {
+			if !calledSearchFilesInRepos.Load() {
 				t.Error("!calledSearchFilesInRepos")
 			}
 		}
@@ -373,7 +373,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if !calledReposList {
 				t.Error("!calledReposList")
 			}
-			if !calledSearchFilesInRepos {
+			if !calledSearchFilesInRepos.Load() {
 				t.Error("!calledSearchFilesInRepos")
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -104,7 +104,7 @@ func TestSearchSuggestions(t *testing.T) {
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
-			calledSearchFilesInRepos = true
+			calledSearchFilesInRepos.Store(true)
 			if want := "foo"; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
@@ -163,7 +163,7 @@ func TestSearchSuggestions(t *testing.T) {
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
-			calledSearchFilesInRepos = true
+			calledSearchFilesInRepos.Store(true)
 			if args.PatternInfo.Pattern != "." && args.PatternInfo.Pattern != "foo" {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, `"foo" or "."`)
 			}
@@ -244,7 +244,7 @@ func TestSearchSuggestions(t *testing.T) {
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
-			calledSearchFilesInRepos = true
+			calledSearchFilesInRepos.Store(true)
 			repos, err := getRepos(context.Background(), args.RepoPromise)
 			if err != nil {
 				t.Error(err)
@@ -354,7 +354,7 @@ func TestSearchSuggestions(t *testing.T) {
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
-			calledSearchFilesInRepos = true
+			calledSearchFilesInRepos.Store(true)
 			repos, err := getRepos(context.Background(), args.RepoPromise)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
We call `searchFilesInRepos` twice in a normal search request. Once for files and once for file contents. This means the mocks we use in tests need to protect against concurrent access. CI picked up a test having race condition. This PR switches  us to using an atomic value.

Each commit is a self contained refactor using comby, getting us to a final state of using atomics.

Note: Technically we should validate which searchFilesInRepos we are calling (ie for file paths or not). However, these sort of conditions are somewhat low value. So rather than doing a bigger change I  just fixed the race condition.