### PR TITLE
search: add homepage footer with links to extensibility

### DIFF
--- a/client/web/src/search/input/SearchPage.scss
+++ b/client/web/src/search/input/SearchPage.scss
@@ -8,13 +8,9 @@
 @import '../panels/HomePanels.scss';
 
 .search-page {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     justify-content: flex-start;
     width: 100%;
     overflow: auto;
-    padding-bottom: 3rem;
 
     &__logo {
         flex: 0 0 auto;

--- a/client/web/src/search/input/SearchPage.scss
+++ b/client/web/src/search/input/SearchPage.scss
@@ -14,7 +14,7 @@
     justify-content: flex-start;
     width: 100%;
     overflow: auto;
-    padding-bottom: 4rem;
+    padding-bottom: 3rem;
 
     &__logo {
         flex: 0 0 auto;
@@ -99,6 +99,10 @@
 
     &__repogroup-listing-title {
         margin-bottom: 0.25rem;
+    }
+
+    &__footer {
+        margin-top: 2rem;
     }
 }
 

--- a/client/web/src/search/input/SearchPage.story.tsx
+++ b/client/web/src/search/input/SearchPage.story.tsx
@@ -58,7 +58,7 @@ const { add } = storiesOf('web/search/input/SearchPage', module).addParameters({
         type: 'figma',
         url: 'https://www.figma.com/file/sPRyyv3nt5h0284nqEuAXE/12192-Sourcegraph-server-page-v1?node-id=255%3A3',
     },
-    chromatic: { viewports: [769, 993, 1200] },
+    chromatic: { viewports: [544, 577, 769, 993, 1200] },
 })
 
 add('Cloud with panels', () => (

--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -97,7 +97,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         )
     )
     return (
-        <div className="web-content search-page">
+        <div className="web-content search-page d-flex flex-column align-items-center pb-5">
             <BrandLogo className="search-page__logo" isLightTheme={props.isLightTheme} variant="logo" />
             {props.isSourcegraphDotCom && <div className="search-page__cloud-tag-line">Search public code</div>}
             <div

--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -34,6 +34,7 @@ import { PrivateCodeCta } from './PrivateCodeCta'
 import { AuthenticatedUser } from '../../auth'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { HomePanels } from '../panels/HomePanels'
+import { SearchPageFooter } from './SearchPageFooter'
 
 export interface SearchPageProps
     extends SettingsCascadeProps<Settings>,
@@ -325,6 +326,8 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                 )}
 
             {props.showEnterpriseHomePanels && props.authenticatedUser && <HomePanels {...props} />}
+
+            <SearchPageFooter className="search-page__footer" />
         </div>
     )
 }

--- a/client/web/src/search/input/SearchPageFooter.test.tsx
+++ b/client/web/src/search/input/SearchPageFooter.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { SearchPageFooter } from './SearchPageFooter'
+
+describe('SearchPageFooter', () => {
+    afterAll(cleanup)
+
+    let container: HTMLElement
+
+    it('should render correctly', () => {
+        container = render(<SearchPageFooter className="test-class" />).container
+        expect(container).toMatchSnapshot()
+    })
+})

--- a/client/web/src/search/input/SearchPageFooter.tsx
+++ b/client/web/src/search/input/SearchPageFooter.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames'
+import React from 'react'
+import { Link } from '../../../../shared/src/components/Link'
+
+export const SearchPageFooter: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+    <footer className={classNames(className, 'd-flex flex-row')}>
+        <h4 className="mb-0">Explore and Extend:</h4>
+        <Link
+            className="border-right px-3"
+            to="https://docs.sourcegraph.com/integration/browser_extension"
+            rel="noopener noreferrer"
+            target="_blank"
+        >
+            Browser extensions
+        </Link>
+        <Link className="border-right px-3" to="/extensions" target="_blank">
+            Sourcegraph extensions
+        </Link>
+        <Link
+            className="border-right px-3"
+            to="https://docs.sourcegraph.com/integration/editor"
+            rel="noopener noreferrer"
+            target="_blank"
+        >
+            Editor plugins
+        </Link>
+        <Link
+            className="pl-3"
+            to="https://docs.sourcegraph.com/admin/external_service"
+            rel="noopener noreferrer"
+            target="_blank"
+        >
+            Code host integrations
+        </Link>
+    </footer>
+)

--- a/client/web/src/search/input/SearchPageFooter.tsx
+++ b/client/web/src/search/input/SearchPageFooter.tsx
@@ -3,34 +3,43 @@ import React from 'react'
 import { Link } from '../../../../shared/src/components/Link'
 
 export const SearchPageFooter: React.FunctionComponent<{ className?: string }> = ({ className }) => (
-    <footer className={classNames(className, 'd-flex flex-row')}>
-        <h4 className="mb-0">Explore and Extend:</h4>
-        <Link
-            className="border-right px-3"
-            to="https://docs.sourcegraph.com/integration/browser_extension"
-            rel="noopener noreferrer"
-            target="_blank"
-        >
-            Browser extensions
-        </Link>
-        <Link className="border-right px-3" to="/extensions" target="_blank">
-            Sourcegraph extensions
-        </Link>
-        <Link
-            className="border-right px-3"
-            to="https://docs.sourcegraph.com/integration/editor"
-            rel="noopener noreferrer"
-            target="_blank"
-        >
-            Editor plugins
-        </Link>
-        <Link
-            className="pl-3"
-            to="https://docs.sourcegraph.com/admin/external_service"
-            rel="noopener noreferrer"
-            target="_blank"
-        >
-            Code host integrations
-        </Link>
+    <footer className={classNames(className, 'd-flex flex-column flex-lg-row align-items-center')}>
+        <h4 className="mb-2 mb-lg-0">Explore and Extend</h4>
+        <span className="d-flex flex-column flex-md-row align-items-center">
+            <span className="d-flex flex-row mb-2 mb-md-0">
+                <Link
+                    className="px-3"
+                    to="https://docs.sourcegraph.com/integration/browser_extension"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    Browser extensions
+                </Link>
+                <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                <Link className="px-3" to="/extensions" target="_blank">
+                    Sourcegraph extensions
+                </Link>
+                <span aria-hidden="true" className="border-right d-none d-md-inline" />
+            </span>
+            <span className="d-flex flex-row">
+                <Link
+                    className="px-3"
+                    to="https://docs.sourcegraph.com/integration/editor"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    Editor plugins
+                </Link>
+                <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                <Link
+                    className="pl-3"
+                    to="https://docs.sourcegraph.com/admin/external_service"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    Code host integrations
+                </Link>
+            </span>
+        </span>
     </footer>
 )

--- a/client/web/src/search/input/__snapshots__/SearchPageFooter.test.tsx.snap
+++ b/client/web/src/search/input/__snapshots__/SearchPageFooter.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchPageFooter should render correctly 1`] = `
+<div>
+  <footer
+    class="test-class d-flex flex-row"
+  >
+    <h4
+      class="mb-0"
+    >
+      Explore and Extend:
+    </h4>
+    <a
+      class="border-right px-3"
+      href="https://docs.sourcegraph.com/integration/browser_extension"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Browser extensions
+    </a>
+    <a
+      class="border-right px-3"
+      href="/extensions"
+      target="_blank"
+    >
+      Sourcegraph extensions
+    </a>
+    <a
+      class="border-right px-3"
+      href="https://docs.sourcegraph.com/integration/editor"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Editor plugins
+    </a>
+    <a
+      class="pl-3"
+      href="https://docs.sourcegraph.com/admin/external_service"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Code host integrations
+    </a>
+  </footer>
+</div>
+`;

--- a/client/web/src/search/input/__snapshots__/SearchPageFooter.test.tsx.snap
+++ b/client/web/src/search/input/__snapshots__/SearchPageFooter.test.tsx.snap
@@ -3,44 +3,68 @@
 exports[`SearchPageFooter should render correctly 1`] = `
 <div>
   <footer
-    class="test-class d-flex flex-row"
+    class="test-class d-flex flex-column flex-lg-row align-items-center"
   >
     <h4
-      class="mb-0"
+      class="mb-2 mb-lg-0"
     >
-      Explore and Extend:
+      Explore and Extend
     </h4>
-    <a
-      class="border-right px-3"
-      href="https://docs.sourcegraph.com/integration/browser_extension"
-      rel="noopener noreferrer"
-      target="_blank"
+    <span
+      class="d-flex flex-column flex-md-row align-items-center"
     >
-      Browser extensions
-    </a>
-    <a
-      class="border-right px-3"
-      href="/extensions"
-      target="_blank"
-    >
-      Sourcegraph extensions
-    </a>
-    <a
-      class="border-right px-3"
-      href="https://docs.sourcegraph.com/integration/editor"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Editor plugins
-    </a>
-    <a
-      class="pl-3"
-      href="https://docs.sourcegraph.com/admin/external_service"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Code host integrations
-    </a>
+      <span
+        class="d-flex flex-row mb-2 mb-md-0"
+      >
+        <a
+          class="px-3"
+          href="https://docs.sourcegraph.com/integration/browser_extension"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Browser extensions
+        </a>
+        <span
+          aria-hidden="true"
+          class="border-right d-none d-md-inline"
+        />
+        <a
+          class="px-3"
+          href="/extensions"
+          target="_blank"
+        >
+          Sourcegraph extensions
+        </a>
+        <span
+          aria-hidden="true"
+          class="border-right d-none d-md-inline"
+        />
+      </span>
+      <span
+        class="d-flex flex-row"
+      >
+        <a
+          class="px-3"
+          href="https://docs.sourcegraph.com/integration/editor"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Editor plugins
+        </a>
+        <span
+          aria-hidden="true"
+          class="border-right d-none d-md-inline"
+        />
+        <a
+          class="pl-3"
+          href="https://docs.sourcegraph.com/admin/external_service"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Code host integrations
+        </a>
+      </span>
+    </span>
   </footer>
 </div>
 `;


### PR DESCRIPTION
Fixes #14638

See storybook for differences in different homepage modes (empty homepage, repogroups, panels)

![image](https://user-images.githubusercontent.com/206864/95901727-9eebec00-0d48-11eb-944a-bc77d6e17bb0.png)

![image](https://user-images.githubusercontent.com/206864/95902341-8af4ba00-0d49-11eb-949d-30571cf66e54.png)
