### PR TITLE
campaigns: update preview icons

### DIFF
--- a/client/web/src/enterprise/campaigns/apply/ChangesetSpecAction.tsx
+++ b/client/web/src/enterprise/campaigns/apply/ChangesetSpecAction.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { ChangesetSpecType, ChangesetSpecFields } from '../../../graphql-operations'
-import ClipboardCheckOutlineIcon from 'mdi-react/ClipboardCheckOutlineIcon'
-import ClipboardAlertOutlineIcon from 'mdi-react/ClipboardAlertOutlineIcon'
-import ClipboardArrowUpOutlineIcon from 'mdi-react/ClipboardArrowUpOutlineIcon'
+import BlankCircleIcon from 'mdi-react/CheckboxBlankCircleOutlineIcon'
+import ImportIcon from 'mdi-react/ImportIcon'
+import UploadIcon from 'mdi-react/UploadIcon'
 
 export interface ChangesetSpecActionProps {
     spec: ChangesetSpecFields
@@ -28,19 +28,19 @@ const iconClassNames = 'm-0 text-nowrap d-flex flex-column align-items-center ju
 
 export const ChangesetSpecActionPublish: React.FunctionComponent<{}> = () => (
     <div className={iconClassNames}>
-        <ClipboardCheckOutlineIcon data-tooltip="This changeset will be published on the code host when the spec is applied." />
-        <span className="text-muted">Will publish</span>
+        <UploadIcon data-tooltip="This changeset will be published to its code host" />
+        <span>Publish</span>
     </div>
 )
 export const ChangesetSpecActionNoPublish: React.FunctionComponent<{}> = () => (
-    <div className={iconClassNames}>
-        <ClipboardAlertOutlineIcon data-tooltip="This changeset will NOT be published on the code host when the spec is applied." />
-        <span className="text-muted">Won't publish</span>
+    <div className={`${iconClassNames} text-muted`}>
+        <BlankCircleIcon data-tooltip="Set publish: true in the changeset template to publish to the code host" />
+        <span>Won't publish</span>
     </div>
 )
 export const ChangesetSpecActionImport: React.FunctionComponent<{}> = () => (
     <div className={iconClassNames}>
-        <ClipboardArrowUpOutlineIcon data-tooltip="This changeset will be imported from the code host." />
-        <span className="text-muted">Will import</span>
+        <ImportIcon data-tooltip="This changeset will be imported and tracked in this campaign" />
+        <span>Import</span>
     </div>
 )


### PR DESCRIPTION
Closes #14426. Here's how it looks now:

![image](https://user-images.githubusercontent.com/229984/95906689-4ec45800-0d4f-11eb-824a-1048d41eaefd.png)

I made a couple of minor changes from [the Figma](https://www.figma.com/file/rhka9j2soFgkdGfb7HnZgP/Preview-icon-improvements---%2314426?node-id=22%3A1587&viewport=-773%2C622%2C1):

1. I adopted the new tooltip text, but copy edited it slightly to make it clearer, particularly the "won't publish" case, which is now more active.
2. I made the "won't publish" case darker than the Figma has it (specifically, by making it `text-muted`): the mock is `$gray-10`, which has a contrast ratio against the background of 3.19, which is below pretty much all the guidelines. `text-muted` is (mostly) OK. We do lose some visual hierarchy as a result, but I think it's the best compromise we have available.