### PR TITLE
codeintel: Store commits as bytea in lsif_nearest_uploads

### DIFF
--- a/enterprise/internal/codeintel/store/commits.go
+++ b/enterprise/internal/codeintel/store/commits.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/batch"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 // scanUploadMeta scans upload metadata grouped by commit from the return value of `*store.query`.
@@ -47,9 +48,9 @@ func (s *store) HasCommit(ctx context.Context, repositoryID int, commit string) 
 	count, _, err := basestore.ScanFirstInt(s.Store.Query(ctx, sqlf.Sprintf(`
 		SELECT COUNT(*)
 		FROM lsif_nearest_uploads
-		WHERE repository_id = %s AND commit = %s AND NOT overwritten
+		WHERE repository_id = %s AND (commit = %s OR commit_bytea = %s) AND NOT overwritten
 		LIMIT 1
-	`, repositoryID, commit)))
+	`, repositoryID, commit, dbutil.CommitBytea(commit))))
 
 	return count > 0, err
 }
@@ -139,6 +140,7 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 		"lsif_nearest_uploads",
 		"repository_id",
 		"commit",
+		"commit_bytea",
 		"upload_id",
 		"distance",
 		"ancestor_visible",
@@ -150,6 +152,7 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 				ctx,
 				repositoryID,
 				commit,
+				dbutil.CommitBytea(commit),
 				uploadMeta.UploadID,
 				uploadMeta.Distance,
 				uploadMeta.AncestorVisible,

--- a/internal/db/dbutil/dbutil.go
+++ b/internal/db/dbutil/dbutil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -384,6 +385,28 @@ func (n *NullJSONRawMessage) Scan(value interface{}) error {
 	}
 
 	return nil
+}
+
+// CommitBytea represents a hex-encoded string that is efficiently encoded in Postgres and should
+// be used in place of a text or varchar type when the table is large (e.g. a record per commit).
+type CommitBytea string
+
+// Scan implements the Scanner interface.
+func (c *CommitBytea) Scan(value interface{}) error {
+	switch value := value.(type) {
+	case nil:
+	case []byte:
+		*c = CommitBytea(hex.EncodeToString(value))
+	default:
+		return fmt.Errorf("value is not []byte: %T", value)
+	}
+
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (c CommitBytea) Value() (driver.Value, error) {
+	return hex.DecodeString(string(c))
 }
 
 // Value implements the driver Valuer interface.

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -636,8 +636,10 @@ Check constraints:
  distance         | integer | not null
  ancestor_visible | boolean | not null
  overwritten      | boolean | not null
+ commit_bytea     | bytea   | 
 Indexes:
     "lsif_nearest_uploads_repository_id_commit" btree (repository_id, commit)
+    "lsif_nearest_uploads_repository_id_commit_bytea" btree (repository_id, commit_bytea)
 
 ```
 

--- a/migrations/frontend/1528395737_compressed_commits.down.sql
+++ b/migrations/frontend/1528395737_compressed_commits.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE lsif_nearest_uploads DROP COLUMN commit_bytea;
+
+COMMIT;

--- a/migrations/frontend/1528395737_compressed_commits.up.sql
+++ b/migrations/frontend/1528395737_compressed_commits.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE lsif_nearest_uploads ADD COLUMN commit_bytea bytea;
+CREATE INDEX lsif_nearest_uploads_repository_id_commit_bytea ON lsif_nearest_uploads USING btree (repository_id, commit_bytea);
+
+-- Mark all repositories as dirty so that we will refresh them
+UPDATE lsif_dirty_repositories SET dirty_token = dirty_token + 1;
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -106,6 +106,8 @@
 // 1528395735_drop_language_from_repo.up.sql (66B)
 // 1528395736_add_index_to_repo_created_at.down.sql (124B)
 // 1528395736_add_index_to_repo_created_at.up.sql (151B)
+// 1528395737_compressed_commits.down.sql (76B)
+// 1528395737_compressed_commits.up.sql (339B)
 
 package migrations
 
@@ -2294,6 +2296,46 @@ func _1528395736_add_index_to_repo_created_atUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395737_compressed_commitsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\xc8\x29\xce\x4c\x8b\xcf\x4b\x4d\x2c\x4a\x2d\x2e\x89\x2f\x2d\xc8\xc9\x4f\x4c\x29\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x48\xce\xcf\xcd\xcd\x2c\x89\x4f\xaa\x2c\x49\x4d\xb4\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x37\x89\xd4\x87\x4c\x00\x00\x00")
+
+func _1528395737_compressed_commitsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395737_compressed_commitsDownSql,
+		"1528395737_compressed_commits.down.sql",
+	)
+}
+
+func _1528395737_compressed_commitsDownSql() (*asset, error) {
+	bytes, err := _1528395737_compressed_commitsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395737_compressed_commits.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x53, 0x22, 0xaf, 0x85, 0xb1, 0xb8, 0x37, 0x13, 0x81, 0xa2, 0x25, 0x5f, 0xbc, 0x93, 0x69, 0x3e, 0x7f, 0xa6, 0xf0, 0xa8, 0x7c, 0x72, 0x4c, 0x58, 0x7e, 0x6a, 0x96, 0xfc, 0x2d, 0x31, 0x73, 0x29}}
+	return a, nil
+}
+
+var __1528395737_compressed_commitsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x6c\x8e\x31\x6b\xc3\x30\x10\x46\x77\xfd\x8a\x6f\x6c\x69\x33\x74\x16\x1d\x1c\x5b\x04\x83\x2d\x97\x44\x86\x6e\x42\xa9\x2f\x58\xc4\x8e\x82\x74\x25\xf8\xdf\x97\xba\x50\x10\x78\x39\x38\x78\xf7\xee\xed\xd5\xa1\xd6\x52\x88\xa2\x31\xea\x08\x53\xec\x1b\x85\x29\xf9\x8b\xbd\x91\x8b\x94\xd8\x7e\xdf\xa7\xe0\x86\x84\xa2\xaa\x50\x76\x4d\xdf\x6a\x7c\x85\x79\xf6\x6c\xcf\x0b\x93\xc3\x3a\xa5\x28\x8f\xaa\x30\x0a\xb5\xae\xd4\xe7\xa6\xc0\x46\xba\x87\xe4\x39\xc4\xc5\xfa\xc1\x66\x8e\x4e\x6f\xff\xec\x4f\xb5\x3e\xe0\xcc\x91\x08\x4f\xd9\xfd\x6b\x16\xf1\x2c\x85\xd8\xed\xd0\xba\x78\x85\x9b\x26\xfc\xa3\x9e\x12\x5c\xc2\xe0\x23\x2f\x48\x01\x3c\x3a\xc6\x83\xf0\xf0\x2b\x75\x89\x94\x46\xf0\x48\xb3\xe8\x3f\xaa\xdf\xfe\x35\x63\xc5\x6d\x26\x39\x29\xf3\x67\xb1\x1c\xae\x74\xc3\x7b\xb6\xbd\xe0\x4d\x0a\x51\x76\x6d\x5b\x1b\x29\x7e\x02\x00\x00\xff\xff\x56\x47\x41\x5f\x53\x01\x00\x00")
+
+func _1528395737_compressed_commitsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395737_compressed_commitsUpSql,
+		"1528395737_compressed_commits.up.sql",
+	)
+}
+
+func _1528395737_compressed_commitsUpSql() (*asset, error) {
+	bytes, err := _1528395737_compressed_commitsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395737_compressed_commits.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8b, 0x9, 0xe7, 0x74, 0x62, 0x6d, 0x77, 0xd6, 0x3b, 0xe, 0xc9, 0xd4, 0x35, 0x4c, 0x8e, 0x33, 0x38, 0xec, 0xd7, 0x40, 0x1b, 0x6e, 0x1f, 0xda, 0xbf, 0x46, 0x11, 0xc4, 0xea, 0x47, 0xb, 0x9d}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2491,6 +2533,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395735_drop_language_from_repo.up.sql":                                    _1528395735_drop_language_from_repoUpSql,
 	"1528395736_add_index_to_repo_created_at.down.sql":                             _1528395736_add_index_to_repo_created_atDownSql,
 	"1528395736_add_index_to_repo_created_at.up.sql":                               _1528395736_add_index_to_repo_created_atUpSql,
+	"1528395737_compressed_commits.down.sql":                                       _1528395737_compressed_commitsDownSql,
+	"1528395737_compressed_commits.up.sql":                                         _1528395737_compressed_commitsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2643,6 +2687,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395735_drop_language_from_repo.up.sql":                                    {_1528395735_drop_language_from_repoUpSql, map[string]*bintree{}},
 	"1528395736_add_index_to_repo_created_at.down.sql":                             {_1528395736_add_index_to_repo_created_atDownSql, map[string]*bintree{}},
 	"1528395736_add_index_to_repo_created_at.up.sql":                               {_1528395736_add_index_to_repo_created_atUpSql, map[string]*bintree{}},
+	"1528395737_compressed_commits.down.sql":                                       {_1528395737_compressed_commitsDownSql, map[string]*bintree{}},
+	"1528395737_compressed_commits.up.sql":                                         {_1528395737_compressed_commitsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
The `lsif_nearest_uploads` table has a row for _every_ commit of a repository that it knows about. This can be massive, and is about half the size of the production database currently. We can do better by storing the integer value of the commit encoded as a variable-length byte (4 byte overhead). This should reduce the size required by this table by about half.

Edit: New column is nullable, old column will be written/read for the future. Will have another update that will stop writing the old column, and a subsequent one to remove it completely. Not sure the timeline here, but I'm assuming this will only be problematic for customers with many, many repos with LISF data.