### PR TITLE
Updates old instructions in our troubleshooting docs

### DIFF
--- a/doc/dev/how-to/troubleshooting_local_development.md
+++ b/doc/dev/how-to/troubleshooting_local_development.md
@@ -31,20 +31,20 @@ While developing Sourcegraph, you may run into:
 
 `frontend | failed to migrate the DB. Please contact hi@sourcegraph.com for further assistance:Dirty database version 1514702776. Fix and force version.`
 
-You may have to run migrations manually. First, install the Go [migrate](https://github.com/golang-migrate/migrate/tree/master/cli#installation) CLI, then run `dev/db/migrate.sh up`
+You may have to run migrations manually. First, install the Go [migrate](https://github.com/golang-migrate/migrate/tree/master/cli#installation) CLI, then run `dev/db/migrate.sh <db_name> up` where the database name is either `frontend` or `codeintel`.
 
 If you get something like `error: Dirty database version 1514702776. Fix and force version.`, you need to roll things back and start from scratch.
 
 ```bash
-dev/db/migrate.sh drop
-dev/db/migrate.sh up
+dev/db/migrate.sh <db_name> drop
+dev/db/migrate.sh <db_name> up
 ```
 
 If you receive errors while migrating, try dropping the database
 
 ```bash
-dev/db/drop-entire-local-database.sh
-dev/db/migrate.sh up
+dev/db/drop-entire-local-database-and-redis.sh
+dev/db/migrate.sh <db_name> up
 ```
 
 ### Internal Server Error

--- a/migrations/frontend/README.md
+++ b/migrations/frontend/README.md
@@ -67,11 +67,11 @@ for private instances (although there will be exceptions due to feature velocity
 
 Up migrations happen automatically on server start-up after running the
 generate scripts. They can also be run manually using the migrate CLI:
-run `./dev/db/migrate.sh up` to move forward to the latest migration. Run
+run `./dev/db/migrate.sh frontend up` to move forward to the latest migration. Run
 `./dev/db/migrate.sh` for a full list of options.
 
-You can run `./dev/db/migrate.sh down 1` to rollback the previous migration. If a migration fails and
-you need to revert to a previous state `./dev/db/migrate.sh force` may be helpful. Alternatively use
+You can run `./dev/db/migrate.sh frontend down 1` to rollback the previous migration. If a migration fails and
+you need to revert to a previous state `./dev/db/migrate.sh frontend force` may be helpful. Alternatively use
 the `dropdb` and `createdb` commands to wipe your local DB and start from a clean state.
 
 **Note:** if you find that you need to run a down migration, that almost certainly means the


### PR DESCRIPTION
It looks like some of our troubleshooting docs referenced an older version of `dev/db/migrate.sh`. This updates the docs.