### PR TITLE
Add label notifier workflow? 

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -12,4 +12,5 @@ jobs:
           with:
              recipients: |
                   team/web=@joelkw
+                  team/cloud=@tsenart
 

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -8,7 +8,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-        - uses: jenschelkopf/issue-label-notification-action@1.3
+        - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # 1.3
           with:
              recipients: |
                   team/web=@joelkw

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -13,4 +13,4 @@ jobs:
              recipients: |
                   team/web=@joelkw
                   team/cloud=@tsenart
-
+                  team/search=@lguychard

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -1,0 +1,15 @@
+name: "Notify users based on issue labels"
+
+on:
+  issues:
+      types: [labeled]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: jenschelkopf/issue-label-notification-action@1.3
+          with:
+             recipients: |
+                  team/web=@joelkw
+


### PR DESCRIPTION
I prefer to get notified when someone adds a new issue with the `team/web` label on it rather than check across various repos or label-filtered searches to make sure I'm aware of new stuff. 

I didn't know of another way to easily keep eyes on all `team/web` issues (if there's an obvious one I'm missing that's native) but I found [this github action](https://github.com/marketplace/actions/issue-label-notifier#example-workflow) and it passed a couple of quick tests I ran [here](https://github.com/Joelkw/test-label-notify/issues). Once/if we add this, I'll post about it in slack so folks know it's a tool available. 

(The way it works is just by tagging in anyone it's set to mention in a github bot comment on the issue, so it's clear someone was notified.) 