### PR TITLE
Hide arrows and borders for Bootstrap popovers

### DIFF
--- a/client/shared/src/extensions/ExtensionStatus.tsx
+++ b/client/shared/src/extensions/ExtensionStatus.tsx
@@ -160,7 +160,12 @@ export class ExtensionStatusPopover extends React.PureComponent<Props> {
                 <button type="button" id="extension-status-popover" className="btn btn-link text-decoration-none px-2">
                     <span className="text-muted">Ext</span> <MenuUpIcon className="icon-inline" />
                 </button>
-                <UncontrolledPopover placement="auto-end" target="extension-status-popover">
+                <UncontrolledPopover
+                    placement="auto-end"
+                    target="extension-status-popover"
+                    hideArrow={true}
+                    popperClassName="border-0"
+                >
                     <ExtensionStatus {...this.props} />
                 </UncontrolledPopover>
             </>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -251,7 +251,13 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                         >
                             <MenuDownIcon className="icon-inline" />
                         </button>
-                        <UncontrolledPopover placement="bottom-start" target="repo-popover" trigger="legacy">
+                        <UncontrolledPopover
+                            placement="bottom-start"
+                            target="repo-popover"
+                            trigger="legacy"
+                            hideArrow={true}
+                            popperClassName="border-0"
+                        >
                             <RepositoriesPopover
                                 currentRepo={repoOrError.id}
                                 history={props.history}

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -138,7 +138,13 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
                         >
                             <MenuDownIcon className="icon-inline" />
                         </button>
-                        <UncontrolledPopover placement="bottom-start" target="repo-revision-popover" trigger="legacy">
+                        <UncontrolledPopover
+                            placement="bottom-start"
+                            target="repo-revision-popover"
+                            trigger="legacy"
+                            hideArrow={true}
+                            popperClassName="border-0"
+                        >
                             <RevisionsPopover
                                 repo={props.repo.id}
                                 repoName={props.repo.name}


### PR DESCRIPTION
When we imported Bootstrap's popover styles, our existing popovers received unwanted arrows. This PR reverts the existing popovers to their original visual state.