### PR TITLE
Fix blob viewer Percy flake

### DIFF
--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -202,6 +202,8 @@ describe('Blob viewer', () => {
 
         it('shows a hover overlay from a hover provider and updates the URL when a token is clicked', async function () {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/blob/test.ts`)
+            await driver.page.evaluate(() => localStorage.removeItem('hover-count'))
+            await driver.page.reload()
 
             // Click on "log" in "console.log()" in line 2
             await driver.page.waitForSelector('.test-log-token', { visible: true })


### PR DESCRIPTION
I saw a Percy snapshot for 'shows a hover overlay from a hover provider' in which InstallBrowserExtensionAlert was displayed. I'm not sure how that happened (could it have ran after the 'browser extension discoverability' block?). 

This will be a short-lived fix, since we'll be able to disable the discoverability features in `commonWebGraphQlResults` soon.