### PR TITLE
Add notice on how to publish remaining changesets

### DIFF
--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -80,11 +80,11 @@ const queryChangesets: typeof _queryChangesets = () =>
             {
                 __typename: 'HiddenExternalChangeset',
                 createdAt: subDays(now, 5).toISOString(),
-                externalState: ChangesetExternalState.OPEN,
+                externalState: null,
                 id: 'someh1',
                 nextSyncAt: null,
                 publicationState: ChangesetPublicationState.UNPUBLISHED,
-                reconcilerState: ChangesetReconcilerState.QUEUED,
+                reconcilerState: ChangesetReconcilerState.COMPLETED,
                 updatedAt: subDays(now, 5).toISOString(),
             },
             {

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -26,6 +26,7 @@ import { CampaignTabs } from './CampaignTabs'
 import { CampaignDetailsActionSection } from './CampaignDetailsActionSection'
 import { BreadcrumbSetters } from '../../../components/Breadcrumbs'
 import { CampaignInfoByline } from './CampaignInfoByline'
+import { UnpublishedNotice } from './UnpublishedNotice'
 
 export interface CampaignDetailsPageProps
     extends ThemeProps,
@@ -140,6 +141,7 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 lastApplier={campaign.lastApplier}
                 className="mb-3"
             />
+            <UnpublishedNotice unpublished={campaign.changesets.stats.unpublished} className="mb-3" />
             <CampaignStatsCard closedAt={campaign.closedAt} stats={campaign.changesets.stats} className="mb-3" />
             <CampaignDescription history={history} description={campaign.description} />
             <CampaignTabs

--- a/client/web/src/enterprise/campaigns/detail/UnpublishedNotice.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/UnpublishedNotice.story.tsx
@@ -1,0 +1,10 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { UnpublishedNotice } from './UnpublishedNotice'
+
+const { add } = storiesOf('web/campaigns/details/UnpublishedNotice', module).addDecorator(story => (
+    <div className="p-3 container web-content">{story()}</div>
+))
+
+add('Some unpublished', () => <EnterpriseWebStory>{() => <UnpublishedNotice unpublished={10} />}</EnterpriseWebStory>)

--- a/client/web/src/enterprise/campaigns/detail/UnpublishedNotice.tsx
+++ b/client/web/src/enterprise/campaigns/detail/UnpublishedNotice.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import classNames from 'classnames'
+import { pluralize } from '../../../../../shared/src/util/strings'
+import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
+
+interface UnpublishedNoticeProps {
+    unpublished: number
+    className?: string
+}
+
+export const UnpublishedNotice: React.FunctionComponent<UnpublishedNoticeProps> = ({ unpublished, className }) => {
+    if (unpublished === 0) {
+        return <></>
+    }
+    return (
+        <div className={classNames('alert alert-secondary', className)}>
+            <SourceBranchIcon className="icon-inline" /> {unpublished} unpublished{' '}
+            {pluralize('changeset', unpublished, 'changesets')}. Set{' '}
+            <code className="badge badge-secondary">published: true</code> in the campaign spec and re-run{' '}
+            <code className="badge badge-secondary">src campaign apply -f $CAMPAIGN_SPEC_FILE</code> to publish to your
+            code host.
+        </div>
+    )
+}

--- a/client/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
@@ -169,6 +169,38 @@ exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
       </Timestamp>
     </div>
   </CampaignInfoByline>
+  <UnpublishedNotice
+    className="mb-3"
+    unpublished={2}
+  >
+    <div
+      className="alert alert-secondary mb-3"
+    >
+      <Memo(SourceBranchIcon)
+        className="icon-inline"
+      />
+       
+      2
+       unpublished
+       
+      changesets
+      . Set
+       
+      <code
+        className="badge badge-secondary"
+      >
+        published: true
+      </code>
+       in the campaign spec and re-run
+       
+      <code
+        className="badge badge-secondary"
+      >
+        src campaign apply -f $CAMPAIGN_SPEC_FILE
+      </code>
+       to publish to your code host.
+    </div>
+  </UnpublishedNotice>
   <CampaignStatsCard
     className="mb-3"
     closedAt={null}
@@ -257,6 +289,7 @@ exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
           >
             <div
               className="m-0 text-nowrap d-flex flex-column align-items-center justify-content-center text-muted flex-grow-0 flex-shrink-0 mx-3"
+              data-tooltip="Set published: true to publish to code host"
             >
               <Memo(SourceBranchIcon) />
               <span
@@ -1005,6 +1038,38 @@ exports[`CampaignDetailsPage viewerCanAdminister: true viewing existing 1`] = `
       </Timestamp>
     </div>
   </CampaignInfoByline>
+  <UnpublishedNotice
+    className="mb-3"
+    unpublished={2}
+  >
+    <div
+      className="alert alert-secondary mb-3"
+    >
+      <Memo(SourceBranchIcon)
+        className="icon-inline"
+      />
+       
+      2
+       unpublished
+       
+      changesets
+      . Set
+       
+      <code
+        className="badge badge-secondary"
+      >
+        published: true
+      </code>
+       in the campaign spec and re-run
+       
+      <code
+        className="badge badge-secondary"
+      >
+        src campaign apply -f $CAMPAIGN_SPEC_FILE
+      </code>
+       to publish to your code host.
+    </div>
+  </UnpublishedNotice>
   <CampaignStatsCard
     className="mb-3"
     closedAt={null}
@@ -1093,6 +1158,7 @@ exports[`CampaignDetailsPage viewerCanAdminister: true viewing existing 1`] = `
           >
             <div
               className="m-0 text-nowrap d-flex flex-column align-items-center justify-content-center text-muted flex-grow-0 flex-shrink-0 mx-3"
+              data-tooltip="Set published: true to publish to code host"
             >
               <Memo(SourceBranchIcon) />
               <span

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetStatusCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetStatusCell.tsx
@@ -39,7 +39,10 @@ export const ChangesetStatusUnpublished: React.FunctionComponent<{ label?: JSX.E
     label = <span className="text-muted">Unpublished</span>,
     className,
 }) => (
-    <div className={classNames(iconClassNames, 'text-muted', className)}>
+    <div
+        className={classNames(iconClassNames, 'text-muted', className)}
+        data-tooltip="Set published: true to publish to code host"
+    >
         <SourceBranchIcon />
         {label}
     </div>


### PR DESCRIPTION
Implements the notice on how to publish changesets when some are unpublished, according to the design.

![image](https://user-images.githubusercontent.com/19534377/95931876-9cca7180-0dca-11eb-97cb-0968e442592c.png)
