### PR TITLE
Update development section

### DIFF
--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -85,7 +85,7 @@ Now, follow the steps below for the browser you intend to work with.
 - Browse to any public repository on GitHub to confirm it is working.
 - After making changes it is necessary to refresh the extension. This is done by going to [chrome://extensions](chrome://extensions) and clicking the "Reload" icon.
 
-![Add dist folder](readme-load-extension-asset.png)
+![File-path](https://user-images.githubusercontent.com/20326070/96001359-37ad6500-0e38-11eb-8d17-60e7c493b2b3.png)
 
 #### Updating the bundle
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -85,7 +85,7 @@ Now, follow the steps below for the browser you intend to work with.
 - Browse to any public repository on GitHub to confirm it is working.
 - After making changes it is necessary to refresh the extension. This is done by going to [chrome://extensions](chrome://extensions) and clicking the "Reload" icon.
 
-![File-path](https://user-images.githubusercontent.com/20326070/96001359-37ad6500-0e38-11eb-8d17-60e7c493b2b3.png)
+![File-path](https://user-images.githubusercontent.com/20326070/96859153-75764300-1461-11eb-8b82-0febc9327723.png)
 
 #### Updating the bundle
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -83,7 +83,7 @@ Now, follow the steps below for the browser you intend to work with.
 - If you already have the Sourcegraph extension installed, disable it using the toggle.
 - Enable 'developer mode', click on [Load unpacked extensions](https://developer.chrome.com/extensions/getstarted#unpacked), save it in the `sourcegraph/client/browser/build/chrome` folder.
 - Browse to any public repository on GitHub to confirm it is working.
-- After making changes it is necessary to refresh the extension. This is done by going to [chrome://extensions](chrome://extensions) and clicking the "Reload" icon.
+- After making changes it is sometimes necessary to refresh the extension. This is done by going to [chrome://extensions](chrome://extensions) and clicking the "Reload" icon.
 
 ![File-path](https://user-images.githubusercontent.com/20326070/96859153-75764300-1461-11eb-8b82-0febc9327723.png)
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -80,10 +80,10 @@ Now, follow the steps below for the browser you intend to work with.
 ### Chrome
 
 - Browse to [chrome://extensions](chrome://extensions).
-- If you already have the Sourcegraph extension installed, disable it by unchecking the "Enabled" box.
-- Click on [Load unpacked extensions](https://developer.chrome.com/extensions/getstarted#unpacked), and select the `build/chrome` folder.
+- If you already have the Sourcegraph extension installed, disable it using the toggle.
+- Enable 'developer mode', click on [Load unpacked extensions](https://developer.chrome.com/extensions/getstarted#unpacked), save it in the `sourcegraph/client/browser/build/chrome` folder.
 - Browse to any public repository on GitHub to confirm it is working.
-- After making changes it is necessary to refresh the extension. This is done by going to [chrome://extensions](chrome://extensions) and clicking "Reload".
+- After making changes it is necessary to refresh the extension. This is done by going to [chrome://extensions](chrome://extensions) and clicking the "Reload" icon.
 
 ![Add dist folder](readme-load-extension-asset.png)
 


### PR DESCRIPTION
Updating the 'development' section with clearer instructions and updated file path

<img width="977" alt="readme-file-path" src="https://user-images.githubusercontent.com/20326070/96001359-37ad6500-0e38-11eb-8d17-60e7c493b2b3.png">
