### PR TITLE
correct link color on extensions page

### DIFF
--- a/client/web/src/extensions/ExtensionCard.scss
+++ b/client/web/src/extensions/ExtensionCard.scss
@@ -33,7 +33,7 @@
     }
 
     &__link {
-        color: var(--body-color);
+        color: var(--link-color);
     }
 
     &__logo {

--- a/client/web/src/extensions/ExtensionCard.scss
+++ b/client/web/src/extensions/ExtensionCard.scss
@@ -32,10 +32,6 @@
         opacity: 1;
     }
 
-    &__link {
-        color: var(--link-color);
-    }
-
     &__logo {
         margin-left: calc(0.5rem - 2px); /* stylelint-disable-line */
         flex: 0 0 auto;

--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -178,10 +178,7 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
                                             ? extension.registryExtension.extensionIDWithoutRegistry
                                             : extension.id
                                     }`}
-                                    className={classNames(
-                                        'font-weight-bold',
-                                        change === 'enabled' ? 'alert-link' : 'extension-card__link'
-                                    )}
+                                    className={classNames('font-weight-bold', change === 'enabled' ? 'alert-link' : '')}
                                 >
                                     {name}
                                 </Link>

--- a/client/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`ExtensionCard renders 1`] = `
             className="mb-0 mr-1 text-truncate flex-1"
           >
             <a
-              className="font-weight-bold extension-card__link"
+              className="font-weight-bold"
               href="/extensions/x/y"
               onClick={[Function]}
             >


### PR DESCRIPTION
The current link color on the extensions page is the grey search page link color. This makes it difficult to tell the card titles are links to the extension pages. 

# Current:

![image](https://user-images.githubusercontent.com/539268/96011044-52abb500-0df7-11eb-8fa3-79e485860646.png)



# Change made by this PR:


![image](https://user-images.githubusercontent.com/539268/96010958-3dcf2180-0df7-11eb-97e3-5fe2a5865d6e.png)



![image](https://user-images.githubusercontent.com/539268/96010794-0f514680-0df7-11eb-943c-3198734a160d.png)
