### PR TITLE
fix bad instructions in docs

### DIFF
--- a/doc/user/campaigns/how-tos/tracking_existing_changesets.md
+++ b/doc/user/campaigns/how-tos/tracking_existing_changesets.md
@@ -9,11 +9,11 @@ name: track-important-milestone
 description: Track all changesets related to our important milestone
 
 importChangesets:
-- repo: github.com/sourcegraph/sourcegraph
+- repository: github.com/sourcegraph/sourcegraph
   externalIDs: [12374, 11675]
-- repo: bitbucket.sgdev.org/SOUR/vegeta
+- repository: bitbucket.sgdev.org/SOUR/vegeta
   externalIDs: [8]
-- repo: gitlab.sgdev.org/sourcegraph/src-cli
+- repository: gitlab.sgdev.org/sourcegraph/src-cli
   externalIDs: [113, 119]
 ```
 


### PR DESCRIPTION
As seen [here](https://github.com/sourcegraph/src-cli/blob/main/internal/campaigns/campaign_spec.go#L58), the field is called `repository`, not `repo`.