### PR TITLE
ensure we have commits locally before finding common merge-base

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -111,7 +111,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 
 	// Make sure we call ResolveRevision before we find the common merge-base, in case
 	// the commits don't exist locally.
-	_, err = git.ResolveRevision(ctx, *grepo, nil, baseRevspec, git.ResolveRevisionOptions{NoEnsureRevision: false})
+	_, err = git.ResolveRevision(ctx, *grepo, nil, baseRevspec, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -109,13 +109,6 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 		return nil, err
 	}
 
-	// Make sure we call ResolveRevision before we find the common merge-base, in case
-	// the commits don't exist locally.
-	_, err = git.ResolveRevision(ctx, *grepo, nil, baseRevspec, git.ResolveRevisionOptions{})
-	if err != nil {
-		return nil, err
-	}
-
 	// Find the common merge-base for the diff. That's the revision the diff applies to,
 	// not the baseRevspec.
 	mergeBaseCommit, err := git.MergeBase(ctx, *grepo, api.CommitID(baseRevspec), api.CommitID(headRevspec))

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -104,37 +104,31 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 		return nil, err
 	}
 
-	var (
-		wg               sync.WaitGroup
-		base, head       *GitCommitResolver
-		baseErr, headErr error
-	)
-
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		// Find the common merge-base for the diff. That's the revision the diff applies to,
-		// not the baseRevspec.
-		mergeBaseCommit, err := git.MergeBase(ctx, *grepo, api.CommitID(baseRevspec), api.CommitID(headRevspec))
-		if err != nil {
-			baseErr = err
-			return
-		}
-		// We use the merge-base as the base commit here, as the diff will only be guaranteed to be
-		// applicable to the file from that revision.
-		commitString := strings.TrimSpace(string(mergeBaseCommit))
-		base, baseErr = getCommit(ctx, *grepo, commitString)
-	}()
-	go func() {
-		defer wg.Done()
-		head, headErr = getCommit(ctx, *grepo, headRevspec)
-	}()
-	wg.Wait()
-	if baseErr != nil {
-		return nil, baseErr
+	head, err := getCommit(ctx, *grepo, headRevspec)
+	if err != nil {
+		return nil, err
 	}
-	if headErr != nil {
-		return nil, headErr
+
+	// Make sure we call ResolveRevision before we find the common merge-base, in case
+	// the commits don't exist locally.
+	_, err = git.ResolveRevision(ctx, *grepo, nil, baseRevspec, git.ResolveRevisionOptions{NoEnsureRevision: false})
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the common merge-base for the diff. That's the revision the diff applies to,
+	// not the baseRevspec.
+	mergeBaseCommit, err := git.MergeBase(ctx, *grepo, api.CommitID(baseRevspec), api.CommitID(headRevspec))
+	if err != nil {
+		return nil, err
+	}
+
+	// We use the merge-base as the base commit here, as the diff will only be guaranteed to be
+	// applicable to the file from that revision.
+	commitString := strings.TrimSpace(string(mergeBaseCommit))
+	base, err := getCommit(ctx, *grepo, commitString)
+	if err != nil {
+		return nil, err
 	}
 
 	return &RepositoryComparisonResolver{

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -216,14 +216,6 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 
 	spec := fmt.Sprintf("%s...%s", baseRev, headRev)
 
-	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
-		if spec != baseRev {
-			t.Fatalf("git.Mocks.ResolveRevision received unknown rev spec: %s", spec)
-		}
-		return api.CommitID(baseRev), nil
-	}
-	t.Cleanup(func() { git.Mocks.ResolveRevision = nil })
-
 	git.Mocks.GetCommit = func(id api.CommitID) (*git.Commit, error) {
 		if string(id) != baseRev && string(id) != headRev {
 			t.Fatalf("git.Mocks.GetCommit received unknown commit id: %s", id)

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -216,6 +216,14 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 
 	spec := fmt.Sprintf("%s...%s", baseRev, headRev)
 
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+		if spec != baseRev {
+			t.Fatalf("git.Mocks.ResolveRevision received unknown rev spec: %s", spec)
+		}
+		return api.CommitID(baseRev), nil
+	}
+	t.Cleanup(func() { git.Mocks.ResolveRevision = nil })
+	
 	git.Mocks.GetCommit = func(id api.CommitID) (*git.Commit, error) {
 		if string(id) != baseRev && string(id) != headRev {
 			t.Fatalf("git.Mocks.GetCommit received unknown commit id: %s", id)

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -223,7 +223,7 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 		return api.CommitID(baseRev), nil
 	}
 	t.Cleanup(func() { git.Mocks.ResolveRevision = nil })
-	
+
 	git.Mocks.GetCommit = func(id api.CommitID) (*git.Commit, error) {
 		if string(id) != baseRev && string(id) != headRev {
 			t.Fatalf("git.Mocks.GetCommit received unknown commit id: %s", id)


### PR DESCRIPTION
Make sure we call `ResolveRevision` before we find the common merge-base, in case the commits don't exist locally.

I tested it by creating this campaign:

```
name: test-3487562349
description: just a random test

importChangesets:
- repository: github.com/sourcegraph/test
  externalIDs: [7]
```

I then added a commit to that PR, went to the campaigns UI, and pressed the "refresh" button. Before this fix, I got [the error](https://github.com/sourcegraph/sourcegraph/issues/12584). After the fix, it correctly refreshed the diff.

Closes #12584.