### PR TITLE
db: check for updated permissions before query

### DIFF
--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -657,10 +657,12 @@ func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 		})
 	}
 
-	if q, err = updateUserPendingPermissionsBatchQuery(updatedPerms...); err != nil {
-		return err
-	} else if err = txs.execute(ctx, q); err != nil {
-		return errors.Wrap(err, "execute update user pending permissions batch query")
+	if len(updatedPerms) > 0 {
+		if q, err = updateUserPendingPermissionsBatchQuery(updatedPerms...); err != nil {
+			return err
+		} else if err = txs.execute(ctx, q); err != nil {
+			return errors.Wrap(err, "execute update user pending permissions batch query")
+		}
 	}
 
 	if q, err = upsertRepoPendingPermissionsBatchQuery(p); err != nil {


### PR DESCRIPTION
I'm not sure if this is the _actual_ right approach, but it does quiet the warnings, at least. See #14738 for more detail on what is happening.

Fixes #14738.