### PR TITLE
Implement `getText` for extension API

### DIFF
--- a/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -373,6 +373,14 @@ declare module 'sourcegraph' {
          * @returns A range spanning a word, or `undefined`.
          */
         getWordRangeAtPosition(position: Position): Range | undefined
+
+        /**
+         * Get the substring of text content from the provided range.
+         *
+         * @param range A range
+         * @returns The text inside the provided range, or `undefined`
+         */
+        getText(range?: Range): string | undefined
     }
 
     /**
@@ -716,7 +724,7 @@ declare module 'sourcegraph' {
          * Display the results of the location provider (with the given ID) in this panel below the
          * {@link PanelView#contents}.
          *
-         * @internal Experimental. Subject to change or removal without notice.
+         * @internal
          */
         component: { locationProvider: string } | null
     }

--- a/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -378,7 +378,7 @@ declare module 'sourcegraph' {
          * Get the substring of text content from the provided range.
          *
          * @param range A range
-         * @returns The text inside the provided range, or `undefined`
+         * @returns The text inside the provided range, or the whole text if no range is provided
          */
         getText(range?: Range): string | undefined
     }
@@ -723,6 +723,8 @@ declare module 'sourcegraph' {
         /**
          * Display the results of the location provider (with the given ID) in this panel below the
          * {@link PanelView#contents}.
+         *
+         * Experimental. Subject to change or removal without notice.
          *
          * @internal
          */

--- a/client/shared/src/api/extension/api/textDocument.test.ts
+++ b/client/shared/src/api/extension/api/textDocument.test.ts
@@ -1,4 +1,4 @@
-import { Position } from '@sourcegraph/extension-api-classes'
+import { Position, Range } from '@sourcegraph/extension-api-classes'
 import { OFFSET_TO_POSITION_TESTS, POSITION_TO_OFFSET_TESTS } from '../../client/types/textDocument.test'
 import { ExtensionDocument, getEOL } from './textDocument'
 
@@ -32,6 +32,23 @@ describe('ExtensionDocument', () => {
             start: { line: 0, character: 3 },
             end: { line: 0, character: 5 },
         }))
+
+    test('getText (one line)', () => {
+        const document = textDocument('aa bb cc')
+        expect(document.getText(document.getWordRangeAtPosition(new Position(0, 3)))).toEqual('bb')
+    })
+
+    test('getText (two lines)', () => {
+        const document = textDocument('aa bb\nbbb ccccc')
+        expect(document.getText(new Range(new Position(0, 3), new Position(1, 3)))).toEqual('bbbbb')
+    })
+
+    test('getText (several lines)', () => {
+        const document = textDocument('this text\ndocument spans\nmultiple \nlines ')
+        expect(document.getText(new Range(new Position(0, 5), new Position(3, 2)))).toEqual(
+            'textdocument spansmultiple li'
+        )
+    })
 })
 
 describe('getEOL', () => {

--- a/client/shared/src/api/extension/api/textDocument.test.ts
+++ b/client/shared/src/api/extension/api/textDocument.test.ts
@@ -33,6 +33,7 @@ describe('ExtensionDocument', () => {
             end: { line: 0, character: 5 },
         }))
 
+    // No need to test invalid ranges for `getText` since that is handled by `validateRange` and `validatePosition`
     test('getText (one line)', () => {
         const document = textDocument('aa bb cc')
         expect(document.getText(document.getWordRangeAtPosition(new Position(0, 3)))).toEqual('bb')

--- a/client/shared/src/api/extension/api/textDocument.ts
+++ b/client/shared/src/api/extension/api/textDocument.ts
@@ -107,10 +107,10 @@ export class ExtensionDocument implements sourcegraph.TextDocument {
 
     public getText(range?: sourcegraph.Range): string | undefined {
         this.throwIfNoModelText()
+        range = range ? this.validateRange(range) : undefined
         if (!range) {
             return undefined
         }
-        range = this.validateRange(range)
         const { start, end } = range
 
         if (start.line === end.line) {

--- a/client/shared/src/api/extension/api/textDocument.ts
+++ b/client/shared/src/api/extension/api/textDocument.ts
@@ -109,7 +109,7 @@ export class ExtensionDocument implements sourcegraph.TextDocument {
         this.throwIfNoModelText()
         range = range ? this.validateRange(range) : undefined
         if (!range) {
-            return undefined
+            return this.text
         }
         const { start, end } = range
 

--- a/client/shared/src/api/extension/api/textDocument.ts
+++ b/client/shared/src/api/extension/api/textDocument.ts
@@ -105,6 +105,32 @@ export class ExtensionDocument implements sourcegraph.TextDocument {
         return undefined
     }
 
+    public getText(range?: sourcegraph.Range): string | undefined {
+        this.throwIfNoModelText()
+        if (!range) {
+            return undefined
+        }
+        range = this.validateRange(range)
+        const { start, end } = range
+
+        if (start.line === end.line) {
+            return this._lines[start.line].slice(start.character, end.character)
+        }
+
+        let text = ''
+        for (let line = start.line; line <= end.line; line++) {
+            if (line === start.line) {
+                text += this._lines[line].slice(start.character)
+            } else if (line === end.line) {
+                text += this._lines[line].slice(0, end.character)
+            } else {
+                text += this._lines[line]
+            }
+        }
+
+        return text
+    }
+
     // Memoize computation of line starts.
     private _lineStarts: PrefixSumComputer | null = null
     private get lineStarts(): PrefixSumComputer {


### PR DESCRIPTION
I wasn't able to find a method like [`getText` from VS Code's extension API](https://code.visualstudio.com/api/references/vscode-api#TextDocument), so I implemented this POC.

Example usage:
```ts
function provideHover(document, position) {
    const word = document.getText(document.getWordRangeAtPosition(position))
    // Elided
}
```

#### Motivation

I went through the extension registry and found only two non-"hello world" extensions that registered hover providers. Both were authored by Sourcegraph contributors and implemented their own version of `getText`, but without the utilities available to `TextDocument` methods ([token-highlights](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-extension-samples/-/blob/token-highlights/src/extension.ts#L3), [string-references](https://sourcegraph.com/github.com/lguychard/sourcegraph-string-references/-/blob/src/util.ts#L35)).

Implementing more helpers would make authoring extensions more accessible and reduce extension bundle sizes due to code reuse.