### PR TITLE
Watch integration test bundle

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,14 @@
       },
     },
     {
+      "label": "Watch web app",
+      "detail": "Watch files and build the JavaScript bundle (no development server).",
+      "type": "npm",
+      "script": "watch-web",
+      "problemMatcher": [],
+      "isBackground": true,
+    },
+    {
       "label": "Watch code generation",
       "detail": "Watch files and generate types when files are changed",
       "type": "npm",

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -8,7 +8,7 @@ frontend: env CONFIGURATION_MODE=server SITE_CONFIG_ESCAPE_HATCH_PATH=$HOME/.sou
 watch: ./dev/changewatch.sh
 nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf 2>&1 | grep -v 'could not open error log file'
 caddy: ./dev/caddy.sh run --watch --config=dev/Caddyfile
-web: ./node_modules/.bin/gulp --color watch
+web: ./node_modules/.bin/gulp --color dev
 syntect_server: ./dev/syntect_server.sh
 zoekt-indexserver-0: ./dev/zoekt/wrapper indexserver 0
 zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1

--- a/doc/dev/background-information/testing.md
+++ b/doc/dev/background-information/testing.md
@@ -127,7 +127,8 @@ Test coverage from integration tests is tracked in [Codecov](https://codecov.io/
 
 To run integration tests for the web app:
 
-1. Run `yarn build-web` in the repository root to build a JavaScript bundle.
+1. Run `yarn watch-web` in the repository root in a separate terminal to watch files and build a JavaScript bundle. You can also launch it as the VS Code task "Watch web app".
+  - Alternatively, `yarn build-web` will only build a bundle once.
 1. Run `yarn test-integration` in the repository root to run the tests.
 
 A Sourcegraph instance does not need to be running, because all backend interactions are stubbed.

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -8,7 +8,7 @@ frontend: env CONFIGURATION_MODE=server SITE_CONFIG_ESCAPE_HATCH_PATH=$HOME/.sou
 watch: ./dev/changewatch.sh
 nginx: nginx -p . -g 'daemon off;' -c $PWD/dev/nginx.conf 2>&1 | grep -v 'could not open error log file'
 caddy: ./dev/caddy.sh run --watch --config=dev/Caddyfile
-web: ./node_modules/.bin/gulp --color watch
+web: ./node_modules/.bin/gulp --color dev
 syntect_server: ./dev/syntect_server.sh
 zoekt-indexserver-0: ./dev/zoekt/wrapper indexserver 0
 zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,13 +29,13 @@ const build = gulp.series(generate, webWebpack)
 /**
  * Watches everything and rebuilds on file changes.
  */
-const watch = gulp.parallel(watchGenerate, webWebpackDevServer)
+const dev = gulp.parallel(watchGenerate, webWebpackDevServer)
 
 module.exports = {
   generate,
   watchGenerate,
   build,
-  watch,
+  dev,
   schema,
   graphQlSchema,
   watchGraphQlSchema,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build-ts": "tsc -b tsconfig.all.json",
     "graphql-lint": "graphql-schema-linter cmd/frontend/graphqlbackend/schema.graphql",
     "build-web": "yarn --cwd client/web run build",
+    "watch-web": "yarn --cwd client/web run watch",
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",


### PR DESCRIPTION
Adds a task to watch the bundle, which is useful when wanting to run integration tests and iterate on the webapp.