### PR TITLE
Add error handling for not found changesets from GitHub

### DIFF
--- a/cmd/repo-updater/repos/bitbucketserver_test.go
+++ b/cmd/repo-updater/repos/bitbucketserver_test.go
@@ -189,7 +189,7 @@ func TestBitbucketServerSource_LoadChangeset(t *testing.T) {
 		{
 			name: "not-found",
 			cs:   changesets[1],
-			err:  `Changeset with external ID "999" not found`,
+			err:  `Changeset with external ID 999 not found`,
 		},
 	}
 

--- a/cmd/repo-updater/repos/github.go
+++ b/cmd/repo-updater/repos/github.go
@@ -249,6 +249,9 @@ func (s GithubSource) LoadChangeset(ctx context.Context, cs *Changeset) error {
 	}
 
 	if err := s.client.LoadPullRequest(ctx, pr); err != nil {
+		if github.IsNotFound(err) {
+			return ChangesetNotFoundError{Changeset: cs}
+		}
 		return err
 	}
 

--- a/cmd/repo-updater/repos/github_test.go
+++ b/cmd/repo-updater/repos/github_test.go
@@ -352,6 +352,14 @@ func TestGithubSource_LoadChangeset(t *testing.T) {
 				Changeset: &campaigns.Changeset{ExternalID: "5550"},
 			},
 		},
+		{
+			name: "not-found",
+			cs: &Changeset{
+				Repo:      &Repo{Metadata: &github.Repository{NameWithOwner: "sourcegraph/sourcegraph"}},
+				Changeset: &campaigns.Changeset{ExternalID: "100000"},
+			},
+			err: "Changeset with external ID 100000 not found",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -372,6 +372,9 @@ func (s *GitLabSource) LoadChangeset(ctx context.Context, cs *Changeset) error {
 
 	mr, err := s.client.GetMergeRequest(ctx, project, gitlab.ID(iid))
 	if err != nil {
+		if gitlab.IsNotFound(err) {
+			return ChangesetNotFoundError{Changeset: cs}
+		}
 		return errors.Wrapf(err, "retrieving merge request %d", iid)
 	}
 

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -498,7 +498,7 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 			p := newGitLabChangesetSourceTestProvider(t)
 			p.changeset.Changeset.ExternalID = "43"
 			p.changeset.Changeset.Metadata = p.mr
-			p.mockGetMergeRequest(43, nil, gitlab.HttpError(404))
+			p.mockGetMergeRequest(43, nil, gitlab.HTTPError(404))
 
 			if err := p.source.LoadChangeset(p.ctx, p.changeset); err == nil {
 				t.Fatal("unexpectedly no error for not found changeset")

--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -494,6 +494,19 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 			}
 		})
 
+		t.Run("not found", func(t *testing.T) {
+			p := newGitLabChangesetSourceTestProvider(t)
+			p.changeset.Changeset.ExternalID = "43"
+			p.changeset.Changeset.Metadata = p.mr
+			p.mockGetMergeRequest(43, nil, gitlab.HttpError(404))
+
+			if err := p.source.LoadChangeset(p.ctx, p.changeset); err == nil {
+				t.Fatal("unexpectedly no error for not found changeset")
+			} else if err.Error() != (ChangesetNotFoundError{Changeset: &Changeset{Changeset: &campaigns.Changeset{ExternalID: "43"}}}).Error() {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+		})
+
 		// The guts of the note and pipeline scenarios are tested in separate
 		// unit tests below for read{Notes,Pipelines}UntilSeen, but we'll do a
 		// couple of quick tests here just to ensure that

--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -121,7 +121,7 @@ type ChangesetNotFoundError struct {
 }
 
 func (e ChangesetNotFoundError) Error() string {
-	return fmt.Sprintf("Changeset with external ID %q not found", e.Changeset.Changeset.ExternalID)
+	return fmt.Sprintf("Changeset with external ID %s not found", e.Changeset.Changeset.ExternalID)
 }
 
 // A SourceResult is sent by a Source over a channel for each repository it

--- a/cmd/repo-updater/repos/testdata/sources/GithubSource_LoadChangeset_not-found.yaml
+++ b/cmd/repo-updater/repos/testdata/sources/GithubSource_LoadChangeset_not-found.yaml
@@ -1,0 +1,58 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label {\n  name\n  color\n  description\n  id\n}\n\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment timelineItems on PullRequestTimelineItems {\n  ... on AssignedEvent {\n    actor {\n      ...actor\n    }\n    assignee {\n      ...actor\n    }\n    createdAt\n  }\n  ... on ClosedEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n    url\n  }\n  ... on IssueComment {\n    databaseId\n    author {\n      ...actor\n    }\n    authorAssociation\n    body\n    createdAt\n    editor {\n      ...actor\n    }\n    url\n    updatedAt\n    includesCreatedEdit\n    publishedAt\n  }\n  ... on RenamedTitleEvent {\n    actor {\n      ...actor\n    }\n    previousTitle\n    currentTitle\n    createdAt\n  }\n  ... on MergedEvent {\n    actor {\n      ...actor\n    }\n    mergeRefName\n    url\n    commit {\n      ...commit\n    }\n    createdAt\n  }\n  ... on PullRequestReview {\n    ...review\n  }\n  ... on PullRequestReviewThread {\n    comments(last: 100) {\n      nodes {\n        databaseId\n        author {\n          ...actor\n        }\n        authorAssociation\n        editor {\n          ...actor\n        }\n        commit {\n          ...commit\n        }\n        body\n        state\n        url\n        createdAt\n        updatedAt\n        includesCreatedEdit\n      }\n    }\n  }\n  ... on ReopenedEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ... on ReviewDismissedEvent {\n    actor {\n      ...actor\n    }\n    review {\n      ...review\n    }\n    dismissalMessage\n    createdAt\n  }\n  ... on ReviewRequestRemovedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ... on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ... on ReviewRequestedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ... on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ... on ReadyForReviewEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ... on ConvertToDraftEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ... on UnassignedEvent {\n    actor {\n      ...actor\n    }\n    assignee {\n      ...actor\n    }\n    createdAt\n  }\n  ... on LabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ... on UnlabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ... on PullRequestCommit {\n    commit {\n      ...commit\n    }\n  }\n}\n\nfragment commitWithChecks on Commit {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last: 20) {\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last: 20) {\n        nodes {\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  isDraft\n  author {\n    ...actor\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first: 100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT, CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW, PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT, REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    nodes {\n      __typename\n      ...timelineItems\n    }\n  }\n}\n\nquery($owner: String!, $name: String!, $number: Int!) {\n\trepository(owner: $owner, name: $name) {\n\t\tpullRequest(number: $number) { ...pr }\n\t}\n}","variables":{"name":"sourcegraph","number":100000,"owner":"sourcegraph"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"repository":{"pullRequest":null}},"errors":[{"type":"NOT_FOUND","path":["repository","pullRequest"],"locations":[{"line":301,"column":3}],"message":"Could not resolve to a PullRequest with the number of 100000."}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Oct 2020 15:15:52 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - CBE9:71A0:204B683C:255E65A9:5F9050A7
+      X-Oauth-Scopes:
+      - read:discussion, read:org, repo
+      X-Ratelimit-Used:
+      - "15"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -127,16 +127,13 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 		return errors.Wrap(err, "failed to load external service")
 	}
 
-	if !e.ch.Unsynced {
-	}
-
 	// Set up a source with which we can modify the changeset.
 	e.ccs, err = e.buildChangesetSource(e.repo, e.extSvc)
 	if err != nil {
 		return err
 	}
 
-	upsertChangesetEvents := true
+	upsertChangeset := true
 	for _, op := range plan.ops.ExecutionOrder() {
 		switch op {
 		case operationSync:
@@ -146,7 +143,7 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 			var notFound bool
 			notFound, err = e.importChangeset(ctx)
 			if notFound {
-				upsertChangesetEvents = false
+				upsertChangeset = false
 			}
 
 		case operationPublish:
@@ -176,7 +173,7 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 		}
 	}
 
-	if upsertChangesetEvents {
+	if upsertChangeset {
 		events := e.ch.Events()
 		SetDerivedState(ctx, e.ch, events)
 

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -133,7 +133,7 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 		return err
 	}
 
-	upsertChangeset := true
+	upsertChangesetEvents := true
 	for _, op := range plan.ops.ExecutionOrder() {
 		switch op {
 		case operationSync:
@@ -143,7 +143,7 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 			var notFound bool
 			notFound, err = e.importChangeset(ctx)
 			if notFound {
-				upsertChangeset = false
+				upsertChangesetEvents = false
 			}
 
 		case operationPublish:
@@ -173,7 +173,7 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 		}
 	}
 
-	if upsertChangeset {
+	if upsertChangesetEvents {
 		events := e.ch.Events()
 		SetDerivedState(ctx, e.ch, events)
 
@@ -641,7 +641,7 @@ func determinePlan(ctx context.Context, tx *Store, ch *campaigns.Changeset) (*pl
 		}
 	}
 
-	delta, err := CompareChangesetSpecs(prev, curr)
+	delta, err := compareChangesetSpecs(prev, curr)
 	if err != nil {
 		return pl, nil
 	}
@@ -859,7 +859,7 @@ func namespaceURL(ns *db.Namespace) string {
 	return prefix + ns.Name
 }
 
-func CompareChangesetSpecs(previous, current *campaigns.ChangesetSpec) (*changesetSpecDelta, error) {
+func compareChangesetSpecs(previous, current *campaigns.ChangesetSpec) (*changesetSpecDelta, error) {
 	delta := &changesetSpecDelta{}
 
 	if previous == nil {

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -658,8 +658,7 @@ func determinePlan(ctx context.Context, tx *Store, ch *campaigns.Changeset) (*pl
 		}
 
 	case campaigns.ChangesetPublicationStatePublished:
-		reopen := reopenAfterDetach(ch)
-		if reopen {
+		if reopenAfterDetach(ch) {
 			pl.SetOp(operationReopen)
 		}
 
@@ -728,27 +727,6 @@ func checkSpecAppliedToCampaign(ctx context.Context, tx *Store, spec *campaigns.
 	}
 
 	return nil
-}
-
-func loadAssociations(ctx context.Context, tx *Store, ch *campaigns.Changeset) (*repos.Repo, *repos.ExternalService, *campaigns.Campaign, error) {
-	reposStore := repos.NewDBStore(tx.Handle().DB(), sql.TxOptions{})
-
-	repo, err := loadRepo(ctx, reposStore, ch.RepoID)
-	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to load repository")
-	}
-
-	extSvc, err := loadExternalService(ctx, reposStore, repo)
-	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to load external service")
-	}
-
-	campaign, err := loadCampaign(ctx, tx, ch.OwnedByCampaignID)
-	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to load campaign")
-	}
-
-	return repo, extSvc, campaign, nil
 }
 
 func loadRepo(ctx context.Context, tx repos.Store, id api.RepoID) (*repos.Repo, error) {

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -52,6 +52,13 @@ func TestReconcilerProcess(t *testing.T) {
 	draftGithubPR := buildGithubPR(clock(), campaigns.ChangesetExternalStateDraft)
 	closedGitHubPR := buildGithubPR(clock(), campaigns.ChangesetExternalStateClosed)
 
+	notFoundErr := repos.ChangesetsNotFoundError{
+		Changesets: []*repos.Changeset{
+			{Changeset: &campaigns.Changeset{ExternalID: "100000"}},
+		},
+	}
+	notFoundErrMsg := notFoundErr.Error()
+
 	campaignSpec := createCampaignSpec(t, ctx, store, "reconciler-test-campaign", admin.ID)
 	campaign := createCampaign(t, ctx, store, "reconciler-test-campaign", admin.ID, campaignSpec.ID)
 
@@ -61,6 +68,7 @@ func TestReconcilerProcess(t *testing.T) {
 		previousSpec *testSpecOpts
 
 		sourcerMetadata interface{}
+		sourcerErr      error
 		// Whether or not the source responds to CreateChangeset with "already exists"
 		alreadyExists bool
 
@@ -644,6 +652,25 @@ func TestReconcilerProcess(t *testing.T) {
 				diffStat: state.DiffStat,
 			},
 		},
+		"syncing not found changeset": {
+			changeset: testChangesetOpts{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				externalID:       "100000",
+				unsynced:         true,
+			},
+			sourcerErr: notFoundErr,
+
+			wantLoadFromCodeHost: true,
+
+			wantChangeset: changesetAssertions{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				failureMessage:   &notFoundErrMsg,
+				externalID:       "100000",
+				reconcilerState:  campaigns.ReconcilerStateErrored,
+				numFailures:      reconcilerMaxNumRetries + 1,
+				unsynced:         false,
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -698,7 +725,7 @@ func TestReconcilerProcess(t *testing.T) {
 			// to create/update a changeset.
 			fakeSource := &ct.FakeChangesetSource{
 				Svc:             extSvc,
-				Err:             nil,
+				Err:             tc.sourcerErr,
 				ChangesetExists: tc.alreadyExists,
 				FakeMetadata:    tc.sourcerMetadata,
 			}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -52,9 +52,9 @@ func TestReconcilerProcess(t *testing.T) {
 	draftGithubPR := buildGithubPR(clock(), campaigns.ChangesetExternalStateDraft)
 	closedGitHubPR := buildGithubPR(clock(), campaigns.ChangesetExternalStateClosed)
 
-	notFoundErr := repos.ChangesetsNotFoundError{
-		Changesets: []*repos.Changeset{
-			{Changeset: &campaigns.Changeset{ExternalID: "100000"}},
+	notFoundErr := repos.ChangesetNotFoundError{
+		Changeset: &repos.Changeset{
+			Changeset: &campaigns.Changeset{ExternalID: "100000"},
 		},
 	}
 	notFoundErrMsg := notFoundErr.Error()
@@ -667,8 +667,8 @@ func TestReconcilerProcess(t *testing.T) {
 				failureMessage:   &notFoundErrMsg,
 				externalID:       "100000",
 				reconcilerState:  campaigns.ReconcilerStateErrored,
-				numFailures:      reconcilerMaxNumRetries + 1,
-				unsynced:         false,
+				numFailures:      reconcilerMaxNumRetries + 999,
+				unsynced:         true,
 			},
 		},
 	}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -1203,7 +1203,7 @@ func TestDecorateChangesetBody(t *testing.T) {
 
 	body := "body"
 	rcs := &repos.Changeset{Body: body, Changeset: cs, Repo: rs[0]}
-	if err := decorateChangesetBody(ctx, store, rcs, campaign); err != nil {
+	if err := decorateChangesetBody(ctx, store, rcs); err != nil {
 		t.Errorf("unexpected non-nil error: %v", err)
 	}
 	if want := body + "\n\n[_Created by Sourcegraph campaign `" + admin.Username + "/reconciler-test-campaign`._](https://sourcegraph.test/users/" + admin.Username + "/campaigns/reconciler-test-campaign)"; rcs.Body != want {

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -468,6 +468,9 @@ func IsNotFound(err error) bool {
 	if err == ErrNotFound || errors.Cause(err) == ErrNotFound {
 		return true
 	}
+	if _, ok := err.(ErrPullRequestNotFound); ok {
+		return true
+	}
 	if HTTPErrorCode(err) == http.StatusNotFound {
 		return true
 	}
@@ -546,3 +549,10 @@ var ErrIncompleteResults = errors.New("github repository search returned incompl
 
 // ErrPullRequestAlreadyExists is when the requested GitHub Pull Request already exists.
 var ErrPullRequestAlreadyExists = errors.New("GitHub pull request already exists")
+
+// ErrPullRequestNotFound is when the requested GitHub Pull Request doesn't exist.
+type ErrPullRequestNotFound int
+
+func (e ErrPullRequestNotFound) Error() string {
+	return fmt.Sprintf("GitHub pull requests not found: %d", e)
+}

--- a/internal/extsvc/github/client_test.go
+++ b/internal/extsvc/github/client_test.go
@@ -245,12 +245,12 @@ func TestClient_LoadPullRequest(t *testing.T) {
 		{
 			name: "non-existing-repo",
 			pr:   &PullRequest{RepoWithOwner: "whoisthis/sourcegraph", Number: 5550},
-			err:  "error in GraphQL response: Could not resolve to a Repository with the name 'whoisthis/sourcegraph'.",
+			err:  "GitHub repository not found",
 		},
 		{
 			name: "non-existing-pr",
 			pr:   &PullRequest{RepoWithOwner: "sourcegraph/sourcegraph", Number: 0},
-			err:  "error in GraphQL response: Could not resolve to a PullRequest with the number of 0.",
+			err:  "GitHub pull requests not found: 0",
 		},
 		{
 			name: "success",

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -250,26 +250,26 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 
 	c.RateLimitMonitor.Update(resp.Header)
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, resp.StatusCode, errors.Wrap(httpError(resp.StatusCode), fmt.Sprintf("unexpected response from GitLab API (%s)", req.URL))
+		return nil, resp.StatusCode, errors.Wrap(HttpError(resp.StatusCode), fmt.Sprintf("unexpected response from GitLab API (%s)", req.URL))
 	}
 
 	return resp.Header, resp.StatusCode, json.NewDecoder(resp.Body).Decode(result)
 }
 
-type httpError int
+type HttpError int
 
-func (err httpError) Error() string {
+func (err HttpError) Error() string {
 	return fmt.Sprintf("HTTP error status %d", err)
 }
 
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from
 // this package. Otherwise it returns 0.
 func HTTPErrorCode(err error) int {
-	e, ok := err.(httpError)
+	e, ok := err.(HttpError)
 	if !ok {
 		// Try one level deeper.
 		err = errors.Cause(err)
-		e, ok = err.(httpError)
+		e, ok = err.(HttpError)
 	}
 	if ok {
 		return int(e)

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -250,26 +250,26 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 
 	c.RateLimitMonitor.Update(resp.Header)
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, resp.StatusCode, errors.Wrap(HttpError(resp.StatusCode), fmt.Sprintf("unexpected response from GitLab API (%s)", req.URL))
+		return nil, resp.StatusCode, errors.Wrap(HTTPError(resp.StatusCode), fmt.Sprintf("unexpected response from GitLab API (%s)", req.URL))
 	}
 
 	return resp.Header, resp.StatusCode, json.NewDecoder(resp.Body).Decode(result)
 }
 
-type HttpError int
+type HTTPError int
 
-func (err HttpError) Error() string {
+func (err HTTPError) Error() string {
 	return fmt.Sprintf("HTTP error status %d", err)
 }
 
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from
 // this package. Otherwise it returns 0.
 func HTTPErrorCode(err error) int {
-	e, ok := err.(HttpError)
+	e, ok := err.(HTTPError)
 	if !ok {
 		// Try one level deeper.
 		err = errors.Cause(err)
-		e, ok = err.(HttpError)
+		e, ok = err.(HTTPError)
 	}
 	if ok {
 		return int(e)


### PR DESCRIPTION
This fixes the implementation of the `ChangesetSource` interface, which states a `LoadChangeset` implementation should throw a `ChangesetNotFoundError`. It also introduces a new operation to the reconciler, which tracks a changeset is initially imported and not just synced, in which case it won't go to the errored state, but remain unsynced and in a terminal error state, so no retries are attempted.

This fixes https://github.com/sourcegraph/sourcegraph/issues/14923