### PR TITLE
Update commit reference for code-intel-extensions for bundled extensions

### DIFF
--- a/client/browser/bundled-code-intel-extensions.json
+++ b/client/browser/bundled-code-intel-extensions.json
@@ -1,4 +1,4 @@
 {
-  "revision": "282caa906a8f5d64f67711809a2c8492908f9fe4",
+  "revision": "2c4895c64e6ce746c935c8d4b677abbb8b0b3803",
   "extensions": ["template"]
 }


### PR DESCRIPTION
Updates the commit of `code-intel-extensions` that gets fetched by the build script for bundled extensions.

If there's already a fetched copy of `code-intel-extensions` locally, then run `yarn run fetch-code-intel-extensions` (inside of `client/browser`) to overwrite the old copy. 

