### PR TITLE
Run paginated queries in SetClonedRepos

### DIFF
--- a/cmd/repo-updater/repos/conf.go
+++ b/cmd/repo-updater/repos/conf.go
@@ -37,3 +37,11 @@ func ConfUserReposMaxPerSite() int {
 	}
 	return v
 }
+
+func ConfRepoSetClonedBatchSize() int {
+	v := conf.Get().RepoSetClonedBatchSize
+	if v == 0 {
+		return 100_000
+	}
+	return v
+}

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -895,7 +895,7 @@ FROM inserted_sources_list
 
 // DefaultSetClonedReposStep is used to determine the number of repos per page
 // the SetClonedRepos function must update.
-var DefaultSetClonedReposStep = 100_000
+var DefaultSetClonedReposStep = 400_000
 
 // SetClonedRepos updates cloned status for all repositories.
 // All repositories whose name is in repoNames will have their cloned column set to true

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -909,7 +909,7 @@ func (s DBStore) SetClonedRepos(ctx context.Context, repoNames ...string) error 
 	if !ok {
 		txstore, err := s.Transact(ctx)
 		if err != nil {
-			return errors.Wrap(err, "scanRepo: failed to create a transaction")
+			return errors.Wrap(err, "SetClonedRepos: failed to create a transaction")
 		}
 		defer txstore.Done(&err)
 		err = txstore.SetClonedRepos(ctx, repoNames...)

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -944,7 +944,7 @@ func (s DBStore) SetClonedRepos(ctx context.Context, repoNames ...string) error 
 		return err
 	}
 
-	// manually truncate the temporaty table as SetClonedRepos might be used multiple times during the same transaction
+	// manually truncate the temporary table as SetClonedRepos might be used multiple times during the same transaction
 	_, err = tx.ExecContext(ctx, "TRUNCATE TABLE cloned_repos")
 	return err
 }
@@ -964,7 +964,7 @@ const setClonedReposQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.SetClonedRepos
 --
 -- This query generates a diff by selecting only
--- the repos that need to be updated for the selected page.
+-- the repos that need to be updated.
 -- Selected repos will have their cloned column reversed if
 -- their cloned column is true but they are not in cloned_repos
 -- or they are in cloned_repos but their cloned column is false.

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -893,10 +893,6 @@ INSERT INTO external_service_repos (
 FROM inserted_sources_list
 `
 
-// DefaultSetClonedReposStep is used to determine the number of repos per page
-// the SetClonedRepos function must update.
-var DefaultSetClonedReposStep = 400_000
-
 // SetClonedRepos updates cloned status for all repositories.
 // All repositories whose name is in repoNames will have their cloned column set to true
 // and every other repository will have it set to false.
@@ -918,7 +914,7 @@ func (s DBStore) SetClonedRepos(ctx context.Context, repoNames ...string) error 
 
 	sort.Strings(repoNames)
 
-	step := DefaultSetClonedReposStep
+	step := ConfRepoSetClonedBatchSize()
 
 	for i := 0; i < len(repoNames); i += step {
 		firstIdx := i

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -1196,11 +1197,10 @@ func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 	servicesPerKind := createExternalServices(t, store)
 
 	// setting the step to a small number to test the pagination system used by SetClonedRepos
-	oldValue := repos.DefaultSetClonedReposStep
-	repos.DefaultSetClonedReposStep = 3
-	defer func() {
-		repos.DefaultSetClonedReposStep = oldValue
-	}()
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
+		RepoSetClonedBatchSize: 3,
+	}})
+	defer conf.Mock(nil)
 
 	return func(t *testing.T) {
 		var repositories repos.Repos

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -1195,6 +1195,13 @@ func isCloned(r *repos.Repo) bool {
 func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 	servicesPerKind := createExternalServices(t, store)
 
+	// setting the step to a small number to test the pagination system used by SetClonedRepos
+	oldValue := repos.DefaultSetClonedReposStep
+	repos.DefaultSetClonedReposStep = 3
+	defer func() {
+		repos.DefaultSetClonedReposStep = oldValue
+	}()
+
 	return func(t *testing.T) {
 		var repositories repos.Repos
 		for i := 0; i < 3; i++ {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -202,7 +202,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}()
 	server.Syncer = syncer
 
-	go syncCloned(ctx, scheduler, gitserver.DefaultClient, store)
+	go syncCloned(ctx, scheduler, gitserver.DefaultClient, store.(repos.Transactor))
 
 	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
 
@@ -335,7 +335,7 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 
 // syncCloned will periodically list the cloned repositories on gitserver and
 // update the scheduler with the list.
-func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store repos.Store) {
+func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store repos.Transactor) {
 	doSync := func() {
 		cloned, err := gitserverClient.ListCloned(ctx)
 		if err != nil {
@@ -345,7 +345,14 @@ func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver
 
 		sched.SetCloned(cloned)
 
-		err = store.SetClonedRepos(ctx, cloned...)
+		tx, err := store.Transact(ctx)
+		if err != nil {
+			log15.Warn("failed to create transaction from store", "error", err)
+			return
+		}
+		defer tx.Done(&err)
+
+		err = tx.SetClonedRepos(ctx, cloned...)
 		if err != nil {
 			log15.Warn("failed to set cloned repository list", "error", err)
 			return

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1223,6 +1223,8 @@ type SiteConfiguration struct {
 	RepoConcurrentExternalServiceSyncers int `json:"repoConcurrentExternalServiceSyncers,omitempty"`
 	// RepoListUpdateInterval description: Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.
 	RepoListUpdateInterval int `json:"repoListUpdateInterval,omitempty"`
+	// RepoSetClonedBatchSize description: Number of database repository rows to update per query.
+	RepoSetClonedBatchSize int `json:"repoSetClonedBatchSize,omitempty"`
 	// SearchIndexEnabled description: Whether indexed search is enabled. If unset Sourcegraph detects the environment to decide if indexed search is enabled. Indexed search is RAM heavy, and is disabled by default in the single docker image. All other environments will have it enabled by default. The size of all your repository working copies is the amount of additional RAM required.
 	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -348,6 +348,12 @@
       "default": 3,
       "group": "External services"
     },
+    "repoSetClonedBatchSize": {
+      "description": "Number of database repository rows to update per query.",
+      "type": "integer",
+      "default": 100000,
+      "group": "External services"
+    },
     "maxReposToSearch": {
       "description": "DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
       "type": "integer",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -353,6 +353,12 @@ const SiteSchemaJSON = `{
       "default": 3,
       "group": "External services"
     },
+    "repoSetClonedBatchSize": {
+      "description": "Number of database repository rows to update per query.",
+      "type": "integer",
+      "default": 100000,
+      "group": "External services"
+    },
     "maxReposToSearch": {
       "description": "DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
       "type": "integer",


### PR DESCRIPTION
This PR modifies the SetClonedRepos method to use the same query as before but on 400k repos pages.
On Cloud, this means running about 4 queries (~around 1.3M cloned repos). This should fix the `pq: temporary file size exceeds temp_file_limit` error by reducing the number of temporary files.

Fixes #14431