### PR TITLE
search: prevent panic on nil SearchResult

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -706,7 +706,9 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 		ev.AddField("status", status)
 		ev.AddField("alert_type", alertType)
 		ev.AddField("duration_ms", time.Since(start).Milliseconds())
-		ev.AddField("result_size", len(rr.SearchResults))
+		if rr != nil {
+			ev.AddField("result_size", len(rr.SearchResults))
+		}
 
 		if honey.Enabled() {
 			_ = ev.Send()


### PR DESCRIPTION
`rr` can be `nil` here, I triggered it with an unconventional query on Sourcegraph.com (doesn't trigger on dev). Wondering if we should just always return a non-nil `rr` from `r.resultsWithTimeoutSuggestion(ctx)`.