### PR TITLE
Delete redis keys in batch

### DIFF
--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -222,18 +222,19 @@ var deleteBatchSize = 5000
 func deleteKeysWithPrefix(c redis.Conn, prefix string) error {
 	const script = `
 redis.replicate_commands()
-local cursor = "0"
+local cursor = '0'
+local prefix = ARGV[1]
 local batchSize = ARGV[2]
 local result = ''
 repeat
-	local keys = redis.call('SCAN', cursor, 'MATCH', ARGV[1], 'COUNT', batchSize)
+	local keys = redis.call('SCAN', cursor, 'MATCH', prefix, 'COUNT', batchSize)
 	if #keys[2] > 0
 	then
 		result = redis.call('DEL', unpack(keys[2]))
 	end
 
 	cursor = keys[1]
-until cursor == "0"
+until cursor == '0'
 return result
 `
 

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -222,6 +222,7 @@ var deleteBatchSize = 8000
 
 func deleteKeysWithPrefix(c redis.Conn, prefix string) error {
 	const script = `
+redis.replicate_commands()
 local cursor = "0"
 local keys = {}
 repeat

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -212,15 +212,29 @@ func SetupForTest(t TB) {
 	}
 }
 
-func deleteKeysWithPrefix(c redis.Conn, prefix string) error {
-	const script = `local keys = redis.call('keys', ARGV[1])
-if #keys > 0 then
-	return redis.call('del', unpack(keys))
-else
-	return ''
-end`
+// The number of keys to delete per batch.
+// The maximum number of keys that can be unpacked
+// is determined by the Lua config LUAI_MAXCSTACK
+// which is 8000 by default.
+// See https://www.lua.org/source/5.1/luaconf.h.html
+// Increase or decrease this value if the Redis configuration changes.
+var deleteBatchSize = 8000
 
-	_, err := c.Do("EVAL", script, 0, prefix+":*")
+func deleteKeysWithPrefix(c redis.Conn, prefix string) error {
+	const script = `
+local keys = redis.call('keys', ARGV[1])
+local batchSize = ARGV[2]
+local i = 0
+
+local result = ''
+while i < #keys do
+	result = redis.call('del', unpack(keys, i + 1, math.min(i + batchSize, #keys)))
+	i = i + batchSize
+end
+return result
+`
+
+	_, err := c.Do("EVAL", script, 0, prefix+":*", deleteBatchSize)
 	return err
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/customer/issues/48 by deleting the v1 redis keys in batch.