### PR TITLE
search: fix comment highlighting in search console

### DIFF
--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -55,7 +55,7 @@ export function getProviders(
         tokens: {
             getInitialState: () => PARSER_STATE,
             tokenize: line => {
-                const result = parseSearchQuery(line)
+                const result = parseSearchQuery(line, options.interpretComments ?? false)
                 if (result.type === 'success') {
                     return {
                         tokens: getMonacoTokens(result.token),


### PR DESCRIPTION
I noticed comments were not highlighted. I went back the previous commits and think it came with e868ed1eb475c984e17c0e22ba51a71cc553bb65, but the line in question wasn't changed. With some debugging saw that `parse` was called twice, once with the flag set, and then it is immediately unset by this call.