### PR TITLE
search: shortcircuit on count for search expressions

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -286,7 +286,7 @@ type searchResolver struct {
 	patternType         query.SearchType
 	versionContext      *string
 	userSettings        *schema.Settings
-	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating a search subexpresions.
+	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating search subexpressions.
 
 	// Cached resolveRepositories results.
 	reposMu  sync.Mutex

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -280,12 +280,13 @@ type resolvedRepositories struct {
 
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
-	query          query.QueryInfo       // the query, either containing and/or expressions or otherwise ordinary
-	originalQuery  string                // the raw string of the original search query
-	pagination     *searchPaginationInfo // pagination information, or nil if the request is not paginated.
-	patternType    query.SearchType
-	versionContext *string
-	userSettings   *schema.Settings
+	query               query.QueryInfo       // the query, either containing and/or expressions or otherwise ordinary
+	originalQuery       string                // the raw string of the original search query
+	pagination          *searchPaginationInfo // pagination information, or nil if the request is not paginated.
+	patternType         query.SearchType
+	versionContext      *string
+	userSettings        *schema.Settings
+	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating a search subexpresions.
 
 	// Cached resolveRepositories results.
 	reposMu  sync.Mutex

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1122,11 +1122,6 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 				// Fail if any subquery fails.
 				return nil, err
 			}
-			if len(newResult.SearchResults) > wantCount {
-				newResult.SearchResults = newResult.SearchResults[:wantCount]
-				newResult.searchResultsCommon.resultCount = int32(wantCount)
-				break
-			}
 			if newResult != nil {
 				srr = union(srr, newResult)
 				if len(srr.SearchResults) > wantCount {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1089,7 +1089,7 @@ func (r *searchResolver) setRepoCacheInvalidation() {
 		seenRepo += 1
 	})
 	query.VisitField(r.query.(*query.AndOrQuery).Query, "repogroup", func(_ string, _ bool, _ query.Annotation) {
-		seenRepo += 1
+		seenRepoGroup += 1
 	})
 	if seenRepo+seenRepoGroup > 1 {
 		r.invalidateRepoCache = true


### PR DESCRIPTION
After merging #13907, my nice big queries for blog post became slow, because no shortcircuiting was happening (it's as if `count:30` was specified for each `or` subexpression, and always run). This PR:

- shortcircuits on subexpression results once we've hit 'enough' results (30 by default). 
- additionally, #13907 invalidates resolved repos for every `or` subexpression. This is overkill: we only need to invalidate the repo cache if there are more than one `repo` or `repogroup` field.

For now it just matters that the search integration tests are green, so that I can publish the blog post: https://buildkite.com/sourcegraph/sourcegraph/builds/76866. I will follow up with an integration test that checks shortcircuiting is honored as expected--this needs some more significant changes to `gqltest`.