### PR TITLE
Clean up `<code>` styles

### DIFF
--- a/client/branded/src/components/CodeSnippet.scss
+++ b/client/branded/src/components/CodeSnippet.scss
@@ -1,5 +1,0 @@
-.code-snippet {
-    &__container {
-        background-color: var(--color-bg-2);
-    }
-}

--- a/client/branded/src/components/CodeSnippet.tsx
+++ b/client/branded/src/components/CodeSnippet.tsx
@@ -14,8 +14,8 @@ interface CodeSnippetProps {
 export const CodeSnippet: React.FunctionComponent<CodeSnippetProps> = ({ code, language, className }) => {
     const highlightedInput = useMemo(() => ({ __html: highlightCodeSafe(code, language) }), [code, language])
     return (
-        <div className={classNames('code-snippet__container rounded p-3', className)}>
-            <pre className="m-0" dangerouslySetInnerHTML={highlightedInput} />
-        </div>
+        <pre className={classNames('bg-code rounded p-3', className)}>
+            <code dangerouslySetInnerHTML={highlightedInput} />
+        </pre>
     )
 }

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -1,12 +1,24 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
 $code-font-size: 12px;
 
+.theme-dark {
+    --code-bg: var(--color-bg-2);
+}
+
+.theme-light {
+    --code-bg: var(--color-bg-2);
+}
+
 code,
 .code {
     font-family: $code-font-family;
     font-size: $code-font-size;
     line-height: 16px;
     white-space: pre;
+}
+
+.bg-code {
+    background-color: var(--code-bg);
 }
 
 kbd {

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -110,8 +110,6 @@ $collapsible-expand-btn-width: 1.25rem;
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;
 
-$code-bg: var(--body-bg);
-
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';

--- a/client/shared/src/components/Markdown.scss
+++ b/client/shared/src/components/Markdown.scss
@@ -52,7 +52,7 @@
 
     code,
     pre {
-        background: $code-bg;
+        background: var(--code-bg);
     }
 
     pre {

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -107,7 +107,6 @@ body,
 @import './repo/settings/RepoSettingsArea';
 @import './repo/actions//InstallBrowserExtensionPopover.scss';
 @import './repo/actions/InstallBrowserExtensionAlert.scss';
-@import '../../branded/src/components/CodeSnippet';
 @import './components/PageHeader';
 @import './components/completion/CompletionWidgetDropdown';
 @import './components/CopyableText';

--- a/client/web/src/enterprise/campaigns/detail/__snapshots__/CampaignSpecTab.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/detail/__snapshots__/CampaignSpecTab.test.tsx.snap
@@ -69,11 +69,10 @@ exports[`CampaignSpecTab input spec is JSON 1`] = `
 }"
     language="json"
   >
-    <div
-      className="code-snippet__container rounded p-3 mb-3"
+    <pre
+      className="bg-code rounded p-3 mb-3"
     >
-      <pre
-        className="m-0"
+      <code
         dangerouslySetInnerHTML={
           Object {
             "__html": "{
@@ -82,7 +81,7 @@ exports[`CampaignSpecTab input spec is JSON 1`] = `
           }
         }
       />
-    </div>
+    </pre>
   </CodeSnippet>
 </CampaignSpecTab>
 `;
@@ -154,18 +153,17 @@ exports[`CampaignSpecTab last apply was an update (after creation) 1`] = `
     code="x"
     language="yaml"
   >
-    <div
-      className="code-snippet__container rounded p-3 mb-3"
+    <pre
+      className="bg-code rounded p-3 mb-3"
     >
-      <pre
-        className="m-0"
+      <code
         dangerouslySetInnerHTML={
           Object {
             "__html": "<span class=\\"hljs-string\\">x</span>",
           }
         }
       />
-    </div>
+    </pre>
   </CodeSnippet>
 </CampaignSpecTab>
 `;
@@ -237,18 +235,17 @@ exports[`CampaignSpecTab last apply was the (initial) creation 1`] = `
     code="x"
     language="yaml"
   >
-    <div
-      className="code-snippet__container rounded p-3 mb-3"
+    <pre
+      className="bg-code rounded p-3 mb-3"
     >
-      <pre
-        className="m-0"
+      <code
         dangerouslySetInnerHTML={
           Object {
             "__html": "<span class=\\"hljs-string\\">x</span>",
           }
         }
       />
-    </div>
+    </pre>
   </CodeSnippet>
 </CampaignSpecTab>
 `;


### PR DESCRIPTION
Add a CSS var `--code-bg` that is used in CodeSnippet and Markdown code blocks. (Because it's used in 2 places, a CSS var is used instead of just `--color-bg-2`.)

Also fix a bug where the CodeExcerpt style was not actually applied in the storybook because only the global stylesheet was being loaded.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->