### PR TITLE
Clean up CSS border color styles

### DIFF
--- a/client/branded/src/components/Tabs.scss
+++ b/client/branded/src/components/Tabs.scss
@@ -27,7 +27,7 @@
     }
     &:not(&--empty) &__spacer,
     &:not(&--empty) &__end-fragment-other-element {
-        border-bottom-color: $color-border;
+        border-bottom-color: var(--border-color);
     }
 
     &__spacer,
@@ -41,18 +41,19 @@
             flex: 1;
         }
 
-        border-bottom-color: $color-bg-3;
-
+        &--inactive {
+            border-bottom-color: var(--border-color);
+        }
         &,
         &:hover {
             text-decoration: none !important; // override .btn-link:focus
         }
         &:hover {
             opacity: 1;
-            border-bottom-color: $color-border-hover;
+            border-bottom-color: var(--link-color);
         }
         &--active {
-            border-bottom-color: $color-border-active !important; // override .btn-link:focus
+            border-bottom-color: var(--primary) !important; // override .btn-link:focus
         }
 
         &--h5like {
@@ -71,22 +72,9 @@
 
 .theme-light {
     .tab-bar {
-        &__tab,
-        &:not(.tab-bar--empty) .tab-bar__spacer,
-        &:not(.tab-bar--empty) .tab-bar__end-fragment-other-element {
-            border-bottom-color: $color-light-border;
-        }
         &__tab {
-            &--active {
-                border-bottom-color: $primary;
-            }
             &--h5like {
                 color: $color-light-text-1 !important;
-            }
-        }
-        &__close-button {
-            &:hover {
-                color: $color-light-text-5;
             }
         }
     }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -10,7 +10,7 @@
     flex-direction: column;
 
     background-color: $color-bg-4;
-    border-top: 1px solid $color-border;
+    border-top: 1px solid var(--border-color);
     width: 100%;
 
     &--resizable {
@@ -54,6 +54,5 @@
 .theme-light {
     .panel {
         background-color: $color-light-bg-2;
-        border-top-color: $color-light-border;
     }
 }

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
@@ -8,7 +8,7 @@
 
     &__list {
         flex: 1;
-        border-right: 1px solid $color-border;
+        border-right: 1px solid var(--border-color);
         width: 100%; // necessary to prevent border-right from shrinking as width narrows
         overflow-y: auto;
     }
@@ -45,13 +45,5 @@
     &__content {
         flex: 1;
         width: 100%;
-    }
-}
-
-.theme-light {
-    .hierarchical-locations-view {
-        &__list {
-            border-right: 1px solid $color-light-border;
-        }
     }
 }

--- a/client/branded/src/global-styles/card.scss
+++ b/client/branded/src/global-styles/card.scss
@@ -1,17 +1,15 @@
 $card-spacer-y: 0.5rem;
 $card-spacer-x: 0.5rem;
 $card-bg: var(--body-bg);
-$card-border-color: var(--card-border-color);
+$card-border-color: var(--border-color);
 $card-cap-bg: var(--card-cap-bg);
 
 @import 'bootstrap/scss/card';
 
 .theme-dark {
     --card-cap-bg: #{$color-bg-3};
-    --card-border-color: #{$color-border};
 }
 
 .theme-light {
     --card-cap-bg: #{rgba($color-light-bg-2, 0.75)};
-    --card-border-color: #{$color-light-border};
 }

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -41,10 +41,6 @@ $color-text: #f2f4f8;
 $color-text-1: #a2b0cd;
 $color-text-2: #f2f4f8;
 $color-text-3: #ffffff;
-$color-border: #2b3750;
-$color-border-hover: #566e9f;
-
-$color-border-active: #329af0;
 
 // TODO add Basics color standards to Dark Theme
 
@@ -115,6 +111,8 @@ $body-bg-color-dark: #04070e;
     --warning: #{$warning};
     --danger: #{$danger};
     --merged: #{$merged};
+}
+.theme-light {
     --body-color: #{$body-color-light};
     --body-bg: #{$body-bg-color-light};
     --color-bg-1: #{$color-light-bg-1};
@@ -125,14 +123,14 @@ $body-bg-color-dark: #04070e;
     --link-color: #{$gray-13};
     --link-active-color: #{$gray-18};
     --link-hover-color: #{$gray-21};
-    --color-border: #{$color-light-border};
-    --color-border-2: #{$color-light-border-2};
+    --border-color: #{$color-light-border};
+    --border-color-2: #{$color-light-border-2};
     --sourcegraph-logo-text-color: #242427;
 }
 .theme-dark {
     --secondary: #{$secondary};
-    --color-border: #{$color-border};
-    --color-border-2: #{$color-border};
+    --border-color: #{$color-bg-3};
+    --border-color-2: #{$color-bg-3};
     --body-color: #{$body-color-dark};
     --body-bg: #{$body-bg-color-dark};
     --color-bg-1: #{$color-bg-1};

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -6,7 +6,7 @@
 
 .theme-dark {
     --dropdown-bg: #0e121b;
-    --dropdown-border-color: #{$color-border};
+    --dropdown-border-color: var(--border-color);
     --dropdown-link-hover-bg: #{$color-bg-2};
     --dropdown-header-color: #{$color-text-1};
     .dropdown-menu {
@@ -17,7 +17,7 @@
 
 .theme-light {
     --dropdown-bg: #ffffff;
-    --dropdown-border-color: #{$color-light-border};
+    --dropdown-border-color: var(--border-color);
     --dropdown-link-hover-bg: #{$color-light-bg-2};
     --dropdown-header-color: #{$color-light-text-2};
     .dropdown-menu {

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -5,7 +5,7 @@
 .theme-dark {
     --input-bg: #0e121b;
     --input-disabled-bg: #2b3750;
-    --input-border-color: #2b3750;
+    --input-border-color: var(--border-color);
     --input-color: #f2f4f8;
     --input-placeholder-color: #{rgba($color-text, 0.5)};
     --input-group-addon-color: #{$color-text-1};
@@ -16,7 +16,7 @@
 .theme-light {
     --input-bg: #ffffff;
     --input-disabled-bg: #e4e9f1;
-    --input-border-color: #e4e9f1;
+    --input-border-color: var(--border-color);
     --input-color: #2b3750;
     --input-placeholder-color: #{rgba($color-light-text-1, 0.7)};
     --input-group-addon-color: #{$color-light-text-1};

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -27,14 +27,7 @@ $body-bg: var(--body-bg);
 
 $text-muted: var(--text-muted);
 
-// Borders
 $border-color: var(--border-color);
-.theme-dark {
-    --border-color: #{$color-border};
-}
-.theme-light {
-    --border-color: #{$color-light-border};
-}
 
 // Links
 
@@ -107,10 +100,9 @@ $dropdown-padding-y: $dropdown-item-padding-y;
 
 $table-cell-padding: 0.625rem;
 $table-hover-bg: #0e121b;
-$table-border-color: #2b3750;
+$table-border-color: var(--border-color);
 
 $table-hover-bg-light: #f2f4f8;
-$table-border-color-light: #e4e9f1;
 
 // Progress
 $progress-height: auto;

--- a/client/branded/src/global-styles/list-group.scss
+++ b/client/branded/src/global-styles/list-group.scss
@@ -1,5 +1,5 @@
 $list-group-bg: transparent;
-$list-group-border-color: $color-border;
+$list-group-border-color: var(--border-color);
 $list-group-item-padding-y: 0.25rem;
 $list-group-item-padding-x: 0.5rem;
 $list-group-action-color: $color-text-1;
@@ -11,9 +11,6 @@ $list-group-action-active-bg: $color-bg-5;
 @import 'bootstrap/scss/list-group';
 
 .theme-light {
-    .list-group-item {
-        border-color: $color-light-border;
-    }
     .list-group-item-action {
         color: $color-light-text-1;
         &:hover,

--- a/client/branded/src/global-styles/tables.scss
+++ b/client/branded/src/global-styles/tables.scss
@@ -1,21 +1,6 @@
 @import 'bootstrap/scss/tables';
 
 .theme-light {
-    .table {
-        th,
-        td {
-            border-top: $table-border-width solid $table-border-color-light;
-        }
-
-        thead th {
-            border-bottom: (2 * $table-border-width) solid $table-border-color-light;
-        }
-
-        tbody + tbody {
-            border-top: (2 * $table-border-width) solid $table-border-color-light;
-        }
-    }
-
     .table-hover {
         tbody tr {
             @include hover {

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.scss
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.scss
@@ -7,7 +7,7 @@
 
     &__section {
         padding: 1rem;
-        border-bottom: 1px solid var(--color-border-2);
+        border-bottom: 1px solid var(--border-color-2);
 
         &:last-of-type {
             border-bottom: none;
@@ -17,7 +17,7 @@
     &__split-section-part {
         padding: 0.75rem 1rem;
         flex: 50%;
-        border-left: 1px solid var(--color-border-2);
+        border-left: 1px solid var(--border-color-2);
         text-align: center;
         &:first-child {
             border-left: none;

--- a/client/browser/src/shared.scss
+++ b/client/browser/src/shared.scss
@@ -23,7 +23,7 @@ $body-color-dark: #f2f4f8;
     --link-color: #566e9f;
     --link-hover-color: #1d2535;
     --dropdown-bg: #{$color-light-bg-1};
-    --dropdown-border-color: #{$color-light-border};
+    --dropdown-border-color: var(--border-color);
 }
 
 .command-palette-button {

--- a/client/web/src/api/graphiql-theme.scss
+++ b/client/web/src/api/graphiql-theme.scss
@@ -24,7 +24,7 @@
     .topBar {
         background: var(--body-bg);
         height: 3rem;
-        border-color: $color-border;
+        border-color: var(--border-color);
         .title {
             white-space: nowrap;
         }
@@ -39,7 +39,7 @@
     .history-contents p,
     .doc-explorer-contents,
     .doc-category-title {
-        border-color: $color-border;
+        border-color: var(--border-color);
     }
     .variable-editor-title,
     .result-window .CodeMirror-gutters,
@@ -90,7 +90,7 @@
         .field-short-description {
             font-family: var(--sans-serif);
             color: $color-text-1;
-            border-left: 3px solid $color-border;
+            border-left: 3px solid var(--border-color);
             padding-left: 0.5rem;
             margin-top: 0.5rem;
             > p {
@@ -102,12 +102,12 @@
             font-family: var(--sans-serif);
             background: rgba(42, 58, 81, 0.7);
             box-shadow: none;
-            border: 1px solid $color-border;
+            border: 1px solid var(--border-color);
             color: inherit;
         }
         .doc-category-item {
             color: inherit;
-            border-bottom: 1px solid $color-border;
+            border-bottom: 1px solid var(--border-color);
             padding-bottom: 1rem;
             .field-name:first-of-type {
                 font-weight: bold;
@@ -209,18 +209,6 @@
 .theme-light {
     .graphiql-container {
         color: $color-light-text-1;
-        .topBar,
-        .variable-editor-title,
-        .resultWrap,
-        .history-contents,
-        .history-contents p,
-        .doc-explorer-contents,
-        .doc-category-title,
-        .doc-explorer-contents .doc-deprecation,
-        .doc-explorer-contents .doc-category-item,
-        .doc-explorer-contents .field-short-description {
-            border-color: $color-light-border;
-        }
         .variable-editor-title,
         .result-window .CodeMirror-gutters,
         .historyPaneWrap,
@@ -266,10 +254,10 @@ body > .CodeMirror-hints {
         color: $color-text;
     }
     .CodeMirror-hint {
-        border-color: $color-border;
+        border-color: var(--border-color);
         color: $color-text;
         &-information {
-            border-color: $color-border;
+            border-color: var(--border-color);
             > .content {
                 color: $color-text;
                 p:nth-child(odd) {
@@ -292,10 +280,8 @@ body.theme-light > .CodeMirror-hints {
         color: $color-light-text-1;
     }
     .CodeMirror-hint {
-        border-color: $color-light-border;
         color: $color-light-text-1;
         &-information {
-            border-color: $color-light-border;
             > .content {
                 color: $color-light-text-1;
             }

--- a/client/web/src/auth/OrDivider.scss
+++ b/client/web/src/auth/OrDivider.scss
@@ -3,6 +3,6 @@
     font-size: 0.75rem; /* stylelint-disable-line declaration-property-unit-whitelist */
 
     &__border {
-        border-bottom: 1px solid var(--color-border-2);
+        border-bottom: 1px solid var(--border-color-2);
     }
 }

--- a/client/web/src/auth/SignInSignUpPageCommon.scss
+++ b/client/web/src/auth/SignInSignUpPageCommon.scss
@@ -11,7 +11,7 @@
 .signin-signup-form {
     max-width: calc(100vw - 2rem);
     background-color: var(--color-bg-1);
-    border: 1px solid var(--color-border-2);
+    border: 1px solid var(--border-color-2);
 
     &__input-container {
         position: relative;

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -22,7 +22,7 @@ $popover-item-padding-v: 0.325rem;
     }
 
     &__node {
-        border-bottom: solid 1px $color-border;
+        border-bottom: solid 1px var(--border-color);
         &:last-child {
             border-bottom: none;
         }
@@ -47,19 +47,5 @@ $popover-item-padding-v: 0.325rem;
         text-align: left;
         font-size: 12px;
         padding: $popover-item-padding-v $popover-item-padding-h;
-    }
-}
-
-.theme-light {
-    .connection-popover {
-        &__node {
-            border-color: $color-light-border;
-        }
-
-        .filtered-connection {
-            &__summary {
-                border-top-color: $color-light-border;
-            }
-        }
     }
 }

--- a/client/web/src/components/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection.scss
@@ -40,7 +40,7 @@
         flex: 0 0;
         padding: $popover-item-padding-v $popover-item-padding-h;
         opacity: 0.7;
-        border-top: solid 1px $color-border;
+        border-top: solid 1px var(--border-color);
     }
 
     &--noncompact {
@@ -62,13 +62,5 @@
 
     &__show-more {
         flex: 0 0 auto;
-    }
-}
-
-.theme-light {
-    .filtered-connection {
-        &--compact .filtered-connection__summary {
-            border-color: $color-light-border;
-        }
     }
 }

--- a/client/web/src/components/SearchResultMatch.scss
+++ b/client/web/src/components/SearchResultMatch.scss
@@ -109,9 +109,10 @@
         left: 50%;
     }
 
+    border-top: 1px solid var(--border-color);
+
     .theme-light & {
         background-color: $color-light-bg-1;
-        border-top: 1px solid $color-light-border;
 
         &:hover {
             background-color: $color-light-bg-4;

--- a/client/web/src/components/d3/BarChart.scss
+++ b/client/web/src/components/d3/BarChart.scss
@@ -11,15 +11,6 @@
 
     .axis path,
     .axis .tick line {
-        stroke: $color-border;
-    }
-}
-
-.theme-light {
-    .d3-bar-chart {
-        .axis path,
-        .axis .tick line {
-            stroke: $color-light-border;
-        }
+        stroke: var(--border-color);
     }
 }

--- a/client/web/src/enterprise/campaigns/apply/ChangesetSpecNode.scss
+++ b/client/web/src/enterprise/campaigns/apply/ChangesetSpecNode.scss
@@ -2,18 +2,10 @@
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;
-        border-top: 1px solid $color-light-bg-2;
+        border-top: 1px solid var(--border-color-2);
         @include media-breakpoint-down(xs) {
             margin-top: 1rem;
             padding-bottom: 1rem;
-        }
-    }
-}
-
-.theme-dark {
-    .changeset-spec-node {
-        &__separator {
-            border-color: $color-light-bg-5;
         }
     }
 }

--- a/client/web/src/enterprise/campaigns/close/ChangesetCloseNode.scss
+++ b/client/web/src/enterprise/campaigns/close/ChangesetCloseNode.scss
@@ -2,18 +2,10 @@
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;
-        border-top: 1px solid $color-light-bg-2;
+        border-top: 1px solid var(--border-color-2);
         @include media-breakpoint-down(xs) {
             margin-top: 1rem;
             padding-bottom: 1rem;
-        }
-    }
-}
-
-.theme-dark {
-    .changeset-close-node {
-        &__separator {
-            border-color: $color-light-bg-5;
         }
     }
 }

--- a/client/web/src/enterprise/campaigns/detail/BurndownChart.tsx
+++ b/client/web/src/enterprise/campaigns/detail/BurndownChart.tsx
@@ -144,7 +144,7 @@ export const CampaignBurndownChart: React.FunctionComponent<Props> = ({
                 <Tooltip
                     labelFormatter={tooltipLabelFormatter as LabelFormatter}
                     isAnimationActive={false}
-                    wrapperStyle={{ border: '1px solid var(--color-border)' }}
+                    wrapperStyle={{ border: '1px solid var(--border-color)' }}
                     contentStyle={tooltipStyle}
                     labelStyle={{ fontWeight: 'bold' }}
                     itemStyle={tooltipStyle}

--- a/client/web/src/enterprise/campaigns/detail/__snapshots__/BurndownChart.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/detail/__snapshots__/BurndownChart.test.tsx.snap
@@ -3679,7 +3679,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
             }
             wrapperStyle={
               Object {
-                "border": "1px solid var(--color-border)",
+                "border": "1px solid var(--border-color)",
               }
             }
           >
@@ -3690,7 +3690,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
                   "MozTransform": "translate(undefinedpx, undefinedpx)",
                   "OTransform": "translate(undefinedpx, undefinedpx)",
                   "WebkitTransform": "translate(undefinedpx, undefinedpx)",
-                  "border": "1px solid var(--color-border)",
+                  "border": "1px solid var(--border-color)",
                   "msTransform": "translate(undefinedpx, undefinedpx)",
                   "pointerEvents": "none",
                   "position": "absolute",
@@ -3760,7 +3760,7 @@ exports[`CampaignBurndownChart renders the chart 1`] = `
                 }
                 wrapperStyle={
                   Object {
-                    "border": "1px solid var(--color-border)",
+                    "border": "1px solid var(--border-color)",
                   }
                 }
               >

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetNode.scss
@@ -2,18 +2,10 @@
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;
-        border-top: 1px solid $color-light-bg-2;
+        border-top: 1px solid var(--border-color-2);
         @include media-breakpoint-down(xs) {
             margin-top: 1rem;
             padding-bottom: 1rem;
-        }
-    }
-}
-
-.theme-dark {
-    .changeset-node {
-        &__separator {
-            border-color: $color-light-bg-5;
         }
     }
 }

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.scss
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.scss
@@ -26,18 +26,10 @@
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;
-        border-top: 1px solid $color-light-bg-2;
+        border-top: 1px solid var(--border-color-2);
         @include media-breakpoint-down(xs) {
             margin-top: 1rem;
             padding-bottom: 1rem;
-        }
-    }
-}
-
-.theme-dark {
-    .campaign-node {
-        &__separator {
-            border-color: $color-light-bg-5;
         }
     }
 }

--- a/client/web/src/marketing/Toast.scss
+++ b/client/web/src/marketing/Toast.scss
@@ -9,7 +9,7 @@
     border-radius: 0.25rem;
     background-color: $color-bg-2;
     color: $color-text-2;
-    border: 1px solid $color-border;
+    border: 1px solid var(--border-color);
 
     &__logo {
         flex: 0 0 auto;
@@ -65,7 +65,6 @@
 
 .theme-light {
     .toast {
-        border: 1px solid $color-light-border;
         background-color: $color-light-bg-2;
         color: $color-light-text-1;
 

--- a/client/web/src/repo/GitReference.scss
+++ b/client/web/src/repo/GitReference.scss
@@ -9,11 +9,8 @@
     border-left: none;
     border-right: none;
     border-top: none;
-    border-bottom: 1px solid #2b3750;
+    border-bottom: 1px solid var(--border-color);
     &:first-of-type {
-        border-top: 1px solid #2b3750;
+        border-top: 1px solid var(--border-color);
     }
-}
-.theme-light .git-ref-node {
-    border-color: #cad2e2;
 }

--- a/client/web/src/repo/GitReferenceTag.scss
+++ b/client/web/src/repo/GitReferenceTag.scss
@@ -6,7 +6,7 @@
     padding: 0 0.175rem;
     margin: 0 0.175rem;
 
-    border: solid 1px rgba(255, 255, 255, 0.3);
+    border: solid 1px var(--border-color);
     border-radius: 0.125rem;
 
     .icon-git-hub {
@@ -27,10 +27,6 @@
 }
 
 .theme-light {
-    .git-ref-tag {
-        border-color: $color-light-border;
-    }
-
     .git-ref-tag-2 {
         background-color: saturate(lighten($color-light-bg-5, 48.5%), 50%);
     }

--- a/client/web/src/repo/RepoHeader.scss
+++ b/client/web/src/repo/RepoHeader.scss
@@ -5,6 +5,7 @@
     flex: none;
     padding: 0;
     align-items: stretch;
+    border-color: var(--border-color);
     border-style: solid;
     border-width: 0 0 1px;
 
@@ -75,13 +76,5 @@
 
     &__spacer {
         flex: 1 1 0;
-    }
-
-    .theme-dark & {
-        border-color: #233043;
-    }
-
-    .theme-light & {
-        border-color: $color-light-border;
     }
 }

--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -10,7 +10,7 @@
     flex-direction: column;
     position: relative;
 
-    border-right: 1px solid #2b3750;
+    border-right: 1px solid var(--border-color);
     width: 100%; // necessary to prevent border-right from shrinking as width narrows
 
     &:not(&--open) {
@@ -32,11 +32,5 @@
         justify-content: center;
 
         border-radius: 0 0 0.25rem;
-    }
-}
-
-.theme-light {
-    .repo-revision-sidebar {
-        border-right-color: $color-light-border;
     }
 }

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.scss
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.scss
@@ -8,7 +8,7 @@
         display: flex;
         align-items: center;
 
-        border: 1px solid #2b3750;
+        border: 1px solid var(--border-color);
         border-radius: 0.125rem;
         margin: 0.5rem 0;
         padding: 0.5rem 0.75rem;
@@ -22,13 +22,5 @@
 
     &__stats {
         width: auto;
-    }
-}
-
-.theme-light {
-    .repo-settings-index-page {
-        &__ref {
-            border-color: $color-light-border;
-        }
     }
 }

--- a/client/web/src/repo/settings/components/ActionContainer.scss
+++ b/client/web/src/repo/settings/components/ActionContainer.scss
@@ -2,7 +2,7 @@
     margin: 1.5rem 0;
     padding: 1rem;
 
-    border: 1px solid #2b3750;
+    border: 1px solid var(--border-color);
     border-radius: 0.125rem;
 
     &__row {
@@ -48,11 +48,5 @@
         width: 100%;
         flex: 1;
         margin-top: 1rem;
-    }
-}
-
-.theme-light {
-    .action-container {
-        border-color: $color-light-border;
     }
 }

--- a/client/web/src/repogroups/RepogroupPage.scss
+++ b/client/web/src/repogroups/RepogroupPage.scss
@@ -80,7 +80,6 @@
     .repogroup-page {
         &__repo-card {
             background: #f7fafd;
-            border-color: $color-light-border-2;
         }
         &__repo-list-icon {
             color: $gray-11;

--- a/client/web/src/savedSearches/SavedSearchModal.scss
+++ b/client/web/src/savedSearches/SavedSearchModal.scss
@@ -1,7 +1,7 @@
 .saved-search-modal-form {
     padding: 1rem;
     background: $white;
-    border: 1px solid #cad3e2;
+    border: 1px solid var(--border-color);
     border-radius: 0.25rem;
     width: 20rem;
     max-width: 100vw;
@@ -12,12 +12,5 @@
 
     &__select {
         margin-bottom: 0.5rem;
-    }
-}
-
-.theme-dark {
-    .saved-search-modal-form {
-        background: $color-bg-1;
-        border: 1px solid #2b3750;
     }
 }

--- a/client/web/src/search/FilterChip.scss
+++ b/client/web/src/search/FilterChip.scss
@@ -3,26 +3,25 @@
     border-radius: 2px;
     margin: 0.25rem 0.5rem 0.25rem 0;
 
+    border-color: var(--border-color-2);
+
     .theme-dark & {
         background: $color-bg-2;
-        border-color: $color-border;
         color: $color-text-1;
     }
     .theme-light & {
         color: $color-light-text-1;
         background: transparent;
-        border-color: $color-light-border-2;
     }
 
     &:hover:not(&--selected) {
+        border-color: var(--border-color);
         .theme-dark & {
             background: $color-bg-3;
-            border-color: $color-bg-3;
             color: #ffffff;
         }
         .theme-light & {
             background: $color-light-bg-4;
-            border-color: $color-light-bg-4;
             color: $color-light-text-6;
         }
     }
@@ -56,14 +55,13 @@
     }
 
     &--selected {
+        border-color: var(--border-color);
         .theme-dark & {
             color: $color-text;
             background: $color-bg-5;
-            border-color: $color-bg-5;
         }
         .theme-light & {
             background: $color-light-bg-3;
-            border-color: $color-light-border;
         }
     }
 }

--- a/client/web/src/search/input/MonacoQueryInput.scss
+++ b/client/web/src/search/input/MonacoQueryInput.scss
@@ -55,11 +55,10 @@
             font-size: 0.65rem;
             line-height: 1;
             padding: 0.25rem 0.375rem;
-            border-color: $gray-13;
+            border-color: var(--border-color);
             color: $color-text-1;
 
             .theme-light & {
-                border-color: $color-light-border;
                 color: $color-light-text-3;
             }
         }

--- a/client/web/src/search/input/interactive/FilterInput.scss
+++ b/client/web/src/search/input/interactive/FilterInput.scss
@@ -3,7 +3,7 @@ $filter-input-padding: 0.25rem;
 
 .filter-input {
     margin: $filter-input-margin-y 0.25rem $filter-input-margin-y 0;
-    border: 1px solid $color-border;
+    border: 1px solid var(--border-color);
     padding: $filter-input-padding;
     border-radius: 2px;
     background-color: $color-bg-2;
@@ -82,7 +82,7 @@ $filter-input-padding: 0.25rem;
         margin-right: 0.25rem;
 
         &--active {
-            border: 1px solid $color-border-active;
+            border: 1px solid var(--primary);
             border-radius: 2px;
             .theme-dark & {
                 background: $color-bg-5;
@@ -97,6 +97,5 @@ $filter-input-padding: 0.25rem;
 .theme-light {
     .filter-input {
         background-color: $color-light-bg-2;
-        border: 1px solid $color-light-border;
     }
 }

--- a/client/web/src/search/input/toggles/Toggles.scss
+++ b/client/web/src/search/input/toggles/Toggles.scss
@@ -9,7 +9,7 @@
         }
         border: 1px solid transparent;
         &--active {
-            border: 1px solid $color-border-active;
+            border: 1px solid var(--primary);
             border-radius: 2px;
             .theme-dark & {
                 background: $color-bg-5;

--- a/client/web/src/search/results/SearchResultsFilterBars.scss
+++ b/client/web/src/search/results/SearchResultsFilterBars.scss
@@ -9,11 +9,10 @@
 
         color: #93a9c8;
         background: $color-bg-1;
-        border-bottom: 1px solid $color-border;
+        border-bottom: 1px solid var(--border-color);
         .theme-light & {
             color: $color-light-text-2;
             background: $color-light-bg-1;
-            border-bottom: 1px solid $color-light-border;
         }
     }
 

--- a/client/web/src/search/results/SearchResultsList.scss
+++ b/client/web/src/search/results/SearchResultsList.scss
@@ -14,7 +14,7 @@
         background-color: $color-light-bg-2;
         padding: 0.25rem 0.5rem;
         text-align: center;
-        border-bottom: 1px solid $color-light-border;
+        border-bottom: 1px solid var(--border-color);
     }
 
     // In narrow windows, make the results flush with the left/right sides,
@@ -41,7 +41,6 @@
         &__jump-to-top {
             color: $color-text-2;
             background-color: $color-bg-2;
-            border-bottom-color: $color-border;
         }
     }
 }

--- a/client/web/src/views/ChartViewContent.scss
+++ b/client/web/src/views/ChartViewContent.scss
@@ -13,7 +13,7 @@
     }
 
     .recharts-tooltip-wrapper {
-        border: 1px solid var(--color-border);
+        border: 1px solid var(--border-color);
         color: var(--body-color) !important;
         background: var(--body-bg) !important;
     }


### PR DESCRIPTION
Previously, we had many ways of setting border colors:

- Sometimes the hex color values would be used directly, and a component would define its own light and dark theme variants. This leads to inconsistent color usage, adds code complexity, and is mistake-prone.
- We had `$color-border`, `$color-border-2`, `$border-color`, `--border-color`, etc.

Now we just have `--border-color` and `--border-color-2` (dimmer, rarely used). Some components' borders will have slightly different colors after this change if they previously used a non-standard border color.




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->