### PR TITLE
docker-images: Install src-cli in ignite-ubuntu base image

### DIFF
--- a/docker-images/ignite-ubuntu/CODENOTIFY
+++ b/docker-images/ignite-ubuntu/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/docker-images/ignite-ubuntu/Dockerfile
+++ b/docker-images/ignite-ubuntu/Dockerfile
@@ -8,3 +8,12 @@ RUN set -ex && \
     docker.io
 
 RUN mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["http://localhost:5000"] }' >/etc/docker/daemon.json
+
+ENV SRC_CLI_VERSION=3.21.2
+
+RUN set -ex && \
+    curl -L -o src-cli.tar.gz "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64.tar.gz" && \
+    tar -xvzf src-cli.tar.gz src && \
+    mv src /usr/local/bin/src && \
+    chmod +x /usr/local/bin/src && \
+    rm -rf src-cli.tar.gz

--- a/docker-images/ignite-ubuntu/Dockerfile
+++ b/docker-images/ignite-ubuntu/Dockerfile
@@ -1,19 +1,19 @@
 FROM weaveworks/ignite-ubuntu:20.04-amd64@sha256:4f5f5ed56fae650ae122daa28a785192dda081be4f0b37dca2eb25ea57840500
 
 # hadolint ignore=DL3008,DL3009
-RUN set -ex &&
-    apt-get update &&
+RUN set -ex && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        docker.io
+    ca-certificates \
+    docker.io
 
 RUN mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["http://localhost:5000"] }' >/etc/docker/daemon.json
 
 ARG SRC_CLI_VERSION
 
-RUN set -ex &&
-    curl -L -o src-cli.tar.gz "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64.tar.gz" &&
-    tar -xvzf src-cli.tar.gz src &&
-    mv src /usr/local/bin/src &&
-    chmod +x /usr/local/bin/src &&
+RUN set -ex && \
+    curl -L -o src-cli.tar.gz "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64.tar.gz" && \
+    tar -xvzf src-cli.tar.gz src && \
+    mv src /usr/local/bin/src && \
+    chmod +x /usr/local/bin/src && \
     rm -rf src-cli.tar.gz

--- a/docker-images/ignite-ubuntu/Dockerfile
+++ b/docker-images/ignite-ubuntu/Dockerfile
@@ -12,8 +12,6 @@ RUN mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["http://localhost:5000"
 ENV SRC_CLI_VERSION=3.21.2
 
 RUN set -ex && \
-    curl -L -o src-cli.tar.gz "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64.tar.gz" && \
-    tar -xvzf src-cli.tar.gz src && \
+    curl -L -o src "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64" && \
     mv src /usr/local/bin/src && \
-    chmod +x /usr/local/bin/src && \
-    rm -rf src-cli.tar.gz
+    chmod +x /usr/local/bin/src

--- a/docker-images/ignite-ubuntu/Dockerfile
+++ b/docker-images/ignite-ubuntu/Dockerfile
@@ -1,17 +1,19 @@
 FROM weaveworks/ignite-ubuntu:20.04-amd64@sha256:4f5f5ed56fae650ae122daa28a785192dda081be4f0b37dca2eb25ea57840500
 
 # hadolint ignore=DL3008,DL3009
-RUN set -ex && \
-    apt-get update && \
+RUN set -ex &&
+    apt-get update &&
     apt-get install -y --no-install-recommends \
-    ca-certificates \
-    docker.io
+        ca-certificates \
+        docker.io
 
 RUN mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["http://localhost:5000"] }' >/etc/docker/daemon.json
 
-ENV SRC_CLI_VERSION=3.21.2
+ARG SRC_CLI_VERSION
 
-RUN set -ex && \
-    curl -L -o src "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64" && \
-    mv src /usr/local/bin/src && \
-    chmod +x /usr/local/bin/src
+RUN set -ex &&
+    curl -L -o src-cli.tar.gz "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64.tar.gz" &&
+    tar -xvzf src-cli.tar.gz src &&
+    mv src /usr/local/bin/src &&
+    chmod +x /usr/local/bin/src &&
+    rm -rf src-cli.tar.gz

--- a/docker-images/ignite-ubuntu/README.md
+++ b/docker-images/ignite-ubuntu/README.md
@@ -2,4 +2,4 @@
 
 We produce a version of Ubuntu 20.04 (Focal Fossa) based on [weaveworks/ignite-ubuntu:20.04-amd64](https://github.com/weaveworks/ignite/blob/46bdd5d48425c4245fbe895e7da3621f491c3660/images/ubuntu/Dockerfile) that also contains the Docker distribution.
 
-This image serves as the base image for precise-code-intel-indexer [Firecracker](https://github.com/firecracker-microvm/firecracker) virtual machines in which we run user configured containers and code.
+This image serves as the base image for [Firecracker](https://github.com/firecracker-microvm/firecracker) virtual machines in which we run user configured containers and code.

--- a/docker-images/ignite-ubuntu/build.sh
+++ b/docker-images/ignite-ubuntu/build.sh
@@ -3,4 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-sourcegraph/ignite-ubuntu}" .
+docker build -t "${IMAGE:-sourcegraph/ignite-ubuntu}" --build-arg SRC_CLI_VERSION="$(go run ../../internal/cmd/src-cli-version/main.go)" .

--- a/internal/cmd/src-cli-version/main.go
+++ b/internal/cmd/src-cli-version/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
+)
+
+func main() {
+	fmt.Printf(srccli.MinimumVersion)
+}


### PR DESCRIPTION
The effort tracked in https://github.com/sourcegraph/sourcegraph/issues/14822 will require that src-cli be available in the virtual machine created in the executor (and is difficult to use a docker image here without DIND because of the way `campagins apply` currently works).