### PR TITLE
Clean up CSS text color styles

### DIFF
--- a/client/branded/src/components/Tabs.scss
+++ b/client/branded/src/components/Tabs.scss
@@ -61,21 +61,11 @@
             font-size: 12px;
             letter-spacing: 1px;
             text-transform: uppercase;
-            color: $color-text !important;
+            color: var(--body-color);
         }
     }
 
     &__spacer {
         flex: 1;
-    }
-}
-
-.theme-light {
-    .tab-bar {
-        &__tab {
-            &--h5like {
-                color: $color-light-text-1 !important;
-            }
-        }
     }
 }

--- a/client/branded/src/global-styles/buttons.scss
+++ b/client/branded/src/global-styles/buttons.scss
@@ -50,11 +50,7 @@
     }
 
     &:hover:not(:disabled):not(.disabled) {
-        color: #ffffff;
-
-        .theme-light & {
-            color: $color-light-text-2;
-        }
+        color: var(--body-color);
     }
 }
 

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -19,13 +19,7 @@ kbd {
     margin: 0 0.125rem;
     vertical-align: middle;
     border-radius: 3px;
-    color: #2a3a51;
-    background-color: #93a9c8;
-    box-shadow: inset 0 -2px 0 #5d7eac;
-
-    .theme-light & {
-        color: $color-light-text-2;
-        background-color: $color-light-bg-2;
-        box-shadow: inset 0 -2px 0 #cad2e2;
-    }
+    color: var(--body-color);
+    background-color: var(--color-bg-2);
+    box-shadow: inset 0 -2px 0 var(--color-bg-3);
 }

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -37,10 +37,6 @@ $color-bg-2: #1d2535;
 $color-bg-3: #2b3750;
 $color-bg-4: $gray-23;
 $color-bg-5: #39496a;
-$color-text: #f2f4f8;
-$color-text-1: #a2b0cd;
-$color-text-2: #f2f4f8;
-$color-text-3: #ffffff;
 
 // TODO add Basics color standards to Dark Theme
 
@@ -52,12 +48,6 @@ $color-light-bg-3: #cad2e2;
 $color-light-bg-4: $gray-02;
 $color-light-bg-5: #566e9f;
 $color-light-bg-6: #070a0d;
-$color-light-text-1: #2b3750;
-$color-light-text-2: #6d727c;
-$color-light-text-3: rgba(57, 73, 106, 0.5);
-$color-light-text-4: #ffffff;
-$color-light-text-5: #07090d;
-$color-light-text-6: #1d2535;
 
 $color-light-border: #cad2e2;
 $color-light-border-2: #e4e9f1;
@@ -97,9 +87,6 @@ $body-bg: var(--body-bg);
 
 $text-muted: var(--text-muted);
 
-$body-color-light: $gray-19;
-$body-color-dark: $white;
-
 $body-bg-color-light: #fbfdff;
 $body-bg-color-dark: #04070e;
 
@@ -113,13 +100,13 @@ $body-bg-color-dark: #04070e;
     --merged: #{$merged};
 }
 .theme-light {
-    --body-color: #{$body-color-light};
+    --body-color: #{$gray-19};
     --body-bg: #{$body-bg-color-light};
     --color-bg-1: #{$color-light-bg-1};
     --color-bg-2: #{$color-light-bg-2};
     --color-bg-3: #{$color-light-bg-3};
     --color-bg-4: #{$color-light-bg-4};
-    --text-muted: #{$color-light-text-2};
+    --text-muted: #6d727c;
     --link-color: #{$gray-13};
     --link-active-color: #{$gray-18};
     --link-hover-color: #{$gray-21};
@@ -131,15 +118,15 @@ $body-bg-color-dark: #04070e;
     --secondary: #{$secondary};
     --border-color: #{$color-bg-3};
     --border-color-2: #{$color-bg-3};
-    --body-color: #{$body-color-dark};
+    --body-color: #ffffff;
     --body-bg: #{$body-bg-color-dark};
     --color-bg-1: #{$color-bg-1};
     --color-bg-2: #{$color-bg-2};
     --color-bg-3: #{$color-bg-3};
     --color-bg-4: #{$color-bg-4};
-    --text-muted: #{$color-text-1};
+    --text-muted: #a2b0cd;
     --link-color: #{$gray-07};
     --link-active-color: #{$gray-02};
-    --link-hover-color: #{$white};
-    --sourcegraph-logo-text-color: #{$white};
+    --link-hover-color: #ffffff;
+    --sourcegraph-logo-text-color: #ffffff;
 }

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -7,8 +7,8 @@
 .theme-dark {
     --dropdown-bg: #0e121b;
     --dropdown-border-color: var(--border-color);
-    --dropdown-link-hover-bg: #{$color-bg-2};
-    --dropdown-header-color: #{$color-text-1};
+    --dropdown-link-hover-bg: var(--color-bg-2);
+    --dropdown-header-color: var(--text-muted);
     .dropdown-menu {
         border-radius: 4px;
         box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
@@ -18,8 +18,8 @@
 .theme-light {
     --dropdown-bg: #ffffff;
     --dropdown-border-color: var(--border-color);
-    --dropdown-link-hover-bg: #{$color-light-bg-2};
-    --dropdown-header-color: #{$color-light-text-2};
+    --dropdown-link-hover-bg: var(--color-bg-2);
+    --dropdown-header-color: var(--text-muted);
     .dropdown-menu {
         border-radius: 4px;
         box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -3,25 +3,25 @@
 @import 'bootstrap/scss/input-group';
 
 .theme-dark {
-    --input-bg: #0e121b;
-    --input-disabled-bg: #2b3750;
+    --input-bg: #0e121b; // even darker than --color-bg-1
+    --input-disabled-bg: var(--color-bg-3);
     --input-border-color: var(--border-color);
-    --input-color: #f2f4f8;
-    --input-placeholder-color: #{rgba($color-text, 0.5)};
-    --input-group-addon-color: #{$color-text-1};
-    --input-group-addon-bg: #{$color-bg-5};
-    --input-group-addon-border-color: #{$color-bg-5};
+    --input-color: var(--body-color);
+    --input-placeholder-color: var(--text-muted);
+    --input-group-addon-color: var(--body-color);
+    --input-group-addon-bg: var(--color-bg-4);
+    --input-group-addon-border-color: var(--color-bg-4);
 }
 
 .theme-light {
-    --input-bg: #ffffff;
-    --input-disabled-bg: #e4e9f1;
+    --input-bg: var(--color-bg-1);
+    --input-disabled-bg: var(--color-bg-3);
     --input-border-color: var(--border-color);
-    --input-color: #2b3750;
-    --input-placeholder-color: #{rgba($color-light-text-1, 0.7)};
-    --input-group-addon-color: #{$color-light-text-1};
-    --input-group-addon-bg: #{$color-light-bg-4};
-    --input-group-addon-border-color: #{$color-light-bg-4};
+    --input-color: var(--body-color);
+    --input-placeholder-color: var(--text-muted);
+    --input-group-addon-color: var(--body-color);
+    --input-group-addon-bg: var(--color-bg-4);
+    --input-group-addon-border-color: var(--color-bg-4);
 }
 
 // Prevent Firefox's default red outline for inputs

--- a/client/branded/src/global-styles/list-group.scss
+++ b/client/branded/src/global-styles/list-group.scss
@@ -2,36 +2,10 @@ $list-group-bg: transparent;
 $list-group-border-color: var(--border-color);
 $list-group-item-padding-y: 0.25rem;
 $list-group-item-padding-x: 0.5rem;
-$list-group-action-color: $color-text-1;
-$list-group-action-hover-color: $color-text;
-$list-group-hover-bg: $color-bg-2;
-$list-group-action-active-color: $color-text-3;
-$list-group-action-active-bg: $color-bg-5;
+$list-group-action-color: var(--body-color);
+$list-group-action-hover-color: var(--body-color);
+$list-group-hover-bg: var(--color-bg-2);
+$list-group-action-active-color: var(--body-color);
+$list-group-action-active-bg: var(--color-bg-3);
 
 @import 'bootstrap/scss/list-group';
-
-.theme-light {
-    .list-group-item-action {
-        color: $color-light-text-1;
-        &:hover,
-        &:focus {
-            color: $color-light-text-6;
-            background-color: $color-light-bg-2;
-        }
-        &.active {
-            color: $color-light-text-4;
-            background-color: $primary;
-        }
-    }
-}
-
-// .list-group-item-$color is too light in the dark theme. Recreate these styles to have colors with less
-// brightness.
-.theme-dark {
-    @each $color, $value in $theme-colors {
-        @include list-group-item-variant($color, theme-color-level($color, 6), theme-color-level($color, -9));
-        a.list-group-item-#{$color}:hover {
-            color: var(--link-hover-color);
-        }
-    }
-}

--- a/client/branded/src/global-styles/web-content.scss
+++ b/client/branded/src/global-styles/web-content.scss
@@ -60,19 +60,11 @@
 
     // Search examples that link to the results page should use this class.
     .search-query-link {
-        color: $white;
-
-        .theme-light & {
-            color: $body-color-light;
-        }
+        color: var(--body-color);
     }
 
     .extension-area-link {
-        color: $gray-07;
-
-        .theme-light & {
-            color: $gray-13;
-        }
+        color: var(--link-color);
 
         &.active {
             color: var(--body-color);

--- a/client/browser/src/shared.scss
+++ b/client/browser/src/shared.scss
@@ -14,12 +14,9 @@ $body-bg-color-light: #ffffff;
 @import '../../shared/src/notifications/NotificationItem';
 @import '../../shared/src/notifications/Notifications';
 
-$body-color-light: #2b3750;
-$body-color-dark: #f2f4f8;
-
 :root {
     --body-bg: #ffffff;
-    --text-muted: #{$color-light-text-2};
+    --text-muted: #888888;
     --link-color: #566e9f;
     --link-hover-color: #1d2535;
     --dropdown-bg: #{$color-light-bg-1};

--- a/client/shared/src/components/CodeExcerpt.scss
+++ b/client/shared/src/components/CodeExcerpt.scss
@@ -13,7 +13,7 @@
         &::before {
             // draw line number with css so it cannot be copied to clipboard
             content: attr(data-line);
-            color: $color-text-1;
+            color: var(--text-muted);
         }
     }
 

--- a/client/shared/src/components/completion/CompletionWidget.story.tsx
+++ b/client/shared/src/components/completion/CompletionWidget.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { text } from '@storybook/addon-knobs'
+import { radios, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React, { useState } from 'react'
 import { CompletionList } from 'sourcegraph'
@@ -13,12 +13,18 @@ const onSelectItem = action('onSelectItem')
 // propagating them to the CompletionWidget element.
 const { add } = storiesOf('shared/CompletionWidget', module)
     .addParameters({ options: { enableShortcuts: false } })
-    .addDecorator(story => (
-        <>
-            <div>{story()}</div>
-            <style>{webStyles}</style>
-        </>
-    ))
+    .addDecorator(story => {
+        const theme = radios('Theme', { Light: 'light', Dark: 'dark' }, 'light')
+        document.body.classList.toggle('theme-light', theme === 'light')
+        document.body.classList.toggle('theme-dark', theme === 'dark')
+
+        return (
+            <>
+                <div>{story()}</div>
+                <style>{webStyles}</style>
+            </>
+        )
+    })
 
 const completionWidgetListItemClassName = 'completion-widget-dropdown__item d-flex align-items-center p-2'
 const StyledCompletionWidget: React.FunctionComponent<CompletionWidgetProps> = props => (
@@ -26,7 +32,7 @@ const StyledCompletionWidget: React.FunctionComponent<CompletionWidgetProps> = p
         {...props}
         listClassName="completion-widget-dropdown d-block list-unstyled rounded border p-0 m-0 mt-3"
         listItemClassName={completionWidgetListItemClassName}
-        selectedListItemClassName="completion-widget-dropdown__item--selected bg-primary"
+        selectedListItemClassName="completion-widget-dropdown__item--selected"
         loadingClassName={completionWidgetListItemClassName}
         noResultsClassName={completionWidgetListItemClassName}
     />

--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -57,10 +57,7 @@ export const RepoQuestionIcon: React.FunctionComponent<IconProps> = props => (
 
 export const FormatListBulletedIcon: React.FunctionComponent<IconProps> = props => (
     <svg {...props} {...sizeProps(props)} className={`mdi-icon${props.className ? ' ' + props.className : ''}`}>
-        <path
-            fill="#000000"
-            d="M7,5H21V7H7V5M7,13V11H21V13H7M4,4.5A1.5,1.5 0 0,1 5.5,6A1.5,1.5 0 0,1 4,7.5A1.5,1.5 0 0,1 2.5,6A1.5,1.5 0 0,1 4,4.5M4,10.5A1.5,1.5 0 0,1 5.5,12A1.5,1.5 0 0,1 4,13.5A1.5,1.5 0 0,1 2.5,12A1.5,1.5 0 0,1 4,10.5M7,19V17H21V19H7M4,16.5A1.5,1.5 0 0,1 5.5,18A1.5,1.5 0 0,1 4,19.5A1.5,1.5 0 0,1 2.5,18A1.5,1.5 0 0,1 4,16.5Z"
-        />
+        <path d="M7,5H21V7H7V5M7,13V11H21V13H7M4,4.5A1.5,1.5 0 0,1 5.5,6A1.5,1.5 0 0,1 4,7.5A1.5,1.5 0 0,1 2.5,6A1.5,1.5 0 0,1 4,4.5M4,10.5A1.5,1.5 0 0,1 5.5,12A1.5,1.5 0 0,1 4,13.5A1.5,1.5 0 0,1 2.5,12A1.5,1.5 0 0,1 4,10.5M7,19V17H21V19H7M4,16.5A1.5,1.5 0 0,1 5.5,18A1.5,1.5 0 0,1 4,19.5A1.5,1.5 0 0,1 2.5,18A1.5,1.5 0 0,1 4,16.5Z" />
     </svg>
 )
 

--- a/client/shared/src/global-styles/icons.scss
+++ b/client/shared/src/global-styles/icons.scss
@@ -35,10 +35,10 @@ img.icon-inline,
 
 // @sourcegraph/react-loading-spinner coloring
 .theme-light {
-    --loading-spinner-outer-color: #{rgba($body-color-light, 0.3)};
-    --loading-spinner-inner-color: #{rgba($body-color-light, 1)};
+    --loading-spinner-outer-color: #{rgba($gray-19, 0.3)};
+    --loading-spinner-inner-color: #{rgba($gray-19, 1)};
 }
 .theme-dark {
-    --loading-spinner-outer-color: #{rgba($body-color-dark, 0.3)};
-    --loading-spinner-inner-color: #{rgba($body-color-dark, 1)};
+    --loading-spinner-outer-color: #{rgba($white, 0.3)};
+    --loading-spinner-inner-color: #{rgba($white, 1)};
 }

--- a/client/web/src/api/graphiql-theme.scss
+++ b/client/web/src/api/graphiql-theme.scss
@@ -17,7 +17,7 @@
 /* stylelint-disable declaration-property-unit-whitelist */
 
 .graphiql-container {
-    color: $color-text;
+    color: var(--body-color);
     font-family: var(--sans-serif);
     margin-bottom: 1px;
 
@@ -48,14 +48,14 @@
     .doc-explorer,
     .doc-explorer-contents,
     .execute-options {
-        background: #1d2837;
+        background: var(--color-bg-2);
     }
     .variable-editor {
         height: auto;
         .variable-editor-title {
             border-bottom: none;
             font-weight: 400;
-            color: #777777;
+            color: var(--text-muted);
         }
     }
     .history-title-bar,
@@ -89,7 +89,7 @@
         }
         .field-short-description {
             font-family: var(--sans-serif);
-            color: $color-text-1;
+            color: var(--body-color);
             border-left: 3px solid var(--border-color);
             padding-left: 0.5rem;
             margin-top: 0.5rem;
@@ -133,7 +133,7 @@
             box-shadow: none;
         }
         &.error {
-            color: $red;
+            color: var(--danger);
         }
     }
     .execute-button {
@@ -142,22 +142,25 @@
     .execute-button,
     .doc-category .show-btn {
         @extend .btn-primary;
-        background: $blue;
-        border-color: $blue;
+        background: var(--primary);
+        border-color: var(--primary);
         fill: #ffffff;
         padding: 0;
         &.error {
-            background: $blue;
+            background: var(--primary);
         }
+    }
+    button {
+        background-image: none !important;
     }
     .toolbar-button,
     .docExplorerShow {
         @extend .btn-secondary;
-        background: $secondary;
-        border-color: $secondary;
+        background: var(--secondary);
+        border-color: var(--secondary);
     }
     .toolbar-button.error {
-        background: $secondary;
+        background: var(--secondary);
     }
     .doc-explorer-back {
         color: var(--link-color);
@@ -179,7 +182,7 @@
         margin: 0 3px 0;
         width: 10px;
         height: 10px;
-        border-color: #ffffff;
+        border-color: var(--body-color);
     }
     .doc-explorer {
         .search-box {
@@ -200,91 +203,41 @@
     }
     button,
     input {
-        color: $color-text;
+        color: var(--body-color);
         font-family: var(--sans-serif);
     }
-}
 
-/* Light theme overrides */
-.theme-light {
-    .graphiql-container {
-        color: $color-light-text-1;
-        .variable-editor-title,
-        .result-window .CodeMirror-gutters,
-        .historyPaneWrap,
-        .history-contents,
-        .doc-explorer,
-        .doc-explorer-contents,
-        .execute-options {
-            background: $color-light-bg-2;
-        }
-        .variable-editor-title,
-        button,
-        input {
-            color: $color-light-text-1;
-        }
-        li:active,
-        li:hover,
-        .history-contents p:active,
-        .history-contents p:hover,
-        .doc-explorer-contents .doc-deprecation,
-        .execute-options > li.selected {
-            background: $color-light-bg-3;
-        }
-        .toolbar-button.error {
-            background: $secondary-light;
-        }
-        .docExplorerShow::before {
-            border-color: $color-light-text-1; /* icon */
-        }
-        .doc-explorer-contents .field-short-description {
-            color: $color-light-text-2;
-        }
-    }
-}
-
-// Tooltip and popover panels are added to the body, so we must handle them
-// separately.
-body > .CodeMirror-lint-tooltip,
-body > .CodeMirror-info,
-body > .CodeMirror-hints {
-    background: #1d2837;
-    color: $color-text;
-    .info-description {
-        color: $color-text;
-    }
-    .CodeMirror-hint {
-        border-color: var(--border-color);
-        color: $color-text;
-        &-information {
-            border-color: var(--border-color);
-            > .content {
-                color: $color-text;
-                p:nth-child(odd) {
-                    margin-right: 1rem;
+    .CodeMirror-hints {
+        border-left: solid 1px var(--dropdown-border-color);
+        border-right: solid 1px var(--dropdown-border-color);
+        .CodeMirror-hint {
+            background-color: var(--dropdown-bg);
+            border-color: var(--dropdown-border-color);
+            color: var(--body-color);
+            &-information {
+                background-color: var(--color-bg-3);
+                border-color: var(--border-color);
+                > .content {
+                    color: var(--body-color);
+                    p:nth-child(odd) {
+                        margin-right: 1rem;
+                    }
                 }
             }
-        }
-        &-active {
-            color: #ffffff !important;
-            background-color: #1c7cd6;
+            &-active {
+                background-color: var(--dropdown-link-hover-bg);
+            }
         }
     }
 }
-body.theme-light > .CodeMirror-lint-tooltip,
-body.theme-light > .CodeMirror-info,
-body.theme-light > .CodeMirror-hints {
-    background: $color-light-bg-2;
-    color: $color-light-text-1;
+
+// Tooltips are added to the body, so we must handle them
+// separately.
+body > .CodeMirror-lint-tooltip,
+body > .CodeMirror-info {
+    background: var(--color-bg-2);
+    color: var(--body-color);
     .info-description {
-        color: $color-light-text-1;
-    }
-    .CodeMirror-hint {
-        color: $color-light-text-1;
-        &-information {
-            > .content {
-                color: $color-light-text-1;
-            }
-        }
+        color: var(--body-color);
     }
 }

--- a/client/web/src/components/completion/CompletionWidgetDropdown.scss
+++ b/client/web/src/components/completion/CompletionWidgetDropdown.scss
@@ -1,13 +1,13 @@
 .completion-widget-dropdown {
     border: 1px solid var(--border-color);
     box-shadow: 0 0 5px rgba(27, 31, 35, 0.1);
+    background-color: var(--dropdown-bg);
 
     &__item {
         border-bottom: 1px solid var(--border-color);
-        background-color: $color-bg-2;
-        color: $color-text-2;
+        color: var(--body-color);
         &--selected {
-            color: #ffffff !important;
+            background-color: var(--dropdown-link-hover-bg);
         }
     }
 
@@ -15,14 +15,5 @@
         border-bottom: 0;
         border-bottom-right-radius: 3px;
         border-bottom-left-radius: 3px;
-    }
-}
-
-.theme-light {
-    .completion-widget-dropdown {
-        &__item {
-            color: $color-light-text-1;
-            background-color: #ffffff;
-        }
     }
 }

--- a/client/web/src/components/diff/FileDiffHunks.scss
+++ b/client/web/src/components/diff/FileDiffHunks.scss
@@ -23,9 +23,9 @@
         vertical-align: top;
 
         font-family: $code-font-family;
-        color: $color-text-1;
+        color: var(--text-muted);
         &:hover {
-            color: $color-text-2;
+            color: var(--body-color);
         }
 
         &::before {
@@ -88,12 +88,6 @@
 
 .theme-light {
     .diff-hunk {
-        &__num {
-            color: $color-light-text-2;
-            &:hover {
-                color: $color-light-text-1;
-            }
-        }
         &__line--both .diff-hunk__num,
         &__num--both {
             background-color: rgba($color-light-bg-2, 0.5);

--- a/client/web/src/components/diff/FileDiffNode.scss
+++ b/client/web/src/components/diff/FileDiffNode.scss
@@ -25,7 +25,7 @@
             text-overflow: ellipsis;
             overflow: hidden;
             font-family: $code-font-family;
-            color: $color-text-2;
+            color: var(--body-color);
             font-size: $code-font-size;
         }
         &-stat {
@@ -44,15 +44,5 @@
 
     &__hunks {
         flex: 1 1 auto;
-    }
-}
-
-.theme-light {
-    .file-diff-node {
-        &__header {
-            &-path {
-                color: $color-light-text-5;
-            }
-        }
     }
 }

--- a/client/web/src/components/shared.tsx
+++ b/client/web/src/components/shared.tsx
@@ -99,7 +99,7 @@ export const WebEditorCompletionWidget: React.FunctionComponent<EditorCompletion
         {...props}
         listClassName="completion-widget-dropdown d-block list-unstyled rounded p-0 m-0 mt-3"
         listItemClassName={completionWidgetListItemClassName}
-        selectedListItemClassName="completion-widget-dropdown__item--selected bg-primary"
+        selectedListItemClassName="completion-widget-dropdown__item--selected"
         loadingClassName={completionWidgetListItemClassName}
         noResultsClassName={completionWidgetListItemClassName}
     />

--- a/client/web/src/marketing/Toast.scss
+++ b/client/web/src/marketing/Toast.scss
@@ -3,12 +3,9 @@
     right: 2rem;
     bottom: 2rem;
     z-index: 100; // Overlay repository/blob contents and search results
-    padding: 1rem;
     display: flex;
     align-items: flex-start;
     border-radius: 0.25rem;
-    background-color: $color-bg-2;
-    color: $color-text-2;
     border: 1px solid var(--border-color);
 
     &__logo {
@@ -35,10 +32,6 @@
         max-width: 400px;
     }
 
-    &__contents-title {
-        margin: 0 0 0.5rem 0;
-    }
-
     &__contents-cta {
         margin-top: 1rem;
     }
@@ -60,18 +53,5 @@
 
     &__close-button {
         flex: 0 0 auto;
-    }
-}
-
-.theme-light {
-    .toast {
-        background-color: $color-light-bg-2;
-        color: $color-light-text-1;
-
-        &__close-button {
-            &:hover {
-                color: $color-light-bg-6;
-            }
-        }
     }
 }

--- a/client/web/src/marketing/Toast.tsx
+++ b/client/web/src/marketing/Toast.tsx
@@ -10,22 +10,23 @@ interface Props {
 }
 
 export const Toast: React.FunctionComponent<Props> = props => (
-    <div className="toast">
-        <div className="toast__contents">
-            <div className="d-flex">
+    <div className="toast card">
+        <div className="card-body px-3 pb-3 pt-2">
+            <header className="card-title d-flex align-items-center">
                 <span className="toast__logo icon-inline">{props.icon}</span>
-                <h2 className="toast__contents-title">{props.title}</h2>
-            </div>
+                <h2 className="mb-0">{props.title}</h2>
+                <div className="flex-1" />
+                <button
+                    type="button"
+                    onClick={props.onDismiss}
+                    className="toast__close-button btn btn-icon test-close-toast"
+                    aria-label="Close"
+                >
+                    <CloseIcon className="icon-inline" />
+                </button>
+            </header>
             {props.subtitle}
             {props.cta && <div className="toast__contents-cta">{props.cta}</div>}
         </div>
-        <button
-            type="button"
-            onClick={props.onDismiss}
-            className="toast__close-button btn btn-icon test-close-toast"
-            aria-label="Close"
-        >
-            <CloseIcon className="icon-inline" />
-        </button>
     </div>
 )

--- a/client/web/src/repo/RepoHeader.scss
+++ b/client/web/src/repo/RepoHeader.scss
@@ -29,13 +29,12 @@
     }
 
     &__action-item--pressed {
+        color: var(--body-color);
         .theme-dark & {
             background-color: $color-bg-2;
-            color: $color-text-3;
         }
         .theme-light & {
             background-color: $color-light-bg-4;
-            color: $color-light-text-1;
         }
     }
 

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -19,7 +19,8 @@
         background: #1c2736;
 
         &-toggle {
-            background: #1c2736;
+            background: var(--color-bg-3);
+            color: var(--text-muted);
 
             position: absolute;
             top: 0;
@@ -52,14 +53,6 @@
     .repo-revision-container {
         &__sidebar {
             background: $color-light-bg-2;
-
-            &-toggle {
-                background: $color-light-bg-2;
-
-                &:hover {
-                    color: $color-light-text-5;
-                }
-            }
         }
 
         &__content {

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -76,7 +76,7 @@ export class RepoRevisionSidebar extends React.PureComponent<Props, State> {
                     onClick={this.onSidebarToggle}
                     data-tooltip="Show sidebar (Alt+S/Opt+S)"
                 >
-                    <FormatListBulletedIcon />
+                    <FormatListBulletedIcon className="icon-inline" />
                 </button>
             )
         }

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.scss
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.scss
@@ -14,12 +14,12 @@
             color: $secondary;
             &--active,
             &:hover {
-                background-color: $color-bg-2;
+                background-color: var(--color-bg-3);
             }
         }
 
         &__name {
-            color: $color-text-2;
+            color: var(--body-color);
         }
 
         &__container-name {
@@ -36,24 +36,6 @@
         &__path {
             .theme-dark & {
                 color: #566e9f;
-            }
-        }
-    }
-}
-
-.theme-light {
-    .repo-revision-sidebar-symbols {
-        &-node {
-            &__link {
-                color: $color-light-text-2;
-                &--active,
-                &:hover {
-                    background-color: $color-light-bg-3;
-                }
-            }
-
-            &__name {
-                color: $color-light-text-1;
             }
         }
     }

--- a/client/web/src/repo/RevisionsPopover.scss
+++ b/client/web/src/repo/RevisionsPopover.scss
@@ -15,20 +15,10 @@
             padding: 0 0.5rem;
         }
         &__link:not(:hover) &__message {
-            color: $color-text;
+            color: var(--body-color);
         }
         &__oid {
             margin-bottom: -0.125rem;
-        }
-    }
-}
-
-.theme-light {
-    .revisions-popover {
-        &-git-commit-node {
-            &__link:not(:hover) .revisions-popover-git-commit-node__message {
-                color: $color-light-text-1;
-            }
         }
     }
 }

--- a/client/web/src/repo/commits/GitCommitNode.scss
+++ b/client/web/src/repo/commits/GitCommitNode.scss
@@ -19,7 +19,7 @@
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
-            color: $color-text-2;
+            color: var(--body-color);
         }
         &-toggle {
             flex: none;
@@ -105,15 +105,5 @@
     }
     &--compact &__oid {
         flex: 0 0 auto;
-    }
-}
-
-.theme-light {
-    .git-commit-node {
-        &__message {
-            &-subject {
-                color: $color-light-text-1;
-            }
-        }
     }
 }

--- a/client/web/src/search/FilterChip.scss
+++ b/client/web/src/search/FilterChip.scss
@@ -3,14 +3,13 @@
     border-radius: 2px;
     margin: 0.25rem 0.5rem 0.25rem 0;
 
+    color: var(--body-color);
     border-color: var(--border-color-2);
 
     .theme-dark & {
         background: $color-bg-2;
-        color: $color-text-1;
     }
     .theme-light & {
-        color: $color-light-text-1;
         background: transparent;
     }
 
@@ -18,11 +17,9 @@
         border-color: var(--border-color);
         .theme-dark & {
             background: $color-bg-3;
-            color: #ffffff;
         }
         .theme-light & {
             background: $color-light-bg-4;
-            color: $color-light-text-6;
         }
     }
 
@@ -33,7 +30,6 @@
 
         .theme-light & {
             background: $color-light-bg-2;
-            color: $color-light-text-2;
         }
 
         .theme-dark & {
@@ -57,7 +53,6 @@
     &--selected {
         border-color: var(--border-color);
         .theme-dark & {
-            color: $color-text;
             background: $color-bg-5;
         }
         .theme-light & {

--- a/client/web/src/search/input/MonacoQueryInput.scss
+++ b/client/web/src/search/input/MonacoQueryInput.scss
@@ -3,7 +3,7 @@
     border: 1px solid $input-border-color;
     // Match padding from the regular query input.
     padding-left: 0.75rem;
-    background-color: #0e121b;
+    background-color: var(--input-bg);
     display: flex;
     align-items: center;
     flex: 1 1 auto;
@@ -47,7 +47,7 @@
             content: 'Tab';
             display: flex;
             align-items: center;
-            border: 1px solid;
+            border: 1px solid var(--text-muted);
             border-radius: 0.25rem;
             height: 1.25rem;
             margin-top: 0.375rem;
@@ -55,12 +55,8 @@
             font-size: 0.65rem;
             line-height: 1;
             padding: 0.25rem 0.375rem;
-            border-color: var(--border-color);
-            color: $color-text-1;
-
-            .theme-light & {
-                color: $color-light-text-3;
-            }
+            color: var(--text-muted);
+            opacity: 0.75;
         }
     }
 
@@ -81,10 +77,6 @@
 }
 
 .theme-light {
-    .monaco-query-input-container {
-        background-color: #ffffff;
-    }
-
     .monaco-icon-label.suggest-icon.customcolor::before {
         background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJtZGktaWNvbiAiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iIzJiMzc1MCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTQsMTJWMTkuODhDMTQuMDQsMjAuMTggMTMuOTQsMjAuNSAxMy43MSwyMC43MUMxMy4zMiwyMS4xIDEyLjY5LDIxLjEgMTIuMywyMC43MUwxMC4yOSwxOC43QzEwLjA2LDE4LjQ3IDkuOTYsMTguMTYgMTAsMTcuODdWMTJIOS45N0w0LjIxLDQuNjJDMy44Nyw0LjE5IDMuOTUsMy41NiA0LjM4LDMuMjJDNC41NywzLjA4IDQuNzgsMyA1LDNWM0gxOVYzQzE5LjIyLDMgMTkuNDMsMy4wOCAxOS42MiwzLjIyQzIwLjA1LDMuNTYgMjAuMTMsNC4xOSAxOS43OSw0LjYyTDE0LjAzLDEySDE0WiIvPjwvc3ZnPg==) !important;
     }

--- a/client/web/src/search/results/SearchResultsFilterBars.scss
+++ b/client/web/src/search/results/SearchResultsFilterBars.scss
@@ -7,13 +7,9 @@
         padding-left: 1rem;
         align-items: center;
 
-        color: #93a9c8;
-        background: $color-bg-1;
+        color: var(--text-muted);
+        background: var(--color-bg-1);
         border-bottom: 1px solid var(--border-color);
-        .theme-light & {
-            color: $color-light-text-2;
-            background: $color-light-bg-1;
-        }
     }
 
     &__filters {

--- a/client/web/src/search/results/SearchResultsList.scss
+++ b/client/web/src/search/results/SearchResultsList.scss
@@ -10,7 +10,7 @@
     }
 
     &__jump-to-top {
-        color: $color-light-text-1;
+        color: var(--body-color);
         background-color: $color-light-bg-2;
         padding: 0.25rem 0.5rem;
         text-align: center;
@@ -39,7 +39,6 @@
 .theme-dark {
     .search-results-list {
         &__jump-to-top {
-            color: $color-text-2;
             background-color: $color-bg-2;
         }
     }

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -101,7 +101,7 @@
 
             &--active {
                 background-color: $primary;
-                color: $color-light-text-4 !important;
+                color: $white !important;
             }
         }
 


### PR DESCRIPTION
Standardizes how components declare text colors. No components declare their own custom theme colors for text anymore; now they use CSS custom properties that can change based on the user's selected theme.

There will be minor changes to the text colors used in various components, but no (intentional) major changes. If we want to tweak colors further, we'll just need to introduce more variables that themes define (which is super easy).

Similar to #14829




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->