### PR TITLE
Work around extension document race condition

### DIFF
--- a/client/shared/src/api/extension/api/documents.ts
+++ b/client/shared/src/api/extension/api/documents.ts
@@ -1,5 +1,5 @@
 import { ProxyMarked, proxyMarker } from 'comlink'
-import { Subject } from 'rxjs'
+import { ReplaySubject } from 'rxjs'
 import { TextDocument } from 'sourcegraph'
 import { TextModelUpdate } from '../../client/services/modelService'
 import { ExtensionDocument } from './textDocument'
@@ -65,7 +65,7 @@ export class ExtensionDocuments implements ExtensionDocumentsAPI, ProxyMarked {
         return [...this.documents.values()]
     }
 
-    public openedTextDocuments = new Subject<TextDocument>()
+    public openedTextDocuments = new ReplaySubject<TextDocument>(1)
 
     public $acceptDocumentData(modelUpdates: readonly TextModelUpdate[]): void {
         for (const update of modelUpdates) {

--- a/client/shared/src/api/integration-test/documents.test.ts
+++ b/client/shared/src/api/integration-test/documents.test.ts
@@ -34,12 +34,15 @@ describe('Documents (integration)', () => {
             } = await integrationTestContext()
 
             const values = collectSubscribableValues(extensionAPI.workspace.openedTextDocuments)
-            expect(values).toEqual([] as TextDocument[])
+            assertToJSON(values, [{ uri: 'file:///f', languageId: 'l', text: 't' }] as TextDocument[])
 
             modelService.addModel({ uri: 'file:///f2', languageId: 'l2', text: 't2' })
             await from(extensionAPI.workspace.openedTextDocuments).pipe(take(1)).toPromise()
 
-            assertToJSON(values, [{ uri: 'file:///f2', languageId: 'l2', text: 't2' }] as TextDocument[])
+            assertToJSON(values, [
+                { uri: 'file:///f', languageId: 'l', text: 't' },
+                { uri: 'file:///f2', languageId: 'l2', text: 't2' },
+            ] as TextDocument[])
         })
     })
 })


### PR DESCRIPTION
Occasionally, the opened text document is sent to extensions before they have been activated. As a result, extensions that use  `openTextDocuments` were flaky.

I didn't look into the root of the race condition (saving that for next iteration), but implemented a quick fix by replacing `Subject` with `ReplaySubject(1)`.

#### Old: Subject. The document is lost, word-count is broken.
![Screenshot from 2020-10-18 19-57-41](https://user-images.githubusercontent.com/37420160/96389387-520b7980-117d-11eb-8fc3-bc01432b0083.png)

#### New: ReplaySubject
![Screenshot from 2020-10-18 19-52-38](https://user-images.githubusercontent.com/37420160/96389442-a282d700-117d-11eb-8bd3-c189e68ddc49.png)


#### Proper timing, subject type didn't matter
![Screenshot from 2020-10-18 19-52-56](https://user-images.githubusercontent.com/37420160/96389401-62bbef80-117d-11eb-8181-59f9ae53abde.png)

