### PR TITLE
Make stacking contexts explicit

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,6 +13,7 @@
     "dbaeumer.vscode-eslint",
     "foxundermoon.shell-format",
     "timonwong.shellcheck",
+    "felixfbecker.css-stacking-contexts",
   ],
   "unwantedRecommendations": ["ms-vscode.vscode-typescript-tslint-plugin", "eg2.tslint"],
 }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -1,5 +1,12 @@
 @import '../../../../shared/src/components/Resizable';
 
+.resizable-panel {
+    isolation: isolate;
+    min-height: 6rem;
+    max-height: calc(100% - 3rem);
+    width: 100%;
+}
+
 .panel {
     flex: 1 1 50%;
     min-height: 0;
@@ -12,12 +19,6 @@
     background-color: $color-bg-4;
     border-top: 1px solid $color-border;
     width: 100%;
-
-    &--resizable {
-        min-height: 6rem;
-        max-height: calc(100% - 3rem);
-        width: 100%;
-    }
 
     &__empty {
         flex: 1;

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -68,7 +68,7 @@ interface PanelItem extends Tab<string> {
  *
  * Other components can contribute panel items to the panel.
  */
-export class Panel extends React.PureComponent<Props, State> {
+class Panel extends React.PureComponent<Props, State> {
     public state: State = {}
 
     private subscriptions = new Subscription()
@@ -168,7 +168,7 @@ function byPriority(a: { priority: number }, b: { priority: number }): number {
 /** A wrapper around Panel that makes it resizable. */
 export const ResizablePanel: React.FunctionComponent<Props> = props => (
     <Resizable
-        className="panel--resizable"
+        className="resizable-panel"
         handlePosition="top"
         defaultSize={350}
         storageKey="panel-size"

--- a/client/browser/src/shared.scss
+++ b/client/browser/src/shared.scss
@@ -46,6 +46,7 @@ $body-color-dark: #f2f4f8;
 }
 
 .command-list-popover {
+    isolation: isolate;
     z-index: 1100; // high enough to prevent most things from obscuring it
     border: 1px solid var(--dropdown-border-color);
     border-radius: 3px;

--- a/client/browser/src/shared/code-hosts/shared/HoverOverlay.scss
+++ b/client/browser/src/shared/code-hosts/shared/HoverOverlay.scss
@@ -1,6 +1,6 @@
-@import '../../global-styles/variables.scss';
 @import '../../../../../shared/src/hover/HoverOverlay.scss';
 
 .hover-overlay {
-    z-index: $default-z-index;
+    isolation: isolate;
+    z-index: 2000;
 }

--- a/client/browser/src/shared/global-styles/variables.scss
+++ b/client/browser/src/shared/global-styles/variables.scss
@@ -1,1 +1,0 @@
-$default-z-index: 2000;

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -2,6 +2,7 @@ $popover-item-padding-h: 0.75rem;
 $popover-item-padding-v: 0.325rem;
 
 .connection-popover {
+    isolation: isolate;
     display: flex;
     flex-direction: column;
 

--- a/client/web/src/enterprise/productSubscription/ProductCertificate.scss
+++ b/client/web/src/enterprise/productSubscription/ProductCertificate.scss
@@ -15,13 +15,12 @@
     }
 
     &__logo {
+        flex: 0;
         height: 5rem;
         z-index: 9;
     }
-    .btn {
-        z-index: 9;
-    }
     .card-footer {
+        flex: 0;
         z-index: 0;
     }
 }

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -37,6 +37,7 @@
     }
 
     &__content {
+        isolation: isolate;
         flex: 1 1 auto;
 
         display: flex;

--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -1,6 +1,7 @@
 @import './RepoRevisionSidebarSymbols';
 
 .repo-revision-sidebar {
+    isolation: isolate;
     flex: 1 1 auto;
     min-height: 0;
 
@@ -21,7 +22,6 @@
         width: 1.25rem;
         height: 1.25rem;
         margin-right: -1.25rem;
-        z-index: 1;
 
         .icon {
             width: 1.125rem;

--- a/client/web/src/repo/RevisionsPopover.scss
+++ b/client/web/src/repo/RevisionsPopover.scss
@@ -1,6 +1,7 @@
 @import '../components/ConnectionPopover';
 
 .revisions-popover {
+    isolation: isolate;
     width: 35rem;
 
     &-git-commit-node {

--- a/client/web/src/repo/actions/InstallBrowserExtensionPopover.scss
+++ b/client/web/src/repo/actions/InstallBrowserExtensionPopover.scss
@@ -1,4 +1,5 @@
 .install-browser-extension-popover {
+    isolation: isolate;
     width: 31rem;
     max-width: 100vw;
     top: -4px !important;

--- a/client/web/src/site-admin/SiteAdminSidebar.scss
+++ b/client/web/src/site-admin/SiteAdminSidebar.scss
@@ -1,3 +1,4 @@
 .site-admin-sidebar {
+    isolation: isolate;
     width: 10rem;
 }

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -1,4 +1,5 @@
 .tree {
+    isolation: isolate;
     flex: 1 1 auto;
     width: 100%;
     overflow: auto;

--- a/client/web/src/user/settings/UserSettingsSidebar.scss
+++ b/client/web/src/user/settings/UserSettingsSidebar.scss
@@ -1,3 +1,4 @@
 .user-settings-sidebar {
+    isolation: isolate;
     width: 12rem;
 }


### PR DESCRIPTION
This is a solution to making sure we manage z-indexes better and avoid problems listed in https://github.com/sourcegraph/sourcegraph/issues/8380

The most important thing about managing z-indexes is understanding where new stacking contexts are created. Or in someone else's words:

> The problem with z-index is that very few people understand how it really works. It’s not complicated, but it if you’ve never taken the time to read its specification, there are almost certainly crucial aspects that you’re completely unaware of.
>
> **The key to avoid getting tripped up is being able to spot when new stacking contexts are formed**. If you’re setting a z-index of a billion on an element and it’s not moving forward in the stacking order, take a look up its ancestor tree and see if any of its parents form stacking contexts. If they do, your z-index of a billion isn’t going to do you any good.
>
> <footer>
> <cite>— <a href="https://philipwalton.com/articles/what-no-one-told-you-about-z-index/">What No One Told You About Z-Index</a>, Philip Walton, Engineer @ Google</cite>
> </footer>

The person who didn't understand how it really works was me a few months ago, and since then I've been thinking about how we can enable everyone in our codebase to avoid the pitfalls _without_ having to study the spec.

To solve this, I wrote a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=felixfbecker.css-stacking-contexts) that highlights where in CSS stacking contexts get created. It will also point out wherever a `z-index` declaration has no effect and offer quick fixes to make it have effect. This PR adds it to the recommended extensions so every dev will have it installed.

I also recommend the [z-index Chrome dev tools extension](https://chrome.google.com/webstore/detail/z-context/jigamimbjojkdgnlldajknogfgncplbh) which does a similar thing in the elements/styles explorer, but can even tell you the parent stacking context because it can read the actual DOM. The new Chromium Edge also has a neat 3D visualization of stacking contexts on the page.

I went through the code and introduced explicit stacking contexts (or just made them explicit) on a bunch of (mostly arbitrary) places using [`isolation: isolate`](https://developer.mozilla.org/en-US/docs/Web/CSS/isolation). This means it is much harder for a descendants of those elements to "leak though" another element on the page like they did in #8380 - either the whole container would be positioned on top, or behind, individual descendants cannot "break out".

I noticed that we actually don't have that many "global" z-indexes anymore, but many are just local settings (which are totally fine and it is now obvious that they are contained to their stacking context). We started using Bootstrap for popovers and the old search suggestions have been replaced by the new smart Monaco search field. Both ensure their floating elements are on top of everything else.

If we start needing to coordinate more z-indexes, we can adopt some pattern of defining them in variables (and this PR puts us in a better position to know where to define them and where the boundaries are). I think for now this tooling is sufficient though.

Closes https://github.com/sourcegraph/sourcegraph/issues/8380

<img width="1048" alt="screenshot1_light" src="https://user-images.githubusercontent.com/10532611/96430049-f800c780-1201-11eb-972b-5f91f0a9dc57.png">

![image](https://user-images.githubusercontent.com/10532611/96440954-f981be00-1208-11eb-9d9b-8ef922ad35bb.png)

![ineffective-z-index_light](https://user-images.githubusercontent.com/10532611/96429976-db648f80-1201-11eb-805a-bf2df8910012.gif)