### PR TITLE
Make sure that global test DB is setup in campaigns integration test

### DIFF
--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
 var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
@@ -18,6 +19,7 @@ func TestIntegration(t *testing.T) {
 
 	t.Parallel()
 
+	dbtesting.SetupGlobalTestDB(t)
 	db := dbtest.NewDB(t, *dsn)
 
 	userID := insertTestUser(t, db)


### PR DESCRIPTION
The test makes use of the global test DB by calling `repos.List` etc. but it only worked when another test setup the global test database.

