### PR TITLE
Allow align attribute for markdown images

### DIFF
--- a/client/shared/src/util/markdown.ts
+++ b/client/shared/src/util/markdown.ts
@@ -118,7 +118,7 @@ export const renderMarkdown = (
                     'class',
                     { name: 'rel', values: ['noopener', 'noreferrer'] },
                 ],
-                img: [...sanitize.defaults.allowedAttributes.img, 'alt', 'width', 'height'],
+                img: [...sanitize.defaults.allowedAttributes.img, 'alt', 'width', 'height', 'align'],
                 // Support different images depending on media queries (e.g. color theme, reduced motion)
                 source: ['srcset', 'media'],
                 // Support SVGs for code insights.


### PR DESCRIPTION
Will improve link-preview-expander's appearance