### PR TITLE
db: Prevent frontend from starting if codeintel-db == frontend db

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"os/user"
 	"strings"
@@ -343,7 +344,18 @@ func serviceConnections() conftypes.ServiceConnections {
 			PostgresDSN:          dbutil.PostgresDSN("", username, os.Getenv),
 			CodeIntelPostgresDSN: dbutil.PostgresDSN("codeintel", username, os.Getenv),
 		}
+
+		// We set this envvar in development to disable the following check
+		if os.Getenv("CODEINTEL_PG_ALLOW_SINGLE_DB") != "" {
+			return
+		}
+
+		// Ensure that the code intelligence database is not pointing at the frontend database
+		if err := comparePostgresDSNs(serviceConnectionsVal.PostgresDSN, serviceConnectionsVal.CodeIntelPostgresDSN); err != nil {
+			panic(err.Error())
+		}
 	})
+
 	return serviceConnectionsVal
 }
 
@@ -357,4 +369,30 @@ func gitServers() []string {
 		}
 	}
 	return strings.Fields(v)
+}
+
+// comparePostgresDSNs returns an error if one of the given Postgres DSN values are
+// not a valid URL, or if they are both valid URLs but point to the same database.
+// We consider two DSNs to be the same when they specify the same host, port, and
+// path. It's possible that different hosts/ports map to the same physical machine,
+// so we could conceivably return false negatives here and the tricksy site-admin
+// may have pulled the wool over our eyes. This shouldn't actually affect anything
+// operationally in the near-term, but may just make migrations harder when we need
+// to have them manually separate the data.
+func comparePostgresDSNs(dsn1, dsn2 string) error {
+	url1, err := url.Parse(dsn1)
+	if err != nil {
+		return fmt.Errorf("illegal Postgres DSN: %s", dsn1)
+	}
+
+	url2, err := url.Parse(dsn2)
+	if err != nil {
+		return fmt.Errorf("illegal Postgres DSN: %s", dsn2)
+	}
+
+	if url1.Host == url2.Host && url1.Path == url2.Path {
+		return fmt.Errorf("database must be distinct: %s and %s seem to refer to the same database", dsn1, dsn2)
+	}
+
+	return nil
 }

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -391,7 +391,7 @@ func comparePostgresDSNs(dsn1, dsn2 string) error {
 	}
 
 	if url1.Host == url2.Host && url1.Path == url2.Path {
-		return fmt.Errorf("database must be distinct: %s and %s seem to refer to the same database", dsn1, dsn2)
+		return fmt.Errorf("codeintel and frontend databases must be distinct: %s and %s seem to refer to the same database", dsn1, dsn2)
 	}
 
 	return nil

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -59,6 +59,7 @@ export CODEINTEL_PGPASSWORD="${PGPASSWORD:-}"
 export CODEINTEL_PGDATABASE="${PGDATABASE:-}"
 export CODEINTEL_PGSSLMODE="${PGSSLMODE:-}"
 export CODEINTEL_PGDATASOURCE="${PGDATASOURCE:-}"
+export CODEINTEL_PG_ALLOW_SINGLE_DB=true
 
 # Default to "info" level debugging, and "condensed" log format (nice for human readers)
 export SRC_LOG_LEVEL=${SRC_LOG_LEVEL:-info}


### PR DESCRIPTION
We require distinct database instances (either different hosts, or a different database on the same host) for the frontend db and the codeintel db. Our docs describe this behavior already, but I forgot to actually add the check here.

Not sure if a panic is appropriate over a log and an os.Exit, and I will very very happily take suggestions for error text.