### PR TITLE
executor: Extract executor-queue from precise-code-intel-indexer

### DIFF
--- a/dev/check/go-dbconn-import.sh
+++ b/dev/check/go-dbconn-import.sh
@@ -7,7 +7,7 @@ echo "--- go dbconn import"
 
 set -euf -o pipefail
 
-allowed='^github.com/sourcegraph/sourcegraph/cmd/frontend|github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend|github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater|github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-*'
+allowed='^github.com/sourcegraph/sourcegraph/cmd/frontend|github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend|github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater|github.com/sourcegraph/sourcegraph/enterprise/cmd/executor-queue|github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-*'
 # shellcheck disable=SC2016
 template='{{with $pkg := .}}{{ range $pkg.Deps }}{{ printf "%s imports %s\n" $pkg.ImportPath .}}{{end}}{{end}}'
 

--- a/dev/prometheus/all/prometheus_targets.yml
+++ b/dev/prometheus/all/prometheus_targets.yml
@@ -55,6 +55,11 @@
     # precise-code-intel-indexer-vm
     - host.docker.internal:6090
 - labels:
+    job: executor-queue
+  targets:
+    # executor-queue
+    - host.docker.internal:6091
+- labels:
     job: postgres_exporter
   targets:
     # postgres exporter

--- a/dev/prometheus/linux/prometheus_targets.yml
+++ b/dev/prometheus/linux/prometheus_targets.yml
@@ -55,6 +55,11 @@
     # precise-code-intel-indexer-vm
     - 127.0.0.1:6090
 - labels:
+    job: executor-queue
+  targets:
+    # executor-queue
+    - 127.0.0.1:6091
+- labels:
     job: postgres_exporter
   targets:
     # postgres exporter

--- a/dev/src-prof-services.json
+++ b/dev/src-prof-services.json
@@ -9,6 +9,7 @@
   { "Name": "precise-code-intel-worker", "Host": "127.0.0.1:6088" },
   { "Name": "precise-code-intel-indexer", "Host": "127.0.0.1:6089" },
   { "Name": "precise-code-intel-indexer-vm", "Host": "127.0.0.1:6090" },
+  { "Name": "executor-queue", "Host": "127.0.0.1:6091" },
   { "Name": "zoekt-indexserver", "Host": "127.0.0.1:6072" },
   { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" }
 ]

--- a/enterprise/cmd/executor-queue/CODENOTIFY
+++ b/enterprise/cmd/executor-queue/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/cmd/executor-queue/Dockerfile
+++ b/enterprise/cmd/executor-queue/Dockerfile
@@ -1,0 +1,19 @@
+FROM sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+# hadolint ignore=DL3018
+RUN apk update && apk add --no-cache \
+    tini
+
+USER sourcegraph
+EXPOSE 3191
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/executor-queue"]
+COPY executor-queue /usr/local/bin/

--- a/enterprise/cmd/executor-queue/build.sh
+++ b/enterprise/cmd/executor-queue/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script builds the executor-queue docker image.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+set -eu
+
+OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
+cleanup() {
+  rm -rf "$OUTPUT"
+}
+trap cleanup EXIT
+
+# Environment for building linux binaries
+export GO111MODULE=on
+export GOARCH=amd64
+export GOOS=linux
+export CGO_ENABLED=0
+
+echo "--- go build"
+pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor-queue"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+
+echo "--- docker build"
+docker build -f enterprise/cmd/executor-queue/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION

--- a/enterprise/cmd/executor-queue/config.go
+++ b/enterprise/cmd/executor-queue/config.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiserver"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+const port = 3191
+
+type Config struct {
+	env.BaseConfig
+
+	MaximumNumTransactions     int
+	JobRequeueDelay            time.Duration
+	JobCleanupInterval         time.Duration
+	MaximumNumMissedHeartbeats int
+}
+
+func (c *Config) Load() {
+	c.MaximumNumTransactions = c.GetInt("EXECUTOR_QUEUE_MAXIMUM_NUM_TRANSACTIONS", "10", "Number of jobs that can be processing at one time.")
+	c.JobRequeueDelay = c.GetInterval("EXECUTOR_QUEUE_JOB_REQUEUE_DELAY", "1m", "The requeue delay of jobs assigned to an unreachable executor.")
+	c.JobCleanupInterval = c.GetInterval("EXECUTOR_QUEUE_JOB_CLEANUP_INTERVAL", "10s", "Interval between cleanup runs.")
+	c.MaximumNumMissedHeartbeats = c.GetInt("EXECUTOR_QUEUE_MAXIMUM_NUM_MISSED_HEARTBEATS", "5", "The number of heartbeats an executor must miss to be considered unreachable.")
+}
+
+func (c *Config) ServerOptions(queueOptions map[string]apiserver.QueueOptions) apiserver.Options {
+	return apiserver.Options{
+		Port:                   port,
+		QueueOptions:           queueOptions,
+		MaximumNumTransactions: c.MaximumNumTransactions,
+		RequeueDelay:           c.JobRequeueDelay,
+		UnreportedMaxAge:       c.JobCleanupInterval * time.Duration(c.MaximumNumMissedHeartbeats),
+		DeathThreshold:         c.JobCleanupInterval * time.Duration(c.MaximumNumMissedHeartbeats),
+		CleanupInterval:        c.JobCleanupInterval,
+	}
+}

--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/config.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/config.go
@@ -1,0 +1,17 @@
+package codeintel
+
+import "github.com/sourcegraph/sourcegraph/internal/env"
+
+type Config struct {
+	env.BaseConfig
+
+	FrontendURL      string
+	FrontendUsername string
+	FrontendPassword string
+}
+
+func (c *Config) Load() {
+	c.FrontendURL = c.Get("EXECUTOR_FRONTEND_URL", "", "The external URL of the sourcegraph instance.")
+	c.FrontendUsername = c.Get("EXECUTOR_FRONTEND_USERNAME", "", "The username supplied to the frontend.")
+	c.FrontendPassword = c.Get("EXECUTOR_FRONTEND_PASSWORD", "", "The password supplied to the frontend.")
+}

--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
@@ -1,0 +1,53 @@
+package codeintel
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiserver"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
+	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+// StalledJobMaximumAge is the maximum allowable duration between updating the state of a
+// job as "processing" and locking the record during processing. An unlocked row that is
+// marked as processing likely indicates that the executor that dequeued the job has died.
+// There should be a nearly-zero delay between these states during normal operation.
+const StalledJobMaximumAge = time.Second * 5
+
+// MaximumNumResets is the maximum number of times a job can be reset. If a job's failed
+// attempts counter reaches this threshold, it will be moved into "errored" rather than
+// "queued" on its next reset.
+const MaximumNumResets = 3
+
+func QueueOptions(db dbutil.DB, config *Config) apiserver.QueueOptions {
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) {
+		return transformRecord(record.(store.Index), config)
+	}
+
+	return apiserver.QueueOptions{
+		Store:             newWorkerStore(db),
+		RecordTransformer: recordTransformer,
+	}
+}
+
+//NewWithDB creates a dbworker store that wraps the campaign_apply_jobs table.
+func newWorkerStore(db dbutil.DB) dbworkerstore.Store {
+	handle := basestore.NewHandleWithDB(db, sql.TxOptions{})
+	options := dbworkerstore.StoreOptions{
+		TableName:         "lsif_indexes",
+		ViewName:          "lsif_indexes_with_repository_name u",
+		ColumnExpressions: store.IndexColumnsWithNullRank,
+		Scan:              store.ScanFirstIndexRecord,
+		OrderByExpression: sqlf.Sprintf("u.queued_at"),
+		StalledMaxAge:     StalledJobMaximumAge,
+		MaxNumResets:      MaximumNumResets,
+	}
+
+	return dbworkerstore.NewStore(handle, options)
+}

--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
@@ -36,7 +36,7 @@ func QueueOptions(db dbutil.DB, config *Config) apiserver.QueueOptions {
 	}
 }
 
-//NewWithDB creates a dbworker store that wraps the campaign_apply_jobs table.
+// newWorkerStore creates a dbworker store that wraps the lsif_indexes table.
 func newWorkerStore(db dbutil.DB) dbworkerstore.Store {
 	handle := basestore.NewHandleWithDB(db, sql.TxOptions{})
 	options := dbworkerstore.StoreOptions{

--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/transform.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/transform.go
@@ -1,0 +1,82 @@
+package codeintel
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
+)
+
+const defaultOutfile = "dump.lsif"
+const uploadRoute = "/.executors/lsif/upload"
+
+func transformRecord(index store.Index, config *Config) (apiclient.Job, error) {
+	dockerSteps := make([]apiclient.DockerStep, 0, len(index.DockerSteps)+2)
+	for _, dockerStep := range index.DockerSteps {
+		dockerSteps = append(dockerSteps, apiclient.DockerStep{
+			Image:    dockerStep.Image,
+			Commands: dockerStep.Commands,
+			Dir:      dockerStep.Root,
+			Env:      nil,
+		})
+	}
+
+	if index.Indexer != "" {
+		dockerSteps = append(dockerSteps, apiclient.DockerStep{
+			Image:    index.Indexer,
+			Commands: index.IndexerArgs,
+			Dir:      index.Root,
+			Env:      nil,
+		})
+	}
+
+	srcEndpoint, err := makeURL(config.FrontendURL, config.FrontendUsername, config.FrontendPassword)
+	if err != nil {
+		return apiclient.Job{}, err
+	}
+
+	root := index.Root
+	if root == "" {
+		root = "."
+	}
+
+	outfile := index.Outfile
+	if outfile == "" {
+		outfile = defaultOutfile
+	}
+
+	return apiclient.Job{
+		ID:             index.ID,
+		Commit:         index.Commit,
+		RepositoryName: index.RepositoryName,
+		DockerSteps:    dockerSteps,
+		CliSteps: []apiclient.CliStep{
+			{
+				Commands: []string{
+					"lsif", "upload",
+					"-no-progress",
+					"-repo", index.RepositoryName,
+					"-commit", index.Commit,
+					"-root", root,
+					"-upload-route", uploadRoute,
+					"-file", outfile,
+				},
+				Dir: index.Root,
+				Env: []string{
+					fmt.Sprintf("SRC_ENDPOINT=%s", srcEndpoint),
+				},
+			},
+		},
+	}, nil
+}
+
+func makeURL(base, username, password string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	u.User = url.UserPassword(username, password)
+	return u.String(), nil
+}

--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/transform_test.go
@@ -1,0 +1,146 @@
+package codeintel
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/store"
+)
+
+func TestTransformRecord(t *testing.T) {
+	index := store.Index{
+		ID:             42,
+		Commit:         "deadbeef",
+		RepositoryName: "linux",
+		DockerSteps: []store.DockerStep{
+			{
+				Image:    "alpine",
+				Commands: []string{"yarn", "install"},
+				Root:     "web",
+			},
+		},
+		Root:        "web",
+		Indexer:     "lsif-node",
+		IndexerArgs: []string{"-p", "."},
+		Outfile:     "",
+	}
+	config := &Config{
+		FrontendURL:      "https://test.io",
+		FrontendUsername: "test",
+		FrontendPassword: "hunter2",
+	}
+
+	job, err := transformRecord(index, config)
+	if err != nil {
+		t.Fatalf("unexpected error transforming record: %s", err)
+	}
+
+	expected := apiclient.Job{
+		ID:                  42,
+		Commit:              "deadbeef",
+		RepositoryName:      "linux",
+		VirtualMachineFiles: nil,
+		DockerSteps: []apiclient.DockerStep{
+			{
+				Image:    "alpine",
+				Commands: []string{"yarn", "install"},
+				Dir:      "web",
+			},
+			{
+				Image:    "lsif-node",
+				Commands: []string{"-p", "."},
+				Dir:      "web",
+			},
+		},
+		CliSteps: []apiclient.CliStep{
+			{
+				Commands: []string{
+					"lsif", "upload",
+					"-no-progress",
+					"-repo", "linux",
+					"-commit", "deadbeef",
+					"-root", "web",
+					"-upload-route", "/.executors/lsif/upload",
+					"-file", "dump.lsif",
+				},
+				Dir: "web",
+				Env: []string{"SRC_ENDPOINT=https://test:hunter2@test.io"},
+			},
+		},
+	}
+	if diff := cmp.Diff(expected, job); diff != "" {
+		t.Errorf("unexpected job (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformRecordWithoutIndexer(t *testing.T) {
+	index := store.Index{
+		ID:             42,
+		Commit:         "deadbeef",
+		RepositoryName: "linux",
+		DockerSteps: []store.DockerStep{
+			{
+				Image:    "alpine",
+				Commands: []string{"yarn", "install"},
+				Root:     "web",
+			},
+			{
+				Image:    "lsif-node",
+				Commands: []string{"-p", "."},
+				Root:     "web",
+			},
+		},
+		Root:        "",
+		Indexer:     "",
+		IndexerArgs: nil,
+		Outfile:     "other/path/lsif.dump",
+	}
+	config := &Config{
+		FrontendURL:      "https://test.io",
+		FrontendUsername: "test",
+		FrontendPassword: "hunter2",
+	}
+
+	job, err := transformRecord(index, config)
+	if err != nil {
+		t.Fatalf("unexpected error transforming record: %s", err)
+	}
+
+	expected := apiclient.Job{
+		ID:                  42,
+		Commit:              "deadbeef",
+		RepositoryName:      "linux",
+		VirtualMachineFiles: nil,
+		DockerSteps: []apiclient.DockerStep{
+			{
+				Image:    "alpine",
+				Commands: []string{"yarn", "install"},
+				Dir:      "web",
+			},
+			{
+				Image:    "lsif-node",
+				Commands: []string{"-p", "."},
+				Dir:      "web",
+			},
+		},
+		CliSteps: []apiclient.CliStep{
+			{
+				Commands: []string{
+					"lsif", "upload",
+					"-no-progress",
+					"-repo", "linux",
+					"-commit", "deadbeef",
+					"-root", ".",
+					"-upload-route", "/.executors/lsif/upload",
+					"-file", "other/path/lsif.dump",
+				},
+				Dir: "",
+				Env: []string{"SRC_ENDPOINT=https://test:hunter2@test.io"},
+			},
+		},
+	}
+	if diff := cmp.Diff(expected, job); diff != "" {
+		t.Errorf("unexpected job (-want +got):\n%s", diff)
+	}
+}

--- a/enterprise/cmd/executor-queue/main.go
+++ b/enterprise/cmd/executor-queue/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor-queue/internal/queues/codeintel"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiserver"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/debugserver"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/tracer"
+)
+
+type config interface {
+	Load()
+	Validate() error
+}
+
+func main() {
+	serviceConfig := &Config{}
+	codeintelConfig := &codeintel.Config{}
+	configs := []config{serviceConfig, codeintelConfig}
+
+	for _, config := range configs {
+		config.Load()
+	}
+
+	env.Lock()
+	env.HandleHelpFlag()
+
+	logging.Init()
+	tracer.Init()
+	trace.Init(true)
+
+	for _, config := range configs {
+		if err := config.Validate(); err != nil {
+			log.Fatalf("failed to load config: %s", err)
+		}
+	}
+
+	db := connectToDatabase()
+
+	queueOptions := map[string]apiserver.QueueOptions{
+		"codeintel": codeintel.QueueOptions(db, codeintelConfig),
+	}
+
+	for queueName, options := range queueOptions {
+		prometheus.DefaultRegisterer.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name:        "src_executor_queue_total",
+			Help:        "Total number of jobs in the queued state.",
+			ConstLabels: map[string]string{"queue": queueName},
+		}, func() float64 {
+			// TODO(efritz) - do not count soft-deleted code intel index records
+			count, err := options.Store.QueuedCount(context.Background(), nil)
+			if err != nil {
+				log15.Error("Failed to get queued job count", "queue", queueName, "error", err)
+			}
+
+			return float64(count)
+		}))
+	}
+
+	goroutine.MonitorBackgroundRoutines(
+		goroutine.NoopStop(debugserver.NewServerRoutine()),
+		apiserver.NewServer(serviceConfig.ServerOptions(queueOptions)),
+	)
+}
+
+func connectToDatabase() *sql.DB {
+	postgresDSN := conf.Get().ServiceConnections.PostgresDSN
+	conf.Watch(func() {
+		if newDSN := conf.Get().ServiceConnections.PostgresDSN; postgresDSN != newDSN {
+			log.Fatalf("detected database DSN change, restarting to take effect: %s", newDSN)
+		}
+	})
+
+	db, err := dbconn.New(postgresDSN, "")
+	if err != nil {
+		log.Fatalf("failed to initialize store: %s", err)
+	}
+
+	return db
+}

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -21,7 +21,10 @@ prometheus: ./dev/prometheus.sh
 grafana: ./dev/grafana.sh
 postgres_exporter: ./dev/postgres_exporter.sh
 
-# Additional enterprise services
+# Enterprise executor services
+executor-queue: executor-queue
+
+# Enterprise code intelligence services
 precise-code-intel-bundle-manager: precise-code-intel-bundle-manager
 precise-code-intel-indexer: precise-code-intel-indexer
 precise-code-intel-indexer-vm: TMPDIR=~/.sourcegraph/indexer-temp precise-code-intel-indexer-vm

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -27,6 +27,7 @@ var allDockerImages = []string{
 	"precise-code-intel-worker",
 	"precise-code-intel-indexer",
 	"precise-code-intel-indexer-vm",
+	"executor-queue",
 
 	// Images under docker-images/
 	"cadvisor",

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -39,6 +39,10 @@ export SOURCEGRAPH_LICENSE_GENERATION_KEY
 export PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187
 export PRECISE_CODE_INTEL_BUNDLE_DIR=$HOME/.sourcegraph/lsif-storage
 
+export EXECUTOR_FRONTEND_URL=http://localhost:3080
+export EXECUTOR_FRONTEND_USERNAME=executor
+export EXECUTOR_FRONTEND_PASSWORD=hunter2
+
 export PRECISE_CODE_INTEL_EXTERNAL_URL=http://localhost:3080
 export PRECISE_CODE_INTEL_EXTERNAL_URL_FROM_DOCKER=http://host.docker.internal:3080
 export PRECISE_CODE_INTEL_INDEX_MANAGER_URL=http://localhost:3189
@@ -48,7 +52,7 @@ export PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH=$HOME/.sourcegraph/images
 export DISABLE_CNCF=notonmybox
 
 export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"
-export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-indexer-vm precise-code-intel-worker "
+export ENTERPRISE_ONLY_COMMANDS=" precise-code-intel-bundle-manager precise-code-intel-indexer precise-code-intel-indexer-vm precise-code-intel-worker executor-queue "
 export ENTERPRISE_COMMANDS="frontend repo-updater ${ENTERPRISE_ONLY_COMMANDS}"
 export ENTERPRISE=1
 export PROCFILE=enterprise/dev/Procfile

--- a/enterprise/internal/apiworker/apiclient/types.go
+++ b/enterprise/internal/apiworker/apiclient/types.go
@@ -1,0 +1,84 @@
+package apiclient
+
+// Job describes a series of steps to perform within an executor.
+type Job struct {
+	// ID is the unique identifier of a job within the source queue. Note
+	// that different queues can share identifiers.
+	ID int `json:"id"`
+
+	// RepositoryName is the name of the repository to be cloned into the
+	// workspace prior to job execution.
+	RepositoryName string `json:"repositoryName"`
+
+	// Commit is the revhash that should be checked out prior to job execution.
+	Commit string `json:"commit"`
+
+	// VirtualMachineFiles is a map from file names to content. Each entry in
+	// this map will be written into the workspace prior to job execution.
+	VirtualMachineFiles map[string]string `json:"files"`
+
+	// DockerSteps describe a series of docker run commands to be invoked in the
+	// workspace. This may be done inside or outside of a Firecracker virtual
+	// machine.
+	DockerSteps []DockerStep `json:"dockerSteps"`
+
+	// CliSteps describe a series of src commands to be invoked in the workspace.
+	// These run after all docker commands have been completed successfully. This
+	// may be done inside or outside of a Firecracker virtual machine.
+	CliSteps []CliStep `json:"cliSteps"`
+}
+
+func (j Job) RecordID() int {
+	return j.ID
+}
+
+type DockerStep struct {
+	// Image specifies the docker image.
+	Image string `json:"image"`
+
+	// Commands specifies the arguments supplied to the end of a docker run command.
+	Commands []string `json:"commands"`
+
+	// Dir specifies the target working directory.
+	Dir string `json:"dir"`
+
+	// Env specifies a set of NAME=value pairs to supply to the docker command.
+	Env []string `json:"env"`
+}
+
+type CliStep struct {
+	// Commands specifies the arguments supplied to the src command.
+	Commands []string `json:"command"`
+
+	// Dir specifies the target working directory.
+	Dir string `json:"dir"`
+
+	// Env specifies a set of NAME=value pairs to supply to the src command.
+	Env []string `json:"env"`
+}
+
+type DequeueRequest struct {
+	ExecutorName string `json:"executorName"`
+}
+
+type SetLogRequest struct {
+	ExecutorName string `json:"executorName"`
+	JobID        int    `json:"jobId"`
+	Contents     string `json:"payload"`
+}
+
+type MarkCompleteRequest struct {
+	ExecutorName string `json:"executorName"`
+	JobID        int    `json:"jobId"`
+}
+
+type MarkErroredRequest struct {
+	ExecutorName string `json:"executorName"`
+	JobID        int    `json:"jobId"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+type HeartbeatRequest struct {
+	ExecutorName string `json:"executorName"`
+	JobIDs       []int  `json:"jobIds"`
+}

--- a/enterprise/internal/apiworker/apiserver/handler.go
+++ b/enterprise/internal/apiworker/apiserver/handler.go
@@ -1,0 +1,230 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/efritz/glock"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+type handler struct {
+	options          Options
+	clock            glock.Clock
+	executors        map[string]*executorMeta
+	dequeueSemaphore chan struct{} // tracks available dequeue slots
+	m                sync.Mutex    // protects executors
+}
+
+type Options struct {
+	// Port is the port on which to listen for HTTP connections.
+	Port int
+
+	// QueueOptions is a map from queue name to options specific to that queue.
+	QueueOptions map[string]QueueOptions
+
+	// MaximumNumTransactions is the maximum number of active records that can be given out
+	// to executors from this machine. The dequeue method will stop returning records while
+	// the number of outstanding transactions is at or above this threshold.
+	MaximumNumTransactions int
+
+	// RequeueDelay controls how far into the future to make a job record visible to the job
+	// queue once the currently processing executor has become unresponsive.
+	RequeueDelay time.Duration
+
+	// UnreportedMaxAge is the maximum time between a record being dequeued and it appearing
+	// in the executor's heartbeat requests before it being considered lost.
+	UnreportedMaxAge time.Duration
+
+	// DeathThreshold is the minimum time since the last heartbeat of an executor before that
+	// executor can be considered as unresponsive. This should be configured to be longer than
+	// the duration between heartbeat interval.
+	DeathThreshold time.Duration
+
+	// CleanupInterval is the duration between periodic invocations of Cleanup, which will
+	// requeue any records that are "lost" according to the thresholds described above.
+	CleanupInterval time.Duration
+}
+
+type QueueOptions struct {
+	// Store is a required dbworker store store for each registered queue.
+	Store store.Store
+
+	// RecordTransformer is a required hook for each registered queue that transforms a generic
+	// record from that queue into the job to be given to an executor.
+	RecordTransformer func(record workerutil.Record) (apiclient.Job, error)
+}
+
+type executorMeta struct {
+	lastUpdate time.Time
+	jobs       []jobMeta
+}
+
+type jobMeta struct {
+	queueName string
+	record    workerutil.Record
+	tx        store.Store
+	started   time.Time
+}
+
+func newHandler(options Options, clock glock.Clock) *handler {
+	dequeueSemaphore := make(chan struct{}, options.MaximumNumTransactions)
+	for i := 0; i < options.MaximumNumTransactions; i++ {
+		dequeueSemaphore <- struct{}{}
+	}
+
+	return &handler{
+		options:          options,
+		clock:            clock,
+		dequeueSemaphore: dequeueSemaphore,
+		executors:        map[string]*executorMeta{},
+	}
+}
+
+var ErrUnknownQueue = errors.New("unknown queue")
+var ErrUnknownJob = errors.New("unknown job")
+
+// dequeue selects a job record from the database and stashes metadata including
+// the job record and the locking transaction. If no job is available for processing,
+// or the server has hit its maximum transactions, a false-valued flag is returned.
+func (m *handler) dequeue(ctx context.Context, queueName, executorName string) (_ apiclient.Job, dequeued bool, _ error) {
+	queueOptions, ok := m.options.QueueOptions[queueName]
+	if !ok {
+		return apiclient.Job{}, false, ErrUnknownQueue
+	}
+
+	select {
+	case <-m.dequeueSemaphore:
+	default:
+		return apiclient.Job{}, false, nil
+	}
+	defer func() {
+		if !dequeued {
+			// Ensure that if we do not dequeue a record successfully we do not
+			// leak from the semaphore. This will happen if the dequeue call fails
+			// or if there are no records to process
+			m.dequeueSemaphore <- struct{}{}
+		}
+	}()
+
+	record, tx, dequeued, err := queueOptions.Store.DequeueWithIndependentTransactionContext(ctx, nil)
+	if err != nil {
+		return apiclient.Job{}, false, err
+	}
+	if !dequeued {
+		return apiclient.Job{}, false, nil
+	}
+
+	job, err := queueOptions.RecordTransformer(record)
+	if err != nil {
+		return apiclient.Job{}, false, tx.Done(err)
+	}
+
+	now := m.clock.Now()
+	m.addMeta(executorName, jobMeta{queueName: queueName, record: record, tx: tx, started: now})
+	return job, true, nil
+}
+
+// setLogContents calls SetLogContents for the given job. If the job identifier is not
+// known, a false-valued flag is returned.
+func (m *handler) setLogContents(ctx context.Context, queueName, executorName string, jobID int, contents string) error {
+	job, err := m.findMeta(queueName, executorName, jobID, false)
+	if err != nil {
+		return err
+	}
+
+	if err := job.tx.SetLogContents(ctx, jobID, contents); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// markComplete calls MarkComplete for the given job, then commits the job's transaction.
+// The job is removed from the executor's job list on success.
+func (m *handler) markComplete(ctx context.Context, queueName, executorName string, jobID int) error {
+	job, err := m.findMeta(queueName, executorName, jobID, true)
+	if err != nil {
+		return err
+	}
+
+	defer func() { m.dequeueSemaphore <- struct{}{} }()
+
+	_, err = job.tx.MarkComplete(ctx, job.record.RecordID())
+
+	if doneErr := job.tx.Done(err); doneErr != err {
+		return doneErr
+	}
+
+	return nil
+}
+
+// markErrored calls MarkErrored for the given job, then commits the job's transaction.
+// The job is removed from the executor's job list on success.
+func (m *handler) markErrored(ctx context.Context, queueName, executorName string, jobID int, errorMessage string) error {
+	job, err := m.findMeta(queueName, executorName, jobID, true)
+	if err != nil {
+		return err
+	}
+
+	defer func() { m.dequeueSemaphore <- struct{}{} }()
+
+	_, err = job.tx.MarkErrored(ctx, job.record.RecordID(), errorMessage)
+
+	if doneErr := job.tx.Done(err); doneErr != err {
+		return doneErr
+	}
+
+	return nil
+}
+
+// findMeta returns the job with the given id and executor name. If the job is
+// unknown, an error is returned. If the remove parameter is true, the job will
+// be removed from the executor's job list on success.
+func (m *handler) findMeta(queueName, executorName string, jobID int, remove bool) (jobMeta, error) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if _, ok := m.options.QueueOptions[queueName]; !ok {
+		return jobMeta{}, ErrUnknownQueue
+	}
+
+	executor, ok := m.executors[executorName]
+	if !ok {
+		return jobMeta{}, ErrUnknownJob
+	}
+
+	for i, job := range executor.jobs {
+		if job.queueName == queueName && job.record.RecordID() == jobID {
+			if remove {
+				l := len(executor.jobs) - 1
+				executor.jobs[i] = executor.jobs[l]
+				executor.jobs = executor.jobs[:l]
+			}
+
+			return job, nil
+		}
+	}
+
+	return jobMeta{}, ErrUnknownJob
+}
+
+// addMeta adds a job to the given executor's job list.
+func (m *handler) addMeta(executorName string, job jobMeta) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	executor, ok := m.executors[executorName]
+	if !ok {
+		executor = &executorMeta{}
+		m.executors[executorName] = executor
+	}
+
+	now := m.clock.Now()
+	executor.jobs = append(executor.jobs, job)
+	executor.lastUpdate = now
+}

--- a/enterprise/internal/apiworker/apiserver/handler_test.go
+++ b/enterprise/internal/apiworker/apiserver/handler_test.go
@@ -1,0 +1,318 @@
+package apiserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/efritz/glock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	workerstoremocks "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store/mocks"
+)
+
+func TestDequeue(t *testing.T) {
+	transformedJob := apiclient.Job{
+		ID: 42,
+		DockerSteps: []apiclient.DockerStep{
+			{
+				Image:    "alpine:latest",
+				Commands: []string{"ls", "-a"},
+			},
+		},
+	}
+
+	store := workerstoremocks.NewMockStore()
+	store.DequeueWithIndependentTransactionContextFunc.SetDefaultReturn(testRecord{ID: 42, Payload: "secret"}, store, true, nil)
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) {
+		if tr, ok := record.(testRecord); !ok {
+			t.Errorf("mismatched record type.")
+		} else if tr.Payload != "secret" {
+			t.Errorf("unexpected payload. want=%q have=%q", "secret", tr.Payload)
+		}
+
+		return transformedJob, nil
+	}
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: store, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 10,
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	job, dequeued, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected job to be dequeued")
+	}
+	if job.ID != 42 {
+		t.Errorf("unexpected id. want=%d have=%d", 42, job.ID)
+	}
+	if diff := cmp.Diff(transformedJob, job); diff != "" {
+		t.Errorf("unexpected job (-want +got):\n%s", diff)
+	}
+}
+
+func TestDequeueNoRecord(t *testing.T) {
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: workerstoremocks.NewMockStore()},
+		},
+		MaximumNumTransactions: 10,
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	_, dequeued, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if dequeued {
+		t.Fatalf("did not expect a job to be dequeued")
+	}
+}
+
+func TestDequeueUnknownQueue(t *testing.T) {
+	options := Options{}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if _, _, err := handler.dequeue(context.Background(), "test_queue", "deadbeef"); err != ErrUnknownQueue {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownQueue, err)
+	}
+}
+
+func TestDequeueMaxTransactions(t *testing.T) {
+	store := workerstoremocks.NewMockStore()
+	store.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 41}, store, true, nil)
+	store.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store, true, nil)
+	store.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 43}, store, true, nil)
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) { return apiclient.Job{}, nil }
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: store, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 2,
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	_, dequeued1, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued1 {
+		t.Fatalf("expected job to be dequeued")
+	}
+
+	_, dequeued2, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued2 {
+		t.Fatalf("expected a second job to be dequeued")
+	}
+
+	_, dequeued3, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if dequeued3 {
+		t.Fatalf("did not expect a third job to be dequeued")
+	}
+
+	if err := handler.markComplete(context.Background(), "test_queue", "deadbeef", 42); err != nil {
+		t.Fatalf("unexpected error completing job: %s", err)
+	}
+
+	_, dequeued4, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued4 {
+		t.Fatalf("expected a third job to be dequeued after a release")
+	}
+}
+
+func TestSetLogContents(t *testing.T) {
+	store := workerstoremocks.NewMockStore()
+	store.DequeueWithIndependentTransactionContextFunc.SetDefaultReturn(testRecord{ID: 42}, store, true, nil)
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) { return apiclient.Job{ID: 42}, nil }
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: store, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 10,
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	job, dequeued, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a job to be dequeued")
+	}
+
+	if err := handler.setLogContents(context.Background(), "test_queue", "deadbeef", job.ID, "<log payload>"); err != nil {
+		t.Fatalf("unexpected error setting log contents: %s", err)
+	}
+
+	if value := len(store.SetLogContentsFunc.History()); value != 1 {
+		t.Fatalf("unexpected number of calls to SetLogContents. want=%d have=%d", 1, value)
+	}
+	call := store.SetLogContentsFunc.History()[0]
+	if call.Arg1 != 42 {
+		t.Errorf("unexpected job identifier. want=%d have=%d", 42, call.Arg1)
+	}
+	if call.Arg2 != "<log payload>" {
+		t.Errorf("unexpected log contents. want=%s have=%s", "<log payload>", call.Arg2)
+	}
+}
+
+func TestSetLogContentsUnknownQueue(t *testing.T) {
+	options := Options{}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if err := handler.setLogContents(context.Background(), "test_queue", "deadbjeef", 42, "<log payload>"); err != ErrUnknownQueue {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownQueue, err)
+	}
+}
+
+func TestSetLogContentsUnknownJob(t *testing.T) {
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: workerstoremocks.NewMockStore()},
+		},
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if err := handler.setLogContents(context.Background(), "test_queue", "deadbeef", 42, "<log payload>"); err != ErrUnknownJob {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownJob, err)
+	}
+}
+
+func TestMarkComplete(t *testing.T) {
+	store := workerstoremocks.NewMockStore()
+	store.DequeueWithIndependentTransactionContextFunc.SetDefaultReturn(testRecord{ID: 42}, store, true, nil)
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) { return apiclient.Job{ID: 42}, nil }
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: store, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 10,
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	job, dequeued, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a job to be dequeued")
+	}
+
+	if err := handler.markComplete(context.Background(), "test_queue", "deadbeef", job.ID); err != nil {
+		t.Fatalf("unexpected error completing job: %s", err)
+	}
+
+	if value := len(store.MarkCompleteFunc.History()); value != 1 {
+		t.Fatalf("unexpected number of calls to MarkComplete. want=%d have=%d", 1, value)
+	}
+	call := store.MarkCompleteFunc.History()[0]
+	if call.Arg1 != 42 {
+		t.Errorf("unexpected job identifier. want=%d have=%d", 42, call.Arg1)
+	}
+}
+
+func TestMarkCompleteUnknownJob(t *testing.T) {
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: workerstoremocks.NewMockStore()},
+		},
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if err := handler.markComplete(context.Background(), "test_queue", "deadbeef", 42); err != ErrUnknownJob {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownJob, err)
+	}
+}
+
+func TestMarkCompleteUnknownQueue(t *testing.T) {
+	options := Options{}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if err := handler.markComplete(context.Background(), "test_queue", "deadbeef", 42); err != ErrUnknownQueue {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownQueue, err)
+	}
+}
+
+func TestMarkErrored(t *testing.T) {
+	store := workerstoremocks.NewMockStore()
+	store.DequeueWithIndependentTransactionContextFunc.SetDefaultReturn(testRecord{ID: 42}, store, true, nil)
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) { return apiclient.Job{ID: 42}, nil }
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: store, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 10,
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	job, dequeued, err := handler.dequeue(context.Background(), "test_queue", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error dequeueing job: %s", err)
+	}
+	if !dequeued {
+		t.Fatalf("expected a job to be dequeued")
+	}
+
+	if err := handler.markErrored(context.Background(), "test_queue", "deadbeef", job.ID, "OH NO"); err != nil {
+		t.Fatalf("unexpected error completing job: %s", err)
+	}
+
+	if value := len(store.MarkErroredFunc.History()); value != 1 {
+		t.Fatalf("unexpected number of calls to MarkErrored. want=%d have=%d", 1, value)
+	}
+	call := store.MarkErroredFunc.History()[0]
+	if call.Arg1 != 42 {
+		t.Errorf("unexpected job identifier. want=%d have=%d", 42, call.Arg1)
+	}
+	if call.Arg2 != "OH NO" {
+		t.Errorf("unexpected job error. want=%s have=%s", "OH NO", call.Arg2)
+	}
+}
+
+func TestMarkErroredUnknownJob(t *testing.T) {
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"test_queue": {Store: workerstoremocks.NewMockStore()},
+		},
+	}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if err := handler.markErrored(context.Background(), "test_queue", "deadbeef", 42, "OH NO"); err != ErrUnknownJob {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownJob, err)
+	}
+}
+
+func TestMarkErroredUnknownQueue(t *testing.T) {
+	options := Options{}
+	handler := newHandler(options, glock.NewMockClock())
+
+	if err := handler.markErrored(context.Background(), "test_queue", "deadbeef", 42, "OH NO"); err != ErrUnknownQueue {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrUnknownQueue, err)
+	}
+}
+
+type testRecord struct {
+	ID      int
+	Payload string
+}
+
+func (r testRecord) RecordID() int { return r.ID }

--- a/enterprise/internal/apiworker/apiserver/lifecycle.go
+++ b/enterprise/internal/apiworker/apiserver/lifecycle.go
@@ -1,0 +1,109 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
+)
+
+var shutdownErr = errors.New("server shutting down")
+
+// heartbeat will release the transaction for any job that is not confirmed to be in-progress
+// by the given executor. This method is called when the executor POSTs its in-progress job
+// identifiers to the /heartbeat route.
+func (h *handler) heartbeat(ctx context.Context, executorName string, jobIDs []int) error {
+	return h.requeueJobs(ctx, h.pruneJobs(executorName, jobIDs))
+}
+
+// cleanup will release the transactions held by any executor that has not sent a heartbeat
+// in a while. This method is called periodically in the background.
+func (h *handler) cleanup(ctx context.Context) error {
+	return h.requeueJobs(ctx, h.pruneExecutors())
+}
+
+// shutdown releases all transactions. This method is called on process shutdown.
+func (h *handler) shutdown() {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	for _, executor := range h.executors {
+		for _, job := range executor.jobs {
+			if err := job.tx.Done(shutdownErr); err != nil && err != shutdownErr {
+				log15.Error(fmt.Sprintf("Failed to close transaction holding job %d", job.record.RecordID()), "err", err)
+			}
+		}
+	}
+}
+
+// pruneJobs updates the set of job identifiers assigned to the given executor and returns
+// any job that was known to us but not reported by the executor.
+func (h *handler) pruneJobs(executorName string, ids []int) (dead []jobMeta) {
+	now := h.clock.Now()
+
+	idMap := map[int]struct{}{}
+	for _, id := range ids {
+		idMap[id] = struct{}{}
+	}
+
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	executor, ok := h.executors[executorName]
+	if !ok {
+		executor = &executorMeta{}
+		h.executors[executorName] = executor
+	}
+
+	var live []jobMeta
+	for _, job := range executor.jobs {
+		if _, ok := idMap[job.record.RecordID()]; ok || now.Sub(job.started) < h.options.UnreportedMaxAge {
+			live = append(live, job)
+		} else {
+			dead = append(dead, job)
+		}
+	}
+
+	executor.jobs = live
+	executor.lastUpdate = now
+	return dead
+}
+
+// pruneExecutors will release the transactions held by any executor that has not sent a
+// heartbeat in a while and return the attached jobs.
+func (h *handler) pruneExecutors() (jobs []jobMeta) {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	for name, executor := range h.executors {
+		if h.clock.Now().Sub(executor.lastUpdate) <= h.options.DeathThreshold {
+			continue
+		}
+
+		jobs = append(jobs, executor.jobs...)
+		delete(h.executors, name)
+	}
+
+	return jobs
+}
+
+// requeueJobs releases and requeues each of the given jobs.
+func (h *handler) requeueJobs(ctx context.Context, jobs []jobMeta) (errs error) {
+	for _, job := range jobs {
+		if err := h.requeueJob(ctx, job); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// requeueJob requeues the given job and releases the associated transaction.
+func (h *handler) requeueJob(ctx context.Context, job jobMeta) error {
+	defer func() { h.dequeueSemaphore <- struct{}{} }()
+
+	err := job.tx.Requeue(ctx, job.record.RecordID(), h.clock.Now().Add(h.options.RequeueDelay))
+	return job.tx.Done(err)
+}

--- a/enterprise/internal/apiworker/apiserver/lifecycle_test.go
+++ b/enterprise/internal/apiworker/apiserver/lifecycle_test.go
@@ -1,0 +1,144 @@
+package apiserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/efritz/glock"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	workerstoremocks "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store/mocks"
+)
+
+func TestHeartbeat(t *testing.T) {
+	store1 := workerstoremocks.NewMockStore()
+	store2 := workerstoremocks.NewMockStore()
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) {
+		return apiclient.Job{ID: record.RecordID()}, nil
+	}
+
+	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 41}, store1, true, nil)
+	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store1, true, nil)
+	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store2, true, nil)
+	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 43}, store2, true, nil)
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"q1": {Store: store1, RecordTransformer: recordTransformer},
+			"q2": {Store: store2, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 10,
+		UnreportedMaxAge:       time.Second,
+	}
+	clock := glock.NewMockClock()
+	handler := newHandler(options, clock)
+
+	_, dequeued1, _ := handler.dequeue(context.Background(), "q1", "deadbeef")
+	_, dequeued2, _ := handler.dequeue(context.Background(), "q1", "deadveal")
+	_, dequeued3, _ := handler.dequeue(context.Background(), "q2", "deadbeef")
+	_, dequeued4, _ := handler.dequeue(context.Background(), "q2", "deadveal")
+	if !dequeued1 || !dequeued2 || !dequeued3 || !dequeued4 {
+		t.Fatalf("failed to dequeue records")
+	}
+
+	assertDoneCounts := func(c1, c2 int) {
+		if value := len(store1.DoneFunc.History()); value != c1 {
+			t.Fatalf("unexpected number of calls to Done. want=%d have=%d", c1, value)
+		}
+		if value := len(store2.DoneFunc.History()); value != c2 {
+			t.Fatalf("unexpected number of calls to Done. want=%d have=%d", c2, value)
+		}
+	}
+
+	// missing all jobs, but they're less than UnreportedMaxAge
+	clock.Advance(time.Second / 2)
+	if err := handler.heartbeat(context.Background(), "deadbeef", []int{}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	if err := handler.heartbeat(context.Background(), "deadveal", []int{}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	assertDoneCounts(0, 0)
+
+	// missing no jobs
+	clock.Advance(time.Minute * 2)
+	if err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 42}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	if err := handler.heartbeat(context.Background(), "deadveal", []int{42, 43}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	assertDoneCounts(0, 0)
+
+	// missing one deadbeef jobs
+	clock.Advance(time.Minute * 2)
+	if err := handler.heartbeat(context.Background(), "deadbeef", []int{41}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	if err := handler.heartbeat(context.Background(), "deadveal", []int{42, 43}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	assertDoneCounts(0, 1)
+
+	// missing two deadveal jobs
+	clock.Advance(time.Minute * 2)
+	if err := handler.heartbeat(context.Background(), "deadbeef", []int{41}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	if err := handler.heartbeat(context.Background(), "deadveal", []int{}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	}
+	assertDoneCounts(1, 2)
+}
+
+func TestCleanup(t *testing.T) {
+	store1 := workerstoremocks.NewMockStore()
+	store2 := workerstoremocks.NewMockStore()
+	recordTransformer := func(record workerutil.Record) (apiclient.Job, error) {
+		return apiclient.Job{ID: record.RecordID()}, nil
+	}
+
+	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 41}, store1, true, nil)
+	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store1, true, nil)
+	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store2, true, nil)
+	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 43}, store2, true, nil)
+
+	options := Options{
+		QueueOptions: map[string]QueueOptions{
+			"q1": {Store: store1, RecordTransformer: recordTransformer},
+			"q2": {Store: store2, RecordTransformer: recordTransformer},
+		},
+		MaximumNumTransactions: 10,
+		DeathThreshold:         time.Minute * 5,
+	}
+	clock := glock.NewMockClock()
+	handler := newHandler(options, clock)
+
+	_, dequeued1, _ := handler.dequeue(context.Background(), "q1", "deadbeef")
+	_, dequeued2, _ := handler.dequeue(context.Background(), "q1", "deadveal")
+	_, dequeued3, _ := handler.dequeue(context.Background(), "q2", "deadbeef")
+	_, dequeued4, _ := handler.dequeue(context.Background(), "q2", "deadveal")
+	if !dequeued1 || !dequeued2 || !dequeued3 || !dequeued4 {
+		t.Fatalf("failed to dequeue records")
+	}
+
+	for i := 0; i < 6; i++ {
+		clock.Advance(time.Minute)
+
+		if err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 42}); err != nil {
+			t.Fatalf("unexpected error performing heartbeat: %s", err)
+		}
+	}
+
+	if err := handler.cleanup(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing cleanup: %s", err)
+	}
+
+	if value := len(store1.DoneFunc.History()); value != 1 {
+		t.Fatalf("unexpected number of calls to Done. want=%d have=%d", 1, value)
+	}
+	if value := len(store2.DoneFunc.History()); value != 1 {
+		t.Fatalf("unexpected number of calls to Done. want=%d have=%d", 1, value)
+	}
+}

--- a/enterprise/internal/apiworker/apiserver/routes.go
+++ b/enterprise/internal/apiworker/apiserver/routes.go
@@ -1,0 +1,134 @@
+package apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
+)
+
+func (h *handler) setupRoutes(router *mux.Router) {
+	var names []string
+	for queueName := range h.options.QueueOptions {
+		names = append(names, regexp.QuoteMeta(queueName))
+	}
+
+	routes := map[string]func(w http.ResponseWriter, r *http.Request){
+		"dequeue":        h.handleDequeue,
+		"setLogContents": h.handleSetLogContents,
+		"markComplete":   h.handleMarkComplete,
+		"markErrored":    h.handleMarkErrored,
+	}
+	for path, handler := range routes {
+		router.Path(fmt.Sprintf("/{queueName:(?:%s)}/%s", strings.Join(names, "|"), path)).Methods("POST").HandlerFunc(handler)
+	}
+
+	router.Path("/heartbeat").Methods("POST").HandlerFunc(h.handleHeartbeat)
+}
+
+// POST /{queueName}/dequeue
+func (h *handler) handleDequeue(w http.ResponseWriter, r *http.Request) {
+	var payload apiclient.DequeueRequest
+
+	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+		job, dequeued, err := h.dequeue(r.Context(), mux.Vars(r)["queueName"], payload.ExecutorName)
+		if !dequeued {
+			return http.StatusNoContent, nil, err
+		}
+
+		return http.StatusOK, job, err
+	})
+}
+
+// POST /{queueName}/setLogContents
+func (h *handler) handleSetLogContents(w http.ResponseWriter, r *http.Request) {
+	var payload apiclient.SetLogRequest
+
+	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+		err := h.setLogContents(r.Context(), mux.Vars(r)["queueName"], payload.ExecutorName, payload.JobID, payload.Contents)
+		return http.StatusNoContent, nil, err
+	})
+}
+
+// POST /{queueName}/markComplete
+func (h *handler) handleMarkComplete(w http.ResponseWriter, r *http.Request) {
+	var payload apiclient.MarkCompleteRequest
+
+	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+		err := h.markComplete(r.Context(), mux.Vars(r)["queueName"], payload.ExecutorName, payload.JobID)
+		if err == ErrUnknownJob {
+			return http.StatusNotFound, nil, nil
+		}
+
+		return http.StatusNoContent, nil, err
+	})
+}
+
+// POST /{queueName}/markErrored
+func (h *handler) handleMarkErrored(w http.ResponseWriter, r *http.Request) {
+	var payload apiclient.MarkErroredRequest
+
+	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+		err := h.markErrored(r.Context(), mux.Vars(r)["queueName"], payload.ExecutorName, payload.JobID, payload.ErrorMessage)
+		if err == ErrUnknownJob {
+			return http.StatusNotFound, nil, nil
+		}
+
+		return http.StatusNoContent, nil, err
+	})
+}
+
+// POST /heartbeat
+func (h *handler) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	var payload apiclient.HeartbeatRequest
+
+	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+		err := h.heartbeat(r.Context(), payload.ExecutorName, payload.JobIDs)
+		return http.StatusNoContent, nil, err
+	})
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// wrapHandler decodes the request body into the given payload pointer, then calls the given
+// handler function. If the body cannot be decoded, a 400 BadRequest is returned and the handler
+// function is not called. If the handler function returns an error, a 500 Internal Server Error
+// is returned. Otherwise, the response status will match the status code value returned from the
+// handler, and the payload value returned from the handler is encoded and written to the
+// response body.
+func (h *handler) wrapHandler(w http.ResponseWriter, r *http.Request, payload interface{}, handler func() (int, interface{}, error)) {
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to unmarshal payload: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	status, payload, err := handler()
+	if err != nil {
+		log15.Error("Handler returned an error", "err", err)
+
+		status = http.StatusInternalServerError
+		payload = errorResponse{Error: err.Error()}
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log15.Error("Failed to serialize payload", "err", err)
+		http.Error(w, fmt.Sprintf("Failed to serialize payload: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(status)
+
+	if status != http.StatusNoContent {
+		_, _ = io.Copy(w, bytes.NewReader(data))
+	}
+}

--- a/enterprise/internal/apiworker/apiserver/server.go
+++ b/enterprise/internal/apiworker/apiserver/server.go
@@ -1,0 +1,28 @@
+package apiserver
+
+import (
+	"context"
+
+	"github.com/efritz/glock"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/httpserver"
+)
+
+// NewServer returns an HTTP job queue server.
+func NewServer(options Options) goroutine.BackgroundRoutine {
+	handler := newHandler(options, glock.NewRealClock())
+
+	return goroutine.CombinedRoutine{
+		httpserver.New(options.Port, handler.setupRoutes),
+		goroutine.NewPeriodicGoroutine(context.Background(), options.CleanupInterval, &handlerWrapper{handler}),
+	}
+}
+
+type handlerWrapper struct{ handler *handler }
+
+var _ goroutine.Handler = &handlerWrapper{}
+
+func (hw *handlerWrapper) Handle(ctx context.Context) error { return hw.handler.cleanup(ctx) }
+func (hw *handlerWrapper) HandleError(err error)            { log15.Error("Failed to requeue jobs", "err", err) }
+func (hw *handlerWrapper) OnShutdown()                      { hw.handler.shutdown() }

--- a/enterprise/internal/codeintel/store/indexes.go
+++ b/enterprise/internal/codeintel/store/indexes.go
@@ -97,6 +97,8 @@ func scanFirstIndexRecord(rows *sql.Rows, err error) (workerutil.Record, bool, e
 	return scanFirstIndex(rows, err)
 }
 
+var ScanFirstIndexRecord = scanFirstIndexRecord
+
 // GetIndexByID returns an index by its identifier and boolean flag indicating its existence.
 func (s *store) GetIndexByID(ctx context.Context, id int) (Index, bool, error) {
 	return scanFirstIndex(s.Store.Query(ctx, sqlf.Sprintf(`
@@ -318,6 +320,8 @@ var indexColumnsWithNullRank = []*sqlf.Query{
 	sqlf.Sprintf(`u.outfile`),
 	sqlf.Sprintf("NULL"),
 }
+
+var IndexColumnsWithNullRank = indexColumnsWithNullRank
 
 // SetIndexLogContents updates the log contents fo the index.
 func (s *store) SetIndexLogContents(ctx context.Context, indexID int, contents string) error {


### PR DESCRIPTION
**Note**: There are actually only 886 SLOC in this PR. The rest are test, mocks, and dev plumbing scripts.

This PR extracts the relevant behaviors from the precise-code-intel-indexer service which is not specific to the _scheduling_ of code intelligence jobs.

**The general idea** is to have a generic queue API with the following endpoints:

- /{queueName}/dequeue attempts to select and lock a row in the database within a transaction which is held for a long time. This job is returned and all subsequent interaction with the queue for this job will specify its ID in the request body.
- /{queueName}/setLogContents sets the log contents for a job record being held by the client.
- /{queueName}/markCompleted marks the job record being held by the client as complete and commits the txn.
- /{queueName}/markErrored marks the job record being held by the client as errored and commits the txn.
- /{queueName}/heartbeat provides a list of jobs being processed by the executor so that we can reconcile orphaned jobs on the executor side and prevents us from holding transactions for job dequeued by executors which have become unresponsive.

In order for this to be fully generic, we define a `Job` type, and install a transformer on the response side of the API specific to a queue. This will allow codeintel, campaigns, and other future users to transform some type of rich database object into a generic job which can be understood by the downstream completely-generic executor process.

This closes https://github.com/sourcegraph/sourcegraph/issues/14834.