### PR TITLE
Configure better Percy widths

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,0 +1,5 @@
+version: 1
+snapshot:
+  widths:
+    - 960 # Half-width browser window (e.g. docked to the side next to an editor)
+    - 1920 # Full-width browser window


### PR DESCRIPTION
Before, we were capturing only desktop and mobile. Mobile is way less important than half-width.