### PR TITLE
extsvc: replace `http.DefaultClient` with `httpcli.ExternalDoer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- The `file:` added to the search field when navigating to a tree or file view will now behave correctly when the file path contains spaces. [#12296](https://github.com/sourcegraph/sourcegraph/issues/12296).
+- The `file:` added to the search field when navigating to a tree or file view will now behave correctly when the file path contains spaces. [#12296](https://github.com/sourcegraph/sourcegraph/issues/12296)
+- OAuth login now respects site configuration `experimentalFeatures: { "tls.external": {...} }` for custom certificates and skipping TLS verify. [#14144](https://github.com/sourcegraph/sourcegraph/issues/14144)
 
 ### Removed
 

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -59,7 +59,7 @@ type Client struct {
 // required to be set before calling any APIs.
 func NewClient(apiURL *url.URL, httpClient httpcli.Doer) *Client {
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = httpcli.ExternalDoer()
 	}
 
 	httpClient = requestCounter.Doer(httpClient, func(u *url.URL) string {

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -14,11 +14,12 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"golang.org/x/time/rate"
 )
 
 var requestCounter = metrics.NewRequestMeter("bitbucket_cloud_requests_count", "Total number of requests sent to the Bitbucket Cloud API.")

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -22,12 +22,13 @@ import (
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/pkg/errors"
 	"github.com/segmentio/fasthash/fnv1"
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/time/rate"
 )
 
 var requestCounter = metrics.NewRequestMeter("bitbucket", "Total number of requests sent to the Bitbucket API.")

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -91,7 +91,7 @@ func NewClient(c *schema.BitbucketServerConnection, httpClient httpcli.Doer) (*C
 	}
 
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = httpcli.ExternalDoer()
 	}
 	httpClient = requestCounter.Doer(httpClient, categorize)
 

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -128,7 +128,7 @@ func newRepoCache(apiURL *url.URL, token string) *rcache.Cache {
 func NewClient(apiURL *url.URL, token string, cli httpcli.Doer) *Client {
 	apiURL = canonicalizedURL(apiURL)
 	if gitHubDisable {
-		cli = disabledClient{}
+		cli = httpcli.ExternalDoer()
 	}
 	if cli == nil {
 		cli = http.DefaultClient

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -129,10 +129,10 @@ func newRepoCache(apiURL *url.URL, token string) *rcache.Cache {
 func NewClient(apiURL *url.URL, token string, cli httpcli.Doer) *Client {
 	apiURL = canonicalizedURL(apiURL)
 	if gitHubDisable {
-		cli = httpcli.ExternalDoer()
+		cli = disabledClient{}
 	}
 	if cli == nil {
-		cli = http.DefaultClient
+		cli = httpcli.ExternalDoer()
 	}
 
 	cli = requestCounter.Doer(cli, func(u *url.URL) string {

--- a/internal/extsvc/github/client.go
+++ b/internal/extsvc/github/client.go
@@ -21,13 +21,14 @@ import (
 	"github.com/graphql-go/graphql/language/parser"
 	"github.com/graphql-go/graphql/language/visitor"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"golang.org/x/time/rate"
 )
 
 var (

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"golang.org/x/time/rate"
 )
 
 var (
@@ -78,7 +79,7 @@ type CommonOp struct {
 
 func NewClientProvider(baseURL *url.URL, cli httpcli.Doer) *ClientProvider {
 	if cli == nil {
-		cli = http.DefaultClient
+		cli = httpcli.ExternalDoer()
 	}
 	cli = requestCounter.Doer(cli, func(u *url.URL) string {
 		// The 3rd component of the Path (/api/v4/XYZ) mostly maps to the type of API


### PR DESCRIPTION
`httpcli.ExternalDoer` respects `tls.external` settings from our site config where `http.DefaultClient` does not.

Fixes #14144
