### PR TITLE
Clean up extension registry page

### DIFF
--- a/client/branded/src/global-styles/web-content.scss
+++ b/client/branded/src/global-styles/web-content.scss
@@ -62,12 +62,4 @@
     .search-query-link {
         color: var(--body-color);
     }
-
-    .extension-area-link {
-        color: var(--link-color);
-
-        &.active {
-            color: var(--body-color);
-        }
-    }
 }

--- a/client/web/src/extensions/ExtensionsArea.tsx
+++ b/client/web/src/extensions/ExtensionsArea.tsx
@@ -78,9 +78,9 @@ export const ExtensionsArea: React.FunctionComponent<ExtensionsAreaProps> = prop
     }
 
     return (
-        <div className="extensions-area web-content">
+        <div className="extensions-area">
             <Breadcrumbs breadcrumbs={breadcrumbs} location={props.location} />
-            <div className="">
+            <div className="web-content">
                 <ExtensionsAreaHeader
                     {...props}
                     {...context}

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -94,7 +94,13 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                         <div className="extension-area-header__wrapper">
                             <div className="mb-3">
                                 <div className="d-flex align-items-start">
-                                    {iconURL && <img className="extension-area-header__icon mr-2" src={iconURL.href} />}
+                                    {iconURL && (
+                                        <img
+                                            className="extension-area-header__icon mr-2"
+                                            src={iconURL.href}
+                                            aria-hidden="true"
+                                        />
+                                    )}
                                     <div>
                                         <h1 className="d-flex align-items-center mb-0 font-weight-normal">{name}</h1>
                                         {manifest && (manifest.description || isWorkInProgress) && (
@@ -153,7 +159,7 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                                             <li key={label} className="nav-item">
                                                 <NavLink
                                                     to={props.url + to}
-                                                    className="nav-link extension-area-link"
+                                                    className="nav-link"
                                                     activeClassName="active"
                                                     exact={exact}
                                                 >

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.scss
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.scss
@@ -6,4 +6,9 @@
     &__sidebar {
         width: 16rem;
     }
+    &__tag {
+        max-width: 24ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -66,7 +66,7 @@ describe('RegistryExtensionOverviewPage', () => {
             expect(
                 toText(
                     output.findAll(({ props: { className } }) =>
-                        className?.includes('registry-extension-overview-page__categories')
+                        className?.includes('test-registry-extension-categories')
                     )
                 )
             ).toEqual(['Other', 'Programming languages' /* no 'invalid' */])

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -1,6 +1,6 @@
 import { parseISO } from 'date-fns'
 import maxDate from 'date-fns/max'
-import { isObject, truncate } from 'lodash'
+import { isObject } from 'lodash'
 import GithubIcon from 'mdi-react/GithubIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
@@ -64,13 +64,13 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                 <aside className="registry-extension-overview-page__sidebar">
                     {categories && (
                         <div className="mb-3">
-                            <h3 className="mb-0">Categories</h3>
-                            <ul className="list-inline registry-extension-overview-page__categories">
-                                {categories.map((category, index) => (
-                                    <li key={index} className="list-inline-item mb-2 small">
+                            <h3>Categories</h3>
+                            <ul className="list-inline test-registry-extension-categories">
+                                {categories.map(category => (
+                                    <li key={category} className="list-inline-item mb-2">
                                         <Link
                                             to={urlToExtensionsQuery(extensionsQuery({ category }))}
-                                            className="rounded border p-1 btm-sm btn-outline extension-area-link"
+                                            className="btn btn-outline-secondary btn-sm"
                                         >
                                             {category}
                                         </Link>
@@ -81,18 +81,17 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                     )}
                     {this.props.extension.manifest &&
                         !isErrorLike(this.props.extension.manifest) &&
-                        this.props.extension.manifest.tags &&
-                        this.props.extension.manifest.tags.length > 0 && (
+                        this.props.extension.manifest.tags?.length && (
                             <div className="mb-3">
-                                <h3 className="mb-0">Tags</h3>
-                                <ul className="list-inline registry-extension-overview-page__tags">
-                                    {this.props.extension.manifest.tags.map((tag, index) => (
-                                        <li key={index} className="list-inline-item mb-2 small">
+                                <h3>Tags</h3>
+                                <ul className="list-inline">
+                                    {this.props.extension.manifest.tags.map(tag => (
+                                        <li key={tag} className="list-inline-item mb-2">
                                             <Link
                                                 to={urlToExtensionsQuery(extensionsQuery({ tag }))}
-                                                className="rounded border p-1 btn-outline btn-sm extension-area-link"
+                                                className="btn btn-outline-secondary btn-sm registry-extension-overview-page__tag"
                                             >
-                                                {truncate(tag, { length: 24 })}
+                                                {tag}
                                             </Link>
                                         </li>
                                     ))}

--- a/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -24,19 +24,17 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
     <div
       className="mb-3"
     >
-      <h3
-        className="mb-0"
-      >
+      <h3>
         Categories
       </h3>
       <ul
-        className="list-inline registry-extension-overview-page__categories"
+        className="list-inline test-registry-extension-categories"
       >
         <li
-          className="list-inline-item mb-2 small"
+          className="list-inline-item mb-2"
         >
           <a
-            className="rounded border p-1 btm-sm btn-outline extension-area-link"
+            className="btn btn-outline-secondary btn-sm"
             href="/extensions?query=category%3AOther"
             onClick={[Function]}
           >
@@ -44,10 +42,10 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
           </a>
         </li>
         <li
-          className="list-inline-item mb-2 small"
+          className="list-inline-item mb-2"
         >
           <a
-            className="rounded border p-1 btm-sm btn-outline extension-area-link"
+            className="btn btn-outline-secondary btn-sm"
             href="/extensions?query=category%3A%22Programming+languages%22"
             onClick={[Function]}
           >
@@ -59,19 +57,17 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
     <div
       className="mb-3"
     >
-      <h3
-        className="mb-0"
-      >
+      <h3>
         Tags
       </h3>
       <ul
-        className="list-inline registry-extension-overview-page__tags"
+        className="list-inline"
       >
         <li
-          className="list-inline-item mb-2 small"
+          className="list-inline-item mb-2"
         >
           <a
-            className="rounded border p-1 btn-outline btn-sm extension-area-link"
+            className="btn btn-outline-secondary btn-sm registry-extension-overview-page__tag"
             href="/extensions?query=tag%3AT1"
             onClick={[Function]}
           >
@@ -79,10 +75,10 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
           </a>
         </li>
         <li
-          className="list-inline-item mb-2 small"
+          className="list-inline-item mb-2"
         >
           <a
-            className="rounded border p-1 btn-outline btn-sm extension-area-link"
+            className="btn btn-outline-secondary btn-sm registry-extension-overview-page__tag"
             href="/extensions?query=tag%3AT2"
             onClick={[Function]}
           >


### PR DESCRIPTION
Cleans up CSS and accessibility issues I found on the registry page.

- Tags were not using `btn-outline-secondary` properly, causing https://github.com/sourcegraph/sourcegraph/pull/14847#issuecomment-712713249 
- Tags were truncated in the DOM, not in CSS, meaning screenreaders would not hear the tag pronounced correctly
- Icon was announced to screen readers with the `data:` URL
- Leftover style in `web-content` (`web-content.scss` should not have any area-specific overrides in it, only global styles.)
- Class names references that don't exist anymore
- CSS class name referenced in test instead of `test-*` class
- React lists were using index as key even though categories are unique

![image](https://user-images.githubusercontent.com/10532611/96580384-7c257e80-12d8-11eb-8aa3-0402b1569f12.png)
