### PR TITLE
Update browser extension icon state on private repositories

### DIFF
--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -15,7 +15,6 @@ import {
     concatMap,
     mapTo,
     catchError,
-    tap,
     distinctUntilChanged,
 } from 'rxjs/operators'
 import addDomainPermissionToggle from 'webext-domain-permission-toggle'

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -47,7 +47,6 @@ initSentry('background')
 
 let customServerOrigins: string[] = []
 
-
 /**
  * For each tab, we store a flag if we know that we are on a private
  * repository. The content script notifies the background page if it's on a
@@ -190,7 +189,7 @@ async function main(): Promise<void> {
     browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         if (changeInfo.status === 'loading') {
             // A new URL is loading in the tab, so clear the cached private repository flag.
-            setTabIsPrivateRepository(tabId, false)
+            tabPrivateRepositoryCache.setTabIsPrivateRepository(tabId, false)
             return
         }
 
@@ -232,7 +231,7 @@ async function main(): Promise<void> {
         ): Promise<void> {
             const tabId = sender.tab?.id
             if (tabId !== undefined) {
-                setTabIsPrivateRepository(tabId, isPrivateRepository)
+                tabPrivateRepositoryCache.setTabIsPrivateRepository(tabId, isPrivateRepository)
             }
             return Promise.resolve()
         },
@@ -415,7 +414,7 @@ function observeCurrentTabId(): Observable<number> {
  * private repository.
  */
 function observeCurrentTabPrivateRepository(): Observable<boolean> {
-    return combineLatest([observeCurrentTabId(), privateRepositoryCacheSubject]).pipe(
+    return combineLatest([observeCurrentTabId(), tabPrivateRepositoryCache.observable]).pipe(
         map(([tabId, privateRepositoryCache]) => !!privateRepositoryCache.get(tabId)),
         distinctUntilChanged()
     )

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -3,7 +3,7 @@ import '../../shared/polyfills'
 
 import { Endpoint } from 'comlink'
 import { without } from 'lodash'
-import { combineLatest, merge, Observable, of, Subscription, timer } from 'rxjs'
+import { combineLatest, merge, Observable, of, Subject, Subscription, timer } from 'rxjs'
 import {
     bufferCount,
     filter,
@@ -15,6 +15,8 @@ import {
     concatMap,
     mapTo,
     catchError,
+    tap,
+    distinctUntilChanged,
 } from 'rxjs/operators'
 import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 import { createExtensionHostWorker } from '../../../../shared/src/api/extension/worker'
@@ -45,6 +47,30 @@ assertEnvironment('BACKGROUND')
 initSentry('background')
 
 let customServerOrigins: string[] = []
+
+/**
+ * For each tab, we store a flag if we know that we are on a private
+ * repository. The content script notifies the background page if it's on a
+ * private repository by `notifyPrivateRepository` message.
+ */
+const tabPrivateRepositoryCache = new Map<number, boolean>()
+const privateRepositoryCacheSubject = new Subject<typeof tabPrivateRepositoryCache>()
+
+/**
+ * Update the background page's cache of which tabs currently contain a private
+ * repository.
+ */
+function setTabIsPrivateRepository(tabId: number, isPrivate: boolean): void {
+    if (!isPrivate) {
+        // An absent value is equivalent to being false; so we can delete it.
+        tabPrivateRepositoryCache.delete(tabId)
+    }
+    tabPrivateRepositoryCache.set(tabId, isPrivate)
+
+    // Emit the updated repository cache when it changes, so that consumers can
+    // observe the value.
+    privateRepositoryCacheSubject.next(tabPrivateRepositoryCache)
+}
 
 const contentScripts = browser.runtime.getManifest().content_scripts
 
@@ -93,12 +119,6 @@ initializeOmniboxInterface(requestGraphQL)
 
 async function main(): Promise<void> {
     const subscriptions = new Subscription()
-    /**
-     * For each tab, we store a flag if we know that we are on a private
-     * repository. The content script notifies the background page if it's on a
-     * private repository by `notifyPrivateRepository` message.
-     */
-    const tabPrivateRepositoryCache = new Map<number, boolean>()
 
     // Open installation page after the extension was installed
     browser.runtime.onInstalled.addListener(event => {
@@ -166,7 +186,7 @@ async function main(): Promise<void> {
     browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         if (changeInfo.status === 'loading') {
             // A new URL is loading in the tab, so clear the cached private repository flag.
-            tabPrivateRepositoryCache.delete(tabId)
+            setTabIsPrivateRepository(tabId, false)
             return
         }
 
@@ -208,7 +228,7 @@ async function main(): Promise<void> {
         ): Promise<void> {
             const tabId = sender.tab?.id
             if (tabId !== undefined) {
-                tabPrivateRepositoryCache.set(tabId, isPrivateRepository)
+                setTabIsPrivateRepository(tabId, isPrivateRepository)
             }
             return Promise.resolve()
         },
@@ -378,6 +398,25 @@ function validateSite(): Observable<boolean> {
     )
 }
 
+/**
+ * Return an observable of the currently active tab id, which changes every time
+ * the user opens or switches to a different tab.
+ */
+function observeCurrentTabId(): Observable<number> {
+    return fromBrowserEvent(browser.tabs.onActivated).pipe(map(([event]) => event.tabId))
+}
+
+/**
+ * Returns an observable that indicates whether the current tab contains a
+ * private repository.
+ */
+function observeCurrentTabPrivateRepository(): Observable<boolean> {
+    return combineLatest([observeCurrentTabId(), privateRepositoryCacheSubject]).pipe(
+        map(([tabId, privateRepositoryCache]) => !!privateRepositoryCache.get(tabId)),
+        distinctUntilChanged()
+    )
+}
+
 function observeSourcegraphUrlValidation(): Observable<boolean> {
     return merge(
         // Whenever the URL was persisted to storage, we can assume it was validated before-hand
@@ -387,17 +426,22 @@ function observeSourcegraphUrlValidation(): Observable<boolean> {
 }
 
 function observeBrowserActionState(): Observable<BrowserActionIconState> {
-    return combineLatest([observeStorageKey('sync', 'disableExtension'), observeSourcegraphUrlValidation()]).pipe(
-        map(([isDisabled, isSourcegraphUrlValid]) => {
+    return combineLatest([
+        observeStorageKey('sync', 'disableExtension'),
+        observeSourcegraphUrlValidation(),
+        observeCurrentTabPrivateRepository(),
+    ]).pipe(
+        map(([isDisabled, isSourcegraphUrlValid, isPrivateRepository]) => {
             if (isDisabled) {
                 return 'inactive'
             }
 
-            if (!isSourcegraphUrlValid) {
+            if (!isSourcegraphUrlValid || isPrivateRepository) {
                 return 'active-with-alert'
             }
 
             return 'active'
-        })
+        }),
+        distinctUntilChanged()
     )
 }

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -72,6 +72,9 @@ const tabPrivateRepositoryCache = (() => {
             // observe the value.
             subject.next(cache)
         },
+        getTabIsPrivateRepository(tabId: number): boolean {
+            return !!cache.get(tabId)
+        },
     }
 })()
 
@@ -237,7 +240,7 @@ async function main(): Promise<void> {
         },
 
         async checkPrivateRepository(tabId: number): Promise<boolean> {
-            return Promise.resolve(!!tabPrivateRepositoryCache.get(tabId))
+            return Promise.resolve(!!tabPrivateRepositoryCache.getTabIsPrivateRepository(tabId))
         },
     }
 


### PR DESCRIPTION
**Summary**

Make browser extension show the alert icon when the user is looking at a private repository. This invites the user to open the options popup, where a message is displayed that indicates the steps to take to use the browser extension on private repositories.

**Implementation**

Update `observeBrowserActionState` to emit `active-with-alert` when the currently active tab is open on a private repository (when the extension is not disabled.) The emitted values of this observable are used to update the icon.

Adds two observables to the background page:

- `observeCurrentTabId()` emits the current active tab id
- `observeCurrentTabPrivateRepository()` emits a boolean flag indicating whether the current active tab contains a private repository.

Also adds a subject that emits the background page's cache of which tabs are open on a private repository: `privateRepositoryCacheSubject`

Now, instead of updating the `tabPrivateRepositoryCache` (a `Map<number, boolean>`) directly when a private repository is detected, the background page calls `setTabIsPrivateRepository` so that the change can be emitted through the subject.



Closes #14867