### PR TITLE
search: fix colon pattern in structural hole

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -74,6 +74,10 @@ func templateToRegexp(buf []byte) []Term {
 		r = next()
 		switch r {
 		case ':':
+			if open > 0 {
+				currentHole = append(currentHole, ':')
+				continue
+			}
 			if len(buf[advance:]) > 0 {
 				r = next()
 				if r == '[' {

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -195,6 +195,11 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 			Pattern: `:[chain~[^(){}\[\],]+\n( +\..*\n)+]`,
 			Want:    `([^(){}\[\],]+\n( +\..*\n)+)`,
 		},
+		{
+			Name:    "Colon regex",
+			Pattern: `:[~:]`,
+			Want:    `(:)`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
Minor fix: `:[~:]` should match a literal colon in structural search. But the regex converter translated this to `(:\])` instead of `(:)`.