### PR TITLE
codeintel: Add an upload store API layer

### DIFF
--- a/enterprise/internal/codeintel/upload_store/config.go
+++ b/enterprise/internal/codeintel/upload_store/config.go
@@ -41,9 +41,6 @@ func (c *Config) loaders() map[string]loader {
 	}
 }
 
-//
-//
-
 type commonConfig struct {
 	// Bucket is the target bucket for LSIF uploads.
 	Bucket string
@@ -51,9 +48,6 @@ type commonConfig struct {
 	// TTL is the maximum age of an upload before deletion in the configured bucket.
 	TTL time.Duration
 }
-
-//
-//
 
 type S3Config struct {
 	commonConfig
@@ -73,9 +67,6 @@ func (c *S3Config) load(parent *env.BaseConfig) {
 	_ = env.Get("AWS_S3_FORCE_PATH_STYLE", "", "If set, S3 virtual host request path are not used. Set this to target a MinIO instance.")
 
 }
-
-//
-//
 
 type GCSConfig struct {
 	commonConfig

--- a/enterprise/internal/codeintel/upload_store/config.go
+++ b/enterprise/internal/codeintel/upload_store/config.go
@@ -1,0 +1,95 @@
+package uploadstore
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+type Config struct {
+	env.BaseConfig
+
+	Backend string
+	S3      S3Config
+	GCS     GCSConfig
+}
+
+func (c *Config) Load() {
+	c.Backend = c.GetOptional(
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND",
+		"The target file service for code intelligence uploads. S3 and GCS are supported.",
+	)
+
+	config, ok := c.loaders()[c.Backend]
+	if !ok {
+		c.AddError(fmt.Errorf("invalid backend %q for PRECISE_CODE_INTEL_UPLOAD_BACKEND: must be S3 or GCS", c.Backend))
+		return
+	}
+
+	config.load(&c.BaseConfig)
+}
+
+type loader interface {
+	load(parent *env.BaseConfig)
+}
+
+func (c *Config) loaders() map[string]loader {
+	return map[string]loader{
+		"S3":  &c.S3,
+		"GCS": &c.GCS,
+	}
+}
+
+//
+//
+
+type commonConfig struct {
+	// Bucket is the target bucket for LSIF uploads.
+	Bucket string
+
+	// TTL is the maximum age of an upload before deletion in the configured bucket.
+	TTL time.Duration
+}
+
+//
+//
+
+type S3Config struct {
+	commonConfig
+}
+
+func (c *S3Config) load(parent *env.BaseConfig) {
+	c.Bucket = parent.Get("PRECISE_CODE_INTEL_UPLOAD_BUCKET", "", "The name of the bucket to store LSIF uploads in.")
+	c.TTL = parent.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TTL", "168h", "The maximum age of an upload before deletion.")
+
+	// Environment variables used by underlying libraries, here for documentation
+	_ = env.Get("AWS_ACCESS_KEY_ID", "", "An AWS access key associated with a user with access to S3.")
+	_ = env.Get("AWS_SECRET_ACCESS_KEY", "", "An AWS secret key associated with a user with access to S3.")
+	_ = env.Get("AWS_SHARED_CREDENTIALS_FILE", " ~/.aws/credentials", "The path to an AWS credentials file.")
+	_ = env.Get("AWS_PROFILE", "default", "The name within the shared credentials file to use.")
+	_ = env.Get("AWS_ENDPOINT", "", "Specifies the URL of the AWS API. Used to target a MinIO instance instead of S3.")
+	_ = env.Get("AWS_REGION", "", "Specifies the AWS Region to send the request to.")
+	_ = env.Get("AWS_S3_FORCE_PATH_STYLE", "", "If set, S3 virtual host request path are not used. Set this to target a MinIO instance.")
+
+}
+
+//
+//
+
+type GCSConfig struct {
+	commonConfig
+
+	// ProjectID specifies the project containing the GCS bucket.
+	ProjectID string
+}
+
+func (c *GCSConfig) load(parent *env.BaseConfig) {
+	c.Bucket = parent.Get("PRECISE_CODE_INTEL_UPLOAD_BUCKET", "", "The name of the bucket to store LSIF uploads in.")
+	c.TTL = parent.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TTL", "168h", "The maximum age of an upload before deletion.")
+	c.ProjectID = parent.Get("PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID", "", "The project containing the GCS bucket.")
+
+	// Environment variables used by underlying libraries, here for documentation
+	_ = env.Get("GOOGLE_APPLICATION_CREDENTIALS", "", "The path to a service account key file with access to GCS.")
+	_ = env.Get("GOOGLE_APPLICATION_CREDENTIALS_JSON", "", "The contents of a service account key file with access to GCS.")
+}

--- a/enterprise/internal/codeintel/upload_store/config.go
+++ b/enterprise/internal/codeintel/upload_store/config.go
@@ -10,15 +10,22 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	Backend string
-	S3      S3Config
-	GCS     GCSConfig
+	Backend      string
+	ManageBucket bool
+	S3           S3Config
+	GCS          GCSConfig
 }
 
 func (c *Config) Load() {
 	c.Backend = c.GetOptional(
 		"PRECISE_CODE_INTEL_UPLOAD_BACKEND",
 		"The target file service for code intelligence uploads. S3 and GCS are supported.",
+	)
+
+	c.ManageBucket = c.GetBool(
+		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET",
+		"true",
+		"Whether or not the client should manage the target bucket configuration.",
 	)
 
 	config, ok := c.loaders()[c.Backend]

--- a/enterprise/internal/codeintel/upload_store/config_test.go
+++ b/enterprise/internal/codeintel/upload_store/config_test.go
@@ -1,0 +1,62 @@
+package uploadstore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigS3(t *testing.T) {
+	env := map[string]string{
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND": "S3",
+		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":  "lsif-uploads",
+		"PRECISE_CODE_INTEL_UPLOAD_TTL":     "8h",
+	}
+
+	config := Config{}
+	config.SetMockGetter(mapGetter(env))
+	config.Load()
+
+	if err := config.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %s", err)
+	}
+
+	if config.S3.Bucket != "lsif-uploads" {
+		t.Errorf("unexpected value for S3.Bucket. want=%s have=%s", "lsif-uploads", config.S3.Bucket)
+	}
+	if config.S3.TTL != 8*time.Hour {
+		t.Errorf("unexpected value for S3.TTL. want=%v have=%v", 8*time.Hour, config.S3.TTL)
+	}
+}
+
+func TestConfigGCS(t *testing.T) {
+	env := map[string]string{
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":        "GCS",
+		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":         "lsif-uploads",
+		"PRECISE_CODE_INTEL_UPLOAD_TTL":            "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID": "test",
+	}
+
+	config := Config{}
+	config.SetMockGetter(mapGetter(env))
+	config.Load()
+
+	if err := config.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %s", err)
+	}
+
+	if config.GCS.Bucket != "lsif-uploads" {
+		t.Errorf("unexpected value for GCS.Bucket. want=%s have=%s", "lsif-uploads", config.GCS.Bucket)
+	}
+	if config.GCS.TTL != 8*time.Hour {
+		t.Errorf("unexpected value for GCS.TTL. want=%v have=%v", 8*time.Hour, config.GCS.TTL)
+	}
+	if config.GCS.ProjectID != "test" {
+		t.Errorf("unexpected value for GCS.ProjectID. want=%s have=%s", "test", config.GCS.ProjectID)
+	}
+}
+
+func mapGetter(env map[string]string) func(name, defaultValue, description string) string {
+	return func(name, defaultValue, description string) string {
+		return env[name]
+	}
+}

--- a/enterprise/internal/codeintel/upload_store/config_test.go
+++ b/enterprise/internal/codeintel/upload_store/config_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestConfigS3(t *testing.T) {
 	env := map[string]string{
-		"PRECISE_CODE_INTEL_UPLOAD_BACKEND": "S3",
-		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":  "lsif-uploads",
-		"PRECISE_CODE_INTEL_UPLOAD_TTL":     "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":       "S3",
+		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":        "lsif-uploads",
+		"PRECISE_CODE_INTEL_UPLOAD_TTL":           "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET": "true",
 	}
 
 	config := Config{}
@@ -33,6 +34,7 @@ func TestConfigGCS(t *testing.T) {
 		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":        "GCS",
 		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":         "lsif-uploads",
 		"PRECISE_CODE_INTEL_UPLOAD_TTL":            "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET":  "true",
 		"PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID": "test",
 	}
 

--- a/enterprise/internal/codeintel/upload_store/gcs.go
+++ b/enterprise/internal/codeintel/upload_store/gcs.go
@@ -2,7 +2,6 @@ package uploadstore
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"time"
@@ -65,14 +64,12 @@ func (s *gcsStore) Upload(ctx context.Context, key string, r io.Reader) (err err
 	defer func() {
 		if closeErr := writer.Close(); closeErr != nil {
 			err = multierror.Append(err, closeErr)
-			fmt.Printf("B %s\n", err)
 		}
 
 		cancel()
 	}()
 
 	_, err = io.Copy(writer, r)
-	fmt.Printf("A %s\n", err)
 	return err
 }
 

--- a/enterprise/internal/codeintel/upload_store/gcs.go
+++ b/enterprise/internal/codeintel/upload_store/gcs.go
@@ -1,0 +1,124 @@
+package uploadstore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/hashicorp/go-multierror"
+	"google.golang.org/api/option"
+)
+
+type gcsStore struct {
+	projectID string
+	bucket    string
+	ttl       time.Duration
+	client    *storage.Client
+}
+
+var _ Store = &gcsStore{}
+
+// newGCSFromConfig creates a new store backed by GCP storage.
+func newGCSFromConfig(ctx context.Context, config *Config) (Store, error) {
+	return newGCS(ctx, config.GCS.ProjectID, config.GCS.Bucket, config.GCS.TTL)
+}
+
+// newGCS creates a new store backed by GCP storage.
+func newGCS(ctx context.Context, projectID, bucket string, ttl time.Duration) (Store, error) {
+	client, err := storage.NewClient(ctx, gcsClientOptions()...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gcsStore{
+		projectID: projectID,
+		bucket:    bucket,
+		ttl:       ttl,
+		client:    client,
+	}, nil
+}
+
+func (s *gcsStore) Init(ctx context.Context) error {
+	if _, err := s.client.Bucket(s.bucket).Attrs(ctx); err != nil {
+		if err != storage.ErrBucketNotExist {
+			return err
+		}
+
+		return s.create(ctx)
+	}
+
+	return s.update(ctx)
+}
+
+func (s *gcsStore) Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error) {
+	return s.client.Bucket(s.bucket).Object(key).NewRangeReader(ctx, skipBytes, -1)
+}
+
+func (s *gcsStore) Upload(ctx context.Context, key string, r io.Reader) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	writer := s.client.Bucket(s.bucket).Object(key).NewWriter(ctx)
+	defer func() {
+		if closeErr := writer.Close(); closeErr != nil {
+			err = multierror.Append(err, closeErr)
+			fmt.Printf("B %s\n", err)
+		}
+
+		cancel()
+	}()
+
+	_, err = io.Copy(writer, r)
+	fmt.Printf("A %s\n", err)
+	return err
+}
+
+func (s *gcsStore) create(ctx context.Context) error {
+	return s.client.Bucket(s.bucket).Create(ctx, s.projectID, &storage.BucketAttrs{
+		Lifecycle: s.lifecycle(),
+	})
+}
+
+func (s *gcsStore) update(ctx context.Context) error {
+	lifecycle := s.lifecycle()
+	_, err := s.client.Bucket(s.bucket).Update(ctx, storage.BucketAttrsToUpdate{
+		Lifecycle: &lifecycle,
+	})
+	return err
+}
+
+func (s *gcsStore) lifecycle() storage.Lifecycle {
+	return storage.Lifecycle{
+		Rules: []storage.LifecycleRule{
+			{
+				Action: storage.LifecycleAction{
+					Type: "Delete",
+				},
+				Condition: storage.LifecycleCondition{
+					AgeInDays: int64(time.Duration(s.ttl) / (time.Hour * 24)),
+				},
+			},
+		},
+	}
+}
+
+// gcsClientOptions returns options used to configure a GCS storage client. If the
+// envvar GOOGLE_APPLICATION_CREDENTIALS is set, it will be used as a path to the GCP
+// credentials file. If the envvar GOOGLE_APPLICATION_CREDENTIALS_JSON is set, it will
+// be used as the JSON payload of a GCP credentials file.
+//
+// See https://cloud.google.com/docs/authentication/production.
+func gcsClientOptions() []option.ClientOption {
+	if value := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); value != "" {
+		return []option.ClientOption{option.WithCredentialsFile(value)}
+	}
+
+	if value := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON"); value != "" {
+		return []option.ClientOption{option.WithCredentialsJSON([]byte(value))}
+	}
+
+	return nil
+}

--- a/enterprise/internal/codeintel/upload_store/s3.go
+++ b/enterprise/internal/codeintel/upload_store/s3.go
@@ -1,0 +1,182 @@
+package uploadstore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+type s3Store struct {
+	bucket   string
+	ttl      time.Duration
+	client   *s3.S3
+	uploader *s3manager.Uploader
+}
+
+var _ Store = &s3Store{}
+
+// newS3FromConfig creates a new store backed by AWS Simple Storage Service.
+func newS3FromConfig(ctx context.Context, config *Config) (Store, error) {
+	return newS3(config.S3.Bucket, config.S3.TTL)
+}
+
+// newS3 creates a new store backed by AWS Simple Storage Service.
+func newS3(bucket string, ttl time.Duration) (Store, error) {
+	sess, err := session.NewSessionWithOptions(awsSessionOptions())
+	if err != nil {
+		return nil, err
+	}
+
+	client := s3.New(sess)
+	uploader := s3manager.NewUploader(sess)
+
+	return &s3Store{
+		bucket:   bucket,
+		ttl:      ttl,
+		client:   client,
+		uploader: uploader,
+	}, nil
+}
+
+func (s *s3Store) Init(ctx context.Context) error {
+	if err := s.create(ctx); err != nil {
+		return err
+	}
+
+	return s.update(ctx)
+}
+
+func (s *s3Store) Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error) {
+	var bytesRange *string
+	if skipBytes > 0 {
+		bytesRange = aws.String(fmt.Sprintf("bytes=%d-", skipBytes))
+	}
+
+	resp, err := s.client.GetObjectWithContext(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Range:  bytesRange,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+func (s *s3Store) Upload(ctx context.Context, key string, r io.Reader) error {
+	_, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Body:   r,
+	})
+
+	return err
+}
+
+func (s *s3Store) create(ctx context.Context) error {
+	createRequest := &s3.CreateBucketInput{
+		Bucket: aws.String(s.bucket),
+	}
+
+	if _, err := s.client.CreateBucketWithContext(ctx, createRequest); err != nil {
+		aerr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+
+		codes := []string{
+			s3.ErrCodeBucketAlreadyExists,
+			s3.ErrCodeBucketAlreadyOwnedByYou,
+		}
+
+		found := false
+		for _, code := range codes {
+			if aerr.Code() == code {
+				found = true
+			}
+		}
+		if !found {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *s3Store) update(ctx context.Context) error {
+	configureRequest := &s3.PutBucketLifecycleConfigurationInput{
+		Bucket:                 aws.String(s.bucket),
+		LifecycleConfiguration: s.lifecycle(),
+	}
+
+	_, err := s.client.PutBucketLifecycleConfiguration(configureRequest)
+	return err
+}
+
+func (s *s3Store) lifecycle() *s3.BucketLifecycleConfiguration {
+	return &s3.BucketLifecycleConfiguration{
+		Rules: []*s3.LifecycleRule{
+			{
+				ID: aws.String("Expiration Rule"),
+				Filter: &s3.LifecycleRuleFilter{
+					Prefix: aws.String(""),
+				},
+				Expiration: &s3.LifecycleExpiration{
+					Days: aws.Int64(int64(time.Duration(s.ttl) / (time.Hour * 24))),
+				},
+				Status: aws.String("Enabled"),
+			},
+		},
+	}
+}
+
+// awsSessionOptions returns the session used to configure the AWS SDK client.
+//
+// Authentication of the client will first prefer environment variables, then will
+// fall back to a credentials file on disk. The following envvars specify an access
+// and secret key, respectively.
+//
+// - AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
+// - AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
+//
+// If these variables are unset, then the client will read the credentails file at
+// the path specified by AWS_SHARED_CREDENTIALS_FILE, or ~/.aws/credentials if not
+// specified. The envvar AWS_PROFILE can be used to specify a non-default profile
+// within the credentails file.
+//
+// To specify a non-default region or endpoint, supply the envvars AWS_REGION and
+// AWS_ENDPOINT, respectively.
+func awsSessionOptions() session.Options {
+	return session.Options{
+		Config: aws.Config{
+			Credentials: credentials.NewCredentials(&credentials.ChainProvider{
+				Providers: []credentials.Provider{
+					&credentials.EnvProvider{},
+					&credentials.SharedCredentialsProvider{},
+				},
+				VerboseErrors: true,
+			}),
+			Endpoint:         awsEnv("AWS_ENDPOINT"),
+			Region:           awsEnv("AWS_REGION"),
+			S3ForcePathStyle: aws.Bool(os.Getenv("AWS_S3_FORCE_PATH_STYLE") != ""),
+		},
+	}
+}
+
+func awsEnv(name string) *string {
+	if value := os.Getenv(name); value != "" {
+		return aws.String(value)
+	}
+
+	return nil
+}

--- a/enterprise/internal/codeintel/upload_store/store.go
+++ b/enterprise/internal/codeintel/upload_store/store.go
@@ -1,0 +1,46 @@
+package uploadstore
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// Store is an expiring key/value store backed by a managed blob store.
+type Store interface {
+	// Init ensures that the underlying target bucket exists and has the expected ACL
+	// and lifecycle configuration.
+	Init(ctx context.Context) error
+
+	// Get returns a reader that streams the content of the object at the given key.
+	// If a positive skipBytes is supplied, the reader will begin reading at that byte
+	// offset.
+	Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error)
+
+	// Upload writes the content in the given reader to the object at the given key.
+	Upload(ctx context.Context, key string, r io.Reader) error
+}
+
+var storeConstructors = map[string]func(ctx context.Context, config *Config) (Store, error){
+	"S3":  newS3FromConfig,
+	"GCS": newGCSFromConfig,
+}
+
+// Create initialize a new store from the given configuration.
+func Create(ctx context.Context, config *Config) (Store, error) {
+	newStore, ok := storeConstructors[config.Backend]
+	if !ok {
+		return nil, fmt.Errorf("unknown upload store backend '%s'", config.Backend)
+	}
+
+	store, err := newStore(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := store.Init(ctx); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	cloud.google.com/go/bigquery v1.6.0 // indirect
 	cloud.google.com/go/pubsub v1.3.1
+	cloud.google.com/go/storage v1.6.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
@@ -13,6 +14,7 @@ require (
 	github.com/aphistic/sweet-junit v0.2.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774
+	github.com/aws/aws-sdk-go v1.29.15
 	github.com/aws/aws-sdk-go-v2 v0.20.0
 	github.com/beevik/etree v1.1.0
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
@@ -188,7 +190,7 @@ require (
 	golang.org/x/sys v0.0.0-20200915084602-288bc346aa39
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.0.0-20200915031644-64986481280e
-	google.golang.org/api v0.29.0 // indirect
+	google.golang.org/api v0.29.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200413115906-b5235f65be36 // indirect
 	google.golang.org/grpc v1.31.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,7 @@ github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774/go.mod h1:5wi5YYOp
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.29.15 h1:0ms/213murpsujhsnxnNKNeVouW60aJqSd992Ks3mxs=
 github.com/aws/aws-sdk-go v1.29.15/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v0.20.0 h1:/yefUjgMrda9PNFwWctBU63nL10CJMdBwkAmaQ4w4Hs=
@@ -1257,8 +1258,6 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20201013124050-0f9dde474446 h1:gjd6ySuHTIaEp2HmT37LJBG6Y2ppxV8dWp3jL2PEL9E=
-github.com/sourcegraph/zoekt v0.0.0-20201013124050-0f9dde474446/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/sourcegraph/zoekt v0.0.0-20201016122840-58ac958bfd1d h1:IG0ewsN3MgowOucyP84n+d/nXe6JGZf9q4+0Ohvue84=
 github.com/sourcegraph/zoekt v0.0.0-20201016122840-58ac958bfd1d/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This closes https://github.com/sourcegraph/sourcegraph/issues/14823.

This creates a persistence layer that will eventually replace the bundle manager's final remaining task: uploading and downloading byte ranges of an LSIF upload. This persistence layer works with 

- GCS, given credentials in the Google Way ™️ 
- S3, given credentials in the Amazon Way ™️ 
- MinIO, given credentials similar to S3 (requires additional vars `AWS_ENDPOINT` and `S3_FORCE_PATH_STYLE`)

For each of these layers, I've hand-verified that:

- the configured bucket is created on client creation if it doesn't exist
- the library does not freak out if the bucket already exists (the APIs for GCS and S3 are asymmetric here)
- each bucket is created with an expiration lifecycle so that objects older than the configured age are automatically deleted
- the expiration lifecycle is recreated if it's deleted or changed (this allows us to change the expiry configuration at runtime without operator intervention)
- buckets are created with sane default (non-public) ACLs
- file content can be uploaded and read back (in full and in chunks)

Unfortunately I found these hard to unit-test, as we're really just writing a compatibility layer on top of a pair of libraries. We could mock them out but I don't know what we get out of that. All of the configuration code was tested (and did find a reference/value-type bug!).

Tips for this are welcome, but I'm confident of the current code.