### PR TITLE
Add meta tag for color-scheme

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -75,6 +75,9 @@ $text-muted: var(--text-muted);
     --merged: #{$merged};
 }
 .theme-light {
+    // Affects default browser styles
+    color-scheme: light;
+
     --body-color: #{$gray-19};
     --body-bg: #fbfdff;
     --color-bg-1: #ffffff;
@@ -91,6 +94,9 @@ $text-muted: var(--text-muted);
     --sourcegraph-logo-text-color: #242427;
 }
 .theme-dark {
+    // Affects default browser styles
+    color-scheme: dark;
+
     --secondary: #{$secondary};
     --border-color: #{$gray-19};
     --border-color-2: #1b1730;

--- a/client/browser/src/browser-extension/ThemeWrapper.tsx
+++ b/client/browser/src/browser-extension/ThemeWrapper.tsx
@@ -13,7 +13,9 @@ export function ThemeWrapper({
     const [isLightTheme, setIsLightTheme] = useState(!darkThemeMediaList.matches)
 
     useEffect(() => {
-        darkThemeMediaList.addListener(event => setIsLightTheme(!event.matches))
+        const listener = (event: MediaQueryListEvent): void => setIsLightTheme(!event.matches)
+        darkThemeMediaList.addEventListener('change', listener)
+        return () => darkThemeMediaList.removeEventListener('change', listener)
     }, [darkThemeMediaList])
 
     useEffect(() => {

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -288,7 +288,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
     public componentDidMount(): void {
         updateUserSessionStores()
 
-        document.body.classList.add('theme')
+        document.documentElement.classList.add('theme')
 
         this.subscriptions.add(
             combineLatest([from(this.platformContext.settings), authenticatedUser.pipe(startWith(null))]).subscribe(
@@ -343,15 +343,13 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
 
     public componentWillUnmount(): void {
         this.subscriptions.unsubscribe()
-        document.body.classList.remove('theme')
-        document.body.classList.remove('theme-light')
-        document.body.classList.remove('theme-dark')
+        document.documentElement.classList.remove('theme', 'theme-light', 'theme-dark')
     }
 
     public componentDidUpdate(): void {
         localStorage.setItem(LIGHT_THEME_LOCAL_STORAGE_KEY, this.state.themePreference)
-        document.body.classList.toggle('theme-light', this.isLightTheme())
-        document.body.classList.toggle('theme-dark', !this.isLightTheme())
+        document.documentElement.classList.toggle('theme-light', this.isLightTheme())
+        document.documentElement.classList.toggle('theme-dark', !this.isLightTheme())
     }
 
     private toggleSearchMode = (event: React.MouseEvent<HTMLAnchorElement>): void => {

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { hot } from 'react-hot-loader/root'
 import { Route } from 'react-router'
 import { BrowserRouter } from 'react-router-dom'
-import { combineLatest, from, fromEventPattern, Subscription, fromEvent, of } from 'rxjs'
+import { combineLatest, from, Subscription, fromEvent, of } from 'rxjs'
 import { startWith, switchMap } from 'rxjs/operators'
 import { setLinkComponent } from '../../shared/src/components/Link'
 import {
@@ -308,11 +308,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
 
         // React to OS theme change
         this.subscriptions.add(
-            fromEventPattern<MediaQueryListEvent>(
-                // Need to use addListener() because addEventListener() is not supported yet in Safari
-                handler => this.darkThemeMediaList.addListener(handler),
-                handler => this.darkThemeMediaList.removeListener(handler)
-            ).subscribe(event => {
+            fromEvent<MediaQueryListEvent>(this.darkThemeMediaList, 'change').subscribe(event => {
                 this.setState({ systemIsLightTheme: !event.matches })
             })
         )

--- a/cmd/frontend/internal/app/templates/ui/app.html
+++ b/cmd/frontend/internal/app/templates/ui/app.html
@@ -9,7 +9,7 @@
 	<meta http-equiv="Content-Language" content="en">
 	<meta name="viewport" content="width=device-width, viewport-fit=cover" />
 	<meta name="referrer" content="origin-when-cross-origin"/>
-    <meta name="color-scheme" content="light dark"/>
+	<meta name="color-scheme" content="light dark"/>
 	{{with .Metadata}}
 	<meta name='description' content="{{.Description}}" />
 		{{if .ShowPreview}}

--- a/cmd/frontend/internal/app/templates/ui/app.html
+++ b/cmd/frontend/internal/app/templates/ui/app.html
@@ -9,6 +9,7 @@
 	<meta http-equiv="Content-Language" content="en">
 	<meta name="viewport" content="width=device-width, viewport-fit=cover" />
 	<meta name="referrer" content="origin-when-cross-origin"/>
+    <meta name="color-scheme" content="light dark"/>
 	{{with .Metadata}}
 	<meta name='description' content="{{.Description}}" />
 		{{if .ShowPreview}}


### PR DESCRIPTION
This prevents flashing a white background when reloading the page in dark mode and lets the browser pick better default styles, e.g. for forms.
It also gives browser extensions adding dark modes to pages the ability to detect we have native dark mode and they shouldn't modify it.

More info: https://web.dev/prefers-color-scheme/

Also updates usage of deprecated APIs and moves the theme to `<html>`/`:root` instead of `<body>`.

I tested manually in Chrome, Firefox and Safari that theme switching and auto-theme-switching still work. 

cc @sqs you may want to copy this for doc, handbook and about.