### PR TITLE
licensing: enforce repository permissions

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/db"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -31,6 +34,25 @@ type Resolver struct {
 	}
 }
 
+// checkLicense returns a user-facing error if the ACLs feature is not purchased
+// with the current license or any error occurred while validating the licence.
+func (r *Resolver) checkLicense() error {
+	if !licensing.EnforceTiers {
+		return nil
+	}
+
+	err := licensing.CheckFeature(licensing.FeatureACLs)
+	if err != nil {
+		if licensing.IsFeatureNotActivated(err) {
+			return err
+		}
+
+		log15.Error("authz.Resolver.checkLicense", "err", err)
+		return errors.New("Unable to check license feature, please refer to logs for actual error message.")
+	}
+	return nil
+}
+
 func NewResolver(db dbutil.DB, clock func() time.Time) graphqlbackend.AuthzResolver {
 	return &Resolver{
 		store:             edb.NewPermsStore(db, clock),
@@ -39,6 +61,10 @@ func NewResolver(db dbutil.DB, clock func() time.Time) graphqlbackend.AuthzResol
 }
 
 func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *graphqlbackend.RepoPermsArgs) (*graphqlbackend.EmptyResponse, error) {
+	if err := r.checkLicense(); err != nil {
+		return nil, err
+	}
+
 	// 🚨 SECURITY: Only site admins can mutate repository permissions.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
@@ -128,6 +154,10 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 }
 
 func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *graphqlbackend.RepositoryIDArgs) (*graphqlbackend.EmptyResponse, error) {
+	if err := r.checkLicense(); err != nil {
+		return nil, err
+	}
+
 	// 🚨 SECURITY: Only site admins can query repository permissions.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
@@ -148,6 +178,10 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 }
 
 func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphqlbackend.UserIDArgs) (*graphqlbackend.EmptyResponse, error) {
+	if err := r.checkLicense(); err != nil {
+		return nil, err
+	}
+
 	// 🚨 SECURITY: Only site admins can query repository permissions.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -41,7 +41,7 @@ func (r *Resolver) checkLicense() error {
 		return nil
 	}
 
-	err := licensing.CheckFeature(licensing.FeatureACLs)
+	err := licensing.Check(licensing.FeatureACLs)
 	if err != nil {
 		if licensing.IsFeatureNotActivated(err) {
 			return err

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -22,7 +22,7 @@ func init() {
 func extensionRegistryViewerPublishers(ctx context.Context) ([]graphqlbackend.RegistryPublisher, error) {
 	// The feature check here makes it so the any "New extension" form will show an error, so the
 	// user finds out before trying to submit the form that the feature is disabled.
-	if err := licensing.CheckFeature(licensing.FeatureExtensionRegistry); err != nil {
+	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/registry/registry_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/registry_graphql.go
@@ -36,7 +36,7 @@ func registryExtensionByIDInt32(ctx context.Context, id int32) (graphqlbackend.R
 }
 
 func extensionRegistryCreateExtension(ctx context.Context, args *graphqlbackend.ExtensionRegistryCreateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
-	if err := licensing.CheckFeature(licensing.FeatureExtensionRegistry); err != nil {
+	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func extensionRegistryDeleteExtension(ctx context.Context, args *graphqlbackend.
 }
 
 func extensionRegistryPublishExtension(ctx context.Context, args *graphqlbackend.ExtensionRegistryPublishExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
-	if err := licensing.CheckFeature(licensing.FeatureExtensionRegistry); err != nil {
+	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -625,7 +625,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 		//	- This is not purchased with the current license
 		if globals.PermissionsUserMapping().Enabled ||
 			len(s.providersByServiceID()) == 0 ||
-			(licensing.EnforceTiers && licensing.CheckFeature(licensing.FeatureACLs) != nil) {
+			(licensing.EnforceTiers && licensing.Check(licensing.FeatureACLs) != nil) {
 			continue
 		}
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/db"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -618,9 +619,13 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 			return
 		}
 
-		// Skip if permissions user mapping is enabled or no authz provider is configured
+		// Skip if:
+		// 	- Permissions user mapping is enabled
+		// 	- No authz provider is configured
+		//	- This is not purchased with the current license
 		if globals.PermissionsUserMapping().Enabled ||
-			len(s.providersByServiceID()) == 0 {
+			len(s.providersByServiceID()) == 0 ||
+			(licensing.EnforceTiers && licensing.CheckFeature(licensing.FeatureACLs) != nil) {
 			continue
 		}
 

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -17,12 +17,12 @@ var EnforceTiers, _ = strconv.ParseBool(env.Get("SRC_ENFORCE_TIERS", "false", "E
 // Feature is a product feature that is selectively activated based on the current license key.
 type Feature string
 
-// CheckFeature checks whether the feature is activated based on the current license. If it is
+// Check checks whether the feature is activated based on the current license. If it is
 // disabled, it returns a non-nil error.
 //
 // The returned error may implement errcode.PresentationError to indicate that it can be displayed
 // directly to the user. Use IsFeatureNotActivated to distinguish between the error reasons.
-func CheckFeature(feature Feature) error {
+func Check(feature Feature) error {
 	if MockCheckFeature != nil {
 		return MockCheckFeature(feature)
 	}
@@ -54,10 +54,10 @@ func checkFeature(info *Info, feature Feature) error {
 	return nil // feature is activated for current license
 }
 
-// MockCheckFeature is for mocking CheckFeature in tests.
+// MockCheckFeature is for mocking Check in tests.
 var MockCheckFeature func(feature Feature) error
 
-// TestingSkipFeatureChecks is for tests that want to mock CheckFeature to always return nil (i.e.,
+// TestingSkipFeatureChecks is for tests that want to mock Check to always return nil (i.e.,
 // behave as though the current license enables all features).
 //
 // It returns a cleanup func so callers can use `defer TestingSkipFeatureChecks()()` in a test body.
@@ -76,7 +76,7 @@ type featureNotActivatedError struct{ errcode.PresentationError }
 // IsFeatureNotActivated reports whether err indicates that the license is valid but does not
 // activate the feature.
 //
-// It is used to distinguish between the multiple reasons for errors from CheckFeature: either
+// It is used to distinguish between the multiple reasons for errors from Check: either
 // failed license verification, or a valid license that does not activate a feature (e.g.,
 // Enterprise Starter not including an Enterprise-only feature).
 func IsFeatureNotActivated(err error) bool {
@@ -98,5 +98,5 @@ func IsFeatureNotActivated(err error) bool {
 // prevented from getting to this point if license verification had failed, so it's not necessary to
 // handle license verification errors here).
 func IsFeatureEnabledLenient(feature Feature) bool {
-	return !IsFeatureNotActivated(CheckFeature(feature))
+	return !IsFeatureNotActivated(Check(feature))
 }

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -2,11 +2,17 @@ package licensing
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
+
+// EnforceTiers is a temporary flag to indicate whether to enforce new license tier constraints defined in
+// RFC 167 to incrementally merge changes into main branch, we'll remove it once fully implemented the RFC.
+var EnforceTiers, _ = strconv.ParseBool(env.Get("SRC_ENFORCE_TIERS", "false", "Enforce license tier constraints defined in RFC 167"))
 
 // Feature is a product feature that is selectively activated based on the current license key.
 type Feature string


### PR DESCRIPTION
This PR:
1. Adds `SRC_ENFORCE_TIERS` env var, see docstring for detailed explanation.
1. Guards write paths of permissions with license check: GraphQL endpoints for explicit permissions and PermsSyncer for mirroring permissions.

Fixes #14025