### PR TITLE
Fix SetClonedRepos

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -339,7 +339,7 @@ func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver
 	doSync := func() {
 		cloned, err := gitserverClient.ListCloned(ctx)
 		if err != nil {
-			log15.Warn("failed to update git fetch scheduler with list of cloned repositories", "error", err)
+			log15.Warn("failed to fetch list of cloned repositories", "error", err)
 			return
 		}
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -356,7 +356,7 @@ func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver
 		doSync()
 		select {
 		case <-ctx.Done():
-		case <-time.After(10 * time.Second):
+		case <-time.After(30 * time.Second):
 		}
 	}
 }


### PR DESCRIPTION
The temporary table seems to make the query hang forever whenever we reach about 100k repos in it.
This PR uses the previous query as it seems to not have this issue. This will fix the problem while we figure out what was wrong with the current query.
Fixes #14938 