### PR TITLE
licensing: make product name recognize new plan tags

### DIFF
--- a/enterprise/internal/licensing/tags.go
+++ b/enterprise/internal/licensing/tags.go
@@ -1,6 +1,10 @@
 package licensing
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
+)
 
 const (
 	// TrueUpUserCountTag is the license tag that indicates that the licensed user count can be
@@ -27,10 +31,25 @@ func ProductNameWithBrand(hasLicense bool, licenseTags []string) string {
 	baseName := "Sourcegraph Enterprise"
 	var name string
 
-	if hasTag("team") {
+	info := &Info{
+		Info: license.Info{
+			Tags: licenseTags,
+		},
+	}
+	plan := info.Plan()
+	// Identify known plans first
+	switch {
+	case strings.HasPrefix(string(plan), "team-"):
 		baseName = "Sourcegraph Team"
-	} else if hasTag("starter") {
-		name = " Starter"
+	case strings.HasPrefix(string(plan), "enterprise-"):
+		baseName = "Sourcegraph Enterprise"
+
+	default:
+		if hasTag("team") {
+			baseName = "Sourcegraph Team"
+		} else if hasTag("starter") {
+			name = " Starter"
+		}
 	}
 
 	var misc []string

--- a/enterprise/internal/licensing/tags_test.go
+++ b/enterprise/internal/licensing/tags_test.go
@@ -22,11 +22,24 @@ func TestProductNameWithBrand(t *testing.T) {
 		{hasLicense: true, licenseTags: []string{"starter", "dev"}, want: "Sourcegraph Enterprise Starter (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"starter", "trial", "dev"}, want: "Sourcegraph Enterprise Starter (trial, dev use only)"},
 		{hasLicense: true, licenseTags: []string{"trial", "dev"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
+
 		{hasLicense: true, licenseTags: []string{"team"}, want: "Sourcegraph Team"},
 		{hasLicense: true, licenseTags: []string{"starter", "team"}, want: "Sourcegraph Team"}, // Team should overrule the old Starter plan
 		{hasLicense: true, licenseTags: []string{"team", "trial"}, want: "Sourcegraph Team (trial)"},
 		{hasLicense: true, licenseTags: []string{"team", "dev"}, want: "Sourcegraph Team (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"team", "dev", "trial"}, want: "Sourcegraph Team (trial, dev use only)"},
+
+		{hasLicense: true, licenseTags: []string{"plan:team-0"}, want: "Sourcegraph Team"},
+		{hasLicense: true, licenseTags: []string{"plan:team-0", "starter"}, want: "Sourcegraph Team"}, // Team should overrule the old Starter plan
+		{hasLicense: true, licenseTags: []string{"plan:team-0", "trial"}, want: "Sourcegraph Team (trial)"},
+		{hasLicense: true, licenseTags: []string{"plan:team-0", "dev"}, want: "Sourcegraph Team (dev use only)"},
+		{hasLicense: true, licenseTags: []string{"plan:team-0", "dev", "trial"}, want: "Sourcegraph Team (trial, dev use only)"},
+
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-0"}, want: "Sourcegraph Enterprise"},
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "starter"}, want: "Sourcegraph Enterprise"}, // Enterprise should overrule the old Starter plan
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "trial"}, want: "Sourcegraph Enterprise (trial)"},
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "dev"}, want: "Sourcegraph Enterprise (dev use only)"},
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "dev", "trial"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("hasLicense=%v licenseTags=%v", test.hasLicense, test.licenseTags), func(t *testing.T) {


### PR DESCRIPTION
New plan tags were added in https://github.com/sourcegraph/sourcegraph/commit/af4b27f5c0ffb4822316f6a33d09b5e6e52f0ea6 but our product name function hasn't been updated to recognize them.