### PR TITLE
oauth: use service ID + client ID as the provider config ID

### DIFF
--- a/enterprise/cmd/frontend/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/auth/oauth/provider.go
@@ -36,7 +36,7 @@ func getProvider(serviceType, id string) *Provider {
 
 func (p *Provider) ConfigID() providers.ConfigID {
 	return providers.ConfigID{
-		ID:   p.ServiceID,
+		ID:   p.OAuth2Config.ClientID,
 		Type: p.ServiceType,
 	}
 }
@@ -82,8 +82,8 @@ type ProviderOp struct {
 func NewProvider(op ProviderOp) *Provider {
 	return &Provider{
 		ProviderOp: op,
-		Login:      stateHandler(true, op.ServiceID, op.StateConfig, op.Login),
-		Callback:   stateHandler(false, op.ServiceID, op.StateConfig, op.Callback),
+		Login:      stateHandler(true, op.OAuth2Config.ClientID, op.StateConfig, op.Login),
+		Callback:   stateHandler(false, op.OAuth2Config.ClientID, op.StateConfig, op.Callback),
 	}
 }
 

--- a/enterprise/cmd/frontend/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/auth/oauth/provider.go
@@ -36,7 +36,7 @@ func getProvider(serviceType, id string) *Provider {
 
 func (p *Provider) ConfigID() providers.ConfigID {
 	return providers.ConfigID{
-		ID:   p.OAuth2Config.ClientID,
+		ID:   p.ServiceID + "::" + p.OAuth2Config.ClientID,
 		Type: p.ServiceType,
 	}
 }
@@ -80,10 +80,11 @@ type ProviderOp struct {
 }
 
 func NewProvider(op ProviderOp) *Provider {
+	providerID := op.ServiceID + "::" + op.OAuth2Config.ClientID
 	return &Provider{
 		ProviderOp: op,
-		Login:      stateHandler(true, op.OAuth2Config.ClientID, op.StateConfig, op.Login),
-		Callback:   stateHandler(false, op.OAuth2Config.ClientID, op.StateConfig, op.Callback),
+		Login:      stateHandler(true, providerID, op.StateConfig, op.Login),
+		Callback:   stateHandler(false, providerID, op.StateConfig, op.Callback),
 	}
 }
 


### PR DESCRIPTION
We used to use `ServiceID` (e.g. `https://github.com/`) as the unique config ID for a given OAuth provider. However it is possible that two auth providers both pointing to GitHub.com but as two different OAuth applications (e.g. GitHub and GitHub Enterprise Cloud).

This PR uses combination of  `<service ID>::<client ID>` as the unique config ID for a given OAuth provider. 

Fixes #14204