### PR TITLE
fix: Fix server upgrade from 3.20 -> 3.21

### DIFF
--- a/cmd/server/shared/copy.go
+++ b/cmd/server/shared/copy.go
@@ -117,6 +117,12 @@ func (e *execer) Run(cmd *exec.Cmd) {
 	e.err = cmd.Run()
 }
 
+func (e *execer) FilterError(match string) {
+	if e.err != nil && strings.Contains(e.err.Error(), match) {
+		e.err = nil
+	}
+}
+
 // Error returns the first error encountered.
 func (e execer) Error() error {
 	return e.err

--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -99,6 +99,7 @@ func postgresProcfile() (string, error) {
 		e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-o -c listen_addresses=127.0.0.1", "-l", "/tmp/pgsql.log", "-w", "start")
 		for _, database := range databases {
 			e.Command("su-exec", "postgres", "createdb", database)
+			e.Command("touch", filepath.Join(markersPath, database))
 		}
 		e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-m", "fast", "-l", "/tmp/pgsql.log", "-w", "stop")
 		if err := e.Error(); err != nil {
@@ -132,6 +133,7 @@ func postgresProcfile() (string, error) {
 			e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-o -c listen_addresses=127.0.0.1", "-l", "/tmp/pgsql.log", "-w", "start")
 			for _, database := range missingDatabases {
 				e.Command("su-exec", "postgres", "createdb", database)
+				e.Command("touch", filepath.Join(markersPath, database))
 			}
 			e.Command("su-exec", "postgres", "pg_ctl", "-D", path, "-m", "fast", "-l", "/tmp/pgsql.log", "-w", "stop")
 			if err := e.Error(); err != nil {


### PR DESCRIPTION
I broke the 3.20 -> 3.21 server upgrade by adding the creation of an extra database but only when the pgsql data directory did not exist. This misses the condition where a frontend database exists from a 3.20 version, but a codeintel database does not. This should close https://github.com/sourcegraph/sourcegraph/issues/14941.

**Summary of changes:**

Add a directory where we touch files after creating a database. On startup, if we're missing an expected file we can create only that database.

Alternatively, I tried to issue a `createdb` call, but that would require that we always start up the postgres instance on startup, then shut it down, even if we don't need to do so. It also required some nasty string comparison of the command output to skip the already exists error.

**Clean:**

```
$ docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:dev
✱ Sourcegraph is initializing the internal database... (may take 15-20 seconds)
16:28:09      repo-updater | t=2020-10-21T16:28:09+0000 lvl=warn msg="No encryption initialized"
16:28:09   zoekt-webserver | 2020/10/21 16:28:09 listening on 127.0.0.1:3070
16:28:18          frontend | t=2020-10-21T16:28:18+0000 lvl=warn msg="No encryption initialized"
16:28:18          frontend | Jaeger URL from env  http://127.0.0.1:16686
16:28:18          frontend | ✱ Sourcegraph is ready at: http://127.0.0.1:7080
```

**Upgrade:**

```
$ docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.20.0
✱ Sourcegraph is initializing the internal database... (may take 15-20 seconds)
16:27:07                          frontend | ✱ Sourcegraph is ready at: http://127.0.0.1:7080

$ docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:dev
✱ Sourcegraph is creating missing databases sourcegraph-codeintel... (may take 15-20 seconds)
16:27:32   zoekt-webserver | 2020/10/21 16:27:32 listening on 127.0.0.1:3070
16:27:32      repo-updater | t=2020-10-21T16:27:32+0000 lvl=warn msg="No encryption initialized"
16:27:37          frontend | t=2020-10-21T16:27:37+0000 lvl=warn msg="No encryption initialized"
16:27:37          frontend | Jaeger URL from env  http://127.0.0.1:16686
16:27:37          frontend | ✱ Sourcegraph is ready at: http://127.0.0.1:7080
```