### PR TITLE
pin latest version of build image

### DIFF
--- a/docker-images/postgres-11.4/build.sh
+++ b/docker-images/postgres-11.4/build.sh
@@ -7,5 +7,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/postgres-11.4:20-04-07_56b20163@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
-docker tag index.docker.io/sourcegraph/postgres-11.4:20-04-07_56b20163@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad "$IMAGE"
+docker pull index.docker.io/sourcegraph/postgres-11.4:20-10-21_9ae31d46@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+docker tag index.docker.io/sourcegraph/postgres-11.4:20-10-21_9ae31d46@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97 "$IMAGE"


### PR DESCRIPTION
Pin new build of postgres to remidate CVE-2019-18218 raised in sourcegraph/customer#115
