### PR TITLE
e2e: use yarn generate

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -13,7 +13,6 @@ steps:
   # setting to pass until tests are 100% confirmed as working, so as to avoid disruting dev workflow on main
   command:
     - .buildkite/test.sh sourcegraph-e2e || true
-  timeout_in_minutes: 20
   label: ':docker::arrow_right::chromium:'
   agents:
     queue: 'baremetal'

--- a/test/e2e/smoke-test.sh
+++ b/test/e2e/smoke-test.sh
@@ -9,8 +9,8 @@ Xvfb "$DISPLAY" -screen 0 1280x1024x24 &
 x11vnc -display "$DISPLAY" -forever -rfbport 5900 >/x11vnc.log 2>&1 &
 
 asdf install
-yarn upgrade
-
+yarn
+yarn generate
 pushd enterprise
 ./cmd/server/pre-build.sh
 ./cmd/server/build.sh

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
 set -x
 
 # shellcheck disable=SC1091
@@ -11,9 +11,9 @@ x11vnc -display "$DISPLAY" -forever -rfbport 5900 >/x11vnc.log 2>&1 &
 asdf install
 yarn
 yarn generate
-pushd enterprise
+pushd enterprise || exit
 ./cmd/server/pre-build.sh
 ./cmd/server/build.sh
-popd
+popd || exit
 ./dev/ci/e2e.sh
 docker image rm -f "${IMAGE}"

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
-set -exo pipefail
+set -x
 
 # shellcheck disable=SC1091
 source /root/.profile

--- a/test/servers.yaml
+++ b/test/servers.yaml
@@ -11,15 +11,4 @@
   shell_commands:
     - |
        cd /sourcegraph
-       Xvfb "$DISPLAY" -screen 0 1280x1024x24 &
-       x11vnc -display "$DISPLAY" -forever -rfbport 5900 >/x11vnc.log 2>&1 &
-
-       asdf install
-       yarn upgrade
-
-       pushd enterprise
-       ./cmd/server/pre-build.sh
-       ./cmd/server/build.sh
-       popd
-       ./dev/ci/e2e.sh
-       docker image rm -f "${IMAGE}"
+       ./test/e2e/test.sh


### PR DESCRIPTION
`yarn upgrade` was incorrectly leftover from testing. `yarn generate` is the correct usage here. 