### PR TITLE
e2e: destroy dangling vagrant boxes

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -7,6 +7,8 @@ env:
   TAG: '${BUILDKITE_BUILD_NUMBER}_${BUILDKITE_RETRY_COUNT}'
   COVERAGE_INSTRUMENT: 'true'
   VAGRANT_RUN_ENV: 'CI'
+  VAGRANT_DOTFILE_PATH: "/var/lib"
+  VAGRANT_DOTFILE_PATH: "/var/lib/buildkite/builds/$BUILDKITE_AGENT_NAME/vagrant.d"
 
 steps:
 - artifact_paths: ./*.png;./e2e.mp4;./ffmpeg.log

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -16,6 +16,9 @@ for i in "${plugins[@]}"; do
   fi
 done
 
+# Destroy dangling vagrant box from previous run if the previous run didn't exit cleanly
+vagrant destroy -f "$box"
+
 vagrant up "$box" --provider=google || exit_code=$?
 vagrant scp "$box":/sourcegraph/puppeteer/*.png ../
 vagrant scp "$box":/sourcegraph/e2e.mp4 ../


### PR DESCRIPTION
This PR moves the `.vagrant` directory to a shared location for each agent, so whenever a e2e run occurs on that agent, it will attempt to clean up if any dangling boxes were left behind from a previous cancelled or failed run. 

Closes #14582