### PR TITLE
authz: add `TouchRepoPermissions` API

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -295,7 +295,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	// return a nil error and log a warning message.
 	if apiErr, ok := err.(*github.APIError); ok && apiErr.Code == http.StatusNotFound {
 		log15.Warn("PermsSyncer.syncRepoPerms.ignoreUnauthorizedAPIError", "repoID", repo.ID, "err", err, "suggestion", "GitHub access token user may only have read access to the repository, but needs write for permissions")
-		return nil
+		return s.permsStore.TouchRepoPermissions(ctx, int32(repoID))
 	}
 
 	if err != nil {

--- a/enterprise/internal/db/integration_test.go
+++ b/enterprise/internal/db/integration_test.go
@@ -26,6 +26,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"LoadRepoPermissions", testPermsStore_LoadRepoPermissions(db)},
 		{"SetUserPermissions", testPermsStore_SetUserPermissions(db)},
 		{"SetRepoPermissions", testPermsStore_SetRepoPermissions(db)},
+		{"TouchRepoPermissions", testPermsStore_TouchRepoPermissions(db)},
 		{"LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
 		{"SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
 		{"ListPendingUsers", testPermsStore_ListPendingUsers(db)},

--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -130,15 +130,15 @@ AND permission = %s
 //
 // Table states for input:
 // 	"user_permissions":
-//   user_id | permission | object_type |  object_ids  | object_ids_ints | updated_at | synced_at
-//  ---------+------------+-------------+--------------+-----------------+------------+-----------
-//         1 |       read |       repos | bitmap{1, 2} |          {1, 2} |      NOW() |     NOW()
+//   user_id | permission | object_type | object_ids_ints | updated_at | synced_at
+//  ---------+------------+-------------+-----------------+------------+-----------
+//         1 |       read |       repos |          {1, 2} |      NOW() |     NOW()
 //
 //  "repo_permissions":
-//   repo_id | permission | user_ids  | user_ids_ints | updated_at |  synced_at
-//  ---------+------------+-----------+---------------+------------+-------------
-//         1 |       read | bitmap{1} |           {1} |      NOW() | <Unchanged>
-//         2 |       read | bitmap{1} |           {1} |      NOW() | <Unchanged>
+//   repo_id | permission | user_ids_ints | updated_at |  synced_at
+//  ---------+------------+---------------+------------+-------------
+//         1 |       read |           {1} |      NOW() | <Unchanged>
+//         2 |       read |           {1} |      NOW() | <Unchanged>
 func (s *PermsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermissions) (err error) {
 	if Mocks.Perms.SetUserPermissions != nil {
 		return Mocks.Perms.SetUserPermissions(ctx, p)
@@ -282,15 +282,15 @@ DO UPDATE SET
 //
 // Table states for input:
 // 	"user_permissions":
-//   user_id | permission | object_type | object_ids | object_ids_ints | updated_at |  synced_at
-//  ---------+------------+-------------+------------+-----------------+------------+-------------
-//         1 |       read |       repos |  bitmap{1} |             {1} |      NOW() | <Unchanged>
-//         2 |       read |       repos |  bitmap{1} |             {1} |      NOW() | <Unchanged>
+//   user_id | permission | object_type | object_ids_ints | updated_at |  synced_at
+//  ---------+------------+-------------+-----------------+------------+-------------
+//         1 |       read |       repos |             {1} |      NOW() | <Unchanged>
+//         2 |       read |       repos |             {1} |      NOW() | <Unchanged>
 //
 //  "repo_permissions":
-//   repo_id | permission |   user_ids   | user_ids_ints | updated_at | synced_at
-//  ---------+------------+--------------+---------------+------------+-----------
-//         1 |       read | bitmap{1, 2} |        {1, 2} |      NOW() |     NOW()
+//   repo_id | permission | user_ids_ints | updated_at | synced_at
+//  ---------+------------+---------------+------------+-----------
+//         1 |       read |        {1, 2} |      NOW() |     NOW()
 func (s *PermsStore) SetRepoPermissions(ctx context.Context, p *authz.RepoPermissions) (err error) {
 	if Mocks.Perms.SetRepoPermissions != nil {
 		return Mocks.Perms.SetRepoPermissions(ctx, p)

--- a/enterprise/internal/db/perms_store_mock.go
+++ b/enterprise/internal/db/perms_store_mock.go
@@ -15,6 +15,7 @@ type MockPerms struct {
 	SetUserPermissions           func(ctx context.Context, p *authz.UserPermissions) error
 	SetRepoPermissions           func(ctx context.Context, p *authz.RepoPermissions) error
 	SetRepoPendingPermissions    func(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) error
+	TouchRepoPermissions         func(ctx context.Context, repoID int32) (err error)
 	ListPendingUsers             func(ctx context.Context) ([]string, error)
 	ListExternalAccounts         func(ctx context.Context, userID int32) ([]*extsvc.Account, error)
 	GetUserIDsByExternalAccounts func(ctx context.Context, accounts *extsvc.Accounts) (map[string]int32, error)

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -656,7 +656,12 @@ func testPermsStore_TouchRepoPermissions(db *sql.DB) func(*testing.T) {
 			cleanupPermsTables(t, s)
 		})
 
-		// Set up test permissions
+		// Touch is an upsert
+		if err := s.TouchRepoPermissions(context.Background(), 1); err != nil {
+			t.Fatal(err)
+		}
+
+		// Set up some permissions
 		rp := &authz.RepoPermissions{
 			RepoID:  1,
 			Perm:    authz.Read,

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -646,6 +646,49 @@ func testPermsStore_SetRepoPermissions(db *sql.DB) func(*testing.T) {
 	}
 }
 
+func testPermsStore_TouchRepoPermissions(db *sql.DB) func(*testing.T) {
+	return func(t *testing.T) {
+		now := time.Now().Truncate(time.Microsecond).Unix()
+		s := NewPermsStore(db, func() time.Time {
+			return time.Unix(atomic.LoadInt64(&now), 0).Truncate(time.Microsecond)
+		})
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
+		})
+
+		// Set up test permissions
+		rp := &authz.RepoPermissions{
+			RepoID:  1,
+			Perm:    authz.Read,
+			UserIDs: toBitmap(2),
+		}
+		if err := s.SetRepoPermissions(context.Background(), rp); err != nil {
+			t.Fatal(err)
+		}
+
+		// Touch the permissions in an hour late
+		now += 3600
+		if err := s.TouchRepoPermissions(context.Background(), 1); err != nil {
+			t.Fatal(err)
+		}
+
+		// Permissions bits shouldn't be affected
+		rp = &authz.RepoPermissions{
+			RepoID: 1,
+			Perm:   authz.Read,
+		}
+		if err := s.LoadRepoPermissions(context.Background(), rp); err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "rp.UserIDs", []int{2}, bitmapToArray(rp.UserIDs))
+
+		// Both times should be updated to "now"
+		if rp.UpdatedAt.Unix() != now || rp.SyncedAt.Unix() != now {
+			t.Fatal("UpdatedAt or SyncedAt was not updated but supposed to")
+		}
+	}
+}
+
 func testPermsStore_LoadUserPendingPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("no matching with different account ID", func(t *testing.T) {


### PR DESCRIPTION
Quoting from docstring:

```
// TouchRepoPermissions only updates the value of both `updated_at` and `synced_at` columns of the
// `repo_permissions` table without modifying the permissions bits. It inserts a new row when the
// row does not yet exist. The use case is to trick the scheduler to skip the repository for syncing
// permissions when we can't sync permissions for the repository (e.g. due to insufficient permissions
// of the access token).
```

_Easier to review by commit._

Tested end-to-end.

Fixes #14701