### PR TITLE
Fix how imported-but-not-found changesets are displayed

### DIFF
--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -37,13 +37,12 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                     rel="noopener noreferrer"
                     className="mr-2"
                 >
-                    {isImporting(node) && (
+                    {(isImporting(node) || importingFailed(node)) && (
                         <>
                             Importing changeset
                             {node.externalID && <> #{node.externalID} </>}
                         </>
                     )}
-                    {importingFailed(node) && <>#{node.externalID}</>}
                     {!isImporting(node) && !importingFailed(node) && (
                         <>
                             {node.title}
@@ -86,6 +85,6 @@ function isImporting(node: ExternalChangesetFields): boolean {
     )
 }
 
-export function importingFailed(node: ExternalChangesetFields): boolean {
+function importingFailed(node: ExternalChangesetFields): boolean {
     return node.reconcilerState === ChangesetReconcilerState.ERRORED && !node.title
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -43,7 +43,8 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                             {node.externalID && <> #{node.externalID} </>}
                         </>
                     )}
-                    {!isImporting(node) && (
+                    {importingFailed(node) && <>#{node.externalID}</>}
+                    {!isImporting(node) && !importingFailed(node) && (
                         <>
                             {node.title}
                             {node.externalID && <> (#{node.externalID}) </>}
@@ -83,4 +84,8 @@ function isImporting(node: ExternalChangesetFields): boolean {
         [ChangesetReconcilerState.QUEUED, ChangesetReconcilerState.PROCESSING].includes(node.reconcilerState) &&
         !node.title
     )
+}
+
+export function importingFailed(node: ExternalChangesetFields): boolean {
+    return node.reconcilerState === ChangesetReconcilerState.ERRORED && !node.title
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
@@ -172,6 +172,7 @@ add('Importing', () => {
                                 url: 'http://test.test/sourcegraph/sourcegraph',
                             },
                             reviewState: null,
+                            currentSpec: null,
                         }}
                         viewerCanAdminister={boolean('viewerCanAdminister', true)}
                         queryExternalChangesetWithFileDiffs={() =>
@@ -216,6 +217,7 @@ add('Importing', () => {
                                 url: 'http://test.test/sourcegraph/sourcegraph',
                             },
                             reviewState: null,
+                            currentSpec: null,
                         }}
                         viewerCanAdminister={boolean('viewerCanAdminister', true)}
                         queryExternalChangesetWithFileDiffs={() =>

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
@@ -145,55 +145,86 @@ add('Importing', () => {
     return (
         <EnterpriseWebStory>
             {props => (
-                <ExternalChangesetNode
-                    {...props}
-                    node={{
-                        __typename: 'ExternalChangeset',
-                        id: 'somechangeset',
-                        updatedAt: now.toISOString(),
-                        nextSyncAt: null,
-                        externalState: null,
-                        // No title yet, still importing.
-                        title: null,
-                        reconcilerState: ChangesetReconcilerState.QUEUED,
-                        publicationState: ChangesetPublicationState.PUBLISHED,
-                        error: null,
-                        body: null,
-                        checkState: null,
-                        createdAt: now.toISOString(),
-                        externalID: '12345',
-                        externalURL: null,
-                        diffStat: {
-                            added: 10,
-                            changed: 20,
-                            deleted: 8,
-                        },
-                        labels: [],
-                        repository: {
-                            id: 'repoid',
-                            name: 'github.com/sourcegraph/sourcegraph',
-                            url: 'http://test.test/sourcegraph/sourcegraph',
-                        },
-                        reviewState: null,
-                        currentSpec: { id: 'spec-rand-id-1' },
-                    }}
-                    viewerCanAdminister={boolean('viewerCanAdminister', true)}
-                    queryExternalChangesetWithFileDiffs={() =>
-                        of({
-                            diff: {
-                                __typename: 'PreviewRepositoryComparison',
-                                fileDiffs: {
-                                    nodes: [],
-                                    totalCount: 0,
-                                    pageInfo: {
-                                        endCursor: null,
-                                        hasNextPage: false,
+                <>
+                    <ExternalChangesetNode
+                        {...props}
+                        node={{
+                            __typename: 'ExternalChangeset',
+                            id: 'somechangeset',
+                            updatedAt: now.toISOString(),
+                            nextSyncAt: null,
+                            externalState: null,
+                            // No title yet, still importing.
+                            title: null,
+                            reconcilerState: ChangesetReconcilerState.QUEUED,
+                            publicationState: ChangesetPublicationState.PUBLISHED,
+                            error: null,
+                            body: null,
+                            checkState: null,
+                            createdAt: now.toISOString(),
+                            externalID: '12345',
+                            externalURL: null,
+                            diffStat: null,
+                            labels: [],
+                            repository: {
+                                id: 'repoid',
+                                name: 'github.com/sourcegraph/sourcegraph',
+                                url: 'http://test.test/sourcegraph/sourcegraph',
+                            },
+                            reviewState: null,
+                        }}
+                        viewerCanAdminister={boolean('viewerCanAdminister', true)}
+                        queryExternalChangesetWithFileDiffs={() =>
+                            of({
+                                diff: {
+                                    __typename: 'PreviewRepositoryComparison',
+                                    fileDiffs: {
+                                        nodes: [],
+                                        totalCount: 0,
+                                        pageInfo: {
+                                            endCursor: null,
+                                            hasNextPage: false,
+                                        },
                                     },
                                 },
+                            })
+                        }
+                    />
+                    <ExternalChangesetNode
+                        {...props}
+                        node={{
+                            __typename: 'ExternalChangeset',
+                            id: 'somechangeset-2',
+                            updatedAt: now.toISOString(),
+                            nextSyncAt: null,
+                            externalState: null,
+                            // No title yet, because it wasn't found.
+                            title: null,
+                            reconcilerState: ChangesetReconcilerState.ERRORED,
+                            publicationState: ChangesetPublicationState.PUBLISHED,
+                            error: 'Changeset with external ID 99999 not found',
+                            body: null,
+                            checkState: null,
+                            createdAt: now.toISOString(),
+                            externalID: '99999',
+                            externalURL: null,
+                            diffStat: null,
+                            labels: [],
+                            repository: {
+                                id: 'repoid',
+                                name: 'github.com/sourcegraph/sourcegraph',
+                                url: 'http://test.test/sourcegraph/sourcegraph',
                             },
-                        })
-                    }
-                />
+                            reviewState: null,
+                        }}
+                        viewerCanAdminister={boolean('viewerCanAdminister', true)}
+                        queryExternalChangesetWithFileDiffs={() =>
+                            of({
+                                diff: null,
+                            })
+                        }
+                    />
+                </>
             )}
         </EnterpriseWebStory>
     )


### PR DESCRIPTION
This changes the ExternalChangesetInfoCell to not show the `()` when the
changeset couldn't be found.

It also updates the story to include an imported-but-not-found changeset
and makes them more accurate by setting `diff: null`.

@eseliger I tried my best. Would appreciate a Zoom call if you have suggestions for improvements.