### PR TITLE
Fix externalURLs alert logic

### DIFF
--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.test.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.test.tsx
@@ -4,11 +4,11 @@ import { mount } from 'enzyme'
 import { noop } from 'lodash'
 
 describe('InstallBrowserExtensionAlert', () => {
-    const serviceTypes = ['github', 'gitlab', 'phabricator', 'bitbucketServer'] as const
+    const serviceTypes = ['github', 'gitlab', 'phabricator', 'bitbucketServer', null] as const
     const integrationTypes = ['Chrome', 'non-Chrome', 'native integration'] as const
     for (const serviceType of serviceTypes) {
         for (const integrationType of integrationTypes) {
-            test(`${serviceType} (${integrationType})`, () => {
+            test(`${serviceType ?? 'none'} (${integrationType})`, () => {
                 expect(
                     mount(
                         <InstallBrowserExtensionAlert
@@ -17,13 +17,17 @@ describe('InstallBrowserExtensionAlert', () => {
                             codeHostIntegrationMessaging={
                                 integrationType === 'native integration' ? 'native-integration' : 'browser-extension'
                             }
-                            externalURLs={[
-                                {
-                                    __typename: 'ExternalLink',
-                                    url: '',
-                                    serviceType,
-                                },
-                            ]}
+                            externalURLs={
+                                serviceType
+                                    ? [
+                                          {
+                                              __typename: 'ExternalLink',
+                                              url: '',
+                                              serviceType,
+                                          },
+                                      ]
+                                    : []
+                            }
                         />
                     )
                 ).toMatchSnapshot()

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -14,23 +14,24 @@ interface Props {
 // TODO(tj): Add Firefox once the Firefox extension is back
 const CHROME_EXTENSION_STORE_LINK = 'https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack'
 
+/** Code hosts the browser extension supports */
+const supportedServiceTypes = new Set<string>(['github', 'gitlab', 'phabricator', 'bitbucketServer'])
+
 export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
     onAlertDismissed,
     externalURLs,
     isChrome,
     codeHostIntegrationMessaging,
 }) => {
-    const { serviceType } = externalURLs[0]
+    const externalLink = externalURLs.find(link => link.serviceType && supportedServiceTypes.has(link.serviceType))
+    if (!externalLink) {
+        return null
+    }
+
+    const { serviceType } = externalLink
     const { displayName, icon } = serviceTypeDisplayNameAndIcon(serviceType)
 
     const Icon = icon || ExportIcon
-
-    const copyCore =
-        serviceType === 'phabricator'
-            ? 'while browsing and reviewing code'
-            : isChrome
-            ? `to ${serviceType === 'gitlab' ? 'MR' : 'PR'}s and file views`
-            : `while browsing files and reading ${serviceType === 'gitlab' ? 'MR' : 'PR'}s`
 
     return (
         <div className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert">
@@ -53,7 +54,7 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
                                 Learn more
                             </a>{' '}
                             or{' '}
-                            <a className="alert-link" href={externalURLs[0].url} target="_blank" rel="noopener">
+                            <a className="alert-link" href={externalLink.url} target="_blank" rel="noopener">
                                 try it out
                             </a>
                         </>
@@ -67,11 +68,30 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
                             >
                                 Install the Sourcegraph browser extension
                             </a>{' '}
-                            to add code intelligence {copyCore} on {displayName} or any other connected code host.
+                            to add code intelligence{' '}
+                            {serviceType === 'github' ||
+                            serviceType === 'bitbucketServer' ||
+                            serviceType === 'gitlab' ? (
+                                <>to {serviceType === 'gitlab' ? 'merge requests' : 'pull requests'} and file views</>
+                            ) : (
+                                <>while browsing and reviewing code</>
+                            )}{' '}
+                            on {displayName}.
                         </>
                     ) : (
                         <>
-                            Get code intelligence {copyCore} on {displayName} or any other connected code host.{' '}
+                            Get code intelligence{' '}
+                            {serviceType === 'github' ||
+                            serviceType === 'bitbucketServer' ||
+                            serviceType === 'gitlab' ? (
+                                <>
+                                    while browsing files and reviewing{' '}
+                                    {serviceType === 'gitlab' ? 'merge requests' : 'pull requests'}
+                                </>
+                            ) : (
+                                <>while browsing and reviewing code</>
+                            )}{' '}
+                            on {displayName}.{' '}
                             <a
                                 href="/help/integration/browser_extension"
                                 target="_blank"

--- a/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
+++ b/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
@@ -43,11 +43,15 @@ exports[`InstallBrowserExtensionAlert bitbucketServer (Chrome) 1`] = `
           Install the Sourcegraph browser extension
         </a>
          
-        to add code intelligence 
-        to PRs and file views
-         on 
+        to add code intelligence
+         
+        to 
+        pull requests
+         and file views
+         
+        on 
         Bitbucket Server
-         or any other connected code host.
+        .
       </p>
     </div>
     <button
@@ -171,11 +175,15 @@ exports[`InstallBrowserExtensionAlert bitbucketServer (non-Chrome) 1`] = `
       <p
         className="install-browser-extension-alert__text my-0 mr-3"
       >
-        Get code intelligence 
-        while browsing files and reading PRs
-         on 
+        Get code intelligence
+         
+        while browsing files and reviewing
+         
+        pull requests
+         
+        on 
         Bitbucket Server
-         or any other connected code host.
+        .
          
         <a
           className="alert-link"
@@ -244,11 +252,15 @@ exports[`InstallBrowserExtensionAlert github (Chrome) 1`] = `
           Install the Sourcegraph browser extension
         </a>
          
-        to add code intelligence 
-        to PRs and file views
-         on 
+        to add code intelligence
+         
+        to 
+        pull requests
+         and file views
+         
+        on 
         GitHub
-         or any other connected code host.
+        .
       </p>
     </div>
     <button
@@ -372,11 +384,15 @@ exports[`InstallBrowserExtensionAlert github (non-Chrome) 1`] = `
       <p
         className="install-browser-extension-alert__text my-0 mr-3"
       >
-        Get code intelligence 
-        while browsing files and reading PRs
-         on 
+        Get code intelligence
+         
+        while browsing files and reviewing
+         
+        pull requests
+         
+        on 
         GitHub
-         or any other connected code host.
+        .
          
         <a
           className="alert-link"
@@ -445,11 +461,15 @@ exports[`InstallBrowserExtensionAlert gitlab (Chrome) 1`] = `
           Install the Sourcegraph browser extension
         </a>
          
-        to add code intelligence 
-        to MRs and file views
-         on 
+        to add code intelligence
+         
+        to 
+        merge requests
+         and file views
+         
+        on 
         GitLab
-         or any other connected code host.
+        .
       </p>
     </div>
     <button
@@ -573,11 +593,15 @@ exports[`InstallBrowserExtensionAlert gitlab (non-Chrome) 1`] = `
       <p
         className="install-browser-extension-alert__text my-0 mr-3"
       >
-        Get code intelligence 
-        while browsing files and reading MRs
-         on 
+        Get code intelligence
+         
+        while browsing files and reviewing
+         
+        merge requests
+         
+        on 
         GitLab
-         or any other connected code host.
+        .
          
         <a
           className="alert-link"
@@ -601,6 +625,33 @@ exports[`InstallBrowserExtensionAlert gitlab (non-Chrome) 1`] = `
     </button>
   </div>
 </InstallBrowserExtensionAlert>
+`;
+
+exports[`InstallBrowserExtensionAlert none (Chrome) 1`] = `
+<InstallBrowserExtensionAlert
+  codeHostIntegrationMessaging="browser-extension"
+  externalURLs={Array []}
+  isChrome={true}
+  onAlertDismissed={[Function]}
+/>
+`;
+
+exports[`InstallBrowserExtensionAlert none (native integration) 1`] = `
+<InstallBrowserExtensionAlert
+  codeHostIntegrationMessaging="native-integration"
+  externalURLs={Array []}
+  isChrome={false}
+  onAlertDismissed={[Function]}
+/>
+`;
+
+exports[`InstallBrowserExtensionAlert none (non-Chrome) 1`] = `
+<InstallBrowserExtensionAlert
+  codeHostIntegrationMessaging="browser-extension"
+  externalURLs={Array []}
+  isChrome={false}
+  onAlertDismissed={[Function]}
+/>
 `;
 
 exports[`InstallBrowserExtensionAlert phabricator (Chrome) 1`] = `
@@ -674,11 +725,13 @@ exports[`InstallBrowserExtensionAlert phabricator (Chrome) 1`] = `
           Install the Sourcegraph browser extension
         </a>
          
-        to add code intelligence 
+        to add code intelligence
+         
         while browsing and reviewing code
-         on 
+         
+        on 
         Phabricator
-         or any other connected code host.
+        .
       </p>
     </div>
     <button
@@ -858,11 +911,13 @@ exports[`InstallBrowserExtensionAlert phabricator (non-Chrome) 1`] = `
       <p
         className="install-browser-extension-alert__text my-0 mr-3"
       >
-        Get code intelligence 
+        Get code intelligence
+         
         while browsing and reviewing code
-         on 
+         
+        on 
         Phabricator
-         or any other connected code host.
+        .
          
         <a
           className="alert-link"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/customer/issues/118

The issue was that the code assumed the array always had an element, but it doesn't need to have.
I also noticed that we didn't check whether we actually support the code host.
With this PR, we take the first code host from external links that we support, and show nothing if there is none.

cc @dadlerj 