### PR TITLE
Faster SetClonedRepos query

### DIFF
--- a/cmd/repo-updater/repos/conf.go
+++ b/cmd/repo-updater/repos/conf.go
@@ -37,11 +37,3 @@ func ConfUserReposMaxPerSite() int {
 	}
 	return v
 }
-
-func ConfRepoSetClonedBatchSize() int {
-	v := conf.Get().RepoSetClonedBatchSize
-	if v == 0 {
-		return 100_000
-	}
-	return v
-}

--- a/cmd/repo-updater/repos/store_test.go
+++ b/cmd/repo-updater/repos/store_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -1184,12 +1183,6 @@ func isCloned(r *repos.Repo) bool {
 
 func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 	servicesPerKind := createExternalServices(t, store)
-
-	// setting the step to a small number to test the pagination system used by SetClonedRepos
-	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
-		RepoSetClonedBatchSize: 3,
-	}})
-	defer conf.Mock(nil)
 
 	return func(t *testing.T) {
 		var repositories repos.Repos

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1225,8 +1225,6 @@ type SiteConfiguration struct {
 	RepoConcurrentExternalServiceSyncers int `json:"repoConcurrentExternalServiceSyncers,omitempty"`
 	// RepoListUpdateInterval description: Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.
 	RepoListUpdateInterval int `json:"repoListUpdateInterval,omitempty"`
-	// RepoSetClonedBatchSize description: Number of database repository rows to update per query.
-	RepoSetClonedBatchSize int `json:"repoSetClonedBatchSize,omitempty"`
 	// SearchIndexEnabled description: Whether indexed search is enabled. If unset Sourcegraph detects the environment to decide if indexed search is enabled. Indexed search is RAM heavy, and is disabled by default in the single docker image. All other environments will have it enabled by default. The size of all your repository working copies is the amount of additional RAM required.
 	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -348,12 +348,6 @@
       "default": 3,
       "group": "External services"
     },
-    "repoSetClonedBatchSize": {
-      "description": "Number of database repository rows to update per query.",
-      "type": "integer",
-      "default": 100000,
-      "group": "External services"
-    },
     "maxReposToSearch": {
       "description": "DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
       "type": "integer",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -353,12 +353,6 @@ const SiteSchemaJSON = `{
       "default": 3,
       "group": "External services"
     },
-    "repoSetClonedBatchSize": {
-      "description": "Number of database repository rows to update per query.",
-      "type": "integer",
-      "default": 100000,
-      "group": "External services"
-    },
     "maxReposToSearch": {
       "description": "DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
       "type": "integer",


### PR DESCRIPTION
This PR improves and simplifies the `SetClonedRepos` query. It also removes the `repoSetClonedBatchSize` setting that was introduced in 3.21.0 and that is no longer necessary.

Co-authored-by: Tomás Senart <tomas@sourcegraph.com>
