### PR TITLE
search: trigger suggestions on printable ASCII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The `file:` added to the search field when navigating to a tree or file view will now behave correctly when the file path contains spaces. [#12296](https://github.com/sourcegraph/sourcegraph/issues/12296)
 - OAuth login now respects site configuration `experimentalFeatures: { "tls.external": {...} }` for custom certificates and skipping TLS verify. [#14144](https://github.com/sourcegraph/sourcegraph/issues/14144)
+- Search input will always show suggestions. Previously we only showed suggestions for letters and some special characters. [#14982](https://github.com/sourcegraph/sourcegraph/pull/14982)
 
 ### Removed
 

--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -24,8 +24,8 @@ const PARSER_STATE: Monaco.languages.IState = {
     equals: () => false,
 }
 
-const alphabet = 'abcdefghijklmnopqrstuvwxyz'
-const specialCharacters = ':-*]'
+const printable = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
+const latin1Alpha = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
 
 /**
  * Returns the providers used by the Monaco query input to provide syntax highlighting,
@@ -77,7 +77,7 @@ export function getProviders(
         },
         completion: {
             // An explicit list of trigger characters is needed for the Monaco editor to show completions.
-            triggerCharacters: [...specialCharacters, ...alphabet, ...alphabet.toUpperCase()],
+            triggerCharacters: [...printable, ...latin1Alpha],
             provideCompletionItems: (textModel, position, context, token) =>
                 parsedQueries
                     .pipe(


### PR DESCRIPTION
We noticed that search suggestions were not triggering after
spacebar. There are many useful suggestions (such as filters to use)
that should appear. We should trigger suggestions on any character
press. However, Monaco requires an explicit trigger list. So instead we
include all printable ASCII characters, and most of the "extended ASCII
table" (Latin-1).