### PR TITLE
repo-updater: Use config value repoListUpdateInterval

### DIFF
--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -63,7 +63,7 @@ type Syncer struct {
 type RunOptions struct {
 	EnqueueInterval func() time.Duration // Defaults to 1 minute
 	IsCloud         bool                 // Defaults to false
-	MinSyncInterval time.Duration        // Defaults to 1 minute
+	MinSyncInterval func() time.Duration // Defaults to 1 minute
 	DequeueInterval time.Duration        // Default to 10 seconds
 }
 
@@ -72,8 +72,8 @@ func (s *Syncer) Run(pctx context.Context, db *sql.DB, store Store, opts RunOpti
 	if opts.EnqueueInterval == nil {
 		opts.EnqueueInterval = func() time.Duration { return time.Minute }
 	}
-	if opts.MinSyncInterval == 0 {
-		opts.MinSyncInterval = time.Minute
+	if opts.MinSyncInterval == nil {
+		opts.MinSyncInterval = func() time.Duration { return time.Minute }
 	}
 	if opts.DequeueInterval == 0 {
 		opts.DequeueInterval = 10 * time.Second
@@ -120,7 +120,7 @@ type syncHandler struct {
 	db              *sql.DB
 	syncer          *Syncer
 	store           Store
-	minSyncInterval time.Duration
+	minSyncInterval func() time.Duration
 }
 
 func (s *syncHandler) Handle(ctx context.Context, tx dbworkerstore.Store, record workerutil.Record) (err error) {
@@ -134,7 +134,7 @@ func (s *syncHandler) Handle(ctx context.Context, tx dbworkerstore.Store, record
 		store = ws.With(tx.Handle().DB())
 	}
 
-	return s.syncer.SyncExternalService(ctx, store, sj.ExternalServiceID, s.minSyncInterval)
+	return s.syncer.SyncExternalService(ctx, store, sj.ExternalServiceID, s.minSyncInterval())
 }
 
 // contextWithSignalCancel will return a context which will be cancelled if

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -1075,7 +1075,7 @@ func testSyncRun(db *sql.DB) func(t *testing.T, store repos.Store) func(t *testi
 				err := syncer.Run(ctx, db, store, repos.RunOptions{
 					EnqueueInterval: func() time.Duration { return time.Second },
 					IsCloud:         false,
-					MinSyncInterval: 1 * time.Millisecond,
+					MinSyncInterval: func() time.Duration { return 1 * time.Millisecond },
 					DequeueInterval: 1 * time.Millisecond,
 				})
 				if err != nil && err != context.Canceled {
@@ -1217,7 +1217,7 @@ func testSyncer(db *sql.DB) func(t *testing.T, store repos.Store) func(t *testin
 				err := syncer.Run(ctx, db, store, repos.RunOptions{
 					EnqueueInterval: func() time.Duration { return time.Second },
 					IsCloud:         false,
-					MinSyncInterval: 1 * time.Minute,
+					MinSyncInterval: func() time.Duration { return 1 * time.Minute },
 					DequeueInterval: 1 * time.Millisecond,
 				})
 				if err != nil && err != context.Canceled {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -198,6 +198,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		log.Fatal(syncer.Run(ctx, db, store, repos.RunOptions{
 			EnqueueInterval: repos.ConfRepoListUpdateInterval,
 			IsCloud:         envvar.SourcegraphDotComMode(),
+			MinSyncInterval: repos.ConfRepoListUpdateInterval,
 		}))
 	}()
 	server.Syncer = syncer


### PR DESCRIPTION
This value was previously used to specify how frequently we would sync
with code hosts so it makes sense to reuse it to set a lower bound on
how often we sync now that we have backoff logic.

Part of: https://github.com/sourcegraph/customer/issues/117