### PR TITLE
Revert "destroy dangling vagrant boxes (#14961)"

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -7,8 +7,6 @@ env:
   TAG: '${BUILDKITE_BUILD_NUMBER}_${BUILDKITE_RETRY_COUNT}'
   COVERAGE_INSTRUMENT: 'true'
   VAGRANT_RUN_ENV: 'CI'
-  VAGRANT_DOTFILE_PATH: "/var/lib"
-  VAGRANT_DOTFILE_PATH: "/var/lib/buildkite/builds/$BUILDKITE_AGENT_NAME/vagrant.d"
 
 steps:
 - artifact_paths: ./*.png;./e2e.mp4;./ffmpeg.log

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -16,9 +16,6 @@ for i in "${plugins[@]}"; do
   fi
 done
 
-# Destroy dangling vagrant box from previous run if the previous run didn't exit cleanly
-vagrant destroy -f "$box"
-
 vagrant up "$box" --provider=google || exit_code=$?
 vagrant scp "$box":/sourcegraph/puppeteer/*.png ../
 vagrant scp "$box":/sourcegraph/e2e.mp4 ../


### PR DESCRIPTION
this env var gets set on the first BK agent, and doesn't change if the build happens on a different agent. We'll have to look at an alternative here 