### PR TITLE
Add support for GitLab Draft/WIP MRs

### DIFF
--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -546,8 +546,7 @@ func (s *GitLabSource) UpdateChangeset(ctx context.Context, c *Changeset) error 
 		return errors.Wrap(err, "updating GitLab merge request")
 	}
 
-	c.Changeset.SetMetadata(updated)
-	return nil
+	return c.Changeset.SetMetadata(updated)
 }
 
 // UndraftChangeset marks the changeset as *not* work in progress anymore.

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -341,7 +341,7 @@ func (s *GitLabSource) CreateChangeset(ctx context.Context, c *Changeset) (bool,
 // CreateDraftChangeset creates a GitLab merge request. If it already exists,
 // *Changeset will be populated and the return value will be true.
 func (s *GitLabSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error) {
-	gitlab.SetWIP(&c.Title)
+	c.Title = gitlab.SetWIP(c.Title)
 
 	exists, err := s.CreateChangeset(ctx, c)
 	if err != nil {
@@ -551,6 +551,6 @@ func (s *GitLabSource) UpdateChangeset(ctx context.Context, c *Changeset) error 
 
 // UndraftChangeset marks the changeset as *not* work in progress anymore.
 func (s *GitLabSource) UndraftChangeset(ctx context.Context, c *Changeset) error {
-	gitlab.UnsetWIP(&c.Title)
+	c.Title = gitlab.UnsetWIP(c.Title)
 	return s.UpdateChangeset(ctx, c)
 }

--- a/cmd/repo-updater/repos/gitlab.go
+++ b/cmd/repo-updater/repos/gitlab.go
@@ -303,6 +303,7 @@ func projectQueryToURL(projectQuery string, perPage int) (string, error) {
 }
 
 var _ ChangesetSource = &GitLabSource{}
+var _ DraftChangesetSource = &GitLabSource{}
 
 // CreateChangeset creates a GitLab merge request. If it already exists,
 // *Changeset will be populated and the return value will be true.
@@ -333,6 +334,30 @@ func (s *GitLabSource) CreateChangeset(ctx context.Context, c *Changeset) (bool,
 
 	if err := c.SetMetadata(mr); err != nil {
 		return exists, errors.Wrap(err, "setting changeset metadata")
+	}
+	return exists, nil
+}
+
+// CreateDraftChangeset creates a GitLab merge request. If it already exists,
+// *Changeset will be populated and the return value will be true.
+func (s *GitLabSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error) {
+	gitlab.SetWIP(&c.Title)
+
+	exists, err := s.CreateChangeset(ctx, c)
+	if err != nil {
+		return exists, err
+	}
+
+	mr, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
+	if !ok {
+		return false, errors.New("Changeset is not a GitLab merge request")
+	}
+
+	// If it already exists, but is not a WIP, we need to update the title.
+	if exists && !mr.WorkInProgress {
+		if err := s.UpdateChangeset(ctx, c); err != nil {
+			return exists, err
+		}
 	}
 	return exists, nil
 }
@@ -521,6 +546,12 @@ func (s *GitLabSource) UpdateChangeset(ctx context.Context, c *Changeset) error 
 		return errors.Wrap(err, "updating GitLab merge request")
 	}
 
-	c.Changeset.Metadata = updated
+	c.Changeset.SetMetadata(updated)
 	return nil
+}
+
+// UndraftChangeset marks the changeset as *not* work in progress anymore.
+func (s *GitLabSource) UndraftChangeset(ctx context.Context, c *Changeset) error {
+	gitlab.UnsetWIP(&c.Title)
+	return s.UpdateChangeset(ctx, c)
 }

--- a/enterprise/internal/campaigns/changeset_history.go
+++ b/enterprise/internal/campaigns/changeset_history.go
@@ -97,19 +97,31 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 			currentExtState = campaigns.ChangesetExternalStateMerged
 			pushStates(et)
 
-		case campaigns.ChangesetEventKindGitLabMarkWorkInProgress,
-			campaigns.ChangesetEventKindGitHubConvertToDraft:
+		case campaigns.ChangesetEventKindGitLabMarkWorkInProgress:
+			// This event only matters when the changeset is open, otherwise a change in the title won't change the overall external state.
+			if currentExtState == campaigns.ChangesetExternalStateOpen {
+				currentExtState = campaigns.ChangesetExternalStateDraft
+				pushStates(et)
+			}
+
+		case campaigns.ChangesetEventKindGitHubConvertToDraft:
 			// Merged is a final state. We can ignore everything after.
 			if currentExtState != campaigns.ChangesetExternalStateMerged {
 				currentExtState = campaigns.ChangesetExternalStateDraft
 				pushStates(et)
 			}
 
+		case campaigns.ChangesetEventKindGitLabUnmarkWorkInProgress:
+			// This event only matters when the changeset is open, otherwise a change in the title won't change the overall external state.
+			if currentExtState == campaigns.ChangesetExternalStateDraft {
+				currentExtState = campaigns.ChangesetExternalStateOpen
+				pushStates(et)
+			}
+
 		case campaigns.ChangesetEventKindGitHubReopened,
 			campaigns.ChangesetEventKindBitbucketServerReopened,
 			campaigns.ChangesetEventKindGitLabReopened,
-			campaigns.ChangesetEventKindGitHubReadyForReview,
-			campaigns.ChangesetEventKindGitLabUnmarkWorkInProgress:
+			campaigns.ChangesetEventKindGitHubReadyForReview:
 			// Merged is a final state. We can ignore everything after.
 			if currentExtState != campaigns.ChangesetExternalStateMerged {
 				currentExtState = campaigns.ChangesetExternalStateOpen

--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -1207,7 +1207,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitHub,
 			name:      "single changeset opened as draft",
 			changesets: []*campaigns.Changeset{
-				setIsDraft(ghChangeset(1, daysAgo(2))),
+				setDraft(ghChangeset(1, daysAgo(2))),
 			},
 			start:  daysAgo(1),
 			events: []*campaigns.ChangesetEvent{},
@@ -1220,7 +1220,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitHub,
 			name:      "single changeset opened as draft then opened for review",
 			changesets: []*campaigns.Changeset{
-				// Not setAsDraft, because the current state is "not in draft anymore".
+				// Not setDraft, because the current state is "not in draft anymore".
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(1),
@@ -1236,7 +1236,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitHub,
 			name:      "single changeset opened as draft then opened for review and converted back",
 			changesets: []*campaigns.Changeset{
-				// Not setAsDraft, because the current state is "not in draft anymore".
+				// Not setDraft, because the current state is "not in draft anymore".
 				ghChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
@@ -1254,7 +1254,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitHub,
 			name:      "single changeset opened as draft then opened for review, converted back and opened for review again",
 			changesets: []*campaigns.Changeset{
-				// Not setAsDraft, because the current state is "not in draft anymore".
+				// Not setDraft, because the current state is "not in draft anymore".
 				ghChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
@@ -1274,7 +1274,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitLab,
 			name:      "GitLab single changeset opened as draft",
 			changesets: []*campaigns.Changeset{
-				setIsWip(glChangeset(1, daysAgo(2))),
+				setDraft(glChangeset(1, daysAgo(2))),
 			},
 			start:  daysAgo(1),
 			events: []*campaigns.ChangesetEvent{},
@@ -1287,7 +1287,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitLab,
 			name:      "GitLab single changeset opened as draft then opened for review",
 			changesets: []*campaigns.Changeset{
-				// Not setIsWip, because the current state is "not a draft anymore".
+				// Not setDraft, because the current state is "not a draft anymore".
 				glChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(1),
@@ -1303,7 +1303,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitLab,
 			name:      "GitLab single changeset opened as draft then opened for review and converted back",
 			changesets: []*campaigns.Changeset{
-				// Not setIsWip, because the current state is "not a draft anymore".
+				// Not setDraft, because the current state is "not a draft anymore".
 				glChangeset(1, daysAgo(2)),
 			},
 			start: daysAgo(2),
@@ -1321,7 +1321,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitLab,
 			name:      "GitLab single changeset opened as draft then opened for review, converted back and opened for review again",
 			changesets: []*campaigns.Changeset{
-				// Not setIsWip, because the current state is "not a draft anymore".
+				// Not setDraft, because the current state is "not a draft anymore".
 				glChangeset(1, daysAgo(3)),
 			},
 			start: daysAgo(3),
@@ -1357,7 +1357,7 @@ func TestCalcCounts(t *testing.T) {
 			codehosts: extsvc.TypeGitLab,
 			name:      "GitLab marked wip while closed",
 			changesets: []*campaigns.Changeset{
-				setIsWip(glChangeset(1, daysAgo(1))),
+				setDraft(glChangeset(1, daysAgo(1))),
 			},
 			start: daysAgo(1),
 			events: []*campaigns.ChangesetEvent{
@@ -1416,13 +1416,13 @@ func setExternalDeletedAt(c *campaigns.Changeset, t time.Time) *campaigns.Change
 	return c
 }
 
-func setIsDraft(c *campaigns.Changeset) *campaigns.Changeset {
-	c.Metadata.(*github.PullRequest).IsDraft = true
-	return c
-}
-
-func setIsWip(c *campaigns.Changeset) *campaigns.Changeset {
-	c.Metadata.(*gitlab.MergeRequest).WorkInProgress = true
+func setDraft(c *campaigns.Changeset) *campaigns.Changeset {
+	switch m := c.Metadata.(type) {
+	case *github.PullRequest:
+		m.IsDraft = true
+	case *gitlab.MergeRequest:
+		m.WorkInProgress = true
+	}
 	return c
 }
 

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -670,7 +670,7 @@ func determinePlan(ctx context.Context, tx *Store, ch *campaigns.Changeset) (*pl
 		}
 
 		// Only do undraft, when the codehost supports draft changesets.
-		if delta.draftChanged && campaigns.ExternalServiceSupports(ch.ExternalServiceType, campaigns.CodehostCapabilityDraftChangesets) {
+		if delta.undraft && campaigns.ExternalServiceSupports(ch.ExternalServiceType, campaigns.CodehostCapabilityDraftChangesets) {
 			pl.AddOp(operationUndraft)
 		}
 
@@ -887,7 +887,7 @@ func compareChangesetSpecs(previous, current *campaigns.ChangesetSpec) (*changes
 	// If was set to "draft" and now "true", need to undraft the changeset.
 	// We currently ignore going from "true" to "draft".
 	if previous.Spec.Published.Draft() && current.Spec.Published.True() {
-		delta.draftChanged = true
+		delta.undraft = true
 	}
 
 	// Diff
@@ -948,7 +948,7 @@ func compareChangesetSpecs(previous, current *campaigns.ChangesetSpec) (*changes
 type changesetSpecDelta struct {
 	titleChanged         bool
 	bodyChanged          bool
-	draftChanged         bool
+	undraft              bool
 	baseRefChanged       bool
 	diffChanged          bool
 	commitMessageChanged bool

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -676,6 +676,28 @@ func TestComputeExternalState(t *testing.T) {
 			},
 			want: cmpgn.ChangesetExternalStateMerged,
 		},
+		{
+			name:      "gitlab draft - no events",
+			changeset: setIsWip(gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil)),
+			history:   []changesetStatesAtTime{},
+			want:      cmpgn.ChangesetExternalStateDraft,
+		},
+		{
+			name:      "gitlab draft - changeset older than events",
+			changeset: gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil),
+			history: []changesetStatesAtTime{
+				{t: daysAgo(0), externalState: campaigns.ChangesetExternalStateDraft},
+			},
+			want: cmpgn.ChangesetExternalStateDraft,
+		},
+		{
+			name:      "gitlab draft - changeset newer than events",
+			changeset: setIsWip(gitLabChangeset(daysAgo(0), gitlab.MergeRequestStateOpened, nil)),
+			history: []changesetStatesAtTime{
+				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
+			},
+			want: cmpgn.ChangesetExternalStateDraft,
+		},
 	}
 
 	for i, tc := range tests {

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -586,7 +586,7 @@ func TestComputeExternalState(t *testing.T) {
 		},
 		{
 			name:      "github draft - no events",
-			changeset: setIsDraft(githubChangeset(daysAgo(10), "OPEN")),
+			changeset: setDraft(githubChangeset(daysAgo(10), "OPEN")),
 			history:   []changesetStatesAtTime{},
 			want:      cmpgn.ChangesetExternalStateDraft,
 		},
@@ -600,7 +600,7 @@ func TestComputeExternalState(t *testing.T) {
 		},
 		{
 			name:      "github draft - changeset newer than events",
-			changeset: setIsDraft(githubChangeset(daysAgo(0), "OPEN")),
+			changeset: setDraft(githubChangeset(daysAgo(0), "OPEN")),
 			history: []changesetStatesAtTime{
 				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},
@@ -678,7 +678,7 @@ func TestComputeExternalState(t *testing.T) {
 		},
 		{
 			name:      "gitlab draft - no events",
-			changeset: setIsWip(gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil)),
+			changeset: setDraft(gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil)),
 			history:   []changesetStatesAtTime{},
 			want:      cmpgn.ChangesetExternalStateDraft,
 		},
@@ -692,7 +692,7 @@ func TestComputeExternalState(t *testing.T) {
 		},
 		{
 			name:      "gitlab draft - changeset newer than events",
-			changeset: setIsWip(gitLabChangeset(daysAgo(0), gitlab.MergeRequestStateOpened, nil)),
+			changeset: setDraft(gitLabChangeset(daysAgo(0), gitlab.MergeRequestStateOpened, nil)),
 			history: []changesetStatesAtTime{
 				{t: daysAgo(10), externalState: campaigns.ChangesetExternalStateClosed},
 			},

--- a/internal/campaigns/changeset_event_test.go
+++ b/internal/campaigns/changeset_event_test.go
@@ -218,6 +218,8 @@ func TestChangesetEvents(t *testing.T) {
 			{ID: 11, System: false, Body: "this is a user note"},
 			{ID: 12, System: true, Body: "approved this merge request"},
 			{ID: 13, System: true, Body: "unapproved this merge request"},
+			{ID: 14, System: true, Body: "marked as a **Work In Progress**"},
+			{ID: 15, System: true, Body: "unmarked as a **Work In Progress**"},
 		}
 
 		pipelines := []*gitlab.Pipeline{
@@ -241,13 +243,25 @@ func TestChangesetEvents(t *testing.T) {
 					ChangesetID: 1234,
 					Kind:        ChangesetEventKindGitLabApproved,
 					Key:         notes[1].Key(),
-					Metadata:    notes[1].ToReview(),
+					Metadata:    notes[1].ToEvent(),
 				},
 				{
 					ChangesetID: 1234,
 					Kind:        ChangesetEventKindGitLabUnapproved,
 					Key:         notes[2].Key(),
-					Metadata:    notes[2].ToReview(),
+					Metadata:    notes[2].ToEvent(),
+				},
+				{
+					ChangesetID: 1234,
+					Kind:        ChangesetEventKindGitLabMarkWorkInProgress,
+					Key:         notes[3].Key(),
+					Metadata:    notes[3].ToEvent(),
+				},
+				{
+					ChangesetID: 1234,
+					Kind:        ChangesetEventKindGitLabUnmarkWorkInProgress,
+					Key:         notes[4].Key(),
+					Metadata:    notes[4].ToEvent(),
 				},
 				{
 					ChangesetID: 1234,

--- a/internal/campaigns/util.go
+++ b/internal/campaigns/util.go
@@ -23,7 +23,7 @@ type CodehostCapabilities map[CodehostCapability]bool
 var SupportedExternalServices = map[string]CodehostCapabilities{
 	extsvc.TypeGitHub:          {CodehostCapabilityLabels: true, CodehostCapabilityDraftChangesets: true},
 	extsvc.TypeBitbucketServer: {},
-	extsvc.TypeGitLab:          {CodehostCapabilityLabels: true},
+	extsvc.TypeGitLab:          {CodehostCapabilityLabels: true, CodehostCapabilityDraftChangesets: true},
 }
 
 // IsRepoSupported returns whether the given ExternalRepoSpec is supported by

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -23,21 +23,22 @@ const (
 )
 
 type MergeRequest struct {
-	ID           ID                `json:"id"`
-	IID          ID                `json:"iid"`
-	ProjectID    ID                `json:"project_id"`
-	Title        string            `json:"title"`
-	Description  string            `json:"description"`
-	State        MergeRequestState `json:"state"`
-	CreatedAt    Time              `json:"created_at"`
-	UpdatedAt    Time              `json:"updated_at"`
-	MergedAt     *Time             `json:"merged_at"`
-	ClosedAt     *Time             `json:"closed_at"`
-	HeadPipeline *Pipeline         `json:"head_pipeline"`
-	Labels       []string          `json:"labels"`
-	SourceBranch string            `json:"source_branch"`
-	TargetBranch string            `json:"target_branch"`
-	WebURL       string            `json:"web_url"`
+	ID             ID                `json:"id"`
+	IID            ID                `json:"iid"`
+	ProjectID      ID                `json:"project_id"`
+	Title          string            `json:"title"`
+	Description    string            `json:"description"`
+	State          MergeRequestState `json:"state"`
+	CreatedAt      Time              `json:"created_at"`
+	UpdatedAt      Time              `json:"updated_at"`
+	MergedAt       *Time             `json:"merged_at"`
+	ClosedAt       *Time             `json:"closed_at"`
+	HeadPipeline   *Pipeline         `json:"head_pipeline"`
+	Labels         []string          `json:"labels"`
+	SourceBranch   string            `json:"source_branch"`
+	TargetBranch   string            `json:"target_branch"`
+	WebURL         string            `json:"web_url"`
+	WorkInProgress bool              `json:"work_in_progress"`
 
 	DiffRefs DiffRefs `json:"diff_refs"`
 

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -48,6 +49,18 @@ type MergeRequest struct {
 	// to do it the old fashioned way with lots of REST requests.
 	Notes     []*Note
 	Pipelines []*Pipeline
+}
+
+func SetWIP(title *string) {
+	if !strings.HasPrefix(*title, "WIP:") {
+		*title = "WIP: " + *title
+	}
+}
+
+func UnsetWIP(title *string) {
+	if strings.HasPrefix(*title, "WIP: ") {
+		*title = strings.TrimPrefix(*title, "WIP: ")
+	}
 }
 
 type DiffRefs struct {

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -51,16 +51,18 @@ type MergeRequest struct {
 	Pipelines []*Pipeline
 }
 
-func SetWIP(title *string) {
-	if !strings.HasPrefix(*title, "WIP:") {
-		*title = "WIP: " + *title
+func SetWIP(title string) string {
+	if !strings.HasPrefix(title, "WIP:") {
+		return "WIP: " + title
 	}
+	return title
 }
 
-func UnsetWIP(title *string) {
-	if strings.HasPrefix(*title, "WIP: ") {
-		*title = strings.TrimPrefix(*title, "WIP: ")
+func UnsetWIP(title string) string {
+	if strings.HasPrefix(title, "WIP: ") {
+		return strings.TrimPrefix(title, "WIP: ")
 	}
+	return title
 }
 
 type DiffRefs struct {

--- a/internal/extsvc/gitlab/merge_requests_test.go
+++ b/internal/extsvc/gitlab/merge_requests_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestWIP(t *testing.T) {
+	t.Run("SetWIP", func(t *testing.T) {
+		tests := []struct{ title, want string }{
+			{title: "My perfect changeset", want: "WIP: My perfect changeset"},
+			{title: "WIP: My perfect changeset", want: "WIP: My perfect changeset"},
+		}
+		for _, tc := range tests {
+			SetWIP(&tc.title)
+			if have, want := tc.title, tc.want; have != want {
+				t.Errorf("incorrect title generated from SetWIP: have=%q want=%q", have, want)
+			}
+		}
+	})
+	t.Run("UnsetWIP", func(t *testing.T) {
+		tests := []struct{ title, want string }{
+			{title: "WIP: My perfect changeset", want: "My perfect changeset"},
+			{title: "My perfect changeset", want: "My perfect changeset"},
+		}
+		for _, tc := range tests {
+			UnsetWIP(&tc.title)
+			if have, want := tc.title, tc.want; have != want {
+				t.Errorf("incorrect title generated from UnsetWIP: have=%q want=%q", have, want)
+			}
+		}
+	})
+}
+
 func TestCreateMergeRequest(t *testing.T) {
 	ctx := context.Background()
 	project := &Project{}

--- a/internal/extsvc/gitlab/merge_requests_test.go
+++ b/internal/extsvc/gitlab/merge_requests_test.go
@@ -15,8 +15,7 @@ func TestWIP(t *testing.T) {
 			{title: "WIP: My perfect changeset", want: "WIP: My perfect changeset"},
 		}
 		for _, tc := range tests {
-			SetWIP(&tc.title)
-			if have, want := tc.title, tc.want; have != want {
+			if have, want := SetWIP(tc.title), tc.want; have != want {
 				t.Errorf("incorrect title generated from SetWIP: have=%q want=%q", have, want)
 			}
 		}
@@ -27,8 +26,7 @@ func TestWIP(t *testing.T) {
 			{title: "My perfect changeset", want: "My perfect changeset"},
 		}
 		for _, tc := range tests {
-			UnsetWIP(&tc.title)
-			if have, want := tc.title, tc.want; have != want {
+			if have, want := UnsetWIP(tc.title), tc.want; have != want {
 				t.Errorf("incorrect title generated from UnsetWIP: have=%q want=%q", have, want)
 			}
 		}

--- a/internal/extsvc/gitlab/notes_test.go
+++ b/internal/extsvc/gitlab/notes_test.go
@@ -148,32 +148,46 @@ func TestNoteKey(t *testing.T) {
 	}
 }
 
-func TestNoteToReview(t *testing.T) {
+func TestNoteToEvent(t *testing.T) {
 	t.Run("non-system note", func(t *testing.T) {
 		note := &Note{System: false}
-		if v := note.ToReview(); v != nil {
-			t.Errorf("unexpected non-nil ToReview value: %+v", v)
+		if v := note.ToEvent(); v != nil {
+			t.Errorf("unexpected non-nil ToEvent value: %+v", v)
 		}
 	})
 
 	t.Run("system, non approval note", func(t *testing.T) {
 		note := &Note{System: true, Body: ""}
-		if v := note.ToReview(); v != nil {
-			t.Errorf("unexpected non-nil ToReview value: %+v", v)
+		if v := note.ToEvent(); v != nil {
+			t.Errorf("unexpected non-nil ToEvent value: %+v", v)
 		}
 	})
 
 	t.Run("system, approval note", func(t *testing.T) {
 		note := &Note{System: true, Body: "approved this merge request"}
-		if v, ok := note.ToReview().(*ReviewApproved); v == nil || !ok {
-			t.Errorf("unexpected ToReview value: %+v", v)
+		if v, ok := note.ToEvent().(*ReviewApprovedEvent); v == nil || !ok {
+			t.Errorf("unexpected ToEvent value: %+v", v)
 		}
 	})
 
 	t.Run("system, unapproval note", func(t *testing.T) {
 		note := &Note{System: true, Body: "unapproved this merge request"}
-		if v, ok := note.ToReview().(*ReviewUnapproved); v == nil || !ok {
-			t.Errorf("unexpected ToReview value: %+v", v)
+		if v, ok := note.ToEvent().(*ReviewUnapprovedEvent); v == nil || !ok {
+			t.Errorf("unexpected ToEvent value: %+v", v)
+		}
+	})
+
+	t.Run("system, wip note", func(t *testing.T) {
+		note := &Note{System: true, Body: "marked as a **Work In Progress**"}
+		if v, ok := note.ToEvent().(*MarkWorkInProgressEvent); v == nil || !ok {
+			t.Errorf("unexpected ToEvent value: %+v", v)
+		}
+	})
+
+	t.Run("system, un wip note", func(t *testing.T) {
+		note := &Note{System: true, Body: "unmarked as a **Work In Progress**"}
+		if v, ok := note.ToEvent().(*UnmarkWorkInProgressEvent); v == nil || !ok {
+			t.Errorf("unexpected ToEvent value: %+v", v)
 		}
 	})
 }


### PR DESCRIPTION
This contains the GitLab part of https://github.com/sourcegraph/sourcegraph/issues/7998.

- In the first commit, I implemented the events and state/history logic required to work for GitLab.
- In the second commit, I implemented the DraftChangesetSource on the GitLab client.
- In the third commit, some cleanup and fixes.

**Tradeoff:** There is no way to tell `Update` events apart, marking as WIP and unmarking do only trigger update events in the webhooks (which is fine I think).