### PR TITLE
Implement action in preview for draft mode

### DIFF
--- a/client/web/src/enterprise/campaigns/apply/ChangesetSpecAction.tsx
+++ b/client/web/src/enterprise/campaigns/apply/ChangesetSpecAction.tsx
@@ -20,8 +20,11 @@ export const ChangesetSpecAction: React.FunctionComponent<ChangesetSpecActionPro
     if (spec.description.__typename === 'ExistingChangesetReference') {
         return <ChangesetSpecActionImport className={className} />
     }
-    if (spec.description.published) {
+    if (spec.description.published === true) {
         return <ChangesetSpecActionPublish className={className} />
+    }
+    if (spec.description.published === 'draft') {
+        return <ChangesetSpecActionPublishDraft className={className} />
     }
     return <ChangesetSpecActionNoPublish className={className} />
 }
@@ -32,6 +35,12 @@ export const ChangesetSpecActionPublish: React.FunctionComponent<{ className?: s
     <div className={classNames(className, iconClassNames)}>
         <UploadIcon data-tooltip="This changeset will be published to its code host" />
         <span>Publish</span>
+    </div>
+)
+export const ChangesetSpecActionPublishDraft: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+    <div className={classNames(className, iconClassNames)}>
+        <UploadIcon className="text-muted" data-tooltip="This changeset will be published as draft to its code host" />
+        <span>Publish draft</span>
     </div>
 )
 export const ChangesetSpecActionNoPublish: React.FunctionComponent<{ className?: string }> = ({ className }) => (

--- a/client/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/apply/VisibleChangesetSpecNode.story.tsx
@@ -2,13 +2,50 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { VisibleChangesetSpecNode } from './VisibleChangesetSpecNode'
 import { addDays } from 'date-fns'
-import { VisibleChangesetSpecFields, ChangesetSpecType } from '../../../graphql-operations'
+import { VisibleChangesetSpecFields, ChangesetSpecType, Scalars } from '../../../graphql-operations'
 import { of } from 'rxjs'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 
 const { add } = storiesOf('web/campaigns/apply/VisibleChangesetSpecNode', module).addDecorator(story => (
     <div className="p-3 container web-content changeset-spec-list__grid">{story()}</div>
 ))
+
+const baseChangeset: (published: Scalars['PublishedValue']) => VisibleChangesetSpecFields = published => ({
+    __typename: 'VisibleChangesetSpec',
+    id: 'someidv2',
+    expiresAt: addDays(new Date(), 7).toISOString(),
+    type: ChangesetSpecType.EXISTING,
+    description: {
+        __typename: 'GitBranchChangesetDescription',
+        baseRepository: { name: 'github.com/sourcegraph/testrepo', url: 'https://test.test/repo' },
+        baseRef: 'master',
+        headRef: 'cool-branch',
+        body: 'Body text',
+        commits: [
+            {
+                subject: 'This is the first line of the commit message',
+                body: `And the more explanatory body. And the more explanatory body.
+And the more explanatory body. And the more explanatory body.
+And the more explanatory body. And the more explanatory body.
+And the more explanatory body. And the more explanatory body. And the more explanatory body.
+And the more explanatory body. And the more explanatory body. And the more explanatory body.`,
+                author: {
+                    avatarURL: null,
+                    displayName: 'john',
+                    email: 'john@test.not',
+                    user: { displayName: 'lejohn', url: '/users/lejohn', username: 'john' },
+                },
+            },
+        ],
+        diffStat: {
+            added: 10,
+            changed: 8,
+            deleted: 2,
+        },
+        title: 'Add prettier to repository',
+        published,
+    },
+})
 
 export const visibleChangesetSpecStories: Record<string, VisibleChangesetSpecFields> = {
     'Import changeset': {
@@ -22,78 +59,9 @@ export const visibleChangesetSpecStories: Record<string, VisibleChangesetSpecFie
             externalID: '123',
         },
     },
-    'Create changeset published': {
-        __typename: 'VisibleChangesetSpec',
-        id: 'someidv2',
-        expiresAt: addDays(new Date(), 7).toISOString(),
-        type: ChangesetSpecType.EXISTING,
-        description: {
-            __typename: 'GitBranchChangesetDescription',
-            baseRepository: { name: 'github.com/sourcegraph/testrepo', url: 'https://test.test/repo' },
-            baseRef: 'master',
-            headRef: 'cool-branch',
-            body: 'Body text',
-            commits: [
-                {
-                    subject: 'This is the first line of the commit message',
-                    body: `And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body. And the more explanatory body.`,
-                    author: {
-                        avatarURL: null,
-                        displayName: 'john',
-                        email: 'john@test.not',
-                        user: { displayName: 'lejohn', url: '/users/lejohn', username: 'john' },
-                    },
-                },
-            ],
-            diffStat: {
-                added: 10,
-                changed: 8,
-                deleted: 2,
-            },
-            published: true,
-            title: 'Add prettier to repository',
-        },
-    },
-    'Create changeset not published': {
-        __typename: 'VisibleChangesetSpec',
-        id: 'someidv3',
-        expiresAt: addDays(new Date(), 7).toISOString(),
-        type: ChangesetSpecType.EXISTING,
-        description: {
-            __typename: 'GitBranchChangesetDescription',
-            baseRepository: { name: 'github.com/sourcegraph/testrepo', url: 'https://test.test/repo' },
-            baseRef: 'master',
-            headRef: 'cool-branch',
-            body: 'Body text',
-            commits: [
-                {
-                    subject: 'This is the first line of the commit message',
-                    body: `And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body. And the more explanatory body.
-And the more explanatory body. And the more explanatory body. And the more explanatory body.`,
-                    author: {
-                        avatarURL: null,
-                        displayName: 'john',
-                        email: 'john@test.not',
-                        user: { displayName: 'lejohn', url: '/users/lejohn', username: 'john' },
-                    },
-                },
-            ],
-            diffStat: {
-                added: 10,
-                changed: 8,
-                deleted: 2,
-            },
-            published: false,
-            title: 'Add prettier to repository',
-        },
-    },
+    'Create changeset published': baseChangeset(true),
+    'Create changeset draft': baseChangeset('draft'),
+    'Create changeset not published': baseChangeset(false),
 }
 
 const queryEmptyFileDiffs = () =>


### PR DESCRIPTION
This is one of the remaining pieces of https://github.com/sourcegraph/sourcegraph/issues/7998. 
We now distinguish the published flag and display a proper action for publish as draft on the preview page.