### PR TITLE
doc: add redirects for code intel hover links

### DIFF
--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -147,6 +147,15 @@
 /user/code_intelligence/languages/go    /user/code_intelligence/how-to/index_a_go_repository 308
 /user/code_intelligence/languages/typescript_and_javascript /user/code_intelligence/how-to/index_a_typescript_and_javascript_repository 308
 
+/user/code_intelligence/explanations/basic_code_intelligence /code_intelligence/explanations/basic_code_intelligence 308
+/user/code_intelligence/explanations/features /code_intelligence/explanations/features 308
+/user/code_intelligence/explanations/precise_code_intelligence /code_intelligence/explanations/precise_code_intelligence 308
+/user/code_intelligence/explanations/writing_an_indexer /code_intelligence/explanations/writing_an_indexer 308
+/user/code_intelligence/how-to/adding_lsif_to_many_repos /code_intelligence/how-to/adding_lsif_to_many_repos 308
+/user/code_intelligence/how-to/adding_lsif_to_workflows /code_intelligence/how-to/adding_lsif_to_workflows 308
+/user/code_intelligence/how-to/index_a_go_repository /code_intelligence/how-to/index_a_go_repository 308
+/user/code_intelligence/how-to/index_a_typescript_and_javascript_repository /code_intelligence/how-to/index_a_typescript_and_javascript_repository 308
+
 /user/markdown  /admin/markdown 308
 /user/organizations/index   /admin/organizations 308
 /user/usage_statistics  /admin/usage_statistics 308

--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -140,6 +140,7 @@
 
 /user/code_intelligence/basic_code_intelligence /user/code_intelligence/explanations/basic_code_intelligence 308
 /user/code_intelligence/features    /user/code_intelligence/explanations/features 308
+/user/code_intelligence/lsif   /user/code_intelligence/explanations/precise_code_intelligence 308
 /user/code_intelligence/precise_code_intelligence   /user/code_intelligence/explanations/precise_code_intelligence 308
 /user/code_intelligence/writing_an_indexer  /user/code_intelligence/explanations/writing_an_indexer 308
 /user/code_intelligence/adding_lsif_to_many_repos   /user/code_intelligence/how-to/adding_lsif_to_many_repos 308


### PR DESCRIPTION
I noticed that some of the hover links created by code-intel-extensions point to documentation files that no longer exist. I've opened https://github.com/sourcegraph/code-intel-extensions/pull/508 to fix this at the source, but we should also add the redirects to make things work ASAP.