### PR TITLE
structural search: fix double colon conversion

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -79,6 +79,11 @@ func templateToRegexp(buf []byte) []Term {
 				continue
 			}
 			if len(buf[advance:]) > 0 {
+				if buf[advance] == ':' {
+					// maybe the start of another hole like ::[foo]
+					currentLiteral = append(currentLiteral, ':')
+					continue
+				}
 				r = next()
 				if r == '[' {
 					open++

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -200,6 +200,16 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 			Pattern: `:[~:]`,
 			Want:    `(:)`,
 		},
+		{
+			Name:    "Colon prefix",
+			Pattern: `::[version]bar`,
+			Want:    `(:)(.|\s)*?(bar)`,
+		},
+		{
+			Name:    "Colon prefix",
+			Pattern: `::::[version]bar`,
+			Want:    `(:::)(.|\s)*?(bar)`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
A dumb thing where parsing `::[stuff]` thought `::` can be treated as literal, when the lookahead `:` could be start of `:[stuff]`.

@mrnugget found it