### PR TITLE
Reconciler hygiene

### DIFF
--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -480,7 +480,7 @@ func buildCommitOpts(repo *repos.Repo, spec *campaigns.ChangesetSpec) (protocol.
 			Date:        spec.CreatedAt,
 		},
 		// We use unified diffs, not git diffs, which means they're missing the
-		// `a/` and `/b` filename prefixes. `-p0` tells `git apply` to not
+		// `a/` and `b/` filename prefixes. `-p0` tells `git apply` to not
 		// expect and strip prefixes.
 		GitApplyArgs: []string{"-p0"},
 		Push:         true,

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -35,7 +35,7 @@ type reconciler struct {
 	sourcer         repos.Sourcer
 	store           *Store
 
-	// This is used to disable a time.Sleep in updateChangeset so that the
+	// This is used to disable a time.Sleep for operationSleep so that the
 	// tests don't run slower.
 	noSleepBeforeSync bool
 }
@@ -237,7 +237,6 @@ func (e *executor) pushChangesetPatch(ctx context.Context) (err error) {
 
 // publishChangeset creates the given changeset on its code host.
 func (e *executor) publishChangeset(ctx context.Context, asDraft bool) (err error) {
-	// Now create the actual pull request on the code host
 	cs := &repos.Changeset{
 		Title:     e.spec.Spec.Title,
 		Body:      e.spec.Spec.Body,
@@ -335,10 +334,6 @@ func (e *executor) loadChangeset(ctx context.Context) error {
 
 // updateChangeset updates the given changeset's attribute on the code host
 // according to its ChangesetSpec and the delta previously computed.
-// If the delta includes only changes to the commit, updateChangeset will only
-// create and force push a new commit.
-// If the delta requires updates to the changeset on the code host, it will
-// update the changeset there.
 func (e *executor) updateChangeset(ctx context.Context) (err error) {
 	cs := repos.Changeset{
 		Title:     e.spec.Spec.Title,

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -66,20 +66,9 @@ func (r *reconciler) process(ctx context.Context, tx *Store, ch *campaigns.Chang
 	// Reset the error message.
 	ch.FailureMessage = nil
 
-	var curr, prev *campaigns.ChangesetSpec
-	if ch.CurrentSpecID != 0 {
-		var err error
-		curr, err = tx.GetChangesetSpecByID(ctx, ch.CurrentSpecID)
-		if err != nil {
-			return err
-		}
-	}
-	if ch.PreviousSpecID != 0 {
-		var err error
-		prev, err = tx.GetChangesetSpecByID(ctx, ch.PreviousSpecID)
-		if err != nil {
-			return err
-		}
+	prev, curr, err := loadChangesetSpecs(ctx, tx, ch)
+	if err != nil {
+		return nil
 	}
 
 	plan, err := determinePlan(ctx, prev, curr, ch)
@@ -780,6 +769,22 @@ func loadCampaign(ctx context.Context, tx *Store, id int64) (*campaigns.Campaign
 	}
 
 	return campaign, nil
+}
+
+func loadChangesetSpecs(ctx context.Context, tx *Store, ch *campaigns.Changeset) (prev, curr *campaigns.ChangesetSpec, err error) {
+	if ch.CurrentSpecID != 0 {
+		curr, err = tx.GetChangesetSpecByID(ctx, ch.CurrentSpecID)
+		if err != nil {
+			return
+		}
+	}
+	if ch.PreviousSpecID != 0 {
+		prev, err = tx.GetChangesetSpecByID(ctx, ch.PreviousSpecID)
+		if err != nil {
+			return
+		}
+	}
+	return
 }
 
 func decorateChangesetBody(ctx context.Context, tx *Store, cs *repos.Changeset) error {

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -525,10 +525,6 @@ func (ops operations) IsNone() bool {
 	return len(ops) == 0
 }
 
-func (ops operations) IsSyncOnly() bool {
-	return len(ops) == 1 && ops[0] == operationSync
-}
-
 func (ops operations) Equal(b operations) bool {
 	if len(ops) != len(b) {
 		return false

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -71,7 +71,7 @@ func (r *reconciler) process(ctx context.Context, tx *Store, ch *campaigns.Chang
 		return nil
 	}
 
-	plan, err := determinePlan(ctx, prev, curr, ch)
+	plan, err := determinePlan(prev, curr, ch)
 	if err != nil {
 		return err
 	}
@@ -595,7 +595,7 @@ func (p *plan) SetOp(op operation) { p.ops = operations{op} }
 // It loads the current ChangesetSpec and if it exists also the previous one.
 // If the current ChangesetSpec is not applied to a campaign, it returns an
 // error.
-func determinePlan(ctx context.Context, previousSpec, currentSpec *campaigns.ChangesetSpec, ch *campaigns.Changeset) (*plan, error) {
+func determinePlan(previousSpec, currentSpec *campaigns.ChangesetSpec, ch *campaigns.Changeset) (*plan, error) {
 	pl := &plan{}
 
 	// If it doesn't have a spec, it's an imported changeset and we can't do

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -105,8 +105,7 @@ type executor struct {
 	tx  *Store
 	ccs repos.ChangesetSource
 
-	repo   *repos.Repo
-	extSvc *repos.ExternalService
+	repo *repos.Repo
 
 	ch    *campaigns.Changeset
 	spec  *campaigns.ChangesetSpec
@@ -126,13 +125,13 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *plan) (err error) {
 		return errors.Wrap(err, "failed to load repository")
 	}
 
-	e.extSvc, err = loadExternalService(ctx, reposStore, e.repo)
+	extSvc, err := loadExternalService(ctx, reposStore, e.repo)
 	if err != nil {
 		return errors.Wrap(err, "failed to load external service")
 	}
 
 	// Set up a source with which we can modify the changeset.
-	e.ccs, err = e.buildChangesetSource(e.repo, e.extSvc)
+	e.ccs, err = e.buildChangesetSource(e.repo, extSvc)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -974,7 +974,7 @@ func TestDeterminePlan(t *testing.T) {
 			currentSpec := createChangesetSpec(t, ctx, tx, tc.currentSpec)
 			tc.changeset.currentSpec = currentSpec.ID
 			cs := createChangeset(t, ctx, tx, tc.changeset)
-			plan, err := determinePlan(ctx, tx, previousSpec, currentSpec, cs)
+			plan, err := determinePlan(ctx, previousSpec, currentSpec, cs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -849,7 +849,7 @@ func TestDeterminePlan(t *testing.T) {
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
 				repo:             githubRepo.ID,
 			},
-			wantOperations: operations{operationPublish},
+			wantOperations: operations{operationPush, operationPublish},
 		},
 		{
 			name: "GitHub publish as draft",
@@ -861,7 +861,7 @@ func TestDeterminePlan(t *testing.T) {
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
 				repo:             githubRepo.ID,
 			},
-			wantOperations: operations{operationPublishDraft},
+			wantOperations: operations{operationPush, operationPublishDraft},
 		},
 		{
 			name: "GitHub publish false",
@@ -918,7 +918,7 @@ func TestDeterminePlan(t *testing.T) {
 				publicationState: campaigns.ChangesetPublicationStateUnpublished,
 				repo:             githubRepo.ID,
 			},
-			wantOperations: operations{operationPublish},
+			wantOperations: operations{operationPush, operationPublish},
 		},
 		{
 			name: "changeset spec changed attribute, needs update",
@@ -954,7 +954,7 @@ func TestDeterminePlan(t *testing.T) {
 				publicationState: campaigns.ChangesetPublicationStatePublished,
 				repo:             githubRepo.ID,
 			},
-			wantOperations: operations{operationUpdate, operationSync},
+			wantOperations: operations{operationPush, operationSleep, operationSync},
 		},
 	}
 

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -966,15 +966,15 @@ func TestDeterminePlan(t *testing.T) {
 			}
 			defer tx.Done(errors.New("fail tx purposefully"))
 			tc.currentSpec.campaignSpec = campaignSpec.ID
-			createPreviousSpec := tc.previousSpec != testSpecOpts{}
-			if createPreviousSpec {
-				previousSpec := createChangesetSpec(t, ctx, tx, tc.previousSpec)
+			var previousSpec *campaigns.ChangesetSpec
+			if tc.previousSpec != (testSpecOpts{}) {
+				previousSpec = createChangesetSpec(t, ctx, tx, tc.previousSpec)
 				tc.changeset.previousSpec = previousSpec.ID
 			}
 			currentSpec := createChangesetSpec(t, ctx, tx, tc.currentSpec)
 			tc.changeset.currentSpec = currentSpec.ID
 			cs := createChangeset(t, ctx, tx, tc.changeset)
-			plan, err := determinePlan(ctx, tx, cs)
+			plan, err := determinePlan(ctx, tx, previousSpec, currentSpec, cs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -974,7 +974,7 @@ func TestDeterminePlan(t *testing.T) {
 			currentSpec := createChangesetSpec(t, ctx, tx, tc.currentSpec)
 			tc.changeset.currentSpec = currentSpec.ID
 			cs := createChangeset(t, ctx, tx, tc.changeset)
-			plan, err := determinePlan(ctx, previousSpec, currentSpec, cs)
+			plan, err := determinePlan(previousSpec, currentSpec, cs)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
- Made determinePlan pure so it doesn't depend on the database anymore
- Deduplicated push logic in publish and update by introducing `operationPush`
- Some code cleanup

This removes the concurrency check from determine plan, but since the changeset was locked in the worker already, I think this is fine.