### PR TITLE
search: barebones frontend recursive descent parser (draft for comments)

### DIFF
--- a/client/shared/src/search/parser/treeParser.test.ts
+++ b/client/shared/src/search/parser/treeParser.test.ts
@@ -1,0 +1,25 @@
+import { treeParse, toString, Node } from './treeParser'
+
+export const treeParseSuccess = (input: string): Node[] => {
+    const result = treeParse(input)
+    if (result.type === 'success') {
+        return result.nodes
+    }
+    return []
+}
+
+export const prettyPrint = (nodes: Node[]): string => {
+    const result: string[] = []
+    for (const node of nodes) {
+        result.push(toString(node))
+    }
+    return result.join(' ')
+}
+
+describe('treeParse', () => {
+    test('and basic', () => expect(prettyPrint(treeParseSuccess('a and b'))).toMatch('(and a b)'))
+    test('or nesting', () =>
+        expect(prettyPrint(treeParseSuccess('a or b or c or d'))).toMatch('(or a (or b (or c d)))'))
+    test('or precedence', () =>
+        expect(prettyPrint(treeParseSuccess('a and b or c and d'))).toMatch('(or (and a b) (and c d)'))
+})

--- a/client/shared/src/search/parser/treeParser.ts
+++ b/client/shared/src/search/parser/treeParser.ts
@@ -1,0 +1,187 @@
+export interface Leaf {
+    type: 'leaf'
+    value: string
+}
+
+enum OperatorKind {
+    Or = 'or',
+    And = 'and',
+}
+
+/**
+ * A nonterminal node for operators 'and' and 'or'.
+ */
+export interface Operator {
+    type: 'operator'
+    operands: Node[]
+    kind: OperatorKind
+}
+
+export type Node = Leaf | Operator
+
+interface ParseError {
+    type: 'error'
+    expected: string
+}
+
+export interface ParseSuccess {
+    type: 'success'
+    nodes: Node[]
+}
+
+export type ParseResult = ParseError | ParseSuccess
+
+export const toString = (node: Node): string => {
+    const result: string[] = []
+    switch (node.type) {
+        case 'operator':
+            for (const operand of node.operands) {
+                result.push(toString(operand))
+            }
+            switch (node.kind) {
+                case OperatorKind.Or:
+                    return `(or ${result.join(' ')})`
+                case OperatorKind.And:
+                    return `(and ${result.join(' ')})`
+            }
+        case 'leaf':
+            return node.value
+    }
+}
+
+interface State {
+    result: ParseResult
+    advance: number
+}
+
+const match = (input: string, value: string): boolean => input.startsWith(value)
+
+const newNodes = (nodes: Node[]): ParseResult => ({
+    type: 'success',
+    nodes,
+})
+
+const newOperator = (nodes: Node[], kind: OperatorKind): ParseResult => ({
+    type: 'success',
+    nodes: [
+        {
+            type: 'operator',
+            operands: nodes,
+            kind,
+        },
+    ],
+})
+
+const newLeaf = (value: string): ParseResult => ({
+    type: 'success',
+    nodes: [
+        {
+            type: 'leaf',
+            value,
+        },
+    ],
+})
+
+/**
+ * parses tokens that are leaves in the tree. {@link State} returns the result of the parse, and how much the caller should advance input.
+ */
+export const scanLeaf = (input: string): State => {
+    let position = 0
+    let current = ''
+    const result: string[] = []
+    while (input.length > 0) {
+        current = input[0]
+        position++
+        input = input.slice(1)
+        if (current === ' ') {
+            position-- // Backtrack.
+            break
+        }
+        result.push(current)
+    }
+    return { result: newLeaf(result.join('')), advance: position }
+}
+
+/**
+ * parses tokens that are leaves in the tree. {@link State} returns the result of the parse, and how much the caller should advance input.
+ */
+export const parseLeaves = (input: string): State => {
+    const nodes: Node[] = []
+    let position = 0
+    while (true) {
+        const current = input[0]
+        if (current === undefined) {
+            break
+        }
+        if (current === ' ') {
+            input = input.slice(1)
+            position++
+        }
+        if (match(input, OperatorKind.And) || match(input, OperatorKind.Or)) {
+            return { result: newNodes(nodes), advance: position } // Caller advances.
+        }
+        const leaf = scanLeaf(input)
+        input = input.slice(leaf.advance)
+        position += leaf.advance
+        if (leaf.result.type === 'error') {
+            return { result: leaf.result, advance: position }
+        }
+        nodes.push(leaf.result.nodes[0])
+    }
+    return { result: newNodes(nodes), advance: position }
+}
+
+/**
+ * parses and-expressions. {@link State} returns the result of the parse, and how much the caller should advance input.
+ */
+export const parseAnd = (input: string): State => {
+    const left = parseLeaves(input)
+    let position = 0
+    input = input.slice(left.advance)
+    position += left.advance
+    if (left.result.type === 'error') {
+        return { result: left.result, advance: position }
+    }
+    if (!match(input, OperatorKind.And)) {
+        return { result: left.result, advance: position }
+    }
+    // Consume 'and'.
+    input = input.slice(OperatorKind.And.length)
+    position += OperatorKind.And.length
+
+    const right = parseAnd(input)
+    position += right.advance
+    if (right.result.type === 'error') {
+        return { result: right.result, advance: position }
+    }
+    return { result: newOperator([left.result.nodes[0], right.result.nodes[0]], OperatorKind.And), advance: position }
+}
+
+/**
+ * parses or-expressions. Or-operators have lower precedence than and-operators, therefore this function calls parseAnd.
+ * {@link State} returns the result of the parse, and how much the caller should advance input.
+ */
+export const parseOr = (input: string): State => {
+    const left = parseAnd(input)
+    let position = 0
+    input = input.slice(left.advance)
+    position += left.advance
+    if (left.result.type === 'error') {
+        return { result: left.result, advance: position }
+    }
+    if (!match(input, OperatorKind.Or)) {
+        return { result: left.result, advance: position }
+    }
+    // Consume 'or'.
+    input = input.slice(OperatorKind.Or.length)
+    position += OperatorKind.Or.length
+
+    const right = parseOr(input)
+    position += right.advance
+    if (right.result.type === 'error') {
+        return { result: right.result, advance: position }
+    }
+    return { result: newOperator([left.result.nodes[0], right.result.nodes[0]], OperatorKind.Or), advance: position }
+}
+
+export const treeParse = (input: string): ParseResult => parseOr(input).result


### PR DESCRIPTION
This implements the barebones recursive descent parsing that ensures operator precedence. I am intentionally leaving out complexity to make this easier for feedback/comments. I don't have TypeScript savvy, I'm sure this can be improved and eager to get comments. It does closely model the initial [Go PR](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/3489c00c1a12e8cc9eb3da31527b06dc49b2aca6?visible=2).

Simplifying decisions I'm not addressing in this PR:

- Just `leaf` for arbitrary leaf nodes. This will be patterns/filters later.
- No parens for grouping here
- A type for errors, but no real error handling
- No range info yet
- Assumes just single space for whitespace-separated tokens

---

There are some notable differences I'm thinking about wrt frontend parser and backend. E.g., in the [Go PR](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/3489c00c1a12e8cc9eb3da31527b06dc49b2aca6?visible=2) it's very reasonable to normalize nested statements like:

`a or b or c or d` => `(or a b c d)`. This is useful when evaluating nodes, no need for those additional `or`s in that context. Note that this normalization is part and parcel of parsing in the Go parser (cf. `reduce`) to avoid doing extra passes. 

One frontend concern is highlighting, and so with the normalization above ^ we would effectively throw away any additional `or` tokens, the output doesn't expose that information for highlighting the concrete syntax. The implication is, this is probably not a normalization we want to apply in the frontend in the interest of highlighting, since we'd like to communicate those `or` tokens to Monaco.

Edit: to be clear, there are ways around this, expanding out `or` infix tokens again, and so on. But it could get icky. So I'm still thinking about this, and the idea right now is to just deal with a parse tree that's close(r) to the original syntax.