### PR TITLE
Fix history calculation when a reviewing user has been deleted

### DIFF
--- a/enterprise/internal/campaigns/changeset_history.go
+++ b/enterprise/internal/campaigns/changeset_history.go
@@ -145,10 +145,8 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 				continue
 			}
 
-			author, err := e.ReviewAuthor()
-			if err != nil {
-				return nil, err
-			}
+			author := e.ReviewAuthor()
+			// If the user has been deleted, skip their reviews, as they don't count towards the final state anymore.
 			if author == "" {
 				continue
 			}
@@ -184,10 +182,8 @@ func computeHistory(ch *campaigns.Changeset, ce ChangesetEvents) (changesetHisto
 		case campaigns.ChangesetEventKindBitbucketServerUnapproved,
 			campaigns.ChangesetEventKindBitbucketServerDismissed,
 			campaigns.ChangesetEventKindGitLabUnapproved:
-			author, err := e.ReviewAuthor()
-			if err != nil {
-				return nil, err
-			}
+			author := e.ReviewAuthor()
+			// If the user has been deleted, skip their reviews, as they don't count towards the final state anymore.
 			if author == "" {
 				continue
 			}

--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -1369,6 +1369,24 @@ func TestCalcCounts(t *testing.T) {
 				{Time: daysAgo(0), Total: 1, Closed: 1},
 			},
 		},
+		{
+			codehosts: extsvc.TypeGitHub,
+			name:      "changeset approved by deleted user",
+			changesets: []*campaigns.Changeset{
+				ghChangeset(1, daysAgo(2)),
+			},
+			start: daysAgo(2),
+			events: []*campaigns.ChangesetEvent{
+				// An empty author ("") usually means the user has been deleted.
+				ghReview(1, daysAgo(1), "", "APPROVED"),
+			},
+			want: []*ChangesetCounts{
+				{Time: daysAgo(2), Total: 1, Open: 1, OpenPending: 1},
+				// A deleted users' review doesn't have an effect on the review state.
+				{Time: daysAgo(1), Total: 1, Open: 1, OpenPending: 1},
+				{Time: daysAgo(0), Total: 1, Open: 1, OpenPending: 1},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/campaigns/changeset_event.go
+++ b/internal/campaigns/changeset_event.go
@@ -97,52 +97,29 @@ func (e *ChangesetEvent) Clone() *ChangesetEvent {
 }
 
 // ReviewAuthor returns the author of the review if the ChangesetEvent is related to a review.
-func (e *ChangesetEvent) ReviewAuthor() (string, error) {
+// Returns an empty string if not a review event or the author has been deleted.
+func (e *ChangesetEvent) ReviewAuthor() string {
 	switch meta := e.Metadata.(type) {
 	case *github.PullRequestReview:
-		login := meta.Author.Login
-		if login == "" {
-			return "", errors.New("review author is blank")
-		}
-		return login, nil
+		return meta.Author.Login
 
 	case *github.ReviewDismissedEvent:
-		login := meta.Review.Author.Login
-		if login == "" {
-			return "", errors.New("review author in dismissed event is blank")
-		}
-		return login, nil
+		return meta.Review.Author.Login
 
 	case *bitbucketserver.Activity:
-		username := meta.User.Name
-		if username == "" {
-			return "", errors.New("activity user is blank")
-		}
-		return username, nil
+		return meta.User.Name
 
 	case *bitbucketserver.ParticipantStatusEvent:
-		username := meta.User.Name
-		if username == "" {
-			return "", errors.New("activity user is blank")
-		}
-		return username, nil
+		return meta.User.Name
 
 	case *gitlab.ReviewApprovedEvent:
-		username := meta.Author.Username
-		if username == "" {
-			return "", errors.New("review user is blank")
-		}
-		return username, nil
+		return meta.Author.Username
 
 	case *gitlab.ReviewUnapprovedEvent:
-		username := meta.Author.Username
-		if username == "" {
-			return "", errors.New("review user is blank")
-		}
-		return username, nil
+		return meta.Author.Username
 
 	default:
-		return "", nil
+		return ""
 	}
 }
 


### PR DESCRIPTION
An empty actor means that the user doesn't exist anymore. On GitHub, it's displayed as the @ghost user.
Since the reviews of undetermined users don't count towards the final review state, they can simply be skipped.
I think for the sake of simplicity, we don't need to over handle some broken data here we can't tell apart from actual empty actors easily.
