### PR TITLE
Add Cases For Connecting To Sourcegraph

### DIFF
--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -6,7 +6,7 @@ Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and
 1. To send pings that:
    - Check for new product updates.
    - Send anonymous, non-specific, aggregate metrics back to Sourcegraph.com. You can see the full list below. 
-1. Sourcegraph extensions are fetched from Sourcegraph.com's extension registry (unless you are using a private extension registry: https://docs.sourcegraph.com/admin/extensions#publish-extensions-to-a-private-extension-registry).
+1. Sourcegraph extensions are fetched from Sourcegraph.com's extension registry (unless you are using a [private extension registry](https://docs.sourcegraph.com/admin/extensions#publish-extensions-to-a-private-extension-registry)).
 
 There are no other automatic external connections to Sourcegraph.com (or any other site on the internet).
 

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -2,6 +2,14 @@
 
 Sourcegraph periodically sends a ping to Sourcegraph.com to help our product and customer teams. It sends only the high-level data below. It never sends code, repository names, usernames, or any other specific data. To learn more, go to the **Site admin > Pings** page on your instance. (The URL is `https://sourcegraph.example.com/site-admin/pings`.)
 
+## Connection to Sourcegraph
+1. To send pings that:
+   - Check for new product updates.
+   - Send anonymous, non-specific, aggregate metrics back to Sourcegraph.com. You can see the full list below. 
+1. Sourcegraph extensions are fetched from Sourcegraph.com's extension registry (unless you are using a private extension registry: https://docs.sourcegraph.com/admin/extensions#publish-extensions-to-a-private-extension-registry).
+
+There are no other automatic external connections to Sourcegraph.com (or any other site on the internet).
+
 ## Critical telemetry
 
 Critical telemetry includes only the high-level data below required for billing, support, updates, and security notices.


### PR DESCRIPTION
Add cases to answer the question we get from many prospects: Will our local Sourcegraph instance need to communicate with any external Sourcegraph machines for any reason?



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
