### PR TITLE
release: create release campaigns

### DIFF
--- a/dev/release/src/campaigns.ts
+++ b/dev/release/src/campaigns.ts
@@ -49,16 +49,13 @@ async function applyCampaign(campaign: CampaignSpec, options: CampaignOptions): 
         JSON.parse(JSON.stringify(campaign, (key, value) => (value === null ? undefined : value))) // eslint-disable-line @typescript-eslint/no-unsafe-return
     )
     console.log(`Rendered campaign spec:\n\n${campaignYAML}`)
-    const campaignScript = `set -ex
 
-(
-cat <<EOF
-${campaignYAML}
-EOF
-) | src campaign apply \\
-    -namespace ${options.namespace} \\
-    -f -`
-    await execa('bash', ['-c', campaignScript], { stdio: 'inherit', env: options.auth })
+    // apply the campaign
+    await execa('src', ['campaign', 'apply', '-namespace', options.namespace, '-f', '-'], {
+        stdout: 'inherit',
+        input: campaignYAML,
+        env: options.auth,
+    })
 
     // return the campaign URL
     return `${options.auth.SRC_ENDPOINT}/organizations/${options.namespace}/campaigns/${options.name}`

--- a/dev/release/src/campaigns.ts
+++ b/dev/release/src/campaigns.ts
@@ -1,0 +1,50 @@
+import { CreatedChangeset } from './github'
+import { readLine } from './util'
+import YAML from 'yaml'
+import * as path from 'path'
+import * as os from 'os'
+import execa from 'execa'
+import { promisify } from 'util'
+import { writeFile as original_writeFile, mkdtemp as original_mkdtemp } from 'fs'
+
+const mkdtemp = promisify(original_mkdtemp)
+const writeFile = promisify(original_writeFile)
+
+async function sourcegraphAuth(): Promise<NodeJS.ProcessEnv> {
+    return {
+        SRC_ENDPOINT: 'https://k8s.sgdev.org',
+        SRC_ACCESS_TOKEN: await readLine('k8s.sgdev.org src-cli token: ', '.secrets/src-cli.txt'),
+    }
+}
+
+export interface CampaignOptions {
+    name: string
+    description: string
+    namespace: string
+    preview?: boolean
+}
+
+export async function importFromCreatedChanges(changes: CreatedChangeset[], options: CampaignOptions): Promise<string> {
+    // create a campaign
+    const importChangesets: { repository: string; externalIDs: number[] }[] = changes.map(change => ({
+        repository: `github.com/${change.repository}`,
+        externalIDs: [change.pullRequestNumber],
+    }))
+    const campaignSpec = {
+        name: options.name,
+        description: options.description,
+        importChangesets,
+    }
+
+    const tmpdir = await mkdtemp(path.join(os.tmpdir(), 'sg-campaigns'))
+    const campaignYAML = YAML.stringify(campaignSpec)
+    console.log(campaignYAML)
+    await writeFile(path.join(tmpdir, 'campaign.yaml'), campaignYAML)
+    const campaignScript = `set -ex
+
+    src campaign ${options.preview ? 'preview' : 'apply'} \\
+        -namespace ${options.namespace} \\
+        -f campaign.yaml`
+    await execa('bash', ['-c', campaignScript], { stdio: 'inherit', cwd: tmpdir, env: await sourcegraphAuth() })
+    return ''
+}

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -202,6 +202,7 @@ export interface CreatedChangeset {
     repository: string
     branch: string
     pullRequestURL: string
+    pullRequestNumber: number
 }
 
 export async function createChangesets(options: ChangesetsOptions): Promise<CreatedChangeset[]> {
@@ -218,14 +219,15 @@ export async function createChangesets(options: ChangesetsOptions): Promise<Crea
     const results: CreatedChangeset[] = []
     for (const change of options.changes) {
         await createBranchWithChanges(octokit, { ...change, dryRun: options.dryRun })
-        let prURL = ''
+        let pullRequest: { url: string; number: number } = { url: '', number: -1 }
         if (!options.dryRun) {
-            prURL = await createPR(octokit, change)
+            pullRequest = await createPR(octokit, change)
         }
         results.push({
             repository: `${change.owner}/${change.repo}`,
             branch: change.base,
-            pullRequestURL: prURL,
+            pullRequestURL: pullRequest.url,
+            pullRequestNumber: pullRequest.number,
         })
     }
 
@@ -315,7 +317,10 @@ async function createPR(
         title: string
         body?: string
     }
-): Promise<string> {
+): Promise<{ url: string; number: number }> {
     const response = await octokit.pulls.create(options)
-    return response.data.html_url
+    return {
+        url: response.data.html_url,
+        number: response.data.number,
+    }
 }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -449,7 +449,7 @@ ${issueCategories
                     `:captain: *Sourcegraph ${parsedVersion.version} release has been staged*
 
 * Campaign: ${publishCampaign}
-* @stephen: update deploy-sourcegraph-docker as needed`,
+* @stephen: update <https://github.com/sourcegraph/deploy-sourcegraph-docker|deploy-sourcegraph-docker> as needed`,
                     slackAnnounceChannel
                 )
             }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -449,8 +449,8 @@ ${issueCategories
                 await postMessage(
                     `:captain: *Sourcegraph ${parsedVersion.version} release has been staged*
 
-                    * Campaign: ${publishCampaign}
-                    * @stephen: update deploy-sourcegraph-docker as needed`,
+* Campaign: ${publishCampaign}
+* @stephen: update deploy-sourcegraph-docker as needed`,
                     slackAnnounceChannel
                 )
             }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -500,7 +500,7 @@ ${issueCategories
         },
     },
     {
-        // Example: yarn run release _test:campaign-import-changes "$(cat ./.secrets/import.json)"
+        // Example: yarn run release _test:campaign-create-from-changes "$(cat ./.secrets/import.json)"
         id: '_test:campaign-create-from-changes',
         run: async (_config, campaignConfigJSON) => {
             const campaignConfig = JSON.parse(campaignConfigJSON) as {

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -450,7 +450,7 @@ ${issueCategories
     },
     {
         id: 'release:add-to-campaign',
-        // Example: yarn run release release:add-to-campaign 3.21.0 sourcegraph/sourcegraph 15032
+        // Example: yarn run release release:add-to-campaign 3.21.0 sourcegraph/about 1797
         run: async (_config, version, changeRepo, changeID) => {
             const parsedVersion = semver.parse(version, { loose: false })
             if (!parsedVersion) {


### PR DESCRIPTION
Adds basic [campaigns](https://docs.sourcegraph.com/campaigns) integration into our [release process (also requires review)](https://github.com/sourcegraph/about/pull/1838) by using the `importChangesets` feature on pull requests that our release tooling already generates.

* `release:publish` now generates a new campaign
   * we do not use `src-cli` to generate the changes right now, since it is not currently possible without per-repository `steps` - this might be enabled by @mrnugget 's https://github.com/sourcegraph/src-cli/pull/361 , this would be really cool
* `release:add-to-campaign` adds an existing change to release-tracking campaign, i.e. to track a blog post PR like https://github.com/sourcegraph/about/pull/1797:
   ```
   yarn run release release:add-to-campaign 3.21.0 sourcegraph/about 1797
   ```

Closes https://github.com/sourcegraph/sourcegraph/issues/14971 

---

To demo what this might look like, I created an example [release-sourcegraph-3.21.0](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.21.0) using "fake" created changesets:

```jsonc
// yarn run release _test:campaign-create-from-changes "$(cat ./.secrets/import.json)"
{
  "name": "release-sourcegraph-3.21.0",
  "description": "[TEST] Track publishing of sourcegraph@3.21.0",
  "changes": [
    {
      "repository": "sourcegraph/sourcegraph",
      "pullRequestNumber": 14880
    },
    {
      "repository": "sourcegraph/deploy-sourcegraph",
      "pullRequestNumber": 1108
    },
    {
      "repository": "sourcegraph/deploy-sourcegraph-dot-com",
      "pullRequestNumber": 3705
    }
  ]
}
```

and added a few other PRs to it using `release:add-to-campaign`:

![image](https://user-images.githubusercontent.com/23356519/97154505-e9d91b00-17ae-11eb-9e96-228c52fe03e6.png)

Opened https://github.com/sourcegraph/sourcegraph/issues/15039 , https://github.com/sourcegraph/sourcegraph/issues/15045 in response to some things I ran into while working on this

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
