### PR TITLE
Improve chromatic load speeds

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,8 +2,11 @@ const path = require('path')
 const { remove } = require('lodash')
 const { DefinePlugin, ProgressPlugin } = require('webpack')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
 
 const monacoEditorPaths = [path.resolve(__dirname, '..', 'node_modules', 'monaco-editor')]
+
+const isChromatic = !!process.env.CHROMATIC
 
 const config = {
   stories: ['../client/**/*.story.tsx'],
@@ -14,13 +17,32 @@ const config = {
    */
   webpackFinal: config => {
     // Include sourcemaps
-    config.mode = 'development'
-    config.devtool = 'cheap-module-eval-source-map'
+    config.mode = isChromatic ? 'production' : 'development'
+    config.devtool = isChromatic ? 'source-map' : 'cheap-module-eval-source-map'
     const definePlugin = config.plugins.find(plugin => plugin instanceof DefinePlugin)
     // @ts-ignore
-    definePlugin.definitions.NODE_ENV = JSON.stringify('development')
+    definePlugin.definitions.NODE_ENV = JSON.stringify(config.mode)
     // @ts-ignore
-    definePlugin.definitions['process.env'].NODE_ENV = JSON.stringify('development')
+    definePlugin.definitions['process.env'].NODE_ENV = JSON.stringify(config.mode)
+
+    if (isChromatic) {
+      config.optimization = {
+        minimize: true,
+        minimizer: [
+          new TerserPlugin({
+            sourceMap: true,
+            terserOptions: {
+              compress: {
+                // // Don't inline functions, which causes name collisions with uglify-es:
+                // https://github.com/mishoo/UglifyJS2/issues/2842
+                inline: 1,
+              },
+            },
+          }),
+        ],
+        namedModules: false,
+      }
+    }
 
     // We don't use Storybook's default Babel config for our repo, it doesn't include everything we need.
     config.module.rules.splice(0, 1)

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -96,6 +96,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.AutomaticRetry(5),
 			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("yarn gulp generate"),
+			bk.Env("CHROMATIC", "1"),
 			bk.Cmd(chromaticCommand))
 
 		// Shared tests


### PR DESCRIPTION
This gets down the uncached page size on a chromatic storybook to 3mb on my local machine from 40.5mb on main. Those with slower internet will thank. But it also affects execution speed as way less bytes of JS needs to be parsed.