### PR TITLE
Allow padding for markdown images

### DIFF
--- a/client/shared/src/util/markdown.ts
+++ b/client/shared/src/util/markdown.ts
@@ -118,7 +118,7 @@ export const renderMarkdown = (
                     'class',
                     { name: 'rel', values: ['noopener', 'noreferrer'] },
                 ],
-                img: [...sanitize.defaults.allowedAttributes.img, 'alt', 'width', 'height', 'align'],
+                img: [...sanitize.defaults.allowedAttributes.img, 'alt', 'width', 'height', 'align', 'style'],
                 // Support different images depending on media queries (e.g. color theme, reduced motion)
                 source: ['srcset', 'media'],
                 // Support SVGs for code insights.
@@ -143,6 +143,9 @@ export const renderMarkdown = (
                 h6: ['id'],
             },
             allowedStyles: {
+                img: {
+                    padding: ALL_VALUES_ALLOWED,
+                },
                 // SVGs are usually for charts in code insights.
                 // Allow them to be responsive.
                 svg: {

--- a/client/shared/src/util/markdown.ts
+++ b/client/shared/src/util/markdown.ts
@@ -145,6 +145,10 @@ export const renderMarkdown = (
             allowedStyles: {
                 img: {
                     padding: ALL_VALUES_ALLOWED,
+                    'padding-left': ALL_VALUES_ALLOWED,
+                    'padding-right': ALL_VALUES_ALLOWED,
+                    'padding-top': ALL_VALUES_ALLOWED,
+                    'padding-bottom': ALL_VALUES_ALLOWED,
                 },
                 // SVGs are usually for charts in code insights.
                 // Allow them to be responsive.


### PR DESCRIPTION
Will make link-preview-expander's hover content look a little better.

**Before**

![Screenshot from 2020-10-25 22-46-51](https://user-images.githubusercontent.com/37420160/97130298-6ae4d380-1717-11eb-8b54-0abb098de915.png)

**After**

![Screenshot from 2020-10-25 22-45-47](https://user-images.githubusercontent.com/37420160/97130293-691b1000-1717-11eb-83a7-df1bb9e37c89.png)