### PR TITLE
Fix extension registry categorization

### DIFF
--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -87,7 +87,10 @@ const extensionRegistryQuery = gql`
     }
 `
 
-export type ConfiguredExtensionCache = Map<string, ConfiguredRegistryExtension<RegistryExtensionFieldsForList>>
+export type ConfiguredExtensionCache = Map<
+    string,
+    Pick<ConfiguredRegistryExtension<RegistryExtensionFieldsForList>, 'manifest' | 'id'>
+>
 
 /** A page that displays overview information about the available extensions. */
 export const ExtensionRegistry: React.FunctionComponent<Props> = props => {

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -69,7 +69,7 @@ describe('RegistryExtensionOverviewPage', () => {
                         className?.includes('test-registry-extension-categories')
                     )
                 )
-            ).toEqual(['Other', 'Programming languages' /* no 'invalid' */])
+            ).toEqual(['Programming languages', 'Other' /* no 'invalid' */])
         })
     })
 })

--- a/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -35,10 +35,10 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           <a
             className="btn btn-outline-secondary btn-sm"
-            href="/extensions?query=category%3AOther"
+            href="/extensions?query=category%3A%22Programming+languages%22"
             onClick={[Function]}
           >
-            Other
+            Programming languages
           </a>
         </li>
         <li
@@ -46,10 +46,10 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           <a
             className="btn btn-outline-secondary btn-sm"
-            href="/extensions?query=category%3A%22Programming+languages%22"
+            href="/extensions?query=category%3AOther"
             onClick={[Function]}
           >
-            Programming languages
+            Other
           </a>
         </li>
       </ul>

--- a/client/web/src/extensions/extension/extension.test.ts
+++ b/client/web/src/extensions/extension/extension.test.ts
@@ -18,10 +18,10 @@ describe('splitExtensionID', () => {
 })
 
 describe('validCategories', () => {
-    test('selects only known categories, sorts, and dedupes', () =>
+    test('selects only known categories and dedupes', () =>
         expect(validCategories(['Programming languages', 'Other', 'x', 'Other'])).toEqual([
-            'Other',
             'Programming languages',
+            'Other',
         ]))
 
     test('returns undefined for undefined', () => expect(validCategories(undefined)).toEqual(undefined))

--- a/client/web/src/extensions/extension/extension.ts
+++ b/client/web/src/extensions/extension/extension.ts
@@ -86,11 +86,9 @@ export function validCategories(categories: ExtensionManifest['categories']): Ex
         return undefined
     }
     const validCategories = uniq(
-        categories
-            .filter((category): category is ExtensionCategory =>
-                EXTENSION_CATEGORIES.includes(category as ExtensionCategory)
-            )
-            .sort()
+        categories.filter((category): category is ExtensionCategory =>
+            EXTENSION_CATEGORIES.includes(category as ExtensionCategory)
+        )
     )
     return validCategories.length === 0 ? undefined : validCategories
 }

--- a/client/web/src/extensions/extensions.test.ts
+++ b/client/web/src/extensions/extensions.test.ts
@@ -1,9 +1,49 @@
+import { ConfiguredRegistryExtension } from '../../../shared/src/extensions/extension'
+import { ExtensionManifest } from '../../../shared/src/extensions/extensionManifest'
 import { ExtensionCategory, EXTENSION_CATEGORIES } from '../../../shared/src/schema/extensionSchema'
 import { Settings } from '../../../shared/src/settings/settings'
 import { createRecord } from '../../../shared/src/util/createRecord'
-import { applyCategoryFilter, applyExtensionsEnablement } from './extensions'
+import { RegistryExtensionFieldsForList } from '../graphql-operations'
+import { ConfiguredExtensionCache } from './ExtensionRegistry'
+import { applyCategoryFilter, applyExtensionsEnablement, configureExtensionRegistry } from './extensions'
 
 describe('extension registry helpers', () => {
+    describe('configureExtensionRegistry', () => {
+        test('should group extensions by first listed category', () => {
+            const configuredExtensionCache: ConfiguredExtensionCache = new Map<
+                string,
+                ConfiguredRegistryExtension<RegistryExtensionFieldsForList>
+            >()
+
+            const nodes: RegistryExtensionFieldsForList[] = [
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                { id: 'sourcegraph/snyk' } as RegistryExtensionFieldsForList,
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                { id: 'sourcegraph/eslint' } as RegistryExtensionFieldsForList,
+            ]
+
+            configuredExtensionCache.set('sourcegraph/snyk', {
+                id: 'sourcegraph/snyk',
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                manifest: {
+                    categories: ['External services', 'Code analysis'],
+                } as ExtensionManifest,
+            })
+
+            configuredExtensionCache.set('sourcegraph/eslint', {
+                id: 'sourcegraph/eslint',
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                manifest: {
+                    categories: ['Code analysis', 'Linters'],
+                } as ExtensionManifest,
+            })
+
+            const { extensionIDsByCategory } = configureExtensionRegistry(nodes, configuredExtensionCache)
+            expect(extensionIDsByCategory['External services'].primaryExtensionIDs).toStrictEqual(['sourcegraph/snyk'])
+            expect(extensionIDsByCategory['Code analysis'].primaryExtensionIDs).toStrictEqual(['sourcegraph/eslint'])
+        })
+    })
+
     const TEST_EXTENSION_CATEGORIES: ExtensionCategory[] = ['Reports and stats', 'Linters']
 
     const extensionsByCategory: Parameters<typeof applyCategoryFilter>[0] = createRecord(

--- a/client/web/src/extensions/extensions.ts
+++ b/client/web/src/extensions/extensions.ts
@@ -12,7 +12,7 @@ import { Settings } from '../../../shared/src/settings/settings'
 import { createRecord } from '../../../shared/src/util/createRecord'
 
 export interface ConfiguredRegistryExtensions {
-    [id: string]: ConfiguredRegistryExtension<RegistryExtensionFieldsForList>
+    [id: string]: Pick<ConfiguredRegistryExtension<RegistryExtensionFieldsForList>, 'manifest' | 'id'>
 }
 
 export interface ConfiguredExtensionRegistry {
@@ -67,7 +67,6 @@ export function configureExtensionRegistry(
         } else {
             categories = NO_VALID_CATEGORIES
         }
-
         // TODO: Add `primaryCategory` to extension schema
         // Primary category is either specified or inferred by array position
         const primaryCategory = categories[0]


### PR DESCRIPTION
Fix #14866.

I used an existing helper function `validCategories` to remove invalid or deprecated categories, but I didn't notice that it sorted the filtered array. I removed the sort and added a test to prevent regressions