### PR TITLE
Don't render 0 when extension tag list is empty

### DIFF
--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -43,6 +43,38 @@ describe('RegistryExtensionOverviewPage', () => {
         ).toMatchSnapshot()
     })
 
+    // Meant to prevent this regression: https://github.com/sourcegraph/sourcegraph/pull/15040
+    test('renders with no tags', () => {
+        const history = createMemoryHistory()
+        expect(
+            renderer
+                .create(
+                    <Router history={history}>
+                        <RegistryExtensionOverviewPage
+                            eventLogger={{ logViewEvent: noop }}
+                            extension={{
+                                id: 'x',
+                                rawManifest: '{}',
+                                manifest: {
+                                    url: 'https://example.com',
+                                    activationEvents: ['*'],
+                                    categories: ['Programming languages', 'Other'],
+                                    tags: [],
+                                    readme: '**A**',
+                                    repository: {
+                                        url: 'https://github.com/foo/bar',
+                                        type: 'git',
+                                    },
+                                },
+                            }}
+                            history={history}
+                        />
+                    </Router>
+                )
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+
     describe('categories', () => {
         test('filters out unrecognized categories', () => {
             const history = createMemoryHistory()

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -81,7 +81,8 @@ export class RegistryExtensionOverviewPage extends React.PureComponent<Props> {
                     )}
                     {this.props.extension.manifest &&
                         !isErrorLike(this.props.extension.manifest) &&
-                        this.props.extension.manifest.tags?.length && (
+                        this.props.extension.manifest.tags &&
+                        this.props.extension.manifest.tags.length > 0 && (
                             <div className="mb-3">
                                 <h3>Tags</h3>
                                 <ul className="list-inline">

--- a/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -138,3 +138,109 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
   </aside>
 </div>
 `;
+
+exports[`RegistryExtensionOverviewPage renders with no tags 1`] = `
+<div
+  className="registry-extension-overview-page d-flex flex-wrap"
+>
+  <div
+    className="registry-extension-overview-page__readme mr-3"
+  >
+    <div
+      className="markdown"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p><strong>A</strong></p>
+",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+  <aside
+    className="registry-extension-overview-page__sidebar"
+  >
+    <div
+      className="mb-3"
+    >
+      <h3>
+        Categories
+      </h3>
+      <ul
+        className="list-inline test-registry-extension-categories"
+      >
+        <li
+          className="list-inline-item mb-2"
+        >
+          <a
+            className="btn btn-outline-secondary btn-sm"
+            href="/extensions?query=category%3AOther"
+            onClick={[Function]}
+          >
+            Other
+          </a>
+        </li>
+        <li
+          className="list-inline-item mb-2"
+        >
+          <a
+            className="btn btn-outline-secondary btn-sm"
+            href="/extensions?query=category%3A%22Programming+languages%22"
+            onClick={[Function]}
+          >
+            Programming languages
+          </a>
+        </li>
+      </ul>
+    </div>
+    <small
+      className="text-muted"
+    >
+      <dl
+        className="border-top pt-2"
+      >
+        <dt
+          className="border-top pt-2"
+        >
+          Extension ID
+        </dt>
+        <dd>
+          x
+        </dd>
+        <dt
+          className="border-top pt-2"
+        >
+          Resources
+        </dt>
+        <dd
+          className="border-bottom pb-2"
+        >
+          <a
+            className="d-block"
+            href="https://example.com"
+            rel="nofollow noopener noreferrer"
+            target="_blank"
+          >
+            Source code (JavaScript)
+          </a>
+          <div
+            className="d-flex"
+          >
+            <GithubIcon
+              className="icon-inline mr-1"
+            />
+            <a
+              className="d-block"
+              href="https://github.com/foo/bar"
+              rel="nofollow noreferrer noopener"
+              target="_blank"
+            >
+              Repository
+            </a>
+          </div>
+        </dd>
+      </dl>
+    </small>
+  </aside>
+</div>
+`;


### PR DESCRIPTION
**Before**

![Screenshot from 2020-10-26 02-01-25](https://user-images.githubusercontent.com/37420160/97139143-37fb0980-1730-11eb-9a93-66cc0b570b88.png)

**After**

![Screenshot from 2020-10-26 02-08-25](https://user-images.githubusercontent.com/37420160/97139150-3cbfbd80-1730-11eb-97b3-b26735067b28.png)

This happens because while 0 is falsy, it's a number, so it's renderable by React