### PR TITLE
licensing: restructure user limit enforcement file

### DIFF
--- a/enterprise/cmd/frontend/authz/authz.go
+++ b/enterprise/cmd/frontend/authz/authz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/enforcement"
 	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/db"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
@@ -113,11 +114,11 @@ func Init(d dbutil.DB, clock func() time.Time) {
 			info, err := licensing.GetConfiguredProductLicenseInfo()
 			if err != nil {
 				log15.Error("Error reading license key for Sourcegraph subscription.", "err", err)
-				licensing.WriteSubscriptionErrorResponse(w, http.StatusInternalServerError, "Error reading Sourcegraph license key", "Site admins may check the logs for more information. Update the license key in the [**site configuration**](/site-admin/configuration).")
+				enforcement.WriteSubscriptionErrorResponse(w, http.StatusInternalServerError, "Error reading Sourcegraph license key", "Site admins may check the logs for more information. Update the license key in the [**site configuration**](/site-admin/configuration).")
 				return
 			}
 			if info != nil && info.IsExpiredWithGracePeriod() {
-				licensing.WriteSubscriptionErrorResponse(w, http.StatusForbidden, "Sourcegraph license expired", "To continue using Sourcegraph, a site admin must renew the Sourcegraph license (or downgrade to only using Sourcegraph Free features). Update the license key in the [**site configuration**](/site-admin/configuration).")
+				enforcement.WriteSubscriptionErrorResponse(w, http.StatusForbidden, "Sourcegraph license expired", "To continue using Sourcegraph, a site admin must renew the Sourcegraph license (or downgrade to only using Sourcegraph Free features). Update the license key in the [**site configuration**](/site-admin/configuration).")
 				return
 			}
 

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -1,0 +1,52 @@
+package enforcement
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+)
+
+// NewPreCreateUserHook returns a PreCreateUserHook closure with
+// the given UsersStore.
+func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
+	return func(ctx context.Context) error {
+		info, err := licensing.GetConfiguredProductLicenseInfo()
+		if err != nil {
+			return err
+		}
+		var licensedUserCount int32
+		if info != nil {
+			licensedUserCount = int32(info.UserCount)
+		} else {
+			licensedUserCount = licensing.NoLicenseMaximumAllowedUserCount
+		}
+
+		// Block creation of a new user beyond the licensed user count (unless true-up is allowed).
+		userCount, err := s.Count(ctx)
+		if err != nil {
+			return err
+		}
+		// Be conservative and treat 0 as unlimited. We don't plan to intentionally generate
+		// licenses with UserCount == 0, but that might result from a bug in license decoding, and
+		// we don't want that to immediately disable Sourcegraph instances.
+		if licensedUserCount > 0 && int32(userCount) >= licensedUserCount {
+			if info != nil && info.HasTag(licensing.TrueUpUserCountTag) {
+				log15.Info("Licensed user count exceeded, but license supports true-up and will not block creation of new user. The new user will be retroactively charged for in the next billing period. Contact sales@sourcegraph.com for help.", "activeUserCount", userCount, "licensedUserCount", licensedUserCount)
+			} else {
+				message := "Unable to create user account: "
+				if info == nil {
+					message += fmt.Sprintf("a Sourcegraph subscription is required to exceed %d users (this instance now has %d users). Contact Sourcegraph to learn more at https://about.sourcegraph.com/contact/sales.", licensing.NoLicenseMaximumAllowedUserCount, userCount)
+				} else {
+					message += "the Sourcegraph subscription's maximum user count has been reached. A site admin must upgrade the Sourcegraph subscription to allow for more users. Contact Sourcegraph at https://about.sourcegraph.com/contact/sales."
+				}
+				return errcode.NewPresentationError(message)
+			}
+		}
+
+		return nil
+	}
+}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -1,4 +1,4 @@
-package licensing
+package enforcement
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 )
 
 func TestEnforcementPreCreateUser(t *testing.T) {
@@ -55,22 +56,22 @@ func TestEnforcementPreCreateUser(t *testing.T) {
 
 		// True-up licenses.
 		{
-			license:         &license.Info{Tags: []string{TrueUpUserCountTag}, UserCount: 10},
+			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 		{
-			license:         &license.Info{Tags: []string{TrueUpUserCountTag}, UserCount: 10},
+			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10},
 			activeUserCount: 15,
 			wantErr:         false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("license %s with %d active users", test.license, test.activeUserCount), func(t *testing.T) {
-			MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+			licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
 				return test.license, "test-signature", nil
 			}
-			defer func() { MockGetConfiguredProductLicenseInfo = nil }()
+			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 			store := fakeStore{count: test.activeUserCount}
 			err := NewPreCreateUserHook(store)(context.Background())
 			if gotErr := err != nil; gotErr != test.wantErr {

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -23,7 +23,7 @@ import (
 func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
-	db.Users.PreCreateUser = licensing.NewPreCreateUserHook(&usersStore{})
+	db.Users.PreCreateUser = enforcement.NewPreCreateUserHook(&usersStore{})
 
 	// Enforce the license's max external service count by preventing the creation of new external
 	// services when the max is reached.


### PR DESCRIPTION
There is no functional change, only merges the `licensing/enforcement.go` into `enforcement` package.

Fixes #14611