### PR TITLE
search: refactor parser to simplify regex and literal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Improved contrast / visibility in comment syntax highlighting. [#14546](https://github.com/sourcegraph/sourcegraph/issues/14546)
 - Campaigns are no longer in beta. [#14900](https://github.com/sourcegraph/sourcegraph/pull/14900)
 - Campaigns now have a fancy new icon. [#14740](https://github.com/sourcegraph/sourcegraph/pull/14740)
+- Search queries with an unbalanced closing paren `)` are now invalid, since this likely indicates an error. Previously, patterns with dangling `)` were valid in some cases. Note that patterns with dangling `)` can still be searched, but should be quoted via `content:"foo)"`. [#15042](https://github.com/sourcegraph/sourcegraph/pull/15042)
 
 ### Fixed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -597,16 +597,35 @@ func TestSearch(t *testing.T) {
 				query: `repo:^github\.com/sgtest/go-diff file:^diff/print\.go Bytes() and Time() patterntype:literal`,
 			},
 			{
-				name:  `Dangling right parens, heuristic for literal search`,
-				query: `repo:^github\.com/sgtest/go-diff$ diffPath) and main patterntype:literal`,
+				name:  `Dangling right parens, supported via content: filter`,
+				query: `repo:^github\.com/sgtest/go-diff$ content:"diffPath)" and main patterntype:literal`,
 			},
 			{
-				name:  `Dangling right parens, heuristic for literal search, double parens`,
-				query: `repo:^github\.com/sgtest/go-diff$ MarshalTo and OrigName)) patterntype:literal`,
+				name:       `Dangling right parens, unsupported in literal search`,
+				query:      `repo:^github\.com/sgtest/go-diff$ diffPath) and main patterntype:literal`,
+				zeroResult: true,
+				wantAlert: &gqltestutil.SearchAlert{
+					Title:       "Unable To Process Query",
+					Description: "Unbalanced expression: unmatched closing parenthesis )",
+				},
 			},
 			{
-				name:  `Dangling right parens, heuristic for literal search, simple group before right paren`,
-				query: `repo:^github\.com/sgtest/go-diff$ MarshalTo and (m.OrigName)) patterntype:literal`,
+				name:       `Dangling right parens, unsupported in literal search, double parens`,
+				query:      `repo:^github\.com/sgtest/go-diff$ MarshalTo and OrigName)) patterntype:literal`,
+				zeroResult: true,
+				wantAlert: &gqltestutil.SearchAlert{
+					Title:       "Unable To Process Query",
+					Description: "Unbalanced expression: unmatched closing parenthesis )",
+				},
+			},
+			{
+				name:       `Dangling right parens, unsupported in literal search, simple group before right paren`,
+				query:      `repo:^github\.com/sgtest/go-diff$ MarshalTo and (m.OrigName)) patterntype:literal`,
+				zeroResult: true,
+				wantAlert: &gqltestutil.SearchAlert{
+					Title:       "Unable To Process Query",
+					Description: "Unbalanced expression: unmatched closing parenthesis )",
+				},
 			},
 			{
 				name:       `Dangling right parens, heuristic for literal search, cannot succeed, too confusing`,
@@ -614,7 +633,7 @@ func TestSearch(t *testing.T) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "Unable To Process Query",
-					Description: "Error parsing regexp: missing closing ): `(respObj.Size`",
+					Description: "Unbalanced expression: unmatched closing parenthesis )",
 				},
 			},
 			{

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/inconshreveable/log15"
 )
 
 /*
@@ -514,9 +512,9 @@ func ScanField(buf []byte) (string, bool, int) {
 // ScanValue scans for a value (e.g., of a parameter, or a string corresponding
 // to a search pattern). Its main function is to determine when to stop scanning
 // a value (e.g., at a parentheses), and which escape sequences to interpret. It
-// returns the scanned value, how much was advanced, and whether the
-// allowDanglingParenthesis heuristic was applied
-func ScanValue(buf []byte, allowDanglingParens bool) (string, int, bool) {
+// returns the scanned value, how much was advanced, and whether to allow
+// scanning dangling parentheses in patterns like "foo(".
+func ScanValue(buf []byte, allowDanglingParens bool) (string, int) {
 	var count, advance, balanced int
 	var r rune
 	var result []rune
@@ -559,7 +557,7 @@ func ScanValue(buf []byte, allowDanglingParens bool) (string, int, bool) {
 		}
 		result = append(result, r)
 	}
-	return string(result), count, balanced != 0
+	return string(result), count
 }
 
 // TryParseDelimiter tries to parse a delimited string, returning the
@@ -624,18 +622,15 @@ func (p *parser) ParseFieldValue() (string, error) {
 	value, advance, ok := ScanBalancedPatternLiteral(p.buf[p.pos:])
 	if !ok {
 		// The above failed, so attempt a best effort.
-		value, advance, _ = ScanValue(p.buf[p.pos:], false)
+		value, advance = ScanValue(p.buf[p.pos:], false)
 	}
 	p.pos += advance
 	return value, nil
 }
 
-// ParsePatternRegexp parses a leaf node Pattern that corresponds to a search pattern.
-// Note that ParsePattern may be called multiple times (a query can have
-// multiple Patterns concatenated together).
-func (p *parser) ParsePatternRegexp() Pattern {
+// Try parse a delimited pattern, quoted as "...", '...', or /.../.
+func (p *parser) TryParseDelimitedPattern() (Pattern, bool) {
 	start := p.pos
-	// If we can parse a well-delimited value, that takes precedence.
 	if value, delimiter, ok := p.TryParseDelimiter(); ok {
 		var labels labels
 		if delimiter == '/' {
@@ -644,73 +639,62 @@ func (p *parser) ParsePatternRegexp() Pattern {
 		} else {
 			labels = Literal | Quoted
 		}
-		return Pattern{
-			Value:   value,
-			Negated: false,
-			Annotation: Annotation{
-				Labels: labels,
-				Range:  newRange(start, p.pos),
-			},
-		}
+		return newPattern(value, false, labels, newRange(start, p.pos)), true
 	}
+	return Pattern{}, false
+}
 
-	if isSet(p.heuristics, parensAsPatterns) {
-		if value, advance, ok := ScanBalancedPatternLiteral(p.buf[p.pos:]); ok {
-			pattern := Pattern{
-				Value:   value,
-				Negated: false,
-				Annotation: Annotation{
-					Labels: Regexp,
-					Range:  newRange(p.pos, p.pos+advance),
-				},
-			}
-			p.pos += advance
-			return pattern
-		}
+func (p *parser) TryScanBalancedPatternLiteral(label labels) (Pattern, bool) {
+	if value, advance, ok := ScanBalancedPatternLiteral(p.buf[p.pos:]); ok {
+		pattern := newPattern(value, false, label, newRange(p.pos, p.pos+advance))
+		p.pos += advance
+		return pattern, true
 	}
+	return Pattern{}, false
+}
 
-	value, advance, sawDanglingParen := ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
-	var labels labels
-	if sawDanglingParen {
-		labels = HeuristicDanglingParens | Regexp
-	} else {
-		labels = Regexp
-	}
-	p.pos += advance
-	// Invariant: the pattern can't be quoted since we checked for that.
+func newPattern(value string, negated bool, labels labels, range_ Range) Pattern {
 	return Pattern{
 		Value:   value,
 		Negated: false,
 		Annotation: Annotation{
 			Labels: labels,
-			Range:  newRange(start, p.pos),
+			Range:  range_,
 		},
 	}
 }
 
-func (p *parser) ParsePatternLiteral() Pattern {
-	start := p.pos
-	if value, advance, ok := ScanBalancedPatternLiteral(p.buf[p.pos:]); ok && value != "" {
-		p.pos += advance
-		return Pattern{
-			Value:   value,
-			Negated: false,
-			Annotation: Annotation{
-				Labels: Literal,
-				Range:  newRange(start, p.pos),
-			},
+// ParsePattern parses a leaf node Pattern that corresponds to a search pattern.
+// Note that ParsePattern may be called multiple times (a query can have
+// multiple Patterns concatenated together).
+func (p *parser) ParsePattern(label labels) Pattern {
+	if label.isSet(Regexp) {
+		// First try parse delimited values for regexp.
+		if pattern, ok := p.TryParseDelimitedPattern(); ok {
+			return pattern
 		}
 	}
-	value, advance := ScanAnyPatternLiteral(p.buf[p.pos:])
-	p.pos += advance
-	return Pattern{
-		Value:   value,
-		Negated: false,
-		Annotation: Annotation{
-			Labels: Literal,
-			Range:  newRange(start, p.pos),
-		},
+
+	if isSet(p.heuristics, parensAsPatterns) {
+		if pattern, ok := p.TryScanBalancedPatternLiteral(label); ok {
+			return pattern
+		}
 	}
+
+	start := p.pos
+	var value string
+	var advance int
+	if label.isSet(Regexp) {
+		value, advance = ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
+	} else {
+		value, advance = ScanAnyPatternLiteral(p.buf[p.pos:])
+	}
+	if isSet(p.heuristics, allowDanglingParens) {
+		label.set(HeuristicDanglingParens)
+	}
+	p.pos += advance
+	return newPattern(value, false, label, newRange(start, p.pos))
+
 }
 
 // ParseParameter returns a leaf node corresponding to the syntax
@@ -769,155 +753,9 @@ func partitionParameters(nodes []Node) []Node {
 	return newOperator(append(unorderedParams, patterns...), And)
 }
 
-// concatPatterns extends the left pattern with the right pattern, appropriately
-// updating the ranges and annotations.
-func concatPatterns(left, right Pattern) (Pattern, error) {
-	if left.Annotation.Range.End.Column != right.Annotation.Range.Start.Column {
-		log15.Warn("parser can't process concatPatterns",
-			"left", left, "right", right,
-			"leftEnd", left.Annotation.Range.End.Column,
-			"rightBegin", right.Annotation.Range.Start.Column)
-		return Pattern{}, &UnsupportedError{Msg: "invalid query syntax"}
-	}
-	left.Value += right.Value
-	left.Annotation.Labels |= right.Annotation.Labels
-	left.Annotation.Range.End.Column += len(right.Value)
-	return left, nil
-}
-
-// parseLeavesLiteral scans for consecutive leaf nodes when interpreting the
-// query as containing literal patterns.
-func (p *parser) parseLeavesLiteral() ([]Node, error) {
-	var nodes []Node
-	start := p.pos
-loop:
-	for {
-		if err := p.skipSpaces(); err != nil {
-			return nil, err
-		}
-		if p.done() {
-			break loop
-		}
-		switch {
-		case p.match(LPAREN):
-			if value, advance, ok := ScanBalancedPatternLiteral(p.buf[p.pos:]); ok {
-				p.pos += advance
-				pattern := Pattern{
-					Value:   value,
-					Negated: false,
-					Annotation: Annotation{
-						Labels: Literal | HeuristicParensAsPatterns,
-						Range:  newRange(start, p.pos),
-					},
-				}
-				nodes = append(nodes, pattern)
-				continue
-			}
-			if isSet(p.heuristics, allowDanglingParens) {
-				// Consume strings containing unbalanced
-				// parentheses up to whitespace.
-				pattern := p.ParsePatternLiteral()
-				pattern.Annotation.Labels |= HeuristicDanglingParens
-				nodes = append(nodes, pattern)
-				continue
-			}
-			_ = p.expect(LPAREN) // Guaranteed to succeed.
-			p.balanced++
-			p.heuristics |= disambiguated
-			result, err := p.parseOr()
-			if err != nil {
-				return nil, err
-			}
-			nodes = append(nodes, result...)
-		case p.match(RPAREN):
-			if p.balanced <= 0 {
-				// This is a dangling right paren. It can't possibly help
-				// us parse a well-formed query, so try treat it as a pattern.
-				pattern := p.ParsePatternLiteral()
-				pattern.Annotation.Labels |= HeuristicDanglingParens
-
-				// Heuristic: This right paren may be one we should associate with a previous pattern, and not
-				// just a dangling one. Check if a pattern occurred before it and append it if so.
-				if pattern.Annotation.Range.Start.Column > 0 {
-					// Heuristic is imprecise and that's OK: It will only look for a 1-byte whitespace
-					// character (not any unicode whitespace) before this paren.
-					if r, _ := utf8.DecodeRune([]byte{p.buf[pattern.Annotation.Range.Start.Column-1]}); !unicode.IsSpace(r) {
-						if len(nodes) > 0 {
-							if previous, ok := nodes[len(nodes)-1].(Pattern); ok {
-								result, err := concatPatterns(previous, pattern)
-								if err != nil {
-									return nil, err
-								}
-								nodes[len(nodes)-1] = result
-								continue
-							}
-						}
-					}
-				}
-
-				nodes = append(nodes, pattern)
-				continue
-			}
-			_ = p.expect(RPAREN) // Guaranteed to succeed.
-			p.balanced--
-			p.heuristics |= disambiguated
-			if len(nodes) == 0 {
-				// We parsed "()", interpret it literally.
-				nodes = []Node{
-					Pattern{
-						Value: "()",
-						Annotation: Annotation{
-							Labels: Literal | HeuristicParensAsPatterns,
-							Range:  newRange(start, p.pos),
-						},
-					},
-				}
-			}
-			break loop
-		case p.matchKeyword(AND), p.matchKeyword(OR):
-			// Caller advances.
-			break loop
-		case p.matchUnaryKeyword(NOT):
-			start := p.pos
-			_ = p.expect(NOT)
-			err := p.skipSpaces()
-			if err != nil {
-				return nil, err
-			}
-			if parameter, ok, _ := p.ParseParameter(); ok {
-				// we don't support NOT -field:value
-				if parameter.Negated {
-					return nil, fmt.Errorf("unexpected NOT before \"-%s:%s\". Remove NOT and try again",
-						parameter.Field, parameter.Value)
-				}
-				parameter.Negated = true
-				parameter.Annotation.Range = newRange(start, p.pos)
-				nodes = append(nodes, parameter)
-				continue
-			}
-			pattern := p.ParsePatternLiteral()
-			pattern.Negated = true
-			pattern.Annotation.Range = newRange(start, p.pos)
-			nodes = append(nodes, pattern)
-		default:
-			parameter, ok, err := p.ParseParameter()
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				nodes = append(nodes, parameter)
-			} else {
-				pattern := p.ParsePatternLiteral()
-				nodes = append(nodes, pattern)
-			}
-		}
-	}
-	return partitionParameters(nodes), nil
-}
-
-// parseLeavesRegexp scans for consecutive leaf nodes when interpreting the
-// query as containing regexp patterns.
-func (p *parser) parseLeavesRegexp() ([]Node, error) {
+// parseLeaves scans for consecutive leaf nodes and applies
+// label to patterns.
+func (p *parser) parseLeaves(label labels) ([]Node, error) {
 	var nodes []Node
 	start := p.pos
 loop:
@@ -932,15 +770,10 @@ loop:
 		case p.match(LPAREN) && !isSet(p.heuristics, allowDanglingParens):
 			if isSet(p.heuristics, parensAsPatterns) {
 				if value, advance, ok := ScanBalancedPatternLiteral(p.buf[p.pos:]); ok {
-					pattern := Pattern{
-						Value:   value,
-						Negated: false,
-						Annotation: Annotation{
-							Labels: Regexp,
-							Range:  newRange(p.pos, p.pos+advance),
-						},
+					if label.isSet(Literal) {
+						label.set(HeuristicParensAsPatterns)
 					}
-
+					pattern := newPattern(value, false, label, newRange(p.pos, p.pos+advance))
 					p.pos += advance
 					nodes = append(nodes, pattern)
 					continue
@@ -957,21 +790,16 @@ loop:
 			}
 			nodes = append(nodes, result...)
 		case p.expect(RPAREN) && !isSet(p.heuristics, allowDanglingParens):
+			if p.balanced <= 0 {
+				return nil, errors.New("unbalanced expression: unmatched closing parenthesis )")
+			}
 			p.balanced--
 			p.heuristics |= disambiguated
 			if len(nodes) == 0 {
 				// We parsed "()".
 				if isSet(p.heuristics, parensAsPatterns) {
 					// Interpret literally.
-					nodes = []Node{
-						Pattern{
-							Value: "()",
-							Annotation: Annotation{
-								Labels: Literal | HeuristicParensAsPatterns,
-								Range:  newRange(start, p.pos),
-							},
-						},
-					}
+					nodes = []Node{newPattern("()", false, Literal|HeuristicParensAsPatterns, newRange(start, p.pos))}
 				} else {
 					// Interpret as a group: return an empty non-nil node.
 					nodes = []Node{Parameter{}}
@@ -999,7 +827,7 @@ loop:
 				nodes = append(nodes, parameter)
 				continue
 			}
-			pattern := p.ParsePatternRegexp()
+			pattern := p.ParsePattern(label)
 			pattern.Negated = true
 			pattern.Annotation.Range = newRange(start, p.pos)
 			nodes = append(nodes, pattern)
@@ -1011,7 +839,7 @@ loop:
 			if ok {
 				nodes = append(nodes, parameter)
 			} else {
-				pattern := p.ParsePatternRegexp()
+				pattern := p.ParsePattern(label)
 				nodes = append(nodes, pattern)
 			}
 		}
@@ -1094,9 +922,9 @@ func (p *parser) parseAnd() ([]Node, error) {
 	var left []Node
 	var err error
 	if p.leafParser == SearchTypeRegex {
-		left, err = p.parseLeavesRegexp()
+		left, err = p.parseLeaves(Regexp)
 	} else {
-		left, err = p.parseLeavesLiteral()
+		left, err = p.parseLeaves(Literal)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/13434. This is a pretty hefty refactor to get rid of a kind of 'forked' handling of parsing. Before, it basically did:

```
              /----- parseLeavesLiteral (literal search)------\                   /--parsePatternLiteral-\
input  -----                                                   ----shared stuff---                        -- ....
              \---------- parseLeavesRegexp (regexp search)---/                   \--parsePatternRegexp--/
```

these forked/analog functions shared things, but also different and separated by the fact that I implemented literal search support after regex. They share enough logic that they should be merged (read: PR has more deletions than additions :P). After this PR, the structure is:

```
input -- parseLeaves (arg has literal or regex context) --- stuff --- parsePattern (arg has context) ---...
```

This will make it easier to translate some of the logic to frontend parser, see #14016.

With this change, I also decide to drop support for dangling closing parentheses. Mainly because I don't think handling this edge case is worth the amount of complexity it adds to the code. There's no harm in dropping support if we flag it, and provide the alternative (`content:"thing with )"`)

