### PR TITLE
Use basestore in repos store

### DIFF
--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -3,10 +3,16 @@ package types
 
 import (
 	"database/sql"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )
 
 // RepoFields are lazy loaded data fields on a Repo (from the DB).
@@ -50,6 +56,22 @@ type SourceInfo struct {
 	CloneURL string
 }
 
+// ExternalServiceID returns the ID of the external service this
+// SourceInfo refers to.
+func (i SourceInfo) ExternalServiceID() int64 {
+	ps := strings.SplitN(i.ID, ":", 3)
+	if len(ps) != 3 {
+		return -1
+	}
+
+	id, err := strconv.ParseInt(ps[2], 10, 64)
+	if err != nil {
+		return -1
+	}
+
+	return id
+}
+
 // Repo represents a source code repository.
 type Repo struct {
 	// ID is the unique numeric ID for this repository.
@@ -72,12 +94,285 @@ type Repo struct {
 	*RepoFields
 }
 
-// Repos is an utility type of a list of repos.
+// CloneURLs returns all the clone URLs this repo is clonable from.
+func (r *Repo) CloneURLs() []string {
+	urls := make([]string, 0, len(r.Sources))
+	for _, src := range r.Sources {
+		if src != nil && src.CloneURL != "" {
+			urls = append(urls, src.CloneURL)
+		}
+	}
+	return urls
+}
+
+// IsDeleted returns true if the repo is deleted.
+func (r *Repo) IsDeleted() bool { return !r.DeletedAt.IsZero() }
+
+// ExternalServiceIDs returns the IDs of the external services this
+// repo belongs to.
+func (r *Repo) ExternalServiceIDs() []int64 {
+	ids := make([]int64, 0, len(r.Sources))
+	for _, src := range r.Sources {
+		ids = append(ids, src.ExternalServiceID())
+	}
+	return ids
+}
+
+// Update updates Repo r with the fields from the given newer Repo n,
+// returning true if modified.
+func (r *Repo) Update(n *Repo) (modified bool) {
+	if r.Name != n.Name {
+		r.Name, modified = n.Name, true
+	}
+
+	if r.URI != n.URI {
+		r.URI, modified = n.URI, true
+	}
+
+	if r.Description != n.Description {
+		r.Description, modified = n.Description, true
+	}
+
+	if n.ExternalRepo != (api.ExternalRepoSpec{}) &&
+		!r.ExternalRepo.Equal(&n.ExternalRepo) {
+		r.ExternalRepo, modified = n.ExternalRepo, true
+	}
+
+	if r.Archived != n.Archived {
+		r.Archived, modified = n.Archived, true
+	}
+
+	if r.Fork != n.Fork {
+		r.Fork, modified = n.Fork, true
+	}
+
+	if r.Private != n.Private {
+		r.Private, modified = n.Private, true
+	}
+
+	if !reflect.DeepEqual(r.Sources, n.Sources) {
+		r.Sources, modified = n.Sources, true
+	}
+
+	// As a special case, we clear out the value of ViewerPermission for GitHub repos as
+	// the value is dependent on the token used to fetch it. We don't want to store this in the DB as it will
+	// flip flop as we fetch the same repo from different external services.
+	switch x := n.Metadata.(type) {
+	case *github.Repository:
+		cp := *x
+		cp.ViewerPermission = ""
+		n = n.With(func(clone *Repo) {
+			// Repo.Clone does not currently clone metadata for any types as they could contain hard to clone
+			// items such as maps. However, we know that copying github.Repository is safe as it only contains values.
+			clone.Metadata = &cp
+		})
+	}
+
+	if !reflect.DeepEqual(r.Metadata, n.Metadata) {
+		r.Metadata, modified = n.Metadata, true
+	}
+
+	return modified
+}
+
+// Clone returns a clone of the given repo.
+func (r *Repo) Clone() *Repo {
+	if r == nil {
+		return nil
+	}
+	clone := *r
+	if r.Sources != nil {
+		clone.Sources = make(map[string]*SourceInfo, len(r.Sources))
+		for k, v := range r.Sources {
+			clone.Sources[k] = v
+		}
+	}
+	return &clone
+}
+
+// Apply applies the given functional options to the Repo.
+func (r *Repo) Apply(opts ...func(*Repo)) {
+	if r == nil {
+		return
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+}
+
+// With returns a clone of the given repo with the given functional options applied.
+func (r *Repo) With(opts ...func(*Repo)) *Repo {
+	clone := r.Clone()
+	clone.Apply(opts...)
+	return clone
+}
+
+// Less compares Repos by the important fields (fields with constraints in our
+// DB). Additionally it will compare on Sources to give a deterministic order
+// on repos returned from a sourcer.
+//
+// NewDiff relies on Less to deterministically decide on the order to merge
+// repositories, as well as which repository to keep on conflicts.
+//
+// Context on using other fields such as timestamps to order/resolve
+// conflicts: We only want to rely on values that have constraints in our
+// database. Timestamps have the following downsides:
+//
+//   - We need to assume the upstream codehost has reasonable values for them
+//   - Not all codehosts set them to relevant values (eg gitolite or other)
+//   - They could change often for codehosts that do set them.
+func (r *Repo) Less(s *Repo) bool {
+	if r.ID != s.ID {
+		return r.ID < s.ID
+	}
+	if r.Name != s.Name {
+		return r.Name < s.Name
+	}
+	if cmp := r.ExternalRepo.Compare(s.ExternalRepo); cmp != 0 {
+		return cmp == -1
+	}
+
+	return sortedSliceLess(sourcesKeys(r.Sources), sourcesKeys(s.Sources))
+}
+
+func (r *Repo) String() string {
+	eid := fmt.Sprintf("{%s %s %s}", r.ExternalRepo.ServiceID, r.ExternalRepo.ServiceType, r.ExternalRepo.ID)
+	if r.IsDeleted() {
+		return fmt.Sprintf("Repo{ID: %d, Name: %q, EID: %s, IsDeleted: true}", r.ID, r.Name, eid)
+	}
+	return fmt.Sprintf("Repo{ID: %d, Name: %q, EID: %s}", r.ID, r.Name, eid)
+}
+
+func sourcesKeys(m map[string]*SourceInfo) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedSliceLess returns true if a < b
+func sortedSliceLess(a, b []string) bool {
+	for i, v := range a {
+		if i == len(b) {
+			return false
+		}
+		if v != b[i] {
+			return v < b[i]
+		}
+	}
+	return len(a) != len(b)
+}
+
+// Repos is an utility type with convenience methods for operating on lists of Repos.
 type Repos []*Repo
 
 func (rs Repos) Len() int           { return len(rs) }
 func (rs Repos) Less(i, j int) bool { return rs[i].ID < rs[j].ID }
 func (rs Repos) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
+
+// IDs returns the list of ids from all Repos.
+func (rs Repos) IDs() []api.RepoID {
+	ids := make([]api.RepoID, len(rs))
+	for i := range rs {
+		ids[i] = rs[i].ID
+	}
+	return ids
+}
+
+// Names returns the list of names from all Repos.
+func (rs Repos) Names() []string {
+	names := make([]string, len(rs))
+	for i := range rs {
+		names[i] = string(rs[i].Name)
+	}
+	return names
+}
+
+// NamesSummary caps the number of repos to 20 when composing a space-separated list string.
+// Used in logging statements.
+func (rs Repos) NamesSummary() string {
+	if len(rs) > 20 {
+		return strings.Join(rs[:20].Names(), " ") + "..."
+	}
+	return strings.Join(rs.Names(), " ")
+}
+
+// Kinds returns the unique set of kinds from all Repos.
+func (rs Repos) Kinds() (kinds []string) {
+	set := map[string]bool{}
+	for _, r := range rs {
+		kind := strings.ToUpper(r.ExternalRepo.ServiceType)
+		if !set[kind] {
+			kinds = append(kinds, kind)
+			set[kind] = true
+		}
+	}
+	return kinds
+}
+
+// ExternalRepos returns the list of set ExternalRepoSpecs from all Repos.
+func (rs Repos) ExternalRepos() []api.ExternalRepoSpec {
+	specs := make([]api.ExternalRepoSpec, 0, len(rs))
+	for _, r := range rs {
+		specs = append(specs, r.ExternalRepo)
+	}
+	return specs
+}
+
+// Sources returns a map of all the sources per repo id.
+func (rs Repos) Sources() map[api.RepoID][]SourceInfo {
+	sources := make(map[api.RepoID][]SourceInfo)
+	for i := range rs {
+		for _, info := range rs[i].Sources {
+			sources[rs[i].ID] = append(sources[rs[i].ID], *info)
+		}
+	}
+
+	return sources
+}
+
+// Concat adds the given Repos to the end of rs.
+func (rs *Repos) Concat(others ...Repos) {
+	for _, o := range others {
+		*rs = append(*rs, o...)
+	}
+}
+
+// Clone returns a clone of Repos.
+func (rs Repos) Clone() Repos {
+	o := make(Repos, 0, len(rs))
+	for _, r := range rs {
+		o = append(o, r.Clone())
+	}
+	return o
+}
+
+// Apply applies the given functional options to the Repo.
+func (rs Repos) Apply(opts ...func(*Repo)) {
+	for _, r := range rs {
+		r.Apply(opts...)
+	}
+}
+
+// With returns a clone of the given repos with the given functional options applied.
+func (rs Repos) With(opts ...func(*Repo)) Repos {
+	clone := rs.Clone()
+	clone.Apply(opts...)
+	return clone
+}
+
+// Filter returns all the Repos that match the given predicate.
+func (rs Repos) Filter(pred func(*Repo) bool) (fs Repos) {
+	for _, r := range rs {
+		if pred(r) {
+			fs = append(fs, r)
+		}
+	}
+	return fs
+}
 
 // ExternalService is a connection to an external service.
 type ExternalService struct {

--- a/internal/db/basestore/store.go
+++ b/internal/db/basestore/store.go
@@ -97,6 +97,11 @@ func (s *Store) Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error)
 	return s.handle.db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 }
 
+// QueryRow performs QueryRowContext on the underlying connection.
+func (s *Store) QueryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
+	return s.handle.db.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+}
+
 // Exec performs a query and throws away the result.
 func (s *Store) Exec(ctx context.Context, query *sqlf.Query) error {
 	rows, err := s.Query(ctx, query)

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	regexpsyntax "regexp/syntax"
 	"strings"
+	"sync"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
@@ -14,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/db/query"
@@ -47,18 +49,49 @@ func (e *RepoNotFoundErr) NotFound() bool {
 	return true
 }
 
-// repos is a DB-backed implementation of the Repos
-type repos struct{}
+// ReposStore is a DB-backed implementation of the Repos.
+type ReposStore struct {
+	*basestore.Store
+
+	m sync.Mutex
+}
+
+// NewReposStoreWithDB instantiates and returns a new ReposStore with prepared statements.
+func NewReposStoreWithDB(db dbutil.DB) *ReposStore {
+	return &ReposStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+}
+
+func (s *ReposStore) With(other basestore.ShareableStore) *ReposStore {
+	return &ReposStore{Store: s.Store.With(other)}
+}
+
+func (s *ReposStore) Transact(ctx context.Context) (*ReposStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	return &ReposStore{Store: txBase}, err
+}
+
+// ensureStore instantiates a basestore.Store if necessary, using the dbconn.Global handle.
+// This function ensures access to dbconn happens after the rest of the code or tests have
+// initialized it.
+func (s *ReposStore) ensureStore() {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.Store == nil {
+		s.Store = basestore.NewWithDB(dbconn.Global, sql.TxOptions{})
+	}
+}
 
 // Get returns metadata for the request repository ID. It fetches data
 // only from the database and NOT from any external sources. If the
 // caller is concerned the copy of the data in the database might be
 // stale, the caller is responsible for fetching data from any
 // external services.
-func (s *repos) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
+func (s *ReposStore) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
 	if Mocks.Repos.Get != nil {
 		return Mocks.Repos.Get(ctx, id)
 	}
+	s.ensureStore()
 
 	repos, err := s.getBySQL(ctx, sqlf.Sprintf("id=%d LIMIT 1", id))
 	if err != nil {
@@ -78,10 +111,11 @@ func (s *repos) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
 // Name is the name for this repository (e.g., "github.com/user/repo"). It is
 // the same as URI, unless the user configures a non-default
 // repositoryPathPattern.
-func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.Repo, error) {
+func (s *ReposStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.Repo, error) {
 	if Mocks.Repos.GetByName != nil {
 		return Mocks.Repos.GetByName(ctx, nameOrURI)
 	}
+	s.ensureStore()
 
 	repos, err := s.getBySQL(ctx, sqlf.Sprintf("name=%s LIMIT 1", nameOrURI))
 	if err != nil {
@@ -109,10 +143,11 @@ func (s *repos) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.R
 
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
-func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
+func (s *ReposStore) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
 	if Mocks.Repos.GetByIDs != nil {
 		return Mocks.Repos.GetByIDs(ctx, ids...)
 	}
+	s.ensureStore()
 
 	if len(ids) == 0 {
 		return []*types.Repo{}, nil
@@ -128,11 +163,12 @@ func (s *repos) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo,
 
 // GetReposSetByIDs returns a map of repositories with the given IDs, indexed by their IDs. The number of results
 // entries could be less than the candidate list due to no repository is associated with some IDs.
-func (s *repos) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
+func (s *ReposStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
 	repos, err := s.GetByIDs(ctx, ids...)
 	if err != nil {
 		return nil, err
 	}
+	s.ensureStore()
 
 	repoMap := make(map[api.RepoID]*types.Repo, len(repos))
 	for _, r := range repos {
@@ -142,10 +178,11 @@ func (s *repos) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (map[ap
 	return repoMap, nil
 }
 
-func (s *repos) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
+func (s *ReposStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)
 	}
+	s.ensureStore()
 
 	tr, ctx := trace.New(ctx, "repos.Count", "")
 	defer func() {
@@ -164,7 +201,8 @@ func (s *repos) Count(ctx context.Context, opt ReposListOptions) (ct int, err er
 	tr.LazyPrintf("SQL: %v", q.Query(sqlf.PostgresBindVar))
 
 	var count int
-	if err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
+
+	if err := s.Store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil
@@ -214,11 +252,11 @@ var getBySQLColumns = []string{
 	getSourcesByRepoQueryStr,
 }
 
-func (s *repos) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+func (s *ReposStore) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	return s.getReposBySQL(ctx, false, querySuffix)
 }
 
-func (s *repos) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+func (s *ReposStore) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	columns := getBySQLColumns
 	if minimal {
 		columns = columns[:6]
@@ -229,7 +267,7 @@ func (s *repos) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sq
 		querySuffix,
 	)
 
-	rows, err := dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +495,7 @@ const (
 // This will not return any repositories from external services that are not present in the Sourcegraph repository.
 // The result list is unsorted and has a fixed maximum limit of 1000 items.
 // Matching is done with fuzzy matching, i.e. "query" will match any repo name that matches the regexp `q.*u.*e.*r.*y`
-func (s *repos) List(ctx context.Context, opt ReposListOptions) (results []*types.Repo, err error) {
+func (s *ReposStore) List(ctx context.Context, opt ReposListOptions) (results []*types.Repo, err error) {
 	tr, ctx := trace.New(ctx, "repos.List", "")
 	defer func() {
 		tr.SetError(err)
@@ -467,6 +505,7 @@ func (s *repos) List(ctx context.Context, opt ReposListOptions) (results []*type
 	if Mocks.Repos.List != nil {
 		return Mocks.Repos.List(ctx, opt)
 	}
+	s.ensureStore()
 
 	conds, err := s.listSQL(opt)
 	if err != nil {
@@ -481,10 +520,11 @@ func (s *repos) List(ctx context.Context, opt ReposListOptions) (results []*type
 }
 
 // Delete deletes repos associated with the given ids and their associated sources.
-func (s *repos) Delete(ctx context.Context, ids ...api.RepoID) error {
+func (s *ReposStore) Delete(ctx context.Context, ids ...api.RepoID) error {
 	if len(ids) == 0 {
 		return nil
 	}
+	s.ensureStore()
 
 	// The number of deleted repos can potentially be higher
 	// than the maximum number of arguments we can pass to postgres.
@@ -496,7 +536,7 @@ func (s *repos) Delete(ctx context.Context, ids ...api.RepoID) error {
 
 	q := sqlf.Sprintf(deleteReposQuery, string(encodedIds))
 
-	_, err = dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	err = s.Exec(ctx, q)
 	if err != nil {
 		return errors.Wrap(err, "delete")
 	}
@@ -521,9 +561,11 @@ AND repo.id = repo_ids.id::int
 // requested information by other services (repo-updater and
 // indexed-search). We special case just returning enabled names so that we
 // read much less data into memory.
-func (s *repos) ListEnabledNames(ctx context.Context) ([]string, error) {
+func (s *ReposStore) ListEnabledNames(ctx context.Context) ([]string, error) {
+	s.ensureStore()
+
 	q := sqlf.Sprintf("SELECT name FROM repo WHERE deleted_at IS NULL")
-	rows, err := dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +614,7 @@ func parsePattern(p string) ([]*sqlf.Query, error) {
 	return []*sqlf.Query{sqlf.Sprintf("(%s)", sqlf.Join(conds, "OR"))}, nil
 }
 
-func (*repos) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
+func (*ReposStore) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 	conds = []*sqlf.Query{
 		sqlf.Sprintf("deleted_at IS NULL"),
 	}

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -49,33 +49,33 @@ func (e *RepoNotFoundErr) NotFound() bool {
 	return true
 }
 
-// ReposStore is a DB-backed implementation of the Repos.
-type ReposStore struct {
+// RepoStore is a DB-backed implementation of the Repos.
+type RepoStore struct {
 	*basestore.Store
 
-	m sync.Mutex
+	mu sync.Mutex
 }
 
-// NewReposStoreWithDB instantiates and returns a new ReposStore with prepared statements.
-func NewReposStoreWithDB(db dbutil.DB) *ReposStore {
-	return &ReposStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+// NewRepoStoreWithDB instantiates and returns a new RepoStore with prepared statements.
+func NewRepoStoreWithDB(db dbutil.DB) *RepoStore {
+	return &RepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
-func (s *ReposStore) With(other basestore.ShareableStore) *ReposStore {
-	return &ReposStore{Store: s.Store.With(other)}
+func (s *RepoStore) With(other basestore.ShareableStore) *RepoStore {
+	return &RepoStore{Store: s.Store.With(other)}
 }
 
-func (s *ReposStore) Transact(ctx context.Context) (*ReposStore, error) {
+func (s *RepoStore) Transact(ctx context.Context) (*RepoStore, error) {
 	txBase, err := s.Store.Transact(ctx)
-	return &ReposStore{Store: txBase}, err
+	return &RepoStore{Store: txBase}, err
 }
 
 // ensureStore instantiates a basestore.Store if necessary, using the dbconn.Global handle.
 // This function ensures access to dbconn happens after the rest of the code or tests have
 // initialized it.
-func (s *ReposStore) ensureStore() {
-	s.m.Lock()
-	defer s.m.Unlock()
+func (s *RepoStore) ensureStore() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if s.Store == nil {
 		s.Store = basestore.NewWithDB(dbconn.Global, sql.TxOptions{})
@@ -87,7 +87,7 @@ func (s *ReposStore) ensureStore() {
 // caller is concerned the copy of the data in the database might be
 // stale, the caller is responsible for fetching data from any
 // external services.
-func (s *ReposStore) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
+func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
 	if Mocks.Repos.Get != nil {
 		return Mocks.Repos.Get(ctx, id)
 	}
@@ -111,7 +111,7 @@ func (s *ReposStore) Get(ctx context.Context, id api.RepoID) (*types.Repo, error
 // Name is the name for this repository (e.g., "github.com/user/repo"). It is
 // the same as URI, unless the user configures a non-default
 // repositoryPathPattern.
-func (s *ReposStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.Repo, error) {
+func (s *RepoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.Repo, error) {
 	if Mocks.Repos.GetByName != nil {
 		return Mocks.Repos.GetByName(ctx, nameOrURI)
 	}
@@ -143,7 +143,7 @@ func (s *ReposStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (*ty
 
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
-func (s *ReposStore) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
+func (s *RepoStore) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
 	if Mocks.Repos.GetByIDs != nil {
 		return Mocks.Repos.GetByIDs(ctx, ids...)
 	}
@@ -163,7 +163,7 @@ func (s *ReposStore) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.
 
 // GetReposSetByIDs returns a map of repositories with the given IDs, indexed by their IDs. The number of results
 // entries could be less than the candidate list due to no repository is associated with some IDs.
-func (s *ReposStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
+func (s *RepoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (map[api.RepoID]*types.Repo, error) {
 	repos, err := s.GetByIDs(ctx, ids...)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func (s *ReposStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (m
 	return repoMap, nil
 }
 
-func (s *ReposStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
+func (s *RepoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)
 	}
@@ -202,7 +202,7 @@ func (s *ReposStore) Count(ctx context.Context, opt ReposListOptions) (ct int, e
 
 	var count int
 
-	if err := s.Store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
+	if err := s.QueryRow(ctx, q).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil
@@ -252,11 +252,11 @@ var getBySQLColumns = []string{
 	getSourcesByRepoQueryStr,
 }
 
-func (s *ReposStore) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+func (s *RepoStore) getBySQL(ctx context.Context, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	return s.getReposBySQL(ctx, false, querySuffix)
 }
 
-func (s *ReposStore) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
+func (s *RepoStore) getReposBySQL(ctx context.Context, minimal bool, querySuffix *sqlf.Query) ([]*types.Repo, error) {
 	columns := getBySQLColumns
 	if minimal {
 		columns = columns[:6]
@@ -495,7 +495,7 @@ const (
 // This will not return any repositories from external services that are not present in the Sourcegraph repository.
 // The result list is unsorted and has a fixed maximum limit of 1000 items.
 // Matching is done with fuzzy matching, i.e. "query" will match any repo name that matches the regexp `q.*u.*e.*r.*y`
-func (s *ReposStore) List(ctx context.Context, opt ReposListOptions) (results []*types.Repo, err error) {
+func (s *RepoStore) List(ctx context.Context, opt ReposListOptions) (results []*types.Repo, err error) {
 	tr, ctx := trace.New(ctx, "repos.List", "")
 	defer func() {
 		tr.SetError(err)
@@ -520,7 +520,7 @@ func (s *ReposStore) List(ctx context.Context, opt ReposListOptions) (results []
 }
 
 // Delete deletes repos associated with the given ids and their associated sources.
-func (s *ReposStore) Delete(ctx context.Context, ids ...api.RepoID) error {
+func (s *RepoStore) Delete(ctx context.Context, ids ...api.RepoID) error {
 	if len(ids) == 0 {
 		return nil
 	}
@@ -561,7 +561,7 @@ AND repo.id = repo_ids.id::int
 // requested information by other services (repo-updater and
 // indexed-search). We special case just returning enabled names so that we
 // read much less data into memory.
-func (s *ReposStore) ListEnabledNames(ctx context.Context) ([]string, error) {
+func (s *RepoStore) ListEnabledNames(ctx context.Context) ([]string, error) {
 	s.ensureStore()
 
 	q := sqlf.Sprintf("SELECT name FROM repo WHERE deleted_at IS NULL")
@@ -614,7 +614,7 @@ func parsePattern(p string) ([]*sqlf.Query, error) {
 	return []*sqlf.Query{sqlf.Sprintf("(%s)", sqlf.Join(conds, "OR"))}, nil
 }
 
-func (*ReposStore) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
+func (*RepoStore) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error) {
 	conds = []*sqlf.Query{
 		sqlf.Sprintf("deleted_at IS NULL"),
 	}

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -131,7 +131,7 @@ INSERT INTO repo (
 //
 // Upsert exists for testing purposes only. Repository mutations are managed
 // by repo-updater.
-func (s *ReposStore) Upsert(ctx context.Context, op InsertRepoOp) error {
+func (s *RepoStore) Upsert(ctx context.Context, op InsertRepoOp) error {
 	insert := false
 
 	// We optimistically assume the repo is already in the table, so first

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -131,7 +131,7 @@ INSERT INTO repo (
 //
 // Upsert exists for testing purposes only. Repository mutations are managed
 // by repo-updater.
-func (s *repos) Upsert(ctx context.Context, op InsertRepoOp) error {
+func (s *ReposStore) Upsert(ctx context.Context, op InsertRepoOp) error {
 	insert := false
 
 	// We optimistically assume the repo is already in the table, so first

--- a/internal/db/stores.go
+++ b/internal/db/stores.go
@@ -4,7 +4,7 @@ var (
 	AccessTokens     = &accessTokens{}
 	ExternalServices = &ExternalServicesStore{}
 	DefaultRepos     = &defaultRepos{}
-	Repos            = &repos{}
+	Repos            = &ReposStore{}
 	Phabricator      = &phabricator{}
 	QueryRunnerState = &queryRunnerState{}
 	Namespaces       = &namespaces{}

--- a/internal/db/stores.go
+++ b/internal/db/stores.go
@@ -4,7 +4,7 @@ var (
 	AccessTokens     = &accessTokens{}
 	ExternalServices = &ExternalServicesStore{}
 	DefaultRepos     = &defaultRepos{}
-	Repos            = &ReposStore{}
+	Repos            = &RepoStore{}
 	Phabricator      = &phabricator{}
 	QueryRunnerState = &queryRunnerState{}
 	Namespaces       = &namespaces{}


### PR DESCRIPTION
It also copies all the `repos.Repo` and `repos.Repos` helpers to the `cmd/frontend/types` package for further use.
The original methods will be cleaned up in future PRs.

Fixes #14754 