### PR TITLE
progress-bot: only show list items

### DIFF
--- a/dev/report_progress_to_slack.sh
+++ b/dev/report_progress_to_slack.sh
@@ -23,7 +23,7 @@ if [ -z "$(cat /tmp/diff.txt)" ]; then
   exit 0
 fi
 
-tail -n +6 </tmp/diff.txt | grep "^\+[^\+]" | cut -c 2- >/tmp/added.txt
+tail -n +6 </tmp/diff.txt | grep "^\+-" | cut -c 2- >/tmp/added.txt
 tail -n +6 </tmp/diff.txt | grep "^\-" | cut -c 2- >/tmp/removed.txt
 
 if [ -z "$(cat /tmp/added.txt)" ]; then


### PR DESCRIPTION
This removes some noise from the progress-bot channel. For example
addition of headings, or notices added to the changelog.

For example this won't show up now:

<img width="994" alt="image" src="https://user-images.githubusercontent.com/187831/97184143-47696980-17a7-11eb-8cc4-d8637d262804.png">

And this will only include the changelog entry:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/187831/97184207-5819df80-17a7-11eb-9e86-59f7e3d2f93a.png">
