### PR TITLE
executor-queue: Update frontend proxy to point to new executor-queue

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -128,7 +128,7 @@ func AllowAnonymousRequest(req *http.Request) bool {
 	}
 
 	// Permission is checked by a shared token
-	if strings.HasPrefix(req.URL.Path, "/.internal-code-intel") {
+	if strings.HasPrefix(req.URL.Path, "/.executors") {
 		return true
 	}
 

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -10,34 +10,35 @@ import (
 // Services is a bag of HTTP handlers and factory functions that are registered by the
 // enterprise frontend setup hook.
 type Services struct {
-	GitHubWebhook                    http.Handler
-	GitLabWebhook                    http.Handler
-	BitbucketServerWebhook           http.Handler
-	NewCodeIntelUploadHandler        NewCodeIntelUploadHandler
-	NewCodeIntelInternalProxyHandler NewCodeIntelInternalProxyHandler
-	AuthzResolver                    graphqlbackend.AuthzResolver
-	CampaignsResolver                graphqlbackend.CampaignsResolver
-	CodeIntelResolver                graphqlbackend.CodeIntelResolver
+	GitHubWebhook             http.Handler
+	GitLabWebhook             http.Handler
+	BitbucketServerWebhook    http.Handler
+	NewCodeIntelUploadHandler NewCodeIntelUploadHandler
+	NewExecutorProxyHandler   NewExecutorProxyHandler
+	AuthzResolver             graphqlbackend.AuthzResolver
+	CampaignsResolver         graphqlbackend.CampaignsResolver
+	CodeIntelResolver         graphqlbackend.CodeIntelResolver
 }
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The
 // resulting handler skips auth checks when the internal flag is true.
 type NewCodeIntelUploadHandler func(internal bool) http.Handler
 
-// NewCodeIntelInternalProxyHandler creates a new proxy handler for internal code intel routes
-// accessible from the precise-code-intel-indexer (deployed separately from the k8s cluster).
-type NewCodeIntelInternalProxyHandler func() http.Handler
+// NewExecutorProxyHandler creates a new proxy handler for routes accessible to the
+// executor services deployed separately from the k8s cluster. This handler is protected
+// via a shared username and password.
+type NewExecutorProxyHandler func() http.Handler
 
 // DefaultServices creates a new Services value that has default implementations for all services.
 func DefaultServices() Services {
 	return Services{
-		GitHubWebhook:                    makeNotFoundHandler("github webhook"),
-		GitLabWebhook:                    makeNotFoundHandler("gitlab webhook"),
-		BitbucketServerWebhook:           makeNotFoundHandler("bitbucket server webhook"),
-		NewCodeIntelUploadHandler:        func(_ bool) http.Handler { return makeNotFoundHandler("code intel upload") },
-		NewCodeIntelInternalProxyHandler: func() http.Handler { return makeNotFoundHandler("code intel internal proxy") },
-		AuthzResolver:                    graphqlbackend.DefaultAuthzResolver,
-		CampaignsResolver:                graphqlbackend.DefaultCampaignsResolver,
+		GitHubWebhook:             makeNotFoundHandler("github webhook"),
+		GitLabWebhook:             makeNotFoundHandler("gitlab webhook"),
+		BitbucketServerWebhook:    makeNotFoundHandler("bitbucket server webhook"),
+		NewCodeIntelUploadHandler: func(_ bool) http.Handler { return makeNotFoundHandler("code intel upload") },
+		NewExecutorProxyHandler:   func() http.Handler { return makeNotFoundHandler("executor proxy") },
+		AuthzResolver:             graphqlbackend.DefaultAuthzResolver,
+		CampaignsResolver:         graphqlbackend.DefaultCampaignsResolver,
 	}
 }
 

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -29,7 +29,7 @@ import (
 
 // newExternalHTTPHandler creates and returns the HTTP handler that serves the app and API pages to
 // external clients.
-func newExternalHTTPHandler(schema *graphql.Schema, gitHubWebhook, gitLabWebhook, bitbucketServerWebhook http.Handler, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newCodeIntelInternalProxyHandler enterprise.NewCodeIntelInternalProxyHandler) (http.Handler, error) {
+func newExternalHTTPHandler(schema *graphql.Schema, gitHubWebhook, gitLabWebhook, bitbucketServerWebhook http.Handler, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newExecutorProxyHandler enterprise.NewExecutorProxyHandler) (http.Handler, error) {
 	// Each auth middleware determines on a per-request basis whether it should be enabled (if not, it
 	// immediately delegates the request to the next middleware in the chain).
 	authMiddlewares := auth.AuthMiddleware()
@@ -49,7 +49,7 @@ func newExternalHTTPHandler(schema *graphql.Schema, gitHubWebhook, gitLabWebhook
 	apiHandler = gziphandler.GzipHandler(apiHandler)
 
 	// 🚨 SECURITY: This handler implements its own token auth inside enterprise
-	internalCodeIntelHandler := newCodeIntelInternalProxyHandler()
+	executorProxyHandler := newExecutorProxyHandler()
 
 	// App handler (HTML pages), the call order of middleware is LIFO.
 	appHandler := app.NewHandler()
@@ -67,7 +67,7 @@ func newExternalHTTPHandler(schema *graphql.Schema, gitHubWebhook, gitLabWebhook
 	// Mount handlers and assets.
 	sm := http.NewServeMux()
 	sm.Handle("/.api/", apiHandler)
-	sm.Handle("/.internal-code-intel/", internalCodeIntelHandler)
+	sm.Handle("/.executors/", executorProxyHandler)
 	sm.Handle("/", appHandler)
 	assetsutil.Mount(sm)
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -219,7 +219,7 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 	}
 
 	// Create the external HTTP handler.
-	externalHandler, err := newExternalHTTPHandler(schema, enterprise.GitHubWebhook, enterprise.GitLabWebhook, enterprise.BitbucketServerWebhook, enterprise.NewCodeIntelUploadHandler, enterprise.NewCodeIntelInternalProxyHandler)
+	externalHandler, err := newExternalHTTPHandler(schema, enterprise.GitHubWebhook, enterprise.GitLabWebhook, enterprise.BitbucketServerWebhook, enterprise.NewCodeIntelUploadHandler, enterprise.NewExecutorProxyHandler)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/executor/CODENOTIFY
+++ b/enterprise/cmd/frontend/internal/executor/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/enterprise/cmd/frontend/internal/executor/init.go
+++ b/enterprise/cmd/frontend/internal/executor/init.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
+)
+
+func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
+	handler, err := codeintel.NewCodeIntelUploadHandler(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	proxyHandler, err := newInternalProxyHandler(handler)
+	if err != nil {
+		return err
+	}
+
+	enterpriseServices.NewExecutorProxyHandler = proxyHandler
+	return nil
+}

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executor"
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
 
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
@@ -30,9 +31,10 @@ func main() {
 
 var initFunctions = map[string]func(ctx context.Context, enterpriseServices *enterprise.Services) error{
 	"authz":     authz.Init,
-	"campaigns": campaigns.Init,
-	"codeintel": codeintel.Init,
 	"licensing": licensing.Init,
+	"executor":  executor.Init,
+	"codeintel": codeintel.Init,
+	"campaigns": campaigns.Init,
 }
 
 func enterpriseSetupHook() enterprise.Services {

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -23,11 +23,10 @@ postgres_exporter: ./dev/postgres_exporter.sh
 
 # Enterprise executor services
 executor-queue: executor-queue
-# executor: EXECUTOR_QUEUE_NAME=codeintel TMPDIR=~/.sourcegraph/indexer-temp executor
+codeintel-executor: EXECUTOR_QUEUE_NAME=codeintel TMPDIR=~/.sourcegraph/indexer-temp executor
 
 # Enterprise code intelligence services
 precise-code-intel-bundle-manager: precise-code-intel-bundle-manager
 precise-code-intel-indexer: precise-code-intel-indexer
-precise-code-intel-indexer-vm: TMPDIR=~/.sourcegraph/indexer-temp precise-code-intel-indexer-vm
 precise-code-intel-worker: precise-code-intel-worker
 minio: ./dev/minio.sh

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -44,13 +44,7 @@ export EXECUTOR_FRONTEND_USERNAME=executor
 export EXECUTOR_FRONTEND_PASSWORD=hunter2
 export EXECUTOR_QUEUE_URL=http://localhost:3191
 export EXECUTOR_USE_FIRECRACKER=false
-
-export PRECISE_CODE_INTEL_EXTERNAL_URL=http://localhost:3080
-export PRECISE_CODE_INTEL_EXTERNAL_URL_FROM_DOCKER=http://host.docker.internal:3080
-export PRECISE_CODE_INTEL_INDEX_MANAGER_URL=http://localhost:3189
-export PRECISE_CODE_INTEL_INTERNAL_PROXY_AUTH_TOKEN=hunter2
-export PRECISE_CODE_INTEL_USE_FIRECRACKER=false
-export PRECISE_CODE_INTEL_IMAGE_ARCHIVE_PATH=$HOME/.sourcegraph/images
+export EXECUTOR_IMAGE_ARCHIVE_PATH=$HOME/.sourcegraph/images
 export DISABLE_CNCF=notonmybox
 
 export WATCH_ADDITIONAL_GO_DIRS="enterprise/cmd enterprise/dev enterprise/internal"


### PR DESCRIPTION
Update the enterprise frontend proxy that handles requests to the precise-code-intel-indexer to point to the new executor-queue service. This closes https://github.com/sourcegraph/sourcegraph/issues/14885.

This change must correspond with a deployment of the executor-queue service in production environments. This change should also correspond to a deployment of the new executor on GCP nodes. A non-symmetric deploy will cause the executor to 404 on all routes when polling for work (causing a short period where the queue will grow without being processed).

Merging is blocked by the following PRs:

- [x] https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3714
- [x] https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3716