### PR TITLE
search: remove quote hint in regex mode if pattern contains colon

### DIFF
--- a/client/shared/src/search/parser/diagnostics.test.ts
+++ b/client/shared/src/search/parser/diagnostics.test.ts
@@ -27,24 +27,6 @@ describe('getDiagnostics()', () => {
         ])
     })
 
-    test('search query containing colon, regexp pattern type, suggest quotes', () => {
-        expect(
-            getDiagnostics(
-                (parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token,
-                SearchPatternType.regexp
-            )
-        ).toStrictEqual([
-            {
-                endColumn: 27,
-                endLineNumber: 1,
-                message: 'Quoting the query may help if you want a literal match.',
-                severity: 4,
-                startColumn: 1,
-                startLineNumber: 1,
-            },
-        ])
-    })
-
     test('search query containing colon, literal pattern type, do not raise error', () => {
         expect(
             getDiagnostics(

--- a/client/shared/src/search/parser/diagnostics.ts
+++ b/client/shared/src/search/parser/diagnostics.ts
@@ -23,14 +23,6 @@ export function getDiagnostics(
                 message: validationResult.reason,
                 ...toMonacoRange(filterType.range),
             })
-        } else if (token.type === 'literal') {
-            if (patternType === SearchPatternType.regexp && token.value.includes(':')) {
-                diagnostics.push({
-                    severity: Monaco.MarkerSeverity.Warning,
-                    message: 'Quoting the query may help if you want a literal match.',
-                    ...toMonacoRange(range),
-                })
-            }
         } else if (token.type === 'quoted') {
             if (patternType === SearchPatternType.literal) {
                 diagnostics.push({


### PR DESCRIPTION
In favor of removing this. It's related to improving other quoting hints, which I'll get to later (https://github.com/sourcegraph/sourcegraph/issues/12802, https://github.com/sourcegraph/sourcegraph/issues/10793, https://github.com/sourcegraph/sourcegraph/issues/11909). 

> As in: I half-know what I’m doing here by using regex. I appreciate the hint though, when I use it the first time.

I don't think there's any way to make this dismissible. The usefulness showing this on first time is outweighed by this showing up every time, and regex is an opt-in toggle, so we can mostly safely assume the user knows what they're dealing with.

Context:

<img width="661" alt="Screen Shot 2020-10-26 at 8 50 28 AM" src="https://user-images.githubusercontent.com/888624/97195232-567cf700-1768-11eb-81a5-00b558848234.png">
