### PR TITLE
Add error codes to campaign errors

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -17,6 +17,44 @@ schema {
 }
 
 """
+This is no type actually returned by any resolver. It just serves as a documentation
+for how errors may look like.
+"""
+type Error {
+    """
+    A string giving more context about the error that ocurred.
+    """
+    message: String!
+    """
+    The GraphQL path to where the error happened. For an error in the query
+    query {
+        user {
+            externalID # This is a nullable field that failed computing.
+        }
+    }
+    the path would be ["user", "externalID"].
+    """
+    path: [String!]!
+    """
+    Optional additional context on the error.
+    """
+    extensions: ErrorExtensions
+}
+
+"""
+Optional additional context on an error returned from a resolver.
+It may also contain more properties, which aren't stricktly typed here.
+For those
+"""
+type ErrorExtensions {
+    """
+    An error code, which can be asserted on.
+    Possible error codes are communicated in the doc string of the field.
+    """
+    code: String
+}
+
+"""
 Represents a null return value.
 """
 type EmptyResponse {
@@ -548,11 +586,10 @@ type Mutation {
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
 
     """
-    CAMPAIGNS
-
-    Create a campaign from a campaign spec and locally computed changeset specs. If a campaign in
-    the same namespace with the same name already exists, an error is returned. The newly created
+    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
     campaign is returned.
+    If a campaign in the same namespace with the same name already exists, an error with the error code
+    ErrMatchingCampaignExists is returned.
     """
     createCampaign(
         """
@@ -565,6 +602,8 @@ type Mutation {
     Create or update a campaign from a campaign spec and locally computed changeset specs. If no
     campaign exists in the namespace with the name given in the campaign spec, a campaign will be
     created. Otherwise, the existing campaign will be updated. The campaign is returned.
+    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
+    will be returned.
     """
     applyCampaign(
         """
@@ -577,7 +616,7 @@ type Mutation {
         parameters does not match the campaign with this ID. This lets callers use a stable ID
         that refers to a specific campaign during an edit session (and is not susceptible to
         conflicts if the underlying campaign is moved to a different namespace, renamed, or
-        deleted).
+        deleted). The returned error has the error code ErrEnsureCampaignFailed.
         """
         ensureCampaign: ID
     ): Campaign!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -17,8 +17,8 @@ schema {
 }
 
 """
-This is no type actually returned by any resolver. It just serves as a documentation
-for how errors may look like.
+This type is not returned by any resolver, but serves to document what an error
+response will look like.
 """
 type Error {
     """
@@ -43,8 +43,7 @@ type Error {
 
 """
 Optional additional context on an error returned from a resolver.
-It may also contain more properties, which aren't stricktly typed here.
-For those
+It may also contain more properties, which aren't strictly typed here.
 """
 type ErrorExtensions {
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10,6 +10,44 @@ schema {
 }
 
 """
+This is no type actually returned by any resolver. It just serves as a documentation
+for how errors may look like.
+"""
+type Error {
+    """
+    A string giving more context about the error that ocurred.
+    """
+    message: String!
+    """
+    The GraphQL path to where the error happened. For an error in the query
+    query {
+        user {
+            externalID # This is a nullable field that failed computing.
+        }
+    }
+    the path would be ["user", "externalID"].
+    """
+    path: [String!]!
+    """
+    Optional additional context on the error.
+    """
+    extensions: ErrorExtensions
+}
+
+"""
+Optional additional context on an error returned from a resolver.
+It may also contain more properties, which aren't stricktly typed here.
+For those
+"""
+type ErrorExtensions {
+    """
+    An error code, which can be asserted on.
+    Possible error codes are communicated in the doc string of the field.
+    """
+    code: String
+}
+
+"""
 Represents a null return value.
 """
 type EmptyResponse {
@@ -541,11 +579,10 @@ type Mutation {
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
 
     """
-    CAMPAIGNS
-
-    Create a campaign from a campaign spec and locally computed changeset specs. If a campaign in
-    the same namespace with the same name already exists, an error is returned. The newly created
+    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
     campaign is returned.
+    If a campaign in the same namespace with the same name already exists, an error with the error code
+    ErrMatchingCampaignExists is returned.
     """
     createCampaign(
         """
@@ -558,6 +595,8 @@ type Mutation {
     Create or update a campaign from a campaign spec and locally computed changeset specs. If no
     campaign exists in the namespace with the name given in the campaign spec, a campaign will be
     created. Otherwise, the existing campaign will be updated. The campaign is returned.
+    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
+    will be returned.
     """
     applyCampaign(
         """
@@ -570,7 +609,7 @@ type Mutation {
         parameters does not match the campaign with this ID. This lets callers use a stable ID
         that refers to a specific campaign during an edit session (and is not susceptible to
         conflicts if the underlying campaign is moved to a different namespace, renamed, or
-        deleted).
+        deleted). The returned error has the error code ErrEnsureCampaignFailed.
         """
         ensureCampaign: ID
     ): Campaign!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -36,7 +36,7 @@ type Error {
 
 """
 Optional additional context on an error returned from a resolver.
-It may also contain more properties, which aren't stricktly typed here.
+It may also contain more properties, which aren't strictly typed here.
 For those
 """
 type ErrorExtensions {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -37,7 +37,6 @@ type Error {
 """
 Optional additional context on an error returned from a resolver.
 It may also contain more properties, which aren't strictly typed here.
-For those
 """
 type ErrorExtensions {
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10,8 +10,8 @@ schema {
 }
 
 """
-This is no type actually returned by any resolver. It just serves as a documentation
-for how errors may look like.
+This type is not returned by any resolver, but serves to document what an error
+response will look like.
 """
 type Error {
     """

--- a/enterprise/internal/campaigns/resolvers/errors.go
+++ b/enterprise/internal/campaigns/resolvers/errors.go
@@ -1,0 +1,61 @@
+package resolvers
+
+type ErrIDIsZero struct{}
+
+func (e ErrIDIsZero) Error() string {
+	return "invalid node id"
+}
+
+func (e ErrIDIsZero) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrIDIsZero"}
+}
+
+type ErrCampaignsDisabled struct{}
+
+func (e ErrCampaignsDisabled) Error() string {
+	return "campaigns are disabled. Set 'campaigns.enabled' in the site configuration to enable the feature."
+}
+
+func (e ErrCampaignsDisabled) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrCampaignsDisabled"}
+}
+
+type ErrCampaignsDotCom struct{}
+
+func (e ErrCampaignsDotCom) Error() string {
+	return "access to campaigns on Sourcegraph.com is currently not available"
+}
+
+func (e ErrCampaignsDotCom) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrCampaignsDotCom"}
+}
+
+type ErrEnsureCampaignFailed struct{}
+
+func (e ErrEnsureCampaignFailed) Error() string {
+	return "a campaign in the given namespace and with the given name exists but does not match the given ID"
+}
+
+func (e ErrEnsureCampaignFailed) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrEnsureCampaignFailed"}
+}
+
+type ErrApplyClosedCampaign struct{}
+
+func (e ErrApplyClosedCampaign) Error() string {
+	return "existing campaign matched by campaign spec is closed"
+}
+
+func (e ErrApplyClosedCampaign) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrApplyClosedCampaign"}
+}
+
+type ErrMatchingCampaignExists struct{}
+
+func (e ErrMatchingCampaignExists) Error() string {
+	return "a campaign matching the given campaign spec already exists"
+}
+
+func (e ErrMatchingCampaignExists) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrMatchingCampaignExists"}
+}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -68,7 +68,7 @@ func TestNullIDResilience(t *testing.T) {
 		if len(errs) == 0 {
 			t.Fatalf("expected errors but none returned (mutation: %q)", m)
 		}
-		if have, want := errs[0].Error(), fmt.Sprintf("graphql: %s", ErrIDIsZero.Error()); have != want {
+		if have, want := errs[0].Error(), fmt.Sprintf("graphql: %s", ErrIDIsZero{}); have != want {
 			t.Fatalf("wrong errors. have=%s, want=%s (mutation: %q)", have, want, m)
 		}
 	}


### PR DESCRIPTION
Some of our resolvers return errors very purposefully, and we did document that _some_ error will be returned, but not which or how to identify this specific error.

I tried making more clear what the error actually looks like and that people using the API can assert on them by adding an error code to them, through an Extensions field that graphql-go provides us with.