### PR TITLE
docs: Add docs to point to S3 or GCS instead of MinIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1654,7 +1654,7 @@ See the changelog entries for 3.0.0 beta releases and our [3.0](doc/admin/migrat
 
 ### Removed
 
-- The deprecated environment variables `SRC_SESSION_STORE_REDIS` and `REDIS_MASTER_ENDPOINT` are no longer used to configure alternative redis endpoints. For more information, see "[Using external databases with Sourcegraph](https://docs.sourcegraph.com/admin/external_database)".
+- The deprecated environment variables `SRC_SESSION_STORE_REDIS` and `REDIS_MASTER_ENDPOINT` are no longer used to configure alternative redis endpoints. For more information, see "[using external services with Sourcegraph](https://docs.sourcegraph.com/admin/external_services)".
 
 ## 2.11.1
 

--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -14,7 +14,7 @@
 - [Set up HTTPS](../http_https_configuration.md)
 - [Use a custom domain](../url.md)
 - [Update Sourcegraph](../updates.md)
-- [Use an external PostgreSQL and Redis database](../external_database.md)
+- [Using external services (PostgreSQL, Redis, S3/GCS)](../external_services/index.md)
 
 ## Advanced tasks
 

--- a/doc/admin/external_services/index.md
+++ b/doc/admin/external_services/index.md
@@ -1,0 +1,19 @@
+# Using external services with Sourcegraph
+
+> NOTE: Using Sourcegraph with an external service is a [paid feature](https://about.sourcegraph.com/pricing). [Contact us](https://about.sourcegraph.com/contact/sales) to get a trial license.
+
+Sourcegraph by default provides versions of services it needs to operate, including:
+
+- A [PostgreSQL](https://www.postgresql.org/) instance for storing long-term information, such as user information when using Sourcegraph's built-in authentication provider instead of an external one.
+- A second PostgreSQL instance for storing large-volume precise code intelligence data.
+- A [Redis](https://redis.io/) instance for storing short-term information such as user sessions.
+- A second Redis instance for storing cache data.
+- A [MinIO](https://min.io/) instance that serves as a local S3-compatible object storage to hold user uploads before they can be processed.
+
+Your Sourcegraph instance can be configured to use an external or managed version of these services. Using a managed version of PostgreSQL can make backups and recovery easier to manage and perform. Using a managed object storage service may decrease your hosting costs as persistent volumes are often more expensive than object storage space.
+
+See the following guides to use an external or managed version of each service type.
+
+- See [Using your own PostgreSQL server](./postgres.md) to replace the bundled PostgreSQL instances.
+- See [Using your own Redis server](./redis.md) to replace the bundled Redis instances.
+- See [Using a managed object storage service (S3 or GCS)](./object_storage.md) to replace the bundled MinIO instance.

--- a/doc/admin/external_services/object_storage.md
+++ b/doc/admin/external_services/object_storage.md
@@ -1,0 +1,33 @@
+# Using a managed object storage service (S3 or GCS)
+
+By default, Sourcegraph will use a MinIO server bundled with the instance to store precise code intelligence indexes uploaded by users. You can configure your instance to instead store this data in an S3 or GCS bucket. Doing so may decrease your hosting costs as persistent volumes are often more expensive than the same storage space in an object store service.
+
+To target a managed object storage service, you will need to set a handful of environment variables for configuration and authentication to the target service. If you are running a sourcegraph/server deployment, set the environment variables on the server container. Otherwise, if running via Docker or Kubernetes, set the environment variables on the `frontend` and `precise-code-intel-worker` containers.
+
+### Using S3
+
+To target an S3 bucket you've already provisioned, set the following environment variables. Authentication is done through an access and secret key pair (and optional session token).
+
+- `PRECISE_CODE_INTEL_UPLOAD_BACKEND=S3`
+- `PRECISE_CODE_INTEL_UPLOAD_BUCKET=<my bucket name>`
+- `PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID=<your access key>`
+- `PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY=<your secret key>`
+- `PRECISE_CODE_INTEL_UPLOAD_AWS_SESSION_TOKEN=<your session token>` (optional)
+- `PRECISE_CODE_INTEL_UPLOAD_AWS_REGION=us-east-1` (default)
+
+### Using GCS
+
+To target a GCS bucket you've already provisioned, set the following environment variables. Authentication is done through a service account key, supplied as either a path to a volume-mounted file, or the contents read in as an environment variable payload.
+
+- `PRECISE_CODE_INTEL_UPLOAD_BACKEND=GCS`
+- `PRECISE_CODE_INTEL_UPLOAD_BUCKET=<my bucket name>`
+- `PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID=<my project id>`
+- `PRECISE_CODE_INTEL_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE=</path/to/file>`
+- `PRECISE_CODE_INTEL_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT=<{"my": "content"}>`
+
+### Provisioning buckets
+
+If you would like to allow your Sourcegraph instance to control the creation and lifecycle configuration management of the target buckets, set the following environment variables:
+
+- `PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET=true`
+- `PRECISE_CODE_INTEL_UPLOAD_TTL=168h` (default)

--- a/doc/admin/external_services/postgres.md
+++ b/doc/admin/external_services/postgres.md
@@ -1,14 +1,4 @@
-# Using external databases with Sourcegraph
-
-> NOTE: Using Sourcegraph with an external database is a [paid feature](https://about.sourcegraph.com/pricing). [Contact us](https://about.sourcegraph.com/contact/sales) to get a trial license.
-
-Sourcegraph by default provides its own PostgreSQL and Redis databases for data storage:
-
-- A PostgreSQL instance for storing long-term information, such as user information when using Sourcegraph's built-in authentication provider instead of an external one.
-- A second PostgreSQL instance for storing large-volume precise code intelligence data.
-- A pair of redis instances for storing short-term information, such as session information and cache data.
-
-## Using your own PostgreSQL server
+# Using your own PostgreSQL server
 
 You can use your own PostgreSQL v9.6+ server with Sourcegraph if you wish. For example, you may prefer this if you already have existing backup infrastructure around your own PostgreSQL server, wish to use Amazon RDS, etc.
 
@@ -30,7 +20,7 @@ To externalize the _code intelligence database_, use the following prefixed `COD
 - `CODEINTEL_PGDATABASE`
 - `CODEINTEL_PGSSLMODE`
 
-:warning: If you have configured both the frontend (pgsql) and code intelligence (codeintel-db) databases with the same values, the Sourcegraph instance will refuse to start. Each database should either be configured to point to distinct hosts (recommended), or configured to point to distinct databases on the same host.
+> NOTE: ⚠️ If you have configured both the frontend (pgsql) and code intelligence (codeintel-db) databases with the same values, the Sourcegraph instance will refuse to start. Each database should either be configured to point to distinct hosts (recommended), or configured to point to distinct databases on the same host.
 
 ### sourcegraph/server
 
@@ -135,23 +125,3 @@ Please refer to our [Postgres](https://docs.sourcegraph.com/admin/postgres) docu
 Most standard PostgreSQL environment variables may be specified (`PGPORT`, etc). See http://www.postgresql.org/docs/current/static/libpq-envars.html for a full list.
 
 > NOTE: On Mac/Windows, if trying to connect to a PostgreSQL server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
-
-## Using your own Redis server
-
-**Version requirements**: We support any version *starting from 5.0*.
-
-Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can do the following:
-
-Add the `REDIS_ENDPOINT` environment variable to your `docker run` command and Sourcegraph will use that Redis server instead of its built-in one. The string must either have the format `$HOST:PORT`
-or follow the [IANA specification for Redis URLs](https://www.iana.org/assignments/uri-schemes/prov/redis) (e.g., `redis://:mypassword@host:6379/2`). For example:
-
-<!--
-  DO NOT CHANGE THIS TO A CODEBLOCK.
-  We want line breaks for readability, but backslashes to escape them do not work cross-platform.
-  This uses line breaks that are rendered but not copy-pasted to the clipboard.
--->
-<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.21.2</code></pre>
-
-> NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
-
-If using Docker for Desktop, `host.docker.internal` will resolve to the host IP address.

--- a/doc/admin/external_services/redis.md
+++ b/doc/admin/external_services/redis.md
@@ -1,0 +1,21 @@
+# Using your own Redis server
+
+**Version requirements**: We support any version *starting from 5.0*.
+
+Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can do the following:
+
+Add the `REDIS_ENDPOINT` environment variable to your `docker run` command and Sourcegraph will use that Redis server instead of its built-in one. The string must either have the format `$HOST:PORT`
+or follow the [IANA specification for Redis URLs](https://www.iana.org/assignments/uri-schemes/prov/redis) (e.g., `redis://:mypassword@host:6379/2`). For example:
+
+<!--
+  DO NOT CHANGE THIS TO A CODEBLOCK.
+  We want line breaks for readability, but backslashes to escape them do not work cross-platform.
+  This uses line breaks that are rendered but not copy-pasted to the clipboard.
+-->
+<pre class="pre-wrap"><code>docker run [...]<span class="virtual-br"></span>   -e REDIS_ENDPOINT=redis.mycompany.org:6379<span class="virtual-br"></span>   sourcegraph/server:3.21.2</code></pre>
+
+> NOTE: On Mac/Windows, if trying to connect to a Redis server on the same host machine, remember that Sourcegraph is running inside a Docker container inside of the Docker virtual machine. You may need to specify your actual machine IP address and not `localhost` or `127.0.0.1` as that refers to the Docker VM itself.
+
+If using Docker for Desktop, `host.docker.internal` will resolve to the host IP address.
+
+

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -25,7 +25,7 @@ Site administrators are the admins responsible for deploying, managing, and conf
 - [Repository permissions](repo/permissions.md)
 - [PostgreSQL configuration](postgres-conf.md)
 - [Upgrading PostgreSQL](postgres.md)
-- [Using external databases (PostgreSQL and Redis)](external_database.md)
+- [Using external services (PostgreSQL, Redis, S3/GCS)](external_services/index.md)
 - [User data deletion](user_data_deletion.md)
 - [Validation](validation.md) **Experimental**
 

--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -156,6 +156,6 @@ The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deplo
 
 ## Using an external database for persistence
 
-The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external databases](../../external_database.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/) and [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/).
+The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external services](../../external_services/index.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/), [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/), and [S3](https://aws.amazon.com/s3/) for storing user uploads.
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -154,6 +154,6 @@ The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deplo
 
 ## Using an external database for persistence
 
-The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external databases](../../external_database.md) for persistence, such as [Digital Ocean Managed Databases](https://www.digitalocean.com/products/managed-databases/) for [Postgres](https://www.digitalocean.com/products/managed-databases-postgresql/) and [Redis](https://www.digitalocean.com/products/managed-databases-redis/).
+The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external services](../../external_services/index.md) for persistence, such as [Digital Ocean Managed Databases](https://www.digitalocean.com/products/managed-databases/) for [Postgres](https://www.digitalocean.com/products/managed-databases-postgresql/), [Redis](https://www.digitalocean.com/products/managed-databases-redis/), and [Spaces](https://www.digitalocean.com/products/spaces/) for storing user uploads.
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -155,6 +155,6 @@ The [Sourcegraph Docker Compose definition](https://github.com/sourcegraph/deplo
 
 ## Using an external database for persistence
 
-The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external databases](../../external_database.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) and [Cloud Memorystore](https://cloud.google.com/memorystore/).
+The Docker Compose configuration has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the containers, you can [use external services](../../external_services/index.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/), [Cloud Memorystore](https://cloud.google.com/memorystore/), and [Cloud Storage](https://cloud.google.com/storage) for storing user uploads.
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -65,6 +65,6 @@ docker run docker run -d --publish 80:7080 --publish 443:7080 --restart unless-s
 
 ## Using an external database for persistence
 
-The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external databases](../../external_database.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/) and [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/).
+The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external services](../../external_services/index.md) for persistence, such as [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/), [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/), and [S3](https://aws.amazon.com/s3/) for storing user uploads.
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/docker/google_cloud.md
+++ b/doc/admin/install/docker/google_cloud.md
@@ -46,6 +46,6 @@ docker run -d ... sourcegraph/server:X.Y.Z
 
 ## Using an external database for persistence
 
-The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external databases](../../external_database.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) and [Cloud Memorystore](https://cloud.google.com/memorystore/).
+The Docker container has its own internal PostgreSQL and Redis databases. To preserve this data when you kill and recreate the container, you can [use external services](../../external_services/index.md) for persistence, such as Google Cloud's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/), [Cloud Memorystore](https://cloud.google.com/memorystore/), and [Cloud Storage](https://cloud.google.com/storage) for storing user uploads.
 
 > NOTE: Use of external databases requires [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).

--- a/doc/admin/install/migrate-backup.md
+++ b/doc/admin/install/migrate-backup.md
@@ -64,7 +64,7 @@ Short-lived data, including session data and some usage statistics, are stored i
 
 ### External data
 
-Certain categories of data can be stored outside of the Sourcegraph deployment. For example, [configuration JSON files can be loaded from disk](../config/advanced_config_file.md), and Sourcegraph can connect to [an external SQL database and Redis server](../external_database.md) instead of using Postgres and Redis internally. 
+Certain categories of data can be stored outside of the Sourcegraph deployment. For example, [configuration JSON files can be loaded from disk](../config/advanced_config_file.md), and Sourcegraph can connect to [external services (PostgreSQL, Redis, S3/GCS)](../external_services/index.md) instead of using PostgreSQL, Redis, and MinIO internally. 
 
 In these cases, no migration should be necessary—simply re-use the existing external data sources on the new Sourcegraph instance.
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -19,7 +19,7 @@ Please upgrade to the [`v3.20.1` tag of deploy-sourcegraph-docker](https://githu
 
 Please upgrade to the [`v3.21.0` tag of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.21.0/docker-compose) by following the [standard upgrade procedure](#standard-upgrade-procedure).
 
-This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
+This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database as described in the [external database documentation](../external_services/postgres.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
 ### If you wish to keep existing LSIF data
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -13,7 +13,7 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 Follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your deployment.
 
-This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
+This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database as described in the [external database documentation](../external_services/postgres.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
 ### If you wish to keep existing LSIF data
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -10,7 +10,7 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 ## 3.20 -> 3.21
 
-This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database  as described in the [external database documentation](../external_database.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
+This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database as described in the [external database documentation](../external_services/postgres.md). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
 ### If you wish to keep existing LSIF data
 


### PR DESCRIPTION
This adds a section to the old "external databases" instructions on how to use S3 or GCS instead of the MinIO container that's bundled with the deployment. This became too big so I split it into a sub directory and updated all inbound links.

The deployment environments have not yet been updated to use these environment variables, but will be after the open PRs to add the minio container are merged (https://github.com/sourcegraph/sourcegraph/pull/15062, https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/169, and https://github.com/sourcegraph/deploy-sourcegraph/pull/1158).