### PR TITLE
Query changeset stats from database

### DIFF
--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -32,7 +32,7 @@ const now = new Date()
 
 const campaignDefaults: CampaignFields = {
     __typename: 'Campaign',
-    stats: {
+    changesetsStats: {
         closed: 1,
         deleted: 1,
         merged: 2,

--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -32,16 +32,14 @@ const now = new Date()
 
 const campaignDefaults: CampaignFields = {
     __typename: 'Campaign',
-    changesets: {
-        stats: {
-            closed: 1,
-            deleted: 1,
-            merged: 2,
-            draft: 1,
-            open: 2,
-            total: 10,
-            unpublished: 4,
-        },
+    stats: {
+        closed: 1,
+        deleted: 1,
+        merged: 2,
+        draft: 1,
+        open: 2,
+        total: 10,
+        unpublished: 4,
     },
     createdAt: subDays(now, 5).toISOString(),
     initialApplier: {

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -33,16 +33,14 @@ const now = new Date()
 
 const campaignDefaults: CampaignFields = {
     __typename: 'Campaign',
-    changesets: {
-        stats: {
-            closed: 1,
-            deleted: 1,
-            draft: 1,
-            merged: 2,
-            open: 2,
-            total: 10,
-            unpublished: 4,
-        },
+    stats: {
+        closed: 1,
+        deleted: 1,
+        draft: 1,
+        merged: 2,
+        open: 2,
+        total: 10,
+        unpublished: 4,
     },
     createdAt: subDays(now, 5).toISOString(),
     initialApplier: {

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -33,7 +33,7 @@ const now = new Date()
 
 const campaignDefaults: CampaignFields = {
     __typename: 'Campaign',
-    stats: {
+    changesetsStats: {
         closed: 1,
         deleted: 1,
         draft: 1,

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
@@ -36,7 +36,7 @@ describe('CampaignDetailsPage', () => {
                     name: 'n',
                     description: 'd',
                     initialApplier: { username: 'alice', url: '/users/alice' },
-                    stats: { total: 10, closed: 0, merged: 0, open: 8, unpublished: 2, deleted: 1, draft: 0 },
+                    changesetsStats: { total: 10, closed: 0, merged: 0, open: 8, unpublished: 2, deleted: 1, draft: 0 },
                     viewerCanAdminister,
                     branch: 'awesome-branch',
                     createdAt: '2020-01-01',

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.test.tsx
@@ -36,10 +36,7 @@ describe('CampaignDetailsPage', () => {
                     name: 'n',
                     description: 'd',
                     initialApplier: { username: 'alice', url: '/users/alice' },
-                    changesets: {
-                        totalCount: 0,
-                        stats: { total: 10, closed: 0, merged: 0, open: 8, unpublished: 2, deleted: 1, draft: 0 },
-                    },
+                    stats: { total: 10, closed: 0, merged: 0, open: 8, unpublished: 2, deleted: 1, draft: 0 },
                     viewerCanAdminister,
                     branch: 'awesome-branch',
                     createdAt: '2020-01-01',

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -141,8 +141,12 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 lastApplier={campaign.lastApplier}
                 className="mb-3"
             />
-            <UnpublishedNotice unpublished={campaign.stats.unpublished} total={campaign.stats.total} className="mb-3" />
-            <CampaignStatsCard closedAt={campaign.closedAt} stats={campaign.stats} className="mb-3" />
+            <UnpublishedNotice
+                unpublished={campaign.changesetsStats.unpublished}
+                total={campaign.changesetsStats.total}
+                className="mb-3"
+            />
+            <CampaignStatsCard closedAt={campaign.closedAt} stats={campaign.changesetsStats} className="mb-3" />
             <CampaignDescription history={history} description={campaign.description} />
             <CampaignTabs
                 campaign={campaign}

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -141,12 +141,8 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 lastApplier={campaign.lastApplier}
                 className="mb-3"
             />
-            <UnpublishedNotice
-                unpublished={campaign.changesets.stats.unpublished}
-                total={campaign.changesets.stats.total}
-                className="mb-3"
-            />
-            <CampaignStatsCard closedAt={campaign.closedAt} stats={campaign.changesets.stats} className="mb-3" />
+            <UnpublishedNotice unpublished={campaign.stats.unpublished} total={campaign.stats.total} className="mb-3" />
+            <CampaignStatsCard closedAt={campaign.closedAt} stats={campaign.stats} className="mb-3" />
             <CampaignDescription history={history} description={campaign.description} />
             <CampaignTabs
                 campaign={campaign}

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import classNames from 'classnames'
-import { CampaignFields, ChangesetStatsFields } from '../../../graphql-operations'
+import { CampaignFields, ChangesetsStatsFields } from '../../../graphql-operations'
 import { CampaignStateBadge } from './CampaignStateBadge'
 import {
     ChangesetStatusUnpublished,
@@ -14,7 +14,7 @@ import {
 import { pluralize } from '../../../../../shared/src/util/strings'
 
 interface CampaignStatsCardProps {
-    stats: ChangesetStatsFields
+    stats: ChangesetsStatsFields
     closedAt: CampaignFields['closedAt']
     className?: string
 }

--- a/client/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/detail/__snapshots__/CampaignDetailsPage.test.tsx.snap
@@ -399,17 +399,14 @@ exports[`CampaignDetailsPage viewerCanAdminister: false viewing existing 1`] = `
       Object {
         "__typename": "Campaign",
         "branch": "awesome-branch",
-        "changesets": Object {
-          "stats": Object {
-            "closed": 0,
-            "deleted": 1,
-            "draft": 0,
-            "merged": 0,
-            "open": 8,
-            "total": 10,
-            "unpublished": 2,
-          },
-          "totalCount": 0,
+        "changesetsStats": Object {
+          "closed": 0,
+          "deleted": 1,
+          "draft": 0,
+          "merged": 0,
+          "open": 8,
+          "total": 10,
+          "unpublished": 2,
         },
         "closedAt": null,
         "createdAt": "2020-01-01",
@@ -1355,17 +1352,14 @@ exports[`CampaignDetailsPage viewerCanAdminister: true viewing existing 1`] = `
       Object {
         "__typename": "Campaign",
         "branch": "awesome-branch",
-        "changesets": Object {
-          "stats": Object {
-            "closed": 0,
-            "deleted": 1,
-            "draft": 0,
-            "merged": 0,
-            "open": 8,
-            "total": 10,
-            "unpublished": 2,
-          },
-          "totalCount": 0,
+        "changesetsStats": Object {
+          "closed": 0,
+          "deleted": 1,
+          "draft": 0,
+          "merged": 0,
+          "open": 8,
+          "total": 10,
+          "unpublished": 2,
         },
         "closedAt": null,
         "createdAt": "2020-01-01",

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -62,7 +62,7 @@ const campaignFragment = gql`
         closedAt
         viewerCanAdminister
 
-        stats {
+        changesetsStats {
             ...ChangesetsStatsFields
         }
 

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -22,8 +22,8 @@ import {
 } from '../../../graphql-operations'
 import { requestGraphQL } from '../../../backend/graphql'
 
-const changesetStatsFragment = gql`
-    fragment ChangesetStatsFields on ChangesetConnectionStats {
+const changesetsStatsFragment = gql`
+    fragment ChangesetsStatsFields on ChangesetsStats {
         total
         closed
         deleted
@@ -62,10 +62,8 @@ const campaignFragment = gql`
         closedAt
         viewerCanAdminister
 
-        changesets {
-            stats {
-                ...ChangesetStatsFields
-            }
+        stats {
+            ...ChangesetsStatsFields
         }
 
         currentSpec {
@@ -73,7 +71,7 @@ const campaignFragment = gql`
         }
     }
 
-    ${changesetStatsFragment}
+    ${changesetsStatsFragment}
 `
 
 const changesetLabelFragment = gql`

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
@@ -19,7 +19,7 @@ export const nodes: Record<string, ListCampaign> = {
 This is my thorough explanation. And it can also get very long, in that case the UI doesn't break though, which is good. And one more line to finally be longer than the viewport.`,
         createdAt: subDays(now, 5).toISOString(),
         closedAt: null,
-        stats: {
+        changesetsStats: {
             open: 10,
             closed: 0,
             merged: 5,
@@ -36,7 +36,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         description: null,
         createdAt: subDays(now, 5).toISOString(),
         closedAt: null,
-        stats: {
+        changesetsStats: {
             open: 10,
             closed: 0,
             merged: 5,
@@ -55,7 +55,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         This is my thorough explanation.`,
         createdAt: subDays(now, 5).toISOString(),
         closedAt: subDays(now, 3).toISOString(),
-        stats: {
+        changesetsStats: {
             open: 0,
             closed: 10,
             merged: 5,

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.story.tsx
@@ -19,12 +19,10 @@ export const nodes: Record<string, ListCampaign> = {
 This is my thorough explanation. And it can also get very long, in that case the UI doesn't break though, which is good. And one more line to finally be longer than the viewport.`,
         createdAt: subDays(now, 5).toISOString(),
         closedAt: null,
-        changesets: {
-            stats: {
-                open: 10,
-                closed: 0,
-                merged: 5,
-            },
+        stats: {
+            open: 10,
+            closed: 0,
+            merged: 5,
         },
         namespace: {
             namespaceName: 'alice',
@@ -38,12 +36,10 @@ This is my thorough explanation. And it can also get very long, in that case the
         description: null,
         createdAt: subDays(now, 5).toISOString(),
         closedAt: null,
-        changesets: {
-            stats: {
-                open: 10,
-                closed: 0,
-                merged: 5,
-            },
+        stats: {
+            open: 10,
+            closed: 0,
+            merged: 5,
         },
         namespace: {
             namespaceName: 'alice',
@@ -59,12 +55,10 @@ This is my thorough explanation. And it can also get very long, in that case the
         This is my thorough explanation.`,
         createdAt: subDays(now, 5).toISOString(),
         closedAt: subDays(now, 3).toISOString(),
-        changesets: {
-            stats: {
-                open: 0,
-                closed: 10,
-                merged: 5,
-            },
+        stats: {
+            open: 0,
+            closed: 10,
+            merged: 5,
         },
         namespace: {
             namespaceName: 'alice',

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -17,7 +17,7 @@ describe('CampaignNode', () => {
 
 - and renders in markdown
         `,
-        changesets: { stats: { merged: 0, open: 1, closed: 3 } },
+        stats: { merged: 0, open: 1, closed: 3 },
         createdAt: '2019-12-04T23:15:01Z',
         closedAt: null,
         namespace: {

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.test.tsx
@@ -17,7 +17,7 @@ describe('CampaignNode', () => {
 
 - and renders in markdown
         `,
-        stats: { merged: 0, open: 1, closed: 3 },
+        changesetsStats: { merged: 0, open: 1, closed: 3 },
         createdAt: '2019-12-04T23:15:01Z',
         closedAt: null,
         namespace: {

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -65,15 +65,15 @@ export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({
         </div>
         <ChangesetStatusOpen
             className="d-block d-sm-flex"
-            label={<span className="text-muted">{node.changesets.stats.open} open</span>}
+            label={<span className="text-muted">{node.stats.open} open</span>}
         />
         <ChangesetStatusClosed
             className="d-block d-sm-flex text-center"
-            label={<span className="text-muted">{node.changesets.stats.closed} closed</span>}
+            label={<span className="text-muted">{node.stats.closed} closed</span>}
         />
         <ChangesetStatusMerged
             className="d-block d-sm-flex"
-            label={<span className="text-muted">{node.changesets.stats.merged} merged</span>}
+            label={<span className="text-muted">{node.stats.merged} merged</span>}
         />
     </>
 )

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.tsx
@@ -65,15 +65,15 @@ export const CampaignNode: React.FunctionComponent<CampaignNodeProps> = ({
         </div>
         <ChangesetStatusOpen
             className="d-block d-sm-flex"
-            label={<span className="text-muted">{node.stats.open} open</span>}
+            label={<span className="text-muted">{node.changesetsStats.open} open</span>}
         />
         <ChangesetStatusClosed
             className="d-block d-sm-flex text-center"
-            label={<span className="text-muted">{node.stats.closed} closed</span>}
+            label={<span className="text-muted">{node.changesetsStats.closed} closed</span>}
         />
         <ChangesetStatusMerged
             className="d-block d-sm-flex"
-            label={<span className="text-muted">{node.stats.merged} merged</span>}
+            label={<span className="text-muted">{node.changesetsStats.merged} merged</span>}
         />
     </>
 )

--- a/client/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/list/__snapshots__/CampaignNode.test.tsx.snap
@@ -6,12 +6,10 @@ exports[`CampaignNode campaign without description 1`] = `
   history="[History]"
   node={
     Object {
-      "changesets": Object {
-        "stats": Object {
-          "closed": 3,
-          "merged": 0,
-          "open": 1,
-        },
+      "changesetsStats": Object {
+        "closed": 3,
+        "merged": 0,
+        "open": 1,
       },
       "closedAt": null,
       "createdAt": "2019-12-04T23:15:01Z",
@@ -187,12 +185,10 @@ exports[`CampaignNode closed campaign 1`] = `
   history="[History]"
   node={
     Object {
-      "changesets": Object {
-        "stats": Object {
-          "closed": 3,
-          "merged": 0,
-          "open": 1,
-        },
+      "changesetsStats": Object {
+        "closed": 3,
+        "merged": 0,
+        "open": 1,
       },
       "closedAt": "2019-12-04T23:19:01Z",
       "createdAt": "2019-12-04T23:15:01Z",
@@ -380,12 +376,10 @@ exports[`CampaignNode open campaign 1`] = `
   history="[History]"
   node={
     Object {
-      "changesets": Object {
-        "stats": Object {
-          "closed": 3,
-          "merged": 0,
-          "open": 1,
-        },
+      "changesetsStats": Object {
+        "closed": 3,
+        "merged": 0,
+        "open": 1,
       },
       "closedAt": null,
       "createdAt": "2019-12-04T23:15:01Z",
@@ -573,12 +567,10 @@ exports[`CampaignNode open campaign on user page 1`] = `
   history="[History]"
   node={
     Object {
-      "changesets": Object {
-        "stats": Object {
-          "closed": 3,
-          "merged": 0,
-          "open": 1,
-        },
+      "changesetsStats": Object {
+        "closed": 3,
+        "merged": 0,
+        "open": 1,
       },
       "closedAt": null,
       "createdAt": "2019-12-04T23:15:01Z",

--- a/client/web/src/enterprise/campaigns/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/list/backend.ts
@@ -23,12 +23,10 @@ const ListCampaignFragment = gql`
         description
         createdAt
         closedAt
-        changesets {
-            stats {
-                open
-                closed
-                merged
-            }
+        stats {
+            open
+            closed
+            merged
         }
     }
 `

--- a/client/web/src/enterprise/campaigns/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/list/backend.ts
@@ -23,7 +23,7 @@ const ListCampaignFragment = gql`
         description
         createdAt
         closedAt
-        stats {
+        changesetsStats {
             open
             closed
             merged

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -30,7 +30,7 @@ const campaignListNode: ListCampaign = {
     url: '/users/alice/campaigns/test-campaign',
     name: 'test-campaign',
     createdAt: subDays(new Date(), 5).toISOString(),
-    stats: { closed: 4, merged: 10, open: 5 },
+    changesetsStats: { closed: 4, merged: 10, open: 5 },
     closedAt: null,
     description: null,
     namespace: {
@@ -250,7 +250,7 @@ function mockCommonGraphQLResponses(
             campaign: {
                 __typename: 'Campaign',
                 id: 'campaign123',
-                stats: { closed: 2, deleted: 1, merged: 3, open: 8, total: 19, unpublished: 3, draft: 2 },
+                changesetsStats: { closed: 2, deleted: 1, merged: 3, open: 8, total: 19, unpublished: 3, draft: 2 },
                 closedAt: null,
                 createdAt: subDays(new Date(), 5).toISOString(),
                 updatedAt: subDays(new Date(), 5).toISOString(),

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -30,7 +30,7 @@ const campaignListNode: ListCampaign = {
     url: '/users/alice/campaigns/test-campaign',
     name: 'test-campaign',
     createdAt: subDays(new Date(), 5).toISOString(),
-    changesets: { stats: { closed: 4, merged: 10, open: 5 } },
+    stats: { closed: 4, merged: 10, open: 5 },
     closedAt: null,
     description: null,
     namespace: {
@@ -250,9 +250,7 @@ function mockCommonGraphQLResponses(
             campaign: {
                 __typename: 'Campaign',
                 id: 'campaign123',
-                changesets: {
-                    stats: { closed: 2, deleted: 1, merged: 3, open: 8, total: 19, unpublished: 3, draft: 2 },
-                },
+                stats: { closed: 2, deleted: 1, merged: 3, open: 8, total: 19, unpublished: 3, draft: 2 },
                 closedAt: null,
                 createdAt: subDays(new Date(), 5).toISOString(),
                 updatedAt: subDays(new Date(), 5).toISOString(),

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -216,7 +216,7 @@ type CampaignResolver interface {
 	Namespace(ctx context.Context) (n NamespaceResolver, err error)
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
-	Stats(ctx context.Context) (ChangesetsStatsResolver, error)
+	ChangesetsStats(ctx context.Context) (ChangesetsStatsResolver, error)
 	Changesets(ctx context.Context, args *ListChangesetsArgs) (ChangesetsConnectionResolver, error)
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
 	ClosedAt() *DateTime

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -216,6 +216,7 @@ type CampaignResolver interface {
 	Namespace(ctx context.Context) (n NamespaceResolver, err error)
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
+	Stats(ctx context.Context) (ChangesetsStatsResolver, error)
 	Changesets(ctx context.Context, args *ListChangesetsArgs) (ChangesetsConnectionResolver, error)
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
 	ClosedAt() *DateTime
@@ -229,7 +230,7 @@ type CampaignsConnectionResolver interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type ChangesetsConnectionStatsResolver interface {
+type ChangesetsStatsResolver interface {
 	Unpublished() int32
 	Draft() int32
 	Open() int32
@@ -243,7 +244,6 @@ type ChangesetsConnectionResolver interface {
 	Nodes(ctx context.Context) ([]ChangesetResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
-	Stats(ctx context.Context) (ChangesetsConnectionStatsResolver, error)
 }
 
 type ChangesetLabelResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1682,7 +1682,7 @@ type ChangesetConnection {
     pageInfo: PageInfo!
 
     """
-    Stats on all the changesets that are in this connection. Pagination has no effect on the stats.
+    Stats on all the changesets that are in this connection. Pagination and filters have no effect on the stats.
     """
     stats: ChangesetConnectionStats!
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1158,7 +1158,7 @@ type Campaign implements Node {
     """
     Stats on all the changesets that are tracked in this campaign.
     """
-    stats: ChangesetsStats!
+    changesetsStats: ChangesetsStats!
 
     """
     The changesets in this campaign that already exist on the code host.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1156,6 +1156,11 @@ type Campaign implements Node {
     closedAt: DateTime
 
     """
+    Stats on all the changesets that are tracked in this campaign.
+    """
+    stats: ChangesetsStats!
+
+    """
     The changesets in this campaign that already exist on the code host.
     """
     changesets(
@@ -1631,7 +1636,7 @@ type ExternalChangeset implements Node & Changeset {
 """
 Used in the campaign page for the overview component.
 """
-type ChangesetConnectionStats {
+type ChangesetsStats {
     """
     The count of unpublished changesets.
     """
@@ -1657,7 +1662,7 @@ type ChangesetConnectionStats {
     """
     deleted: Int!
     """
-    The count of all changesets. Equal to totalCount of the connection.
+    The count of all changesets.
     """
     total: Int!
 }
@@ -1680,11 +1685,6 @@ type ChangesetConnection {
     Pagination information.
     """
     pageInfo: PageInfo!
-
-    """
-    Stats on all the changesets that are in this connection. Pagination and filters have no effect on the stats.
-    """
-    stats: ChangesetConnectionStats!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1675,7 +1675,7 @@ type ChangesetConnection {
     pageInfo: PageInfo!
 
     """
-    Stats on all the changesets that are in this connection. Pagination has no effect on the stats.
+    Stats on all the changesets that are in this connection. Pagination and filters have no effect on the stats.
     """
     stats: ChangesetConnectionStats!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1149,6 +1149,11 @@ type Campaign implements Node {
     closedAt: DateTime
 
     """
+    Stats on all the changesets that are tracked in this campaign.
+    """
+    stats: ChangesetsStats!
+
+    """
     The changesets in this campaign that already exist on the code host.
     """
     changesets(
@@ -1624,7 +1629,7 @@ type ExternalChangeset implements Node & Changeset {
 """
 Used in the campaign page for the overview component.
 """
-type ChangesetConnectionStats {
+type ChangesetsStats {
     """
     The count of unpublished changesets.
     """
@@ -1650,7 +1655,7 @@ type ChangesetConnectionStats {
     """
     deleted: Int!
     """
-    The count of all changesets. Equal to totalCount of the connection.
+    The count of all changesets.
     """
     total: Int!
 }
@@ -1673,11 +1678,6 @@ type ChangesetConnection {
     Pagination information.
     """
     pageInfo: PageInfo!
-
-    """
-    Stats on all the changesets that are in this connection. Pagination and filters have no effect on the stats.
-    """
-    stats: ChangesetConnectionStats!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1151,7 +1151,7 @@ type Campaign implements Node {
     """
     Stats on all the changesets that are tracked in this campaign.
     """
-    stats: ChangesetsStats!
+    changesetsStats: ChangesetsStats!
 
     """
     The changesets in this campaign that already exist on the code host.

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -82,7 +82,7 @@ type Campaign struct {
 	UpdatedAt               string
 	ClosedAt                string
 	URL                     string
-	Stats                   ChangesetsStats
+	ChangesetsStats         ChangesetsStats
 	Changesets              ChangesetConnection
 	ChangesetCountsOverTime []ChangesetCounts
 	DiffStat                DiffStat

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -82,6 +82,7 @@ type Campaign struct {
 	UpdatedAt               string
 	ClosedAt                string
 	URL                     string
+	Stats                   ChangesetsStats
 	Changesets              ChangesetConnection
 	ChangesetCountsOverTime []ChangesetCounts
 	DiffStat                DiffStat
@@ -157,10 +158,9 @@ type ChangesetConnection struct {
 	Nodes      []Changeset
 	TotalCount int
 	PageInfo   PageInfo
-	Stats      ChangesetConnectionStats
 }
 
-type ChangesetConnectionStats struct {
+type ChangesetsStats struct {
 	Unpublished int
 	Draft       int
 	Open        int

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -141,6 +141,16 @@ func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
 	return &graphqlbackend.DateTime{Time: r.Campaign.ClosedAt}
 }
 
+func (r *campaignResolver) Stats(ctx context.Context) (graphqlbackend.ChangesetsStatsResolver, error) {
+	stats, err := r.store.GetChangesetsStats(ctx, ee.GetChangesetsStatsOpts{
+		CampaignID: r.Campaign.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &changesetsStatsResolver{stats: stats}, nil
+}
+
 func (r *campaignResolver) Changesets(
 	ctx context.Context,
 	args *graphqlbackend.ListChangesetsArgs,

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -141,7 +141,7 @@ func (r *campaignResolver) ClosedAt() *graphqlbackend.DateTime {
 	return &graphqlbackend.DateTime{Time: r.Campaign.ClosedAt}
 }
 
-func (r *campaignResolver) Stats(ctx context.Context) (graphqlbackend.ChangesetsStatsResolver, error) {
+func (r *campaignResolver) ChangesetsStats(ctx context.Context) (graphqlbackend.ChangesetsStatsResolver, error) {
 	stats, err := r.store.GetChangesetsStats(ctx, ee.GetChangesetsStatsOpts{
 		CampaignID: r.Campaign.ID,
 	})

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -75,16 +75,6 @@ func (r *changesetsConnectionResolver) TotalCount(ctx context.Context) (int32, e
 	return int32(len(cs)), nil
 }
 
-func (r *changesetsConnectionResolver) Stats(ctx context.Context) (graphqlbackend.ChangesetsConnectionStatsResolver, error) {
-	stats, err := r.store.GetChangesetsStats(ctx, ee.GetChangesetsStatsOpts{
-		CampaignID: r.opts.CampaignID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &changesetsConnectionStatsResolver{stats: stats}, nil
-}
-
 // compute loads all changesets matched by r.opts, but without a
 // limit.
 // If r.optsSafe is true, it returns all of them. If not, it filters out the
@@ -156,30 +146,4 @@ func (r *changesetsConnectionResolver) PageInfo(ctx context.Context) (*graphqlut
 	}
 
 	return graphqlutil.HasNextPage(false), nil
-}
-
-type changesetsConnectionStatsResolver struct {
-	stats campaigns.ChangesetsStats
-}
-
-func (r *changesetsConnectionStatsResolver) Unpublished() int32 {
-	return r.stats.Unpublished
-}
-func (r *changesetsConnectionStatsResolver) Draft() int32 {
-	return r.stats.Draft
-}
-func (r *changesetsConnectionStatsResolver) Open() int32 {
-	return r.stats.Open
-}
-func (r *changesetsConnectionStatsResolver) Merged() int32 {
-	return r.stats.Merged
-}
-func (r *changesetsConnectionStatsResolver) Closed() int32 {
-	return r.stats.Closed
-}
-func (r *changesetsConnectionStatsResolver) Deleted() int32 {
-	return r.stats.Deleted
-}
-func (r *changesetsConnectionStatsResolver) Total() int32 {
-	return r.stats.Total
 }

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -171,15 +171,6 @@ func TestChangesetConnectionResolver(t *testing.T) {
 			}
 
 			wantChangesets := apitest.ChangesetConnection{
-				// Stats: apitest.ChangesetsStats{
-				// 	Unpublished: 1,
-				// 	Draft:       0,
-				// 	Open:        tc.wantOpen,
-				// 	Merged:      1,
-				// 	Closed:      0,
-				// 	Deleted:     0,
-				// 	Total:       tc.wantTotalCount,
-				// },
 				TotalCount: tc.wantTotalCount,
 				PageInfo: apitest.PageInfo{
 					EndCursor:   wantEndCursor,

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -171,15 +171,15 @@ func TestChangesetConnectionResolver(t *testing.T) {
 			}
 
 			wantChangesets := apitest.ChangesetConnection{
-				Stats: apitest.ChangesetConnectionStats{
-					Unpublished: 1,
-					Draft:       0,
-					Open:        tc.wantOpen,
-					Merged:      1,
-					Closed:      0,
-					Deleted:     0,
-					Total:       tc.wantTotalCount,
-				},
+				// Stats: apitest.ChangesetsStats{
+				// 	Unpublished: 1,
+				// 	Draft:       0,
+				// 	Open:        tc.wantOpen,
+				// 	Merged:      1,
+				// 	Closed:      0,
+				// 	Deleted:     0,
+				// 	Total:       tc.wantTotalCount,
+				// },
 				TotalCount: tc.wantTotalCount,
 				PageInfo: apitest.PageInfo{
 					EndCursor:   wantEndCursor,
@@ -231,7 +231,6 @@ query($campaign: ID!, $first: Int, $after: String, $reviewState: ChangesetReview
     ... on Campaign {
       changesets(first: $first, after: $after, reviewState: $reviewState) {
         totalCount
-        stats { unpublished, draft, open, merged, closed, deleted, total }
         nodes {
           __typename
 

--- a/enterprise/internal/campaigns/resolvers/changesets_stats.go
+++ b/enterprise/internal/campaigns/resolvers/changesets_stats.go
@@ -1,0 +1,34 @@
+package resolvers
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+type changesetsStatsResolver struct {
+	stats campaigns.ChangesetsStats
+}
+
+var _ graphqlbackend.ChangesetsStatsResolver = &changesetsStatsResolver{}
+
+func (r *changesetsStatsResolver) Unpublished() int32 {
+	return r.stats.Unpublished
+}
+func (r *changesetsStatsResolver) Draft() int32 {
+	return r.stats.Draft
+}
+func (r *changesetsStatsResolver) Open() int32 {
+	return r.stats.Open
+}
+func (r *changesetsStatsResolver) Merged() int32 {
+	return r.stats.Merged
+}
+func (r *changesetsStatsResolver) Closed() int32 {
+	return r.stats.Closed
+}
+func (r *changesetsStatsResolver) Deleted() int32 {
+	return r.stats.Deleted
+}
+func (r *changesetsStatsResolver) Total() int32 {
+	return r.stats.Total
+}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -648,7 +648,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
 			changesetTypes:  map[string]int{"ExternalChangeset": 2},
 			changesetsCount: 2,
-			changesetStats:  apitest.ChangesetConnectionStats{Open: 2, Total: 2},
+			changesetStats:  apitest.ChangesetsStats{Open: 2, Total: 2},
 			campaignDiffStat: apitest.DiffStat{
 				Added:   2 * changesetDiffStat.Added,
 				Changed: 2 * changesetDiffStat.Changed,
@@ -673,7 +673,7 @@ func TestRepositoryPermissions(t *testing.T) {
 				"HiddenExternalChangeset": 1,
 			},
 			changesetsCount: 2,
-			changesetStats:  apitest.ChangesetConnectionStats{Open: 2, Total: 2},
+			changesetStats:  apitest.ChangesetsStats{Open: 2, Total: 2},
 			campaignDiffStat: apitest.DiffStat{
 				Added:   1 * changesetDiffStat.Added,
 				Changed: 1 * changesetDiffStat.Changed,
@@ -700,7 +700,6 @@ func TestRepositoryPermissions(t *testing.T) {
 		}
 		wantCheckStateResponse := want
 		wantCheckStateResponse.changesetsCount = 1
-		wantCheckStateResponse.changesetStats = apitest.ChangesetConnectionStats{Open: 1, Total: 1}
 		wantCheckStateResponse.changesetTypes = map[string]int{
 			"ExternalChangeset": 1,
 			// No HiddenExternalChangeset
@@ -789,7 +788,7 @@ func TestRepositoryPermissions(t *testing.T) {
 type wantCampaignResponse struct {
 	changesetTypes   map[string]int
 	changesetsCount  int
-	changesetStats   apitest.ChangesetConnectionStats
+	changesetStats   apitest.ChangesetsStats
 	campaignDiffStat apitest.DiffStat
 }
 
@@ -807,7 +806,7 @@ func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, 
 		t.Fatalf("unexpected changesets total count (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(w.changesetStats, response.Node.Changesets.Stats); diff != "" {
+	if diff := cmp.Diff(w.changesetStats, response.Node.Stats); diff != "" {
 		t.Fatalf("unexpected changesets stats (-want +got):\n%s", diff)
 	}
 
@@ -828,11 +827,12 @@ const queryCampaignPermLevels = `
 query($campaign: ID!, $reviewState: ChangesetReviewState, $checkState: ChangesetCheckState) {
   node(id: $campaign) {
     ... on Campaign {
-      id
+	  id
+
+	  stats { unpublished, open, merged, closed, total }
 
       changesets(first: 100, reviewState: $reviewState, checkState: $checkState) {
         totalCount
-		stats { unpublished, open, merged, closed, total }
         nodes {
           __typename
           ... on HiddenExternalChangeset {

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -806,7 +806,7 @@ func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, 
 		t.Fatalf("unexpected changesets total count (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(w.changesetStats, response.Node.Stats); diff != "" {
+	if diff := cmp.Diff(w.changesetStats, response.Node.ChangesetsStats); diff != "" {
 		t.Fatalf("unexpected changesets stats (-want +got):\n%s", diff)
 	}
 
@@ -829,7 +829,7 @@ query($campaign: ID!, $reviewState: ChangesetReviewState, $checkState: Changeset
     ... on Campaign {
 	  id
 
-	  stats { unpublished, open, merged, closed, total }
+	  changesetsStats { unpublished, open, merged, closed, total }
 
       changesets(first: 100, reviewState: $reviewState, checkState: $checkState) {
         totalCount

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -772,3 +772,55 @@ func scanChangeset(t *campaigns.Changeset, s scanner) error {
 
 	return nil
 }
+
+type GetChangesetsStatsOpts struct {
+	CampaignID int64
+}
+
+func (s *Store) GetChangesetsStats(ctx context.Context, opts GetChangesetsStatsOpts) (stats campaigns.ChangesetsStats, err error) {
+	q := GetChangesetsStatsQuery(opts)
+	err = s.query(ctx, q, func(sc scanner) (err error) {
+		if err = sc.Scan(
+			&stats.Total,
+			&stats.Unpublished,
+			&stats.Closed,
+			&stats.Draft,
+			&stats.Merged,
+			&stats.Open,
+			&stats.Deleted,
+		); err != nil {
+			return err
+		}
+		return err
+	})
+	if err != nil {
+		return stats, err
+	}
+	return stats, err
+}
+
+const getChangesetStatsFmtstr = `
+-- source: enterprise/internal/campaigns/store_changesets.go:GetChangesetsStats
+SELECT
+	COUNT(*) AS total,
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'UNPUBLISHED') AS unpublished,
+	COUNT(*) FILTER (WHERE changesets.external_state = 'CLOSED') AS closed,
+	COUNT(*) FILTER (WHERE changesets.external_state = 'DRAFT') AS draft,
+	COUNT(*) FILTER (WHERE changesets.external_state = 'MERGED') AS merged,
+	COUNT(*) FILTER (WHERE changesets.external_state = 'OPEN') AS open,
+	COUNT(*) FILTER (WHERE changesets.external_state = 'DELETED') AS deleted
+FROM changesets
+INNER JOIN repo on repo.id = changesets.repo_id
+WHERE
+	%s
+`
+
+func GetChangesetsStatsQuery(opts GetChangesetsStatsOpts) *sqlf.Query {
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("repo.deleted_at IS NULL"),
+	}
+	if opts.CampaignID != 0 {
+		preds = append(preds, sqlf.Sprintf("changesets.campaign_ids ? %s", opts.CampaignID))
+	}
+	return sqlf.Sprintf(getChangesetStatsFmtstr, sqlf.Join(preds, " AND "))
+}

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -808,11 +808,11 @@ const getChangesetStatsFmtstr = `
 SELECT
 	COUNT(*) AS total,
 	COUNT(*) FILTER (WHERE changesets.publication_state = 'UNPUBLISHED') AS unpublished,
-	COUNT(*) FILTER (WHERE changesets.external_state = 'CLOSED') AS closed,
-	COUNT(*) FILTER (WHERE changesets.external_state = 'DRAFT') AS draft,
-	COUNT(*) FILTER (WHERE changesets.external_state = 'MERGED') AS merged,
-	COUNT(*) FILTER (WHERE changesets.external_state = 'OPEN') AS open,
-	COUNT(*) FILTER (WHERE changesets.external_state = 'DELETED') AS deleted
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'CLOSED') AS closed,
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'DRAFT') AS draft,
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'MERGED') AS merged,
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'OPEN') AS open,
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'DELETED') AS deleted
 FROM changesets
 INNER JOIN repo on repo.id = changesets.repo_id
 WHERE

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -773,14 +773,18 @@ func scanChangeset(t *campaigns.Changeset, s scanner) error {
 	return nil
 }
 
+// GetChangesetsStatsOpts captures the query options needed for
+// retrieving changesets stats.
 type GetChangesetsStatsOpts struct {
 	CampaignID int64
 }
 
+// GetChangesetsStats returns statistics on all the changesets associated to the given campaign,
+// or all changesets across the instance.
 func (s *Store) GetChangesetsStats(ctx context.Context, opts GetChangesetsStatsOpts) (stats campaigns.ChangesetsStats, err error) {
-	q := GetChangesetsStatsQuery(opts)
-	err = s.query(ctx, q, func(sc scanner) (err error) {
-		if err = sc.Scan(
+	q := getChangesetsStatsQuery(opts)
+	err = s.query(ctx, q, func(sc scanner) error {
+		if err := sc.Scan(
 			&stats.Total,
 			&stats.Unpublished,
 			&stats.Closed,
@@ -796,7 +800,7 @@ func (s *Store) GetChangesetsStats(ctx context.Context, opts GetChangesetsStatsO
 	if err != nil {
 		return stats, err
 	}
-	return stats, err
+	return stats, nil
 }
 
 const getChangesetStatsFmtstr = `
@@ -815,7 +819,7 @@ WHERE
 	%s
 `
 
-func GetChangesetsStatsQuery(opts GetChangesetsStatsOpts) *sqlf.Query {
+func getChangesetsStatsQuery(opts GetChangesetsStatsOpts) *sqlf.Query {
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
 	}

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -1048,17 +1048,20 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		opts1 := baseOpts
 		opts1.campaign = campaignID
 		opts1.externalState = cmpgn.ChangesetExternalStateClosed
+		opts1.publicationState = cmpgn.ChangesetPublicationStatePublished
 		createChangeset(t, ctx, s, opts1)
 
 		opts2 := baseOpts
 		opts2.campaign = campaignID
 		opts2.externalState = cmpgn.ChangesetExternalStateDeleted
+		opts2.publicationState = cmpgn.ChangesetPublicationStatePublished
 		createChangeset(t, ctx, s, opts2)
 
 		opts3 := baseOpts
 		opts3.campaign = campaignID
 		opts3.ownedByCampaign = campaignID
 		opts3.externalState = cmpgn.ChangesetExternalStateOpen
+		opts3.publicationState = cmpgn.ChangesetPublicationStatePublished
 		createChangeset(t, ctx, s, opts3)
 
 		opts4 := baseOpts
@@ -1066,12 +1069,14 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		opts4.repo = deletedRepo.ID
 		opts4.campaign = campaignID
 		opts4.externalState = cmpgn.ChangesetExternalStateOpen
+		opts4.publicationState = cmpgn.ChangesetPublicationStatePublished
 		createChangeset(t, ctx, s, opts4)
 
 		opts5 := baseOpts
 		// In a different campaign.
 		opts5.campaign = campaignID + 999
 		opts5.externalState = cmpgn.ChangesetExternalStateOpen
+		opts5.publicationState = cmpgn.ChangesetPublicationStatePublished
 		createChangeset(t, ctx, s, opts5)
 
 		t.Run("global", func(t *testing.T) {

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -647,6 +647,11 @@ func WithExternalID(id string) func(*Changeset) bool {
 	return func(c *Changeset) bool { return c.ExternalID == id }
 }
 
+// ChangesetsStats holds stats information on a list of changesets.
+type ChangesetsStats struct {
+	Unpublished, Draft, Open, Merged, Closed, Deleted, Total int32
+}
+
 // ChangesetEventKindFor returns the ChangesetEventKind for the given
 // specific code host event.
 func ChangesetEventKindFor(e interface{}) ChangesetEventKind {


### PR DESCRIPTION
This requires us to load all changesets, which we won't do anymore once we can fetch from the database using DB based authz. Hence, I propose we move away from iterating in the application layer and instead asking the DB for it.
Also, on my local instance where I have 10k changesets in one of my campaigns, it significantly slows down page loads, worth mentioning even on the global campaigns list page, because we display some of the stats there. This get's it down to some ms again.