### PR TITLE
Update logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href="https://sourcegraph.com"><img alt="Sourcegraph" src="https://sourcegraphstatic.com/sourcegraph-logo.png" height="32px" /></a>
+# <a href="https://sourcegraph.com"><picture><source srcset="./ui/assets/img/sourcegraph-head-logo.svg" media="(prefers-color-scheme: dark)"/><img alt="Sourcegraph" src="./ui/assets/img/sourcegraph-light-head-logo.svg" height="48px" /></picture></a>
 
 [![build](https://badge.buildkite.com/00bbe6fa9986c78b8e8591cffeb0b0f2e8c4bb610d7e339ff6.svg?branch=master)](https://buildkite.com/sourcegraph/sourcegraph)
 [![apache license](https://img.shields.io/badge/license-Apache-blue.svg)](LICENSE)


### PR DESCRIPTION
Noticed this was still using the outdated logo. Updated to reference the current logo from the repo and define light and dark versions.