### PR TITLE
executor: Fix src-cli commands

### DIFF
--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -29,8 +28,7 @@ func main() {
 	env.HandleHelpFlag()
 
 	logging.Init()
-	tracer.Init()
-	trace.Init(true)
+	trace.Init(false)
 
 	if err := config.Validate(); err != nil {
 		log.Fatalf("failed to read config: %s", err)

--- a/enterprise/internal/apiworker/command/firecracker_test.go
+++ b/enterprise/internal/apiworker/command/firecracker_test.go
@@ -24,10 +24,8 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	expected := command{
 		Commands: []string{
 			"ignite", "exec", "deadbeef", "--",
-			"ls", "-a",
+			"cd /work/subdir && TEST=true ls -a",
 		},
-		Dir: "/work/subdir",
-		Env: []string{"TEST=true"},
 	}
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)
@@ -55,14 +53,16 @@ func TestFormatFirecrackerCommandDocker(t *testing.T) {
 	expected := command{
 		Commands: []string{
 			"ignite", "exec", "deadbeef", "--",
-			"docker", "run", "--rm",
-			"--cpus", "4",
-			"--memory", "20G",
-			"-v", "/work:/data",
-			"-w", "/data/subdir",
-			"-e", "TEST=true",
-			"alpine:latest",
-			"ls", "-a",
+			strings.Join([]string{
+				"docker", "run", "--rm",
+				"--cpus", "4",
+				"--memory", "20G",
+				"-v", "/work:/data",
+				"-w", "/data/subdir",
+				"-e", "TEST=true",
+				"alpine:latest",
+				"ls", "-a",
+			}, " "),
 		},
 	}
 	if diff := cmp.Diff(expected, actual); diff != "" {


### PR DESCRIPTION
Non-root directories and environment variables were not being passed in to the firecracker VM. This fixes that issue in a shoddy way which should be updated as follows:

- Collect all commands that must run in the VM
- Compile them into scripts
- Copy those scripts into the VM
- Invoke the scripts as a single command

This will make it so the `Command` field on the jobs are actually commands and not arguments to a docker entrypoint. This places an additional restriction on containers we're using that they will be able to invoke such scripts (so they must necessarily have some `sh` equivalent). This seems fine to me.