### PR TITLE
search: refactor front end parser types

### DIFF
--- a/client/shared/src/search/parser/completion.ts
+++ b/client/shared/src/search/parser/completion.ts
@@ -213,7 +213,7 @@ export async function getCompletionItems(
     if (!tokenAtColumn) {
         throw new Error('getCompletionItems: no token at column')
     }
-    const { token, range } = tokenAtColumn
+    const token = tokenAtColumn
     // When the token at column is a literal or whitespace, show
     // static filter type suggestions, followed by dynamic suggestions.
     if (token.type === 'literal' || token.type === 'whitespace') {
@@ -221,7 +221,7 @@ export async function getCompletionItems(
         const staticSuggestions = FILTER_TYPE_COMPLETIONS.map(
             (suggestion): Monaco.languages.CompletionItem => ({
                 ...suggestion,
-                range: toMonacoRange(range),
+                range: toMonacoRange(token.range),
                 command: TRIGGER_SUGGESTIONS,
             })
         )
@@ -244,7 +244,7 @@ export async function getCompletionItems(
                     .filter(isDefined)
                     .map(completionItem => ({
                         ...completionItem,
-                        range: toMonacoRange(range),
+                        range: toMonacoRange(token.range),
                         // Set a sortText so that dynamic suggestions
                         // are shown after filter type suggestions.
                         sortText: '1',
@@ -259,7 +259,7 @@ export async function getCompletionItems(
         if (!completingValue) {
             return null
         }
-        const resolvedFilter = resolveFilter(token.filterType.token.value)
+        const resolvedFilter = resolveFilter(token.filterType.value)
         if (!resolvedFilter) {
             return null
         }
@@ -290,9 +290,7 @@ export async function getCompletionItems(
                         // is a regex pattern, Monaco's filtering might hide some suggestions.
                         filterText:
                             filterValue &&
-                            (filterValue?.token.type === 'literal'
-                                ? filterValue.token.value
-                                : filterValue.token.quotedValue),
+                            (filterValue?.type === 'literal' ? filterValue.value : filterValue.quotedValue),
                         range: filterValue ? toMonacoRange(filterValue.range) : defaultRange,
                         command: COMPLETION_ITEM_SELECTED,
                     })),

--- a/client/shared/src/search/parser/diagnostics.ts
+++ b/client/shared/src/search/parser/diagnostics.ts
@@ -11,10 +11,10 @@ export function getDiagnostics(
     patternType: SearchPatternType
 ): Monaco.editor.IMarkerData[] {
     const diagnostics: Monaco.editor.IMarkerData[] = []
-    for (const { token, range } of members) {
+    for (const token of members) {
         if (token.type === 'filter') {
             const { filterType, filterValue } = token
-            const validationResult = validateFilter(filterType.token.value, filterValue)
+            const validationResult = validateFilter(filterType.value, filterValue)
             if (validationResult.valid) {
                 continue
             }
@@ -29,7 +29,7 @@ export function getDiagnostics(
                     severity: Monaco.MarkerSeverity.Warning,
                     message:
                         'Your search is interpreted literally and contains quotes. Did you mean to search for quotes?',
-                    ...toMonacoRange(range),
+                    ...toMonacoRange(token.range),
                 })
             }
         }

--- a/client/shared/src/search/parser/filters.test.ts
+++ b/client/shared/src/search/parser/filters.test.ts
@@ -8,60 +8,61 @@ describe('validateFilter()', () => {
         expected: ReturnType<typeof validateFilter>
         token: Literal | Quoted
     }
+    const range = { start: 0, end: 1 }
     const TESTCASES: TestCase[] = [
         {
             description: 'Valid repo filter',
             filterType: 'repo',
             expected: { valid: true },
-            token: { type: 'literal', value: 'a' },
+            token: { type: 'literal', value: 'a', range },
         },
         {
             description: 'Valid repo filter - quoted value',
             filterType: 'repo',
             expected: { valid: true },
-            token: { type: 'quoted', quotedValue: 'a' },
+            token: { type: 'quoted', quotedValue: 'a', range },
         },
         {
             description: 'Valid repo filter - alias',
             filterType: 'repo',
             expected: { valid: true },
-            token: { type: 'quoted', quotedValue: 'a' },
+            token: { type: 'quoted', quotedValue: 'a', range },
         },
         {
             description: 'Invalid filter type',
             filterType: 'repoo',
             expected: { valid: false, reason: 'Invalid filter type.' },
-            token: { type: 'literal', value: 'a' },
+            token: { type: 'literal', value: 'a', range },
         },
         {
             description: 'Valid case filter',
             filterType: 'case',
             expected: { valid: true },
-            token: { type: 'literal', value: 'yes' },
+            token: { type: 'literal', value: 'yes', range },
         },
         {
             description: 'Valid quoted value for case filter',
             filterType: 'case',
             expected: { valid: true },
-            token: { type: 'quoted', quotedValue: 'yes' },
+            token: { type: 'quoted', quotedValue: 'yes', range },
         },
         {
             description: 'Invalid literal value for case filter',
             filterType: 'case',
             expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no.' },
-            token: { type: 'literal', value: 'yess' },
+            token: { type: 'literal', value: 'yess', range },
         },
         {
             description: 'Valid case-insensitive repo filter',
             filterType: 'RePo',
             expected: { valid: true },
-            token: { type: 'literal', value: 'a' },
+            token: { type: 'literal', value: 'a', range },
         },
     ]
 
     for (const { description, filterType, expected, token } of TESTCASES) {
         test(description, () => {
-            expect(validateFilter(filterType, { token, range: { start: 0, end: 1 } })).toStrictEqual(expected)
+            expect(validateFilter(filterType, token)).toStrictEqual(expected)
         })
     }
 })

--- a/client/shared/src/search/parser/filters.ts
+++ b/client/shared/src/search/parser/filters.ts
@@ -258,9 +258,9 @@ export const validateFilter = (
     if (
         definition.discreteValues &&
         (!filterValue ||
-            (filterValue.token.type !== 'literal' && filterValue.token.type !== 'quoted') ||
-            (filterValue.token.type === 'literal' && !isValidDiscreteValue(definition, filterValue.token.value)) ||
-            (filterValue.token.type === 'quoted' && !isValidDiscreteValue(definition, filterValue.token.quotedValue)))
+            (filterValue.type !== 'literal' && filterValue.type !== 'quoted') ||
+            (filterValue.type === 'literal' && !isValidDiscreteValue(definition, filterValue.value)) ||
+            (filterValue.type === 'quoted' && !isValidDiscreteValue(definition, filterValue.quotedValue)))
     ) {
         return {
             valid: false,

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -10,11 +10,11 @@ export const getHoverResult = (
     { column }: Pick<Monaco.Position, 'column'>
 ): Monaco.languages.Hover | null => {
     const tokenAtColumn = members.find(({ range }) => range.start + 1 <= column && range.end + 1 >= column)
-    if (!tokenAtColumn || tokenAtColumn.token.type !== 'filter') {
+    if (!tokenAtColumn || tokenAtColumn.type !== 'filter') {
         return null
     }
-    const { filterType } = tokenAtColumn.token
-    const resolvedFilter = resolveFilter(filterType.token.value)
+    const token = tokenAtColumn
+    const resolvedFilter = resolveFilter(token.filterType.value)
     if (!resolvedFilter) {
         return null
     }

--- a/client/shared/src/search/parser/parser.test.ts
+++ b/client/shared/src/search/parser/parser.test.ts
@@ -3,11 +3,11 @@ import { parseSearchQuery } from './parser'
 describe('parseSearchQuery()', () => {
     test('empty', () =>
         expect(parseSearchQuery('')).toMatchObject({
-            range: {
-                start: 0,
-                end: 1,
-            },
             token: {
+                range: {
+                    start: 0,
+                    end: 1,
+                },
                 members: [],
                 type: 'sequence',
             },
@@ -16,20 +16,18 @@ describe('parseSearchQuery()', () => {
 
     test('whitespace', () =>
         expect(parseSearchQuery('  ')).toMatchObject({
-            range: {
-                start: 0,
-                end: 2,
-            },
             token: {
+                range: {
+                    start: 0,
+                    end: 2,
+                },
                 members: [
                     {
                         range: {
                             end: 2,
                             start: 0,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                 ],
                 type: 'sequence',
@@ -39,21 +37,19 @@ describe('parseSearchQuery()', () => {
 
     test('literal', () =>
         expect(parseSearchQuery('a')).toMatchObject({
-            range: {
-                start: 0,
-                end: 1,
-            },
             token: {
+                range: {
+                    start: 0,
+                    end: 1,
+                },
                 members: [
                     {
                         range: {
                             start: 0,
                             end: 1,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'a',
-                        },
+                        type: 'literal',
+                        value: 'a',
                     },
                 ],
                 type: 'sequence',
@@ -63,21 +59,19 @@ describe('parseSearchQuery()', () => {
 
     test('triple quotes', () => {
         expect(parseSearchQuery('"""')).toMatchObject({
-            range: {
-                end: 3,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 3,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 3,
                             start: 0,
                         },
-                        token: {
-                            type: 'literal',
-                            value: '"""',
-                        },
+                        type: 'literal',
+                        value: '"""',
                     },
                 ],
                 type: 'sequence',
@@ -88,42 +82,34 @@ describe('parseSearchQuery()', () => {
 
     test('filter', () =>
         expect(parseSearchQuery('f:b')).toMatchObject({
-            range: {
-                end: 3,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 3,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 3,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 1,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'f',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 1,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 3,
-                                    start: 2,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'b',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'f',
                         },
+                        filterValue: {
+                            range: {
+                                end: 3,
+                                start: 2,
+                            },
+                            type: 'literal',
+                            value: 'b',
+                        },
+                        type: 'filter',
                     },
                 ],
                 type: 'sequence',
@@ -133,42 +119,34 @@ describe('parseSearchQuery()', () => {
 
     test('negated filter', () =>
         expect(parseSearchQuery('-f:b')).toMatchObject({
-            range: {
-                end: 4,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 4,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 4,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 2,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: '-f',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 2,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 4,
-                                    start: 3,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'b',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: '-f',
                         },
+                        filterValue: {
+                            range: {
+                                end: 4,
+                                start: 3,
+                            },
+                            type: 'literal',
+                            value: 'b',
+                        },
+                        type: 'filter',
                     },
                 ],
                 type: 'sequence',
@@ -178,42 +156,34 @@ describe('parseSearchQuery()', () => {
 
     test('filter with quoted value', () => {
         expect(parseSearchQuery('f:"b"')).toMatchObject({
-            range: {
-                end: 5,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 5,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 5,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 1,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'f',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 1,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 5,
-                                    start: 2,
-                                },
-                                token: {
-                                    quotedValue: 'b',
-                                    type: 'quoted',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'f',
                         },
+                        filterValue: {
+                            range: {
+                                end: 5,
+                                start: 2,
+                            },
+                            quotedValue: 'b',
+                            type: 'quoted',
+                        },
+                        type: 'filter',
                     },
                 ],
                 type: 'sequence',
@@ -224,42 +194,34 @@ describe('parseSearchQuery()', () => {
 
     test('filter with a value ending with a colon', () => {
         expect(parseSearchQuery('f:a:')).toStrictEqual({
-            range: {
-                end: 4,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 4,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 4,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 1,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'f',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 1,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 4,
-                                    start: 2,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'a:',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'f',
                         },
+                        filterValue: {
+                            range: {
+                                end: 4,
+                                start: 2,
+                            },
+                            type: 'literal',
+                            value: 'a:',
+                        },
+                        type: 'filter',
                     },
                 ],
                 type: 'sequence',
@@ -270,42 +232,34 @@ describe('parseSearchQuery()', () => {
 
     test('filter where the value is a colon', () => {
         expect(parseSearchQuery('f::')).toStrictEqual({
-            range: {
-                end: 3,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 3,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 3,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 1,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'f',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 1,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 3,
-                                    start: 2,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: ':',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'f',
                         },
+                        filterValue: {
+                            range: {
+                                end: 3,
+                                start: 2,
+                            },
+                            type: 'literal',
+                            value: ':',
+                        },
+                        type: 'filter',
                     },
                 ],
                 type: 'sequence',
@@ -316,21 +270,19 @@ describe('parseSearchQuery()', () => {
 
     test('quoted', () =>
         expect(parseSearchQuery('"a:b"')).toMatchObject({
-            range: {
-                end: 5,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 5,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 5,
                             start: 0,
                         },
-                        token: {
-                            quotedValue: 'a:b',
-                            type: 'quoted',
-                        },
+                        quotedValue: 'a:b',
+                        type: 'quoted',
                     },
                 ],
                 type: 'sequence',
@@ -340,21 +292,19 @@ describe('parseSearchQuery()', () => {
 
     test('quoted (escaped quotes)', () =>
         expect(parseSearchQuery('"-\\"a\\":b"')).toMatchObject({
-            range: {
-                end: 10,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 10,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 10,
                             start: 0,
                         },
-                        token: {
-                            quotedValue: '-\\"a\\":b',
-                            type: 'quoted',
-                        },
+                        quotedValue: '-\\"a\\":b',
+                        type: 'quoted',
                     },
                 ],
                 type: 'sequence',
@@ -364,141 +314,109 @@ describe('parseSearchQuery()', () => {
 
     test('complex query', () =>
         expect(parseSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchObject({
-            range: {
-                end: 58,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 58,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 30,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 4,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'repo',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 4,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 30,
-                                    start: 5,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: '^github\\.com/gorilla/mux$',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'repo',
                         },
+                        filterValue: {
+                            range: {
+                                end: 30,
+                                start: 5,
+                            },
+                            type: 'literal',
+                            value: '^github\\.com/gorilla/mux$',
+                        },
+                        type: 'filter',
                     },
                     {
                         range: {
                             end: 31,
                             start: 30,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 38,
                             start: 31,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 35,
-                                    start: 31,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'lang',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 35,
+                                start: 31,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 38,
-                                    start: 36,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'go',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'lang',
                         },
+                        filterValue: {
+                            range: {
+                                end: 38,
+                                start: 36,
+                            },
+                            type: 'literal',
+                            value: 'go',
+                        },
+                        type: 'filter',
                     },
                     {
                         range: {
                             end: 39,
                             start: 38,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 51,
                             start: 39,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 44,
-                                    start: 39,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: '-file',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 44,
+                                start: 39,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 51,
-                                    start: 45,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'mux.go',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: '-file',
                         },
+                        filterValue: {
+                            range: {
+                                end: 51,
+                                start: 45,
+                            },
+                            type: 'literal',
+                            value: 'mux.go',
+                        },
+                        type: 'filter',
                     },
                     {
                         range: {
                             end: 52,
                             start: 51,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 58,
                             start: 52,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'Router',
-                        },
+                        type: 'literal',
+                        value: 'Router',
                     },
                 ],
                 type: 'sequence',
@@ -508,138 +426,108 @@ describe('parseSearchQuery()', () => {
 
     test('parenthesized parameters', () => {
         expect(parseSearchQuery('repo:a (file:b and c)')).toMatchObject({
-            range: {
-                end: 21,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 21,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 6,
                             start: 0,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 4,
-                                    start: 0,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'repo',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 4,
+                                start: 0,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 6,
-                                    start: 5,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'a',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'repo',
                         },
+                        filterValue: {
+                            range: {
+                                end: 6,
+                                start: 5,
+                            },
+                            type: 'literal',
+                            value: 'a',
+                        },
+                        type: 'filter',
                     },
                     {
                         range: {
                             end: 7,
                             start: 6,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 8,
                             start: 7,
                         },
-                        token: {
-                            type: 'openingParen',
-                        },
+                        type: 'openingParen',
                     },
                     {
                         range: {
                             end: 14,
                             start: 8,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 12,
-                                    start: 8,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'file',
-                                },
-                                type: 'success',
+                        filterType: {
+                            range: {
+                                end: 12,
+                                start: 8,
                             },
-                            filterValue: {
-                                range: {
-                                    end: 14,
-                                    start: 13,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'b',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'file',
                         },
+                        filterValue: {
+                            range: {
+                                end: 14,
+                                start: 13,
+                            },
+                            type: 'literal',
+                            value: 'b',
+                        },
+                        type: 'filter',
                     },
                     {
                         range: {
                             end: 15,
                             start: 14,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 18,
                             start: 15,
                         },
-                        token: {
-                            type: 'operator',
-                            value: 'and',
-                        },
+                        type: 'operator',
+                        value: 'and',
                     },
                     {
                         range: {
                             end: 19,
                             start: 18,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 20,
                             start: 19,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'c',
-                        },
+                        type: 'literal',
+                        value: 'c',
                     },
                     {
                         range: {
                             end: 21,
                             start: 20,
                         },
-                        token: {
-                            type: 'closingParen',
-                        },
+                        type: 'closingParen',
                     },
                 ],
                 type: 'sequence',
@@ -650,168 +538,134 @@ describe('parseSearchQuery()', () => {
 
     test('nested parenthesized parameters', () => {
         expect(parseSearchQuery('(a and (b or c) and d)')).toMatchObject({
-            range: {
-                end: 22,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 22,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 1,
                             start: 0,
                         },
-                        token: {
-                            type: 'openingParen',
-                        },
+                        type: 'openingParen',
                     },
                     {
                         range: {
                             end: 2,
                             start: 1,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'a',
-                        },
+                        type: 'literal',
+                        value: 'a',
                     },
                     {
                         range: {
                             end: 3,
                             start: 2,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 6,
                             start: 3,
                         },
-                        token: {
-                            type: 'operator',
-                        },
+                        type: 'operator',
                     },
                     {
                         range: {
                             end: 7,
                             start: 6,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 8,
                             start: 7,
                         },
-                        token: {
-                            type: 'openingParen',
-                        },
+                        type: 'openingParen',
                     },
                     {
                         range: {
                             end: 9,
                             start: 8,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'b',
-                        },
+                        type: 'literal',
+                        value: 'b',
                     },
                     {
                         range: {
                             end: 10,
                             start: 9,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 12,
                             start: 10,
                         },
-                        token: {
-                            type: 'operator',
-                        },
+                        type: 'operator',
                     },
                     {
                         range: {
                             end: 13,
                             start: 12,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 14,
                             start: 13,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'c',
-                        },
+                        type: 'literal',
+                        value: 'c',
                     },
                     {
                         range: {
                             end: 15,
                             start: 14,
                         },
-                        token: {
-                            type: 'closingParen',
-                        },
+                        type: 'closingParen',
                     },
                     {
                         range: {
                             end: 16,
                             start: 15,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 19,
                             start: 16,
                         },
-                        token: {
-                            type: 'operator',
-                        },
+                        type: 'operator',
                     },
                     {
                         range: {
                             end: 20,
                             start: 19,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 21,
                             start: 20,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'd',
-                        },
+                        type: 'literal',
+                        value: 'd',
                     },
                     {
                         range: {
                             end: 22,
                             start: 21,
                         },
-                        token: {
-                            type: 'closingParen',
-                        },
+                        type: 'closingParen',
                     },
                 ],
                 type: 'sequence',
@@ -822,42 +676,36 @@ describe('parseSearchQuery()', () => {
 
     test('do not treat links as filters', () => {
         expect(parseSearchQuery('http://example.com repo:a')).toMatchObject({
-            range: {
-                end: 25,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 25,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             end: 18,
                             start: 0,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'http://example.com',
-                        },
+                        type: 'literal',
+                        value: 'http://example.com',
                     },
                     {
                         range: {
                             end: 19,
                             start: 18,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             end: 25,
                             start: 19,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    end: 23,
-                                    start: 19,
-                                },
+                        filterType: {
+                            range: {
+                                end: 23,
+                                start: 19,
                             },
                         },
                     },
@@ -874,98 +722,79 @@ repo:sourcegraph
 // search for thing
 thing`
         expect(parseSearchQuery(query, true)).toMatchObject({
-            range: {
-                end: 70,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 70,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             start: 0,
                             end: 27,
                         },
-                        token: {
-                            type: 'comment',
-                            value: '// saucegraph is best graph',
-                        },
+                        type: 'comment',
+                        value: '// saucegraph is best graph',
                     },
                     {
                         range: {
                             start: 27,
                             end: 28,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             start: 28,
                             end: 44,
                         },
-                        token: {
-                            filterType: {
-                                range: {
-                                    start: 28,
-                                    end: 32,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'repo',
-                                },
+                        filterType: {
+                            range: {
+                                start: 28,
+                                end: 32,
                             },
-                            filterValue: {
-                                range: {
-                                    start: 33,
-                                    end: 44,
-                                },
-                                token: {
-                                    type: 'literal',
-                                    value: 'sourcegraph',
-                                },
-                                type: 'success',
-                            },
-                            type: 'filter',
+                            type: 'literal',
+                            value: 'repo',
                         },
+                        filterValue: {
+                            range: {
+                                start: 33,
+                                end: 44,
+                            },
+                            type: 'literal',
+                            value: 'sourcegraph',
+                        },
+                        type: 'filter',
                     },
                     {
                         range: {
                             start: 44,
                             end: 45,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             start: 45,
                             end: 64,
                         },
-                        token: {
-                            type: 'comment',
-                            value: '// search for thing',
-                        },
+                        type: 'comment',
+                        value: '// search for thing',
                     },
                     {
                         range: {
                             start: 64,
                             end: 65,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             start: 65,
                             end: 70,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'thing',
-                        },
+                        type: 'literal',
+                        value: 'thing',
                     },
                 ],
                 type: 'sequence',
@@ -976,40 +805,34 @@ thing`
 
     test('do not interpret C-style comments', () => {
         expect(parseSearchQuery('// thing')).toMatchObject({
-            range: {
-                end: 8,
-                start: 0,
-            },
             token: {
+                range: {
+                    end: 8,
+                    start: 0,
+                },
                 members: [
                     {
                         range: {
                             start: 0,
                             end: 2,
                         },
-                        token: {
-                            type: 'literal',
-                            value: '//',
-                        },
+                        type: 'literal',
+                        value: '//',
                     },
                     {
                         range: {
                             start: 2,
                             end: 3,
                         },
-                        token: {
-                            type: 'whitespace',
-                        },
+                        type: 'whitespace',
                     },
                     {
                         range: {
                             start: 3,
                             end: 8,
                         },
-                        token: {
-                            type: 'literal',
-                            value: 'thing',
-                        },
+                        type: 'literal',
+                        value: 'thing',
                     },
                 ],
                 type: 'sequence',

--- a/client/shared/src/search/parser/parser.ts
+++ b/client/shared/src/search/parser/parser.ts
@@ -28,6 +28,7 @@ export const toMonacoRange = ({ start, end }: CharacterRange): IRange => ({
  */
 export interface Literal {
     type: 'literal'
+    range: CharacterRange
     value: string
 }
 
@@ -38,8 +39,9 @@ export interface Literal {
  */
 export interface Filter {
     type: 'filter'
-    filterType: Pick<ParseSuccess<Literal>, 'range' | 'token'>
-    filterValue: Pick<ParseSuccess<Literal | Quoted>, 'range' | 'token'> | undefined
+    range: CharacterRange
+    filterType: Literal
+    filterValue: Quoted | Literal | undefined
 }
 
 /**
@@ -49,6 +51,7 @@ export interface Filter {
  */
 export interface Operator {
     type: 'operator'
+    range: CharacterRange
     value: string
 }
 
@@ -57,7 +60,8 @@ export interface Operator {
  */
 export interface Sequence {
     type: 'sequence'
-    members: Pick<ParseSuccess<Token>, 'range' | 'token'>[]
+    range: CharacterRange
+    members: Token[]
 }
 
 /**
@@ -67,6 +71,7 @@ export interface Sequence {
  */
 export interface Quoted {
     type: 'quoted'
+    range: CharacterRange
     quotedValue: string
 }
 
@@ -77,18 +82,26 @@ export interface Quoted {
  */
 export interface Comment {
     type: 'comment'
+    range: CharacterRange
     value: string
 }
 
-export type Token =
-    | { type: 'whitespace' }
-    | { type: 'openingParen' }
-    | { type: 'closingParen' }
-    | { type: 'operator' }
-    | Comment
-    | Literal
-    | Filter
-    | Quoted
+export interface Whitespace {
+    type: 'whitespace'
+    range: CharacterRange
+}
+
+export interface OpeningParen {
+    type: 'openingParen'
+    range: CharacterRange
+}
+
+export interface ClosingParen {
+    type: 'closingParen'
+    range: CharacterRange
+}
+
+export type Token = Whitespace | OpeningParen | ClosingParen | Operator | Comment | Literal | Filter | Quoted
 
 export type Term = Token | Sequence
 
@@ -120,11 +133,6 @@ export interface ParseSuccess<T = Term> {
      * The resulting term.
      */
     token: T
-
-    /**
-     * The character range that was successfully parsed.
-     */
-    range: CharacterRange
 }
 
 /**
@@ -139,7 +147,7 @@ type Parser<T = Term> = (input: string, start: number) => ParserResult<T>
  * by the given `parseToken` parsers are found in a search query.
  */
 const zeroOrMore = (parseToken: Parser<Term>): Parser<Sequence> => (input, start) => {
-    const members: Pick<ParseSuccess<Token>, 'range' | 'token'>[] = []
+    const members: Token[] = []
     let adjustedStart = start
     let end = start + 1
     while (input[adjustedStart] !== undefined) {
@@ -152,16 +160,14 @@ const zeroOrMore = (parseToken: Parser<Term>): Parser<Sequence> => (input, start
                 members.push(member)
             }
         } else {
-            const { range, token } = result
-            members.push({ range, token })
+            members.push(result.token)
         }
-        end = result.range.end
+        end = result.token.range.end
         adjustedStart = end
     }
     return {
         type: 'success',
-        range: { start, end },
-        token: { type: 'sequence', members },
+        token: { type: 'sequence', members, range: { start, end } },
     }
 }
 
@@ -201,8 +207,7 @@ const quoted: Parser<Quoted> = (input, start) => {
     return {
         type: 'success',
         // end + 1 as `end` is currently the index of the quote in the string.
-        range: { start, end: end + 1 },
-        token: { type: 'quoted', quotedValue: input.slice(start + 1, end) },
+        token: { type: 'quoted', quotedValue: input.slice(start + 1, end), range: { start, end: end + 1 } },
     }
 }
 
@@ -216,8 +221,7 @@ const character = (character: string): Parser<Literal> => (input, start) => {
     }
     return {
         type: 'success',
-        range: { start, end: start + 1 },
-        token: { type: 'literal', value: character },
+        token: { type: 'literal', value: character, range: { start, end: start + 1 } },
     }
 }
 
@@ -245,28 +249,33 @@ const pattern = <T extends Term = Literal>(
         const range = { start, end: start + match[0].length }
         return {
             type: 'success',
-            range,
             token: output
                 ? typeof output === 'function'
                     ? output(input, range)
                     : output
-                : ({ type: 'literal', value: match[0] } as T),
+                : ({ type: 'literal', value: match[0], range } as T),
         }
     }
 }
 
-const whitespace = pattern(/\s+/, { type: 'whitespace' as const }, 'whitespace')
+const whitespace = pattern(
+    /\s+/,
+    (_input, range): Whitespace => ({
+        type: 'whitespace',
+        range,
+    })
+)
 
 const literal = pattern(/[^\s)]+/)
 
 const operator = pattern(
     /(and|AND|or|OR|not|NOT)/,
-    (input, { start, end }): Operator => ({ type: 'operator', value: input.slice(start, end) })
+    (input, { start, end }): Operator => ({ type: 'operator', value: input.slice(start, end), range: { start, end } })
 )
 
 const comment = pattern(
     /\/\/.*/,
-    (input, { start, end }): Comment => ({ type: 'comment', value: input.slice(start, end) })
+    (input, { start, end }): Comment => ({ type: 'comment', value: input.slice(start, end), range: { start, end } })
 )
 
 const filterKeyword = pattern(new RegExp(`-?(${filterTypeKeysWithAliases.join('|')})+(?=:)`, 'i'))
@@ -275,34 +284,33 @@ const filterDelimiter = character(':')
 
 const filterValue = oneOf<Quoted | Literal>(quoted, literal)
 
-const openingParen = pattern(/\(/, { type: 'openingParen' as const })
+const openingParen = pattern(/\(/, (_input, range): OpeningParen => ({ type: 'openingParen', range }))
 
-const closingParen = pattern(/\)/, { type: 'closingParen' as const })
+const closingParen = pattern(/\)/, (_input, range): ClosingParen => ({ type: 'closingParen', range }))
 
 /**
  * Returns a {@link Parser} that succeeds if a token parsed by `parseToken`,
  * followed by whitespace or EOF, is found in the search query.
  */
 const followedBy = (parseToken: Parser<Token>, parseNext: Parser<Token>): Parser<Sequence> => (input, start) => {
-    const members: Pick<ParseSuccess<Token>, 'range' | 'token'>[] = []
+    const members: Token[] = []
     const tokenResult = parseToken(input, start)
     if (tokenResult.type === 'error') {
         return tokenResult
     }
-    members.push({ token: tokenResult.token, range: tokenResult.range })
-    let { end } = tokenResult.range
+    members.push(tokenResult.token)
+    let { end } = tokenResult.token.range
     if (input[end] !== undefined) {
         const separatorResult = parseNext(input, end)
         if (separatorResult.type === 'error') {
             return separatorResult
         }
-        members.push({ token: separatorResult.token, range: separatorResult.range })
-        end = separatorResult.range.end
+        members.push(separatorResult.token)
+        end = separatorResult.token.range.end
     }
     return {
         type: 'success',
-        range: { start, end },
-        token: { type: 'sequence', members },
+        token: { type: 'sequence', members, range: { start, end } },
     }
 }
 
@@ -316,22 +324,24 @@ const filter: Parser<Filter> = (input, start) => {
     if (parsedKeyword.type === 'error') {
         return parsedKeyword
     }
-    const parsedDelimiter = filterDelimiter(input, parsedKeyword.range.end)
+    const parsedDelimiter = filterDelimiter(input, parsedKeyword.token.range.end)
     if (parsedDelimiter.type === 'error') {
         return parsedDelimiter
     }
     const parsedValue =
-        input[parsedDelimiter.range.end] === undefined ? undefined : filterValue(input, parsedDelimiter.range.end)
+        input[parsedDelimiter.token.range.end] === undefined
+            ? undefined
+            : filterValue(input, parsedDelimiter.token.range.end)
     if (parsedValue && parsedValue.type === 'error') {
         return parsedValue
     }
     return {
         type: 'success',
-        range: { start, end: parsedValue ? parsedValue.range.end : parsedDelimiter.range.end },
         token: {
             type: 'filter',
-            filterType: parsedKeyword,
-            filterValue: parsedValue,
+            range: { start, end: parsedValue ? parsedValue.token.range.end : parsedDelimiter.token.range.end },
+            filterType: parsedKeyword.token,
+            filterValue: parsedValue?.token,
         },
     }
 }
@@ -344,9 +354,7 @@ const createParser = (terms: Parser<Token>[]): Parser<Sequence> =>
             whitespace,
             openingParen,
             closingParen,
-            ...terms.map(token =>
-                followedBy(token, oneOf<{ type: 'whitespace' } | { type: 'closingParen' }>(whitespace, closingParen))
-            )
+            ...terms.map(token => followedBy(token, oneOf<Whitespace | ClosingParen>(whitespace, closingParen)))
         )
     )
 

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -6,11 +6,11 @@ import { Sequence } from './parser'
  */
 export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.languages.IToken[] {
     const tokens: Monaco.languages.IToken[] = []
-    for (const { token, range } of parsedQuery.members) {
+    for (const token of parsedQuery.members) {
         switch (token.type) {
             case 'whitespace':
                 tokens.push({
-                    startIndex: range.start,
+                    startIndex: token.range.start,
                     scopes: 'whitespace',
                 })
                 break
@@ -30,19 +30,19 @@ export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.
                 break
             case 'operator':
                 tokens.push({
-                    startIndex: range.start,
+                    startIndex: token.range.start,
                     scopes: 'operator',
                 })
                 break
             case 'comment':
                 tokens.push({
-                    startIndex: range.start,
+                    startIndex: token.range.start,
                     scopes: 'comment',
                 })
                 break
             default:
                 tokens.push({
-                    startIndex: range.start,
+                    startIndex: token.range.start,
                     scopes: 'identifier',
                 })
                 break

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -654,11 +654,10 @@ export function generateFiltersQuery(filtersInQuery: FiltersToTypeAndValue): str
 export function parsePatternTypeFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
     const parsedQuery = parseSearchQuery(query)
     if (parsedQuery.type === 'success') {
-        for (const member of parsedQuery.token.members) {
-            const token = member.token
+        for (const token of parsedQuery.token.members) {
             if (
                 token.type === 'filter' &&
-                token.filterType.token.value.toLowerCase() === 'patterntype' &&
+                token.filterType.value.toLowerCase() === 'patterntype' &&
                 token.filterValue
             ) {
                 return {
@@ -675,9 +674,8 @@ export function parsePatternTypeFromQuery(query: string): { range: CharacterRang
 export function parseCaseSensitivityFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
     const parsedQuery = parseSearchQuery(query)
     if (parsedQuery.type === 'success') {
-        for (const member of parsedQuery.token.members) {
-            const token = member.token
-            if (token.type === 'filter' && token.filterType.token.value.toLowerCase() === 'case' && token.filterValue) {
+        for (const token of parsedQuery.token.members) {
+            if (token.type === 'filter' && token.filterType.value.toLowerCase() === 'case' && token.filterValue) {
                 return {
                     range: { start: token.filterType.range.start, end: token.filterValue.range.end },
                     value: query.slice(token.filterValue.range.start, token.filterValue.range.end),

--- a/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -6,10 +6,10 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: stri
     const tokens = useMemo(() => {
         const parsedQuery = parseSearchQuery(query)
         return parsedQuery.type === 'success'
-            ? parsedQuery.token.members.map(({ token, range }) => {
+            ? parsedQuery.token.members.map(token => {
                   if (token.type === 'filter') {
                       return (
-                          <Fragment key={range.start}>
+                          <Fragment key={token.range.start}>
                               <span className="search-keyword">
                                   {query.slice(token.filterType.range.start, token.filterType.range.end)}:
                               </span>
@@ -21,12 +21,12 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: stri
                   }
                   if (token.type === 'operator') {
                       return (
-                          <span className="search-operator" key={range.start}>
-                              {query.slice(range.start, range.end)}
+                          <span className="search-operator" key={token.range.start}>
+                              {query.slice(token.range.start, token.range.end)}
                           </span>
                       )
                   }
-                  return <Fragment key={range.start}>{query.slice(range.start, range.end)}</Fragment>
+                  return <Fragment key={token.range.start}>{query.slice(token.range.start, token.range.end)}</Fragment>
               })
             : [<Fragment key="0">{query}</Fragment>]
     }, [query])

--- a/client/web/src/search/input/helpers.ts
+++ b/client/web/src/search/input/helpers.ts
@@ -25,25 +25,24 @@ export function convertPlainTextToInteractiveQuery(
     let newNavbarQuery = ''
 
     if (parsedQuery.type === 'success') {
-        for (const member of parsedQuery.token.members) {
+        for (const token of parsedQuery.token.members) {
             if (
-                member.token.type === 'filter' &&
-                member.token.filterValue &&
-                validateFilter(member.token.filterType.token.value, member.token.filterValue).valid
+                token.type === 'filter' &&
+                token.filterValue &&
+                validateFilter(token.filterType.value, token.filterValue).valid
             ) {
-                const filterType = member.token.filterType.token.value as FilterType
+                const filterType = token.filterType.value as FilterType
                 newFiltersInQuery[isSingularFilter(filterType) ? filterType : uniqueId(filterType)] = {
                     type: isNegatedFilter(filterType) ? resolveNegatedFilter(filterType) : filterType,
-                    value: query.slice(member.token.filterValue.range.start, member.token.filterValue.range.end),
+                    value: query.slice(token.filterValue.range.start, token.filterValue.range.end),
                     editable: false,
                     negated: isNegatedFilter(filterType),
                 }
             } else if (
-                member.token.type !== 'filter' ||
-                (member.token.type === 'filter' &&
-                    !validateFilter(member.token.filterType.token.value, member.token.filterValue).valid)
+                token.type !== 'filter' ||
+                (token.type === 'filter' && !validateFilter(token.filterType.value, token.filterValue).valid)
             ) {
-                newNavbarQuery = [newNavbarQuery, query.slice(member.range.start, member.range.end)]
+                newNavbarQuery = [newNavbarQuery, query.slice(token.range.start, token.range.end)]
                     .filter(query => query.length > 0)
                     .join('')
             }

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -129,23 +129,23 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
         const queryFromURL = parseSearchURLQuery(url.search)
         const parsedQuery = parseSearchQuery(queryFromURL || '')
         if (parsedQuery.type === 'success') {
-            for (const member of parsedQuery.token.members) {
+            for (const token of parsedQuery.token.members) {
                 if (
-                    member.token.type === 'filter' &&
-                    (member.token.filterType.token.value === FilterType.repo ||
-                        member.token.filterType.token.value === FILTERS[FilterType.repo].alias)
+                    token.type === 'filter' &&
+                    (token.filterType.value === FilterType.repo ||
+                        token.filterType.value === FILTERS[FilterType.repo].alias)
                 ) {
                     if (
-                        member.token.filterValue?.token.type === 'literal' &&
-                        !recentlySearchedRepos.includes(member.token.filterValue.token.value)
+                        token.filterValue?.type === 'literal' &&
+                        !recentlySearchedRepos.includes(token.filterValue.value)
                     ) {
-                        recentlySearchedRepos.push(member.token.filterValue.token.value)
+                        recentlySearchedRepos.push(token.filterValue.value)
                     }
                     if (
-                        member.token.filterValue?.token.type === 'quoted' &&
-                        !recentlySearchedRepos.includes(member.token.filterValue.token.quotedValue)
+                        token.filterValue?.type === 'quoted' &&
+                        !recentlySearchedRepos.includes(token.filterValue.quotedValue)
                     ) {
-                        recentlySearchedRepos.push(member.token.filterValue.token.quotedValue)
+                        recentlySearchedRepos.push(token.filterValue.quotedValue)
                     }
                 }
             }

--- a/client/web/src/search/queryTelemetry.tsx
+++ b/client/web/src/search/queryTelemetry.tsx
@@ -14,9 +14,9 @@ export function queryTelemetryData(query: string, caseSensitive: boolean) {
 function filterExistsInQuery(parsedQuery: ParserResult<Sequence>, filterToMatch: string): boolean {
     if (parsedQuery.type === 'success') {
         const members = parsedQuery.token.members
-        for (const member of members) {
-            if (member.token.type === 'filter') {
-                const resolvedFilter = resolveFilter(member.token.filterType.token.value)
+        for (const token of members) {
+            if (token.type === 'filter') {
+                const resolvedFilter = resolveFilter(token.filterType.value)
                 if (resolvedFilter !== undefined && resolvedFilter.type === filterToMatch) {
                     return true
                 }

--- a/client/web/src/search/results/SearchResultTab.tsx
+++ b/client/web/src/search/results/SearchResultTab.tsx
@@ -47,16 +47,12 @@ export const SearchResultTabHeader: React.FunctionComponent<Props> = ({
     if (parsedQuery.type === 'success') {
         // Parse any `type:` filter that exists in a query so
         // we can check whether this tab should be active.
-        for (const member of parsedQuery.token.members) {
-            if (
-                member.token.type === 'filter' &&
-                member.token.filterType.token.value === 'type' &&
-                member.token.filterValue
-            ) {
+        for (const token of parsedQuery.token.members) {
+            if (token.type === 'filter' && token.filterType.value === 'type' && token.filterValue) {
                 typeInQuery =
-                    member.token.filterValue.token.type === 'literal'
-                        ? (member.token.filterValue.token.value as SearchType)
-                        : (member.token.filterValue.token.quotedValue as SearchType)
+                    token.filterValue.type === 'literal'
+                        ? (token.filterValue.value as SearchType)
+                        : (token.filterValue.quotedValue as SearchType)
             }
         }
     }


### PR DESCRIPTION
Set up for using the current parser as a tokenizer for further parsing.

By commit:

1. Pulls apart the "list" type (`Sequence`) from true `Token` types. I think the distinct separation of `Token` and `Sequence` is clearer, and though I'm intrigued by the use of the Typescript utility types, think the removal of `Exclude<Token, Sequence>` improves things. The union of `Token` and `Sequence` I'm calling `Term`

2. This commit pulls `range` out of `ParseSuccess`. In general `range` I felt range is better suited attached to `Token`/`Term` rather than the result type (and parent to the Token/Term). At the "cost" of adding `range` as a member to each token, it simplifies all the cases where we do `Pick<ParseSuccess<Token>, 'range' | 'token'>` and just use `Token` directly instead.

3. This updates references to `token`, and tests. There's quite a bit of shrinking and simpler code because the above two commits flatten range into tokens, and removes the `token` prop that nests tokens in sequences. 

---

<details>
  <summary>Expand for old context</summary>

High level context, but: I'm strongly considering reuse of our existing parser for lexing (generate sequence of tokens), and then feed those tokens into the parsing routine similar to https://github.com/sourcegraph/sourcegraph/pull/15013. I sense it'll separate concerns for what we need in the frontend better than putting it into one routine (can go into details later).

In this PR I'm refactoring some parts of the parser (i.e., maybe lexer-to-be :-)) that helps my understanding and push along the above, and also, I ran into a Typescript question that baffles me.

By commit:

1. Pulls apart the "list" type (`Sequence`) from true `Token` types. I think the distinct separation of `Token` and `Sequence` is clearer, and though I'm intrigued by the use of the Typescript utility types, think the removal of `Exclude<Token, Sequence>` improves things. The union of `Token` and `Sequence` I'm calling `Term`

2. This commit pulls `range` out of `ParseSuccess`. In general `range` I felt range is better suited attached to `Token`/`Term` rather than the result type (and parent to the Token/Term). At the "cost" of adding `range` as a member to each token, it simplifies all the cases where we do `Pick<ParseSuccess<Token>, 'range' | 'token'>` and just use `Token` directly instead.

3. This updates references to `token`, and tests. There's quite a bit of shrinking and simpler code because the above two commits flatten range into tokens, and removes the `token` prop that nests tokens in sequences. 

Now the one thing that baffles me: after updating references in (3), I get:

> Unsafe member access FOO on an any value.

but only in _some_ places, and not others. So I don't know why I see this and how to fix it. I can't wait to hear the answer to why this is. See commit and inline comments.

---

~Note: Build fails to something unrelated in to this PR, it fails for me branching off main, based on some extension snapshot, not the changes in this PR.~ rebased

</details>