### PR TITLE
Fix styling of code in docs

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -118,9 +118,9 @@ pre, code, kbd {
 code {
     background-color: var(--code-bg);
     padding: .2em .4em;
+    border-radius: 0.2em;
     margin: 0;
     font-size: 85%;
-    border-radius: 6px;
 }
 
 /* LAYOUT */

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -117,8 +117,10 @@ pre, code, kbd {
 
 code {
     background-color: var(--code-bg);
-    padding: 0.2em;
-    border-radius: 0.2em;
+    padding: .2em .4em;
+    margin: 0;
+    font-size: 85%;
+    border-radius: 6px;
 }
 
 /* LAYOUT */


### PR DESCRIPTION
Made the font slightly smaller, since the monospace font on the same line is larger.

Before:

![image](https://user-images.githubusercontent.com/1185253/97438834-a2c16600-1925-11eb-9ff4-412c9e42a0e3.png)

After:

![image](https://user-images.githubusercontent.com/1185253/97438847-ab19a100-1925-11eb-8101-095f7776490c.png)
