### PR TITLE
Update RegistryExtensionOverviewPage snapshot

### DIFF
--- a/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -174,10 +174,10 @@ exports[`RegistryExtensionOverviewPage renders with no tags 1`] = `
         >
           <a
             className="btn btn-outline-secondary btn-sm"
-            href="/extensions?query=category%3AOther"
+            href="/extensions?query=category%3A%22Programming+languages%22"
             onClick={[Function]}
           >
-            Other
+            Programming languages
           </a>
         </li>
         <li
@@ -185,10 +185,10 @@ exports[`RegistryExtensionOverviewPage renders with no tags 1`] = `
         >
           <a
             className="btn btn-outline-secondary btn-sm"
-            href="/extensions?query=category%3A%22Programming+languages%22"
+            href="/extensions?query=category%3AOther"
             onClick={[Function]}
           >
-            Programming languages
+            Other
           </a>
         </li>
       </ul>


### PR DESCRIPTION
Snapshot was out of date since it was added in #15040 and extension categorization was changed/fixed in #15038, but these PRs were merged simultaneously without consideration for the dependency between them.