### PR TITLE
Introduce goroutine package to campaigns background jobs

### DIFF
--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -51,7 +51,7 @@ func enterpriseInit(
 		server.ChangesetSyncRegistry = syncRegistry
 	}
 
-	campaigns.SetupCampaignsBackgroundJobs(ctx, db, campaignsStore, repoStore, cf)
+	campaigns.StartBackgroundJobs(ctx, db, campaignsStore, repoStore, cf)
 
 	// TODO(jchen): This is an unfortunate compromise to not rewrite ossDB.ExternalServices for now.
 	dbconn.Global = db

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
@@ -23,7 +21,6 @@ import (
 	ossDB "github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 )
@@ -43,36 +40,18 @@ func enterpriseInit(
 	server *repoupdater.Server,
 ) (debugDumpers []debugserver.Dumper) {
 	ctx := context.Background()
-	campaignsStore := campaigns.NewStore(db)
+	clock := func() time.Time {
+		return time.Now().UTC().Truncate(time.Microsecond)
+	}
+
+	campaignsStore := campaigns.NewStoreWithClock(db, clock)
 
 	syncRegistry := campaigns.NewSyncRegistry(ctx, campaignsStore, repoStore, cf)
 	if server != nil {
 		server.ChangesetSyncRegistry = syncRegistry
 	}
 
-	clock := func() time.Time {
-		return time.Now().UTC().Truncate(time.Microsecond)
-	}
-
-	sourcer := repos.NewSourcer(cf)
-	go campaigns.RunWorkers(ctx, campaignsStore, gitserver.DefaultClient, sourcer)
-
-	// Set up expired spec deletion
-	go func() {
-		for {
-			// We first need to delete expired ChangesetSpecs...
-			if err := campaignsStore.DeleteExpiredChangesetSpecs(ctx); err != nil {
-				log15.Error("DeleteExpiredChangesetSpecs", "error", err)
-			}
-			// ... and then the CampaignSpecs, due to the campaign_spec_id
-			// foreign key on changeset_specs.
-			if err := campaignsStore.DeleteExpiredCampaignSpecs(ctx); err != nil {
-				log15.Error("DeleteExpiredCampaignSpecs", "error", err)
-			}
-
-			time.Sleep(2 * time.Minute)
-		}
-	}()
+	campaigns.SetupCampaignsBackgroundJobs(ctx, db, campaignsStore, repoStore, cf)
 
 	// TODO(jchen): This is an unfortunate compromise to not rewrite ossDB.ExternalServices for now.
 	dbconn.Global = db

--- a/enterprise/internal/campaigns/background.go
+++ b/enterprise/internal/campaigns/background.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-func SetupCampaignsBackgroundJobs(ctx context.Context, db *sql.DB, campaignsStore *Store, repoStore repos.Store, cf *httpcli.Factory) {
+func StartBackgroundJobs(ctx context.Context, db *sql.DB, campaignsStore *Store, repoStore repos.Store, cf *httpcli.Factory) {
 	sourcer := repos.NewSourcer(cf)
 
 	reconcilerWorker := NewWorker(ctx, campaignsStore, gitserver.DefaultClient, sourcer)

--- a/enterprise/internal/campaigns/background.go
+++ b/enterprise/internal/campaigns/background.go
@@ -1,0 +1,37 @@
+package campaigns
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+func SetupCampaignsBackgroundJobs(ctx context.Context, db *sql.DB, campaignsStore *Store, repoStore repos.Store, cf *httpcli.Factory) {
+	sourcer := repos.NewSourcer(cf)
+
+	reconcilerWorker := NewWorker(ctx, campaignsStore, gitserver.DefaultClient, sourcer)
+
+	expireSpecs := goroutine.NewHandlerWithErrorMessage("expire campaigns specs", func(ctx context.Context) error {
+		// We first need to delete expired ChangesetSpecs...
+		if err := campaignsStore.DeleteExpiredChangesetSpecs(ctx); err != nil {
+			return errors.Wrap(err, "DeleteExpiredChangesetSpecs")
+		}
+		// ... and then the CampaignSpecs, due to the campaign_spec_id
+		// foreign key on changeset_specs.
+		if err := campaignsStore.DeleteExpiredCampaignSpecs(ctx); err != nil {
+			return errors.Wrap(err, "DeleteExpiredCampaignSpecs")
+		}
+		return nil
+	})
+
+	// Set up expired spec deletion.
+	expireWorker := goroutine.NewPeriodicGoroutine(ctx, 2*time.Minute, expireSpecs)
+
+	goroutine.MonitorBackgroundRoutines(expireWorker, reconcilerWorker)
+}

--- a/enterprise/internal/campaigns/workers.go
+++ b/enterprise/internal/campaigns/workers.go
@@ -18,15 +18,15 @@ import (
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
-// RunWorkers starts a dbworker.NewWorker that fetches enqueued changesets
+// NewWorker creates a dbworker.NewWorker that fetches enqueued changesets
 // from the database and passes them to the changeset reconciler for
 // processing.
-func RunWorkers(
+func NewWorker(
 	ctx context.Context,
 	s *Store,
 	gitClient GitserverClient,
 	sourcer repos.Sourcer,
-) {
+) *workerutil.Worker {
 	r := &reconciler{gitserverClient: gitClient, sourcer: sourcer, store: s}
 
 	options := workerutil.WorkerOptions{
@@ -56,7 +56,7 @@ func RunWorkers(
 	})
 
 	worker := dbworker.NewWorker(ctx, workerStore, r.HandlerFunc(), options)
-	worker.Start()
+	return worker
 }
 
 // reconcilerMaxNumRetries is the maximum number of attempts the reconciler


### PR DESCRIPTION
While trying to understand how the syncer works, I discovered we could make use of the new goroutine package here, which adds some nicer error logging and signal handling.