### PR TITLE
Campaigns tutorial: search & replace specific terms

### DIFF
--- a/doc/campaigns/tutorials/index.md
+++ b/doc/campaigns/tutorials/index.md
@@ -5,3 +5,4 @@ The following is a list of tutorials that show how to use [Sourcegraph campaigns
 - [Refactoring Go code using Comby](refactor_go_comby.md)
 - [Updating Go import statements using Comby](updating_go_import_statements.md)
 - [Update base images in Dockerfiles](update_base_images_in_dockerfiles.md)
+- [Search and replace specific terms](search_and_replace_specific_terms.md)

--- a/doc/campaigns/tutorials/search_and_replace_specific_terms.md
+++ b/doc/campaigns/tutorials/search_and_replace_specific_terms.md
@@ -29,6 +29,8 @@ This tutorial shows you how to create [a campaign spec](../explanations/introduc
 
 The campaign spec can be easily changed to search and replace other terms in other file types.
 
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_teaser.png" class="screenshot center">
+
 ### Prerequisites
 
 We recommend using the latest version of Sourcegraph when working with campaigns and that you have a basic understanding of how to create campaign specs and run them. See the following documents for more information:
@@ -76,8 +78,11 @@ changesetTemplate:
 
     > The `namespace` is either your Sourcegraph username or the name of a Sourcegraph organisation under which you want to create the campaign. If you're not sure what to choose, use your username.
 1. Wait for it to run and compute the changes for each repository.
+    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_wait_run.png" class="screenshot">
 1. Open the preview URL that the command printed out.
+    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_click_url.png" class="screenshot">
 1. Examine the preview. Confirm that the changes are what you intended. If not, edit your campaign spec and then rerun the command above.
+    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_preview.png" class="screenshot">
 1. Click the **Apply spec** button to create the campaign.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the campaign spec](../campaign_spec_yaml_reference.md#changesettemplate-published) and re-running the `src campaign preview` command.
 

--- a/doc/campaigns/tutorials/search_and_replace_specific_terms.md
+++ b/doc/campaigns/tutorials/search_and_replace_specific_terms.md
@@ -1,0 +1,118 @@
+# Search and replace specific terms
+
+<style>
+.markdown-body pre.chroma {
+  font-size: 0.75em;
+}
+
+img.screenshot {
+    max-width: 600px;
+    margin: 1em;
+    margin-bottom: 0.5em;
+    border: 1px solid lightgrey;
+    border-radius: 10px;
+}
+
+img.center {
+  display: block;
+  margin: auto
+}
+
+</style>
+
+<p class="lead">
+Create a campaign that changes wording in every repository.
+</p>
+
+### Introduction
+
+This tutorial shows you how to create [a campaign spec](../explanations/introduction_to_campaigns.md#campaign-spec) that replaces the words `allowlist` and `denylist` with `allowlist` and `denylist` in every Markdown file across your complete code base.
+
+The campaign spec is can be easily be changed to search and replace other terms in other file types.
+
+### Prerequisites
+
+We recommend using the latest version of Sourcegraph when working with campaigns and that you have a basic understanding of how to create campaign specs and run them. See the following documents for more information:
+
+1. ["Quickstart"](../quickstart.md)
+1. ["Introduction to campaigns"](../explanations/introduction_to_campaigns.md)
+
+### Create the campaign spec
+
+Save the following campaign spec YAML as `allowlist-denylist.campaign.yaml`:
+
+```yaml
+name: use-allowlist-denylist-wording
+description: This campaign updates our Markdown docs to use the terms "allowlist" and "denylist" instead of "whitelist" and "blacklist".
+
+# Search for repositories in which the term "whitelist" or "blacklist" appears
+# in Markdown files.
+on:
+  - repositoriesMatchingQuery: whitelist OR blacklist lang:markdown -file:vendor -file:node_modules
+
+# In each repository
+steps:
+  # find all *.md or *.markdown files, that are not in a vendor or node_modules
+  # folder, and replace the terms in them:
+  - run: |
+      find . -type f \( -name '*.md' -or -name '*.markdown' \) -not -path "*/vendor/*" -not -path "*/node_modules/*" |\
+      xargs sed -i 's/whitelist/allowlist/g; s/blacklist/denylist/g'
+    container: alpine:3
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Replace whitelist/blacklist with allowlist/denylist
+  body: This replaces the terms whitelist/blacklist in Markdown files with allowlist/denylist
+  branch: campaigns/allowlist-denylist # Push the commit to this branch.
+  commit:
+    message: Replace whitelist/blacklist with allowlist/denylist
+  published: false
+```
+
+### Create the campaign
+
+1. In your terminal, run this command:
+
+    <pre>src campaign preview -f use-allowlist-denylist-wording.campaign.yaml -namespace <em>USERNAME_OR_ORG</em></pre>
+
+    > The `namespace` is either your Sourcegraph username or the name of a Sourcegraph organisation under which you want to create the campaign. If you're not sure what to choose, use your username.
+1. Wait for it to run and compute the changes for each repository.
+1. Open the preview URL that the command printed out.
+1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.
+1. Click the **Apply spec** button to create the campaign.
+1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the campaign spec](../campaign_spec_yaml_reference.md#changesettemplate-published) and re-running the `src campaign preview` command.
+
+### Using `ruplacer` to replace terms in multiple case styles
+
+With [ruplacer](https://github.com/TankerHQ/ruplacer) we can easily search and replace terms in multiple case styles: `white_list`, `WhiteList`, `WHITE_LIST` etc.
+
+To use `ruplacer` in our campaign spec, all we need to do is to build a small Docker image in which `ruplacer` is availabe.
+
+Save the following in a `Dockerfile`:
+
+```dockerfile
+FROM rust
+RUN cargo install ruplacer
+```
+
+Then build a Docker image, tagged with `ruplacer`, out of it by running the following command in your terminal:
+
+```
+docker build . -t ruplacer
+```
+
+Once that is done, we can replace the `steps` in our campaign spec with the following:
+
+```yaml
+steps:
+  - run: |
+      find . -type f \( -name '*.md' -or -name '*.markdown' \) -not -path "*/vendor/*" -not -path "*/node_modules/*" >> /tmp/find_result.txt \
+      && cat /tmp/find_result.txt | while read file;
+      do
+        ruplacer --subvert whitelist allowlist --go ${file} || echo "nothing to replace";
+        ruplacer --subvert blacklist denylist --go ${file} || echo "nothing to replace";
+      done
+    container: ruplacer
+```
+
+Save the file and run the `src campaign preview` command from above again to use `ruplacer` to replace variations of terms.

--- a/doc/campaigns/tutorials/search_and_replace_specific_terms.md
+++ b/doc/campaigns/tutorials/search_and_replace_specific_terms.md
@@ -26,7 +26,7 @@ Create a campaign that changes wording in every repository.
 
 ### Introduction
 
-This tutorial shows you how to create [a campaign spec](../explanations/introduction_to_campaigns.md#campaign-spec) that replaces the words `allowlist` and `denylist` with `allowlist` and `denylist` in every Markdown file across your complete code base.
+This tutorial shows you how to create [a campaign spec](../explanations/introduction_to_campaigns.md#campaign-spec) that replaces the words `allowlist` and `denylist` with `allowlist` and `denylist` in every Markdown file across your entire code base.
 
 The campaign spec is can be easily be changed to search and replace other terms in other file types.
 

--- a/doc/campaigns/tutorials/search_and_replace_specific_terms.md
+++ b/doc/campaigns/tutorials/search_and_replace_specific_terms.md
@@ -25,7 +25,7 @@ Create a campaign that changes wording in every repository.
 
 ### Introduction
 
-This tutorial shows you how to create [a campaign spec](../explanations/introduction_to_campaigns.md#campaign-spec) that replaces the words `allowlist` and `denylist` with `allowlist` and `denylist` in every Markdown file across your entire code base.
+This tutorial shows you how to create [a campaign spec](../explanations/introduction_to_campaigns.md#campaign-spec) that replaces the words `whitelist` and `blacklist` with `allowlist` and `denylist` in every Markdown file across your entire code base.
 
 The campaign spec can be easily changed to search and replace other terms in other file types.
 

--- a/doc/campaigns/tutorials/search_and_replace_specific_terms.md
+++ b/doc/campaigns/tutorials/search_and_replace_specific_terms.md
@@ -17,7 +17,6 @@ img.center {
   display: block;
   margin: auto
 }
-
 </style>
 
 <p class="lead">
@@ -78,7 +77,7 @@ changesetTemplate:
     > The `namespace` is either your Sourcegraph username or the name of a Sourcegraph organisation under which you want to create the campaign. If you're not sure what to choose, use your username.
 1. Wait for it to run and compute the changes for each repository.
 1. Open the preview URL that the command printed out.
-1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the campaign spec and then rerun the command above.
+1. Examine the preview. Confirm that the changes are what you intended. If not, edit your campaign spec and then rerun the command above.
 1. Click the **Apply spec** button to create the campaign.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the campaign spec](../campaign_spec_yaml_reference.md#changesettemplate-published) and re-running the `src campaign preview` command.
 
@@ -86,7 +85,7 @@ changesetTemplate:
 
 With [ruplacer](https://github.com/TankerHQ/ruplacer) we can easily search and replace terms in multiple case styles: `white_list`, `WhiteList`, `WHITE_LIST` etc.
 
-To use `ruplacer` in our campaign spec, all we need to do is to build a small Docker image in which `ruplacer` is availabe.
+To use `ruplacer` in our campaign spec, all we need to do is to build a small Docker image in which `ruplacer` is available.
 
 Save the following in a `Dockerfile`:
 

--- a/doc/campaigns/tutorials/search_and_replace_specific_terms.md
+++ b/doc/campaigns/tutorials/search_and_replace_specific_terms.md
@@ -28,7 +28,7 @@ Create a campaign that changes wording in every repository.
 
 This tutorial shows you how to create [a campaign spec](../explanations/introduction_to_campaigns.md#campaign-spec) that replaces the words `allowlist` and `denylist` with `allowlist` and `denylist` in every Markdown file across your entire code base.
 
-The campaign spec is can be easily be changed to search and replace other terms in other file types.
+The campaign spec can be easily changed to search and replace other terms in other file types.
 
 ### Prerequisites
 


### PR DESCRIPTION
This adds a tutorial to the campaigns docs that shows how to replace "whitelist" & "blacklist" with "allowlist" & "denylist" in Markdown files.

As you can see I decided against using the templated-campaigns-spec prototype for this, since it's not merged yet and not released and the experimental features aren't documented yet. Instead I wrote two campaign specs (one using `sed`, one using `ruplacer`) that can be run with the current Sourcegraph and src-cli versions.

I also decided to only run this over Markdown files to demonstrate how to do filtering of files — in the `repositoriesMatchingQuery` and in `steps.Run` — and since search & replacing such common terms across code files, config files, JSON files, etc. is simply not valuable because it breaks a ton of stuff and basically every occurrence needs to be manually confirmed.

Edit:

Once the prototype is merged I want to extend this tutorial to show how to only search & replace in specific files yielded by the search.

![image](https://user-images.githubusercontent.com/1185253/97553297-8e3ca680-19d5-11eb-9d43-4be8d8524256.png)
