### PR TITLE
codeintel: Add file size results to upload store

### DIFF
--- a/enterprise/internal/codeintel/upload_store/gcs_api.go
+++ b/enterprise/internal/codeintel/upload_store/gcs_api.go
@@ -26,7 +26,7 @@ type gcsObjectHandle interface {
 }
 
 type gcsComposer interface {
-	Run(ctx context.Context) error
+	Run(ctx context.Context) (*storage.ObjectAttrs, error)
 }
 
 type gcsAPIShim struct{ *storage.Client }
@@ -83,7 +83,6 @@ func (s *objectHandleShim) ComposerFrom(sources ...gcsObjectHandle) gcsComposer 
 	return &composerShim{s.ObjectHandle.ComposerFrom(rawSources...)}
 }
 
-func (s *composerShim) Run(ctx context.Context) error {
-	_, err := s.Composer.Run(ctx)
-	return err
+func (s *composerShim) Run(ctx context.Context) (*storage.ObjectAttrs, error) {
+	return s.Composer.Run(ctx)
 }

--- a/enterprise/internal/codeintel/upload_store/s3_api.go
+++ b/enterprise/internal/codeintel/upload_store/s3_api.go
@@ -8,6 +8,7 @@ import (
 )
 
 type s3API interface {
+	HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	CreateMultipartUpload(ctx context.Context, input *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	AbortMultipartUpload(ctx context.Context, input *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
@@ -34,6 +35,10 @@ func (s *s3APIShim) CreateBucket(ctx context.Context, input *s3.CreateBucketInpu
 
 func (s *s3APIShim) PutBucketLifecycleConfiguration(ctx context.Context, input *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
 	return s.S3.PutBucketLifecycleConfigurationWithContext(ctx, input)
+}
+
+func (s *s3APIShim) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	return s.S3.HeadObjectWithContext(ctx, input)
 }
 
 func (s *s3APIShim) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {

--- a/enterprise/internal/codeintel/upload_store/s3_client.go
+++ b/enterprise/internal/codeintel/upload_store/s3_client.go
@@ -62,12 +62,30 @@ func (s *s3Store) Init(ctx context.Context) error {
 		return nil
 	}
 
-	if err := s.create(ctx); err != nil {
-		return errors.Wrap(err, "failed to create bucket")
+	//
+	// TODO - rewrite, test
+
+	tryCreate := func() error {
+		if err := s.create(ctx); err != nil {
+			return errors.Wrap(err, "failed to create bucket")
+		}
+
+		if err := s.update(ctx); err != nil {
+			return errors.Wrap(err, "failed to update bucket attributes")
+		}
+
+		return nil
 	}
 
-	if err := s.update(ctx); err != nil {
-		return errors.Wrap(err, "failed to update bucket attributes")
+	var err error
+	for i := 0; i < 20; i++ {
+		if i > 0 {
+			<-time.After(time.Second)
+		}
+
+		if err = tryCreate(); err == nil {
+			break
+		}
 	}
 
 	return nil
@@ -91,23 +109,27 @@ func (s *s3Store) Get(ctx context.Context, key string, skipBytes int64) (io.Read
 	return resp.Body, nil
 }
 
-func (s *s3Store) Upload(ctx context.Context, key string, r io.Reader) error {
-	err := s.uploader.Upload(ctx, &s3manager.UploadInput{
+func (s *s3Store) Upload(ctx context.Context, key string, r io.Reader) (int64, error) {
+	cr := &countingReader{r: r}
+
+	if err := s.uploader.Upload(ctx, &s3manager.UploadInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
-		Body:   r,
-	})
+		Body:   cr,
+	}); err != nil {
+		return 0, errors.Wrap(err, "failed to upload object")
+	}
 
-	return errors.Wrap(err, "failed to upload object")
+	return int64(cr.n), nil
 }
 
-func (s *s3Store) Compose(ctx context.Context, destination string, sources ...string) (err error) {
+func (s *s3Store) Compose(ctx context.Context, destination string, sources ...string) (_ int64, err error) {
 	multipartUpload, err := s.client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(destination),
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to create multipart upload")
+		return 0, errors.Wrap(err, "failed to create multipart upload")
 	}
 
 	defer func() {
@@ -151,7 +173,7 @@ func (s *s3Store) Compose(ctx context.Context, destination string, sources ...st
 
 		return nil
 	}); err != nil {
-		return err
+		return 0, err
 	}
 
 	var parts []*s3.CompletedPart
@@ -170,23 +192,18 @@ func (s *s3Store) Compose(ctx context.Context, destination string, sources ...st
 		UploadId:        multipartUpload.UploadId,
 		MultipartUpload: &s3.CompletedMultipartUpload{Parts: parts},
 	}); err != nil {
-		return errors.Wrap(err, "failed to complete multipart upload")
+		return 0, errors.Wrap(err, "failed to complete multipart upload")
 	}
 
-	return nil
-}
-
-func (s *s3Store) deleteSources(ctx context.Context, bucket string, sources []string) error {
-	return invokeParallel(sources, func(index int, source string) error {
-		if _, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(source),
-		}); err != nil {
-			return errors.Wrap(err, "failed to delete source object")
-		}
-
-		return nil
+	obj, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: multipartUpload.Bucket,
+		Key:    multipartUpload.Key,
 	})
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to stat composed object")
+	}
+
+	return *obj.ContentLength, nil
 }
 
 func (s *s3Store) create(ctx context.Context) error {
@@ -239,6 +256,19 @@ func (s *s3Store) lifecycle() *s3.BucketLifecycleConfiguration {
 	}
 }
 
+func (s *s3Store) deleteSources(ctx context.Context, bucket string, sources []string) error {
+	return invokeParallel(sources, func(index int, source string) error {
+		if _, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(source),
+		}); err != nil {
+			return errors.Wrap(err, "failed to delete source object")
+		}
+
+		return nil
+	})
+}
+
 // awsSessionOptions returns the session used to configure the AWS SDK client.
 //
 // Authentication of the client will first prefer environment variables, then will
@@ -278,4 +308,15 @@ func awsEnv(name string) *string {
 	}
 
 	return nil
+}
+
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (r *countingReader) Read(p []byte) (n int, err error) {
+	n, err = r.r.Read(p)
+	r.n += n
+	return n, err
 }

--- a/enterprise/internal/codeintel/upload_store/s3_client.go
+++ b/enterprise/internal/codeintel/upload_store/s3_client.go
@@ -62,30 +62,12 @@ func (s *s3Store) Init(ctx context.Context) error {
 		return nil
 	}
 
-	//
-	// TODO - rewrite, test
-
-	tryCreate := func() error {
-		if err := s.create(ctx); err != nil {
-			return errors.Wrap(err, "failed to create bucket")
-		}
-
-		if err := s.update(ctx); err != nil {
-			return errors.Wrap(err, "failed to update bucket attributes")
-		}
-
-		return nil
+	if err := s.create(ctx); err != nil {
+		return errors.Wrap(err, "failed to create bucket")
 	}
 
-	var err error
-	for i := 0; i < 20; i++ {
-		if i > 0 {
-			<-time.After(time.Second)
-		}
-
-		if err = tryCreate(); err == nil {
-			break
-		}
+	if err := s.update(ctx); err != nil {
+		return errors.Wrap(err, "failed to update bucket attributes")
 	}
 
 	return nil

--- a/enterprise/internal/codeintel/upload_store/store.go
+++ b/enterprise/internal/codeintel/upload_store/store.go
@@ -18,12 +18,12 @@ type Store interface {
 	Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error)
 
 	// Upload writes the content in the given reader to the object at the given key.
-	Upload(ctx context.Context, key string, r io.Reader) error
+	Upload(ctx context.Context, key string, r io.Reader) (int64, error)
 
 	// Compose will concatenate the given source objects together and write to the given
 	// destination object. The source objects will be removed if the composed write is
 	// successful.
-	Compose(ctx context.Context, destination string, sources ...string) error
+	Compose(ctx context.Context, destination string, sources ...string) (int64, error)
 }
 
 var storeConstructors = map[string]func(ctx context.Context, config *Config) (Store, error){
@@ -47,5 +47,5 @@ func Create(ctx context.Context, config *Config) (Store, error) {
 		return nil, err
 	}
 
-	return store, nil
+	return store, err
 }


### PR DESCRIPTION
In preparation for https://github.com/sourcegraph/sourcegraph/issues/14826, I found that the API I had proposed earlier was underspecified. This change now returns the size of the functions after `Upload` and `Compose` operations.
