### PR TITLE
server: Add default configuration to connect to the codeintel upload store

### DIFF
--- a/cmd/server/shared/minio.go
+++ b/cmd/server/shared/minio.go
@@ -8,10 +8,10 @@ import (
 	"github.com/inconshreveable/log15"
 )
 
-func maybeMinio() ([]string, error) {
+func maybeMinio() []string {
 	if os.Getenv("DISABLE_MINIO") != "" {
 		log15.Info("WARNING: Running with minio disabled")
-		return []string{""}, nil
+		return []string{""}
 	}
 
 	// Set default for MinIO auth and point at local MinIO endpoint
@@ -24,5 +24,5 @@ func maybeMinio() ([]string, error) {
 	// Configure MinIO service
 	dataDir := filepath.Join(os.Getenv("DATA_DIR"), "minio")
 	procline := fmt.Sprintf(`minio: /usr/local/bin/minio server %s >> /var/opt/sourcegraph/minio.log 2>&1`, dataDir)
-	return []string{procline}, nil
+	return []string{procline}
 }

--- a/cmd/server/shared/minio.go
+++ b/cmd/server/shared/minio.go
@@ -14,9 +14,14 @@ func maybeMinio() ([]string, error) {
 		return []string{""}, nil
 	}
 
+	// Set default for MinIO auth and point at local MinIO endpoint
+	// All other variables will default to contacting a MinIO instance
+	// with our default credentials running in a sibling container.
 	SetDefaultEnv("MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
 	SetDefaultEnv("MINIO_SECRET_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://127.0.0.1:9000")
 
+	// Configure MinIO service
 	dataDir := filepath.Join(os.Getenv("DATA_DIR"), "minio")
 	procline := fmt.Sprintf(`minio: /usr/local/bin/minio server %s >> /var/opt/sourcegraph/minio.log 2>&1`, dataDir)
 	return []string{procline}, nil

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -150,11 +150,7 @@ func Main() {
 		procfile = append(procfile, monitoringLines...)
 	}
 
-	minioLines, err := maybeMinio()
-	if err != nil {
-		log.Fatal(err)
-	}
-	if len(minioLines) != 0 {
+	if minioLines := maybeMinio(); len(minioLines) != 0 {
 		procfile = append(procfile, minioLines...)
 	}
 

--- a/enterprise/internal/codeintel/upload_store/config.go
+++ b/enterprise/internal/codeintel/upload_store/config.go
@@ -2,6 +2,7 @@ package uploadstore
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -12,82 +13,33 @@ type Config struct {
 
 	Backend      string
 	ManageBucket bool
+	Bucket       string
+	TTL          time.Duration
 	S3           S3Config
 	GCS          GCSConfig
-}
-
-func (c *Config) Load() {
-	c.Backend = c.GetOptional(
-		"PRECISE_CODE_INTEL_UPLOAD_BACKEND",
-		"The target file service for code intelligence uploads. S3 and GCS are supported.",
-	)
-
-	c.ManageBucket = c.GetBool(
-		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET",
-		"false",
-		"Whether or not the client should manage the target bucket configuration.",
-	)
-
-	config, ok := c.loaders()[c.Backend]
-	if !ok {
-		c.AddError(fmt.Errorf("invalid backend %q for PRECISE_CODE_INTEL_UPLOAD_BACKEND: must be S3 or GCS", c.Backend))
-		return
-	}
-
-	config.load(&c.BaseConfig)
 }
 
 type loader interface {
 	load(parent *env.BaseConfig)
 }
 
-func (c *Config) loaders() map[string]loader {
-	return map[string]loader{
-		"S3":  &c.S3,
-		"GCS": &c.GCS,
+func (c *Config) Load() {
+	c.Backend = strings.ToLower(c.Get("PRECISE_CODE_INTEL_UPLOAD_BACKEND", "MinIO", "The target file service for code intelligence uploads. S3, GCS, and MinIO are supported."))
+	c.ManageBucket = c.GetBool("PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET", "true", "Whether or not the client should manage the target bucket configuration.")
+	c.Bucket = c.Get("PRECISE_CODE_INTEL_UPLOAD_BUCKET", "lsif-uploads", "The name of the bucket to store LSIF uploads in.")
+	c.TTL = c.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TTL", "168h", "The maximum age of an upload before deletion.")
+
+	loaders := map[string]loader{
+		"s3":    &c.S3,
+		"minio": &c.S3,
+		"gcs":   &c.GCS,
 	}
-}
 
-type commonConfig struct {
-	// Bucket is the target bucket for LSIF uploads.
-	Bucket string
+	config, ok := loaders[c.Backend]
+	if !ok {
+		c.AddError(fmt.Errorf("invalid backend %q for PRECISE_CODE_INTEL_UPLOAD_BACKEND: must be S3, GCS, or MinIO", c.Backend))
+		return
+	}
 
-	// TTL is the maximum age of an upload before deletion in the configured bucket.
-	TTL time.Duration
-}
-
-type S3Config struct {
-	commonConfig
-}
-
-func (c *S3Config) load(parent *env.BaseConfig) {
-	c.Bucket = parent.Get("PRECISE_CODE_INTEL_UPLOAD_BUCKET", "", "The name of the bucket to store LSIF uploads in.")
-	c.TTL = parent.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TTL", "168h", "The maximum age of an upload before deletion.")
-
-	// Environment variables used by underlying libraries, here for documentation
-	_ = env.Get("AWS_ACCESS_KEY_ID", "", "An AWS access key associated with a user with access to S3.")
-	_ = env.Get("AWS_SECRET_ACCESS_KEY", "", "An AWS secret key associated with a user with access to S3.")
-	_ = env.Get("AWS_SHARED_CREDENTIALS_FILE", " ~/.aws/credentials", "The path to an AWS credentials file.")
-	_ = env.Get("AWS_PROFILE", "default", "The name within the shared credentials file to use.")
-	_ = env.Get("AWS_ENDPOINT", "", "Specifies the URL of the AWS API. Used to target a MinIO instance instead of S3.")
-	_ = env.Get("AWS_REGION", "", "Specifies the AWS Region to send the request to.")
-	_ = env.Get("AWS_S3_FORCE_PATH_STYLE", "", "If set, S3 virtual host request path are not used. Set this to target a MinIO instance.")
-
-}
-
-type GCSConfig struct {
-	commonConfig
-
-	// ProjectID specifies the project containing the GCS bucket.
-	ProjectID string
-}
-
-func (c *GCSConfig) load(parent *env.BaseConfig) {
-	c.Bucket = parent.Get("PRECISE_CODE_INTEL_UPLOAD_BUCKET", "", "The name of the bucket to store LSIF uploads in.")
-	c.TTL = parent.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TTL", "168h", "The maximum age of an upload before deletion.")
-	c.ProjectID = parent.Get("PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID", "", "The project containing the GCS bucket.")
-
-	// Environment variables used by underlying libraries, here for documentation
-	_ = env.Get("GOOGLE_APPLICATION_CREDENTIALS", "", "The path to a service account key file with access to GCS.")
-	_ = env.Get("GOOGLE_APPLICATION_CREDENTIALS_JSON", "", "The contents of a service account key file with access to GCS.")
+	config.load(&c.BaseConfig)
 }

--- a/enterprise/internal/codeintel/upload_store/config.go
+++ b/enterprise/internal/codeintel/upload_store/config.go
@@ -25,9 +25,14 @@ type loader interface {
 
 func (c *Config) Load() {
 	c.Backend = strings.ToLower(c.Get("PRECISE_CODE_INTEL_UPLOAD_BACKEND", "MinIO", "The target file service for code intelligence uploads. S3, GCS, and MinIO are supported."))
-	c.ManageBucket = c.GetBool("PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET", "true", "Whether or not the client should manage the target bucket configuration.")
+	c.ManageBucket = c.GetBool("PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET", "false", "Whether or not the client should manage the target bucket configuration.")
 	c.Bucket = c.Get("PRECISE_CODE_INTEL_UPLOAD_BUCKET", "lsif-uploads", "The name of the bucket to store LSIF uploads in.")
 	c.TTL = c.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TTL", "168h", "The maximum age of an upload before deletion.")
+
+	if c.Backend == "minio" {
+		// No manual provisioning
+		c.ManageBucket = true
+	}
 
 	loaders := map[string]loader{
 		"s3":    &c.S3,

--- a/enterprise/internal/codeintel/upload_store/config_test.go
+++ b/enterprise/internal/codeintel/upload_store/config_test.go
@@ -5,12 +5,44 @@ import (
 	"time"
 )
 
+func TestConfigDefaults(t *testing.T) {
+	config := Config{}
+	config.SetMockGetter(mapGetter(nil))
+	config.Load()
+
+	if err := config.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %s", err)
+	}
+
+	if config.Bucket != "lsif-uploads" {
+		t.Errorf("unexpected value for S3.Bucket. want=%s have=%s", "lsif-uploads", config.Bucket)
+	}
+	if config.TTL != 24*7*time.Hour {
+		t.Errorf("unexpected value for S3.TTL. want=%v have=%v", 24*7*time.Hour, config.TTL)
+	}
+	if config.S3.AccessKeyID != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("unexpected value for S3.AccessKeyID. want=%s have=%s", "AKIAIOSFODNN7EXAMPLE", config.S3.AccessKeyID)
+	}
+	if config.S3.SecretAccessKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("unexpected value for S3.SecretAccessKey. want=%s have=%s", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", config.S3.SecretAccessKey)
+	}
+	if config.S3.Endpoint != "http://minio:9000" {
+		t.Errorf("unexpected value for S3.Endpoint. want=%s have=%s", "us-east-1", config.S3.Endpoint)
+	}
+	if config.S3.Region != "us-east-1" {
+		t.Errorf("unexpected value for S3.Region. want=%s have=%s", "us-east-1", config.S3.Region)
+	}
+}
+
 func TestConfigS3(t *testing.T) {
 	env := map[string]string{
-		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":       "S3",
-		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":        "lsif-uploads",
-		"PRECISE_CODE_INTEL_UPLOAD_TTL":           "8h",
-		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET": "true",
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":               "S3",
+		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":                "lsif-uploads",
+		"PRECISE_CODE_INTEL_UPLOAD_TTL":                   "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET":         "true",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID":     "access-key-id",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY": "secret-access-key",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_SESSION_TOKEN":     "session-token",
 	}
 
 	config := Config{}
@@ -21,21 +53,79 @@ func TestConfigS3(t *testing.T) {
 		t.Fatalf("unexpected validation error: %s", err)
 	}
 
-	if config.S3.Bucket != "lsif-uploads" {
-		t.Errorf("unexpected value for S3.Bucket. want=%s have=%s", "lsif-uploads", config.S3.Bucket)
+	if config.Bucket != "lsif-uploads" {
+		t.Errorf("unexpected value for S3.Bucket. want=%s have=%s", "lsif-uploads", config.Bucket)
 	}
-	if config.S3.TTL != 8*time.Hour {
-		t.Errorf("unexpected value for S3.TTL. want=%v have=%v", 8*time.Hour, config.S3.TTL)
+	if config.TTL != 8*time.Hour {
+		t.Errorf("unexpected value for S3.TTL. want=%v have=%v", 8*time.Hour, config.TTL)
+	}
+	if config.S3.AccessKeyID != "access-key-id" {
+		t.Errorf("unexpected value for S3.AccessKeyID. want=%s have=%s", "access-key-id", config.S3.AccessKeyID)
+	}
+	if config.S3.SecretAccessKey != "secret-access-key" {
+		t.Errorf("unexpected value for S3.SecretAccessKey. want=%s have=%s", "secret-access-key", config.S3.SecretAccessKey)
+	}
+	if config.S3.SessionToken != "session-token" {
+		t.Errorf("unexpected value for S3.SessionToken. want=%s have=%s", "session-token", config.S3.SessionToken)
+	}
+}
+
+func TestConfigMinIOSessionOptions(t *testing.T) {
+	config := Config{}
+	config.SetMockGetter(mapGetter(nil))
+	config.Load()
+
+	options := s3SessionOptions("minio", config.S3)
+
+	if value := *options.Config.Region; value != "us-east-1" {
+		t.Errorf("unexpected region. want=%s have=%s", "us-east-1", value)
+	}
+	if value := *options.Config.Endpoint; value != "http://minio:9000" {
+		t.Errorf("unexpected endpoint. want=%s have=%s", "http://minio:9000", value)
+	}
+	if options.Config.S3ForcePathStyle == nil || !*options.Config.S3ForcePathStyle {
+		t.Errorf("expected path style option")
+	}
+}
+
+func TestConfigS3SessionOptions(t *testing.T) {
+	env := map[string]string{
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":               "S3",
+		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":                "lsif-uploads",
+		"PRECISE_CODE_INTEL_UPLOAD_TTL":                   "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET":         "true",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_REGION":            "us-east-2",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID":     "access-key-id",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY": "secret-access-key",
+		"PRECISE_CODE_INTEL_UPLOAD_AWS_SESSION_TOKEN":     "session-token",
+	}
+
+	config := Config{}
+	config.SetMockGetter(mapGetter(env))
+	config.Load()
+
+	options := s3SessionOptions("s3", config.S3)
+
+	if value := *options.Config.Region; value != "us-east-2" {
+		t.Errorf("unexpected region. want=%s have=%s", "us-east-2", value)
+	}
+	if options.Config.Endpoint != nil {
+		t.Errorf("unexpected endpoint option")
+	}
+	if options.Config.S3ForcePathStyle != nil {
+		t.Errorf("unexpected path style option")
 	}
 }
 
 func TestConfigGCS(t *testing.T) {
 	env := map[string]string{
-		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":        "GCS",
-		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":         "lsif-uploads",
-		"PRECISE_CODE_INTEL_UPLOAD_TTL":            "8h",
-		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET":  "true",
-		"PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID": "test",
+		"PRECISE_CODE_INTEL_UPLOAD_BACKEND":                                     "GCS",
+		"PRECISE_CODE_INTEL_UPLOAD_BUCKET":                                      "lsif-uploads",
+		"PRECISE_CODE_INTEL_UPLOAD_TTL":                                         "8h",
+		"PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET":                               "true",
+		"PRECISE_CODE_INTEL_UPLOAD_GCP_PROJECT_ID":                              "test-project-id",
+		"PRECISE_CODE_INTEL_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE":         "test-credentials-file",
+		"PRECISE_CODE_INTEL_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT": "test-credentials-file-contents",
 	}
 
 	config := Config{}
@@ -46,19 +136,29 @@ func TestConfigGCS(t *testing.T) {
 		t.Fatalf("unexpected validation error: %s", err)
 	}
 
-	if config.GCS.Bucket != "lsif-uploads" {
-		t.Errorf("unexpected value for GCS.Bucket. want=%s have=%s", "lsif-uploads", config.GCS.Bucket)
+	if config.Bucket != "lsif-uploads" {
+		t.Errorf("unexpected value for GCS.Bucket. want=%s have=%s", "lsif-uploads", config.Bucket)
 	}
-	if config.GCS.TTL != 8*time.Hour {
-		t.Errorf("unexpected value for GCS.TTL. want=%v have=%v", 8*time.Hour, config.GCS.TTL)
+	if config.TTL != 8*time.Hour {
+		t.Errorf("unexpected value for GCS.TTL. want=%v have=%v", 8*time.Hour, config.TTL)
 	}
-	if config.GCS.ProjectID != "test" {
-		t.Errorf("unexpected value for GCS.ProjectID. want=%s have=%s", "test", config.GCS.ProjectID)
+	if config.GCS.ProjectID != "test-project-id" {
+		t.Errorf("unexpected value for GCS.ProjectID. want=%s have=%s", "tesT-project-id", config.GCS.ProjectID)
+	}
+	if config.GCS.CredentialsFile != "test-credentials-file" {
+		t.Errorf("unexpected value for GCS.CredentialsFile. want=%s have=%s", "test-credentials-file", config.GCS.CredentialsFile)
+	}
+	if config.GCS.CredentialsFileContents != "test-credentials-file-contents" {
+		t.Errorf("unexpected value for GCS.CredentialsFileContents. want=%s have=%s", "test-credentials-file-contents", config.GCS.CredentialsFileContents)
 	}
 }
 
 func mapGetter(env map[string]string) func(name, defaultValue, description string) string {
 	return func(name, defaultValue, description string) string {
-		return env[name]
+		if v, ok := env[name]; ok {
+			return v
+		}
+
+		return defaultValue
 	}
 }

--- a/enterprise/internal/codeintel/upload_store/gcs_client_test.go
+++ b/enterprise/internal/codeintel/upload_store/gcs_client_test.go
@@ -17,7 +17,7 @@ func TestGCSInit(t *testing.T) {
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.AttrsFunc.SetDefaultReturn(nil, storage.ErrBucketNotExist)
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, true)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, true, GCSConfig{ProjectID: "pid"})
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -43,7 +43,7 @@ func TestGCSInitBucketExists(t *testing.T) {
 	bucketHandle := NewMockGcsBucketHandle()
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, true)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, true, GCSConfig{ProjectID: "pid"})
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -68,7 +68,7 @@ func TestGCSUnmanagedInit(t *testing.T) {
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.AttrsFunc.SetDefaultReturn(nil, storage.ErrBucketNotExist)
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, false)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"})
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -92,7 +92,7 @@ func TestGCSGet(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, false)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"})
 	rc, err := client.Get(context.Background(), "test-key", 0)
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
@@ -131,7 +131,7 @@ func TestGCSGetSkipBytes(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, false)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"})
 	rc, err := client.Get(context.Background(), "test-key", 20)
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
@@ -173,7 +173,7 @@ func TestGCSUpload(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewWriterFunc.SetDefaultReturn(nopCloser{buf})
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, false)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"})
 
 	size, err := client.Upload(context.Background(), "test-key", bytes.NewReader([]byte("TEST PAYLOAD")))
 	if err != nil {
@@ -218,7 +218,7 @@ func TestGCSCombine(t *testing.T) {
 		}[name]
 	})
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, false)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"})
 
 	size, err := client.Compose(context.Background(), "test-key", "test-src1", "test-src2", "test-src3")
 	if err != nil {
@@ -273,7 +273,7 @@ func TestGCSDelete(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := newGCSWithClient(gcsClient, "pid", "test-bucket", time.Hour*24, false)
+	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"})
 	if err := client.Delete(context.Background(), "test-key"); err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
@@ -290,7 +290,7 @@ func TestGCSDelete(t *testing.T) {
 }
 
 func TestGCSLifecycle(t *testing.T) {
-	client := newGCSWithClient(nil, "pid", "test-bucket", time.Hour*24*3, true)
+	client := newGCSWithClient(nil, "test-bucket", time.Hour*24*3, true, GCSConfig{ProjectID: "pid"})
 
 	if lifecycle := client.lifecycle(); len(lifecycle.Rules) != 1 {
 		t.Fatalf("unexpected lifecycle rules")


### PR DESCRIPTION
This adds the default variables required to connect to MinIO in the server environment and changes the variables so that they are correct for docker/k8s deployments out of the box. Only server, dev, and cloud should need to update any of these variables.

While updating values I realized that our defaults were broken (we were unable to _unset_ some variables that enabled some non-opt-out functionality). This is now corrected.

Related documentation change: https://github.com/sourcegraph/sourcegraph/pull/15071