### PR TITLE
search: basic streaming search integration test

### DIFF
--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -9,6 +9,7 @@ import { WebGraphQlOperations } from '../graphql-operations'
 import { SharedGraphQlOperations } from '../../../shared/src/graphql-operations'
 import html from 'tagged-template-noop'
 import { commonWebGraphQlResults } from './graphQlResults'
+import { SearchEvent } from '../search/stream'
 
 export interface ServerSideEvent {
     name: string
@@ -30,7 +31,7 @@ export interface WebIntegrationTestContext
      *
      * @param overrides The array of events to return.
      */
-    overrideSearchStreamEvents: (overrides: ServerSideEvent[]) => void
+    overrideSearchStreamEvents: (overrides: SearchEvent[]) => void
 }
 
 /**
@@ -70,7 +71,7 @@ export const createWebIntegrationTestContext = async ({
             `)
         })
 
-    let searchStreamEventOverrides: ServerSideEvent[] = []
+    let searchStreamEventOverrides: SearchEvent[] = []
     sharedTestContext.server
         .get(new URL('/search/stream?*params', driver.sourcegraphBaseUrl).href)
         .intercept((request, response) => {
@@ -81,7 +82,7 @@ export const createWebIntegrationTestContext = async ({
             }
 
             const responseContent = searchStreamEventOverrides
-                .map(event => `event: ${event.name}\ndata: ${JSON.stringify(event.data)}\n\n`)
+                .map(event => `event: ${event.type}\ndata: ${JSON.stringify(event.data)}\n\n`)
                 .join('')
             response.status(200).type('text/event-stream').send(responseContent)
         })

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -10,6 +10,11 @@ import { SharedGraphQlOperations } from '../../../shared/src/graphql-operations'
 import html from 'tagged-template-noop'
 import { commonWebGraphQlResults } from './graphQlResults'
 
+export interface ServerSideEvent {
+    name: string
+    data: string
+}
+
 export interface WebIntegrationTestContext
     extends IntegrationTestContext<
         WebGraphQlOperations & SharedGraphQlOperations,
@@ -19,6 +24,13 @@ export interface WebIntegrationTestContext
      * Overrides `window.context` from the default created by `createJsContext()`.
      */
     overrideJsContext: (jsContext: SourcegraphContext) => void
+
+    /**
+     * Configures fake responses for streaming search
+     *
+     * @param overrides The array of events to return.
+     */
+    overrideSearchStreamEvents: (overrides: ServerSideEvent[]) => void
 }
 
 /**
@@ -58,10 +70,31 @@ export const createWebIntegrationTestContext = async ({
             `)
         })
 
+    let searchStreamEventOverrides: ServerSideEvent[] = []
+    sharedTestContext.server
+        .get(new URL('/search/stream?*params', driver.sourcegraphBaseUrl).href)
+        .intercept((request, response) => {
+            if (!searchStreamEventOverrides || searchStreamEventOverrides.length === 0) {
+                throw new Error(
+                    'Search stream event overrides missing. Call overrideSearchStreamEvents() to set the events.'
+                )
+            }
+
+            const responseContent = searchStreamEventOverrides
+                .map(event => `event: ${event.name}\ndata: ${event.data}\n\n`)
+                .join('')
+
+            console.log('intercepted streaming search')
+            response.status(200).type('text/event-stream').send(responseContent)
+        })
+
     return {
         ...sharedTestContext,
         overrideJsContext: overrides => {
             jsContext = overrides
+        },
+        overrideSearchStreamEvents: overrides => {
+            searchStreamEventOverrides = overrides
         },
     }
 }

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -12,7 +12,7 @@ import { commonWebGraphQlResults } from './graphQlResults'
 
 export interface ServerSideEvent {
     name: string
-    data: string
+    data: unknown
 }
 
 export interface WebIntegrationTestContext
@@ -81,10 +81,8 @@ export const createWebIntegrationTestContext = async ({
             }
 
             const responseContent = searchStreamEventOverrides
-                .map(event => `event: ${event.name}\ndata: ${event.data}\n\n`)
+                .map(event => `event: ${event.name}\ndata: ${JSON.stringify(event.data)}\n\n`)
                 .join('')
-
-            console.log('intercepted streaming search')
             response.status(200).type('text/event-stream').send(responseContent)
         })
 

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -11,11 +11,6 @@ import html from 'tagged-template-noop'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { SearchEvent } from '../search/stream'
 
-export interface ServerSideEvent {
-    name: string
-    data: unknown
-}
-
 export interface WebIntegrationTestContext
     extends IntegrationTestContext<
         WebGraphQlOperations & SharedGraphQlOperations,

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -497,8 +497,8 @@ describe('Search', () => {
 
         test('Streaming search with single repo result', async () => {
             const searchStreamEvents: ServerSideEvent[] = [
-                { name: 'repomatches', data: '[{"repository":"github.com/sourcegraph/sourcegraph"}]' },
-                { name: 'done', data: '{}' },
+                { name: 'repomatches', data: [{ repository: 'github.com/sourcegraph/sourcegraph' }] },
+                { name: 'done', data: {} },
             ]
 
             testContext.overrideGraphQL({ ...commonSearchGraphQLResults, ...viewerSettingsWithStreamingSearch })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -10,6 +10,7 @@ import { test } from 'mocha'
 import { siteGQLID, siteID } from './jscontext'
 import { createTreeEntriesResult } from './graphQlResponseHelpers'
 import { SharedGraphQlOperations } from '../../../shared/src/graphql-operations'
+import { SearchEvent } from '../search/stream'
 
 const searchResults = (): SearchResult => ({
     search: {
@@ -495,10 +496,10 @@ describe('Search', () => {
             }),
         }
 
-        test('Streaming search with single repo result', async () => {
-            const searchStreamEvents: ServerSideEvent[] = [
-                { name: 'repomatches', data: [{ repository: 'github.com/sourcegraph/sourcegraph' }] },
-                { name: 'done', data: {} },
+        test.only('Streaming search with single repo result', async () => {
+            const searchStreamEvents: SearchEvent[] = [
+                { type: 'repomatches', data: [{ repository: 'github.com/sourcegraph/sourcegraph' }] },
+                { type: 'done', data: {} },
             ]
 
             testContext.overrideGraphQL({ ...commonSearchGraphQLResults, ...viewerSettingsWithStreamingSearch })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -5,7 +5,7 @@ import { ILanguage, IRepository } from '../../../shared/src/graphql/schema'
 import { RepoGroupsResult, SearchResult, SearchSuggestionsResult, WebGraphQlOperations } from '../graphql-operations'
 import { Driver, createDriverForTest } from '../../../shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
-import { WebIntegrationTestContext, createWebIntegrationTestContext, ServerSideEvent } from './context'
+import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { test } from 'mocha'
 import { siteGQLID, siteID } from './jscontext'
 import { createTreeEntriesResult } from './graphQlResponseHelpers'
@@ -496,7 +496,7 @@ describe('Search', () => {
             }),
         }
 
-        test.only('Streaming search with single repo result', async () => {
+        test('Streaming search with single repo result', async () => {
             const searchStreamEvents: SearchEvent[] = [
                 { type: 'repomatches', data: [{ repository: 'github.com/sourcegraph/sourcegraph' }] },
                 { type: 'done', data: {} },


### PR DESCRIPTION
Mocking streaming search events in integration tests in a kinda hacky way. PollyJS doesn't seem to support keeping requests alive, so all events need to sent at once. Note that due to our current implementation of streaming search ('fake streaming'), the `done` event needs to be sent and we can't (yet) test partial results.