### PR TITLE
Automatically clean orphaned asdf directories

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -7,21 +7,21 @@ ORPHAN_ASDF=()
 mapfile ORPHAN_ASDF < <(find "$HOME/.asdf/installs/" -maxdepth 2 -empty)
 
 for dir in "${ORPHAN_ASDF[@]}"; do
-  echo "Removing orphaned .asdf directory: ${dir}"
-  rm -rf "${dir}"
+    echo "Removing orphaned .asdf directory: ${dir}"
+    rm -rf "${dir}"
 done
 
 TOOL_VERSION_FILES=()
 mapfile -d $'\0' TOOL_VERSION_FILES < <(fd .tool-versions --hidden --absolute-path --print0)
 
 for file in "${TOOL_VERSION_FILES[@]}"; do
-  echo "Installing asdf dependencies as defined in ${file}:"
-  parent=$(dirname "${file}")
-  pushd "${parent}"
+    echo "Installing asdf dependencies as defined in ${file}:"
+    parent=$(dirname "${file}")
+    pushd "${parent}"
 
-  asdf install
+    asdf install
 
-  popd
+    popd
 done
 
 popd

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,17 +3,25 @@
 set -eu
 pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
+ORPHAN_ASDF=()
+mapfile ORPHAN_ASDF < <(find "$HOME/.asdf/installs/" -maxdepth 2 -empty)
+
+for dir in "${ORPHAN_ASDF[@]}"; do
+  echo "Removing orphaned .asdf directory: ${dir}"
+  rm -rf "${dir}"
+done
+
 TOOL_VERSION_FILES=()
 mapfile -d $'\0' TOOL_VERSION_FILES < <(fd .tool-versions --hidden --absolute-path --print0)
 
 for file in "${TOOL_VERSION_FILES[@]}"; do
-    echo "Installing asdf dependencies as defined in ${file}:"
-    parent=$(dirname "${file}")
-    pushd "${parent}"
+  echo "Installing asdf dependencies as defined in ${file}:"
+  parent=$(dirname "${file}")
+  pushd "${parent}"
 
-    asdf install
+  asdf install
 
-    popd
+  popd
 done
 
 popd


### PR DESCRIPTION
Some agents had empty `asdf` version folder, which is used to verified if a version needs to be installed, this lead to multiple CI jobs failing because `go` was actually missing.

This setups up a cleanup job before running `asdf install` which should clean empty folders, although it will not catch other bad installation scenarios. Ideally ephemeral nodes should fix this problem.