### PR TITLE
Only update text model when blob loads

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -37,6 +37,7 @@ import { ThemeProps } from '../../../../shared/src/theme'
 import { LineDecorationAttachment } from './LineDecorationAttachment'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { HoverThresholdProps } from '../RepoContainer'
+import { File2 } from '../../../../shared/src/graphql/schema'
 
 /**
  * toPortalID builds an ID that will be used for the {@link LineDecorationAttachment} portal containers.
@@ -52,8 +53,7 @@ interface BlobProps
         HoverThresholdProps,
         ExtensionsControllerProps,
         ThemeProps {
-    /** The raw content of the blob. */
-    content: string
+    blob: File2
 
     /** The trusted syntax-highlighted code as HTML */
     html: string
@@ -291,12 +291,10 @@ export class Blob extends React.Component<BlobProps, BlobState> {
 
         /** Emits when the URL's target blob (repository, revision, path, and content) changes. */
         const modelChanges: Observable<
-            AbsoluteRepoFile & ModeSpec & Pick<BlobProps, 'content' | 'isLightTheme'>
+            AbsoluteRepoFile & ModeSpec & Pick<BlobProps, 'blob' | 'isLightTheme'>
         > = this.componentUpdates.pipe(
-            map(props =>
-                pick(props, 'repoName', 'revision', 'commitID', 'filePath', 'mode', 'content', 'isLightTheme')
-            ),
-            distinctUntilChanged((a, b) => isEqual(a, b)),
+            map(props => pick(props, 'repoName', 'revision', 'commitID', 'filePath', 'mode', 'blob', 'isLightTheme')),
+            distinctUntilChanged((a, b) => isEqual(a, b) || a.blob === b.blob),
             share()
         )
 
@@ -308,7 +306,7 @@ export class Blob extends React.Component<BlobProps, BlobState> {
                     this.props.extensionsController.services.model.addModel({
                         uri,
                         languageId: model.mode,
-                        text: model.content,
+                        text: model.blob.content,
                     })
                 }
                 this.props.extensionsController.services.viewer.removeAllViewers()

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -299,7 +299,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                 <Blob
                     {...props}
                     className="blob-page__blob test-repo-blob"
-                    content={blobOrError.content}
+                    blob={blobOrError}
                     html={blobOrError.highlight.html}
                     wrapCode={wrapCode}
                     renderMode={renderMode}


### PR DESCRIPTION
Fix #14965.

<details>
<summary>Before (starts on windows.ts)</summary>
<img src="https://user-images.githubusercontent.com/37420160/97504452-48d49680-194d-11eb-97cc-08c6ca2c4be6.gif" />
</details>

<details>
<summary>After (starts on windows.ts)</summary>
<img src="https://user-images.githubusercontent.com/37420160/97504459-4c681d80-194d-11eb-97ae-57a934061733.gif" />
</details>

Tested with a mock extension that decorates lines with absolute import paths. Note that it used to decorate lines with relative import paths on which the previous file had absolute import paths.

Fix: Only emit `modelChanges` when `blobOrError` has updated. Previously, since `blobOrError` is only updated after file info, some emitted models had the `AbsoluteRepoFile` data of the currently viewed file but the text content of the previously viewed file.

What happened when `blobOrError` loaded? The [model service already had an entry for the inaccurate model](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d727380fc0f2e0627d50484d1dcf462c8b5cece7/-/blob/client/web/src/repo/blob/Blob.tsx#L307), so extensions never saw the real text content.

We can't compare `blobOrError.content` since some files may actually have the same text content, in which case `modelChanges` wouldn't emit. 