### PR TITLE
search: refactor pattern scanner to recognize NOT keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - OAuth login now respects site configuration `experimentalFeatures: { "tls.external": {...} }` for custom certificates and skipping TLS verify. [#14144](https://github.com/sourcegraph/sourcegraph/issues/14144)
 - If the `HEAD` file in a cloned repo is absent or truncated, background cleanup activities will use a best-effort default to remedy the situation. [#14962](https://github.com/sourcegraph/sourcegraph/pull/14962)
 - Search input will always show suggestions. Previously we only showed suggestions for letters and some special characters. [#14982](https://github.com/sourcegraph/sourcegraph/pull/14982)
+- Fixed an issue where `not` keywords were not recognized inside expression groups, and treated incorrectly as patterns. [#15139](https://github.com/sourcegraph/sourcegraph/pull/15139)
 
 ### Removed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -597,6 +597,18 @@ func TestSearch(t *testing.T) {
 				query: `repo:^github\.com/sgtest/go-diff file:^diff/print\.go Bytes() and Time() patterntype:literal`,
 			},
 			{
+				name:  `Literals, simple not keyword inside group`,
+				query: `repo:^github\.com/sgtest/go-diff$ (not .svg) patterntype:literal`,
+			},
+			{
+				name:  `Literals, not keyword and implicit and inside group`,
+				query: `repo:^github\.com/sgtest/go-diff$ (a/foo not .svg) patterntype:literal`,
+			},
+			{
+				name:  `Literals, not and and keyword inside group`,
+				query: `repo:^github\.com/sgtest/go-diff$ (a/foo and not .svg) patterntype:literal`,
+			},
+			{
 				name:  `Dangling right parens, supported via content: filter`,
 				query: `repo:^github\.com/sgtest/go-diff$ content:"diffPath)" and main patterntype:literal`,
 			},

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -66,13 +66,10 @@ type Operator struct {
 }
 
 func (node Pattern) String() string {
-	var v string
 	if node.Negated {
-		v = fmt.Sprintf("NOT %s", node.Value)
-	} else {
-		v = node.Value
+		return fmt.Sprintf("(not %s)", strconv.Quote(node.Value))
 	}
-	return strconv.Quote(v)
+	return strconv.Quote(node.Value)
 }
 
 func (node Parameter) String() string {
@@ -237,7 +234,8 @@ func (p *parser) matchKeyword(keyword keyword) bool {
 
 // matchUnaryKeyword is like match but expects the keyword to be followed by whitespace.
 func (p *parser) matchUnaryKeyword(keyword keyword) bool {
-	if p.pos != 0 && !isSpace(p.buf[p.pos-1:p.pos]) {
+	if p.pos != 0 && !(isSpace(p.buf[p.pos-1:p.pos]) || p.buf[p.pos-1] == '(') {
+		// "not" must be preceded by a space or ( anywhere except the beginning of the string
 		return false
 	}
 	v, err := p.peek(len(string(keyword)))
@@ -291,17 +289,25 @@ func ScanAnyPattern(buf []byte) (scanned string, count int) {
 	return scanned, count
 }
 
-// isField returns whether the prefix of the buf matches a recognized field.
-func isField(buf []byte) bool {
-	field, _, _ := ScanField(buf)
-	return field != ""
-}
-
-// ScanBalancedPattern attempts to scan parentheses as literal patterns.
-// It returns the scanned string, how much to advance, and whether it succeeded.
-// Basically it scans any literal string, including whitespace, but ensures that
-// a resulting string does not contain 'and' or 'or keywords, nor parameters, and
-// is balanced.
+// ScanBalancedPattern attempts to scan parentheses as literal patterns. This
+// ensures that we interpret patterns containing parentheses _as patterns_ and not
+// groups. For example, it accepts these patterns:
+//
+// ((a|b)|c)              - a regular expression with balanced parentheses for grouping
+// myFunction(arg1, arg2) - a literal string with parens that should be literally interpreted
+// foo(...)               - a structural search pattern
+//
+// If it weren't for this scanner, the above parentheses would have to be
+// interpreted as part of the query language group syntax, like these:
+//
+// (foo or (bar and baz))
+//
+// So, this scanner detects parentheses as patterns without needing the user to
+// explicitly escape them. As such, there are cases where this scanner should
+// not succeed:
+//
+// (foo or (bar and baz)) - a valid query with and/or expression groups in the query langugae
+// (repo:foo bar baz)     - a valid query containing a recognized repo: field. Here parentheses are interpreted as a group, not a pattern.
 func ScanBalancedPattern(buf []byte) (scanned string, count int, ok bool) {
 	var advance, balanced int
 	var r rune
@@ -314,7 +320,31 @@ func ScanBalancedPattern(buf []byte) (scanned string, count int, ok bool) {
 		return r
 	}
 
-	var token []byte
+	// looks ahead to see if there are any recognized fields or operators.
+	keepScanning := func() bool {
+		if field, _, _ := ScanField(buf); field != "" {
+			// This "pattern" contains a recognized field, reject it.
+			return false
+		}
+		lookahead := func(v string) bool {
+			if len(buf) < len(v) {
+				return false
+			}
+			lookaheadStr := string(buf[:len(v)])
+			return strings.EqualFold(lookaheadStr, v)
+		}
+		if lookahead("and ") ||
+			lookahead("or ") ||
+			lookahead("not ") {
+			// This "pattern" contains a recognized keyword, reject it.
+			return false
+		}
+		return true
+	}
+
+	if !keepScanning() {
+		return "", 0, false
+	}
 
 loop:
 	for len(buf) > 0 {
@@ -327,6 +357,9 @@ loop:
 			count = start
 			break loop
 		case r == '(':
+			if !keepScanning() {
+				return "", 0, false
+			}
 			balanced++
 			result = append(result, r)
 		case r == ')':
@@ -341,11 +374,9 @@ loop:
 			}
 			result = append(result, r)
 		case unicode.IsSpace(r):
-			if isField(token) {
-				// This is not a pattern, one of the tokens match a field.
+			if !keepScanning() {
 				return "", 0, false
 			}
-			token = []byte{}
 
 			// We see a space and the pattern is unbalanced, so assume this
 			// this space is still part of the pattern.
@@ -363,23 +394,11 @@ loop:
 			}
 			result = append(result, r)
 		default:
-			token = append(token, []byte(string(r))...)
 			result = append(result, r)
 		}
 	}
 
-	if isField(token) {
-		// This is not a pattern, one of the tokens match a field.
-		return "", 0, false
-	}
-
-	scanned = string(result)
-	if ContainsAndOrKeyword(scanned) {
-		// Reject if we scanned 'and' or 'or'. Preceding parentheses
-		// likely refer to a group, not a pattern.
-		return "", 0, false
-	}
-	return scanned, count, balanced == 0
+	return string(result), count, balanced == 0
 }
 
 // ScanDelimited takes a delimited (e.g., quoted) value for some arbitrary

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -66,14 +66,6 @@ func containsField(nodes []Node, field string) bool {
 	})
 }
 
-// ContainsAndOrKeyword returns true if this query contains or- or and-
-// keywords. It is a temporary signal to determine whether we can fallback to
-// the older existing search functionality.
-func ContainsAndOrKeyword(input string) bool {
-	lower := strings.ToLower(input)
-	return strings.Contains(lower, " and ") || strings.Contains(lower, " or ")
-}
-
 // ContainsRegexpMetasyntax returns true if a string is a valid regular
 // expression and contains regex metasyntax (i.e., it is not a literal).
 func ContainsRegexpMetasyntax(input string) bool {

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -273,18 +273,6 @@ func TestPartitionSearchPattern(t *testing.T) {
 	}
 }
 
-func TestContainsAndOrKeyword(t *testing.T) {
-	if !ContainsAndOrKeyword("foo OR bar") {
-		t.Errorf("Expected query to contain keyword")
-	}
-	if !ContainsAndOrKeyword("repo:foo AND bar") {
-		t.Errorf("Expected query to contain keyword")
-	}
-	if ContainsAndOrKeyword("repo:foo bar") {
-		t.Errorf("Did not expect query to contain keyword")
-	}
-}
-
 func TestForAll(t *testing.T) {
 	nodes := []Node{
 		Parameter{Field: "repo", Value: "foo"},


### PR DESCRIPTION
A clean up of `ScanBalancedPattern` that addresses an issue with `not` I found along the way:

- `(foo not bar)` -> `not` keywords inside parentheses were not treated as keywords, but patterns
- `(not foo)` -> extra scanner handling to detect when `not` keyword happens after an opening paren

I've documented the `ScanBalancedPattern` more clearly because it's really the crux of making patterns play nice with our own language syntax. The same logic has to go in the frontend parser, which is why I did a pass on this.

