### PR TITLE
search: test concat substitution with negated patterns

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -496,9 +496,11 @@ func space(patterns []Pattern) Pattern {
 }
 
 // substituteConcat returns a function that concatenates all contiguous patterns
-// in the tree, rooted by a concat operator. The callback parameter defines how
-// the function concatenates patterns. The return value of callback is
-// substituted in-place in the tree.
+// in the tree, rooted by a concat operator. Concat operators containing negated
+// patterns are lifted out: (concat "a" (not "b")) -> ("a" (not "b"))
+//
+// The callback parameter defines how the function concatenates patterns. The
+// return value of callback is substituted in-place in the tree.
 func substituteConcat(callback func([]Pattern) Pattern) func(nodes []Node) []Node {
 	isPattern := func(node Node) bool {
 		if pattern, ok := node.(Pattern); ok && !pattern.Negated {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -271,6 +271,11 @@ func TestSubstituteConcat(t *testing.T) {
 			concat: fuzzyRegexp,
 			want:   `"(a).*?(b)" (and "c" "d") "(e).*?(f)" (or "g" "h") "(i j k)"`,
 		},
+		{
+			input:  "(a not b not c d)",
+			concat: space,
+			want:   `"a" (not "b") (not "c") "d"`,
+		},
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {


### PR DESCRIPTION
Stacked on #15139.

No changes to behavior, just expanded documentation and a test for currently untested behavior after https://github.com/sourcegraph/sourcegraph/pull/15139.

The `substituteConcat` function has an auxiliary role in transformer trees like:

```
(concat "a" (not "b")) -> ("a" (not "b"))
```

This is important because our evaluator doesn't need to know how to evaluate this `concat` expression.