### PR TITLE
search: invalidate repo cache for expressions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1079,21 +1079,19 @@ func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchR
 	return result, nil
 }
 
-// setRepoCacheInvalidation sets whether resolved repos should be invalidated when
+// invalidateRepoCache returns whether resolved repos should be invalidated when
 // evaluating subexpressions. If a query contains more than one repo or repogroup
 // field, we should invalidate resolved repos, since multiple repo or repogroups
 // imply that different repos may need to be resolved.
-func (r *searchResolver) setRepoCacheInvalidation() {
+func invalidateRepoCache(q []query.Node) bool {
 	var seenRepo, seenRepoGroup int
-	query.VisitField(r.query.(*query.AndOrQuery).Query, "repo", func(_ string, _ bool, _ query.Annotation) {
+	query.VisitField(q, "repo", func(_ string, _ bool, _ query.Annotation) {
 		seenRepo += 1
 	})
-	query.VisitField(r.query.(*query.AndOrQuery).Query, "repogroup", func(_ string, _ bool, _ query.Annotation) {
+	query.VisitField(q, "repogroup", func(_ string, _ bool, _ query.Annotation) {
 		seenRepoGroup += 1
 	})
-	if seenRepo+seenRepoGroup > 1 {
-		r.invalidateRepoCache = true
-	}
+	return seenRepo+seenRepoGroup > 1
 }
 
 func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolver, err error) {
@@ -1115,6 +1113,9 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 			wantCount, _ = strconv.Atoi(countStr) // Invariant: count is validated.
 		}
 
+		if invalidateRepoCache(q.Query) {
+			r.invalidateRepoCache = true
+		}
 		for _, disjunct := range query.Dnf(q.Query) {
 			disjunct = query.ConcatRevFilters(disjunct)
 			newResult, err := r.evaluate(ctx, disjunct)

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -743,6 +743,10 @@ func TestSearch(t *testing.T) {
 				name:  `Or distributive property on repo`,
 				query: `(repo:^github\.com/sgtest/go-diff$@garo/lsif-indexing-campaign:test-already-exist-pr or repo:^github\.com/sgtest/sourcegraph-typescript$) file:README.md #`,
 			},
+			{
+				name:  `Or distributive property on repo where only one repo contains match (tests repo cache is invalidated)`,
+				query: `(repo:^github\.com/sgtest/sourcegraph-typescript$ or repo:^github\.com/sgtest/go-diff$) package diff provides`,
+			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
I noticed a lint message that `setRepoCacheInvalidation()` wasn't being called, somewhere. Indeed! The repo cache was not invalidated when it needed to be.

Previously, for a query like this, there wouldn't be matches, even though there are matches in `repo:bar`:

`(repo:foo or repo:bar) pattern-that-matches-only-in-bar`

But, if you changed the order to `(repo:bar or repo:foo) pattern-that-matches-only-in-bar`, it would find a hit (`repo:bar` is in the cache).

This PR makes sure to invalidate the repos when needed, and the integration tests that there are non-zero hits for the previous failing case.

