### PR TITLE
zoekt: Configure and instrument zoekt-webserver watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - GraphQL syntax highlighting is now back (special thanks to @rvantonder) [#13935](https://github.com/sourcegraph/sourcegraph/issues/13935)
 - Campaigns now support publishing GitHub draft PRs and GitLab WIP MRs. [#7998](https://github.com/sourcegraph/sourcegraph/issues/7998)
+- `indexed-searcher`'s watchdog can be configured and has additional instrumentation. This is useful when diagnosing [zoekt-webserver is restarting due to watchdog](https://docs.sourcegraph.com/admin/observability/troubleshooting#scenario-zoekt-webserver-is-restarting-due-to-watchdog). [#15148](https://github.com/sourcegraph/sourcegraph/pull/15148)
 
 ### Changed
 

--- a/doc/admin/observability/troubleshooting.md
+++ b/doc/admin/observability/troubleshooting.md
@@ -207,6 +207,29 @@ If you are seeing this error on large scale deployments with a lot repos to be i
         262144
 1. Ensure the change will persist a system reboot by updating the `vm.max_map_count` setting in `/etc/sysctl.conf`.
 
+#### Scenario: zoekt-webserver is restarting due to watchdog
+
+zoekt-webserver has a built in watchdog which ensures it can respond to search requests. If the watchdog fails, it will panic causing the process to exit with a non-zero exit code. This is like a Kubernetes health check, but works across all our deployment environments.
+
+By default the watchdog runs every 30s. If the watchdog fails 3 consecutive times (with a 30s sleep in-between) it will trigger the panic. This is usually indicative a server which is consistently overloaded. It is recommended to increase the CPU quota assigned to it or horizontally scale to more replicas.
+
+From Sourcegraph 3.22 you can configure the watchdog via environment variables:
+
+- `ZOEKT_WATCHDOG_TICK` :: Duration of how often it runs. (default 30s)
+- `ZOEKT_WATCHDOG_ERRORS` :: Consecutive error count before exit. (default 3)
+
+If either is 0 the watchdog is disabled.
+
+You can further diagnose an overloaded zoekt-webserver via watchdog logs or metrics. See log messages mentioning watchdog, or view the following metrics in grafana:
+
+- `zoekt_webserver_watchdog_errors` :: The current error count for zoekt
+  watchdog.
+- `zoekt_webserver_watchdog_total` :: The total number of requests done by
+  zoekt watchdog.
+- `zoekt_webserver_watchdog_errors_total` :: The total number of errors from
+  zoekt watchdog.
+
+
 ## Actions
 
 This section contains various actions that can be taken to collect information or update Sourcegraph

--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ replace (
 )
 
 // We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201016122840-58ac958bfd1d
+replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201029093708-48642cac2d97
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -1260,6 +1260,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20201016122840-58ac958bfd1d h1:IG0ewsN3MgowOucyP84n+d/nXe6JGZf9q4+0Ohvue84=
 github.com/sourcegraph/zoekt v0.0.0-20201016122840-58ac958bfd1d/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
+github.com/sourcegraph/zoekt v0.0.0-20201029093708-48642cac2d97 h1:q1bkCVcIj7zFZJUSNxDzlslGWwWxeyf38DvEaT1UQ5s=
+github.com/sourcegraph/zoekt v0.0.0-20201029093708-48642cac2d97/go.mod h1:yTwy+EEnG1R+5aoAJ9ZpqEYZWRITHtG6TTEZQ7oyVsU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
We add configuration to tune how often the watchdog runs, the error
threshold as well as the ability to turn it off.

- ZOEKT_WATCHDOG_TICK :: Duration of how often it runs. (30s)
- ZOEKT_WATCHDOG_ERRORS :: Consecutive error count before exit. (3)

If either is 0 the watchdog is disabled.

Additionally we add logging around when the state of the watchdog
changes. We include metrics around the state of the watchdog. We have
noticed in practice the watchdog failing. This is likely due to an
overloaded system. The extra metrics/logging will help us see how
overloaded the system is.

See commits in the Zoekt repo
https://github.com/sourcegraph/zoekt/compare/58ac958bfd1d...48642cac2d97

- https://github.com/sourcegraph/zoekt/commit/48642ca zoekt-webserver: Configure watchdog via environment variables
- https://github.com/sourcegraph/zoekt/commit/c984eb3 zoekt-webserver: metrics and logs for watchdog

Part of https://github.com/sourcegraph/customer/issues/114