### PR TITLE
release: add release:close, rename release:publish to release:stage

### DIFF
--- a/dev/release/src/campaigns.ts
+++ b/dev/release/src/campaigns.ts
@@ -36,6 +36,10 @@ export function releaseTrackingCampaign(version: string, auth: SourcegraphAuth):
     }
 }
 
+export function campaignURL(options: CampaignOptions): string {
+    return `${options.auth.SRC_ENDPOINT}/organizations/${options.namespace}/campaigns/${options.name}`
+}
+
 interface CampaignSpec {
     name: string
     description: string
@@ -53,8 +57,7 @@ async function applyCampaign(campaign: CampaignSpec, options: CampaignOptions): 
         env: options.auth,
     })
 
-    // return the campaign URL
-    return `${options.auth.SRC_ENDPOINT}/organizations/${options.namespace}/campaigns/${options.name}`
+    return campaignURL(options)
 }
 
 export async function createCampaign(changes: CreatedChangeset[], options: CampaignOptions): Promise<string> {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/14912 with a new `release:close` announcement command (mostly a convenience for now, but can possibly attach more automation to this in the future)

To avoid confusion, rename `release:publish` to `release:stage` (since it just opens PRs, so is more a stage than a publish anyway)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
