### PR TITLE
authz: fix permissions metrics

### DIFF
--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -1538,7 +1538,7 @@ WHERE
 			SELECT users.id FROM users
 			WHERE users.deleted_at IS NULL
 		)
-AND	perms.updated_at <= %s
+AND perms.updated_at <= %s
 `, stale)
 	if err := s.execute(ctx, q, &m.UsersWithStalePerms); err != nil {
 		return nil, errors.Wrap(err, "users with stale perms")

--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -1539,7 +1539,7 @@ WHERE
 			WHERE users.deleted_at IS NULL
 		)
 AND	perms.updated_at <= %s
-`, stale) // TODO: Update tests to simulate deleted users
+`, stale)
 	if err := s.execute(ctx, q, &m.UsersWithStalePerms); err != nil {
 		return nil, errors.Wrap(err, "users with stale perms")
 	}
@@ -1553,7 +1553,7 @@ WHERE perms.user_id IN
 		SELECT users.id FROM users
 		WHERE users.deleted_at IS NULL
 	)
-`) // TODO: Update tests to simulate deleted users
+`)
 	if err := s.execute(ctx, q, &seconds); err != nil {
 		return nil, errors.Wrap(err, "users perms gap seconds")
 	}
@@ -1569,7 +1569,7 @@ WHERE perms.repo_id IN
 		AND repo.private = TRUE
 	)
 AND perms.updated_at <= %s
-`, stale) // TODO: Update tests to simulate public repos that have rows in repo_permissions
+`, stale)
 	if err := s.execute(ctx, q, &m.ReposWithStalePerms); err != nil {
 		return nil, errors.Wrap(err, "repos with stale perms")
 	}
@@ -1584,7 +1584,7 @@ WHERE perms.repo_id IN
 			repo.deleted_at IS NULL
 		AND repo.private = TRUE
 	)
-`) // TODO: Update tests to simulate public repos that have rows in repo_permissions
+`)
 	if err := s.execute(ctx, q, &seconds); err != nil {
 		return nil, errors.Wrap(err, "repos perms gap seconds")
 	}

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -2432,12 +2432,17 @@ func testPermsStore_Metrics(db *sql.DB) func(*testing.T) {
 			t.Fatal(err)
 		}
 
+		// TODO: Set up test users and repos
+
 		// Mock rows for testing
 		qs := []*sqlf.Query{
-			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 1`, clock().Add(-1*time.Minute)),
-			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 2`, clock()),
-			sqlf.Sprintf(`UPDATE repo_permissions SET updated_at = %s WHERE repo_id = 1`, clock().Add(-2*time.Minute)),
-			sqlf.Sprintf(`UPDATE repo_permissions SET updated_at = %s WHERE repo_id = 2`, clock()),
+			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 1`, clock()),
+			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 2`, clock().Add(-1*time.Minute)),
+			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 3`, clock().Add(-2*time.Minute)), // Meant to be excluded because it has been deleted
+			sqlf.Sprintf(`UPDATE repo_permissions SET updated_at = %s WHERE repo_id = 1`, clock()),
+			sqlf.Sprintf(`UPDATE repo_permissions SET updated_at = %s WHERE repo_id = 2`, clock().Add(-2*time.Minute)),
+			sqlf.Sprintf(`UPDATE repo_permissions SET updated_at = %s WHERE repo_id = 3`, clock().Add(-3*time.Minute)), // Meant to be excluded because it has been deleted
+			sqlf.Sprintf(`UPDATE repo_permissions SET updated_at = %s WHERE repo_id = 4`, clock().Add(-3*time.Minute)), // Meant to be excluded because it is public
 		}
 		for _, q := range qs {
 			if err := s.execute(ctx, q); err != nil {

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -2427,7 +2427,7 @@ func testPermsStore_Metrics(db *sql.DB) func(*testing.T) {
 			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(1, 'private_repo_1', TRUE)`),
 			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(2, 'private_repo_2', TRUE)`),
 			sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(3, 'private_repo_3', FALSE, NOW())`),
-			sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(4, 'private_repo_4', TRUE, NOW())`),
+			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(4, 'private_repo_4', TRUE)`),
 		}
 		for _, q := range qs {
 			if err := s.execute(ctx, q); err != nil {

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -2408,34 +2408,59 @@ WHERE repo_id = 2`, clock().AddDate(1, 0, 0))
 func testPermsStore_Metrics(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		s := NewPermsStore(db, clock)
-		t.Cleanup(func() {
-			cleanupPermsTables(t, s)
-		})
 
 		ctx := context.Background()
+		t.Cleanup(func() {
+			cleanupPermsTables(t, s)
 
-		// Set up some permissions
-		err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-			RepoID:  1,
-			Perm:    authz.Read,
-			UserIDs: toBitmap(1, 2),
+			if t.Failed() {
+				return
+			}
+
+			if err := s.execute(ctx, sqlf.Sprintf(`DELETE FROM repo`)); err != nil {
+				t.Fatal(err)
+			}
 		})
-		if err != nil {
-			t.Fatal(err)
+
+		// Set up repositories in various states (public/private, deleted/not, etc.)
+		qs := []*sqlf.Query{
+			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(1, 'private_repo_1', TRUE)`),
+			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(2, 'private_repo_2', TRUE)`),
+			sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(3, 'private_repo_3', FALSE, NOW())`),
+			sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(4, 'private_repo_4', TRUE, NOW())`),
 		}
-		err = s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-			RepoID:  2,
-			Perm:    authz.Read,
-			UserIDs: toBitmap(1, 2),
-		})
-		if err != nil {
-			t.Fatal(err)
+		for _, q := range qs {
+			if err := s.execute(ctx, q); err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		// TODO: Set up test users and repos
+		// Set up users in various states (deleted/not, etc.)
+		qs = []*sqlf.Query{
+			sqlf.Sprintf(`INSERT INTO users(id, username) VALUES(1, 'user1')`),
+			sqlf.Sprintf(`INSERT INTO users(id, username) VALUES(2, 'user2')`),
+			sqlf.Sprintf(`INSERT INTO users(id, username, deleted_at) VALUES(3, 'user3', NOW())`),
+		}
+		for _, q := range qs {
+			if err := s.execute(ctx, q); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Set up permissions for the various repos.
+		for i := 0; i < 4; i++ {
+			err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
+				RepoID:  int32(i),
+				Perm:    authz.Read,
+				UserIDs: toBitmap(1, 2, 3, 4),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 
 		// Mock rows for testing
-		qs := []*sqlf.Query{
+		qs = []*sqlf.Query{
 			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 1`, clock()),
 			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 2`, clock().Add(-1*time.Minute)),
 			sqlf.Sprintf(`UPDATE user_permissions SET updated_at = %s WHERE user_id = 3`, clock().Add(-2*time.Minute)), // Meant to be excluded because it has been deleted
@@ -2462,7 +2487,7 @@ func testPermsStore_Metrics(db *sql.DB) func(*testing.T) {
 			ReposPermsGapSeconds: 120,
 		}
 		if diff := cmp.Diff(expMetrics, m); diff != "" {
-			t.Fatal(diff)
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }


### PR DESCRIPTION
This updates the `PermStore` metrics to take into account whether users and repos have been deleted, made private, etc. 

fixes #14894