### PR TITLE
Disable Percy snapshot for hover overlay

### DIFF
--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -191,13 +191,14 @@ describe('Blob viewer', () => {
                     response.type('application/javascript; charset=utf-8').send(extensionBundleString)
                 })
         })
-        it('truncates long file paths properly', async function () {
+        it('truncates long file paths properly', async () => {
             await driver.page.goto(
                 `${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/this_is_a_long_file_path/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java`
             )
             await driver.page.waitForSelector('.test-repo-blob')
             await driver.page.waitForSelector('.test-breadcrumb')
-            await percySnapshot(driver.page, this.test!.fullTitle())
+            // Uncomment this snapshot once https://github.com/sourcegraph/sourcegraph/issues/15126 is resolved
+            // await percySnapshot(driver.page, this.test!.fullTitle())
         })
 
         it.skip('shows a hover overlay from a hover provider when a token is hovered', async () => {

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import { commonWebGraphQlResults } from './graphQlResults'
-import { Driver, createDriverForTest, percySnapshot } from '../../../shared/src/testing/driver'
+import { Driver, createDriverForTest } from '../../../shared/src/testing/driver'
 import { ExtensionManifest } from '../../../shared/src/schema/extensionSchema'
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import {
@@ -209,8 +209,6 @@ describe('Blob viewer', () => {
 
         it('shows a hover overlay from a hover provider and updates the URL when a token is clicked', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/blob/test.ts`)
-            await driver.page.evaluate(() => localStorage.removeItem('hover-count'))
-            await driver.page.reload()
 
             // Click on "log" in "console.log()" in line 2
             await driver.page.waitForSelector('.test-log-token', { visible: true })

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -206,7 +206,7 @@ describe('Blob viewer', () => {
             // TODO
         })
 
-        it('shows a hover overlay from a hover provider and updates the URL when a token is clicked', async function () {
+        it('shows a hover overlay from a hover provider and updates the URL when a token is clicked', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/blob/test.ts`)
             await driver.page.evaluate(() => localStorage.removeItem('hover-count'))
             await driver.page.reload()
@@ -217,7 +217,8 @@ describe('Blob viewer', () => {
 
             await driver.assertWindowLocation('/github.com/sourcegraph/test/-/blob/test.ts#L2:9')
             assert.deepStrictEqual(await getHoverContents(), ['Test hover content\n'])
-            await percySnapshot(driver.page, this.test!.fullTitle())
+            // Uncomment this snapshot once https://github.com/sourcegraph/sourcegraph/issues/15126 is resolved
+            // await percySnapshot(driver.page, this.test!.fullTitle())
         })
 
         it.skip('gets displayed when navigating to a URL with a token position', async () => {


### PR DESCRIPTION
Context in #14939 and #15126. Puppeteer instances use unique user data directories, so the localStorage race-condition theory, the last "obvious" culprit, has been debunked. Commenting out both snapshots in the `blob-viewer` test file for now.