### PR TITLE
Fix observing/parsing local storage client settings

### DIFF
--- a/client/browser/src/shared/platform/settings.ts
+++ b/client/browser/src/shared/platform/settings.ts
@@ -34,10 +34,12 @@ function observeLocalStorageKey(key: string, defaultValue: string): Observable<s
 }
 
 const createStorageSettingsCascade: () => Observable<SettingsCascade> = () => {
-    /** Observable of the JSONC string of the settings. */
+    /** Observable of the JSONC string of the settings.
+     *
+     * NOTE: We can't use LocalStorageSubject here because the JSONC string is stored raw in localStorage and LocalStorageSubject also does parsing.
+     * This could be changed, but users already have settings stored, so it would need a migration for little benefit.
+     */
     const storageObservable = isInPage
-        // NOTE: We can't use LocalStorageSubject here because the JSONC string is stored raw in localStorage and LocalStorageSubject also does parsing.
-        // This could be changed, but users already have settings stored, so it would need a migration for little benefit.
         ? observeLocalStorageKey(inPageClientSettingsKey, '{}')
         : observeStorageKey('sync', 'clientSettings')
 
@@ -48,7 +50,7 @@ const createStorageSettingsCascade: () => Observable<SettingsCascade> = () => {
         viewerCanAdminister: true,
     }
 
-    return storageSubject.pipe(
+    return storageObservable.pipe(
         map(clientSettingsString => parseJSONC(clientSettingsString || '')),
         map(clientSettings => ({
             subjects: [

--- a/client/browser/src/shared/platform/settings.ts
+++ b/client/browser/src/shared/platform/settings.ts
@@ -19,7 +19,7 @@ import { isInPage } from '../context'
 const inPageClientSettingsKey = 'sourcegraphClientSettings'
 
 /**
- * Returns an observable that emits the localStorage value for the given key on
+ * Returns an observable that emits the localStorage value (as a raw string) for the given key on
  * every storage update event, starting with the current value.
  */
 function observeLocalStorageKey(key: string, defaultValue: string): Observable<string> {
@@ -34,7 +34,10 @@ function observeLocalStorageKey(key: string, defaultValue: string): Observable<s
 }
 
 const createStorageSettingsCascade: () => Observable<SettingsCascade> = () => {
-    const storageSubject = isInPage
+    /** Observable of the JSONC string of the settings. */
+    const storageObservable = isInPage
+        // NOTE: We can't use LocalStorageSubject here because the JSONC string is stored raw in localStorage and LocalStorageSubject also does parsing.
+        // This could be changed, but users already have settings stored, so it would need a migration for little benefit.
         ? observeLocalStorageKey(inPageClientSettingsKey, '{}')
         : observeStorageKey('sync', 'clientSettings')
 

--- a/client/browser/src/shared/platform/settings.ts
+++ b/client/browser/src/shared/platform/settings.ts
@@ -1,6 +1,6 @@
 import { applyEdits, parse as parseJSONC } from '@sqs/jsonc-parser'
 import { setProperty } from '@sqs/jsonc-parser/lib/edit'
-import { BehaviorSubject, from, fromEvent, Observable } from 'rxjs'
+import { from, fromEvent, Observable } from 'rxjs'
 import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators'
 import { SettingsEdit } from '../../../../shared/src/api/client/services/settings'
 import { dataOrThrowErrors, gql } from '../../../../shared/src/graphql/graphql'


### PR DESCRIPTION
**Background**

Fix #15088 

`LocalStorageSubject` is used in the native integration to observe updates to `localStorage` for the value of `sourcegraphClientSettings` but it automatically parses the values as JSON.

This is a mismatch with the behavior of the other observer we use, `observeStorageKey` for extension storage. In `createStorageSettingsCascade` we switch between these two storage locations as if they were equivalent, based on whether we're in a browser extension or a native integration (using `isInPage`)

This caused the bug in the native integration in which we double-parse values that are coming from `LocalStorageSubject` and it throws a `e.charCodeAt is not a function` error.

**Implementation**

This change drops the usage of `LocalStorageSubject` in this particular instance, in favor of `observeLocalStorageKey` which mirrors the behavior of `observeStorageKey`.