### PR TITLE
search: add graphQL schema and stubs for code monitoring

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -1,0 +1,215 @@
+package graphqlbackend
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+
+	"github.com/graph-gophers/graphql-go"
+)
+
+// TODO: MonitorConnection
+// TODO: Events
+// TODO: in-memory store implementation
+// TODO: modification
+
+//
+// Monitor
+//
+type MonitorResolver interface {
+	ID() graphql.ID
+	CreatedBy(ctx context.Context) (*UserResolver, error)
+	CreatedAt() DateTime
+	Description() string
+	Owner(ctx context.Context) (Owner, error)
+	Trigger(ctx context.Context) (Trigger, error)
+	Actions(ctx context.Context) (ActionConnectionResolver, error)
+}
+
+type monitor struct {
+	userID graphql.ID
+}
+
+func (m *monitor) Actions(ctx context.Context) (ActionConnectionResolver, error) {
+	return &actionConnectionResolver{
+			monitorID: m.ID(),
+			userID:    m.userID}, // TODO: remove this. This is just for the stub implementation.
+		nil
+}
+
+func (m *monitor) ID() graphql.ID {
+	return graphql.ID("ID not implemented")
+}
+
+func (m *monitor) CreatedBy(ctx context.Context) (*UserResolver, error) {
+	return UserByID(ctx, m.userID)
+}
+
+func (m *monitor) CreatedAt() DateTime {
+	return DateTime{time.Now()}
+}
+
+func (m *monitor) Description() string {
+	return "description not implemented"
+}
+
+func (m *monitor) Trigger(ctx context.Context) (Trigger, error) {
+	return &trigger{&monitorQuery{monitorID: m.ID()}}, nil
+}
+
+//
+// Owner <<UNION>>
+//
+type Owner interface {
+	ToUser() (*UserResolver, bool)
+	ToOrg() (*OrgResolver, bool)
+}
+
+func (m *monitor) Owner(ctx context.Context) (Owner, error) {
+	user, err := UserByID(ctx, m.userID)
+	return &owner{user: user}, err
+}
+
+type owner struct {
+	user *UserResolver
+	org  *OrgResolver
+}
+
+func (o *owner) ToUser() (*UserResolver, bool) {
+	return o.user, o.user != nil
+}
+
+func (o *owner) ToOrg() (*OrgResolver, bool) {
+	return o.org, o.org != nil
+}
+
+//
+// Trigger
+//
+type Trigger interface {
+	ToMonitorQuery() (MonitorQueryResolver, bool)
+}
+
+type trigger struct {
+	query MonitorQueryResolver
+}
+
+func (t *trigger) ToMonitorQuery() (MonitorQueryResolver, bool) {
+	return t.query, t.query != nil
+}
+
+//
+// Query
+//
+type MonitorQueryResolver interface {
+	ID() graphql.ID
+	Query() string
+}
+
+type monitorQuery struct {
+	monitorID graphql.ID
+}
+
+func (q *monitorQuery) ID() graphql.ID {
+	return "monitorQuery ID not implemented"
+}
+
+func (q *monitorQuery) Query() string {
+	return "repo:github.com/sourcegraph/sourcegraph file:code_monitors not implemented"
+}
+
+//
+// ActionConnection
+//
+type ActionConnectionResolver interface {
+	Nodes(ctx context.Context) ([]Action, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type actionConnectionResolver struct {
+	userID    graphql.ID //  TODO: remove this. This is just for the stub implementation.
+	monitorID graphql.ID
+}
+
+func (a *actionConnectionResolver) Nodes(ctx context.Context) ([]Action, error) {
+	return []Action{&action{email: &monitorEmail{id: "42", userID: a.userID}}}, nil
+}
+
+func (a *actionConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *actionConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// Action <<UNION>>
+//
+type Action interface {
+	ToMonitorEmail() (MonitorEmailResolver, bool)
+}
+
+type action struct {
+	email MonitorEmailResolver
+}
+
+func (a *action) ToMonitorEmail() (MonitorEmailResolver, bool) {
+	return a.email, a.email != nil
+}
+
+//
+// Email
+//
+type MonitorEmailResolver interface {
+	ID() graphql.ID
+	Enabled() bool
+	Priority() string
+	Header() string
+	Recipient(ctx context.Context) (MonitorEmailRecipient, error)
+}
+
+type monitorEmail struct {
+	userID graphql.ID //  TODO: remove this. This is just for the stub implementation.
+	id     graphql.ID
+}
+
+func (m *monitorEmail) Recipient(ctx context.Context) (MonitorEmailRecipient, error) {
+	user, err := UserByID(ctx, m.userID)
+	return &monitorEmailRecipient{
+		user: user,
+	}, err
+}
+
+func (m *monitorEmail) Enabled() bool {
+	return true
+}
+
+func (m *monitorEmail) Priority() string {
+	return "NORMAL"
+}
+
+func (m *monitorEmail) Header() string {
+	return "Header not implemented"
+}
+
+func (m *monitorEmail) ID() graphql.ID {
+	return "monitorEmail ID not implemented"
+}
+
+//
+// MonitorEmailRecipient <<UNION>>
+//
+type MonitorEmailRecipient interface {
+	ToUser() (*UserResolver, bool)
+}
+
+type monitorEmailRecipient struct {
+	user *UserResolver
+}
+
+func (o *monitorEmailRecipient) ToUser() (*UserResolver, bool) {
+	return o.user, o.user != nil
+}

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TODO: add events for triggers and actions
-// TODO: in-memory store implementation
+// TODO: add mock-store
 // TODO: add mutations
 
 //

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -9,14 +9,53 @@ import (
 	"github.com/graph-gophers/graphql-go"
 )
 
-// TODO: MonitorConnection
-// TODO: Events
+// TODO: add events for triggers and actions
 // TODO: in-memory store implementation
-// TODO: modification
+// TODO: add mutations
+
+//
+// MonitorConnection
+//
+type ListMonitorsArgs struct {
+	First int32
+	After *string
+}
+
+func monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+	// TODO: fetch data
+	return &monitorConnection{userID: userID}, nil
+}
+
+type MonitorConnectionResolver interface {
+	Nodes(ctx context.Context) ([]MonitorResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type monitorConnection struct {
+	userID graphql.ID
+}
+
+func (m *monitorConnection) Nodes(ctx context.Context) ([]MonitorResolver, error) {
+	return []MonitorResolver{&monitor{userID: m.userID}}, nil
+}
+
+func (m *monitorConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (m *monitorConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
 
 //
 // Monitor
 //
+type ListActionArgs struct {
+	First int32
+	After *string
+}
+
 type MonitorResolver interface {
 	ID() graphql.ID
 	CreatedBy(ctx context.Context) (*UserResolver, error)
@@ -24,18 +63,11 @@ type MonitorResolver interface {
 	Description() string
 	Owner(ctx context.Context) (Owner, error)
 	Trigger(ctx context.Context) (Trigger, error)
-	Actions(ctx context.Context) (ActionConnectionResolver, error)
+	Actions(ctx context.Context, args *ListActionArgs) (ActionConnectionResolver, error)
 }
 
 type monitor struct {
 	userID graphql.ID
-}
-
-func (m *monitor) Actions(ctx context.Context) (ActionConnectionResolver, error) {
-	return &actionConnectionResolver{
-			monitorID: m.ID(),
-			userID:    m.userID}, // TODO: remove this. This is just for the stub implementation.
-		nil
 }
 
 func (m *monitor) ID() graphql.ID {
@@ -56,6 +88,14 @@ func (m *monitor) Description() string {
 
 func (m *monitor) Trigger(ctx context.Context) (Trigger, error) {
 	return &trigger{&monitorQuery{monitorID: m.ID()}}, nil
+}
+
+func (m *monitor) Actions(ctx context.Context, args *ListActionArgs) (ActionConnectionResolver, error) {
+	// TODO: fetch data
+	return &actionConnection{
+			monitorID: m.ID(),
+			userID:    m.userID}, // TODO: remove this. This is just for the stub implementation.
+		nil
 }
 
 //
@@ -85,7 +125,7 @@ func (o *owner) ToOrg() (*OrgResolver, bool) {
 }
 
 //
-// Trigger
+// Trigger <<UNION>>
 //
 type Trigger interface {
 	ToMonitorQuery() (MonitorQueryResolver, bool)
@@ -128,20 +168,20 @@ type ActionConnectionResolver interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type actionConnectionResolver struct {
+type actionConnection struct {
 	userID    graphql.ID //  TODO: remove this. This is just for the stub implementation.
 	monitorID graphql.ID
 }
 
-func (a *actionConnectionResolver) Nodes(ctx context.Context) ([]Action, error) {
+func (a *actionConnection) Nodes(ctx context.Context) ([]Action, error) {
 	return []Action{&action{email: &monitorEmail{id: "42", userID: a.userID}}}, nil
 }
 
-func (a *actionConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+func (a *actionConnection) TotalCount(ctx context.Context) (int32, error) {
 	return 1, nil
 }
 
-func (a *actionConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+func (a *actionConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	return graphqlutil.HasNextPage(false), nil
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -375,6 +375,21 @@ func (r *NodeResolver) ToAccessToken() (*accessTokenResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToMonitor() (MonitorResolver, bool) {
+	n, ok := r.Node.(MonitorResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToMonitorQuery() (MonitorQueryResolver, bool) {
+	n, ok := r.Node.(MonitorQueryResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToMonitorEmail() (MonitorEmailResolver, bool) {
+	n, ok := r.Node.(MonitorEmailResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToCampaign() (CampaignResolver, bool) {
 	n, ok := r.Node.(CampaignResolver)
 	return n, ok

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2868,7 +2868,7 @@ type Monitor implements Node {
     trigger: Trigger
     actions(
         """
-        Returns the first n monitors form the list
+        Returns the first n actions from the list
         """
         first: Int = 50
         """
@@ -2886,7 +2886,7 @@ type MonitorQuery implements Node {
 }
 
 """
-We will support different kinds of triggers
+Supported triggers for code monitors
 """
 union Trigger = MonitorQuery
 
@@ -2908,7 +2908,7 @@ type ActionConnection  {
 }
 
 """
-We will support different kind of actions
+Supported actions for code monitors
 """
 union Action = MonitorEmail
 
@@ -2926,7 +2926,7 @@ enum MonitorEmailPriority {
 }
 
 """
-Eventually we may add Org or arbitrary email strings
+Supported types of recipients for email actions
 """
 union MonitorEmailRecipient = User
 
@@ -5663,7 +5663,7 @@ type User implements Node & SettingsSubject & Namespace {
     """
     monitors(
         """
-        Returns the first n monitors form the list
+        Returns the first n monitors from the list
         """
         first: Int = 50
         """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2840,6 +2840,72 @@ type SavedSearch implements Node {
 }
 
 """
+CODE MONITORS
+"""
+type Monitor implements Node {
+    id: ID!
+    createdBy: User!
+    createdAt: DateTime!
+    description: String!
+    owner: Owner!
+    trigger: Trigger
+    actions: ActionConnection
+}
+
+union Owner = User | Org
+
+type MonitorQuery implements Node {
+    id: ID!
+    query: String!
+}
+
+"""
+We will support different kinds of triggers
+"""
+union Trigger = MonitorQuery
+
+type ActionConnection  {
+"""
+A list of actions.
+"""
+nodes: [Action!]!
+
+"""
+The total number of campaigns in the connection.
+"""
+totalCount: Int!
+
+"""
+Pagination information.
+"""
+pageInfo: PageInfo!
+}
+
+"""
+We will support different kind of actions
+"""
+union Action = MonitorEmail
+
+type MonitorEmail implements Node {
+    id: ID!
+    enabled: Boolean!
+    priority: MonitorEmailPriority!
+    header: String!
+    recipient: MonitorEmailRecipient!
+}
+
+enum MonitorEmailPriority {
+    NORMAL
+    CRITICAL
+}
+
+"""
+Eventually we may add Org or arbitrary email strings
+"""
+union MonitorEmailRecipient = User
+
+
+"""
 A search query description.
 """
 type SearchQueryDescription {
@@ -5380,6 +5446,7 @@ type UserConnection {
 A user.
 """
 type User implements Node & SettingsSubject & Namespace {
+    monitor: Monitor!
     """
     The unique ID for the user.
     """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2842,6 +2842,23 @@ type SavedSearch implements Node {
 """
 CODE MONITORS
 """
+type MonitorConnection  {
+    """
+    A list of monitors.
+    """
+    nodes: [Monitor!]!
+
+    """
+    The total number of monitors in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
 type Monitor implements Node {
     id: ID!
     createdBy: User!
@@ -2849,7 +2866,16 @@ type Monitor implements Node {
     description: String!
     owner: Owner!
     trigger: Trigger
-    actions: ActionConnection
+    actions(
+        """
+        Returns the first n monitors form the list
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): ActionConnection!
 }
 
 union Owner = User | Org
@@ -2865,20 +2891,20 @@ We will support different kinds of triggers
 union Trigger = MonitorQuery
 
 type ActionConnection  {
-"""
-A list of actions.
-"""
-nodes: [Action!]!
+    """
+    A list of actions.
+    """
+    nodes: [Action!]!
 
-"""
-The total number of campaigns in the connection.
-"""
-totalCount: Int!
+    """
+    The total number of actions in the connection.
+    """
+    totalCount: Int!
 
-"""
-Pagination information.
-"""
-pageInfo: PageInfo!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
 }
 
 """
@@ -5446,7 +5472,6 @@ type UserConnection {
 A user.
 """
 type User implements Node & SettingsSubject & Namespace {
-    monitor: Monitor!
     """
     The unique ID for the user.
     """
@@ -5632,6 +5657,20 @@ type User implements Node & SettingsSubject & Namespace {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+
+    """
+    A list of monitors owned by the user or her organization
+    """
+    monitors(
+        """
+        Returns the first n monitors form the list
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2840,11 +2840,7 @@ type SavedSearch implements Node {
 }
 
 """
-CODE MONITORS
-"""
-
-"""
-A list of monitors
+A list of code monitors
 """
 type MonitorConnection {
     """
@@ -2915,7 +2911,13 @@ union Owner = User | Org
 A query that can serve as a trigger for code monitors.
 """
 type MonitorQuery implements Node {
+    """
+    The unique id of a trigger query.
+    """
     id: ID!
+    """
+    A query.
+    """
     query: String!
 }
 
@@ -2925,7 +2927,7 @@ Supported triggers for code monitors.
 union MonitorTrigger = MonitorQuery
 
 """
-A list of code monitors.
+A list of actions.
 """
 type MonitorActionConnection {
     """
@@ -2974,7 +2976,7 @@ type MonitorEmail implements Node {
     """
     recipient: MonitorEmailRecipient!
 }
-    
+
 """
 The priority of an email action.
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2842,7 +2842,11 @@ type SavedSearch implements Node {
 """
 CODE MONITORS
 """
-type MonitorConnection  {
+
+"""
+A list of monitors
+"""
+type MonitorConnection {
     """
     A list of monitors.
     """
@@ -2859,42 +2863,75 @@ type MonitorConnection  {
     pageInfo: PageInfo!
 }
 
+"""
+A code monitor with one trigger and possibly many actions.
+"""
 type Monitor implements Node {
+    """
+    The code monitor's unique ID.
+    """
     id: ID!
+    """
+    The user who created the code monitor.
+    """
     createdBy: User!
+    """
+    The time at which the code monitor was created.
+    """
     createdAt: DateTime!
+    """
+    A meaningful description of the code monitor.
+    """
     description: String!
+    """
+    Owners can edit the code monitor.
+    """
     owner: Owner!
-    trigger: Trigger
+    """
+    Triggers trigger actions. There can only be one trigger per monitor.
+    """
+    trigger: MonitorTrigger
+    """
+    One or more actions that are triggered by the trigger.
+    """
     actions(
         """
-        Returns the first n actions from the list
+        Returns the first n actions from the list.
         """
         first: Int = 50
         """
         Opaque pagination cursor.
         """
         after: String
-    ): ActionConnection!
+    ): MonitorActionConnection!
 }
 
+"""
+An owner can either be an user or an organization.
+"""
 union Owner = User | Org
 
+"""
+A query that can serve as a trigger for code monitors.
+"""
 type MonitorQuery implements Node {
     id: ID!
     query: String!
 }
 
 """
-Supported triggers for code monitors
+Supported triggers for code monitors.
 """
-union Trigger = MonitorQuery
+union MonitorTrigger = MonitorQuery
 
-type ActionConnection  {
+"""
+A list of code monitors.
+"""
+type MonitorActionConnection {
     """
     A list of actions.
     """
-    nodes: [Action!]!
+    nodes: [MonitorAction!]!
 
     """
     The total number of actions in the connection.
@@ -2908,28 +2945,48 @@ type ActionConnection  {
 }
 
 """
-Supported actions for code monitors
+Supported actions for code monitors.
 """
-union Action = MonitorEmail
+union MonitorAction = MonitorEmail
 
+"""
+Email is one of the supported actions of code monitors.
+"""
 type MonitorEmail implements Node {
+    """
+    The unique id of an email action.
+    """
     id: ID!
+    """
+    Whether the email action is enabled or not.
+    """
     enabled: Boolean!
+    """
+    The priority of the email action.
+    """
     priority: MonitorEmailPriority!
+    """
+    Use header to automatically approve the message in a read-only or moderated mailing list.
+    """
     header: String!
+    """
+    The recipients of the email.
+    """
     recipient: MonitorEmailRecipient!
 }
-
+    
+"""
+The priority of an email action.
+"""
 enum MonitorEmailPriority {
     NORMAL
     CRITICAL
 }
 
 """
-Supported types of recipients for email actions
+Supported types of recipients for email actions.
 """
 union MonitorEmailRecipient = User
-
 
 """
 A search query description.
@@ -5659,11 +5716,11 @@ type User implements Node & SettingsSubject & Namespace {
     ): CampaignConnection!
 
     """
-    A list of monitors owned by the user or her organization
+    A list of monitors owned by the user or her organization.
     """
     monitors(
         """
-        Returns the first n monitors from the list
+        Returns the first n monitors from the list.
         """
         first: Int = 50
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2858,7 +2858,7 @@ type Monitor implements Node {
     createdAt: DateTime!
     description: String!
     owner: Owner!
-    trigger: Trigger
+    trigger: MonitorTrigger
     actions(
         """
         Returns the first n actions from the list.
@@ -2868,7 +2868,7 @@ type Monitor implements Node {
         Opaque pagination cursor.
         """
         after: String
-    ): ActionConnection!
+    ): MonitorActionConnection!
 }
 
 union Owner = User | Org
@@ -2881,13 +2881,13 @@ type MonitorQuery implements Node {
 """
 Supported triggers for code monitors.
 """
-union Trigger = MonitorQuery
+union MonitorTrigger = MonitorQuery
 
-type ActionConnection {
+type MonitorActionConnection {
     """
     A list of actions.
     """
-    nodes: [Action!]!
+    nodes: [MonitorAction!]!
 
     """
     The total number of actions in the connection.
@@ -2903,7 +2903,7 @@ type ActionConnection {
 """
 Supported actions for code monitors.
 """
-union Action = MonitorEmail
+union MonitorAction = MonitorEmail
 
 type MonitorEmail implements Node {
     id: ID!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2879,7 +2879,7 @@ type MonitorQuery implements Node {
 }
 
 """
-We will support different kinds of triggers
+Supported triggers for code monitors
 """
 union Trigger = MonitorQuery
 
@@ -2901,7 +2901,7 @@ type ActionConnection  {
 }
 
 """
-We will support different kind of actions
+Supported actions for code monitors
 """
 union Action = MonitorEmail
 
@@ -2919,7 +2919,7 @@ enum MonitorEmailPriority {
 }
 
 """
-Eventually we may add Org or arbitrary email strings
+Supported types of recipients for email actions
 """
 union MonitorEmailRecipient = User
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2835,6 +2835,23 @@ type SavedSearch implements Node {
 """
 CODE MONITORS
 """
+type MonitorConnection  {
+    """
+    A list of monitors.
+    """
+    nodes: [Monitor!]!
+
+    """
+    The total number of monitors in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
 type Monitor implements Node {
     id: ID!
     createdBy: User!
@@ -2842,7 +2859,16 @@ type Monitor implements Node {
     description: String!
     owner: Owner!
     trigger: Trigger
-    actions: ActionConnection
+    actions(
+        """
+        Returns the first n monitors form the list
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): ActionConnection!
 }
 
 union Owner = User | Org
@@ -2858,20 +2884,20 @@ We will support different kinds of triggers
 union Trigger = MonitorQuery
 
 type ActionConnection  {
-"""
-A list of actions.
-"""
-nodes: [Action!]!
+    """
+    A list of actions.
+    """
+    nodes: [Action!]!
 
-"""
-The total number of campaigns in the connection.
-"""
-totalCount: Int!
+    """
+    The total number of actions in the connection.
+    """
+    totalCount: Int!
 
-"""
-Pagination information.
-"""
-pageInfo: PageInfo!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
 }
 
 """
@@ -5439,7 +5465,6 @@ type UserConnection {
 A user.
 """
 type User implements Node & SettingsSubject & Namespace {
-    monitor: Monitor!
     """
     The unique ID for the user.
     """
@@ -5625,6 +5650,20 @@ type User implements Node & SettingsSubject & Namespace {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+
+    """
+    A list of monitors owned by the user or her organization
+    """
+    monitors(
+        """
+        Returns the first n monitors form the list
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2833,7 +2833,7 @@ type SavedSearch implements Node {
 }
 
 """
-CODE MONITORS
+A list of code monitors
 """
 type MonitorConnection {
     """
@@ -2852,13 +2852,37 @@ type MonitorConnection {
     pageInfo: PageInfo!
 }
 
+"""
+A code monitor with one trigger and possibly many actions.
+"""
 type Monitor implements Node {
+    """
+    The code monitor's unique ID.
+    """
     id: ID!
+    """
+    The user who created the code monitor.
+    """
     createdBy: User!
+    """
+    The time at which the code monitor was created.
+    """
     createdAt: DateTime!
+    """
+    A meaningful description of the code monitor.
+    """
     description: String!
+    """
+    Owners can edit the code monitor.
+    """
     owner: Owner!
+    """
+    Triggers trigger actions. There can only be one trigger per monitor.
+    """
     trigger: MonitorTrigger
+    """
+    One or more actions that are triggered by the trigger.
+    """
     actions(
         """
         Returns the first n actions from the list.
@@ -2871,8 +2895,14 @@ type Monitor implements Node {
     ): MonitorActionConnection!
 }
 
+"""
+An owner can either be an user or an organization.
+"""
 union Owner = User | Org
 
+"""
+A query that can serve as a trigger for code monitors.
+"""
 type MonitorQuery implements Node {
     id: ID!
     query: String!
@@ -2883,6 +2913,9 @@ Supported triggers for code monitors.
 """
 union MonitorTrigger = MonitorQuery
 
+"""
+A list of actions.
+"""
 type MonitorActionConnection {
     """
     A list of actions.
@@ -2905,14 +2938,35 @@ Supported actions for code monitors.
 """
 union MonitorAction = MonitorEmail
 
+"""
+Email is one of the supported actions of code monitors.
+"""
 type MonitorEmail implements Node {
+    """
+    The unique id of an email action.
+    """
     id: ID!
+    """
+    Whether the email action is enabled or not.
+    """
     enabled: Boolean!
+    """
+    The priority of the email action.
+    """
     priority: MonitorEmailPriority!
+    """
+    Use header to automatically approve the message in a read-only or moderated mailing list.
+    """
     header: String!
+    """
+    The recipients of the email.
+    """
     recipient: MonitorEmailRecipient!
 }
 
+"""
+The priority of an email action.
+"""
 enum MonitorEmailPriority {
     NORMAL
     CRITICAL

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2861,7 +2861,7 @@ type Monitor implements Node {
     trigger: Trigger
     actions(
         """
-        Returns the first n monitors form the list
+        Returns the first n actions from the list
         """
         first: Int = 50
         """
@@ -5656,7 +5656,7 @@ type User implements Node & SettingsSubject & Namespace {
     """
     monitors(
         """
-        Returns the first n monitors form the list
+        Returns the first n monitors from the list
         """
         first: Int = 50
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2861,7 +2861,7 @@ type Monitor implements Node {
     trigger: Trigger
     actions(
         """
-        Returns the first n actions from the list
+        Returns the first n actions from the list.
         """
         first: Int = 50
         """
@@ -2879,7 +2879,7 @@ type MonitorQuery implements Node {
 }
 
 """
-Supported triggers for code monitors
+Supported triggers for code monitors.
 """
 union Trigger = MonitorQuery
 
@@ -2901,7 +2901,7 @@ type ActionConnection {
 }
 
 """
-Supported actions for code monitors
+Supported actions for code monitors.
 """
 union Action = MonitorEmail
 
@@ -2919,7 +2919,7 @@ enum MonitorEmailPriority {
 }
 
 """
-Supported types of recipients for email actions
+Supported types of recipients for email actions.
 """
 union MonitorEmailRecipient = User
 
@@ -5651,11 +5651,11 @@ type User implements Node & SettingsSubject & Namespace {
     ): CampaignConnection!
 
     """
-    A list of monitors owned by the user or her organization
+    A list of monitors owned by the user or her organization.
     """
     monitors(
         """
-        Returns the first n monitors from the list
+        Returns the first n monitors from the list.
         """
         first: Int = 50
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2833,6 +2833,72 @@ type SavedSearch implements Node {
 }
 
 """
+CODE MONITORS
+"""
+type Monitor implements Node {
+    id: ID!
+    createdBy: User!
+    createdAt: DateTime!
+    description: String!
+    owner: Owner!
+    trigger: Trigger
+    actions: ActionConnection
+}
+
+union Owner = User | Org
+
+type MonitorQuery implements Node {
+    id: ID!
+    query: String!
+}
+
+"""
+We will support different kinds of triggers
+"""
+union Trigger = MonitorQuery
+
+type ActionConnection  {
+"""
+A list of actions.
+"""
+nodes: [Action!]!
+
+"""
+The total number of campaigns in the connection.
+"""
+totalCount: Int!
+
+"""
+Pagination information.
+"""
+pageInfo: PageInfo!
+}
+
+"""
+We will support different kind of actions
+"""
+union Action = MonitorEmail
+
+type MonitorEmail implements Node {
+    id: ID!
+    enabled: Boolean!
+    priority: MonitorEmailPriority!
+    header: String!
+    recipient: MonitorEmailRecipient!
+}
+
+enum MonitorEmailPriority {
+    NORMAL
+    CRITICAL
+}
+
+"""
+Eventually we may add Org or arbitrary email strings
+"""
+union MonitorEmailRecipient = User
+
+
+"""
 A search query description.
 """
 type SearchQueryDescription {
@@ -5373,6 +5439,7 @@ type UserConnection {
 A user.
 """
 type User implements Node & SettingsSubject & Namespace {
+    monitor: Monitor!
     """
     The unique ID for the user.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2904,7 +2904,13 @@ union Owner = User | Org
 A query that can serve as a trigger for code monitors.
 """
 type MonitorQuery implements Node {
+    """
+    The unique id of a trigger query.
+    """
     id: ID!
+    """
+    A query.
+    """
     query: String!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2835,7 +2835,7 @@ type SavedSearch implements Node {
 """
 CODE MONITORS
 """
-type MonitorConnection  {
+type MonitorConnection {
     """
     A list of monitors.
     """
@@ -2883,7 +2883,7 @@ Supported triggers for code monitors
 """
 union Trigger = MonitorQuery
 
-type ActionConnection  {
+type ActionConnection {
     """
     A list of actions.
     """
@@ -2922,7 +2922,6 @@ enum MonitorEmailPriority {
 Supported types of recipients for email actions
 """
 union MonitorEmailRecipient = User
-
 
 """
 A search query description.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -341,6 +341,9 @@ func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 	return backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
 }
 
-func (r *UserResolver) Monitor(ctx context.Context) (MonitorResolver, error) {
-	return &monitor{userID: r.ID()}, nil
+func (r *UserResolver) Monitors(ctx context.Context, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+		return nil, err
+	}
+	return monitors(ctx, r.ID(), args)
 }

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -340,3 +340,7 @@ func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 	// 🚨 SECURITY: Only site admins are allowed to change a user's username when auth.enableUsernameChanges == false.
 	return backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
 }
+
+func (r *UserResolver) Monitor(ctx context.Context) (MonitorResolver, error) {
+	return &monitor{userID: r.ID()}, nil
+}


### PR DESCRIPTION
This PR adds code-monitors to our GraphQL schema. The goal is to first merge a stub implementation to unlock frontend work. 

The schema follows [this design](https://drive.google.com/file/d/1pNwzYTbt46IeH3S0RuiUrC69K9xxdldM/view?usp=sharing). There are still some things missing (events, mutations, mock-store), but I wanted to break it down to limit the size of the PRs. 

For the review, I think the most important parts are the changes to the `schema.graphql` and `user.go`.

Here is an example of a query that will work:
```
{
  user(username: "stefan") {
    monitors(first: 1) {
      nodes {
        id
        createdBy {
          username
        }
        createdAt
        description
        owner {
          __typename
          ... on User {
            username
          }
        }
        trigger {
          __typename
          ... on MonitorQuery {
            query
          }
        }
        actions(first: 1) {
          nodes {
            ... on MonitorEmail {
              recipient {
                __typename
                ... on User {
                  username
                }
              }
              priority
              enabled
              header
            }
          }
          totalCount
        }
      }
      totalCount
    }
  }
}
```


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
