### PR TITLE
Bump src-cli MinimumVersion to newest release

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.21.2"
+const MinimumVersion = "3.21.5"


### PR DESCRIPTION
Release 3.21.5 contains the experimental templating support.