### PR TITLE
search: parameterize quoted parser with delimiter

### DIFF
--- a/client/shared/src/search/parser/parser.test.ts
+++ b/client/shared/src/search/parser/parser.test.ts
@@ -268,8 +268,30 @@ describe('parseSearchQuery()', () => {
         })
     })
 
-    test('quoted', () =>
+    test('quoted, double quotes', () =>
         expect(parseSearchQuery('"a:b"')).toMatchObject({
+            token: {
+                range: {
+                    end: 5,
+                    start: 0,
+                },
+                members: [
+                    {
+                        range: {
+                            end: 5,
+                            start: 0,
+                        },
+                        quotedValue: 'a:b',
+                        type: 'quoted',
+                    },
+                ],
+                type: 'sequence',
+            },
+            type: 'success',
+        }))
+
+    test('quoted, single quotes', () =>
+        expect(parseSearchQuery("'a:b'")).toMatchObject({
             token: {
                 range: {
                     end: 5,


### PR DESCRIPTION
Stacked on #15201. This generalizes the `quoted` scanner to accept arbitrary delimiters--before we only recognized double-quoted delimited strings. We need to recognize three delimited values:

- `"double quotes"`
- `'single quotes'`
- `/regexp-string/`

Added a test case for single quotes, the `/.../` case will come later.