### PR TITLE
search frontend: add balanced pattern scanner

### DIFF
--- a/client/shared/src/search/parser/parser.test.ts
+++ b/client/shared/src/search/parser/parser.test.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { parseSearchQuery, scanBalancedPattern } from './parser'
 
 expect.addSnapshotSerializer({
-    serialize: (value, _config, _indentation, _depth, _references, _printer) => JSON.stringify(value),
-    test: _value => true,
+    serialize: value => JSON.stringify(value),
+    test: () => true,
 })
 
 describe('scanBalancedPattern()', () => {
@@ -27,37 +26,43 @@ describe('scanBalancedPattern()', () => {
 
     test('not recognized, contains not operator', () => {
         expect(scanBalancedPattern('(foo not bar)', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"not recognized filter or operator","at":5}'
+            '{"type":"error","expected":"no recognized filter or operator","at":5}'
         )
     })
 
     test('not recognized, starts with a not operator', () => {
         expect(scanBalancedPattern('(not chocolate)', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"not a recognized filter or operator","at":1}'
+            '{"type":"error","expected":"no recognized filter or operator","at":1}'
         )
     })
 
     test('not recognized, contains an or operator', () => {
         expect(scanBalancedPattern('(foo OR bar)', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"not recognized filter or operator","at":5}'
+            '{"type":"error","expected":"no recognized filter or operator","at":5}'
         )
     })
 
-    test('not recognized, contains an and oeprator', () => {
+    test('not recognized, contains an and operator', () => {
         expect(scanBalancedPattern('repo:foo AND bar', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"not a recognized filter or operator","at":0}'
+            '{"type":"error","expected":"no recognized filter or operator","at":0}'
         )
     })
 
     test('not recognized, contains a recognized repo field', () => {
         expect(scanBalancedPattern('repo:foo bar', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"not a recognized filter or operator","at":0}'
+            '{"type":"error","expected":"no recognized filter or operator","at":0}'
         )
     })
 
     test('balanced, no conflicting tokens', () => {
         expect(scanBalancedPattern('(bor band )', 0)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"literal","range":{"start":0,"end":11},"value":"(bor band )"}}'
+        )
+    })
+
+    test('not recognized, unbalanced', () => {
+        expect(scanBalancedPattern('foo(', 0)).toMatchInlineSnapshot(
+            '{"type":"error","expected":"no unbalanced parentheses","at":4}'
         )
     })
 })

--- a/client/shared/src/search/parser/parser.ts
+++ b/client/shared/src/search/parser/parser.ts
@@ -272,122 +272,6 @@ const scanToken = <T extends Term = Literal>(
     }
 }
 
-const keepScanning = (input: string, start: number): boolean => {
-    const result = oneOf<Literal | Sequence>(filterKeyword, followedBy(operator, whitespace))(input, start)
-    return result.type !== 'success'
-}
-
-/**
- * ScanBalancedPattern attempts to scan parentheses as literal patterns. This
- * ensures that we interpret patterns containing parentheses _as patterns_ and not
- * groups. For example, it accepts these patterns:
- *
- * ((a|b)|c)              - a regular expression with balanced parentheses for grouping
- * myFunction(arg1, arg2) - a literal string with parens that should be literally interpreted
- * foo(...)               - a structural search pattern
- *
- * If it weren't for this scanner, the above parentheses would have to be
- * interpreted as part of the query language group syntax, like these:
- *
- * (foo or (bar and baz))
- *
- * So, this scanner detects parentheses as patterns without needing the user to
- * explicitly escape them. As such, there are cases where this scanner should
- * not succeed:
- *
- * (foo or (bar and baz)) - a valid query with and/or expression groups in the query langugae
- * (repo:foo bar baz)     - a valid query containing a recognized repo: field. Here parentheses are interpreted as a group, not a pattern.
- */
-export const scanBalancedPattern: Parser<Literal> = (input, start) => {
-    let adjustedStart = start
-    let balanced = 0
-    let current = ''
-    const result: string[] = []
-
-    const nextChar = (): string => {
-        current = input[adjustedStart]
-        adjustedStart++
-        return current
-    }
-
-    if (!keepScanning(input, start)) {
-        return {
-            type: 'error',
-            expected: 'not a recognized filter or operator',
-            at: start,
-        }
-    }
-
-    while (input[adjustedStart] !== undefined) {
-        current = nextChar()
-        if (current === ' ' && balanced === 0) {
-            // Stop scanning a potential pattern when we see whitespace in a balanced state.
-            adjustedStart-- // Backtrack.
-            break
-        } else if (current === '(') {
-            if (!keepScanning(input, adjustedStart)) {
-                return {
-                    type: 'error',
-                    expected: 'not a recognized filter or operator',
-                    at: adjustedStart,
-                }
-            }
-            balanced++
-            result.push(current)
-        } else if (current === ')') {
-            balanced--
-            if (balanced < 0) {
-                // This paren is an unmatched closing paren, so we stop treating it as a potential
-                // pattern here--it might be closing a group.
-                adjustedStart-- // Backtrack.
-                balanced = 0 // Pattern is balanced up to this point
-                break
-            }
-            result.push(current)
-        } else if (current === ' ') {
-            if (!keepScanning(input, adjustedStart)) {
-                return {
-                    type: 'error',
-                    expected: 'not recognized filter or operator',
-                    at: adjustedStart,
-                }
-            }
-            result.push(current)
-        } else if (current === '\\') {
-            if (input[adjustedStart] !== undefined) {
-                current = nextChar()
-                // Accept anything anything escaped. The point is to consume escaped spaces like "\ "
-                // so that we don't recognize it as terminating a pattern.
-                result.push('\\', current)
-                continue
-            }
-            result.push(current)
-        } else {
-            result.push(current)
-        }
-    }
-
-    if (balanced !== 0) {
-        return {
-            type: 'error',
-            expected: 'not unbalanced parentheses',
-            at: adjustedStart,
-        }
-    }
-
-    return {
-        type: 'success',
-        token: {
-            type: 'literal',
-            range: {
-                start,
-                end: adjustedStart,
-            },
-            value: result.join(''),
-        },
-    }
-}
-
 const whitespace = scanToken(
     /\s+/,
     (_input, range): Whitespace => ({
@@ -472,6 +356,120 @@ const filter: Parser<Filter> = (input, start) => {
             range: { start, end: parsedValue ? parsedValue.token.range.end : parsedDelimiter.token.range.end },
             filterType: parsedKeyword.token,
             filterValue: parsedValue?.token,
+        },
+    }
+}
+
+const scanFilterOrOperator = oneOf<Literal | Sequence>(filterKeyword, followedBy(operator, whitespace))
+const keepScanning = (input: string, start: number): boolean => scanFilterOrOperator(input, start).type !== 'success'
+
+/**
+ * ScanBalancedPattern attempts to scan balanced parentheses as literal patterns. This
+ * ensures that we interpret patterns containing parentheses _as patterns_ and not
+ * groups. For example, it accepts these patterns:
+ *
+ * ((a|b)|c)              - a regular expression with balanced parentheses for grouping
+ * myFunction(arg1, arg2) - a literal string with parens that should be literally interpreted
+ * foo(...)               - a structural search pattern
+ *
+ * If it weren't for this scanner, the above parentheses would have to be
+ * interpreted as part of the query language group syntax, like these:
+ *
+ * (foo or (bar and baz))
+ *
+ * So, this scanner detects parentheses as patterns without needing the user to
+ * explicitly escape them. As such, there are cases where this scanner should
+ * not succeed:
+ *
+ * (foo or (bar and baz)) - a valid query with and/or expression groups in the query langugae
+ * (repo:foo bar baz)     - a valid query containing a recognized repo: field. Here parentheses are interpreted as a group, not a pattern.
+ */
+export const scanBalancedPattern: Parser<Literal> = (input, start) => {
+    let adjustedStart = start
+    let balanced = 0
+    let current = ''
+    const result: string[] = []
+
+    const nextChar = (): string => {
+        current = input[adjustedStart]
+        adjustedStart += 1
+        return current
+    }
+
+    if (!keepScanning(input, start)) {
+        return {
+            type: 'error',
+            expected: 'no recognized filter or operator',
+            at: start,
+        }
+    }
+
+    while (input[adjustedStart] !== undefined) {
+        current = nextChar()
+        if (current === ' ' && balanced === 0) {
+            // Stop scanning a potential pattern when we see whitespace in a balanced state.
+            adjustedStart -= 1 // Backtrack.
+            break
+        } else if (current === '(') {
+            if (!keepScanning(input, adjustedStart)) {
+                return {
+                    type: 'error',
+                    expected: 'no recognized filter or operator',
+                    at: adjustedStart,
+                }
+            }
+            balanced += 1
+            result.push(current)
+        } else if (current === ')') {
+            balanced -= 1
+            if (balanced < 0) {
+                // This paren is an unmatched closing paren, so we stop treating it as a potential
+                // pattern here--it might be closing a group.
+                adjustedStart -= 1 // Backtrack.
+                balanced = 0 // Pattern is balanced up to this point
+                break
+            }
+            result.push(current)
+        } else if (current === ' ') {
+            if (!keepScanning(input, adjustedStart)) {
+                return {
+                    type: 'error',
+                    expected: 'no recognized filter or operator',
+                    at: adjustedStart,
+                }
+            }
+            result.push(current)
+        } else if (current === '\\') {
+            if (input[adjustedStart] !== undefined) {
+                current = nextChar()
+                // Accept anything anything escaped. The point is to consume escaped spaces like "\ "
+                // so that we don't recognize it as terminating a pattern.
+                result.push('\\', current)
+                continue
+            }
+            result.push(current)
+        } else {
+            result.push(current)
+        }
+    }
+
+    if (balanced !== 0) {
+        return {
+            type: 'error',
+            expected: 'no unbalanced parentheses',
+            at: adjustedStart,
+        }
+    }
+
+    return {
+        type: 'success',
+        token: {
+            type: 'literal',
+            range: {
+                start,
+                end: adjustedStart,
+            },
+            value: result.join(''),
         },
     }
 }

--- a/client/shared/src/search/parser/parser.ts
+++ b/client/shared/src/search/parser/parser.ts
@@ -390,10 +390,9 @@ export const scanBalancedPattern: Parser<Literal> = (input, start) => {
     let current = ''
     const result: string[] = []
 
-    const nextChar = (): string => {
+    const nextChar = (): void => {
         current = input[adjustedStart]
         adjustedStart += 1
-        return current
     }
 
     if (!keepScanning(input, start)) {
@@ -405,7 +404,7 @@ export const scanBalancedPattern: Parser<Literal> = (input, start) => {
     }
 
     while (input[adjustedStart] !== undefined) {
-        current = nextChar()
+        nextChar()
         if (current === ' ' && balanced === 0) {
             // Stop scanning a potential pattern when we see whitespace in a balanced state.
             adjustedStart -= 1 // Backtrack.
@@ -441,7 +440,7 @@ export const scanBalancedPattern: Parser<Literal> = (input, start) => {
             result.push(current)
         } else if (current === '\\') {
             if (input[adjustedStart] !== undefined) {
-                current = nextChar()
+                nextChar()
                 // Accept anything anything escaped. The point is to consume escaped spaces like "\ "
                 // so that we don't recognize it as terminating a pattern.
                 result.push('\\', current)


### PR DESCRIPTION
Stacked on #15202. 

This introduces the scanner that recognizes search patterns where parentheses are significant (e.g., groupings in regular expressions) versus parentheses delineating groups in our language. It's probably the most sophisticated part of the scanner/parser things. The additions in this PR are basically in one-to-one correspondence with the [backend `scanBalancedPattern` function](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/query/parser.go#L411) and [tests](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/query/parser_test.go#L1420).

This PR does not _use_ the function yet, because the context for calling this function depends on some things. I'm isolating the parts for easier review/testing.

Down the line, I'll look into making a shared test output file/fixture for common functions like these.