### PR TITLE
Revert "Onboarding tour: default to false for enterprise (#14777)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Homepage panel engagement metrics will be sent back in pings. [#14589](https://github.com/sourcegraph/sourcegraph/pull/14589)
 - Homepage now has a footer with links to different extensibility features. [#14638](https://github.com/sourcegraph/sourcegraph/issues/14638)
 - Added an onboarding tour of Sourcegraph for new users. It can be enabled in user settings with `experimentalFeatures.showOnboardingTour` [#14636](https://github.com/sourcegraph/sourcegraph/pull/14636)
+- Added an onboarding tour of Sourcegraph for new users. [#14636](https://github.com/sourcegraph/sourcegraph/pull/14636)
 - Repository GraphQL queries now support an `after` parameter that permits cursor-based pagination. [#13715](https://github.com/sourcegraph/sourcegraph/issues/13715)
 - Searches in the Recent Searches panel and other places are now syntax highlighted. [#14443](https://github.com/sourcegraph/sourcegraph/issues/14443)
 

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -99,6 +99,11 @@ describe('Search', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
 
+    const waitAndFocusInput = async () => {
+        await driver.page.waitForSelector('.monaco-editor .view-lines')
+        await driver.page.click('.monaco-editor .view-lines')
+    }
+
     describe('Interactive search mode', () => {
         const viewerSettingsWithSplitSearchModes: Partial<WebGraphQlOperations> = {
             ViewerSettings: () => ({
@@ -398,6 +403,7 @@ describe('Search', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await driver.page.waitForSelector('.test-query-input', { visible: true })
             await driver.page.waitForSelector('.test-case-sensitivity-toggle')
+            await waitAndFocusInput()
             await driver.page.type('.test-query-input', 'test')
             await driver.page.click('.test-case-sensitivity-toggle')
             await driver.assertWindowLocation('/search?q=test&patternType=literal&case=yes')
@@ -423,6 +429,7 @@ describe('Search', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await driver.page.waitForSelector('.test-query-input', { visible: true })
             await driver.page.waitForSelector('.test-structural-search-toggle')
+            await waitAndFocusInput()
             await driver.page.type('.test-query-input', 'test')
             await driver.page.click('.test-structural-search-toggle')
             await driver.assertWindowLocation('/search?q=test&patternType=structural')
@@ -433,6 +440,7 @@ describe('Search', () => {
                 ...commonSearchGraphQLResults,
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
+            await waitAndFocusInput()
             await driver.page.waitForSelector('.test-query-input', { visible: true })
             await driver.page.waitForSelector('.test-structural-search-toggle')
             await driver.page.click('.test-structural-search-toggle')

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -65,7 +65,7 @@ export function experimentalFeaturesFromSettings(
         copyQueryButton = false,
         searchStreaming = false,
         showRepogroupHomepage = false,
-        showOnboardingTour = false,
+        showOnboardingTour = true, // Default to true if not set
         showEnterpriseHomePanels = true, // Default to true if not set
         showMultilineSearchConsole = false,
         showQueryBuilder = false,

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -57,7 +57,7 @@
         "showOnboardingTour": {
           "description": "Enables the onboarding tour.",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": { "pointer": true }
         },
         "showEnterpriseHomePanels": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -62,7 +62,7 @@ const SettingsSchemaJSON = `{
         "showOnboardingTour": {
           "description": "Enables the onboarding tour.",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": { "pointer": true }
         },
         "showEnterpriseHomePanels": {


### PR DESCRIPTION
Re-enables the search tour by default, now that the fix for https://github.com/sourcegraph/sourcegraph/issues/14783 is implemented. 

This reverts commit 2d393e2d2831a619cc02de54242e9e58a3dd24df.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
