### PR TITLE
db: ListExternalAccounts excludes deleted rows

### DIFF
--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -1302,14 +1302,15 @@ func (s *PermsStore) ListExternalAccounts(ctx context.Context, userID int32) (ac
 
 	q := sqlf.Sprintf(`
 -- source: enterprise/internal/db/perms_store.go:PermsStore.ListExternalAccounts
-SELECT id, user_id,
-       service_type, service_id, client_id, account_id,
-       auth_data, account_data,
-       created_at, updated_at
+SELECT
+    id, user_id,
+    service_type, service_id, client_id, account_id,
+    auth_data, account_data,
+    created_at, updated_at
 FROM user_external_accounts
 WHERE
-	user_id = %s
-AND	deleted_at IS NULL
+    user_id = %s
+AND deleted_at IS NULL
 ORDER BY id ASC
 `, userID)
 	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)

--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -1307,7 +1307,9 @@ SELECT id, user_id,
        auth_data, account_data,
        created_at, updated_at
 FROM user_external_accounts
-WHERE user_id = %d
+WHERE
+	user_id = %s
+AND	deleted_at IS NULL
 ORDER BY id ASC
 `, userID)
 	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -1935,16 +1935,19 @@ func testPermsStore_ListExternalAccounts(db *sql.DB) func(*testing.T) {
 
 		// Set up test users and external accounts
 		extSQL := `
-INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at)
-	VALUES(%s, %s, %s, %s, %s, %s, %s)
+INSERT INTO
+	user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at)
+VALUES
+	(%s, %s, %s, %s, %s, %s, %s, %s)
 `
 		qs := []*sqlf.Query{
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`), // ID=1
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),   // ID=2
 
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock()), // ID=1
-			sqlf.Sprintf(extSQL, 1, "github", "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock()),          // ID=2
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock()),     // ID=3
+			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil), // ID=1
+			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitHub, "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock(), nil), // ID=2
+			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock(), nil),     // ID=3
+			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitHub, "https://github.com/", "bob_github", "bob_github_client_id", clock(), clock(), clock()), // ID=4
 		}
 		for _, q := range qs {
 			if err := s.execute(ctx, q); err != nil {


### PR DESCRIPTION
Deleted rows in `user_external_accounts` wasn't being excluded in `PermsStore.ListExternalAccounts`, now fixes it.