### PR TITLE
search: add events to MonitorActions

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -266,9 +266,10 @@ type monitorActionEventConnection struct {
 }
 
 func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]MonitorEventResolver, error) {
+	notImplemented := "message not implemented"
 	return []MonitorEventResolver{
-			&monitorEvent{id: "314", status: "SUCCESS", message: "", timeStamp: DateTime{time.Now()}},
-			&monitorEvent{id: "315", status: "ERROR", message: "message not implemented", timeStamp: DateTime{time.Now()}},
+			&monitorEvent{id: "314", status: "SUCCESS", timestamp: DateTime{time.Now()}},
+			&monitorEvent{id: "315", status: "ERROR", message: &notImplemented, timestamp: DateTime{time.Now()}},
 		},
 		nil
 }
@@ -292,15 +293,15 @@ type ListEventsArgs struct {
 type MonitorEventResolver interface {
 	ID() graphql.ID
 	Status() string
-	Message() string
-	TimeStamp() DateTime
+	Message() *string
+	Timestamp() DateTime
 }
 
 type monitorEvent struct {
 	id        graphql.ID
 	status    string
-	message   string
-	timeStamp DateTime
+	message   *string
+	timestamp DateTime
 }
 
 func (m *monitorEvent) ID() graphql.ID {
@@ -311,10 +312,10 @@ func (m *monitorEvent) Status() string {
 	return m.status
 }
 
-func (m *monitorEvent) Message() string {
+func (m *monitorEvent) Message() *string {
 	return m.message
 }
 
-func (m *monitorEvent) TimeStamp() DateTime {
-	return m.timeStamp
+func (m *monitorEvent) Timestamp() DateTime {
+	return m.timestamp
 }

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -203,7 +203,7 @@ type MonitorEmailResolver interface {
 	Priority() string
 	Header() string
 	Recipient(ctx context.Context) (MonitorEmailRecipient, error)
-	Events(ctx context.Context) (MonitorActionEventConnectionResolver, error)
+	Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
 }
 
 type monitorEmail struct {
@@ -234,7 +234,7 @@ func (m *monitorEmail) ID() graphql.ID {
 	return "monitorEmail ID not implemented"
 }
 
-func (m *monitorEmail) Events(ctx context.Context) (MonitorActionEventConnectionResolver, error) {
+func (m *monitorEmail) Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error) {
 	return &monitorActionEventConnection{}, nil
 }
 
@@ -284,6 +284,11 @@ func (a *monitorActionEventConnection) PageInfo(ctx context.Context) (*graphqlut
 //
 // MonitorEvent
 //
+type ListEventsArgs struct {
+	First int32
+	After *string
+}
+
 type MonitorEventResolver interface {
 	ID() graphql.ID
 	Status() string

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -203,6 +203,7 @@ type MonitorEmailResolver interface {
 	Priority() string
 	Header() string
 	Recipient(ctx context.Context) (MonitorEmailRecipient, error)
+	Events(ctx context.Context) (MonitorActionEventConnectionResolver, error)
 }
 
 type monitorEmail struct {
@@ -233,6 +234,10 @@ func (m *monitorEmail) ID() graphql.ID {
 	return "monitorEmail ID not implemented"
 }
 
+func (m *monitorEmail) Events(ctx context.Context) (MonitorActionEventConnectionResolver, error) {
+	return &monitorActionEventConnection{}, nil
+}
+
 //
 // MonitorEmailRecipient <<UNION>>
 //
@@ -246,4 +251,65 @@ type monitorEmailRecipient struct {
 
 func (o *monitorEmailRecipient) ToUser() (*UserResolver, bool) {
 	return o.user, o.user != nil
+}
+
+//
+// MonitorActionEventConnection
+//
+type MonitorActionEventConnectionResolver interface {
+	Nodes(ctx context.Context) ([]MonitorEventResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type monitorActionEventConnection struct {
+}
+
+func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]MonitorEventResolver, error) {
+	return []MonitorEventResolver{
+			&monitorEvent{id: "314", status: "SUCCESS", message: "", timeStamp: DateTime{time.Now()}},
+			&monitorEvent{id: "315", status: "FAILURE", message: "message not implemented", timeStamp: DateTime{time.Now()}},
+		},
+		nil
+}
+
+func (a *monitorActionEventConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *monitorActionEventConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// MonitorEvent
+//
+type MonitorEventResolver interface {
+	ID() graphql.ID
+	Status() string
+	Message() string
+	TimeStamp() DateTime
+}
+
+type monitorEvent struct {
+	id        graphql.ID
+	status    string
+	message   string
+	timeStamp DateTime
+}
+
+func (m *monitorEvent) ID() graphql.ID {
+	return m.id
+}
+
+func (m *monitorEvent) Status() string {
+	return m.status
+}
+
+func (m *monitorEvent) Message() string {
+	return m.message
+}
+
+func (m *monitorEvent) TimeStamp() DateTime {
+	return m.timeStamp
 }

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -268,7 +268,7 @@ type monitorActionEventConnection struct {
 func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]MonitorEventResolver, error) {
 	return []MonitorEventResolver{
 			&monitorEvent{id: "314", status: "SUCCESS", message: "", timeStamp: DateTime{time.Now()}},
-			&monitorEvent{id: "315", status: "FAILURE", message: "message not implemented", timeStamp: DateTime{time.Now()}},
+			&monitorEvent{id: "315", status: "ERROR", message: "message not implemented", timeStamp: DateTime{time.Now()}},
 		},
 		nil
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -390,6 +390,11 @@ func (r *NodeResolver) ToMonitorEmail() (MonitorEmailResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToMonitorEvent() (MonitorEventResolver, bool) {
+	n, ok := r.Node.(MonitorEventResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToCampaign() (CampaignResolver, bool) {
 	n, ok := r.Node.(CampaignResolver)
 	return n, ok

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2975,6 +2975,19 @@ type MonitorEmail implements Node {
     The recipients of the email.
     """
     recipient: MonitorEmailRecipient!
+    """
+    A list of events.
+    """
+    events(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEventConnection!
 }
 
 """
@@ -2989,6 +3002,55 @@ enum MonitorEmailPriority {
 Supported types of recipients for email actions.
 """
 union MonitorEmailRecipient = User
+
+"""
+A list of events.
+"""
+type MonitorActionEventConnection {
+    """
+    A list of events.
+    """
+    nodes: [MonitorEvent!]!
+    """
+    The total number of events in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+An event documents the result of a trigger or an execution of an action.
+"""
+type MonitorEvent implements Node {
+    """
+    The unique id of an event.
+    """
+    id: ID!
+    """
+    The status of an event.
+    """
+    status: EventStatus!
+    """
+    A message with details regarding the status of the event.
+    """
+    message: String!
+    """
+    The time and date of the event.
+    """
+    timeStamp: DateTime!
+}
+
+"""
+Supported status of monitor events.
+"""
+enum EventStatus {
+    PENDING
+    SUCCESS
+    ERROR
+}
 
 """
 A search query description.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3036,11 +3036,11 @@ type MonitorEvent implements Node {
     """
     A message with details regarding the status of the event.
     """
-    message: String!
+    message: String
     """
     The time and date of the event.
     """
-    timeStamp: DateTime!
+    timestamp: DateTime!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2968,6 +2968,10 @@ type MonitorEmail implements Node {
     The recipients of the email.
     """
     recipient: MonitorEmailRecipient!
+    """
+    A list of events.
+    """
+    events: MonitorActionEventConnection!
 }
 
 """
@@ -2982,6 +2986,55 @@ enum MonitorEmailPriority {
 Supported types of recipients for email actions.
 """
 union MonitorEmailRecipient = User
+
+"""
+A list of events.
+"""
+type MonitorActionEventConnection {
+    """
+    A list of events.
+    """
+    nodes: [MonitorEvent!]!
+    """
+    The total number of events in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+An event documents the result of a trigger or an execution of an action.
+"""
+type MonitorEvent implements Node {
+    """
+    The unique id of an event.
+    """
+    id: ID!
+    """
+    The status of an event.
+    """
+    status: EventStatus!
+    """
+    A message with details regarding the status of the event.
+    """
+    message: String!
+    """
+    The time and date of the event.
+    """
+    timeStamp: DateTime!
+}
+
+"""
+Supported status of monitor events.
+"""
+enum EventStatus {
+    PENDING
+    SUCCESS
+    ERROR
+}
 
 """
 A search query description.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2971,7 +2971,16 @@ type MonitorEmail implements Node {
     """
     A list of events.
     """
-    events: MonitorActionEventConnection!
+    events(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEventConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3029,11 +3029,11 @@ type MonitorEvent implements Node {
     """
     A message with details regarding the status of the event.
     """
-    message: String!
+    message: String
     """
     The time and date of the event.
     """
-    timeStamp: DateTime!
+    timestamp: DateTime!
 }
 
 """


### PR DESCRIPTION
A follow-up of #15184 

This PR adds `MonitorEvents` to `MonitorEmail`. Events document the result of triggers or actions; they will be displayed to the user. The resolvers are merely stubs for now. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
