### PR TITLE
search: add events to MonitorTrigger

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -144,6 +144,7 @@ func (t *monitorTrigger) ToMonitorQuery() (MonitorQueryResolver, bool) {
 type MonitorQueryResolver interface {
 	ID() graphql.ID
 	Query() string
+	Events(ctx context.Context, args *ListEventsArgs) MonitorTriggerEventConnectionResolver
 }
 
 type monitorQuery struct {
@@ -156,6 +157,59 @@ func (q *monitorQuery) ID() graphql.ID {
 
 func (q *monitorQuery) Query() string {
 	return "repo:github.com/sourcegraph/sourcegraph file:code_monitors not implemented"
+}
+
+func (q *monitorQuery) Events(ctx context.Context, args *ListEventsArgs) MonitorTriggerEventConnectionResolver {
+	return &monitorTriggerEventConnection{}
+}
+
+//
+// MonitorTriggerEventConnection
+//
+type MonitorTriggerEventConnectionResolver interface {
+	Nodes(ctx context.Context) ([]MonitorTriggerEventResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type monitorTriggerEventConnection struct {
+}
+
+func (a *monitorTriggerEventConnection) Nodes(ctx context.Context) ([]MonitorTriggerEventResolver, error) {
+	return []MonitorTriggerEventResolver{&monitorTriggerEvent{}}, nil
+}
+
+func (a *monitorTriggerEventConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *monitorTriggerEventConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// MonitorTriggerEvent
+//
+type MonitorTriggerEventResolver interface {
+	Event() (MonitorEventResolver, error)
+	ActionEvents(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
+}
+
+type monitorTriggerEvent struct {
+}
+
+func (m monitorTriggerEvent) Event() (MonitorEventResolver, error) {
+	dummy := "trigger status details not implemented"
+	return &monitorEvent{
+		id:        "42",
+		status:    "SUCCESS",
+		message:   &dummy,
+		timestamp: DateTime{time.Now()},
+	}, nil
+}
+
+func (m monitorTriggerEvent) ActionEvents(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error) {
+	return &monitorActionEventConnection{}, nil
 }
 
 //

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -199,10 +199,6 @@ func (a *monitorTriggerEventConnection) PageInfo(ctx context.Context) (*graphqlu
 //
 // MonitorTriggerEvent
 //
-//type MonitorTriggerEventResolver interface {
-//	Event() (MonitorEventResolver, error)
-//	ActionEvents(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
-//}
 type MonitorTriggerEventResolver interface {
 	ID() graphql.ID
 	Status() string
@@ -352,7 +348,7 @@ func (o *monitorEmailRecipient) ToUser() (*UserResolver, bool) {
 // MonitorActionEventConnection
 //
 type MonitorActionEventConnectionResolver interface {
-	Nodes(ctx context.Context) ([]MonitorEventResolver, error)
+	Nodes(ctx context.Context) ([]MonitorActionEventResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
@@ -360,11 +356,11 @@ type MonitorActionEventConnectionResolver interface {
 type monitorActionEventConnection struct {
 }
 
-func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]MonitorEventResolver, error) {
+func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]MonitorActionEventResolver, error) {
 	notImplemented := "message not implemented"
-	return []MonitorEventResolver{
-			&monitorEvent{id: "314", status: "SUCCESS", timestamp: DateTime{time.Now()}},
-			&monitorEvent{id: "315", status: "ERROR", message: &notImplemented, timestamp: DateTime{time.Now()}},
+	return []MonitorActionEventResolver{
+			&monitorActionEvent{id: "314", status: "SUCCESS", timestamp: DateTime{time.Now()}},
+			&monitorActionEvent{id: "315", status: "ERROR", message: &notImplemented, timestamp: DateTime{time.Now()}},
 		},
 		nil
 }
@@ -385,32 +381,32 @@ type ListEventsArgs struct {
 	After *string
 }
 
-type MonitorEventResolver interface {
+type MonitorActionEventResolver interface {
 	ID() graphql.ID
 	Status() string
 	Message() *string
 	Timestamp() DateTime
 }
 
-type monitorEvent struct {
+type monitorActionEvent struct {
 	id        graphql.ID
 	status    string
 	message   *string
 	timestamp DateTime
 }
 
-func (m *monitorEvent) ID() graphql.ID {
+func (m *monitorActionEvent) ID() graphql.ID {
 	return m.id
 }
 
-func (m *monitorEvent) Status() string {
+func (m *monitorActionEvent) Status() string {
 	return m.status
 }
 
-func (m *monitorEvent) Message() *string {
+func (m *monitorActionEvent) Message() *string {
 	return m.message
 }
 
-func (m *monitorEvent) Timestamp() DateTime {
+func (m *monitorActionEvent) Timestamp() DateTime {
 	return m.timestamp
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -390,8 +390,13 @@ func (r *NodeResolver) ToMonitorEmail() (MonitorEmailResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToMonitorEvent() (MonitorEventResolver, bool) {
-	n, ok := r.Node.(MonitorEventResolver)
+func (r *NodeResolver) ToMonitorActionEvent() (MonitorActionEventResolver, bool) {
+	n, ok := r.Node.(MonitorActionEventResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToMonitorTriggerEvent() (MonitorTriggerEventResolver, bool) {
+	n, ok := r.Node.(MonitorTriggerEventResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2957,17 +2957,29 @@ type MonitorTriggerEventConnection {
 }
 
 """
-A trigger event is a simple monitor event together with a list of events from associated actions
+A trigger event is an event together with a list of associated actions.
 """
 type MonitorTriggerEvent {
     """
-    The trigger event.
+    The unique id of an event.
     """
-    event: MonitorEvent
+    id: ID!
     """
-    A list of events of associated actions.
+    The status of an event.
     """
-    actionEvents(
+    status: EventStatus!
+    """
+    A message with details regarding the status of the event.
+    """
+    message: String
+    """
+    The time and date of the event.
+    """
+    timestamp: DateTime!
+    """
+    A list of actions.
+    """
+    actions(
         """
         Returns the first n events from the list.
         """
@@ -2976,7 +2988,7 @@ type MonitorTriggerEvent {
         Opaque pagination cursor.
         """
         after: String
-    ): MonitorActionEventConnection!
+    ): MonitorActionConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2924,7 +2924,7 @@ type MonitorQuery implements Node {
     """
     query: String!
     """
-    A list of events
+    A list of events.
     """
     events(
         """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2923,6 +2923,60 @@ type MonitorQuery implements Node {
     A query.
     """
     query: String!
+    """
+    A list of events
+    """
+    events(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorTriggerEventConnection!
+}
+
+"""
+A list of trigger events.
+"""
+type MonitorTriggerEventConnection {
+    """
+    A list of events.
+    """
+    nodes: [MonitorTriggerEvent!]!
+    """
+    The total number of events in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A trigger event is a simple monitor event together with a list of events from associated actions
+"""
+type MonitorTriggerEvent {
+    """
+    The trigger event.
+    """
+    event: MonitorEvent
+    """
+    A list of events of associated actions.
+    """
+    actionEvents(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEventConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2959,7 +2959,7 @@ type MonitorTriggerEventConnection {
 """
 A trigger event is an event together with a list of associated actions.
 """
-type MonitorTriggerEvent {
+type MonitorTriggerEvent implements Node {
     """
     The unique id of an event.
     """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3080,7 +3080,7 @@ type MonitorActionEventConnection {
     """
     A list of events.
     """
-    nodes: [MonitorEvent!]!
+    nodes: [MonitorActionEvent!]!
     """
     The total number of events in the connection.
     """
@@ -3094,7 +3094,7 @@ type MonitorActionEventConnection {
 """
 An event documents the result of a trigger or an execution of an action.
 """
-type MonitorEvent implements Node {
+type MonitorActionEvent implements Node {
     """
     The unique id of an event.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2950,17 +2950,29 @@ type MonitorTriggerEventConnection {
 }
 
 """
-A trigger event is a simple monitor event together with a list of events from associated actions
+A trigger event is an event together with a list of associated actions.
 """
 type MonitorTriggerEvent {
     """
-    The trigger event.
+    The unique id of an event.
     """
-    event: MonitorEvent
+    id: ID!
     """
-    A list of events of associated actions.
+    The status of an event.
     """
-    actionEvents(
+    status: EventStatus!
+    """
+    A message with details regarding the status of the event.
+    """
+    message: String
+    """
+    The time and date of the event.
+    """
+    timestamp: DateTime!
+    """
+    A list of actions.
+    """
+    actions(
         """
         Returns the first n events from the list.
         """
@@ -2969,7 +2981,7 @@ type MonitorTriggerEvent {
         Opaque pagination cursor.
         """
         after: String
-    ): MonitorActionEventConnection!
+    ): MonitorActionConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2952,7 +2952,7 @@ type MonitorTriggerEventConnection {
 """
 A trigger event is an event together with a list of associated actions.
 """
-type MonitorTriggerEvent {
+type MonitorTriggerEvent implements Node {
     """
     The unique id of an event.
     """
@@ -3073,7 +3073,7 @@ type MonitorActionEventConnection {
     """
     A list of events.
     """
-    nodes: [MonitorEvent!]!
+    nodes: [MonitorActionEvent!]!
     """
     The total number of events in the connection.
     """
@@ -3087,7 +3087,7 @@ type MonitorActionEventConnection {
 """
 An event documents the result of a trigger or an execution of an action.
 """
-type MonitorEvent implements Node {
+type MonitorActionEvent implements Node {
     """
     The unique id of an event.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2916,6 +2916,60 @@ type MonitorQuery implements Node {
     A query.
     """
     query: String!
+    """
+    A list of events
+    """
+    events(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorTriggerEventConnection!
+}
+
+"""
+A list of trigger events.
+"""
+type MonitorTriggerEventConnection {
+    """
+    A list of events.
+    """
+    nodes: [MonitorTriggerEvent!]!
+    """
+    The total number of events in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A trigger event is a simple monitor event together with a list of events from associated actions
+"""
+type MonitorTriggerEvent {
+    """
+    The trigger event.
+    """
+    event: MonitorEvent
+    """
+    A list of events of associated actions.
+    """
+    actionEvents(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEventConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2917,7 +2917,7 @@ type MonitorQuery implements Node {
     """
     query: String!
     """
-    A list of events
+    A list of events.
     """
     events(
         """


### PR DESCRIPTION
Relates to #15270, #15184

This PR completes the query-part of the GraphQL schema for code monitors.

By requirement, we have to be able to link action events to the events
of their associated trigger. Hence each trigger event is linked to associated
actions which in turn can be queried for their events. 

**Also in this PR**
- Rename of MonitorEvent to MonitorActionEvent.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
