### PR TITLE
#14751 Add externalURL to account update emails

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -156,22 +156,22 @@ func SendUserEmailVerificationEmail(ctx context.Context, email, code string) err
 		To:       []string{email},
 		Template: verifyEmailTemplates,
 		Data: struct {
-			Email       string
-			URL         string
-			ExternalURL string
+			Email string
+			URL   string
+			Host  string
 		}{
 			Email: email,
 			URL: globals.ExternalURL().ResolveReference(&url.URL{
 				Path:     verifyEmailPath.Path,
 				RawQuery: q.Encode(),
 			}).String(),
-			ExternalURL: globals.ExternalURL().String(),
+			Host: globals.ExternalURL().Host,
 		},
 	})
 }
 
 var verifyEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `Verify your email on Sourcegraph ({{.ExternalURL}})`,
+	Subject: `Verify your email on Sourcegraph ({{.Host}})`,
 	Text: `
 Verify your email address {{printf "%q" .Email}} on Sourcegraph by following this link:
 
@@ -202,29 +202,29 @@ func (userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, id int32, chan
 		To:       []string{email},
 		Template: updateAccountEmailTemplate,
 		Data: struct {
-			Email       string
-			Change      string
-			Username    string
-			ExternalURL string
+			Email    string
+			Change   string
+			Username string
+			Host     string
 		}{
-			Email:       email,
-			Change:      change,
-			Username:    usr.Username,
-			ExternalURL: globals.ExternalURL().String(),
+			Email:    email,
+			Change:   change,
+			Username: usr.Username,
+			Host:     globals.ExternalURL().Host,
 		},
 	})
 }
 
 var updateAccountEmailTemplate = txemail.MustValidate(txtypes.Templates{
-	Subject: `Update to your Sourcegraph account ({{.ExternalURL}})`,
+	Subject: `Update to your Sourcegraph account ({{.Host}})`,
 	Text: `
-Somebody (likely you) {{.Change}} for the user {{.Username}} on Sourcegraph ({{.ExternalURL}}).
+Somebody (likely you) {{.Change}} for the user {{.Username}} on Sourcegraph ({{.Host}}).
 
 If this was not you please change your password immediately.
 `,
 	HTML: `
 <p>
-Somebody (likely you) <strong>{{.Change}}</strong> for the user <strong>{{.Username}}</strong> on Sourcegraph ({{.ExternalURL}}).
+Somebody (likely you) <strong>{{.Change}}</strong> for the user <strong>{{.Username}}</strong> on Sourcegraph ({{.Host}}).
 </p>
 
 <p><strong>If this was not you please change your password immediately.</strong></p>

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -156,20 +156,22 @@ func SendUserEmailVerificationEmail(ctx context.Context, email, code string) err
 		To:       []string{email},
 		Template: verifyEmailTemplates,
 		Data: struct {
-			Email string
-			URL   string
+			Email       string
+			URL         string
+			ExternalURL string
 		}{
 			Email: email,
 			URL: globals.ExternalURL().ResolveReference(&url.URL{
 				Path:     verifyEmailPath.Path,
 				RawQuery: q.Encode(),
 			}).String(),
+			ExternalURL: globals.ExternalURL().String(),
 		},
 	})
 }
 
 var verifyEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `Verify your email on Sourcegraph`,
+	Subject: `Verify your email on Sourcegraph ({{.ExternalURL}})`,
 	Text: `
 Verify your email address {{printf "%q" .Email}} on Sourcegraph by following this link:
 
@@ -200,27 +202,29 @@ func (userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, id int32, chan
 		To:       []string{email},
 		Template: updateAccountEmailTemplate,
 		Data: struct {
-			Email    string
-			Change   string
-			Username string
+			Email       string
+			Change      string
+			Username    string
+			ExternalURL string
 		}{
-			Email:    email,
-			Change:   change,
-			Username: usr.Username,
+			Email:       email,
+			Change:      change,
+			Username:    usr.Username,
+			ExternalURL: globals.ExternalURL().String(),
 		},
 	})
 }
 
 var updateAccountEmailTemplate = txemail.MustValidate(txtypes.Templates{
-	Subject: `Update to your Sourcegraph account`,
+	Subject: `Update to your Sourcegraph account ({{.ExternalURL}})`,
 	Text: `
-Somebody (likely you) {{.Change}} for the user {{.Username}} on Sourcegraph.
+Somebody (likely you) {{.Change}} for the user {{.Username}} on Sourcegraph ({{.ExternalURL}}).
 
 If this was not you please change your password immediately.
 `,
 	HTML: `
 <p>
-Somebody (likely you) <strong>{{.Change}}</strong> for the user <strong>{{.Username}}</strong> on Sourcegraph.
+Somebody (likely you) <strong>{{.Change}}</strong> for the user <strong>{{.Username}}</strong> on Sourcegraph ({{.ExternalURL}}).
 </p>
 
 <p><strong>If this was not you please change your password immediately.</strong></p>

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -145,11 +145,13 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 		To:       []string{"a@example.com"},
 		Template: verifyEmailTemplates,
 		Data: struct {
-			Email string
-			URL   string
+			Email       string
+			URL         string
+			ExternalURL string
 		}{
-			Email: "a@example.com",
-			URL:   "http://example.com/-/verify-email?code=c&email=a%40example.com",
+			Email:       "a@example.com",
+			URL:         "http://example.com/-/verify-email?code=c&email=a%40example.com",
+			ExternalURL: "https://example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)
@@ -185,13 +187,15 @@ func TestSendUserEmailOnFieldUpdate(t *testing.T) {
 		To:       []string{"a@example.com"},
 		Template: updateAccountEmailTemplate,
 		Data: struct {
-			Email    string
-			Change   string
-			Username string
+			Email       string
+			Change      string
+			Username    string
+			ExternalURL string
 		}{
-			Email:    "a@example.com",
-			Change:   "updated password",
-			Username: "Foo",
+			Email:       "a@example.com",
+			Change:      "updated password",
+			Username:    "Foo",
+			ExternalURL: "https://example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -145,13 +145,13 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 		To:       []string{"a@example.com"},
 		Template: verifyEmailTemplates,
 		Data: struct {
-			Email       string
-			URL         string
-			ExternalURL string
+			Email string
+			URL   string
+			Host  string
 		}{
-			Email:       "a@example.com",
-			URL:         "http://example.com/-/verify-email?code=c&email=a%40example.com",
-			ExternalURL: "http://example.com",
+			Email: "a@example.com",
+			URL:   "http://example.com/-/verify-email?code=c&email=a%40example.com",
+			Host:  "example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)
@@ -187,15 +187,15 @@ func TestSendUserEmailOnFieldUpdate(t *testing.T) {
 		To:       []string{"a@example.com"},
 		Template: updateAccountEmailTemplate,
 		Data: struct {
-			Email       string
-			Change      string
-			Username    string
-			ExternalURL string
+			Email    string
+			Change   string
+			Username string
+			Host     string
 		}{
-			Email:       "a@example.com",
-			Change:      "updated password",
-			Username:    "Foo",
-			ExternalURL: "http://example.com",
+			Email:    "a@example.com",
+			Change:   "updated password",
+			Username: "Foo",
+			Host:     "example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -151,7 +151,7 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 		}{
 			Email:       "a@example.com",
 			URL:         "http://example.com/-/verify-email?code=c&email=a%40example.com",
-			ExternalURL: "https://example.com",
+			ExternalURL: "http://example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)
@@ -195,7 +195,7 @@ func TestSendUserEmailOnFieldUpdate(t *testing.T) {
 			Email:       "a@example.com",
 			Change:      "updated password",
 			Username:    "Foo",
-			ExternalURL: "https://example.com",
+			ExternalURL: "http://example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -67,13 +67,13 @@ func HandleResetPasswordInit(w http.ResponseWriter, r *http.Request) {
 		To:       []string{formData.Email},
 		Template: resetPasswordEmailTemplates,
 		Data: struct {
-			Username    string
-			URL         string
-			ExternalURL string
+			Username string
+			URL      string
+			Host     string
 		}{
-			Username:    usr.Username,
-			URL:         globals.ExternalURL().ResolveReference(resetURL).String(),
-			ExternalURL: globals.ExternalURL().String(),
+			Username: usr.Username,
+			URL:      globals.ExternalURL().ResolveReference(resetURL).String(),
+			Host:     globals.ExternalURL().Host,
 		},
 	}); err != nil {
 		httpLogAndError(w, "Could not send reset password email", http.StatusInternalServerError, "err", err)
@@ -82,9 +82,9 @@ func HandleResetPasswordInit(w http.ResponseWriter, r *http.Request) {
 }
 
 var resetPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `Reset your Sourcegraph password ({{.ExternalURL}})`,
+	Subject: `Reset your Sourcegraph password ({{.Host}})`,
 	Text: `
-Somebody (likely you) requested a password reset for the user {{.Username}} on Sourcegraph ({{.ExternalURL}}).
+Somebody (likely you) requested a password reset for the user {{.Username}} on Sourcegraph ({{.Host}}).
 
 To reset the password for {{.Username}} on Sourcegraph, follow this link:
 
@@ -93,7 +93,7 @@ To reset the password for {{.Username}} on Sourcegraph, follow this link:
 	HTML: `
 <p>
   Somebody (likely you) requested a password reset for <strong>{{.Username}}</strong>
-  on Sourcegraph ({{.ExternalURL}}).
+  on Sourcegraph ({{.Host}}).
 </p>
 
 <p><strong><a href="{{.URL}}">Reset password for {{.Username}}</a></strong></p>
@@ -124,13 +124,13 @@ func HandleSetPasswordEmail(ctx context.Context, id int32) (string, error) {
 		To:       []string{e},
 		Template: setPasswordEmailTemplates,
 		Data: struct {
-			Username    string
-			URL         string
-			ExternalURL string
+			Username string
+			URL      string
+			Host     string
 		}{
-			Username:    usr.Username,
-			URL:         rus,
-			ExternalURL: globals.ExternalURL().String(),
+			Username: usr.Username,
+			URL:      rus,
+			Host:     globals.ExternalURL().Host,
 		},
 	}); err != nil {
 		return "", err
@@ -139,9 +139,9 @@ func HandleSetPasswordEmail(ctx context.Context, id int32) (string, error) {
 }
 
 var setPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `Set your Sourcegraph password`,
+	Subject: `Set your Sourcegraph password ({{.Host}})`,
 	Text: `
-Your administrator created an account for you on Sourcegraph ({{.ExternalURL}}).
+Your administrator created an account for you on Sourcegraph ({{.Host}}).
 
 To set the password for {{.Username}} on Sourcegraph, follow this link:
 
@@ -149,7 +149,7 @@ To set the password for {{.Username}} on Sourcegraph, follow this link:
 `,
 	HTML: `
 <p>
-  Your administrator created an account for you on Sourcegraph ({{.ExternalURL}}).
+  Your administrator created an account for you on Sourcegraph ({{.Host}}).
 </p>
 
 <p><strong><a href="{{.URL}}">Set password for {{.Username}}</a></strong></p>

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -67,11 +67,13 @@ func HandleResetPasswordInit(w http.ResponseWriter, r *http.Request) {
 		To:       []string{formData.Email},
 		Template: resetPasswordEmailTemplates,
 		Data: struct {
-			Username string
-			URL      string
+			Username    string
+			URL         string
+			ExternalURL string
 		}{
-			Username: usr.Username,
-			URL:      globals.ExternalURL().ResolveReference(resetURL).String(),
+			Username:    usr.Username,
+			URL:         globals.ExternalURL().ResolveReference(resetURL).String(),
+			ExternalURL: globals.ExternalURL().String(),
 		},
 	}); err != nil {
 		httpLogAndError(w, "Could not send reset password email", http.StatusInternalServerError, "err", err)
@@ -79,21 +81,22 @@ func HandleResetPasswordInit(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-var setPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `Set your Sourcegraph password`,
+var resetPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
+	Subject: `Reset your Sourcegraph password ({{.ExternalURL}})`,
 	Text: `
-Your administrator created an account for you on Sourcegraph.
+Somebody (likely you) requested a password reset for the user {{.Username}} on Sourcegraph ({{.ExternalURL}}).
 
-To set the password for {{.Username}} on Sourcegraph, follow this link:
+To reset the password for {{.Username}} on Sourcegraph, follow this link:
 
   {{.URL}}
 `,
 	HTML: `
 <p>
-  Your administrator created an account for you on Sourcegraph.
+  Somebody (likely you) requested a password reset for <strong>{{.Username}}</strong>
+  on Sourcegraph ({{.ExternalURL}}).
 </p>
 
-<p><strong><a href="{{.URL}}">Set password for {{.Username}}</a></strong></p>
+<p><strong><a href="{{.URL}}">Reset password for {{.Username}}</a></strong></p>
 `,
 })
 
@@ -121,11 +124,13 @@ func HandleSetPasswordEmail(ctx context.Context, id int32) (string, error) {
 		To:       []string{e},
 		Template: setPasswordEmailTemplates,
 		Data: struct {
-			Username string
-			URL      string
+			Username    string
+			URL         string
+			ExternalURL string
 		}{
-			Username: usr.Username,
-			URL:      rus,
+			Username:    usr.Username,
+			URL:         rus,
+			ExternalURL: globals.ExternalURL().String(),
 		},
 	}); err != nil {
 		return "", err
@@ -133,22 +138,21 @@ func HandleSetPasswordEmail(ctx context.Context, id int32) (string, error) {
 	return rus, nil
 }
 
-var resetPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `Reset your Sourcegraph password`,
+var setPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
+	Subject: `Set your Sourcegraph password`,
 	Text: `
-Somebody (likely you) requested a password reset for the user {{.Username}} on Sourcegraph.
+Your administrator created an account for you on Sourcegraph ({{.ExternalURL}}).
 
-To reset the password for {{.Username}} on Sourcegraph, follow this link:
+To set the password for {{.Username}} on Sourcegraph, follow this link:
 
   {{.URL}}
 `,
 	HTML: `
 <p>
-  Somebody (likely you) requested a password reset for <strong>{{.Username}}</strong>
-  on Sourcegraph.
+  Your administrator created an account for you on Sourcegraph ({{.ExternalURL}}).
 </p>
 
-<p><strong><a href="{{.URL}}">Reset password for {{.Username}}</a></strong></p>
+<p><strong><a href="{{.URL}}">Set password for {{.Username}}</a></strong></p>
 `,
 })
 


### PR DESCRIPTION
This PR addresses #14751, one of the example issues from my onboarding (here #15187)
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

A couple of questions on how i've tackled this:
* do we want to format the URL a little more nicely? perhaps strip the scheme from the URL?
* are we confident in accessing these globals without nil-checks?