### PR TITLE
debugserver: Explicit shutdown

### DIFF
--- a/enterprise/cmd/executor-queue/main.go
+++ b/enterprise/cmd/executor-queue/main.go
@@ -73,9 +73,14 @@ func main() {
 		log.Fatalf("failed to create listener: %s", err)
 	}
 
+	debugServer, err := debugserver.NewServerRoutine()
+	if err != nil {
+		log.Fatalf("Failed to create listener: %s", err)
+	}
+
 	goroutine.MonitorBackgroundRoutines(
 		context.Background(),
-		goroutine.NoopStop(debugserver.NewServerRoutine()),
+		debugServer,
 		server,
 	)
 }

--- a/enterprise/cmd/executor-queue/main.go
+++ b/enterprise/cmd/executor-queue/main.go
@@ -77,10 +77,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create listener: %s", err)
 	}
+	go debugServer.Start()
 
 	goroutine.MonitorBackgroundRoutines(
 		context.Background(),
-		debugServer,
 		server,
 	)
 }

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -35,8 +35,13 @@ func main() {
 		log.Fatalf("failed to read config: %s", err)
 	}
 
+	debugServer, err := debugserver.NewServerRoutine()
+	if err != nil {
+		log.Fatalf("Failed to create listener: %s", err)
+	}
+
 	routines := []goroutine.BackgroundRoutine{
-		goroutine.NoopStop(debugserver.NewServerRoutine()),
+		debugServer,
 		apiworker.NewWorker(config.APIWorkerOptions(nil)),
 	}
 	if !config.DisableHealthServer {

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -39,9 +39,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create listener: %s", err)
 	}
+	go debugServer.Start()
 
 	routines := []goroutine.BackgroundRoutine{
-		debugServer,
 		apiworker.NewWorker(config.APIWorkerOptions(nil)),
 	}
 	if !config.DisableHealthServer {

--- a/enterprise/cmd/precise-code-intel-bundle-manager/main.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/main.go
@@ -89,10 +89,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create listener: %s", err)
 	}
+	go debugServer.Start()
 
 	routines := []goroutine.BackgroundRoutine{
 		server,
-		debugServer,
 	}
 
 	if !disableJanitor {

--- a/enterprise/cmd/precise-code-intel-bundle-manager/main.go
+++ b/enterprise/cmd/precise-code-intel-bundle-manager/main.go
@@ -85,9 +85,14 @@ func main() {
 	janitorMetrics := janitor.NewJanitorMetrics(prometheus.DefaultRegisterer)
 	janitor := janitor.New(store, lsifstore.New(codeIntelDB), bundleDir, janitorInterval, maxUploadAge, maxUploadPartAge, maxDataAge, janitorMetrics)
 
+	debugServer, err := debugserver.NewServerRoutine()
+	if err != nil {
+		log.Fatalf("Failed to create listener: %s", err)
+	}
+
 	routines := []goroutine.BackgroundRoutine{
 		server,
-		goroutine.NoopStop(debugserver.NewServerRoutine()),
+		debugServer,
 	}
 
 	if !disableJanitor {

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -103,6 +103,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create listener: %s", err)
 	}
+	go debugServer.Start()
 
 	routines := []goroutine.BackgroundRoutine{
 		managerRoutine,
@@ -110,7 +111,6 @@ func main() {
 		indexResetter,
 		indexabilityUpdater,
 		scheduler,
-		debugServer,
 	}
 
 	if !disableJanitor {

--- a/enterprise/cmd/precise-code-intel-indexer/main.go
+++ b/enterprise/cmd/precise-code-intel-indexer/main.go
@@ -99,13 +99,18 @@ func main() {
 	janitor := janitor.New(s, janitorInterval, janitorMetrics)
 	managerRoutine := goroutine.NewPeriodicGoroutine(context.Background(), cleanupInterval, indexManager)
 
+	debugServer, err := debugserver.NewServerRoutine()
+	if err != nil {
+		log.Fatalf("Failed to create listener: %s", err)
+	}
+
 	routines := []goroutine.BackgroundRoutine{
 		managerRoutine,
 		server,
 		indexResetter,
 		indexabilityUpdater,
 		scheduler,
-		goroutine.NoopStop(debugserver.NewServerRoutine()),
+		debugServer,
 	}
 
 	if !disableJanitor {

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -89,6 +89,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create listener: %s", err)
 	}
+	go debugServer.Start()
 
 	goroutine.MonitorBackgroundRoutines(
 		context.Background(),
@@ -96,7 +97,6 @@ func main() {
 		uploadResetter,
 		commitUpdater,
 		worker,
-		debugServer,
 	)
 }
 

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -85,13 +85,18 @@ func main() {
 		observationContext,
 	)
 
+	debugServer, err := debugserver.NewServerRoutine()
+	if err != nil {
+		log.Fatalf("Failed to create listener: %s", err)
+	}
+
 	goroutine.MonitorBackgroundRoutines(
 		context.Background(),
 		server,
 		uploadResetter,
 		commitUpdater,
 		worker,
-		goroutine.NoopStop(debugserver.NewServerRoutine()),
+		debugServer,
 	)
 }
 

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -26,8 +26,8 @@ postgres_exporter: ./dev/postgres_exporter.sh
 # Enterprise executor services
 # TODO: These two services take 20s to shut down on sigint.
 # Fix this and you get to remove the badge of unix shame! :)
-executor-queue: ./dev/badge-of-unix-shame.sh executor-queue
-codeintel-executor: EXECUTOR_QUEUE_NAME=codeintel TMPDIR=~/.sourcegraph/indexer-temp ./dev/badge-of-unix-shame.sh  executor
+executor-queue: executor-queue
+codeintel-executor: EXECUTOR_QUEUE_NAME=codeintel TMPDIR=~/.sourcegraph/indexer-temp executor
 
 # Enterprise code intelligence services
 precise-code-intel-bundle-manager: precise-code-intel-bundle-manager

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -24,8 +24,6 @@ grafana: ./dev/grafana.sh
 postgres_exporter: ./dev/postgres_exporter.sh
 
 # Enterprise executor services
-# TODO: These two services take 20s to shut down on sigint.
-# Fix this and you get to remove the badge of unix shame! :)
 executor-queue: executor-queue
 codeintel-executor: EXECUTOR_QUEUE_NAME=codeintel TMPDIR=~/.sourcegraph/indexer-temp executor
 

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -11,8 +11,11 @@ import (
 	"strings"
 
 	"github.com/felixge/fgprof"
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"golang.org/x/net/trace"
 )
 
@@ -64,11 +67,16 @@ type Service struct {
 	DefaultPath string
 }
 
-// Start runs a debug server (pprof, prometheus, etc) if it is configured (via
-// SRC_PROF_HTTP environment variable). It is blocking.
-func Start(extra ...Endpoint) {
+// Dumper is a service which can dump its state for debugging.
+type Dumper interface {
+	// DebugDump returns a snapshot of the current state.
+	DebugDump() interface{}
+}
+
+// NewServerRoutine returns a background routine that exposes pprof and metrics endpoints.
+func NewServerRoutine(extra ...Endpoint) (goroutine.BackgroundRoutine, error) {
 	if addr == "" {
-		return
+		return goroutine.NoopRoutine(), nil
 	}
 
 	// we're protected by adminOnly on the front of this
@@ -76,61 +84,55 @@ func Start(extra ...Endpoint) {
 		return true, true
 	}
 
-	pp := http.NewServeMux()
-	index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`
+	handler := httpserver.NewHandler(func(router *mux.Router) {
+		index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`
 				<a href="vars">Vars</a><br>
 				<a href="debug/pprof/">PProf</a><br>
 				<a href="metrics">Metrics</a><br>
 				<a href="debug/requests">Requests</a><br>
 				<a href="debug/events">Events</a><br>
 			`))
-		for _, e := range extra {
-			fmt.Fprintf(w, `<a href="%s">%s</a><br>`, strings.TrimPrefix(e.Path, "/"), e.Name)
-		}
-		_, _ = w.Write([]byte(`
+			for _, e := range extra {
+				fmt.Fprintf(w, `<a href="%s">%s</a><br>`, strings.TrimPrefix(e.Path, "/"), e.Name)
+			}
+			_, _ = w.Write([]byte(`
 				<br>
 				<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>
 				<form method="post" action="freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>
 			`))
+		})
+
+		router.Handle("/", index)
+		router.Handle("/debug", index)
+		router.Handle("/vars", http.HandlerFunc(expvarHandler))
+		router.Handle("/gc", http.HandlerFunc(gcHandler))
+		router.Handle("/freeosmemory", http.HandlerFunc(freeOSMemoryHandler))
+		router.Handle("/debug/fgprof", fgprof.Handler())
+		router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+		router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		router.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
+		router.Handle("/debug/events", http.HandlerFunc(trace.Events))
+		router.Handle("/metrics", promhttp.Handler())
+
+		for _, e := range extra {
+			router.Handle(e.Path, e.Handler)
+		}
 	})
-	pp.Handle("/", index)
-	pp.Handle("/debug", index)
-	pp.Handle("/vars", http.HandlerFunc(expvarHandler))
-	pp.Handle("/gc", http.HandlerFunc(gcHandler))
-	pp.Handle("/freeosmemory", http.HandlerFunc(freeOSMemoryHandler))
-	pp.Handle("/debug/fgprof", fgprof.Handler())
-	pp.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-	pp.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-	pp.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-	pp.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	pp.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-	pp.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
-	pp.Handle("/debug/events", http.HandlerFunc(trace.Events))
 
-	pp.Handle("/metrics", promhttp.Handler())
-	for _, e := range extra {
-		pp.Handle(e.Path, e.Handler)
+	return httpserver.NewFromAddr(addr, handler, httpserver.Options{})
+}
+
+// Start runs a debug server (pprof, prometheus, etc) if it is configured (via
+// SRC_PROF_HTTP environment variable). It is blocking.
+func Start(extra ...Endpoint) {
+	debugServer, err := NewServerRoutine(extra...)
+	if err != nil {
+		log.Fatalf("Failed to create listener: %s", err)
 	}
-	log.Println("warning: could not start debug HTTP server:", http.ListenAndServe(addr, pp))
-}
 
-// Dumper is a service which can dump its state for debugging.
-type Dumper interface {
-	// DebugDump returns a snapshot of the current state.
-	DebugDump() interface{}
-}
-
-// ServerRoutine is a type wrapping the `Start` method so it can be used
-// easily by the goroutine package.
-type ServerRoutine struct {
-	extra []Endpoint
-}
-
-func NewServerRoutine(extra ...Endpoint) *ServerRoutine {
-	return &ServerRoutine{extra: extra}
-}
-
-func (r *ServerRoutine) Start() {
-	Start(r.extra...)
+	debugServer.Start()
 }

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -93,9 +93,11 @@ func NewServerRoutine(extra ...Endpoint) (goroutine.BackgroundRoutine, error) {
 				<a href="debug/requests">Requests</a><br>
 				<a href="debug/events">Events</a><br>
 			`))
+
 			for _, e := range extra {
 				fmt.Fprintf(w, `<a href="%s">%s</a><br>`, strings.TrimPrefix(e.Path, "/"), e.Name)
 			}
+
 			_, _ = w.Write([]byte(`
 				<br>
 				<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>

--- a/internal/goroutine/background.go
+++ b/internal/goroutine/background.go
@@ -34,16 +34,16 @@ type BackgroundRoutine interface {
 // immediately.
 func MonitorBackgroundRoutines(ctx context.Context, routines ...BackgroundRoutine) {
 	signals := make(chan os.Signal, 2)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP)
+	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT)
 	monitorBackgroundRoutines(ctx, signals, routines...)
 }
 
 func monitorBackgroundRoutines(ctx context.Context, signals <-chan os.Signal, routines ...BackgroundRoutine) {
-	var wg sync.WaitGroup
-	startAll(&wg, routines...)
+	wg := &sync.WaitGroup{}
+	startAll(wg, routines...)
 	waitForSignal(ctx, signals)
-	stopAll(&wg, routines...)
-	wg.Wait()
+	stopAll(wg, routines...)
+	wg.Done()
 }
 
 // startAll calls each routine's Start method in its own goroutine and registers
@@ -98,23 +98,23 @@ func exitAfterSignals(signals <-chan os.Signal, numSignals int) {
 type CombinedRoutine []BackgroundRoutine
 
 func (r CombinedRoutine) Start() {
-	var wg sync.WaitGroup
-	startAll(&wg, r...)
+	wg := &sync.WaitGroup{}
+	startAll(wg, r...)
 	wg.Wait()
 }
 
 func (r CombinedRoutine) Stop() {
-	var wg sync.WaitGroup
-	stopAll(&wg, r...)
+	wg := &sync.WaitGroup{}
+	stopAll(wg, r...)
 	wg.Wait()
 }
 
-type noopStop struct{ r StartableRoutine }
+type noopRoutine struct{}
 
-func (r noopStop) Start() { r.r.Start() }
-func (r noopStop) Stop()  {}
+func (r noopRoutine) Start() {}
+func (r noopRoutine) Stop()  {}
 
-// NoopStop wraps a startable routine in a type with a noop Stop method.
-func NoopStop(r StartableRoutine) BackgroundRoutine {
-	return noopStop{r}
+// NoopRoutine does nothing for start or stop.
+func NoopRoutine() BackgroundRoutine {
+	return noopRoutine{}
 }

--- a/internal/goroutine/background.go
+++ b/internal/goroutine/background.go
@@ -43,7 +43,7 @@ func monitorBackgroundRoutines(ctx context.Context, signals <-chan os.Signal, ro
 	startAll(wg, routines...)
 	waitForSignal(ctx, signals)
 	stopAll(wg, routines...)
-	wg.Done()
+	wg.Wait()
 }
 
 // startAll calls each routine's Start method in its own goroutine and registers


### PR DESCRIPTION
Moving the debugserver into a background goroutine with a no-op stop meant that the start method never unblocked. This uses the httpserver package to enable graceful shutdown.