### PR TITLE
httpserver: Do not use loopback interface if host is empty

### DIFF
--- a/internal/httpserver/listener.go
+++ b/internal/httpserver/listener.go
@@ -9,11 +9,6 @@ import (
 // NewListener returns a TCP listener accepting connections
 // on the given address.
 func NewListener(addr string) (_ net.Listener, err error) {
-	addr, err = SanitizeAddr(addr)
-	if err != nil {
-		return nil, err
-	}
-
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, err
@@ -25,13 +20,13 @@ func NewListener(addr string) (_ net.Listener, err error) {
 // SanitizeAddr replaces the host in the given address with
 // 127.0.0.1 if no host is supplied or if running in insecure
 // dev mode.
-func SanitizeAddr(addr string) (string, error) {
+func SanitizeAddr(addr string, enforceHost bool) (string, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
 	}
 
-	if host == "" || env.InsecureDev {
+	if host == "" && env.InsecureDev {
 		host = "127.0.0.1"
 	}
 

--- a/internal/httpserver/listener.go
+++ b/internal/httpserver/listener.go
@@ -9,6 +9,11 @@ import (
 // NewListener returns a TCP listener accepting connections
 // on the given address.
 func NewListener(addr string) (_ net.Listener, err error) {
+	addr, err = SanitizeAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, err
@@ -20,7 +25,7 @@ func NewListener(addr string) (_ net.Listener, err error) {
 // SanitizeAddr replaces the host in the given address with
 // 127.0.0.1 if no host is supplied or if running in insecure
 // dev mode.
-func SanitizeAddr(addr string, enforceHost bool) (string, error) {
+func SanitizeAddr(addr string) (string, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
I rewrote the debug server to use a new version of the httpserver base package. This used `|| env.InsecureDev` to check if it should replace the host with `127.0.0.1`. Obviously nothing external can attach to the same loopback interface from outside the container. 

There was a short outage where a bunch of code intel servers all stopped listening at once, and I think this explains it.