### PR TITLE
licensing: check unknown plans

### DIFF
--- a/enterprise/internal/licensing/conf.go
+++ b/enterprise/internal/licensing/conf.go
@@ -7,8 +7,11 @@ import (
 func init() {
 	conf.ContributeValidator(func(cfg conf.Unified) conf.Problems {
 		if cfg.SiteConfiguration.LicenseKey != "" {
-			if _, _, err := ParseProductLicenseKeyWithBuiltinOrGenerationKey(cfg.SiteConfiguration.LicenseKey); err != nil {
+			info, _, err := ParseProductLicenseKeyWithBuiltinOrGenerationKey(cfg.SiteConfiguration.LicenseKey)
+			if err != nil {
 				return conf.NewSiteProblems("should provide a valid license key")
+			} else if err = info.hasUnknownPlan(); EnforceTiers && err != nil {
+				return conf.NewSiteProblems(err.Error())
 			}
 		}
 		return nil

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -119,9 +119,8 @@ func GetConfiguredProductLicenseInfoWithSignature() (*Info, string, error) {
 				return nil, "", err
 			}
 
-			badTag, unknown := info.hasUnknownPlan()
-			if EnforceTiers && unknown {
-				return nil, "", errors.Errorf("The license has an unrecognizable plan in tag %q, please contact Sourcegraph support.", badTag)
+			if err = info.hasUnknownPlan(); EnforceTiers && err != nil {
+				return nil, "", err
 			}
 
 			lastKeyText = keyText

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -118,6 +118,12 @@ func GetConfiguredProductLicenseInfoWithSignature() (*Info, string, error) {
 			if err != nil {
 				return nil, "", err
 			}
+
+			badTag, unknown := info.hasUnknownPlan()
+			if EnforceTiers && unknown {
+				return nil, "", errors.Errorf("The license has an unrecognizable plan in tag %q, please contact Sourcegraph support.", badTag)
+			}
+
 			lastKeyText = keyText
 			lastInfo = info
 			lastSignature = signature

--- a/enterprise/internal/licensing/plans.go
+++ b/enterprise/internal/licensing/plans.go
@@ -1,6 +1,10 @@
 package licensing
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
 
 // A Plan is a pricing plan, with an associated set of features that it offers.
 type Plan string
@@ -62,9 +66,9 @@ func (info *Info) Plan() Plan {
 	return oldEnterprise
 }
 
-// hasUnknownPlan returns true and the tag in trouble if the plan is presented in the license tags
-// but unrecognizable. It returns false if there is no tags found for plans.
-func (info *Info) hasUnknownPlan() (string, bool) {
+// hasUnknownPlan returns an error if the plan is presented in the license tags
+// but unrecognizable. It returns nil if there is no tags found for plans.
+func (info *Info) hasUnknownPlan() error {
 	for _, tag := range info.Tags {
 		// A tag that begins with "plan:" indicates the license's plan.
 		if !strings.HasPrefix(tag, planTagPrefix) {
@@ -73,8 +77,8 @@ func (info *Info) hasUnknownPlan() (string, bool) {
 
 		plan := Plan(tag[len(planTagPrefix):])
 		if !plan.isKnown() {
-			return tag, true
+			return errors.Errorf("The license has an unrecognizable plan in tag %q, please contact Sourcegraph support.", tag)
 		}
 	}
-	return "", false
+	return nil
 }

--- a/enterprise/internal/licensing/plans.go
+++ b/enterprise/internal/licensing/plans.go
@@ -61,3 +61,20 @@ func (info *Info) Plan() Plan {
 	// Backcompat: no tags means it is the old "Enterprise" plan.
 	return oldEnterprise
 }
+
+// hasUnknownPlan returns true and the tag in trouble if the plan is presented in the license tags
+// but unrecognizable. It returns false if there is no tags found for plans.
+func (info *Info) hasUnknownPlan() (string, bool) {
+	for _, tag := range info.Tags {
+		// A tag that begins with "plan:" indicates the license's plan.
+		if !strings.HasPrefix(tag, planTagPrefix) {
+			continue
+		}
+
+		plan := Plan(tag[len(planTagPrefix):])
+		if !plan.isKnown() {
+			return tag, true
+		}
+	}
+	return "", false
+}

--- a/enterprise/internal/licensing/plans_test.go
+++ b/enterprise/internal/licensing/plans_test.go
@@ -71,13 +71,13 @@ func TestInfo_hasUnknownPlan(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("tags: %v", test.tags), func(t *testing.T) {
-			if test.wantErr == "" {
-				test.wantErr = "<nil>"
+			var gotErr string
+			err := (&Info{Info: license.Info{Tags: test.tags}}).hasUnknownPlan()
+			if err != nil {
+				gotErr = err.Error()
 			}
 
-			err := (&Info{Info: license.Info{Tags: test.tags}}).hasUnknownPlan()
-			got := fmt.Sprintf("%v", err)
-			if diff := cmp.Diff(test.wantErr, got); diff != "" {
+			if diff := cmp.Diff(test.wantErr, gotErr); diff != "" {
 				t.Fatalf("Mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/enterprise/internal/licensing/plans_test.go
+++ b/enterprise/internal/licensing/plans_test.go
@@ -51,3 +51,31 @@ func TestInfo_Plan(t *testing.T) {
 		})
 	}
 }
+
+func TestInfo_hasUnknownPlan(t *testing.T) {
+	tests := []struct {
+		tags        []string
+		wantTag     string
+		wantUnknown bool
+	}{
+		{tags: []string{""}, wantUnknown: false},
+		{tags: []string{"foo"}, wantUnknown: false},
+		{tags: []string{"foo", oldEnterpriseStarter.tag()}, wantUnknown: false},
+		{tags: []string{"foo", oldEnterprise.tag()}, wantUnknown: false},
+		{tags: []string{"foo", team.tag()}, wantUnknown: false},
+		{tags: []string{"foo", enterprise.tag()}, wantUnknown: false},
+		{tags: []string{"starter"}, wantUnknown: false},
+
+		{tags: []string{"foo", "plan:xyz"}, wantTag: "plan:xyz", wantUnknown: true},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("tags: %v", test.tags), func(t *testing.T) {
+			tag, unknown := (&Info{Info: license.Info{Tags: test.tags}}).hasUnknownPlan()
+			if tag != test.wantTag {
+				t.Errorf("Tag: got %q, want %q", tag, test.wantTag)
+			} else if unknown != test.wantUnknown {
+				t.Errorf("Unknown: got %v, want %v", unknown, test.wantUnknown)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Check unknown plans we found from license tags, and report an error when found.

Fixes #14031