### PR TITLE
search frontend: prioritize pattern scanning by search kind

### DIFF
--- a/client/shared/src/search/parser/completion.ts
+++ b/client/shared/src/search/parser/completion.ts
@@ -214,9 +214,9 @@ export async function getCompletionItems(
         throw new Error('getCompletionItems: no token at column')
     }
     const token = tokenAtColumn
-    // When the token at column is a literal or whitespace, show
-    // static filter type suggestions, followed by dynamic suggestions.
-    if (token.type === 'literal' || token.type === 'whitespace') {
+    // When the token at column is labeled as a pattern or whitespace, and none of filter,
+    // operator, nor quoted value, show static filter type suggestions, followed by dynamic suggestions.
+    if (token.type === 'pattern' || token.type === 'whitespace') {
         // Offer autocompletion of filter values
         const staticSuggestions = FILTER_TYPE_COMPLETIONS.map(
             (suggestion): Monaco.languages.CompletionItem => ({
@@ -230,7 +230,7 @@ export async function getCompletionItems(
         // This avoids blocking on dynamic suggestions to display
         // the suggestions widget.
         if (
-            token.type === 'literal' &&
+            token.type === 'pattern' &&
             staticSuggestions.some(({ label }) => label.startsWith(token.value.toLowerCase()))
         ) {
             return { suggestions: staticSuggestions }

--- a/client/shared/src/search/parser/parser.test.ts
+++ b/client/shared/src/search/parser/parser.test.ts
@@ -6,62 +6,63 @@ expect.addSnapshotSerializer({
 })
 
 describe('scanBalancedPattern()', () => {
+    const scanLiteralBalancedPattern = scanBalancedPattern()
     test('balanced, scans up to whitespace', () => {
-        expect(scanBalancedPattern()('foo OR bar', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('foo OR bar', 0)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"foo"}}'
         )
     })
 
     test('balanced, consumes spaces', () => {
-        expect(scanBalancedPattern()('(hello there)', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('(hello there)', 0)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":13},"kind":1,"value":"(hello there)"}}'
         )
     })
 
     test('balanced, consumes unrecognized filter-like value', () => {
-        expect(scanBalancedPattern()('( general:kenobi )', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('( general:kenobi )', 0)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"( general:kenobi )"}}'
         )
     })
 
     test('not recognized, contains not operator', () => {
-        expect(scanBalancedPattern()('(foo not bar)', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('(foo not bar)', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":5}'
         )
     })
 
     test('not recognized, starts with a not operator', () => {
-        expect(scanBalancedPattern()('(not chocolate)', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('(not chocolate)', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":1}'
         )
     })
 
     test('not recognized, contains an or operator', () => {
-        expect(scanBalancedPattern()('(foo OR bar)', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('(foo OR bar)', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":5}'
         )
     })
 
     test('not recognized, contains an and operator', () => {
-        expect(scanBalancedPattern()('repo:foo AND bar', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('repo:foo AND bar', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":0}'
         )
     })
 
     test('not recognized, contains a recognized repo field', () => {
-        expect(scanBalancedPattern()('repo:foo bar', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('repo:foo bar', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":0}'
         )
     })
 
     test('balanced, no conflicting tokens', () => {
-        expect(scanBalancedPattern()('(bor band )', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('(bor band )', 0)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":11},"kind":1,"value":"(bor band )"}}'
         )
     })
 
     test('not recognized, unbalanced', () => {
-        expect(scanBalancedPattern()('foo(', 0)).toMatchInlineSnapshot(
+        expect(scanLiteralBalancedPattern('foo(', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no unbalanced parentheses","at":4}'
         )
     })

--- a/client/shared/src/search/parser/parser.test.ts
+++ b/client/shared/src/search/parser/parser.test.ts
@@ -1,4 +1,4 @@
-import { parseSearchQuery, scanBalancedPattern } from './parser'
+import { parseSearchQuery, scanBalancedPattern, PatternKind } from './parser'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value),
@@ -7,67 +7,67 @@ expect.addSnapshotSerializer({
 
 describe('scanBalancedPattern()', () => {
     test('balanced, scans up to whitespace', () => {
-        expect(scanBalancedPattern('foo OR bar', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"literal","range":{"start":0,"end":3},"value":"foo"}}'
+        expect(scanBalancedPattern()('foo OR bar', 0)).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"foo"}}'
         )
     })
 
     test('balanced, consumes spaces', () => {
-        expect(scanBalancedPattern('(hello there)', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"literal","range":{"start":0,"end":13},"value":"(hello there)"}}'
+        expect(scanBalancedPattern()('(hello there)', 0)).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":13},"kind":1,"value":"(hello there)"}}'
         )
     })
 
     test('balanced, consumes unrecognized filter-like value', () => {
-        expect(scanBalancedPattern('( general:kenobi )', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"literal","range":{"start":0,"end":18},"value":"( general:kenobi )"}}'
+        expect(scanBalancedPattern()('( general:kenobi )', 0)).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"( general:kenobi )"}}'
         )
     })
 
     test('not recognized, contains not operator', () => {
-        expect(scanBalancedPattern('(foo not bar)', 0)).toMatchInlineSnapshot(
+        expect(scanBalancedPattern()('(foo not bar)', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":5}'
         )
     })
 
     test('not recognized, starts with a not operator', () => {
-        expect(scanBalancedPattern('(not chocolate)', 0)).toMatchInlineSnapshot(
+        expect(scanBalancedPattern()('(not chocolate)', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":1}'
         )
     })
 
     test('not recognized, contains an or operator', () => {
-        expect(scanBalancedPattern('(foo OR bar)', 0)).toMatchInlineSnapshot(
+        expect(scanBalancedPattern()('(foo OR bar)', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":5}'
         )
     })
 
     test('not recognized, contains an and operator', () => {
-        expect(scanBalancedPattern('repo:foo AND bar', 0)).toMatchInlineSnapshot(
+        expect(scanBalancedPattern()('repo:foo AND bar', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":0}'
         )
     })
 
     test('not recognized, contains a recognized repo field', () => {
-        expect(scanBalancedPattern('repo:foo bar', 0)).toMatchInlineSnapshot(
+        expect(scanBalancedPattern()('repo:foo bar', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no recognized filter or operator","at":0}'
         )
     })
 
     test('balanced, no conflicting tokens', () => {
-        expect(scanBalancedPattern('(bor band )', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"literal","range":{"start":0,"end":11},"value":"(bor band )"}}'
+        expect(scanBalancedPattern()('(bor band )', 0)).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":11},"kind":1,"value":"(bor band )"}}'
         )
     })
 
     test('not recognized, unbalanced', () => {
-        expect(scanBalancedPattern('foo(', 0)).toMatchInlineSnapshot(
+        expect(scanBalancedPattern()('foo(', 0)).toMatchInlineSnapshot(
             '{"type":"error","expected":"no unbalanced parentheses","at":4}'
         )
     })
 })
 
-describe('parseSearchQuery()', () => {
+describe('parseSearchQuery() for literal search', () => {
     test('empty', () =>
         expect(parseSearchQuery('')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[],"range":{"start":0,"end":1}}}'
@@ -80,12 +80,12 @@ describe('parseSearchQuery()', () => {
 
     test('literal', () =>
         expect(parseSearchQuery('a')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"literal","value":"a","range":{"start":0,"end":1}}],"range":{"start":0,"end":1}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":1},"kind":1,"value":"a"}],"range":{"start":0,"end":1}}}'
         ))
 
     test('triple quotes', () => {
         expect(parseSearchQuery('"""')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"literal","value":"\\"\\"\\"","range":{"start":0,"end":3}}],"range":{"start":0,"end":3}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"\\"\\"\\""}],"range":{"start":0,"end":3}}}'
         )
     })
 
@@ -134,40 +134,66 @@ describe('parseSearchQuery()', () => {
 
     test('complex query', () =>
         expect(parseSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":30},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"filterType":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"filterValue":{"type":"literal","value":"go","range":{"start":36,"end":38}}},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"filterType":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"filterValue":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}}},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"literal","value":"Router","range":{"start":52,"end":58}}],"range":{"start":0,"end":58}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":30},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"filterType":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"filterValue":{"type":"literal","value":"go","range":{"start":36,"end":38}}},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"filterType":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"filterValue":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}}},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}],"range":{"start":0,"end":58}}}'
         ))
 
     test('parenthesized parameters', () => {
         expect(parseSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}}},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}}},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"operator","value":"and","range":{"start":15,"end":18}},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"literal","value":"c","range":{"start":19,"end":20}},{"type":"closingParen","range":{"start":20,"end":21}}],"range":{"start":0,"end":21}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}}},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}}},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"operator","value":"and","range":{"start":15,"end":18}},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}],"range":{"start":0,"end":21}}}'
         )
     })
 
     test('nested parenthesized parameters', () => {
         expect(parseSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"literal","value":"a","range":{"start":1,"end":2}},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"operator","value":"and","range":{"start":3,"end":6}},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"literal","value":"b","range":{"start":8,"end":9}},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"operator","value":"or","range":{"start":10,"end":12}},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"literal","value":"c","range":{"start":13,"end":14}},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"operator","value":"and","range":{"start":16,"end":19}},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"literal","value":"d","range":{"start":20,"end":21}},{"type":"closingParen","range":{"start":21,"end":22}}],"range":{"start":0,"end":22}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":2},"kind":1,"value":"a"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"operator","value":"and","range":{"start":3,"end":6}},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"pattern","range":{"start":8,"end":9},"kind":1,"value":"b"},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"operator","value":"or","range":{"start":10,"end":12}},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"pattern","range":{"start":13,"end":14},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"operator","value":"and","range":{"start":16,"end":19}},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"pattern","range":{"start":20,"end":21},"kind":1,"value":"d"},{"type":"closingParen","range":{"start":21,"end":22}}],"range":{"start":0,"end":22}}}'
         )
     })
 
     test('do not treat links as filters', () => {
         expect(parseSearchQuery('http://example.com repo:a')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"literal","value":"http://example.com","range":{"start":0,"end":18}},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"filterType":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"filterValue":{"type":"literal","value":"a","range":{"start":24,"end":25}}}],"range":{"start":0,"end":25}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"filterType":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"filterValue":{"type":"literal","value":"a","range":{"start":24,"end":25}}}],"range":{"start":0,"end":25}}}'
+        )
+    })
+})
+
+describe('parseSearchQuery() for regexp', () => {
+    test('interpret regexp pattern with match groups', () => {
+        expect(
+            parseSearchQuery('((sauce|graph)(\\s)?)is best(g*r*a*p*h*)', false, PatternKind.Regexp)
+        ).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":22},"kind":2,"value":"((sauce|graph)(\\\\s)?)is"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":39},"kind":2,"value":"best(g*r*a*p*h*)"}],"range":{"start":0,"end":39}}}'
         )
     })
 
+    test('interpret regexp pattern with match groups between operators', () => {
+        expect(
+            parseSearchQuery('(((sauce|graph)\\s?) or (best)) and (gr|aph)', false, PatternKind.Regexp)
+        ).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":19},"kind":2,"value":"((sauce|graph)\\\\s?)"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"operator","value":"or","range":{"start":20,"end":22}},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":29},"kind":2,"value":"(best)"},{"type":"closingParen","range":{"start":29,"end":30}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"operator","value":"and","range":{"start":31,"end":34}},{"type":"whitespace","range":{"start":34,"end":35}},{"type":"pattern","range":{"start":35,"end":43},"kind":2,"value":"(gr|aph)"}],"range":{"start":0,"end":43}}}'
+        )
+    })
+
+    test('interpret regexp slash quotes', () => {
+        expect(parseSearchQuery('r:a /a regexp \\ pattern/', false, PatternKind.Regexp)).toMatchInlineSnapshot(
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"r","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a","range":{"start":2,"end":3}}},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}],"range":{"start":0,"end":24}}}'
+        )
+    })
+})
+
+describe('parseSearchQuery() with comments', () => {
     test('interpret C-style comments', () => {
         const query = `// saucegraph is best graph
 repo:sourcegraph
 // search for thing
 thing`
         expect(parseSearchQuery(query, true)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"filterType":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"filterValue":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}}},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"literal","value":"thing","range":{"start":65,"end":70}}],"range":{"start":0,"end":70}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"filterType":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"filterValue":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}}},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}],"range":{"start":0,"end":70}}}'
         )
     })
 
     test('do not interpret C-style comments', () => {
         expect(parseSearchQuery('// thing')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"literal","value":"//","range":{"start":0,"end":2}},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"literal","value":"thing","range":{"start":3,"end":8}}],"range":{"start":0,"end":8}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":2},"kind":1,"value":"//"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"pattern","range":{"start":3,"end":8},"kind":1,"value":"thing"}],"range":{"start":0,"end":8}}}'
         )
     })
 })

--- a/client/shared/src/search/parser/parser.ts
+++ b/client/shared/src/search/parser/parser.ts
@@ -21,7 +21,7 @@ export const toMonacoRange = ({ start, end }: CharacterRange): IRange => ({
     endColumn: end + 1,
 })
 
-enum PatternKind {
+export enum PatternKind {
     Literal = 1,
     Regexp,
     Structural,
@@ -360,6 +360,16 @@ const filter: Parser<Filter> = (input, start) => {
     }
 }
 
+const createPattern = (value: string, range: CharacterRange, kind: PatternKind): ParseSuccess<Pattern> => ({
+    type: 'success',
+    token: {
+        type: 'pattern',
+        range,
+        kind,
+        value,
+    },
+})
+
 const scanFilterOrOperator = oneOf<Literal | Sequence>(filterKeyword, followedBy(operator, whitespace))
 const keepScanning = (input: string, start: number): boolean => scanFilterOrOperator(input, start).type !== 'success'
 
@@ -384,7 +394,7 @@ const keepScanning = (input: string, start: number): boolean => scanFilterOrOper
  * (foo or (bar and baz)) - a valid query with and/or expression groups in the query langugae
  * (repo:foo bar baz)     - a valid query containing a recognized repo: field. Here parentheses are interpreted as a group, not a pattern.
  */
-export const scanBalancedPattern: Parser<Literal> = (input, start) => {
+export const scanBalancedPattern = (kind = PatternKind.Literal): Parser<Pattern> => (input, start) => {
     let adjustedStart = start
     let balanced = 0
     let current = ''
@@ -460,43 +470,59 @@ export const scanBalancedPattern: Parser<Literal> = (input, start) => {
         }
     }
 
-    return {
-        type: 'success',
-        token: {
-            type: 'literal',
-            range: {
-                start,
-                end: adjustedStart,
-            },
-            value: result.join(''),
-        },
-    }
+    return createPattern(result.join(''), { start, end: adjustedStart }, kind)
 }
 
-const baseTerms: Parser<Token>[] = [operator, filter, quoted('"'), quoted("'"), literal]
+const scanPattern = (kind: PatternKind): Parser<Pattern> => (input, start) => {
+    const balancedPattern = scanBalancedPattern(kind)(input, start)
+    if (balancedPattern.type === 'success') {
+        return createPattern(balancedPattern.token.value, balancedPattern.token.range, kind)
+    }
 
-const createParser = (terms: Parser<Token>[]): Parser<Sequence> =>
-    zeroOrMore(
+    const anyPattern = literal(input, start)
+    if (anyPattern.type === 'success') {
+        return createPattern(anyPattern.token.value, anyPattern.token.range, kind)
+    }
+
+    return anyPattern
+}
+
+const whitespaceOrClosingParen = oneOf<Whitespace | ClosingParen>(whitespace, closingParen)
+
+/**
+ * A {@link Parser} for a Sourcegraph search query, interpreting patterns for {@link PatternKind}.
+ *
+ * @param interpretComments Interpets C-style line comments for multiline queries.
+ */
+const createParser = (kind: PatternKind, interpretComments?: boolean): Parser<Sequence> => {
+    const baseQuotedScanner = [quoted('"'), quoted("'")]
+    const quotedScanner = kind === PatternKind.Regexp ? [quoted('/'), ...baseQuotedScanner] : baseQuotedScanner
+
+    const baseScanner = [operator, filter, ...quotedScanner, scanPattern(kind)]
+    const tokenScanner: Parser<Token>[] = interpretComments ? [comment, ...baseScanner] : baseScanner
+
+    const baseEarlyPatternScanner = [...quotedScanner, scanBalancedPattern(kind)]
+    const earlyPatternScanner = interpretComments ? [comment, ...baseEarlyPatternScanner] : baseEarlyPatternScanner
+
+    return zeroOrMore(
         oneOf<Term>(
             whitespace,
+            ...earlyPatternScanner.map(token => followedBy(token, whitespaceOrClosingParen)),
             openingParen,
             closingParen,
-            ...terms.map(token => followedBy(token, oneOf<Whitespace | ClosingParen>(whitespace, closingParen)))
+            ...tokenScanner.map(token => followedBy(token, whitespaceOrClosingParen))
         )
     )
-
-/**
- * A {@link Parser} for a Sourcegraph search query.
- */
-const searchQuery = createParser(baseTerms)
-
-/**
- * A {@link Parser} for a Sourcegraph search query containing comments.
- */
-const searchQueryWithComments = createParser([comment, ...baseTerms])
+}
 
 /**
  * Parses a search query string.
  */
-export const parseSearchQuery = (query: string, interpretComments?: boolean): ParserResult<Sequence> =>
-    interpretComments ? searchQueryWithComments(query, 0) : searchQuery(query, 0)
+export const parseSearchQuery = (
+    query: string,
+    interpretComments?: boolean,
+    kind = PatternKind.Literal
+): ParserResult<Sequence> => {
+    const scanner = createParser(kind, interpretComments)
+    return scanner(query, 0)
+}

--- a/client/shared/src/search/parser/parser.ts
+++ b/client/shared/src/search/parser/parser.ts
@@ -21,6 +21,11 @@ export const toMonacoRange = ({ start, end }: CharacterRange): IRange => ({
     endColumn: end + 1,
 })
 
+/**
+ * A label associated with a pattern token. We don't use SearchPatternType because
+ * that is used as a global quantifier for all patterns in a query. PatternKind
+ * allows to qualify multiple pattern tokens differently within a single query.
+ */
 export enum PatternKind {
     Literal = 1,
     Regexp,


### PR DESCRIPTION
This PR uses the `scanBalancedPattern` function to preemptively try parse patterns with balanced parens, before interpreting them as groups (see inline comment about the change).

Patterns are labeled as `type:pattern` now, instead of `type:literal`, and captures what kind of pattern it is (regex, literal, structural). I recommend split diff because it's quite easy to see how this affects updated tests 😍 

The scanner is almost feature-complete for parsing, just need to take care of some smaller details, e.g.,  in regexp mode, parens are escapable with `\(`, but in literal search they are not. I will go on to write the parse phase next though before addressing these nitty-gritty details, so that I can use the same backend tests.

FYI, for practical purposes, a literal scan/parse satisfies the needs for structural search until we process it further, so patterns are not labeled as `Structural` in the scanner, but will be useful later.