### PR TITLE
search: add boolean to code monitor

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -81,7 +81,7 @@ func (m *monitor) Description() string {
 	return "description not implemented"
 }
 
-func (m *monitor) Enabled() bool {
+func (*monitor) Enabled() bool {
 	return true
 }
 

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -56,6 +56,7 @@ type MonitorResolver interface {
 	CreatedAt() DateTime
 	Description() string
 	Owner(ctx context.Context) (Owner, error)
+	Enabled() bool
 	Trigger(ctx context.Context) (MonitorTrigger, error)
 	Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error)
 }
@@ -78,6 +79,10 @@ func (m *monitor) CreatedAt() DateTime {
 
 func (m *monitor) Description() string {
 	return "description not implemented"
+}
+
+func (m *monitor) Enabled() bool {
+	return true
 }
 
 func (m *monitor) Trigger(ctx context.Context) (MonitorTrigger, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2884,6 +2884,10 @@ type Monitor implements Node {
     """
     owner: Owner!
     """
+    Whether the code monitor is currently enabled.
+    """
+    enabled: Boolean!
+    """
     Triggers trigger actions. There can only be one trigger per monitor.
     """
     trigger: MonitorTrigger

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2877,6 +2877,10 @@ type Monitor implements Node {
     """
     owner: Owner!
     """
+    Whether the code monitor is currently enabled.
+    """
+    enabled: Boolean!
+    """
     Triggers trigger actions. There can only be one trigger per monitor.
     """
     trigger: MonitorTrigger


### PR DESCRIPTION
the schema for code monitors was missing a boolean to indicate whether the code monitor as
a whole is enabled or not. We already have a boolean on the level of actions.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
