### PR TITLE
git: test error cases in RawLogDiffSearch

### DIFF
--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 
 func TestRepository_BlameFile(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	gitCommands := []string{
 		"echo line1 > f",

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
-var ctx = context.Background()
-
 func TestRepository_GetCommit(t *testing.T) {
+	ctx := context.Background()
+
 	gitCommands := []string{
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
@@ -83,6 +83,7 @@ func TestRepository_GetCommit(t *testing.T) {
 
 func TestRepository_HasCommitAfter(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	testCases := []struct {
 		commitDates []string
@@ -158,6 +159,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 
 func TestRepository_Commits(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// TODO(sqs): test CommitsOptions.Base
 
@@ -238,6 +240,7 @@ func TestRepository_Commits(t *testing.T) {
 
 func TestRepository_Commits_options(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	gitCommands := []string{
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
@@ -322,6 +325,7 @@ func TestRepository_Commits_options(t *testing.T) {
 
 func TestRepository_Commits_options_path(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	gitCommands := []string{
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -101,7 +102,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			results, complete, err := RawLogDiffSearch(ctx, repo, test.opt)
+			results, complete, err := RawLogDiffSearch(context.Background(), repo, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -149,7 +150,7 @@ func TestRepository_RawLogDiffSearch_empty(t *testing.T) {
 
 	for label, test := range tests {
 		for opt, want := range test.want {
-			results, complete, err := RawLogDiffSearch(ctx, test.repo, *opt)
+			results, complete, err := RawLogDiffSearch(context.Background(), test.repo, *opt)
 			if err != nil {
 				t.Errorf("%s: %+v: %s", label, *opt, err)
 				continue

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -69,6 +69,24 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
 		}},
 	}, {
+		name: "refglob",
+		opt: RawLogDiffSearchOptions{
+			Query: TextSearchOptions{Pattern: "root"},
+			Diff:  true,
+			Args:  []string{"--glob=refs/tags/*"},
+		},
+		want: []*LogCommitSearchResult{{
+			Commit: Commit{
+				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
+				Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Committer: &Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+				Message:   "root",
+			},
+			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
+			SourceRefs: []string{"refs/tags/mytag"},
+			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
+		}},
+	}, {
 		name: "empty-query",
 		opt: RawLogDiffSearchOptions{
 			Query: TextSearchOptions{Pattern: ""},

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -118,7 +118,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 	}
 }
 
-func TestRepository_RawLogDiffSearch_emptyCommit(t *testing.T) {
+func TestRepository_RawLogDiffSearch_empty(t *testing.T) {
 	t.Parallel()
 
 	gitCommands := []string{
@@ -129,8 +129,16 @@ func TestRepository_RawLogDiffSearch_emptyCommit(t *testing.T) {
 		repo gitserver.Repo
 		want map[*RawLogDiffSearchOptions][]*LogCommitSearchResult
 	}{
-		"git cmd": {
+		"commit": {
 			repo: MakeGitRepository(t, gitCommands...),
+			want: map[*RawLogDiffSearchOptions][]*LogCommitSearchResult{
+				{
+					Paths: PathOptions{IncludePatterns: []string{"/xyz.txt"}, IsRegExp: true},
+				}: nil, // want no matches
+			},
+		},
+		"repo": {
+			repo: MakeGitRepository(t),
 			want: map[*RawLogDiffSearchOptions][]*LogCommitSearchResult{
 				{
 					Paths: PathOptions{IncludePatterns: []string{"/xyz.txt"}, IsRegExp: true},

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -76,7 +75,7 @@ func ExecReader(ctx context.Context, repo gitserver.Repo, args []string) (io.Rea
 
 func readUntilTimeout(ctx context.Context, cmd *gitserver.Cmd) (data []byte, complete bool, err error) {
 	sr, err := gitserver.StdoutReader(ctx, cmd)
-	if urlErr, ok := err.(*url.Error); ok && urlErr.Err == context.DeadlineExceeded {
+	if errors.Is(err, context.DeadlineExceeded) {
 		// Continue; the gitserver call exceeded our deadline before the command
 		// produced any output.
 	} else if err != nil {

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -90,9 +90,6 @@ func readUntilTimeout(ctx context.Context, cmd *gitserver.Cmd) (data []byte, com
 			complete = true
 		} else if err != context.DeadlineExceeded {
 			data = bytes.TrimSpace(data)
-			if isBadObjectErr(string(data), "") || isInvalidRevisionRangeError(string(data), "") {
-				return nil, true, &gitserver.RevisionNotFoundError{Repo: cmd.Repo.Name, Spec: "UNKNOWN"}
-			}
 			if len(data) > 100 {
 				data = append(data[:100], []byte("... (truncated)")...)
 			}

--- a/internal/vcs/git/exec_test.go
+++ b/internal/vcs/git/exec_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -54,7 +55,7 @@ func TestExecSafe(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.args), func(t *testing.T) {
-			stdout, stderr, exitCode, err := ExecSafe(ctx, repo, test.args)
+			stdout, stderr, exitCode, err := ExecSafe(context.Background(), repo, test.args)
 			if err == nil && test.wantError {
 				t.Errorf("got error %v, want error %v", err, test.wantError)
 			}

--- a/internal/vcs/git/merge_base_test.go
+++ b/internal/vcs/git/merge_base_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -8,6 +9,7 @@ import (
 
 func TestMerger_MergeBase(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// TODO(sqs): implement for hg
 	// TODO(sqs): make a more complex test case

--- a/internal/vcs/git/object_test.go
+++ b/internal/vcs/git/object_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -30,7 +31,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			oid, objectType, err := GetObject(ctx, test.repo, test.objectName)
+			oid, objectType, err := GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -54,7 +55,7 @@ func TestRepository_ListBranches(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		branches, err := ListBranches(ctx, test.repo, BranchesOptions{})
+		branches, err := ListBranches(context.Background(), test.repo, BranchesOptions{})
 		if err != nil {
 			t.Errorf("%s: Branches: %s", label, err)
 			continue
@@ -107,7 +108,7 @@ func TestRepository_Branches_MergedInto(t *testing.T) {
 		},
 	} {
 		for branch, mergedInto := range test.wantBranches {
-			branches, err := ListBranches(ctx, test.repo, BranchesOptions{MergedInto: branch})
+			branches, err := ListBranches(context.Background(), test.repo, BranchesOptions{MergedInto: branch})
 			if err != nil {
 				t.Errorf("%s: Branches: %s", label, err)
 				continue
@@ -148,7 +149,7 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 
 	for label, test := range tests {
 		for commit, wantBranches := range test.commitToWantBranches {
-			branches, err := ListBranches(ctx, test.repo, BranchesOptions{ContainsCommit: commit})
+			branches, err := ListBranches(context.Background(), test.repo, BranchesOptions{ContainsCommit: commit})
 			if err != nil {
 				t.Errorf("%s: Branches: %s", label, err)
 				continue
@@ -198,7 +199,7 @@ func TestRepository_Branches_BehindAheadCounts(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		branches, err := ListBranches(ctx, test.repo, BranchesOptions{BehindAheadBranch: "master"})
+		branches, err := ListBranches(context.Background(), test.repo, BranchesOptions{BehindAheadBranch: "master"})
 		if err != nil {
 			t.Errorf("%s: Branches: %s", label, err)
 			continue
@@ -253,7 +254,7 @@ func TestRepository_Branches_IncludeCommit(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		branches, err := ListBranches(ctx, test.repo, BranchesOptions{IncludeCommit: true})
+		branches, err := ListBranches(context.Background(), test.repo, BranchesOptions{IncludeCommit: true})
 		if err != nil {
 			t.Errorf("%s: Branches: %s", label, err)
 			continue
@@ -291,7 +292,7 @@ func TestRepository_ListTags(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		tags, err := ListTags(ctx, test.repo)
+		tags, err := ListTags(context.Background(), test.repo)
 		if err != nil {
 			t.Errorf("%s: ListTags: %s", label, err)
 			continue

--- a/internal/vcs/git/revisions_test.go
+++ b/internal/vcs/git/revisions_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -41,7 +42,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.branch, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -72,7 +73,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.branch, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.branch, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -104,7 +105,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.tag, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -135,7 +136,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, test.tag, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.tag, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -104,6 +104,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 
 func TestRepository_FileSystem(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// In all tests, repo should contain three commits. The first commit
 	// (whose ID is in the 'first' field) has a file at dir1/file1 with the
@@ -296,6 +297,7 @@ func TestRepository_FileSystem(t *testing.T) {
 
 func TestRepository_FileSystem_quoteChars(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// The repo contains 3 files: one whose filename includes a
 	// non-ASCII char, one whose filename contains a double quote, and
@@ -366,6 +368,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 
 func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	submodDir := InitGitRepository(t,
 		"touch f",


### PR DESCRIPTION
We increase the test coverage of diff/commit search. In particular the testing added focuses on error cases that can occur. Currently there is error code inspecting output of git in multiple parts of the log parsing code. This made it tricky converting the function to be stream based. As such these are added to ensure we do not regress.