### PR TITLE
Fix broken links to campaigns docs on dotcom

### DIFF
--- a/client/web/src/enterprise/campaigns/global/marketing/CampaignsDotComPage.tsx
+++ b/client/web/src/enterprise/campaigns/global/marketing/CampaignsDotComPage.tsx
@@ -46,16 +46,16 @@ export const CampaignsDotComPage: React.FunctionComponent<CampaignsDotComPagePro
                     </li>
                     <li>
                         Follow the{' '}
-                        <a href="https://docs.sourcegraph.com/campaigns/getting_started" rel="noopener">
-                            Getting started with campaigns
+                        <a href="https://docs.sourcegraph.com/campaigns/quickstart" rel="noopener">
+                            quickstart guide for campaigns
                         </a>{' '}
-                        guide to enable campaigns on your instance and start using them.
+                        to enable campaigns on your instance and start using them.
                     </li>
                 </ol>
 
                 <p>
                     Learn more about campaigns{' '}
-                    <a href="https://docs.sourcegraph.com/user/campaigns" rel="noopener">
+                    <a href="https://docs.sourcegraph.com/campaigns" rel="noopener">
                         in the documentation
                     </a>
                     .

--- a/client/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/global/marketing/__snapshots__/CampaignsDotComPage.test.tsx.snap
@@ -88,20 +88,20 @@ exports[`CampaignsDotComPage renders 1`] = `
             Follow the
              
             <a
-              href="https://docs.sourcegraph.com/campaigns/getting_started"
+              href="https://docs.sourcegraph.com/campaigns/quickstart"
               rel="noopener"
             >
-              Getting started with campaigns
+              quickstart guide for campaigns
             </a>
              
-            guide to enable campaigns on your instance and start using them.
+            to enable campaigns on your instance and start using them.
           </li>
         </ol>
         <p>
           Learn more about campaigns
            
           <a
-            href="https://docs.sourcegraph.com/user/campaigns"
+            href="https://docs.sourcegraph.com/campaigns"
             rel="noopener"
           >
             in the documentation


### PR DESCRIPTION
Ran into this on sourcegraph.com/campaigns.