### PR TITLE
Fix homepage panel pings

### DIFF
--- a/cmd/frontend/internal/usagestats/homepage_panels.go
+++ b/cmd/frontend/internal/usagestats/homepage_panels.go
@@ -34,7 +34,7 @@ FROM (
     NULLIF(COUNT(*) FILTER (WHERE name = 'SavedSearchesPanelLoaded'), 0)              :: FLOAT AS savedSearchesPanelLoaded,
     NULLIF(COUNT(*) FILTER (WHERE name = 'SavedSearchesPanelCreateButtonClicked'), 0) :: FLOAT AS savedSearchesPanelCreateButtonClicked,
 
-    NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name  = 'RecentFilesPanelFileClicked'), 0)                :: FLOAT AS uniqueRecentFilesPanelFileClicked,
+    NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name  = 'RecentFilesPanelFileClicked'), 0)          :: FLOAT AS uniqueRecentFilesPanelFileClicked,
     NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name = 'RecentFilesPanelLoaded'), 0)                :: FLOAT AS uniqueRecentFilesPanelLoaded,
     NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name = 'RecentSearchesPanelSearchClicked'), 0)      :: FLOAT AS uniqueRecentSearchesPanelSearchClicked,
     NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name = 'RecentSearchesPanelLoaded'), 0)             :: FLOAT AS uniqueRecentSearchesPanelLoaded,

--- a/cmd/frontend/internal/usagestats/homepage_panels.go
+++ b/cmd/frontend/internal/usagestats/homepage_panels.go
@@ -34,6 +34,7 @@ FROM (
     NULLIF(COUNT(*) FILTER (WHERE name = 'SavedSearchesPanelLoaded'), 0)              :: FLOAT AS savedSearchesPanelLoaded,
     NULLIF(COUNT(*) FILTER (WHERE name = 'SavedSearchesPanelCreateButtonClicked'), 0) :: FLOAT AS savedSearchesPanelCreateButtonClicked,
 
+    NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name  = 'RecentFilesPanelFileClicked'), 0)                :: FLOAT AS uniqueRecentFilesPanelFileClicked,
     NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name = 'RecentFilesPanelLoaded'), 0)                :: FLOAT AS uniqueRecentFilesPanelLoaded,
     NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name = 'RecentSearchesPanelSearchClicked'), 0)      :: FLOAT AS uniqueRecentSearchesPanelSearchClicked,
     NULLIF(COUNT(DISTINCT user_id) FILTER (WHERE name = 'RecentSearchesPanelLoaded'), 0)             :: FLOAT AS uniqueRecentSearchesPanelLoaded,

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -1243,18 +1243,18 @@ type SavedSearches struct {
 // Panel homepage represents interaction data on the
 // enterprise homepage panels.
 type HomepagePanels struct {
-	RecentFilesClickedPercentage           float64
-	RecentSearchClickedPercentage          float64
-	RecentRepositoriesClickedPercentage    float64
-	SavedSearchesClickedPercentage         float64
-	NewSavedSearchesClickedPercentage      float64
-	TotalPanelViews                        float64
-	UsersFilesClickedPercentage            float64
-	UsersSearchClickedPercentage           float64
-	UsersRepositoriesClickedPercentage     float64
-	UsersSavedSearchesClickedPercentage    float64
-	UsersNewSavedSearchesClickedPercentage float64
-	PercentUsersShown                      float64
+	RecentFilesClickedPercentage           *float64
+	RecentSearchClickedPercentage          *float64
+	RecentRepositoriesClickedPercentage    *float64
+	SavedSearchesClickedPercentage         *float64
+	NewSavedSearchesClickedPercentage      *float64
+	TotalPanelViews                        *float64
+	UsersFilesClickedPercentage            *float64
+	UsersSearchClickedPercentage           *float64
+	UsersRepositoriesClickedPercentage     *float64
+	UsersSavedSearchesClickedPercentage    *float64
+	UsersNewSavedSearchesClickedPercentage *float64
+	PercentUsersShown                      *float64
 }
 
 // Secret represents the secrets table


### PR DESCRIPTION
@ebrodymoore told me that the `homepagePanels` ping currently returns `null`. This PR fixes it.

There were two issues that are fixed:
* one variable in the SQL query `uniqueRecentFilesPanelFileClicked` didn't exist
* scanning into the HomepagePanels object failed when `null` was returned as it couldn't be converted to a float

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
