### PR TITLE
repo-updater: handle error from remoteRepoSync

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -456,6 +456,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 				repoResult, err := s.remoteRepoSync(ctx, codehost, string(args.Repo))
 				if err != nil {
 					log15.Error("async remoteRepoSync failed", "repo", args.Repo, "error", err)
+					return
 				}
 
 				// Since we don't support private repositories on Cloud,


### PR DESCRIPTION
Currently production is panicing if we try to fetch a repository which
is blocked. In particular for youtube-dl repo GitHub is returning:

  status 451: Repository access blocked

This leads to us returning an error and a nil repoResult. We then try to
access the nil repoResult. This adds in the appropriate early return to
avoid reading repoResult.