### PR TITLE
search: add code monitoring feature flag and basic homepage

### DIFF
--- a/client/web/src/code-monitoring/CodeMonitoringNavItem.tsx
+++ b/client/web/src/code-monitoring/CodeMonitoringNavItem.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
+import { LinkWithIconOnlyTooltip } from '../components/LinkWithIconOnlyTooltip'
+
+export const CodeMonitoringNavItem: React.FunctionComponent = () => (
+    <LinkWithIconOnlyTooltip
+        to="/code-monitoring"
+        text="Code Monitoring"
+        icon={VideoInputAntennaIcon}
+        className="nav-link btn btn-link px-1 text-decoration-none"
+        activeClassName="active"
+    />
+)

--- a/client/web/src/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/code-monitoring/CodeMonitoringPage.story.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { CodeMonitoringPage } from './CodeMonitoringPage'
+import { storiesOf } from '@storybook/react'
+import { WebStory } from '../components/WebStory'
+
+const { add } = storiesOf('web/code-monitoring/CodeMonitoringPage', module)
+
+add('Example', () => <WebStory>{props => <CodeMonitoringPage {...props} />}</WebStory>, {
+    design: {
+        type: 'figma',
+        url:
+            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+    },
+})

--- a/client/web/src/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/code-monitoring/CodeMonitoringPage.tsx
@@ -1,0 +1,42 @@
+import * as H from 'history'
+import React, { useMemo } from 'react'
+import { Breadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
+import { PageHeader } from '../components/PageHeader'
+import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
+
+interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters {
+    location: H.Location
+}
+
+export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => {
+    props.useBreadcrumb(
+        useMemo(
+            () => ({
+                key: 'Code Monitoring',
+                element: <>Code Monitoring</>,
+            }),
+            []
+        )
+    )
+
+    return (
+        <div className="w-100">
+            <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
+            <div className="container mt-3 web-content">
+                <PageHeader
+                    title={
+                        <>
+                            Code Monitoring{' '}
+                            <sup>
+                                <span className="badge badge-info text-uppercase">Prototype</span>
+                            </sup>
+                        </>
+                    }
+                    icon={VideoInputAntennaIcon}
+                    actions={<></>}
+                />
+                <div>Hello world</div>
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/code-monitoring/CodeMonitoringPage.tsx
@@ -1,8 +1,9 @@
 import * as H from 'history'
 import React, { useMemo } from 'react'
+import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
 import { Breadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
 import { PageHeader } from '../components/PageHeader'
-import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
+import { PageTitle } from '../components/PageTitle'
 
 interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters {
     location: H.Location
@@ -23,6 +24,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
         <div className="w-100">
             <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
             <div className="container mt-3 web-content">
+                <PageTitle title="Code Monitoring" />
                 <PageHeader
                     title={
                         <>
@@ -33,7 +35,6 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                         </>
                     }
                     icon={VideoInputAntennaIcon}
-                    actions={<></>}
                 />
                 <div>Hello world</div>
             </div>

--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -22,6 +22,7 @@ import {
 import { isErrorLike } from '../../../shared/src/util/errors'
 import { Settings } from '../schema/settings.schema'
 import { InsightsNavItem } from '../insights/InsightsNavLink'
+import { CodeMonitoringNavItem } from '../code-monitoring/CodeMonitoringNavItem'
 import { AuthenticatedUser } from '../auth'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { ExtensionsNavItem } from '../extensions/ExtensionsNavItem'
@@ -74,6 +75,13 @@ export class NavLinks extends React.PureComponent<Props> {
                     !this.props.minimalNavLinks && (
                         <li className="nav-item">
                             <InsightsNavItem />
+                        </li>
+                    )}
+                {!isErrorLike(this.props.settingsCascade.final) &&
+                    this.props.settingsCascade.final?.experimentalFeatures?.codeMonitoring &&
+                    !this.props.minimalNavLinks && (
+                        <li className="nav-item">
+                            <CodeMonitoringNavItem />
                         </li>
                     )}
                 {!this.props.minimalNavLinks && (

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -190,6 +190,14 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             !!props.settingsCascade.final?.experimentalFeatures?.codeInsights,
     },
     {
+        path: '/code-monitoring',
+        exact: true,
+        render: lazyComponent(() => import('./code-monitoring/CodeMonitoringPage'), 'CodeMonitoringPage'),
+        condition: props =>
+            !isErrorLike(props.settingsCascade.final) &&
+            !!props.settingsCascade.final?.experimentalFeatures?.codeMonitoring,
+    },
+    {
         path: '/views',
         render: lazyComponent(() => import('./views/ViewsArea'), 'ViewsArea'),
     },

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -43,6 +43,7 @@ const (
 	routeRepoStats      = "repo-stats"
 	routeInsights       = "insights"
 	routeCampaigns      = "campaigns"
+	routeCodeMonitoring = "code-monitoring"
 	routeThreads        = "threads"
 	routeTree           = "tree"
 	routeBlob           = "blob"
@@ -119,6 +120,7 @@ func newRouter() *mux.Router {
 	r.Path("/sign-up").Methods("GET").Name(uirouter.RouteSignUp)
 	r.PathPrefix("/insights").Methods("GET").Name(routeInsights)
 	r.PathPrefix("/campaigns").Methods("GET").Name(routeCampaigns)
+	r.PathPrefix("/code-monitoring").Methods("GET").Name(routeCodeMonitoring)
 	r.PathPrefix("/organizations").Methods("GET").Name(routeOrganizations)
 	r.PathPrefix("/settings").Methods("GET").Name(routeSettings)
 	r.PathPrefix("/site-admin").Methods("GET").Name(routeSiteAdmin)
@@ -200,6 +202,7 @@ func initRouter() {
 	router.Get(routeThreads).Handler(handler(serveBrandedPageString("Threads", nil)))
 	router.Get(routeInsights).Handler(handler(serveBrandedPageString("Insights", nil)))
 	router.Get(routeCampaigns).Handler(handler(serveBrandedPageString("Campaigns", nil)))
+	router.Get(routeCodeMonitoring).Handler(handler(serveBrandedPageString("Code Monitoring", nil)))
 	router.Get(uirouter.RouteSignIn).Handler(handler(serveSignIn))
 	router.Get(uirouter.RouteSignUp).Handler(handler(serveBrandedPageString("Sign up", nil)))
 	router.Get(routeOrganizations).Handler(handler(serveBrandedPageString("Organization", nil)))

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1095,6 +1095,8 @@ type Settings struct {
 type SettingsExperimentalFeatures struct {
 	// CodeInsights description: Enables code insights on directory pages.
 	CodeInsights *bool `json:"codeInsights,omitempty"`
+	// CodeMonitoring description: Enables code monitoring on directory pages.
+	CodeMonitoring *bool `json:"codeMonitoring,omitempty"`
 	// CopyQueryButton description: Enables displaying the copy query button in the search bar when hovering over the global navigation bar.
 	CopyQueryButton *bool `json:"copyQueryButton,omitempty"`
 	// SearchStats description: Enables a new page that shows language statistics about the results for a search query.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -24,6 +24,12 @@
           "default": false,
           "!go": { "pointer": true }
         },
+        "codeMonitoring": {
+          "description": "Enables code monitoring on directory pages.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
         "searchStats": {
           "description": "Enables a new page that shows language statistics about the results for a search query.",
           "type": "boolean",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -29,6 +29,12 @@ const SettingsSchemaJSON = `{
           "default": false,
           "!go": { "pointer": true }
         },
+        "codeMonitoring": {
+          "description": "Enables code monitoring on directory pages.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
         "searchStats": {
           "description": "Enables a new page that shows language statistics about the results for a search query.",
           "type": "boolean",


### PR DESCRIPTION
Fixes #15283 and #15353

- Create feature flag for code monitoring
- Create basic homepage for code monitoring
- Create routes for code monitoring homepage, conditional on the feature flag being enabled
- Added nav link to code monitoring page when feature flag is on

![image](https://user-images.githubusercontent.com/206864/98031807-e6095200-1dc7-11eb-814e-76990d12a9dd.png)
