### PR TITLE
search console: add keyboard buttons for shortcut

### DIFF
--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -141,7 +141,8 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                     <div className="mb-1 d-flex align-items-center justify-content-between">
                         <div />
                         <button className="btn btn-lg btn-primary" type="button" onClick={triggerSearch}>
-                            Search
+                            Search &nbsp; {window.navigator.platform.includes('Mac') ? <kbd>⌘</kbd> : <kbd>Ctrl</kbd>}+
+                            <kbd>⏎</kbd>
                         </button>
                     </div>
                     <MonacoEditor


### PR DESCRIPTION
Couldn't resist. This is for search console page at https://sourcegraph.com/search/console

<img width="212" alt="Screen Shot 2020-11-03 at 1 51 59 PM" src="https://user-images.githubusercontent.com/888624/98039414-e6abe380-1ddb-11eb-80bc-da93e2085e7b.png">

<img width="193" alt="Screen Shot 2020-11-03 at 1 54 39 PM" src="https://user-images.githubusercontent.com/888624/98039573-2377da80-1ddc-11eb-9b4f-96751659b004.png">


Alt:

<img width="205" alt="Screen Shot 2020-11-03 at 1 53 50 PM" src="https://user-images.githubusercontent.com/888624/98039504-08a56600-1ddc-11eb-85ae-e50fb46e8a44.png">


