### PR TITLE
search frontend: decode query URL before parsing for case check

### DIFF
--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -53,7 +53,7 @@ export function parseSearchURLVersionContext(query: string): string | undefined 
 }
 
 export function searchURLIsCaseSensitive(query: string): boolean {
-    const queryCaseSensitivity = parseCaseSensitivityFromQuery(query)
+    const queryCaseSensitivity = parseCaseSensitivityFromQuery(parseSearchURLQuery(query) || '')
     if (queryCaseSensitivity) {
         // if `case:` filter exists in the query, override the existing case: query param
         return discreteValueAliases.yes.includes(queryCaseSensitivity.value)


### PR DESCRIPTION
The `query` argument for this function is the URL path, like `/search?q=whatever&patternType=literal&case=yes`. The `parseCaseSensitivityFromQuery` expects the query string, like `whatever case:yes`. I suspect that the check `if (queryCaseSensitivity) ...` never really did anything. 

I found this while trying to parse regex inputs, and seeing that this URL path is "invalid", raising the question of why I was seeing this string at the point of parsing the query. 

Maybe @attfarhan can add a test for `searchURLIsCaseSensitive`, but I'd like this to not block merging this fix :-)