### PR TITLE
dev/gqltest: move test repos from GitHub.com to GHE

### DIFF
--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -30,10 +30,10 @@ func TestExternalService(t *testing.T) {
 				Repos                 []string `json:"repos"`
 				RepositoryPathPattern string   `json:"repositoryPathPattern"`
 			}{
-				URL:                   "http://github.com",
+				URL:                   "https://ghe.sgdev.org/",
 				Token:                 *githubToken,
 				Repos:                 []string{repo},
-				RepositoryPathPattern: "foobar/{host}/{nameWithOwner}",
+				RepositoryPathPattern: "github.com/{nameWithOwner}",
 			}),
 		})
 		// The repo-updater might not be up yet but it will eventually catch up for the external
@@ -48,7 +48,7 @@ func TestExternalService(t *testing.T) {
 			}
 		}()
 
-		err = client.WaitForReposToBeCloned("foobar/" + slug)
+		err = client.WaitForReposToBeCloned(slug)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -61,7 +61,7 @@ func TestExternalService(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		wantURL := *baseURL + "/foobar/" + slug // <baseURL>/foobar/github.com/sgtest/go-diff
+		wantURL := *baseURL + "/" + slug // <baseURL>/github.com/sgtest/go-diff
 		if diff := cmp.Diff(wantURL, resp.Request.URL.String()); diff != "" {
 			t.Fatalf("URL mismatch (-want +got):\n%s", diff)
 		}

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -38,6 +38,13 @@ func TestMain(m *testing.M) {
 
 	*baseURL = strings.TrimSuffix(*baseURL, "/")
 
+	// Make it possible to use a different token on non-default branches
+	// so we don't break builds on the default branch.
+	mockGitHubToken := os.Getenv("MOCK_GITHUB_TOKEN")
+	if mockGitHubToken != "" {
+		*githubToken = mockGitHubToken
+	}
+
 	needsSiteInit, err := gqltestutil.NeedsSiteInit(*baseURL)
 	if err != nil {
 		log.Fatal("Failed to check if site needs init: ", err)

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -25,11 +25,12 @@ func TestSearch(t *testing.T) {
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "gqltest-github-search",
 		Config: mustMarshalJSONString(struct {
-			URL   string   `json:"url"`
-			Token string   `json:"token"`
-			Repos []string `json:"repos"`
+			URL                   string   `json:"url"`
+			Token                 string   `json:"token"`
+			Repos                 []string `json:"repos"`
+			RepositoryPathPattern string   `json:"repositoryPathPattern"`
 		}{
-			URL:   "http://github.com",
+			URL:   "https://ghe.sgdev.org/",
 			Token: *githubToken,
 			Repos: []string{
 				"sgtest/java-langserver",
@@ -41,6 +42,7 @@ func TestSearch(t *testing.T) {
 				"sgtest/mux",      // Fork
 				"sgtest/archived", // Archived
 			},
+			RepositoryPathPattern: "github.com/{nameWithOwner}",
 		}),
 	})
 	if err != nil {

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -12,7 +12,7 @@ import (
 //
 // This method requires the authenticated user to be a site admin.
 func (c *Client) WaitForReposToBeCloned(repos ...string) error {
-	timeout := 30 * time.Second
+	timeout := 45 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
We're having many clone failures from GitHub.com in our CI, so I copied test repos to our private GHE instance and updating gqltest to clone from GHE.

Also increased wait for clone timeout from 30s to 45s because I notice many builds are finishing tests almost at 30s, slow cloning could be a cause of previous failures.

Context: https://sourcegraph.slack.com/archives/C08JA8Q1H/p1604319938082500

cc @rvantonder The only change for local use of `dev/gqltest` is to use the same personal access token placed in our "dev-private" repo for `GITHUB_TOKEN`:

https://github.com/sourcegraph/dev-private/blob/e2f43d2f6007b2b42a0738e069eae4aff79b61ed/enterprise/dev/external-services-config.json#L42