### PR TITLE
git: stream output from log in batches into show 

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -336,6 +336,18 @@ type onelineCommit struct {
 	sourceRef string // `git log --source` source ref
 }
 
+// logOnelineBatchScanner wraps logOnelineScanner to batch up reads.
+func logOnelineBatchScanner(scan func() (*onelineCommit, error), maxBatchSize int, debounce time.Duration) func() ([]*onelineCommit, error) {
+	// TODO stub impl, do batching
+	return func() ([]*onelineCommit, error) {
+		commit, err := scan()
+		if err != nil {
+			return nil, err
+		}
+		return []*onelineCommit{commit}, nil
+	}
+}
+
 // logOnelineScanner parses the commits from the reader of:
 //
 //   git log --oneline -z --source --no-patch

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -422,17 +422,9 @@ func logOnelineBatchScanner(scan func() (*onelineCommit, error), maxBatchSize in
 			}
 		}
 
-		if len(commits) > 0 {
-			// Note: err can be non-nil here. The next call to this
-			// function will return err.
-			return commits, nil
-		}
-
-		if err == nil {
-			panic("err should be set if commits is empty")
-		}
-
-		return nil, err
+		// Note: err can be non-nil here. The next call to this
+		// function will return err.
+		return commits, nil
 	}
 
 	return next, cleanup

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -377,10 +377,14 @@ func logOnelineScanner(r io.Reader) func() (*onelineCommit, error) {
 	scanner.Split(scanNull)
 	return func() (*onelineCommit, error) {
 		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return nil, err
+			err := scanner.Err()
+			if err == nil {
+				return nil, io.EOF
+			} else if strings.Contains(err.Error(), "does not have any commits yet") {
+				// Treat empty repositories as having no commits without failing
+				return nil, io.EOF
 			}
-			return nil, io.EOF
+			return nil, err
 		}
 
 		e := scanner.Bytes()

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -406,8 +407,58 @@ func TestRepository_Commits_options_path(t *testing.T) {
 	}
 }
 
-// Test we return errLogOnelineBatchScannerClosed is returned. I fear this may
-// introduce flakey coverage.
+// Test we return errLogOnelineBatchScannerClosed is returned. It is very
+// complicated to ensure we cover the code paths we care about.
+func TestLogOnelineBatchScanner_batchclosed(t *testing.T) {
+	t.Parallel()
+
+	// We want this flow. This is to ensure we close while doing batch
+	// collection.
+	//
+	// 1. scan
+	// 2. scan
+	// 3. cleanup
+	// 4. scan
+	//
+	// So we use channels to orchestrate it, named after the numbered step
+	// above.
+	step3 := make(chan struct{})
+	step4 := make(chan struct{})
+	scanCount := 0
+	scan := func() (*onelineCommit, error) {
+		// make things a little slower to allow other goroutines to run.
+		time.Sleep(10 * time.Millisecond)
+
+		scanCount++
+		if scanCount == 2 {
+			// allow step3 to run (cleanup)
+			close(step3)
+		} else if scanCount == 3 {
+			// we are step4, wait for step3 to run
+			<-step4
+		}
+		return &onelineCommit{}, nil
+	}
+
+	next, cleanup := logOnelineBatchScanner(scan, 10000, 5*time.Second)
+
+	go func() {
+		<-step3
+		cleanup()
+		close(step4)
+	}()
+
+	var err error
+	for err == nil {
+		_, err = next()
+	}
+	if err != errLogOnelineBatchScannerClosed {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+// This test is much simpler since we just set the batchsize to 1 to ensure we
+// only ever test the first attempt to read resultC
 func TestLogOnelineBatchScanner_closed(t *testing.T) {
 	t.Parallel()
 
@@ -415,9 +466,7 @@ func TestLogOnelineBatchScanner_closed(t *testing.T) {
 		return &onelineCommit{}, nil
 	}
 
-	next, cleanup := logOnelineBatchScanner(scan, 100, 5*time.Second)
-	_, _ = next()
-
+	next, cleanup := logOnelineBatchScanner(scan, 1, 5*time.Second)
 	cleanup()
 
 	var err error
@@ -425,6 +474,84 @@ func TestLogOnelineBatchScanner_closed(t *testing.T) {
 		_, err = next()
 	}
 	if err != errLogOnelineBatchScannerClosed {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestLogOnelineBatchScanner_debounce(t *testing.T) {
+	t.Parallel()
+
+	// used to prevent scan blocking forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// First call return a commit. Second call wait until timeout on ctx.
+	scanCount := 0
+	scan := func() (*onelineCommit, error) {
+		scanCount++
+		if scanCount == 1 {
+			return &onelineCommit{}, nil
+		} else {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+	}
+
+	next, cleanup := logOnelineBatchScanner(scan, 100, time.Millisecond)
+	defer cleanup()
+
+	commits, err := next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(commits) != 1 {
+		t.Fatalf("expected 1 commit, got %d", len(commits))
+	}
+	if ctx.Err() != nil {
+		t.Fatal("timedout out before debounce timeout")
+	}
+}
+
+func TestLogOnelineBatchScanner_empty(t *testing.T) {
+	t.Parallel()
+
+	scan := func() (*onelineCommit, error) {
+		return nil, io.EOF
+	}
+
+	next, cleanup := logOnelineBatchScanner(scan, 100, 5*time.Second)
+	defer cleanup()
+
+	if _, err := next(); err != io.EOF {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestLogOnelineBatchScanner_small(t *testing.T) {
+	t.Parallel()
+
+	wantCommits := 20
+	scanCount := 0
+	scan := func() (*onelineCommit, error) {
+		scanCount++
+		if scanCount <= wantCommits {
+			return &onelineCommit{}, nil
+		} else {
+			return nil, io.EOF
+		}
+	}
+
+	// ensure batch size is bigger than number of commits we return.
+	next, cleanup := logOnelineBatchScanner(scan, wantCommits*3, 5*time.Second)
+	defer cleanup()
+
+	if commits, err := next(); err != nil {
+		t.Fatal("expected commits, got err:", err)
+	} else if len(commits) != wantCommits {
+		t.Fatalf("wanted %d commits, got %d", wantCommits, len(commits))
+	}
+
+	if _, err := next(); err != io.EOF {
 		t.Fatal("unexpected error:", err)
 	}
 }

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -405,3 +405,26 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		}
 	}
 }
+
+// Test we return errLogOnelineBatchScannerClosed is returned. I fear this may
+// introduce flakey coverage.
+func TestLogOnelineBatchScanner_closed(t *testing.T) {
+	t.Parallel()
+
+	scan := func() (*onelineCommit, error) {
+		return &onelineCommit{}, nil
+	}
+
+	next, cleanup := logOnelineBatchScanner(scan, 100, 5*time.Second)
+	_, _ = next()
+
+	cleanup()
+
+	var err error
+	for err == nil {
+		_, err = next()
+	}
+	if err != errLogOnelineBatchScannerClosed {
+		t.Fatal("unexpected error:", err)
+	}
+}

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -245,9 +245,7 @@ func rawLogSearch(ctx context.Context, repo gitserver.Repo, opt RawLogDiffSearch
 	// Run `git log` oneline command and read list of matching commits.
 	onelineCmd := gitserver.DefaultClient.Command("git", onelineArgs...)
 	onelineCmd.Repo = repo
-	ctxLog, cancel := withDeadlinePercentage(ctx, 0.5)
-	defer cancel()
-	onelineReader, err := gitserver.StdoutReader(ctxLog, onelineCmd)
+	onelineReader, err := gitserver.StdoutReader(ctx, onelineCmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This greatly improves the perfomance of diff/commit search by streaming
the log output into the part which does git show. This also makes it
straight forward to change the API for RawLogDiffSearch into a stream
based API.

We want to pass multiple commits to `git show` to amortize the cost of starting up git / RPC costs. So we batch up the commits returned from `git log`. However, the time between `git log` outputting a commit and the next is unbounded. We scan over the `io.Reader` returned from gitserver for running the `git log` command. Because it's an `io.Reader`, we don't have a way to timeout a read. As such we wrap our scanner in a goroutine to send down the scans over a channel. This allows us to implement the timeout behaviour of returning what has been fetched so far.