### PR TITLE
Change ExternalService nullable variables from pointers to values

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -43,9 +43,9 @@ func externalServiceByID(ctx context.Context, gqlID graphql.ID) (*externalServic
 	// 🚨 SECURITY: Only site admins may read all or a user's external services.
 	// Otherwise, the authenticated user can only read external services under the same namespace.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		if es.NamespaceUserID == nil {
+		if es.NamespaceUserID == 0 {
 			return nil, err
-		} else if actor.FromContext(ctx).UID != *es.NamespaceUserID {
+		} else if actor.FromContext(ctx).UID != es.NamespaceUserID {
 			return nil, errors.New("the authenticated user does not have access to this external service")
 		}
 	}
@@ -91,10 +91,10 @@ func (r *externalServiceResolver) UpdatedAt() DateTime {
 }
 
 func (r *externalServiceResolver) Namespace() *graphql.ID {
-	if r.externalService.NamespaceUserID == nil {
+	if r.externalService.NamespaceUserID == 0 {
 		return nil
 	}
-	userID := MarshalUserID(*r.externalService.NamespaceUserID)
+	userID := MarshalUserID(r.externalService.NamespaceUserID)
 	return &userID
 }
 

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -87,7 +87,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		Config:      args.Input.Config,
 	}
 	if namespaceUserID > 0 {
-		externalService.NamespaceUserID = &namespaceUserID
+		externalService.NamespaceUserID = namespaceUserID
 	}
 
 	if err := db.ExternalServices.Create(ctx, conf.Get, externalService); err != nil {
@@ -130,9 +130,9 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *updateEx
 	// 🚨 SECURITY: Only site admins may update all or a user's external services.
 	// Otherwise, the authenticated user can only update external services under the same namespace.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		if es.NamespaceUserID == nil {
+		if es.NamespaceUserID == 0 {
 			return nil, err
-		} else if actor.FromContext(ctx).UID != *es.NamespaceUserID {
+		} else if actor.FromContext(ctx).UID != es.NamespaceUserID {
 			return nil, errors.New("the authenticated user does not have access to this external service")
 		}
 	}
@@ -212,9 +212,9 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *deleteEx
 	// 🚨 SECURITY: Only site admins may delete all or a user's external services.
 	// Otherwise, the authenticated user can only delete external services under the same namespace.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		if es.NamespaceUserID == nil {
+		if es.NamespaceUserID == 0 {
 			return nil, err
-		} else if actor.FromContext(ctx).UID != *es.NamespaceUserID {
+		} else if actor.FromContext(ctx).UID != es.NamespaceUserID {
 			return nil, errors.New("the authenticated user does not have access to this external service")
 		}
 	}
@@ -223,7 +223,7 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *deleteEx
 		return nil, err
 	}
 	now := time.Now()
-	es.DeletedAt = &now
+	es.DeletedAt = now
 
 	// The user doesn't care if triggering syncing failed when deleting a
 	// service, so kick off in the background.

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -113,10 +113,10 @@ func TestAddExternalService(t *testing.T) {
 			}
 
 			// We want to check the namespace field is populated
-			if result.externalService.NamespaceUserID == nil {
+			if result.externalService.NamespaceUserID == 0 {
 				t.Fatal("NamespaceUserID: want non-nil but got nil")
-			} else if *result.externalService.NamespaceUserID != userID {
-				t.Fatalf("NamespaceUserID: want %d but got %d", userID, *result.externalService.NamespaceUserID)
+			} else if result.externalService.NamespaceUserID != userID {
+				t.Fatalf("NamespaceUserID: want %d but got %d", userID, result.externalService.NamespaceUserID)
 			}
 		})
 
@@ -161,10 +161,10 @@ func TestAddExternalService(t *testing.T) {
 			}
 
 			// We want to check the namespace field is populated
-			if result.externalService.NamespaceUserID == nil {
+			if result.externalService.NamespaceUserID == 0 {
 				t.Fatal("NamespaceUserID: want non-nil but got nil")
-			} else if *result.externalService.NamespaceUserID != userID {
-				t.Fatalf("NamespaceUserID: want %d but got %d", userID, *result.externalService.NamespaceUserID)
+			} else if result.externalService.NamespaceUserID != userID {
+				t.Fatalf("NamespaceUserID: want %d but got %d", userID, result.externalService.NamespaceUserID)
 			}
 		})
 	})
@@ -249,7 +249,7 @@ func TestUpdateExternalService(t *testing.T) {
 			db.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
 				return &types.ExternalService{
 					ID:              id,
-					NamespaceUserID: &userID,
+					NamespaceUserID: userID,
 				}, nil
 			}
 			defer func() {
@@ -278,7 +278,7 @@ func TestUpdateExternalService(t *testing.T) {
 			db.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
 				return &types.ExternalService{
 					ID:              id,
-					NamespaceUserID: &userID,
+					NamespaceUserID: userID,
 				}, nil
 			}
 			calledUpdate := false
@@ -349,14 +349,14 @@ func TestUpdateExternalService(t *testing.T) {
 		if cachedUpdate == nil {
 			return &types.ExternalService{
 				ID:              id,
-				NamespaceUserID: &userID,
+				NamespaceUserID: userID,
 			}, nil
 		}
 		return &types.ExternalService{
 			ID:              id,
 			DisplayName:     *cachedUpdate.DisplayName,
 			Config:          *cachedUpdate.Config,
-			NamespaceUserID: &userID,
+			NamespaceUserID: userID,
 		}, nil
 	}
 	t.Cleanup(func() {
@@ -427,7 +427,7 @@ func TestDeleteExternalService(t *testing.T) {
 			db.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
 				return &types.ExternalService{
 					ID:              id,
-					NamespaceUserID: &userID,
+					NamespaceUserID: userID,
 				}, nil
 			}
 			defer func() {
@@ -454,7 +454,7 @@ func TestDeleteExternalService(t *testing.T) {
 			db.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
 				return &types.ExternalService{
 					ID:              id,
-					NamespaceUserID: &userID,
+					NamespaceUserID: userID,
 				}, nil
 			}
 			calledDelete := false
@@ -489,7 +489,7 @@ func TestDeleteExternalService(t *testing.T) {
 		userID := int32(1)
 		return &types.ExternalService{
 			ID:              id,
-			NamespaceUserID: &userID,
+			NamespaceUserID: userID,
 		}, nil
 	}
 	t.Cleanup(func() {

--- a/cmd/frontend/types/types.go
+++ b/cmd/frontend/types/types.go
@@ -393,10 +393,10 @@ type ExternalService struct {
 	Config          string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
-	DeletedAt       *time.Time
-	LastSyncAt      *time.Time
-	NextSyncAt      *time.Time
-	NamespaceUserID *int32
+	DeletedAt       time.Time
+	LastSyncAt      time.Time
+	NextSyncAt      time.Time
+	NamespaceUserID int32
 }
 
 // URN returns a unique resource identifier of this external service,
@@ -431,7 +431,7 @@ func (e *ExternalService) Update(n *ExternalService) (modified bool) {
 		e.UpdatedAt, modified = n.UpdatedAt, true
 	}
 
-	if (e.DeletedAt == nil && n.DeletedAt != nil) || (e.DeletedAt != nil && (n.DeletedAt == nil || !e.DeletedAt.Equal(*n.DeletedAt))) {
+	if !e.DeletedAt.Equal(n.DeletedAt) {
 		e.DeletedAt, modified = n.DeletedAt, true
 	}
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -214,7 +214,7 @@ func newExternalServices(es ...*repos.ExternalService) []api.ExternalService {
 		}
 
 		if e.IsDeleted() {
-			svc.DeletedAt = &e.DeletedAt
+			svc.DeletedAt = e.DeletedAt
 		}
 
 		svcs = append(svcs, svc)
@@ -362,7 +362,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 }
 
 func externalServiceValidate(ctx context.Context, req *protocol.ExternalServiceSyncRequest) error {
-	if req.ExternalService.DeletedAt != nil {
+	if !req.ExternalService.DeletedAt.IsZero() {
 		// We don't need to check deleted services.
 		return nil
 	}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -858,7 +858,7 @@ func apiExternalServices(es ...*repos.ExternalService) []api.ExternalService {
 		}
 
 		if e.IsDeleted() {
-			svc.DeletedAt = &e.DeletedAt
+			svc.DeletedAt = e.DeletedAt
 		}
 
 		svcs = append(svcs, svc)

--- a/enterprise/internal/campaigns/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer_test.go
@@ -410,15 +410,14 @@ func TestSyncRegistry(t *testing.T) {
 		ID:        1,
 		Kind:      extsvc.KindGitHub,
 		Config:    `{"url": "https://example.com/"}`,
-		DeletedAt: &now,
+		DeletedAt: now,
 	})
 	assertSyncerCount(0)
 
 	// And added again
 	r.HandleExternalServiceSync(api.ExternalService{
-		ID:        1,
-		Kind:      extsvc.KindGitHub,
-		DeletedAt: nil,
+		ID:   1,
+		Kind: extsvc.KindGitHub,
 	})
 	assertSyncerCount(1)
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -122,10 +122,10 @@ type ExternalService struct {
 	Config          string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
-	DeletedAt       *time.Time
-	LastSyncAt      *time.Time
-	NextSyncAt      *time.Time
-	NamespaceUserID *int32
+	DeletedAt       time.Time
+	LastSyncAt      time.Time
+	NextSyncAt      time.Time
+	NamespaceUserID int32
 }
 
 func cmp(a, b string) int {

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -433,7 +433,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 			Kind:            extsvc.KindGitHub,
 			DisplayName:     "GITHUB #1",
 			Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-			NamespaceUserID: &user.ID,
+			NamespaceUserID: user.ID,
 		},
 		{
 			Kind:        extsvc.KindGitHub,
@@ -699,7 +699,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 
 		want.Apply(func(e *types.ExternalService) {
 			e.UpdatedAt = now
-			e.DeletedAt = &now
+			e.DeletedAt = now
 		})
 
 		if err = tx.Upsert(ctx, want.Clone()...); err != nil {

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -607,8 +607,8 @@ func newRepoRecord(r *types.Repo) (*repoRecord, error) {
 		URI:                 nullStringColumn(r.URI),
 		Description:         r.Description,
 		CreatedAt:           r.CreatedAt.UTC(),
-		UpdatedAt:           nullTimeColumn(&r.UpdatedAt),
-		DeletedAt:           nullTimeColumn(&r.DeletedAt),
+		UpdatedAt:           nullTimeColumn(r.UpdatedAt),
+		DeletedAt:           nullTimeColumn(r.DeletedAt),
 		ExternalServiceType: nullStringColumn(r.ExternalRepo.ServiceType),
 		ExternalServiceID:   nullStringColumn(r.ExternalRepo.ServiceID),
 		ExternalID:          nullStringColumn(r.ExternalRepo.ID),
@@ -620,13 +620,18 @@ func newRepoRecord(r *types.Repo) (*repoRecord, error) {
 	}, nil
 }
 
-func nullTimeColumn(t *time.Time) *time.Time {
-	if t == nil || t.IsZero() {
+func nullTimeColumn(t time.Time) *time.Time {
+	if t.IsZero() {
 		return nil
 	}
+	return &t
+}
 
-	ut := t.UTC()
-	return &ut
+func nullInt32Column(n int32) *int32 {
+	if n == 0 {
+		return nil
+	}
+	return &n
 }
 
 func nullStringColumn(s string) *string {

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -381,7 +381,7 @@ func Test_GetUserAddedRepos(t *testing.T) {
 		Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 		CreatedAt:       now,
 		UpdatedAt:       now,
-		NamespaceUserID: &user.ID,
+		NamespaceUserID: user.ID,
 	}
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}

--- a/internal/db/users_test.go
+++ b/internal/db/users_test.go
@@ -545,7 +545,7 @@ func TestUsers_Delete(t *testing.T) {
 				Kind:            extsvc.KindGitHub,
 				DisplayName:     "GITHUB #1",
 				Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-				NamespaceUserID: &user.ID,
+				NamespaceUserID: user.ID,
 			})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
After discussing with @tsenart it turns out it is easier to use zero values rather than pointers for ExternalService's `DeletedAt`, `NamespaceUserID`, `LastSyncAt` and `NextSyncAt` members