### PR TITLE
Fix closed draft PRs incorrectly being recognized as draft

### DIFF
--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -424,7 +424,7 @@ func computeSingleChangesetExternalState(c *campaigns.Changeset) (s campaigns.Ch
 
 	switch m := c.Metadata.(type) {
 	case *github.PullRequest:
-		if m.IsDraft {
+		if m.IsDraft && m.State == string(campaigns.ChangesetExternalStateOpen) {
 			s = campaigns.ChangesetExternalStateDraft
 		} else {
 			s = campaigns.ChangesetExternalState(m.State)

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -607,6 +607,12 @@ func TestComputeExternalState(t *testing.T) {
 			want: cmpgn.ChangesetExternalStateDraft,
 		},
 		{
+			name:      "github draft closed",
+			changeset: setDraft(githubChangeset(daysAgo(1), "CLOSED")),
+			history:   []changesetStatesAtTime{{t: daysAgo(2), externalState: campaigns.ChangesetExternalStateClosed}},
+			want:      cmpgn.ChangesetExternalStateClosed,
+		},
+		{
 			name:      "bitbucketserver - no events",
 			changeset: bitbucketChangeset(daysAgo(10), "OPEN", "NEEDS_WORK"),
 			history:   []changesetStatesAtTime{},


### PR DESCRIPTION
That's been an oversight of mine, I did it for GitLab, but didn't for GitHub 🤔 