### PR TITLE
Don't request unused diffStat on campaign

### DIFF
--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -48,11 +48,6 @@ const campaignDefaults: CampaignFields = {
         url: '/users/alice',
         username: 'alice',
     },
-    diffStat: {
-        added: 10,
-        changed: 8,
-        deleted: 10,
-    },
     id: 'specid',
     url: '/users/alice/campaigns/specid',
     namespace: {

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -49,11 +49,6 @@ const campaignDefaults: CampaignFields = {
         url: '/users/alice',
         username: 'alice',
     },
-    diffStat: {
-        added: 10,
-        changed: 8,
-        deleted: 10,
-    },
     id: 'specid',
     url: '/users/alice/campaigns/awesome-campaign',
     namespace: {

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -68,16 +68,10 @@ const campaignFragment = gql`
             }
         }
 
-        diffStat {
-            ...DiffStatFields
-        }
-
         currentSpec {
             originalInput
         }
     }
-
-    ${diffStatFields}
 
     ${changesetStatsFragment}
 `

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -267,11 +267,6 @@ function mockCommonGraphQLResponses(
                     url: namespaceURL,
                 },
                 url: `${namespaceURL}/campaigns/test-campaign`,
-                diffStat: {
-                    added: 1000,
-                    changed: 29,
-                    deleted: 817,
-                },
                 viewerCanAdminister: true,
                 lastAppliedAt: subDays(new Date(), 5).toISOString(),
                 lastApplier: {


### PR DESCRIPTION
Until #15073 is solved, we don't need this field and it's currently compute heavy so we shouldn't fetch it and drop then. 