### PR TITLE
search frontend: fix off-by-one column hover range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - If the `HEAD` file in a cloned repo is absent or truncated, background cleanup activities will use a best-effort default to remedy the situation. [#14962](https://github.com/sourcegraph/sourcegraph/pull/14962)
 - Search input will always show suggestions. Previously we only showed suggestions for letters and some special characters. [#14982](https://github.com/sourcegraph/sourcegraph/pull/14982)
 - Fixed an issue where `not` keywords were not recognized inside expression groups, and treated incorrectly as patterns. [#15139](https://github.com/sourcegraph/sourcegraph/pull/15139)
+- Fixed an issue where hover pop-ups would not show on the first character of a valid hover range in search queries. [#15410](https://github.com/sourcegraph/sourcegraph/pull/15410)
 
 ### Removed
 

--- a/client/shared/src/search/parser/hover.test.ts
+++ b/client/shared/src/search/parser/hover.test.ts
@@ -18,6 +18,19 @@ describe('getHoverResult()', () => {
                 startLineNumber: 1,
             },
         })
+        expect(getHoverResult(parsedQuery, { column: 18 })).toStrictEqual({
+            contents: [
+                {
+                    value: 'Include only results from files matching the given search pattern.',
+                },
+            ],
+            range: {
+                endColumn: 40,
+                endLineNumber: 1,
+                startColumn: 18,
+                startLineNumber: 1,
+            },
+        })
         expect(getHoverResult(parsedQuery, { column: 30 })).toStrictEqual({
             contents: [
                 {

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -9,7 +9,7 @@ export const getHoverResult = (
     { members }: Pick<Sequence, 'members'>,
     { column }: Pick<Monaco.Position, 'column'>
 ): Monaco.languages.Hover | null => {
-    const tokenAtColumn = members.find(({ range }) => range.start + 1 <= column && range.end + 1 >= column)
+    const tokenAtColumn = members.find(({ range }) => range.start + 1 <= column && range.end >= column)
     if (!tokenAtColumn || tokenAtColumn.type !== 'filter') {
         return null
     }


### PR DESCRIPTION
Thought I was going crazy trying out range highlighting/hover ranges. Turns out there's an off-by-one: hovering on the first character of any hover range would not work (e.g., `f` in `field:foo` would not pop a hover) and any character after a hover-able field would show the hover (e.g., `repo:foo<space>thing` would show the repo hover when on the `<space`>.

![off-by-one-hover-1](https://user-images.githubusercontent.com/888624/98169109-e6c5e500-1ea8-11eb-84f2-b843f41c540d.gif)


I've added a regression test that covers the behavior.