### PR TITLE
use --remove-orphans to delete dangling containers

### DIFF
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -150,7 +150,7 @@ Then on your server:
 
 ```sh
 cd deploy-sourcegraph-docker/docker-compose/
-docker-compose down
+docker-compose down --remove-orphans
 git pull
 docker-compose up -d
 ```


### PR DESCRIPTION
The use of `remove-orphans` ensures that any containers not part of the compose file are removed when services are brought down.

