### PR TITLE
GraphQL schema and resolver stubs for campaigns user tokens

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -73,20 +73,21 @@ type ChangesetEventsConnectionArgs struct {
 	After *string
 }
 
-type CreateCampaignsUserTokenArgs struct {
+type CreateCampaignsCredentialArgs struct {
 	ExternalServiceKind string
 	ExternalServiceURL  string
 	User                graphql.ID
-	Token               string
+	Credential          string
 }
 
-type DeleteCampaignsUserTokenArgs struct {
-	CampaignsUserToken graphql.ID
+type DeleteCampaignsCredentialArgs struct {
+	CampaignsCredential graphql.ID
 }
 
-type ListConfiguredExternalServicesArgs struct {
-	First int32
-	After *string
+type ListCampaignsCodeHostsArgs struct {
+	First  int32
+	After  *string
+	UserID int64
 }
 
 type CampaignsResolver interface {
@@ -99,8 +100,8 @@ type CampaignsResolver interface {
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (CampaignSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
-	CreateCampaignsUserToken(ctx context.Context, args *CreateCampaignsUserTokenArgs) (CampaignsUserTokenResolver, error)
-	DeleteCampaignsUserToken(ctx context.Context, args *DeleteCampaignsUserTokenArgs) (*EmptyResponse, error)
+	CreateCampaignsCredential(ctx context.Context, args *CreateCampaignsCredentialArgs) (CampaignsCredentialResolver, error)
+	DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error)
 
 	// Queries
 	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
@@ -111,8 +112,8 @@ type CampaignsResolver interface {
 	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
 	ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error)
 
-	CampaignsUserTokenByID(ctx context.Context, id graphql.ID) (CampaignsUserTokenResolver, error)
-	ConfiguredExternalServices(ctx context.Context, userID graphql.ID) (ConfiguredExternalServicesConnectionResolver, error)
+	CampaignsCredentialByID(ctx context.Context, id graphql.ID) (CampaignsCredentialResolver, error)
+	CampaignsCodeHosts(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 }
 
 type CampaignSpecResolver interface {
@@ -208,19 +209,19 @@ type GitCommitDescriptionResolver interface {
 	Diff() string
 }
 
-type ConfiguredExternalServicesConnectionResolver interface {
-	Nodes(ctx context.Context) ([]ConfiguredExternalServiceResolver, error)
+type CampaignsCodeHostConnectionResolver interface {
+	Nodes(ctx context.Context) ([]CampaignsCodeHostResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type ConfiguredExternalServiceResolver interface {
+type CampaignsCodeHostResolver interface {
 	ExternalServiceKind() string
 	ExternalServiceURL() string
-	ConfiguredToken() CampaignsUserTokenResolver
+	Credential() CampaignsCredentialResolver
 }
 
-type CampaignsUserTokenResolver interface {
+type CampaignsCredentialResolver interface {
 	ID() graphql.ID
 	ExternalServiceKind() string
 	ExternalServiceURL() string
@@ -405,11 +406,11 @@ func (defaultCampaignsResolver) DeleteCampaign(ctx context.Context, args *Delete
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) CreateCampaignsUserToken(ctx context.Context, args *CreateCampaignsUserTokenArgs) (CampaignsUserTokenResolver, error) {
+func (defaultCampaignsResolver) CreateCampaignsCredential(ctx context.Context, args *CreateCampaignsCredentialArgs) (CampaignsCredentialResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) DeleteCampaignsUserToken(ctx context.Context, args *DeleteCampaignsUserTokenArgs) (*EmptyResponse, error) {
+func (defaultCampaignsResolver) DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
@@ -438,10 +439,10 @@ func (defaultCampaignsResolver) ChangesetSpecByID(ctx context.Context, id graphq
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) CampaignsUserTokenByID(ctx context.Context, id graphql.ID) (CampaignsUserTokenResolver, error) {
+func (defaultCampaignsResolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (CampaignsCredentialResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) ConfiguredExternalServices(ctx context.Context, userID graphql.ID) (ConfiguredExternalServicesConnectionResolver, error) {
+func (defaultCampaignsResolver) CampaignsCodeHosts(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -73,6 +73,22 @@ type ChangesetEventsConnectionArgs struct {
 	After *string
 }
 
+type CreateCampaignsUserTokenArgs struct {
+	ExternalServiceKind string
+	ExternalServiceURL  string
+	User                graphql.ID
+	Token               string
+}
+
+type DeleteCampaignsUserTokenArgs struct {
+	CampaignsUserToken graphql.ID
+}
+
+type ListConfiguredExternalServicesArgs struct {
+	First int32
+	After *string
+}
+
 type CampaignsResolver interface {
 	// Mutations
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
@@ -83,6 +99,8 @@ type CampaignsResolver interface {
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (CampaignSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
+	CreateCampaignsUserToken(ctx context.Context, args *CreateCampaignsUserTokenArgs) (CampaignsUserTokenResolver, error)
+	DeleteCampaignsUserToken(ctx context.Context, args *DeleteCampaignsUserTokenArgs) (*EmptyResponse, error)
 
 	// Queries
 	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
@@ -92,6 +110,9 @@ type CampaignsResolver interface {
 
 	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
 	ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error)
+
+	CampaignsUserTokenByID(ctx context.Context, id graphql.ID) (CampaignsUserTokenResolver, error)
+	ConfiguredExternalServices(ctx context.Context, userID graphql.ID) (ConfiguredExternalServicesConnectionResolver, error)
 }
 
 type CampaignSpecResolver interface {
@@ -185,6 +206,25 @@ type GitCommitDescriptionResolver interface {
 	Body() *string
 	Author() *PersonResolver
 	Diff() string
+}
+
+type ConfiguredExternalServicesConnectionResolver interface {
+	Nodes(ctx context.Context) ([]ConfiguredExternalServiceResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type ConfiguredExternalServiceResolver interface {
+	ExternalServiceKind() string
+	ExternalServiceURL() string
+	ConfiguredToken() CampaignsUserTokenResolver
+}
+
+type CampaignsUserTokenResolver interface {
+	ID() graphql.ID
+	ExternalServiceKind() string
+	ExternalServiceURL() string
+	CreatedAt() DateTime
 }
 
 type ChangesetCountsArgs struct {
@@ -365,6 +405,14 @@ func (defaultCampaignsResolver) DeleteCampaign(ctx context.Context, args *Delete
 	return nil, campaignsOnlyInEnterprise
 }
 
+func (defaultCampaignsResolver) CreateCampaignsUserToken(ctx context.Context, args *CreateCampaignsUserTokenArgs) (CampaignsUserTokenResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) DeleteCampaignsUserToken(ctx context.Context, args *DeleteCampaignsUserTokenArgs) (*EmptyResponse, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
 // Queries
 func (defaultCampaignsResolver) CampaignByID(ctx context.Context, id graphql.ID) (CampaignResolver, error) {
 	return nil, campaignsOnlyInEnterprise
@@ -387,5 +435,13 @@ func (defaultCampaignsResolver) CampaignSpecByID(ctx context.Context, id graphql
 }
 
 func (defaultCampaignsResolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) CampaignsUserTokenByID(ctx context.Context, id graphql.ID) (CampaignsUserTokenResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) ConfiguredExternalServices(ctx context.Context, userID graphql.ID) (ConfiguredExternalServicesConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -447,6 +447,11 @@ func (r *NodeResolver) ToVisibleChangesetSpec() (VisibleChangesetSpecResolver, b
 	return n.ToVisibleChangesetSpec()
 }
 
+func (r *NodeResolver) ToCampaignsUserToken() (CampaignsUserTokenResolver, bool) {
+	n, ok := r.Node.(CampaignsUserTokenResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToProductLicense() (ProductLicense, bool) {
 	n, ok := r.Node.(ProductLicense)
 	return n, ok
@@ -573,6 +578,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return r.ChangesetSpecByID(ctx, id)
 	case "Changeset":
 		return r.ChangesetByID(ctx, id)
+	case "CampaignsUserToken":
+		return r.CampaignsUserTokenByID(ctx, id)
 	case "ProductLicense":
 		if f := ProductLicenseByID; f != nil {
 			return f(ctx, id)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -447,8 +447,8 @@ func (r *NodeResolver) ToVisibleChangesetSpec() (VisibleChangesetSpecResolver, b
 	return n.ToVisibleChangesetSpec()
 }
 
-func (r *NodeResolver) ToCampaignsUserToken() (CampaignsUserTokenResolver, bool) {
-	n, ok := r.Node.(CampaignsUserTokenResolver)
+func (r *NodeResolver) ToCampaignsCredential() (CampaignsCredentialResolver, bool) {
+	n, ok := r.Node.(CampaignsCredentialResolver)
 	return n, ok
 }
 
@@ -578,8 +578,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return r.ChangesetSpecByID(ctx, id)
 	case "Changeset":
 		return r.ChangesetByID(ctx, id)
-	case "CampaignsUserToken":
-		return r.CampaignsUserTokenByID(ctx, id)
+	case "CampaignsCredential":
+		return r.CampaignsCredentialByID(ctx, id)
 	case "ProductLicense":
 		if f := ProductLicenseByID; f != nil {
 			return f(ctx, id)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -701,6 +701,35 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 
     """
+    Create a new credential for the user for the given external service kind/URL tuple.
+    If another token for that code host already exists, an error with the error code
+    ErrDuplicateToken is returned.
+    """
+    createCampaignsUserToken(
+        """
+        The user that'll be owning the campaigns user token.
+        """
+        user: ID!
+        """
+        The kind of external service being configured.
+        """
+        externalServiceKind: ExternalServiceKind!
+        """
+        The URL of the external service being configured.
+        """
+        externalServiceURL: String!
+        """
+        The user token. This can never be retrieved through the API and will be stored encrypted.
+        """
+        token: String!
+    ): CampaignsUserToken!
+
+    """
+    Hard-deletes a given campaigns user token.
+    """
+    deleteCampaignsUserToken(campaignsUserToken: ID!): EmptyResponse!
+
+    """
     OBSERVABILITY
 
     Set the status of a test alert of the specified parameters - useful for validating
@@ -726,6 +755,66 @@ enum ChangesetSpecType {
     References a branch and a patch to be applied to create the changeset from.
     """
     BRANCH
+}
+
+"""
+A connection of all configured external services accessible by the user this is requested on.
+"""
+type ConfiguredExternalServicesConnection {
+    """
+    A list of configured external services.
+    """
+    nodes: [ConfiguredExternalService!]!
+
+    """
+    The total number of configured external services in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A configured external service. This service is accessible by the user it belongs to.
+"""
+type ConfiguredExternalService {
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+    """
+    The configured token, if any.
+    """
+    configuredToken: CampaignsUserToken
+}
+
+"""
+A user token configured for campaigns use on the specified code host.
+"""
+type CampaignsUserToken implements Node {
+    """
+    A globally unique identifier.
+    """
+    id: ID!
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+    """
+    The date and time this token has been created at.
+    """
+    createdAt: DateTime!
 }
 
 """
@@ -5843,6 +5932,23 @@ type User implements Node & SettingsSubject & Namespace {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+
+    """
+    Returns a connection of configured external services accessible by this user.
+    That are, all external services configured on the Sourcegraph instance on which the
+    user can access at least one repository. They are connected to CampaignsUserToken resources,
+    if one has been created for the user/code host connection tuple before.
+    """
+    configuredExternalServices(
+        """
+        Returns the first n configured external services from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): ConfiguredExternalServicesConnection!
 
     """
     A list of monitors owned by the user or her organization.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -701,33 +701,31 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 
     """
-    Create a new credential for the user for the given external service kind/URL tuple.
+    Create a new credential for the requesting user for the given code host.
     If another token for that code host already exists, an error with the error code
     ErrDuplicateToken is returned.
     """
-    createCampaignsUserToken(
-        """
-        The user that'll be owning the campaigns user token.
-        """
-        user: ID!
+    createCampaignsCredential(
         """
         The kind of external service being configured.
         """
         externalServiceKind: ExternalServiceKind!
+
         """
         The URL of the external service being configured.
         """
         externalServiceURL: String!
+
         """
-        The user token. This can never be retrieved through the API and will be stored encrypted.
+        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
         """
-        token: String!
-    ): CampaignsUserToken!
+        credential: String!
+    ): CampaignsCredential!
 
     """
-    Hard-deletes a given campaigns user token.
+    Hard-deletes a given campaigns credential.
     """
-    deleteCampaignsUserToken(campaignsUserToken: ID!): EmptyResponse!
+    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
 
     """
     OBSERVABILITY
@@ -744,27 +742,14 @@ type Mutation {
 }
 
 """
-The type of the changeset spec.
+A connection of all code hosts usable with campaigns and accessible by the user
+this is requested on.
 """
-enum ChangesetSpecType {
+type CampaignsCodeHostConnection {
     """
-    References an existing changeset on a code host to be imported.
+    A list of code hosts.
     """
-    EXISTING
-    """
-    References a branch and a patch to be applied to create the changeset from.
-    """
-    BRANCH
-}
-
-"""
-A connection of all configured external services accessible by the user this is requested on.
-"""
-type ConfiguredExternalServicesConnection {
-    """
-    A list of configured external services.
-    """
-    nodes: [ConfiguredExternalService!]!
+    nodes: [CampaignsCodeHost!]!
 
     """
     The total number of configured external services in the connection.
@@ -778,43 +763,62 @@ type ConfiguredExternalServicesConnection {
 }
 
 """
-A configured external service. This service is accessible by the user it belongs to.
+A code host usable with campaigns. This service is accessible by the user it belongs to.
 """
-type ConfiguredExternalService {
+type CampaignsCodeHost {
     """
     The kind of external service.
     """
     externalServiceKind: ExternalServiceKind!
+
     """
     The URL of the external service.
     """
     externalServiceURL: String!
+
     """
-    The configured token, if any.
+    The configured credential, if any.
     """
-    configuredToken: CampaignsUserToken
+    credential: CampaignsCredential
 }
 
 """
 A user token configured for campaigns use on the specified code host.
 """
-type CampaignsUserToken implements Node {
+type CampaignsCredential implements Node {
     """
     A globally unique identifier.
     """
     id: ID!
+
     """
     The kind of external service.
     """
     externalServiceKind: ExternalServiceKind!
+
     """
     The URL of the external service.
     """
     externalServiceURL: String!
+
     """
     The date and time this token has been created at.
     """
     createdAt: DateTime!
+}
+
+"""
+The type of the changeset spec.
+"""
+enum ChangesetSpecType {
+    """
+    References an existing changeset on a code host to be imported.
+    """
+    EXISTING
+    """
+    References a branch and a patch to be applied to create the changeset from.
+    """
+    BRANCH
 }
 
 """
@@ -5934,21 +5938,20 @@ type User implements Node & SettingsSubject & Namespace {
     ): CampaignConnection!
 
     """
-    Returns a connection of configured external services accessible by this user.
-    That are, all external services configured on the Sourcegraph instance on which the
-    user can access at least one repository. They are connected to CampaignsUserToken resources,
-    if one has been created for the user/code host connection tuple before.
+    Returns a connection of configured external services accessible by this user, for usage with campaigns.
+    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
+    connected to CampaignCredential resources, if one has been created for the code host connection before.
     """
-    configuredExternalServices(
+    campaignsCodeHosts(
         """
-        Returns the first n configured external services from the list.
+        Returns the first n code hosts from the list.
         """
         first: Int = 50
         """
         Opaque pagination cursor.
         """
         after: String
-    ): ConfiguredExternalServicesConnection!
+    ): CampaignsCodeHostConnection!
 
     """
     A list of monitors owned by the user or her organization.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -694,6 +694,35 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 
     """
+    Create a new credential for the user for the given external service kind/URL tuple.
+    If another token for that code host already exists, an error with the error code
+    ErrDuplicateToken is returned.
+    """
+    createCampaignsUserToken(
+        """
+        The user that'll be owning the campaigns user token.
+        """
+        user: ID!
+        """
+        The kind of external service being configured.
+        """
+        externalServiceKind: ExternalServiceKind!
+        """
+        The URL of the external service being configured.
+        """
+        externalServiceURL: String!
+        """
+        The user token. This can never be retrieved through the API and will be stored encrypted.
+        """
+        token: String!
+    ): CampaignsUserToken!
+
+    """
+    Hard-deletes a given campaigns user token.
+    """
+    deleteCampaignsUserToken(campaignsUserToken: ID!): EmptyResponse!
+
+    """
     OBSERVABILITY
 
     Set the status of a test alert of the specified parameters - useful for validating
@@ -719,6 +748,66 @@ enum ChangesetSpecType {
     References a branch and a patch to be applied to create the changeset from.
     """
     BRANCH
+}
+
+"""
+A connection of all configured external services accessible by the user this is requested on.
+"""
+type ConfiguredExternalServicesConnection {
+    """
+    A list of configured external services.
+    """
+    nodes: [ConfiguredExternalService!]!
+
+    """
+    The total number of configured external services in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A configured external service. This service is accessible by the user it belongs to.
+"""
+type ConfiguredExternalService {
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+    """
+    The configured token, if any.
+    """
+    configuredToken: CampaignsUserToken
+}
+
+"""
+A user token configured for campaigns use on the specified code host.
+"""
+type CampaignsUserToken implements Node {
+    """
+    A globally unique identifier.
+    """
+    id: ID!
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+    """
+    The date and time this token has been created at.
+    """
+    createdAt: DateTime!
 }
 
 """
@@ -5836,6 +5925,23 @@ type User implements Node & SettingsSubject & Namespace {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+
+    """
+    Returns a connection of configured external services accessible by this user.
+    That are, all external services configured on the Sourcegraph instance on which the
+    user can access at least one repository. They are connected to CampaignsUserToken resources,
+    if one has been created for the user/code host connection tuple before.
+    """
+    configuredExternalServices(
+        """
+        Returns the first n configured external services from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): ConfiguredExternalServicesConnection!
 
     """
     A list of monitors owned by the user or her organization.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -694,33 +694,31 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 
     """
-    Create a new credential for the user for the given external service kind/URL tuple.
+    Create a new credential for the requesting user for the given code host.
     If another token for that code host already exists, an error with the error code
     ErrDuplicateToken is returned.
     """
-    createCampaignsUserToken(
-        """
-        The user that'll be owning the campaigns user token.
-        """
-        user: ID!
+    createCampaignsCredential(
         """
         The kind of external service being configured.
         """
         externalServiceKind: ExternalServiceKind!
+
         """
         The URL of the external service being configured.
         """
         externalServiceURL: String!
+
         """
-        The user token. This can never be retrieved through the API and will be stored encrypted.
+        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
         """
-        token: String!
-    ): CampaignsUserToken!
+        credential: String!
+    ): CampaignsCredential!
 
     """
-    Hard-deletes a given campaigns user token.
+    Hard-deletes a given campaigns credential.
     """
-    deleteCampaignsUserToken(campaignsUserToken: ID!): EmptyResponse!
+    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
 
     """
     OBSERVABILITY
@@ -737,27 +735,14 @@ type Mutation {
 }
 
 """
-The type of the changeset spec.
+A connection of all code hosts usable with campaigns and accessible by the user
+this is requested on.
 """
-enum ChangesetSpecType {
+type CampaignsCodeHostConnection {
     """
-    References an existing changeset on a code host to be imported.
+    A list of code hosts.
     """
-    EXISTING
-    """
-    References a branch and a patch to be applied to create the changeset from.
-    """
-    BRANCH
-}
-
-"""
-A connection of all configured external services accessible by the user this is requested on.
-"""
-type ConfiguredExternalServicesConnection {
-    """
-    A list of configured external services.
-    """
-    nodes: [ConfiguredExternalService!]!
+    nodes: [CampaignsCodeHost!]!
 
     """
     The total number of configured external services in the connection.
@@ -771,43 +756,62 @@ type ConfiguredExternalServicesConnection {
 }
 
 """
-A configured external service. This service is accessible by the user it belongs to.
+A code host usable with campaigns. This service is accessible by the user it belongs to.
 """
-type ConfiguredExternalService {
+type CampaignsCodeHost {
     """
     The kind of external service.
     """
     externalServiceKind: ExternalServiceKind!
+
     """
     The URL of the external service.
     """
     externalServiceURL: String!
+
     """
-    The configured token, if any.
+    The configured credential, if any.
     """
-    configuredToken: CampaignsUserToken
+    credential: CampaignsCredential
 }
 
 """
 A user token configured for campaigns use on the specified code host.
 """
-type CampaignsUserToken implements Node {
+type CampaignsCredential implements Node {
     """
     A globally unique identifier.
     """
     id: ID!
+
     """
     The kind of external service.
     """
     externalServiceKind: ExternalServiceKind!
+
     """
     The URL of the external service.
     """
     externalServiceURL: String!
+
     """
     The date and time this token has been created at.
     """
     createdAt: DateTime!
+}
+
+"""
+The type of the changeset spec.
+"""
+enum ChangesetSpecType {
+    """
+    References an existing changeset on a code host to be imported.
+    """
+    EXISTING
+    """
+    References a branch and a patch to be applied to create the changeset from.
+    """
+    BRANCH
 }
 
 """
@@ -5927,21 +5931,20 @@ type User implements Node & SettingsSubject & Namespace {
     ): CampaignConnection!
 
     """
-    Returns a connection of configured external services accessible by this user.
-    That are, all external services configured on the Sourcegraph instance on which the
-    user can access at least one repository. They are connected to CampaignsUserToken resources,
-    if one has been created for the user/code host connection tuple before.
+    Returns a connection of configured external services accessible by this user, for usage with campaigns.
+    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
+    connected to CampaignCredential resources, if one has been created for the code host connection before.
     """
-    configuredExternalServices(
+    campaignsCodeHosts(
         """
-        Returns the first n configured external services from the list.
+        Returns the first n code hosts from the list.
         """
         first: Int = 50
         """
         Opaque pagination cursor.
         """
         after: String
-    ): ConfiguredExternalServicesConnection!
+    ): CampaignsCodeHostConnection!
 
     """
     A list of monitors owned by the user or her organization.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -330,9 +330,9 @@ func (r *UserResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)
 }
 
-func (r *UserResolver) ConfiguredExternalServices(ctx context.Context, args *ListConfiguredExternalServicesArgs) (ConfiguredExternalServicesConnectionResolver, error) {
-	userID := r.ID()
-	return EnterpriseResolvers.campaignsResolver.ConfiguredExternalServices(ctx, userID)
+func (r *UserResolver) CampaignsCodeHosts(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error) {
+	args.UserID = int64(r.user.ID)
+	return EnterpriseResolvers.campaignsResolver.CampaignsCodeHosts(ctx, args)
 }
 
 func viewerCanChangeUsername(ctx context.Context, userID int32) bool {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -330,6 +330,11 @@ func (r *UserResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)
 }
 
+func (r *UserResolver) ConfiguredExternalServices(ctx context.Context, args *ListConfiguredExternalServicesArgs) (ConfiguredExternalServicesConnectionResolver, error) {
+	userID := r.ID()
+	return EnterpriseResolvers.campaignsResolver.ConfiguredExternalServices(ctx, userID)
+}
+
 func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		return false

--- a/enterprise/internal/campaigns/resolvers/user_tokens.go
+++ b/enterprise/internal/campaigns/resolvers/user_tokens.go
@@ -1,0 +1,80 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+)
+
+func (r *Resolver) CreateCampaignsUserToken(ctx context.Context, args *graphqlbackend.CreateCampaignsUserTokenArgs) (graphqlbackend.CampaignsUserTokenResolver, error) {
+	return &campaignsUserTokenResolver{}, errors.New("not implemented")
+}
+
+func (r *Resolver) DeleteCampaignsUserToken(ctx context.Context, args *graphqlbackend.DeleteCampaignsUserTokenArgs) (*graphqlbackend.EmptyResponse, error) {
+	return &graphqlbackend.EmptyResponse{}, errors.New("not implemented")
+}
+
+func (r *Resolver) CampaignsUserTokenByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignsUserTokenResolver, error) {
+	return &campaignsUserTokenResolver{}, nil
+}
+
+func (r *Resolver) ConfiguredExternalServices(ctx context.Context, userID graphql.ID) (graphqlbackend.ConfiguredExternalServicesConnectionResolver, error) {
+	return &configuredExternalServicesConnectionResolver{}, nil
+}
+
+type campaignsUserTokenResolver struct{}
+
+var _ graphqlbackend.CampaignsUserTokenResolver = &campaignsUserTokenResolver{}
+
+func (c *campaignsUserTokenResolver) ID() graphql.ID {
+	return graphql.ID("stub")
+}
+
+func (c *campaignsUserTokenResolver) ExternalServiceKind() string {
+	return extsvc.KindGitHub
+}
+
+func (c *campaignsUserTokenResolver) ExternalServiceURL() string {
+	return "https://github.com/"
+}
+
+func (c *campaignsUserTokenResolver) CreatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: time.Now()}
+}
+
+type configuredExternalServiceResolver struct{}
+
+var _ graphqlbackend.ConfiguredExternalServiceResolver = &configuredExternalServiceResolver{}
+
+func (c *configuredExternalServiceResolver) ExternalServiceKind() string {
+	return extsvc.KindGitHub
+}
+
+func (c *configuredExternalServiceResolver) ExternalServiceURL() string {
+	return "https://github.com/"
+}
+
+func (c *configuredExternalServiceResolver) ConfiguredToken() graphqlbackend.CampaignsUserTokenResolver {
+	return &campaignsUserTokenResolver{}
+}
+
+type configuredExternalServicesConnectionResolver struct{}
+
+var _ graphqlbackend.ConfiguredExternalServicesConnectionResolver = &configuredExternalServicesConnectionResolver{}
+
+func (c *configuredExternalServicesConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (c *configuredExternalServicesConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+func (c *configuredExternalServicesConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ConfiguredExternalServiceResolver, error) {
+	return []graphqlbackend.ConfiguredExternalServiceResolver{&configuredExternalServiceResolver{}}, nil
+}

--- a/enterprise/internal/campaigns/resolvers/user_tokens.go
+++ b/enterprise/internal/campaigns/resolvers/user_tokens.go
@@ -11,70 +11,70 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
-func (r *Resolver) CreateCampaignsUserToken(ctx context.Context, args *graphqlbackend.CreateCampaignsUserTokenArgs) (graphqlbackend.CampaignsUserTokenResolver, error) {
-	return &campaignsUserTokenResolver{}, errors.New("not implemented")
+func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlbackend.CreateCampaignsCredentialArgs) (graphqlbackend.CampaignsCredentialResolver, error) {
+	return &campaignsCredentialResolver{}, errors.New("not implemented")
 }
 
-func (r *Resolver) DeleteCampaignsUserToken(ctx context.Context, args *graphqlbackend.DeleteCampaignsUserTokenArgs) (*graphqlbackend.EmptyResponse, error) {
+func (r *Resolver) DeleteCampaignsCredential(ctx context.Context, args *graphqlbackend.DeleteCampaignsCredentialArgs) (*graphqlbackend.EmptyResponse, error) {
 	return &graphqlbackend.EmptyResponse{}, errors.New("not implemented")
 }
 
-func (r *Resolver) CampaignsUserTokenByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignsUserTokenResolver, error) {
-	return &campaignsUserTokenResolver{}, nil
+func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignsCredentialResolver, error) {
+	return &campaignsCredentialResolver{}, nil
 }
 
-func (r *Resolver) ConfiguredExternalServices(ctx context.Context, userID graphql.ID) (graphqlbackend.ConfiguredExternalServicesConnectionResolver, error) {
-	return &configuredExternalServicesConnectionResolver{}, nil
+func (r *Resolver) CampaignsCodeHosts(ctx context.Context, args *graphqlbackend.ListCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {
+	return &campaignsCodeHostConnectionResolver{}, nil
 }
 
-type campaignsUserTokenResolver struct{}
+type campaignsCredentialResolver struct{}
 
-var _ graphqlbackend.CampaignsUserTokenResolver = &campaignsUserTokenResolver{}
+var _ graphqlbackend.CampaignsCredentialResolver = &campaignsCredentialResolver{}
 
-func (c *campaignsUserTokenResolver) ID() graphql.ID {
+func (c *campaignsCredentialResolver) ID() graphql.ID {
 	return graphql.ID("stub")
 }
 
-func (c *campaignsUserTokenResolver) ExternalServiceKind() string {
+func (c *campaignsCredentialResolver) ExternalServiceKind() string {
 	return extsvc.KindGitHub
 }
 
-func (c *campaignsUserTokenResolver) ExternalServiceURL() string {
+func (c *campaignsCredentialResolver) ExternalServiceURL() string {
 	return "https://github.com/"
 }
 
-func (c *campaignsUserTokenResolver) CreatedAt() graphqlbackend.DateTime {
+func (c *campaignsCredentialResolver) CreatedAt() graphqlbackend.DateTime {
 	return graphqlbackend.DateTime{Time: time.Now()}
 }
 
-type configuredExternalServiceResolver struct{}
+type campaignsCodeHostResolver struct{}
 
-var _ graphqlbackend.ConfiguredExternalServiceResolver = &configuredExternalServiceResolver{}
+var _ graphqlbackend.CampaignsCodeHostResolver = &campaignsCodeHostResolver{}
 
-func (c *configuredExternalServiceResolver) ExternalServiceKind() string {
+func (c *campaignsCodeHostResolver) ExternalServiceKind() string {
 	return extsvc.KindGitHub
 }
 
-func (c *configuredExternalServiceResolver) ExternalServiceURL() string {
+func (c *campaignsCodeHostResolver) ExternalServiceURL() string {
 	return "https://github.com/"
 }
 
-func (c *configuredExternalServiceResolver) ConfiguredToken() graphqlbackend.CampaignsUserTokenResolver {
-	return &campaignsUserTokenResolver{}
+func (c *campaignsCodeHostResolver) Credential() graphqlbackend.CampaignsCredentialResolver {
+	return &campaignsCredentialResolver{}
 }
 
-type configuredExternalServicesConnectionResolver struct{}
+type campaignsCodeHostConnectionResolver struct{}
 
-var _ graphqlbackend.ConfiguredExternalServicesConnectionResolver = &configuredExternalServicesConnectionResolver{}
+var _ graphqlbackend.CampaignsCodeHostConnectionResolver = &campaignsCodeHostConnectionResolver{}
 
-func (c *configuredExternalServicesConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+func (c *campaignsCodeHostConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	return 1, nil
 }
 
-func (c *configuredExternalServicesConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+func (c *campaignsCodeHostConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	return graphqlutil.HasNextPage(false), nil
 }
 
-func (c *configuredExternalServicesConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.ConfiguredExternalServiceResolver, error) {
-	return []graphqlbackend.ConfiguredExternalServiceResolver{&configuredExternalServiceResolver{}}, nil
+func (c *campaignsCodeHostConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.CampaignsCodeHostResolver, error) {
+	return []graphqlbackend.CampaignsCodeHostResolver{&campaignsCodeHostResolver{}}, nil
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -142,6 +142,31 @@ func KindToType(kind string) string {
 	}
 }
 
+// TypeToKind returns a Kind constants given a Type
+// It will panic when given an unknown type.
+func TypeToKind(t string) string {
+	switch t {
+	case TypeAWSCodeCommit:
+		return KindAWSCodeCommit
+	case TypeBitbucketServer:
+		return KindBitbucketServer
+	case TypeBitbucketCloud:
+		return KindBitbucketCloud
+	case TypeGitHub:
+		return KindGitHub
+	case TypeGitLab:
+		return KindGitLab
+	case TypeGitolite:
+		return KindGitolite
+	case TypePhabricator:
+		return KindPhabricator
+	case TypeOther:
+		return KindOther
+	default:
+		panic(fmt.Sprintf("unknown type: %q", t))
+	}
+}
+
 var (
 	// Precompute these for use in ParseServiceType below since the constants are mixed case
 	bbsLower = strings.ToLower(TypeBitbucketServer)


### PR DESCRIPTION
Adds the schema for https://github.com/sourcegraph/sourcegraph/issues/14990.

This should not break anything as I implemented stub resolvers for everything to make graphql-go happy to start up again, so if we get approval here I think we can go ahead and merge already, for smaller follow-up PRs.