### PR TITLE
Allow users to create campaigns

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -55,8 +55,11 @@ func campaignsCreateAccess(ctx context.Context) error {
 		return ErrCampaignsDotCom{}
 	}
 
-	// Only site-admins can create campaigns/patchsets/changesets
-	return backend.CheckCurrentUserIsSiteAdmin(ctx)
+	act := actor.FromContext(ctx)
+	if !act.IsAuthenticated() {
+		return backend.ErrNotAuthenticated
+	}
+	return nil
 }
 
 // checkLicense returns a user-facing error if the campaigns feature is not purchased


### PR DESCRIPTION
This allows users to create campaigns and fixes https://github.com/sourcegraph/sourcegraph/issues/15310.

This should only be merged once we have the user tokens in.