### PR TITLE
Follow returnTo redirect when logging in via OAuth

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -40,6 +40,17 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
         provider => provider.isBuiltin
     )
 
+    function addRedirect(url?: string): string {
+        if (url === undefined) {
+            return ''
+        }
+        const parsedUrl = new URL(url, window.location.origin)
+
+        parsedUrl.searchParams.append('redirect', getReturnTo(props.location))
+
+        return parsedUrl.toString()
+    }
+
     const body =
         !builtInAuthProvider && thirdPartyAuthProviders.length === 0 ? (
             <div className="alert alert-info mt-3">
@@ -69,7 +80,7 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
                         // here because this list will not be updated during this component's lifetime.
                         /* eslint-disable react/no-array-index-key */
                         <div className="mb-2" key={index}>
-                            <a href={provider.authenticationURL} className="btn btn-secondary btn-block">
+                            <a href={addRedirect(provider.authenticationURL)} className="btn btn-secondary btn-block">
                                 {provider.displayName === 'GitHub' && (
                                     <>
                                         <GithubIcon className="icon-inline" />{' '}

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -40,17 +40,6 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
         provider => provider.isBuiltin
     )
 
-    function addRedirect(url?: string): string {
-        if (url === undefined) {
-            return ''
-        }
-        const parsedUrl = new URL(url, window.location.origin)
-
-        parsedUrl.searchParams.append('redirect', getReturnTo(props.location))
-
-        return parsedUrl.toString()
-    }
-
     const body =
         !builtInAuthProvider && thirdPartyAuthProviders.length === 0 ? (
             <div className="alert alert-info mt-3">
@@ -80,7 +69,7 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
                         // here because this list will not be updated during this component's lifetime.
                         /* eslint-disable react/no-array-index-key */
                         <div className="mb-2" key={index}>
-                            <a href={addRedirect(provider.authenticationURL)} className="btn btn-secondary btn-block">
+                            <a href={provider.authenticationURL} className="btn btn-secondary btn-block">
                                 {provider.displayName === 'GitHub' && (
                                     <>
                                         <GithubIcon className="icon-inline" />{' '}

--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -75,9 +75,6 @@ type Info struct {
 	DisplayName string
 
 	// AuthenticationURL is the URL to visit in order to initiate authenticating via this provider.
-	//
-	// TODO(sqs): Support "return-to" post-authentication-redirect destinations so newly authed
-	// users aren't dumped back onto the homepage.
 	AuthenticationURL string
 }
 

--- a/enterprise/cmd/frontend/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/auth/oauth/provider.go
@@ -107,9 +107,6 @@ func stateHandler(isLogin bool, providerID string, config gologin.CookieConfig, 
 			return
 		}
 		if isLogin {
-			// if we have a redirect param use that, otherwise we'll try and pull
-			// the 'returnTo' param from the referrer URL, this is usually the login
-			// page where the user has been dumped to after following a link.
 			redirect, err := getRedirect(req)
 			if err != nil {
 				log15.Error("Failed to parse URL from Referrer header", "error", err)
@@ -180,6 +177,9 @@ func randomState() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+// if we have a redirect param use that, otherwise we'll try and pull
+// the 'returnTo' param from the referrer URL, this is usually the login
+// page where the user has been dumped to after following a link.
 func getRedirect(req *http.Request) (string, error) {
 	redirect := req.URL.Query().Get("redirect")
 	if redirect != "" {

--- a/enterprise/cmd/frontend/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/auth/oauth/provider.go
@@ -198,9 +198,8 @@ func getRedirect(req *http.Request) (string, error) {
 	// we limit the redirect URL to only permit certain urls
 	if !canRedirect(returnTo) {
 		return "", fmt.Errorf("invalid URL in returnTo parameter: %s", returnTo)
-	} else {
-		return returnTo, nil
 	}
+	return returnTo, nil
 }
 
 // canRedirect is used to limit the set of URLs we will redirect to

--- a/enterprise/cmd/frontend/auth/oauth/provider_test.go
+++ b/enterprise/cmd/frontend/auth/oauth/provider_test.go
@@ -1,0 +1,23 @@
+package oauth
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestCanRedirect(t *testing.T) {
+	tc := map[string]bool{
+		"https://evilhost.com/nasty-stuff":  false,
+		"/search?foo=bar":                   true,
+		"http://example.com/search?foo=bar": true,
+		"http://localhost:1111/oh-dear":     false,
+	}
+	for tURL, expected := range tc {
+		t.Run(tURL, func(t *testing.T) {
+			got := canRedirect(url.PathEscape(tURL))
+			if got != expected {
+				t.Errorf("Expected %t got %t", expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes https://github.com/sourcegraph/sourcegraph/issues/15132

So this change has a very small surface area for a lot of time spent digging, but i suppose that's on purpose as i'm now (fairly) intimately familiar with how our OAuth providers work. 

I'm not 100% happy with how this change is implemented, as it feels somewhat fragile and counterintuitive to have this logic live within the sign in page view logic, but it was the change with the smallest surface area.

some other approaches i considered were:
* Refactoring the auth Provider interface to accept arguments when returning the authentication URL. This felt like a pretty large change with a lot of dependencies that i don't yet know about, and didn't feel appropriate to tackle in my first day.
* Pulling the returnTo param from the Referrer header in https://github.com/sourcegraph/sourcegraph/blob/eceb1cd9065249fabf0b50936300a59e0de4cdb2/enterprise/cmd/frontend/auth/oauth/provider.go#L98 this feels like a similar surface area to the change i've made, but feels slightly more fragile to subsequent changes. If we'd prefer to go this route i'm happy to make this change. of course i'm happy to make any change as this is my job and that's what i'm supposed to do 😂 

EDIT: we decided to move this to the backend https://github.com/sourcegraph/sourcegraph/pull/15439#discussion_r518054930

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
