### PR TITLE
search: migrate code monitors to enterprise

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -18,6 +18,7 @@ type Services struct {
 	AuthzResolver             graphqlbackend.AuthzResolver
 	CampaignsResolver         graphqlbackend.CampaignsResolver
 	CodeIntelResolver         graphqlbackend.CodeIntelResolver
+	CodeMonitorsResolver      graphqlbackend.CodeMonitorsResolver
 }
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The
@@ -39,6 +40,7 @@ func DefaultServices() Services {
 		NewExecutorProxyHandler:   func() http.Handler { return makeNotFoundHandler("executor proxy") },
 		AuthzResolver:             graphqlbackend.DefaultAuthzResolver,
 		CampaignsResolver:         graphqlbackend.DefaultCampaignsResolver,
+		CodeMonitorsResolver:      graphqlbackend.DefaultCodeMonitorsResolver,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -2,52 +2,20 @@ package graphqlbackend
 
 import (
 	"context"
-	"time"
+	"errors"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 )
 
-//
-// MonitorConnection
-//
-type ListMonitorsArgs struct {
-	First int32
-	After *string
-}
-
-func monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
-	return &monitorConnection{userID: userID}, nil
+type CodeMonitorsResolver interface {
+	Monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
 }
 
 type MonitorConnectionResolver interface {
 	Nodes(ctx context.Context) ([]MonitorResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
-}
-
-type monitorConnection struct {
-	userID graphql.ID
-}
-
-func (m *monitorConnection) Nodes(ctx context.Context) ([]MonitorResolver, error) {
-	return []MonitorResolver{&monitor{userID: m.userID}}, nil
-}
-
-func (m *monitorConnection) TotalCount(ctx context.Context) (int32, error) {
-	return 1, nil
-}
-
-func (m *monitorConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
-}
-
-//
-// Monitor
-//
-type ListActionArgs struct {
-	First int32
-	After *string
 }
 
 type MonitorResolver interface {
@@ -61,123 +29,22 @@ type MonitorResolver interface {
 	Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error)
 }
 
-type monitor struct {
-	userID graphql.ID
-}
-
-func (m *monitor) ID() graphql.ID {
-	return graphql.ID("ID not implemented")
-}
-
-func (m *monitor) CreatedBy(ctx context.Context) (*UserResolver, error) {
-	return UserByID(ctx, m.userID)
-}
-
-func (m *monitor) CreatedAt() DateTime {
-	return DateTime{time.Now()}
-}
-
-func (m *monitor) Description() string {
-	return "description not implemented"
-}
-
-func (*monitor) Enabled() bool {
-	return true
-}
-
-func (m *monitor) Trigger(ctx context.Context) (MonitorTrigger, error) {
-	return &monitorTrigger{&monitorQuery{monitorID: m.ID(), userID: m.userID}}, nil
-}
-
-func (m *monitor) Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error) {
-	return &monitorActionConnection{
-			monitorID: m.ID(),
-			userID:    m.userID},
-		nil
-}
-
-func (m *monitor) Owner(ctx context.Context) (n NamespaceResolver, err error) {
-	n.Namespace, err = UserByID(ctx, m.userID)
-	return n, err
-}
-
-//
-// MonitorTrigger <<UNION>>
-//
 type MonitorTrigger interface {
 	ToMonitorQuery() (MonitorQueryResolver, bool)
 }
 
-type monitorTrigger struct {
-	query MonitorQueryResolver
-}
-
-func (t *monitorTrigger) ToMonitorQuery() (MonitorQueryResolver, bool) {
-	return t.query, t.query != nil
-}
-
-//
-// Query
-//
 type MonitorQueryResolver interface {
 	ID() graphql.ID
 	Query() string
 	Events(ctx context.Context, args *ListEventsArgs) MonitorTriggerEventConnectionResolver
 }
 
-type monitorQuery struct {
-	monitorID graphql.ID
-	userID    graphql.ID // TODO: remove this. Just for stub implementation
-}
-
-func (q *monitorQuery) ID() graphql.ID {
-	return "monitorQuery ID not implemented"
-}
-
-func (q *monitorQuery) Query() string {
-	return "repo:github.com/sourcegraph/sourcegraph file:code_monitors not implemented"
-}
-
-func (q *monitorQuery) Events(ctx context.Context, args *ListEventsArgs) MonitorTriggerEventConnectionResolver {
-	return &monitorTriggerEventConnection{monitorID: q.monitorID, userID: q.userID}
-}
-
-//
-// MonitorTriggerEventConnection
-//
 type MonitorTriggerEventConnectionResolver interface {
 	Nodes(ctx context.Context) ([]MonitorTriggerEventResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type monitorTriggerEventConnection struct {
-	monitorID graphql.ID
-	userID    graphql.ID // TODO: remove this. Just for stub implementation
-}
-
-func (a *monitorTriggerEventConnection) Nodes(ctx context.Context) ([]MonitorTriggerEventResolver, error) {
-	return []MonitorTriggerEventResolver{&monitorTriggerEvent{
-		id:        "42",
-		status:    "SUCCESS",
-		message:   nil,
-		timestamp: DateTime{time.Now()},
-		monitorID: a.monitorID,
-		userID:    a.userID,
-	}}, nil
-}
-
-func (a *monitorTriggerEventConnection) TotalCount(ctx context.Context) (int32, error) {
-	return 1, nil
-}
-
-func (a *monitorTriggerEventConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
-}
-
-//
-// MonitorTriggerEvent
-//
 type MonitorTriggerEventResolver interface {
 	ID() graphql.ID
 	Status() string
@@ -186,82 +53,16 @@ type MonitorTriggerEventResolver interface {
 	Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error)
 }
 
-type monitorTriggerEvent struct {
-	id        graphql.ID
-	status    string
-	message   *string
-	timestamp DateTime
-	monitorID graphql.ID
-
-	userID graphql.ID // TODO: remove this. Just for stub implementation
-}
-
-func (m *monitorTriggerEvent) ID() graphql.ID {
-	return m.id
-}
-
-func (m *monitorTriggerEvent) Status() string {
-	return m.status
-}
-
-func (m *monitorTriggerEvent) Message() *string {
-	return m.message
-}
-
-func (m *monitorTriggerEvent) Timestamp() DateTime {
-	return m.timestamp
-}
-
-func (m *monitorTriggerEvent) Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error) {
-	return MonitorActionConnectionResolver(&monitorActionConnection{userID: m.userID, monitorID: m.monitorID, triggerEventID: &m.id}), nil
-}
-
-// ActionConnection
-//
 type MonitorActionConnectionResolver interface {
 	Nodes(ctx context.Context) ([]MonitorAction, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-type monitorActionConnection struct {
-	userID    graphql.ID //  TODO: remove this. This is just for the stub implementation.
-	monitorID graphql.ID
-
-	// triggerEventID is used to link action events to a trigger event
-	triggerEventID *graphql.ID
-}
-
-func (a *monitorActionConnection) Nodes(ctx context.Context) ([]MonitorAction, error) {
-	return []MonitorAction{&action{email: &monitorEmail{id: "42", userID: a.userID}}}, nil
-}
-
-func (a *monitorActionConnection) TotalCount(ctx context.Context) (int32, error) {
-	return 1, nil
-}
-
-func (a *monitorActionConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
-}
-
-//
-// Action <<UNION>>
-//
 type MonitorAction interface {
 	ToMonitorEmail() (MonitorEmailResolver, bool)
 }
 
-type action struct {
-	email MonitorEmailResolver
-}
-
-func (a *action) ToMonitorEmail() (MonitorEmailResolver, bool) {
-	return a.email, a.email != nil
-}
-
-//
-// Email
-//
 type MonitorEmailResolver interface {
 	ID() graphql.ID
 	Enabled() bool
@@ -271,93 +72,14 @@ type MonitorEmailResolver interface {
 	Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
 }
 
-type monitorEmail struct {
-	userID graphql.ID //  TODO: remove this. This is just for the stub implementation.
-	id     graphql.ID
-
-	// If triggerEventID == nil, all events of this action will be returned.
-	// Otherwise, only those events of this action which are related to the specified
-	// trigger event will be returned.
-	triggerEventID *graphql.ID
-}
-
-func (m *monitorEmail) Recipient(ctx context.Context) (MonitorEmailRecipient, error) {
-	user, err := UserByID(ctx, m.userID)
-	return &monitorEmailRecipient{
-		user: user,
-	}, err
-}
-
-func (m *monitorEmail) Enabled() bool {
-	return true
-}
-
-func (m *monitorEmail) Priority() string {
-	return "NORMAL"
-}
-
-func (m *monitorEmail) Header() string {
-	return "Header not implemented"
-}
-
-func (m *monitorEmail) ID() graphql.ID {
-	return "monitorEmail ID not implemented"
-}
-
-func (m *monitorEmail) Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error) {
-	return &monitorActionEventConnection{}, nil
-}
-
-//
-// MonitorEmailRecipient <<UNION>>
-//
 type MonitorEmailRecipient interface {
 	ToUser() (*UserResolver, bool)
 }
 
-type monitorEmailRecipient struct {
-	user *UserResolver
-}
-
-func (o *monitorEmailRecipient) ToUser() (*UserResolver, bool) {
-	return o.user, o.user != nil
-}
-
-//
-// MonitorActionEventConnection
-//
 type MonitorActionEventConnectionResolver interface {
 	Nodes(ctx context.Context) ([]MonitorActionEventResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
-}
-
-type monitorActionEventConnection struct {
-}
-
-func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]MonitorActionEventResolver, error) {
-	notImplemented := "message not implemented"
-	return []MonitorActionEventResolver{
-			&monitorActionEvent{id: "314", status: "SUCCESS", timestamp: DateTime{time.Now()}},
-			&monitorActionEvent{id: "315", status: "ERROR", message: &notImplemented, timestamp: DateTime{time.Now()}},
-		},
-		nil
-}
-
-func (a *monitorActionEventConnection) TotalCount(ctx context.Context) (int32, error) {
-	return 1, nil
-}
-
-func (a *monitorActionEventConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
-}
-
-//
-// MonitorEvent
-//
-type ListEventsArgs struct {
-	First int32
-	After *string
 }
 
 type MonitorActionEventResolver interface {
@@ -367,25 +89,28 @@ type MonitorActionEventResolver interface {
 	Timestamp() DateTime
 }
 
-type monitorActionEvent struct {
-	id        graphql.ID
-	status    string
-	message   *string
-	timestamp DateTime
+type ListEventsArgs struct {
+	First int32
+	After *string
 }
 
-func (m *monitorActionEvent) ID() graphql.ID {
-	return m.id
+type ListMonitorsArgs struct {
+	First int32
+	After *string
 }
 
-func (m *monitorActionEvent) Status() string {
-	return m.status
+type ListActionArgs struct {
+	First int32
+	After *string
 }
 
-func (m *monitorActionEvent) Message() *string {
-	return m.message
+var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
+
+var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
+
+type defaultCodeMonitorsResolver struct {
 }
 
-func (m *monitorActionEvent) Timestamp() DateTime {
-	return m.timestamp
+func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -325,7 +325,7 @@ func prometheusGraphQLRequestName(requestName string) string {
 	return "other"
 }
 
-func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz AuthzResolver) (*graphql.Schema, error) {
+func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz AuthzResolver, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
 	resolver := &schemaResolver{
 		CampaignsResolver: defaultCampaignsResolver{},
 		AuthzResolver:     defaultAuthzResolver{},
@@ -343,7 +343,10 @@ func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz A
 		EnterpriseResolvers.authzResolver = authz
 		resolver.AuthzResolver = authz
 	}
-
+	if codeMonitors != nil {
+		EnterpriseResolvers.codeMonitorsResolver = codeMonitors
+		resolver.CodeMonitorsResolver = codeMonitors
+	}
 	return graphql.ParseSchema(
 		Schema,
 		resolver,
@@ -531,18 +534,21 @@ type schemaResolver struct {
 	CampaignsResolver
 	AuthzResolver
 	CodeIntelResolver
+	CodeMonitorsResolver
 }
 
 // EnterpriseResolvers holds the instances of resolvers which are enabled only
 // in enterprise mode. These resolver instances are nil when running as OSS.
 var EnterpriseResolvers = struct {
-	codeIntelResolver CodeIntelResolver
-	authzResolver     AuthzResolver
-	campaignsResolver CampaignsResolver
+	codeIntelResolver    CodeIntelResolver
+	authzResolver        AuthzResolver
+	campaignsResolver    CampaignsResolver
+	codeMonitorsResolver CodeMonitorsResolver
 }{
-	codeIntelResolver: defaultCodeIntelResolver{},
-	authzResolver:     defaultAuthzResolver{},
-	campaignsResolver: defaultCampaignsResolver{},
+	codeIntelResolver:    defaultCodeIntelResolver{},
+	authzResolver:        defaultAuthzResolver{},
+	campaignsResolver:    defaultCampaignsResolver{},
+	codeMonitorsResolver: defaultCodeMonitorsResolver{},
 }
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -17,7 +17,7 @@ func mustParseGraphQLSchema(t *testing.T) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil)
+		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil, nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -345,5 +345,5 @@ func (r *UserResolver) Monitors(ctx context.Context, args *ListMonitorsArgs) (Mo
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
 		return nil, err
 	}
-	return monitors(ctx, r.ID(), args)
+	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.ID(), args)
 }

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -213,7 +213,7 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 		return err
 	}
 
-	schema, err := graphqlbackend.NewSchema(enterprise.CampaignsResolver, enterprise.CodeIntelResolver, enterprise.AuthzResolver)
+	schema, err := graphqlbackend.NewSchema(enterprise.CampaignsResolver, enterprise.CodeIntelResolver, enterprise.AuthzResolver, enterprise.CodeMonitorsResolver)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -43,7 +43,7 @@ func mustParseGraphQLSchema(t *testing.T, db *sql.DB) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = graphqlbackend.NewSchema(nil, nil, NewResolver(db, clock))
+		parsedSchema, parseSchemaErr = graphqlbackend.NewSchema(nil, nil, NewResolver(db, clock), nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -1,0 +1,13 @@
+package codemonitors
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers"
+)
+
+func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
+	enterpriseServices.CodeMonitorsResolver = &resolvers.Resolver{}
+	return nil
+}

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
@@ -30,11 +32,12 @@ func main() {
 }
 
 var initFunctions = map[string]func(ctx context.Context, enterpriseServices *enterprise.Services) error{
-	"authz":     authz.Init,
-	"licensing": licensing.Init,
-	"executor":  executor.Init,
-	"codeintel": codeintel.Init,
-	"campaigns": campaigns.Init,
+	"authz":        authz.Init,
+	"licensing":    licensing.Init,
+	"executor":     executor.Init,
+	"codeintel":    codeintel.Init,
+	"campaigns":    campaigns.Init,
+	"codemonitors": codemonitors.Init,
 }
 
 func enterpriseSetupHook() enterprise.Services {

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -76,7 +76,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestCampaignsListing(t *testing.T) {
 	store := ee.NewStore(dbconn.Global)
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -82,7 +82,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -61,7 +61,7 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -109,7 +109,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	addChangeset(t, ctx, store, campaign, changeset3.ID)
 	addChangeset(t, ctx, store, campaign, changeset4.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -172,7 +172,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -89,7 +89,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	addChangeset(t, ctx, store, campaign, changeset.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -68,7 +68,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -54,7 +54,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	testRev := api.CommitID("b69072d5f687b31b9f6ae3ceafdc24c259c4b9ec")
 	mockBackendCommits(t, testRev)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -174,7 +174,7 @@ func TestChangesetResolver(t *testing.T) {
 	// Associate the changeset with a campaign, so it's considered in syncer logic.
 	addChangeset(t, ctx, store, campaign, syncedGitHubChangeset.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -36,7 +36,7 @@ func TestPermissionLevels(t *testing.T) {
 
 	store := ee.NewStore(dbconn.Global)
 	sr := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(sr, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +553,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	store := ee.NewStore(dbconn.Global)
 	sr := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(sr, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -28,7 +28,7 @@ import (
 func TestNullIDResilience(t *testing.T) {
 	sr := &Resolver{store: ee.NewStore(dbconn.Global)}
 
-	s, err := graphqlbackend.NewSchema(sr, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func TestApplyCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func TestCreateCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,7 +527,7 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -1,0 +1,307 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+)
+
+type Resolver struct {
+}
+
+func (*Resolver) Monitors(ctx context.Context, userID graphql.ID, args *graphqlbackend.ListMonitorsArgs) (graphqlbackend.MonitorConnectionResolver, error) {
+	return &monitorConnection{userID: userID}, nil
+}
+
+//
+// MonitorConnection
+//
+type monitorConnection struct {
+	userID graphql.ID
+}
+
+func (m *monitorConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorResolver, error) {
+	return []graphqlbackend.MonitorResolver{&monitor{userID: m.userID}}, nil
+}
+
+func (m *monitorConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (m *monitorConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// Monitor
+//
+type monitor struct {
+	userID graphql.ID
+}
+
+func (m *monitor) ID() graphql.ID {
+	return "ID not implemented"
+}
+
+func (m *monitor) CreatedBy(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+	return graphqlbackend.UserByID(ctx, m.userID)
+}
+
+func (m *monitor) CreatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: time.Now()}
+}
+
+func (m *monitor) Description() string {
+	return "description not implemented"
+}
+
+func (*monitor) Enabled() bool {
+	return true
+}
+
+func (m *monitor) Trigger(ctx context.Context) (graphqlbackend.MonitorTrigger, error) {
+	return &monitorTrigger{&monitorQuery{monitorID: m.ID(), userID: m.userID}}, nil
+}
+
+func (m *monitor) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
+	return &monitorActionConnection{
+			monitorID: m.ID(),
+			userID:    m.userID},
+		nil
+}
+
+func (m *monitor) Owner(ctx context.Context) (n graphqlbackend.NamespaceResolver, err error) {
+	n.Namespace, err = graphqlbackend.UserByID(ctx, m.userID)
+	return n, err
+}
+
+//
+// MonitorTrigger <<UNION>>
+//
+type monitorTrigger struct {
+	query graphqlbackend.MonitorQueryResolver
+}
+
+func (t *monitorTrigger) ToMonitorQuery() (graphqlbackend.MonitorQueryResolver, bool) {
+	return t.query, t.query != nil
+}
+
+//
+// Query
+//
+type monitorQuery struct {
+	monitorID graphql.ID
+	userID    graphql.ID // TODO: remove this. Just for stub implementation
+}
+
+func (q *monitorQuery) ID() graphql.ID {
+	return "monitorQuery ID not implemented"
+}
+
+func (q *monitorQuery) Query() string {
+	return "repo:github.com/sourcegraph/sourcegraph file:code_monitors not implemented"
+}
+
+func (q *monitorQuery) Events(ctx context.Context, args *graphqlbackend.ListEventsArgs) graphqlbackend.MonitorTriggerEventConnectionResolver {
+	return &monitorTriggerEventConnection{monitorID: q.monitorID, userID: q.userID}
+}
+
+//
+// MonitorTriggerEventConnection
+//
+type monitorTriggerEventConnection struct {
+	monitorID graphql.ID
+	userID    graphql.ID // TODO: remove this. Just for stub implementation
+}
+
+func (a *monitorTriggerEventConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorTriggerEventResolver, error) {
+	return []graphqlbackend.MonitorTriggerEventResolver{&monitorTriggerEvent{
+		id:        "42",
+		status:    "SUCCESS",
+		message:   nil,
+		timestamp: graphqlbackend.DateTime{Time: time.Now()},
+		monitorID: a.monitorID,
+		userID:    a.userID,
+	}}, nil
+}
+
+func (a *monitorTriggerEventConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *monitorTriggerEventConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// MonitorTriggerEvent
+//
+type monitorTriggerEvent struct {
+	id        graphql.ID
+	status    string
+	message   *string
+	timestamp graphqlbackend.DateTime
+	monitorID graphql.ID
+
+	userID graphql.ID // TODO: remove this. Just for stub implementation
+}
+
+func (m *monitorTriggerEvent) ID() graphql.ID {
+	return m.id
+}
+
+func (m *monitorTriggerEvent) Status() string {
+	return m.status
+}
+
+func (m *monitorTriggerEvent) Message() *string {
+	return m.message
+}
+
+func (m *monitorTriggerEvent) Timestamp() graphqlbackend.DateTime {
+	return m.timestamp
+}
+
+func (m *monitorTriggerEvent) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
+	return graphqlbackend.MonitorActionConnectionResolver(&monitorActionConnection{userID: m.userID, monitorID: m.monitorID, triggerEventID: &m.id}), nil
+}
+
+// ActionConnection
+//
+type monitorActionConnection struct {
+	userID    graphql.ID //  TODO: remove this. This is just for the stub implementation.
+	monitorID graphql.ID
+
+	// triggerEventID is used to link action events to a trigger event
+	triggerEventID *graphql.ID
+}
+
+func (a *monitorActionConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorAction, error) {
+	return []graphqlbackend.MonitorAction{&action{email: &monitorEmail{id: "42", userID: a.userID}}}, nil
+}
+
+func (a *monitorActionConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *monitorActionConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// Action <<UNION>>
+//
+type action struct {
+	email graphqlbackend.MonitorEmailResolver
+}
+
+func (a *action) ToMonitorEmail() (graphqlbackend.MonitorEmailResolver, bool) {
+	return a.email, a.email != nil
+}
+
+//
+// Email
+//
+type monitorEmail struct {
+	userID graphql.ID //  TODO: remove this. This is just for the stub implementation.
+	id     graphql.ID
+
+	// If triggerEventID == nil, all events of this action will be returned.
+	// Otherwise, only those events of this action which are related to the specified
+	// trigger event will be returned.
+	triggerEventID *graphql.ID
+}
+
+func (m *monitorEmail) Recipient(ctx context.Context) (graphqlbackend.MonitorEmailRecipient, error) {
+	user, err := graphqlbackend.UserByID(ctx, m.userID)
+	return &monitorEmailRecipient{
+		user: user,
+	}, err
+}
+
+func (m *monitorEmail) Enabled() bool {
+	return true
+}
+
+func (m *monitorEmail) Priority() string {
+	return "NORMAL"
+}
+
+func (m *monitorEmail) Header() string {
+	return "Header not implemented"
+}
+
+func (m *monitorEmail) ID() graphql.ID {
+	return "monitorEmail ID not implemented"
+}
+
+func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEventsArgs) (graphqlbackend.MonitorActionEventConnectionResolver, error) {
+	return &monitorActionEventConnection{}, nil
+}
+
+//
+// MonitorEmailRecipient <<UNION>>
+//
+type MonitorEmailRecipient interface {
+	ToUser() (*graphqlbackend.UserResolver, bool)
+}
+
+type monitorEmailRecipient struct {
+	user *graphqlbackend.UserResolver
+}
+
+func (o *monitorEmailRecipient) ToUser() (*graphqlbackend.UserResolver, bool) {
+	return o.user, o.user != nil
+}
+
+//
+// MonitorActionEventConnection
+//
+type monitorActionEventConnection struct {
+}
+
+func (a *monitorActionEventConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorActionEventResolver, error) {
+	notImplemented := "message not implemented"
+	return []graphqlbackend.MonitorActionEventResolver{
+			&monitorActionEvent{id: "314", status: "SUCCESS", timestamp: graphqlbackend.DateTime{Time: time.Now()}},
+			&monitorActionEvent{id: "315", status: "ERROR", message: &notImplemented, timestamp: graphqlbackend.DateTime{Time: time.Now()}},
+		},
+		nil
+}
+
+func (a *monitorActionEventConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *monitorActionEventConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
+}
+
+//
+// MonitorEvent
+//
+type monitorActionEvent struct {
+	id        graphql.ID
+	status    string
+	message   *string
+	timestamp graphqlbackend.DateTime
+}
+
+func (m *monitorActionEvent) ID() graphql.ID {
+	return m.id
+}
+
+func (m *monitorActionEvent) Status() string {
+	return m.status
+}
+
+func (m *monitorActionEvent) Message() *string {
+	return m.message
+}
+
+func (m *monitorActionEvent) Timestamp() graphqlbackend.DateTime {
+	return m.timestamp
+}


### PR DESCRIPTION
Code Monitors is going to be an enterprise feature.

This PR moves the resolvers for code monitors from `graphqlbackend` to `enterprise/internal/codemonitors`. I followed the design of `codeintel` and `campaigns`. I didn't change anything in the schema or the resolvers (stubs).

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
