### PR TITLE
db: add user credentials table and CRUD (ish) methods

### DIFF
--- a/internal/db/mockstores.go
+++ b/internal/db/mockstores.go
@@ -6,14 +6,15 @@ var Mocks MockStores
 type MockStores struct {
 	AccessTokens MockAccessTokens
 
-	Repos         MockRepos
-	Namespaces    MockNamespaces
-	Orgs          MockOrgs
-	OrgMembers    MockOrgMembers
-	SavedSearches MockSavedSearches
-	Settings      MockSettings
-	Users         MockUsers
-	UserEmails    MockUserEmails
+	Repos           MockRepos
+	Namespaces      MockNamespaces
+	Orgs            MockOrgs
+	OrgMembers      MockOrgMembers
+	SavedSearches   MockSavedSearches
+	Settings        MockSettings
+	Users           MockUsers
+	UserCredentials MockUserCredentials
+	UserEmails      MockUserEmails
 
 	Phabricator MockPhabricator
 

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -1122,6 +1122,26 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.user_credentials"
+```
+        Column         |           Type           |                           Modifiers                           
+-----------------------+--------------------------+---------------------------------------------------------------
+ id                    | bigint                   | not null default nextval('user_credentials_id_seq'::regclass)
+ domain                | text                     | not null
+ user_id               | integer                  | not null
+ external_service_type | text                     | not null
+ external_service_id   | text                     | not null
+ credential            | text                     | not null
+ created_at            | timestamp with time zone | not null default now()
+ updated_at            | timestamp with time zone | not null default now()
+Indexes:
+    "user_credentials_pkey" PRIMARY KEY, btree (id)
+    "user_credentials_domain_user_id_external_service_type_exter_key" UNIQUE CONSTRAINT, btree (domain, user_id, external_service_type, external_service_id)
+Foreign-key constraints:
+    "user_credentials_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
+
+```
+
 # Table "public.user_emails"
 ```
           Column           |           Type           |       Modifiers        
@@ -1250,6 +1270,7 @@ Referenced by:
     TABLE "settings" CONSTRAINT "settings_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "settings" CONSTRAINT "settings_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "survey_responses" CONSTRAINT "survey_responses_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
+    TABLE "user_credentials" CONSTRAINT "user_credentials_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "user_emails" CONSTRAINT "user_emails_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
     TABLE "user_external_accounts" CONSTRAINT "user_external_accounts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
 Triggers:

--- a/internal/db/stores.go
+++ b/internal/db/stores.go
@@ -13,6 +13,7 @@ var (
 	SavedSearches    = &savedSearches{}
 	Settings         = &settings{}
 	Users            = &users{}
+	UserCredentials  = &userCredentials{}
 	UserEmails       = &userEmails{}
 	EventLogs        = &eventLogs{}
 

--- a/internal/db/user_credentials.go
+++ b/internal/db/user_credentials.go
@@ -200,7 +200,7 @@ func (*userCredentials) List(ctx context.Context, opts UserCredentialsListOpts) 
 	}
 	defer rows.Close()
 
-	creds := []*UserCredential{}
+	var creds []*UserCredential
 	for rows.Next() {
 		cred := UserCredential{}
 		if err := scanUserCredential(&cred, rows); err != nil {

--- a/internal/db/user_credentials.go
+++ b/internal/db/user_credentials.go
@@ -33,12 +33,16 @@ const (
 	UserCredentialDomainCampaigns = "campaigns"
 )
 
-// userCredentialNotFoundErr is returned when a credential cannot be found from
+// UserCredentialNotFoundErr is returned when a credential cannot be found from
 // its ID or scope.
-type userCredentialNotFoundErr struct{ args []interface{} }
+type UserCredentialNotFoundErr struct{ args []interface{} }
 
-func (err userCredentialNotFoundErr) Error() string {
+func (err UserCredentialNotFoundErr) Error() string {
 	return fmt.Sprintf("user credential not found: %v", err.args)
+}
+
+func (UserCredentialNotFoundErr) NotFound() bool {
+	return true
 }
 
 // userCredentials provides access to the `user_credentials` table.
@@ -65,7 +69,7 @@ func (*userCredentials) Delete(ctx context.Context, id int64) error {
 	if rows, err := res.RowsAffected(); err != nil {
 		return err
 	} else if rows == 0 {
-		return userCredentialNotFoundErr{args: []interface{}{id}}
+		return UserCredentialNotFoundErr{args: []interface{}{id}}
 	}
 
 	return nil
@@ -85,7 +89,7 @@ func (*userCredentials) GetByID(ctx context.Context, id int64) (*UserCredential,
 	cred := UserCredential{}
 	row := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err := scanUserCredential(&cred, row); err == sql.ErrNoRows {
-		return nil, userCredentialNotFoundErr{args: []interface{}{id}}
+		return nil, UserCredentialNotFoundErr{args: []interface{}{id}}
 	} else if err != nil {
 		return nil, err
 	}
@@ -110,7 +114,7 @@ func (*userCredentials) GetByScope(ctx context.Context, scope UserCredentialScop
 	cred := UserCredential{}
 	row := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err := scanUserCredential(&cred, row); err == sql.ErrNoRows {
-		return nil, userCredentialNotFoundErr{args: []interface{}{scope}}
+		return nil, UserCredentialNotFoundErr{args: []interface{}{scope}}
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/db/user_credentials.go
+++ b/internal/db/user_credentials.go
@@ -1,0 +1,397 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/secret"
+)
+
+// UserCredential represents a row in the `user_credentials` table.
+type UserCredential struct {
+	ID                  int64
+	Domain              string
+	UserID              int32
+	ExternalServiceType string
+	ExternalServiceID   string
+	Credential          auth.Authenticator
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// This const block contains the valid domain values for user credentials.
+const (
+	UserCredentialDomainCampaigns = "campaigns"
+)
+
+// userCredentialNotFoundErr is returned when a credential cannot be found from
+// its ID or scope.
+type userCredentialNotFoundErr struct{ args []interface{} }
+
+func (err userCredentialNotFoundErr) Error() string {
+	return fmt.Sprintf("user credential not found: %v", err.args)
+}
+
+// userCredentials provides access to the `user_credentials` table.
+type userCredentials struct{}
+
+type UserCredentialScope struct {
+	Domain              string
+	UserID              int32
+	ExternalServiceType string
+	ExternalServiceID   string
+}
+
+func (*userCredentials) Delete(ctx context.Context, id int64) error {
+	if Mocks.UserCredentials.Delete != nil {
+		return Mocks.UserCredentials.Delete(ctx, id)
+	}
+
+	q := sqlf.Sprintf("DELETE FROM user_credentials WHERE id = %s", id)
+	res, err := dbconn.Global.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return err
+	}
+
+	if rows, err := res.RowsAffected(); err != nil {
+		return err
+	} else if rows == 0 {
+		return userCredentialNotFoundErr{args: []interface{}{id}}
+	}
+
+	return nil
+}
+
+func (*userCredentials) GetByID(ctx context.Context, id int64) (*UserCredential, error) {
+	if Mocks.UserCredentials.GetByID != nil {
+		return Mocks.UserCredentials.GetByID(ctx, id)
+	}
+
+	q := sqlf.Sprintf(
+		"SELECT %s FROM user_credentials WHERE id = %s",
+		sqlf.Join(userCredentialsColumns, ", "),
+		id,
+	)
+
+	cred := UserCredential{}
+	row := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err := scanUserCredential(&cred, row); err == sql.ErrNoRows {
+		return nil, userCredentialNotFoundErr{args: []interface{}{id}}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &cred, nil
+}
+
+func (*userCredentials) GetByScope(ctx context.Context, scope UserCredentialScope) (*UserCredential, error) {
+	if Mocks.UserCredentials.GetByScope != nil {
+		return Mocks.UserCredentials.GetByScope(ctx, scope)
+	}
+
+	q := sqlf.Sprintf(
+		userCredentialsGetByScopeQueryFmtstr,
+		sqlf.Join(userCredentialsColumns, ", "),
+		scope.Domain,
+		scope.UserID,
+		scope.ExternalServiceType,
+		scope.ExternalServiceID,
+	)
+
+	cred := UserCredential{}
+	row := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err := scanUserCredential(&cred, row); err == sql.ErrNoRows {
+		return nil, userCredentialNotFoundErr{args: []interface{}{scope}}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &cred, nil
+}
+
+// UserCredentialsListOpts provide the options when listing credentials. At
+// least one option must be set.
+type UserCredentialsListOpts struct {
+	*LimitOffset
+	Scope UserCredentialScope
+}
+
+// sql overrides LimitOffset.SQL() to give a LIMIT clause with one extra value
+// so we can populate the next cursor.
+func (opts *UserCredentialsListOpts) sql() *sqlf.Query {
+	if opts.LimitOffset == nil || opts.Limit == 0 {
+		return &sqlf.Query{}
+	}
+
+	return (&LimitOffset{Limit: opts.Limit + 1, Offset: opts.Offset}).SQL()
+}
+
+func (*userCredentials) List(ctx context.Context, opts UserCredentialsListOpts) ([]*UserCredential, int, error) {
+	if Mocks.UserCredentials.List != nil {
+		return Mocks.UserCredentials.List(ctx, opts)
+	}
+
+	preds := []*sqlf.Query{}
+	if opts.Scope.Domain != "" {
+		preds = append(preds, sqlf.Sprintf("domain = %s", opts.Scope.Domain))
+	}
+	if opts.Scope.UserID != 0 {
+		preds = append(preds, sqlf.Sprintf("user_id = %s", opts.Scope.UserID))
+	}
+	if opts.Scope.ExternalServiceType != "" {
+		preds = append(preds, sqlf.Sprintf("external_service_type = %s", opts.Scope.ExternalServiceType))
+	}
+	if opts.Scope.ExternalServiceID != "" {
+		preds = append(preds, sqlf.Sprintf("external_service_id = %s", opts.Scope.ExternalServiceID))
+	}
+
+	q := sqlf.Sprintf(
+		userCredentialsListQueryFmtstr,
+		sqlf.Join(userCredentialsColumns, ", "),
+		sqlf.Join(preds, "\n AND "),
+		opts.sql(),
+	)
+
+	rows, err := dbconn.Global.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	creds := []*UserCredential{}
+	for rows.Next() {
+		cred := UserCredential{}
+		if err := scanUserCredential(&cred, rows); err != nil {
+			return nil, 0, err
+		}
+		creds = append(creds, &cred)
+	}
+
+	// Check if there were more results than the limit: if so, then we need to
+	// set the return cursor and lop off the extra credential that we retrieved.
+	next := 0
+	if opts.LimitOffset != nil && opts.Limit != 0 && len(creds) == opts.Limit+1 {
+		next = opts.Offset + opts.Limit
+		creds = creds[:len(creds)-1]
+	}
+
+	return creds, next, nil
+}
+
+func (*userCredentials) Upsert(ctx context.Context, scope UserCredentialScope, credential auth.Authenticator) (*UserCredential, error) {
+	if Mocks.UserCredentials.Upsert != nil {
+		return Mocks.UserCredentials.Upsert(ctx, scope, credential)
+	}
+
+	raw, err := marshalCredential(credential)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling credential")
+	}
+
+	q := sqlf.Sprintf(
+		userCredentialsUpsertQueryFmtstr,
+		scope.Domain,
+		scope.UserID,
+		scope.ExternalServiceType,
+		scope.ExternalServiceID,
+		secret.StringValue{S: &raw},
+		sqlf.Join(userCredentialsColumns, ", "),
+	)
+
+	cred := UserCredential{}
+	row := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err := scanUserCredential(&cred, row); err != nil {
+		return nil, err
+	}
+
+	return &cred, nil
+}
+
+// 🐉 This marks the end of the public API. Beyond here are dragons.
+
+// userCredentialsColumns are the columns that must be selected by
+// user_credentials queries in order to use scanUserCredential().
+var userCredentialsColumns = []*sqlf.Query{
+	sqlf.Sprintf("id"),
+	sqlf.Sprintf("domain"),
+	sqlf.Sprintf("user_id"),
+	sqlf.Sprintf("external_service_type"),
+	sqlf.Sprintf("external_service_id"),
+	sqlf.Sprintf("credential"),
+	sqlf.Sprintf("created_at"),
+	sqlf.Sprintf("updated_at"),
+}
+
+// The more unwieldy queries are below rather than inline in the above methods
+// in a vain attempt to improve their readability.
+
+const userCredentialsGetByScopeQueryFmtstr = `
+-- source: internal/db/user_credentials.go:GetByScope
+SELECT %s
+FROM user_credentials
+WHERE
+	domain = %s AND
+	user_id = %s AND
+	external_service_type = %s AND
+	external_service_id = %s
+`
+
+const userCredentialsListQueryFmtstr = `
+-- source: internal/db/user_credentials.go:List
+SELECT %s
+FROM user_credentials
+WHERE %s
+ORDER BY created_at ASC, domain ASC, user_id ASC, external_service_id ASC
+%s  -- LIMIT clause
+`
+
+const userCredentialsUpsertQueryFmtstr = `
+-- source: internal/db/user_credentials.go:Upsert
+INSERT INTO
+	user_credentials (
+		domain,
+		user_id,
+		external_service_type,
+		external_service_id,
+		credential,
+		created_at,
+		updated_at
+	)
+	VALUES (
+		%s,
+		%s,
+		%s,
+		%s,
+		%s,
+		NOW(),
+		NOW()
+	)
+	ON CONFLICT (
+		domain,
+		user_id,
+		external_service_type,
+		external_service_id
+	) DO UPDATE SET
+		credential = excluded.credential,
+		updated_at = excluded.updated_at
+	RETURNING %s
+`
+
+// scanUserCredential scans a credential from the given scanner into the given
+// credential.
+//
+// s is inspired by the campaigns scanner type, but also matches sql.Row, which
+// is generally used directly in this module.
+func scanUserCredential(cred *UserCredential, s interface {
+	Scan(...interface{}) error
+}) error {
+	// Set up a string for the credential to be decrypted into.
+	raw := ""
+
+	if err := s.Scan(
+		&cred.ID,
+		&cred.Domain,
+		&cred.UserID,
+		&cred.ExternalServiceType,
+		&cred.ExternalServiceID,
+		&secret.StringValue{S: &raw},
+		&cred.CreatedAt,
+		&cred.UpdatedAt,
+	); err != nil {
+		return err
+	}
+
+	// Now we have the credential, we need to unmarshal it into the right Go
+	// type.
+	var err error
+	if cred.Credential, err = unmarshalCredential(raw); err != nil {
+		return errors.Wrap(err, "unmarshalling credential")
+	}
+
+	return nil
+}
+
+// Define credential type strings that we'll use when encoding credentials.
+const (
+	credTypeOAuthClient                        = "OAuthClient"
+	credTypeBasicAuth                          = "BasicAuth"
+	credTypeOAuthBearerToken                   = "OAuthBearerToken"
+	credTypeBitbucketServerSudoableOAuthClient = "BitbucketSudoableOAuthClient"
+	credTypeGitLabSudoableToken                = "GitLabSudoableToken"
+)
+
+// marshalCredential encodes an Authenticator into a JSON string.
+func marshalCredential(a auth.Authenticator) (string, error) {
+	var t string
+	switch a.(type) {
+	case *auth.OAuthClient:
+		t = credTypeOAuthClient
+	case *auth.BasicAuth:
+		t = credTypeBasicAuth
+	case *auth.OAuthBearerToken:
+		t = credTypeOAuthBearerToken
+	case *bitbucketserver.SudoableOAuthClient:
+		t = credTypeBitbucketServerSudoableOAuthClient
+	case *gitlab.SudoableToken:
+		t = credTypeGitLabSudoableToken
+	default:
+		return "", errors.Errorf("unknown Authenticator implementation type: %T", a)
+	}
+
+	raw, err := json.Marshal(struct {
+		Type string
+		Auth auth.Authenticator
+	}{
+		Type: t,
+		Auth: a,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return string(raw), nil
+}
+
+// unmarshalCredential decodes a JSON string into an Authenticator.
+func unmarshalCredential(raw string) (auth.Authenticator, error) {
+	// We do two unmarshals: the first just to get the type, and then the second
+	// to actually unmarshal the authenticator itself.
+	var partial struct {
+		Type string
+		Auth json.RawMessage
+	}
+	if err := json.Unmarshal([]byte(raw), &partial); err != nil {
+		return nil, err
+	}
+
+	var a interface{}
+	switch partial.Type {
+	case credTypeOAuthClient:
+		a = &auth.OAuthClient{}
+	case credTypeBasicAuth:
+		a = &auth.BasicAuth{}
+	case credTypeOAuthBearerToken:
+		a = &auth.OAuthBearerToken{}
+	case credTypeBitbucketServerSudoableOAuthClient:
+		a = &bitbucketserver.SudoableOAuthClient{}
+	case credTypeGitLabSudoableToken:
+		a = &gitlab.SudoableToken{}
+	default:
+		return nil, errors.Errorf("unknown credential type: %s", partial.Type)
+	}
+
+	if err := json.Unmarshal(partial.Auth, &a); err != nil {
+		return nil, err
+	}
+
+	return a.(auth.Authenticator), nil
+}

--- a/internal/db/user_credentials_mock.go
+++ b/internal/db/user_credentials_mock.go
@@ -7,9 +7,9 @@ import (
 )
 
 type MockUserCredentials struct {
+	Create     func(context.Context, UserCredentialScope, auth.Authenticator) (*UserCredential, error)
 	Delete     func(context.Context, int64) error
 	GetByID    func(context.Context, int64) (*UserCredential, error)
 	GetByScope func(context.Context, UserCredentialScope) (*UserCredential, error)
 	List       func(context.Context, UserCredentialsListOpts) ([]*UserCredential, int, error)
-	Upsert     func(context.Context, UserCredentialScope, auth.Authenticator) (*UserCredential, error)
 }

--- a/internal/db/user_credentials_mock.go
+++ b/internal/db/user_credentials_mock.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+)
+
+type MockUserCredentials struct {
+	Delete     func(context.Context, int64) error
+	GetByID    func(context.Context, int64) (*UserCredential, error)
+	GetByScope func(context.Context, UserCredentialScope) (*UserCredential, error)
+	List       func(context.Context, UserCredentialsListOpts) ([]*UserCredential, int, error)
+	Upsert     func(context.Context, UserCredentialScope, auth.Authenticator) (*UserCredential, error)
+}

--- a/internal/db/user_credentials_test.go
+++ b/internal/db/user_credentials_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
@@ -457,7 +458,7 @@ func TestUserCredentials_Invalid(t *testing.T) {
 
 func TestUserCredentialNotFoundErr(t *testing.T) {
 	err := UserCredentialNotFoundErr{}
-	if have := err.NotFound(); !have {
+	if have := errcode.IsNotFound(err); !have {
 		t.Error("UserCredentialNotFoundErr does not say it represents a not found error")
 	}
 }

--- a/internal/db/user_credentials_test.go
+++ b/internal/db/user_credentials_test.go
@@ -1,0 +1,514 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/gomodule/oauth1/oauth"
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/secret"
+)
+
+func TestUserCredentials_Delete(t *testing.T) {
+	ctx, user := setUpUserCredentialTest(t)
+
+	t.Run("nonextant", func(t *testing.T) {
+		err := UserCredentials.Delete(ctx, 1)
+		if err == nil {
+			t.Error("unexpected nil error")
+		}
+
+		e, ok := err.(userCredentialNotFoundErr)
+		if !ok {
+			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
+		}
+		if len(e.args) != 1 || e.args[0].(int64) != 1 {
+			t.Errorf("unexpected args: have=%v want=[1]", e.args)
+		}
+	})
+
+	t.Run("extant", func(t *testing.T) {
+		scope := UserCredentialScope{
+			Domain:              UserCredentialDomainCampaigns,
+			UserID:              user.ID,
+			ExternalServiceType: "github",
+			ExternalServiceID:   "https://github.com",
+		}
+		token := &auth.OAuthBearerToken{Token: "abcdef"}
+
+		cred, err := UserCredentials.Upsert(ctx, scope, token)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := UserCredentials.Delete(ctx, cred.ID); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+
+		_, err = UserCredentials.GetByID(ctx, cred.ID)
+		if _, ok := err.(userCredentialNotFoundErr); !ok {
+			t.Errorf("unexpected error retrieving credential after deletion: %v", err)
+		}
+	})
+}
+
+func TestUserCredentials_GetByID(t *testing.T) {
+	ctx, user := setUpUserCredentialTest(t)
+
+	t.Run("nonextant", func(t *testing.T) {
+		cred, err := UserCredentials.GetByID(ctx, 1)
+		if cred != nil {
+			t.Errorf("unexpected non-nil credential: %v", cred)
+		}
+		if err == nil {
+			t.Error("unexpected nil error")
+		}
+
+		e, ok := err.(userCredentialNotFoundErr)
+		if !ok {
+			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
+		}
+		if len(e.args) != 1 || e.args[0].(int64) != 1 {
+			t.Errorf("unexpected args: have=%v want=[1]", e.args)
+		}
+	})
+
+	t.Run("extant", func(t *testing.T) {
+		scope := UserCredentialScope{
+			Domain:              UserCredentialDomainCampaigns,
+			UserID:              user.ID,
+			ExternalServiceType: "github",
+			ExternalServiceID:   "https://github.com",
+		}
+		token := &auth.OAuthBearerToken{Token: "abcdef"}
+
+		want, err := UserCredentials.Upsert(ctx, scope, token)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have, err := UserCredentials.GetByID(ctx, want.ID)
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Errorf("unexpected credential:\n%s", diff)
+		}
+	})
+}
+
+func TestUserCredentials_GetByScope(t *testing.T) {
+	ctx, user := setUpUserCredentialTest(t)
+
+	scope := UserCredentialScope{
+		Domain:              UserCredentialDomainCampaigns,
+		UserID:              user.ID,
+		ExternalServiceType: "github",
+		ExternalServiceID:   "https://github.com",
+	}
+	token := &auth.OAuthBearerToken{Token: "abcdef"}
+
+	t.Run("nonextant", func(t *testing.T) {
+		cred, err := UserCredentials.GetByScope(ctx, scope)
+		if cred != nil {
+			t.Errorf("unexpected non-nil credential: %v", cred)
+		}
+		if err == nil {
+			t.Error("unexpected nil error")
+		}
+
+		e, ok := err.(userCredentialNotFoundErr)
+		if !ok {
+			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
+		}
+		if diff := cmp.Diff(e.args, []interface{}{scope}); diff != "" {
+			t.Errorf("unexpected args:\n%s", diff)
+		}
+	})
+
+	t.Run("extant", func(t *testing.T) {
+		want, err := UserCredentials.Upsert(ctx, scope, token)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have, err := UserCredentials.GetByScope(ctx, scope)
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		if diff := cmp.Diff(have, want); diff != "" {
+			t.Errorf("unexpected credential:\n%s", diff)
+		}
+	})
+}
+
+func TestUserCredentials_List(t *testing.T) {
+	ctx, user := setUpUserCredentialTest(t)
+
+	githubScope := UserCredentialScope{
+		Domain:              UserCredentialDomainCampaigns,
+		UserID:              user.ID,
+		ExternalServiceType: "github",
+		ExternalServiceID:   "https://github.com",
+	}
+	gitlabScope := UserCredentialScope{
+		Domain:              UserCredentialDomainCampaigns,
+		UserID:              user.ID,
+		ExternalServiceType: "gitlab",
+		ExternalServiceID:   "https://gitlab.com",
+	}
+	token := &auth.OAuthBearerToken{Token: "abcdef"}
+
+	// Unlike the other tests in this file, we'll set up a couple of credentials
+	// right now, and then list from there.
+	github, err := UserCredentials.Upsert(ctx, githubScope, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitlab, err := UserCredentials.Upsert(ctx, gitlabScope, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+			Scope: UserCredentialScope{
+				Domain: "this is not a valid domain",
+			},
+		})
+		if err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+		if next != 0 {
+			t.Errorf("unexpected next: have=%d want=%d", next, 0)
+		}
+		if len(creds) != 0 {
+			t.Errorf("unexpected non-zero number of credentials: %v", creds)
+		}
+	})
+
+	t.Run("no options", func(t *testing.T) {
+		creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{})
+		if err == nil {
+			t.Error("unexpected nil error")
+		}
+		if next != 0 {
+			t.Errorf("unexpected next: have=%d want=%d", next, 0)
+		}
+		if len(creds) != 0 {
+			t.Errorf("unexpected non-zero number of credentials: %v", creds)
+		}
+	})
+
+	for name, tc := range map[string]struct {
+		scope UserCredentialScope
+		want  *UserCredential
+	}{
+		"service ID only": {
+			scope: UserCredentialScope{
+				ExternalServiceID: "https://github.com",
+			},
+			want: github,
+		},
+		"service type only": {
+			scope: UserCredentialScope{
+				ExternalServiceType: "gitlab",
+			},
+			want: gitlab,
+		},
+		"full scope": {
+			scope: githubScope,
+			want:  github,
+		},
+	} {
+		t.Run("single match on "+name, func(t *testing.T) {
+			creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+				Scope: tc.scope,
+			})
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if next != 0 {
+				t.Errorf("unexpected next: have=%d want=%d", next, 0)
+			}
+			if diff := cmp.Diff(creds, []*UserCredential{tc.want}); diff != "" {
+				t.Errorf("unexpected credentials:\n%s", diff)
+			}
+		})
+	}
+
+	for name, scope := range map[string]UserCredentialScope{
+		"domain only":  {Domain: UserCredentialDomainCampaigns},
+		"user ID only": {UserID: user.ID},
+		"domain and user ID": {
+			Domain: UserCredentialDomainCampaigns,
+			UserID: user.ID,
+		},
+	} {
+		t.Run("multiple matches on "+name, func(t *testing.T) {
+			creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+				Scope: scope,
+			})
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if next != 0 {
+				t.Errorf("unexpected next: have=%d want=%d", next, 0)
+			}
+			if diff := cmp.Diff(creds, []*UserCredential{github, gitlab}); diff != "" {
+				t.Errorf("unexpected credentials:\n%s", diff)
+			}
+		})
+
+		t.Run("pagination for "+name, func(t *testing.T) {
+			creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+				LimitOffset: &LimitOffset{Limit: 1},
+				Scope:       scope,
+			})
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if next != 1 {
+				t.Errorf("unexpected next: have=%d want=%d", next, 1)
+			}
+			if diff := cmp.Diff(creds, []*UserCredential{github}); diff != "" {
+				t.Errorf("unexpected credentials:\n%s", diff)
+			}
+
+			creds, next, err = UserCredentials.List(ctx, UserCredentialsListOpts{
+				LimitOffset: &LimitOffset{Limit: 1, Offset: next},
+				Scope:       scope,
+			})
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if next != 0 {
+				t.Errorf("unexpected next: have=%d want=%d", next, 0)
+			}
+			if diff := cmp.Diff(creds, []*UserCredential{gitlab}); diff != "" {
+				t.Errorf("unexpected credentials:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUserCredentials_Upsert(t *testing.T) {
+	ctx, user := setUpUserCredentialTest(t)
+
+	// Instead of two of every animal, we want two of every authenticator. Same,
+	// same.
+	for nameFrom, from := range createUserCredentialAuths(t) {
+		for nameTo, to := range createUserCredentialAuths(t) {
+			t.Run(fmt.Sprintf("%s → %s", nameFrom, nameTo), func(t *testing.T) {
+				var cred *UserCredential
+				scope := UserCredentialScope{
+					Domain:              UserCredentialDomainCampaigns,
+					UserID:              user.ID,
+					ExternalServiceType: "github",
+					ExternalServiceID:   "https://github.com",
+				}
+
+				t.Run("insert", func(t *testing.T) {
+					var err error
+					if cred, err = UserCredentials.Upsert(ctx, scope, from); err != nil {
+						t.Errorf("unexpected non-nil error: %v", err)
+					} else if cred == nil {
+						t.Error("unexpected nil credential")
+					}
+
+					if cred.ID == 0 {
+						t.Error("unexpected zero ID")
+					}
+					if cred.Domain != scope.Domain {
+						t.Errorf("unexpected domain: have=%q want=%q", cred.Domain, scope.Domain)
+					}
+					if cred.UserID != scope.UserID {
+						t.Errorf("unexpected ID: have=%d want=%d", cred.UserID, scope.UserID)
+					}
+					if cred.ExternalServiceType != scope.ExternalServiceType {
+						t.Errorf("unexpected external service type: have=%q want=%q", cred.ExternalServiceType, scope.ExternalServiceType)
+					}
+					if cred.ExternalServiceID != scope.ExternalServiceID {
+						t.Errorf("unexpected external service id: have=%q want=%q", cred.ExternalServiceID, scope.ExternalServiceID)
+					}
+					if diff := cmp.Diff(cred.Credential, from); diff != "" {
+						t.Errorf("unexpected credential:\n%s", diff)
+					}
+					if cred.CreatedAt.IsZero() {
+						t.Errorf("unexpected zero creation time")
+					}
+					if cred.UpdatedAt.IsZero() {
+						t.Errorf("unexpected zero update time")
+					}
+				})
+
+				t.Run("update", func(t *testing.T) {
+					var err error
+					var updated *UserCredential
+					if updated, err = UserCredentials.Upsert(ctx, scope, to); err != nil {
+						t.Errorf("unexpected non-nil error: %v", err)
+					} else if cred == nil {
+						t.Error("unexpected nil credential")
+					}
+
+					if cred.ID != updated.ID {
+						t.Errorf("unexpected ID change: old=%d new=%d", cred.ID, updated.ID)
+					}
+					if updated.Domain != scope.Domain {
+						t.Errorf("unexpected domain: have=%q want=%q", cred.Domain, scope.Domain)
+					}
+					if updated.UserID != scope.UserID {
+						t.Errorf("unexpected ID: have=%d want=%d", cred.UserID, scope.UserID)
+					}
+					if updated.ExternalServiceType != scope.ExternalServiceType {
+						t.Errorf("unexpected external service type: have=%q want=%q", cred.ExternalServiceType, scope.ExternalServiceType)
+					}
+					if updated.ExternalServiceID != scope.ExternalServiceID {
+						t.Errorf("unexpected external service id: have=%q want=%q", cred.ExternalServiceID, scope.ExternalServiceID)
+					}
+					if diff := cmp.Diff(updated.Credential, to); diff != "" {
+						t.Errorf("unexpected credential:\n%s", diff)
+					}
+					if cred.CreatedAt != updated.CreatedAt {
+						t.Errorf("unexpected creation time change: old=%v new=%v", cred.CreatedAt, updated.CreatedAt)
+					}
+					if cred.UpdatedAt == updated.UpdatedAt {
+						t.Errorf("unexpected updated time non-change: old=%v new=%v", cred.UpdatedAt, updated.UpdatedAt)
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestUserCredentials_Invalid(t *testing.T) {
+	ctx, user := setUpUserCredentialTest(t)
+
+	t.Run("marshal", func(t *testing.T) {
+		if _, err := UserCredentials.Upsert(ctx, UserCredentialScope{}, &invalidAuth{}); err == nil {
+			t.Error("unexpected nil error")
+		}
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		// We'll set up some cases here that just shouldn't happen at all, and
+		// make sure they bubble up with errors where we expect. Let's define a
+		// helper to make that easier.
+
+		insertRawCredential := func(t *testing.T, domain string, raw string) int64 {
+			q := sqlf.Sprintf(
+				userCredentialsUpsertQueryFmtstr,
+				domain,
+				user.ID,
+				"type",
+				"id",
+				secret.StringValue{S: &raw},
+				sqlf.Sprintf("id"),
+			)
+
+			var id int64
+			row := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+			if err := row.Scan(&id); err != nil {
+				t.Fatal(err)
+			}
+
+			return id
+		}
+
+		for name, id := range map[string]int64{
+			"invalid credential type": insertRawCredential(t, "invalid", `{"type":"InvalidType"}`),
+			"lying credential type":   insertRawCredential(t, "lying", `{"type":"BasicAuth","username":42}`),
+			"malformed JSON":          insertRawCredential(t, "malformed", "this is not valid JSON"),
+		} {
+			t.Run(name, func(t *testing.T) {
+				if _, err := UserCredentials.GetByID(ctx, id); err == nil {
+					t.Error("unexpected nil error")
+				} else if _, ok := err.(userCredentialNotFoundErr); ok {
+					t.Error("unexpected not found error")
+				}
+			})
+		}
+	})
+}
+
+func createUserCredentialAuths(t *testing.T) map[string]auth.Authenticator {
+	t.Helper()
+
+	createOAuthClient := func(t *testing.T, token, secret string) *oauth.Client {
+		t.Helper()
+
+		// Generate a random key so we can test different clients are different.
+		// Note that this is wildly insecure.
+		key, err := rsa.GenerateKey(rand.Reader, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &oauth.Client{
+			Credentials: oauth.Credentials{
+				Token:  token,
+				Secret: secret,
+			},
+			PrivateKey: key,
+		}
+	}
+
+	auths := make(map[string]auth.Authenticator)
+	for _, a := range []auth.Authenticator{
+		&auth.OAuthClient{Client: createOAuthClient(t, "abc", "def")},
+		&auth.BasicAuth{Username: "foo", Password: "bar"},
+		&auth.OAuthBearerToken{Token: "abcdef"},
+		&bitbucketserver.SudoableOAuthClient{
+			Client:   auth.OAuthClient{Client: createOAuthClient(t, "ghi", "jkl")},
+			Username: "neo",
+		},
+		&gitlab.SudoableToken{Token: "mnop", Sudo: "qrs"},
+	} {
+		auths[reflect.TypeOf(a).String()] = a
+	}
+
+	return auths
+}
+
+func setUpUserCredentialTest(t *testing.T) (context.Context, *types.User) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Helper()
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	// Create a user that allows us to link the credential somewhere.
+	user, err := Users.Create(ctx, NewUser{
+		Email:                 "a@example.com",
+		Username:              "u2",
+		Password:              "pw",
+		EmailVerificationCode: "c",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ctx, user
+}
+
+type invalidAuth struct{}
+
+var _ auth.Authenticator = &invalidAuth{}
+
+func (*invalidAuth) Authenticate(_ *http.Request) error { panic("should not be called") }
+func (*invalidAuth) Hash() string                       { panic("should not be called") }

--- a/internal/db/user_credentials_test.go
+++ b/internal/db/user_credentials_test.go
@@ -31,7 +31,7 @@ func TestUserCredentials_Delete(t *testing.T) {
 			t.Error("unexpected nil error")
 		}
 
-		e, ok := err.(userCredentialNotFoundErr)
+		e, ok := err.(UserCredentialNotFoundErr)
 		if !ok {
 			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
 		}
@@ -59,7 +59,7 @@ func TestUserCredentials_Delete(t *testing.T) {
 		}
 
 		_, err = UserCredentials.GetByID(ctx, cred.ID)
-		if _, ok := err.(userCredentialNotFoundErr); !ok {
+		if _, ok := err.(UserCredentialNotFoundErr); !ok {
 			t.Errorf("unexpected error retrieving credential after deletion: %v", err)
 		}
 	})
@@ -77,7 +77,7 @@ func TestUserCredentials_GetByID(t *testing.T) {
 			t.Error("unexpected nil error")
 		}
 
-		e, ok := err.(userCredentialNotFoundErr)
+		e, ok := err.(UserCredentialNotFoundErr)
 		if !ok {
 			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
 		}
@@ -130,7 +130,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 			t.Error("unexpected nil error")
 		}
 
-		e, ok := err.(userCredentialNotFoundErr)
+		e, ok := err.(UserCredentialNotFoundErr)
 		if !ok {
 			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
 		}
@@ -447,12 +447,19 @@ func TestUserCredentials_Invalid(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				if _, err := UserCredentials.GetByID(ctx, id); err == nil {
 					t.Error("unexpected nil error")
-				} else if _, ok := err.(userCredentialNotFoundErr); ok {
+				} else if _, ok := err.(UserCredentialNotFoundErr); ok {
 					t.Error("unexpected not found error")
 				}
 			})
 		}
 	})
+}
+
+func TestUserCredentialNotFoundErr(t *testing.T) {
+	err := UserCredentialNotFoundErr{}
+	if have := err.NotFound(); !have {
+		t.Error("UserCredentialNotFoundErr does not say it represents a not found error")
+	}
 }
 
 func createUserCredentialAuths(t *testing.T) map[string]auth.Authenticator {

--- a/migrations/frontend/1528395739_user_credentials.down.sql
+++ b/migrations/frontend/1528395739_user_credentials.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS user_credentials;
+
+COMMIT;

--- a/migrations/frontend/1528395739_user_credentials.up.sql
+++ b/migrations/frontend/1528395739_user_credentials.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_credentials (
+    id BIGSERIAL PRIMARY KEY,
+    domain TEXT NOT NULL,
+    user_id INTEGER NOT NULL,
+    external_service_type TEXT NOT NULL,
+    external_service_id TEXT NOT NULL,
+    credential TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- deleted_at is intentionally left out: given the secret nature of tokens,
+    -- users will likely want to be certain that tokens are deleted when
+    -- removed, even with encryption in place.
+
+    -- Set up the foreign key.
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE DEFERRABLE,
+
+    -- Set up a unique constraint across the fields that are, in fact, unique.
+    UNIQUE (domain, user_id, external_service_type, external_service_id)
+);
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -110,6 +110,8 @@
 // 1528395737_compressed_commits.up.sql (339B)
 // 1528395738_nullable_commit.down.sql (255B)
 // 1528395738_nullable_commit.up.sql (259B)
+// 1528395739_user_credentials.down.sql (56B)
+// 1528395739_user_credentials.up.sql (854B)
 
 package migrations
 
@@ -2378,6 +2380,46 @@ func _1528395738_nullable_commitUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395739_user_credentialsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x2d\x4e\x2d\x8a\x4f\x2e\x4a\x4d\x49\xcd\x2b\xc9\x4c\xcc\x29\xb6\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x77\x25\x18\x56\x38\x00\x00\x00")
+
+func _1528395739_user_credentialsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395739_user_credentialsDownSql,
+		"1528395739_user_credentials.down.sql",
+	)
+}
+
+func _1528395739_user_credentialsDownSql() (*asset, error) {
+	bytes, err := _1528395739_user_credentialsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395739_user_credentials.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xec, 0xee, 0xa4, 0x33, 0x3c, 0x8e, 0xa3, 0xc7, 0xc6, 0x31, 0x9e, 0x9e, 0x58, 0x8e, 0xf0, 0xe1, 0x4d, 0x68, 0x22, 0x24, 0x1e, 0x18, 0xe0, 0xdf, 0x7f, 0xfa, 0x60, 0x8, 0x8a, 0xca, 0xd4, 0x2}}
+	return a, nil
+}
+
+var __1528395739_user_credentialsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x93\xc1\x72\xda\x3c\x14\x85\xf7\x3c\xc5\x59\xc2\x8c\x93\x07\xf8\xb3\x72\xe0\xc2\xaf\xa9\x31\xa9\x2d\x26\x49\x37\x8c\x6a\x5f\x82\x06\x45\xa6\xf2\x35\x94\xb7\xef\xc8\x98\x74\x26\xa5\x9b\x2e\xad\xa3\x73\xf4\x5d\xf9\xe8\x91\x16\x2a\x7f\x18\x8d\xa6\x05\xa5\x9a\xa0\xd3\xc7\x8c\xa0\xe6\xc8\x57\x1a\xf4\xa2\x4a\x5d\xa2\x6b\x39\x6c\xaa\xc0\x35\x7b\xb1\xc6\xb5\x18\x8f\x00\xc0\xd6\x78\x54\x8b\x92\x0a\x95\x66\x78\x2a\xd4\x32\x2d\x5e\xf1\x85\x5e\x93\x5e\xad\x9b\x77\x63\x3d\x34\xbd\xe8\x3e\x2b\x5f\x67\xd9\x45\xe9\xe3\x6c\x0d\x95\x6b\x5a\x50\xf1\x49\xe5\x9f\xc2\xc1\x1b\xb7\x69\x39\x1c\x6d\xc5\x1b\x39\x1f\xf8\x56\xcc\x1f\x1b\x6d\x7d\x6b\xdb\x6f\xee\xbf\xa8\x46\xb8\xde\x18\x81\x56\x4b\x2a\x75\xba\x7c\xc2\xb3\xd2\xff\xf7\x9f\xf8\xb6\xca\xe9\xc3\x81\x19\xcd\xd3\x75\x16\x23\x9e\xc7\x93\x61\x96\x43\xfd\xcf\xfe\x3e\xe0\xee\x0e\x35\x3b\x1e\x32\x6c\x0b\xeb\x25\xe2\x36\xde\x38\x77\x86\xe3\xad\xa0\xe9\xe4\x3f\xbc\xd9\x23\x7b\xc8\x8e\xd1\x72\x15\x58\xe0\x8d\x74\x81\xd1\x6c\x21\xcd\x9e\x7d\x9b\x5c\xf3\xe2\xfd\xb6\x38\x59\xe7\xe0\xec\x9e\xdd\x19\x27\xe3\x05\xd2\xe0\x3b\xa3\xe2\x20\xf1\xbf\xc8\xce\xc8\x60\x84\x09\x7c\x85\xc0\x69\xc7\xfe\x1a\x14\xf8\xbd\x39\x72\x9d\x80\xe3\xd1\x27\x2b\x3b\xb0\xaf\xc2\xf9\x10\xf1\x60\x3d\x0e\xce\x54\x7c\xff\x31\x48\xc9\x82\xee\xd0\x33\x6e\x9b\xc0\xf6\xcd\x63\xcf\xe7\xfb\x5e\x9e\xaf\x0a\x52\x8b\x3c\xf6\x03\xe3\xa1\x01\x13\x14\x34\xa7\x82\xf2\x29\x95\x03\xf5\x38\xae\xae\x72\xcc\x28\x23\x4d\x98\xa6\xe5\x34\x9d\x51\xbc\x39\x2a\x8a\x58\xcd\xe4\xf3\x69\x06\x9d\xb7\x3f\x3a\x46\xd5\xf8\x56\x82\xb1\x5e\x60\xaa\xd0\xb4\xed\x05\xc4\xb2\xab\xdb\xcb\xb8\x26\x70\x12\xb1\xb7\xa6\x92\x64\xb0\x5d\xe8\xd6\xb9\xfa\xba\x26\x8c\x2f\xa5\x4d\xae\x15\x4d\x6e\xb7\xf1\xc6\xb2\xad\x27\xa3\x49\x7c\x45\xab\xe5\x52\xe9\x87\xd1\xaf\x00\x00\x00\xff\xff\x05\x84\xdf\xdc\x56\x03\x00\x00")
+
+func _1528395739_user_credentialsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395739_user_credentialsUpSql,
+		"1528395739_user_credentials.up.sql",
+	)
+}
+
+func _1528395739_user_credentialsUpSql() (*asset, error) {
+	bytes, err := _1528395739_user_credentialsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395739_user_credentials.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1c, 0x39, 0xaa, 0x83, 0x5c, 0x45, 0x7b, 0xa7, 0x2d, 0xc8, 0xb9, 0x5f, 0x8d, 0x0, 0x2c, 0x3a, 0x37, 0x56, 0x4c, 0x5a, 0x9e, 0x10, 0x4, 0xd6, 0x93, 0x63, 0xa5, 0x62, 0x6d, 0x76, 0x9f, 0xd5}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2579,6 +2621,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395737_compressed_commits.up.sql":                                         _1528395737_compressed_commitsUpSql,
 	"1528395738_nullable_commit.down.sql":                                          _1528395738_nullable_commitDownSql,
 	"1528395738_nullable_commit.up.sql":                                            _1528395738_nullable_commitUpSql,
+	"1528395739_user_credentials.down.sql":                                         _1528395739_user_credentialsDownSql,
+	"1528395739_user_credentials.up.sql":                                           _1528395739_user_credentialsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2735,6 +2779,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395737_compressed_commits.up.sql":                                         {_1528395737_compressed_commitsUpSql, map[string]*bintree{}},
 	"1528395738_nullable_commit.down.sql":                                          {_1528395738_nullable_commitDownSql, map[string]*bintree{}},
 	"1528395738_nullable_commit.up.sql":                                            {_1528395738_nullable_commitUpSql, map[string]*bintree{}},
+	"1528395739_user_credentials.down.sql":                                         {_1528395739_user_credentialsDownSql, map[string]*bintree{}},
+	"1528395739_user_credentials.up.sql":                                           {_1528395739_user_credentialsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This splits the original `campaign_user_credentials` (née `campaign_user_tokens`) table out from the draft #15301 PR, and refactors the Go types and methods to fit into `internal/db`, since this is now going to be a more generic table so others can reuse it at a later stage.

It might be easiest to read this in conjunction with the [high level plan for campaign user token support](https://docs.google.com/document/d/1AM37p6WoHh01R403BYnqguQQgeXEaBYEvd6s_ldTOAA/edit?usp=sharing), if you haven't already, since that should fill in most of the blanks on usage.

Random notes on design decisions that might be considered "interesting":

* Although records can be uniquely identified by `(domain, user_id, external_service_type, external_service_id)`, a `bigserial` field called `id` is still present to make addressing these records through GraphQL easier.
* Rather than separating create and update, the `userCredentials` type exposes an `Upsert` method, given the unique identifier noted above and the fact there's only one actual field that depends on it. This should align better with how we'll be using these records in practice.

This is also my first foray into the `secret` package, so if I'm misusing its encrypted field capabilities, now would be a good time to know that. :grimacing: 