### PR TITLE
Add docs about how import works in extensions and about testing

### DIFF
--- a/doc/extensions/authoring/importing_sourcegraph.md
+++ b/doc/extensions/authoring/importing_sourcegraph.md
@@ -22,7 +22,7 @@ or bundled with your project, the `sourcegraph` module is actually injected
 dynamically when your extension is loaded within a Sourcegraph instance.
 
 The `sourcegraph` module that you install as a `package.json` dependency is
-actually a set of Typescript type definitions that allow you to use the
+actually a set of TypeScript type definitions that allow you to use the
 Sourcegraph API's interfaces. The module doesn't contain the implementations of
 these interfaces.
 

--- a/doc/extensions/authoring/importing_sourcegraph.md
+++ b/doc/extensions/authoring/importing_sourcegraph.md
@@ -1,0 +1,37 @@
+# Importing the Sourcegraph API module
+
+In order to use the Sourcegraph extension API, your extension needs to import
+the `sourcegraph` module at the top of the file.
+
+This import will look like this:
+
+```typescript
+import * as sourcegraph from 'sourcegraph'
+```
+
+Or, with the equivalent `require` syntax:
+
+```typescript
+const sourcegraph = require('sourcegraph')
+```
+
+## How the import works
+
+Unlike a regular module that is installed with `npm` or `yarn` and is packaged
+or bundled with your project, the `sourcegraph` module is actually injected
+dynamically when your extension is loaded within a Sourcegraph instance.
+
+The `sourcegraph` module that you install as a `package.json` dependency is
+actually a set of Typescript type definitions that allow you to use the
+Sourcegraph API's interfaces. The module doesn't contain the implementations of
+these interfaces.
+
+## Testing
+
+Because the `sourcegraph` module doesn't actually contain any implementation
+code, a separate helper module is provided to create stubs of the API for
+testing:
+[@sourcegraph/extension-api-stubs](https://github.com/sourcegraph/extension-api-stubs).
+
+See [Testing extensions](testing_extensions.md) for more about writing automated
+tests for your extension.

--- a/doc/extensions/authoring/index.md
+++ b/doc/extensions/authoring/index.md
@@ -2,13 +2,14 @@
 
 A [Sourcegraph extension](../index.md) is a single JavaScript file that runs in users' web browsers in a Web Worker and has an exported `activate` function. The JavaScript file is usually produced by compiling and bundling one or more TypeScript source files.
 
-The [Sourcegraph extension API](https://unpkg.com/sourcegraph/dist/docs/index.html) (generated from [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/packages/sourcegraph-extension-api/src/sourcegraph.d.ts)) is available to extensions by importing the `sourcegraph` module (`import * as sourcegraph from 'sourcegraph'` or `require('sourcegraph')`). Writing a Sourcegraph extension is very similar to writing an editor extension for [VS Code](https://code.visualstudio.com/docs/extensions/overview).
+The [Sourcegraph extension API](https://unpkg.com/sourcegraph/dist/docs/index.html) (generated from [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/packages/sourcegraph-extension-api/src/sourcegraph.d.ts)) is available to extensions by [importing the `sourcegraph` module](importing_sourcegraph.md). Writing a Sourcegraph extension is very similar to writing an editor extension for [VS Code](https://code.visualstudio.com/docs/extensions/overview).
 
 ## Topics
 
 - [Extension API documentation](https://unpkg.com/sourcegraph/dist/docs/index.html) (full API is in [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/packages/sourcegraph-extension-api/src/sourcegraph.d.ts))
 - [Set up your development environment](development_environment.md)
 - [Creating an extension](creating.md)
+- [Importing the `sourcegraph` module](importing_sourcegraph.md)
 - [Local development](local_development.md)
 - [Contribution points (actions, menus, etc.)](contributions.md)
 - [Extension manifest (`package.json`)](manifest.md)
@@ -19,6 +20,7 @@ The [Sourcegraph extension API](https://unpkg.com/sourcegraph/dist/docs/index.ht
 - [Sample extensions (`sourcegraph-extension-samples`)](https://github.com/sourcegraph/sourcegraph-extension-samples)
 - [Cookbook (sample code)](cookbook.md)
 - [UX style guide](ux_style_guide.md)
+- [Testing extensions](testing_extensions.md)
 
 ## Tutorials
 

--- a/doc/extensions/authoring/testing_extensions.md
+++ b/doc/extensions/authoring/testing_extensions.md
@@ -1,0 +1,10 @@
+# Testing extensions
+
+For any extension that uses the Sourcegraph API, you may want to write automated
+tests to make sure that your extension is using the API correctly.
+
+The
+[`@sourcegraph/extension-api-stubs`](https://github.com/sourcegraph/extension-api-stubs)
+module is a useful tool to mock the Sourcegraph API and make assertions about
+the calls that your extensions makes to it.
+


### PR DESCRIPTION
Currently there is no mention of how to test extensions, and no mention of `@sourcegraph/extension-api-stubs` in the docs.

There is also no explanation about how importing the `sourcegraph` module works -- namely that it's an empty module.

This adds pages to the extension docs to cover these topics.
