### PR TITLE
release: automate updates for deploy-sourcegraph-docker docs

### DIFF
--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -11,7 +11,8 @@ It takes less than 5 minutes to run and install Sourcegraph using Docker Compose
 ```bash
 git clone https://github.com/sourcegraph/deploy-sourcegraph-docker
 cd deploy-sourcegraph-docker/docker-compose
-git checkout v3.21.2
+SOURCEGRAPH_VERSION="v3.21.2"
+git checkout $SOURCEGRAPH_VERSION
 docker-compose up -d
 ```
 

--- a/doc/admin/install/docker-compose/migrate.md
+++ b/doc/admin/install/docker-compose/migrate.md
@@ -9,7 +9,7 @@ Sourcegraph's core data (including user accounts, configuration, repository-meta
 ### Version requirements
 
 * This migration can only be done with Sourcegraph v3.13.1+. If you are not currently on at least this version, please upgrade first.
-* Do NOT attempt to upgrade at the same time as migrating to docker-compose. Use the docker-compose version corresponding to your current version. For example, if you are running `sourcegraph/server:3.21.2` you must follow this guide using the Docker Compose deployment version `v3.19.2`.
+* Do NOT attempt to upgrade at the same time as migrating to docker-compose. Use the docker-compose version corresponding to your current version. For example, if you are running the `sourcegraph/server` image version `v3.19.2` you must follow this guide using the Docker Compose deployment version `v3.19.2`.
 
 ### Storage location change
 


### PR DESCRIPTION
Removes the following steps from `deploy-sourcegraph-docker` releases (https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/172) by including them when staging the release PRs with `yarn run release release:stage` (diff generated with `dryRun.changesets: true`):

- [x] `deploy-sourcegraph-docker`: `docker-compose/README.md` => no version references in the README, nothing done
- [x] replace two instances: https://github.com/sourcegraph/sourcegraph/blob/master/doc/admin/install/docker-compose/index.md => now replaces `SOURCEGRAPH_VERSION=` variables:
~~~diff
+++ b/doc/admin/install/docker-compose/index.md
@@ -34,7 +34,7 @@ We **strongly** recommend that you create your own fork of [sourcegraph/deploy-s
 * Create a `release` branch (to track all of your customizations to Sourcegraph. When you upgrade Sourcegraph's Docker Compose definition, you will merge upstream into this branch.
 
 ```bash
-SOURCEGRAPH_VERSION="v3.21.2"
+SOURCEGRAPH_VERSION="v3.22.0"
 git checkout $SOURCEGRAPH_VERSION -b release
 ```
~~~
- [x] add a new section with all relevant upgrade details: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a718276cbdc4c9e079d5495cb34ce663c5d35c01/-/blob/doc/admin/updates/docker_compose.md#updating-a-docker-compose-sourcegraph-instance => generates stub:
```diff
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -11,6 +11,10 @@ Upgrades should happen across consecutive minor versions of Sourcegraph. For exa
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## 3.21 -> 3.22
+
+TODO
+
 ## 3.21.0 -> 3.21.1
```
- [x] Update `latestReleaseDockerComposeOrPureDocker` in https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/internal/app/pkg/updatecheck/handler.go#L47 => generates update with Comby:
```diff
        // latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
        // Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
        // available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-       latestReleaseDockerComposeOrPureDocker = newBuild("3.21.2")
+       latestReleaseDockerComposeOrPureDocker = newBuild("3.22.0")
 )
```

Closes sourcegraph/sourcegraph#15325 , docs update in https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/172