### PR TITLE
conf: read conf source first and then wait for updates

### DIFF
--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -135,6 +135,11 @@ func (s *Server) Start() {
 func (s *Server) watchSource() {
 	ctx := context.Background()
 	for {
+		err := s.updateFromSource(ctx)
+		if err != nil {
+			log.Printf("failed to read configuration: %s. Fix your Sourcegraph configuration to resolve this error. Visit https://docs.sourcegraph.com/ to learn more.", err)
+		}
+
 		jitter := time.Duration(rand.Int63n(5 * int64(time.Second)))
 
 		var signalDoneReading chan struct{}
@@ -143,11 +148,6 @@ func (s *Server) watchSource() {
 			// File was changed on FS, so check now.
 		case <-time.After(jitter):
 			// File possibly changed on FS, so check now.
-		}
-
-		err := s.updateFromSource(ctx)
-		if err != nil {
-			log.Printf("failed to read configuration: %s. Fix your Sourcegraph configuration to resolve this error. Visit https://docs.sourcegraph.com/ to learn more.", err)
 		}
 
 		if signalDoneReading != nil {


### PR DESCRIPTION
This changes the conf server so it reads the configuration at startup and _then_ waits for updates/jitter-timer.

Before this change `frontend` would hang between 0-5 seconds (max time of jitter) when starting up, because it was waiting for the configuration to be read in this line:

https://github.com/sourcegraph/sourcegraph/blob/6a14d3cd1595f6576e64a74c98834bdc80710886/cmd/frontend/internal/cli/serve_cmd.go#L180

Since at the point in time when the `watchSource` goroutine is kicked off, we already have setup the conf package (see [here](https://github.com/sourcegraph/sourcegraph/blob/6a14d3cd1595f6576e64a74c98834bdc80710886/cmd/frontend/internal/cli/serve_cmd.go#L128-L133)), it's okay to read the configuration and _then_ wait for the jitter, especially since the jitter could be 0seconds anyway.