### PR TITLE
Make ErrPublishSameBranch a terminal error and don't retry

### DIFF
--- a/cmd/repo-updater/repos/sources.go
+++ b/cmd/repo-updater/repos/sources.go
@@ -124,6 +124,8 @@ func (e ChangesetNotFoundError) Error() string {
 	return fmt.Sprintf("Changeset with external ID %s not found", e.Changeset.Changeset.ExternalID)
 }
 
+func (e ChangesetNotFoundError) Terminal() bool { return true }
+
 // A SourceResult is sent by a Source over a channel for each repository it
 // yields when listing repositories
 type SourceResult struct {

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -1049,10 +1049,25 @@ func TestReconcilerProcess_PublishedChangesetDuplicateBranch(t *testing.T) {
 		Sourcer:           repos.NewFakeSourcer(nil, &ct.FakeChangesetSource{}),
 		Store:             store,
 	}
-	haveErr := rec.process(ctx, store, otherChangeset)
-	if !errors.Is(haveErr, ErrPublishSameBranch) {
-		t.Fatalf("reconciler process failed with wrong error: %s", haveErr)
+
+	err := rec.process(ctx, store, otherChangeset)
+	if err != nil {
+		t.Fatalf("reconciler process failed: %s", err)
 	}
+
+	// We expect the changeset to be errored, but without any retries left, so
+	// we don't retry.
+	wantMsg := ErrPublishSameBranch{}.Error()
+	reloadAndAssertChangeset(t, ctx, store, otherChangeset, changesetAssertions{
+		repo:            otherChangeset.RepoID,
+		currentSpec:     otherChangesetSpec.ID,
+		ownedByCampaign: otherCampaign.ID,
+
+		failureMessage:   &wantMsg,
+		reconcilerState:  campaigns.ReconcilerStateErrored,
+		publicationState: campaigns.ChangesetPublicationStateUnpublished,
+		numFailures:      ReconcilerMaxNumRetries + 999,
+	})
 }
 
 func buildGithubPR(now time.Time, externalState campaigns.ChangesetExternalState) *github.PullRequest {

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -157,6 +157,17 @@ func IsTimeout(err error) bool {
 	})
 }
 
+// IsTerminal will check if err or one of its causes is a terminal error that cannot be retried.
+func IsTerminal(err error) bool {
+	type terminaler interface {
+		Terminal() bool
+	}
+	return isErrorPredicate(err, func(err error) bool {
+		e, ok := err.(terminaler)
+		return ok && e.Terminal()
+	})
+}
+
 // isErrorPredicate returns true if err or one of its causes returns true when
 // passed to p.
 func isErrorPredicate(err error, p func(err error) bool) bool {


### PR DESCRIPTION
This fixes #15373 by making ErrPublishSameBranch a terminal error that
causes the reconciler to not dequeue the changeset again.

It also adds the tiny helper function `errcode.IsTerminal` (that mirrors
other functions in there) and changes the `repos.ChangesetNotFoundError`
to also be a terminal error.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
