### PR TITLE
release: adjust tooling to work better with patch steps

### DIFF
--- a/dev/release/src/campaigns.ts
+++ b/dev/release/src/campaigns.ts
@@ -3,64 +3,65 @@ import { readLine } from './util'
 import YAML from 'yaml'
 import execa from 'execa'
 import fetch from 'node-fetch'
+import commandExists from 'command-exists'
 
 // https://about.sourcegraph.com/handbook/engineering/deployments/instances#k8s-sgdev-org
 const DEFAULT_SRC_ENDPOINT = 'https://k8s.sgdev.org'
 
-export interface SourcegraphAuth {
+interface SourcegraphCLIConfig {
     SRC_ENDPOINT: string
     SRC_ACCESS_TOKEN: string
     [index: string]: string
 }
 
-export async function sourcegraphAuth(): Promise<SourcegraphAuth> {
+/**
+ * Retrieves src-cli configuration and ensures src-cli exists.
+ */
+export async function sourcegraphCLIConfig(): Promise<SourcegraphCLIConfig> {
+    await commandExists('src') // CLI must be present for campaigns interactions
     return {
         SRC_ENDPOINT: DEFAULT_SRC_ENDPOINT,
         SRC_ACCESS_TOKEN: await readLine('k8s.sgdev.org src-cli token: ', '.secrets/src-cli.txt'),
     }
 }
 
+/**
+ * Parameters defining a campaign to interact with.
+ *
+ * Generate `cliConfig` using `sourcegraphCLIConfig()`.
+ */
 export interface CampaignOptions {
     name: string
     description: string
     namespace: string
-    auth: SourcegraphAuth
+    cliConfig: SourcegraphCLIConfig
 }
 
-export function releaseTrackingCampaign(version: string, auth: SourcegraphAuth): CampaignOptions {
+/**
+ * Generate campaign configuration for a given release.
+ */
+export function releaseTrackingCampaign(version: string, cliConfig: SourcegraphCLIConfig): CampaignOptions {
     return {
         name: `release-sourcegraph-${version}`,
         description: `Track publishing of sourcegraph@${version}`,
         namespace: 'sourcegraph',
-        auth,
+        cliConfig,
     }
 }
 
+/**
+ * Generates a URL for a campaign that would be created under the given camapign options.
+ *
+ * Does not ensure the campaign exists.
+ */
 export function campaignURL(options: CampaignOptions): string {
-    return `${options.auth.SRC_ENDPOINT}/organizations/${options.namespace}/campaigns/${options.name}`
+    return `${options.cliConfig.SRC_ENDPOINT}/organizations/${options.namespace}/campaigns/${options.name}`
 }
 
-interface CampaignSpec {
-    name: string
-    description: string
-    importChangesets: { repository: string; externalIDs: number[] }[]
-}
-
-async function applyCampaign(campaign: CampaignSpec, options: CampaignOptions): Promise<string> {
-    const campaignYAML = YAML.stringify(campaign)
-    console.log(`Rendered campaign spec:\n\n${campaignYAML}`)
-
-    // apply the campaign
-    await execa('src', ['campaign', 'apply', '-namespace', options.namespace, '-f', '-'], {
-        stdout: 'inherit',
-        input: campaignYAML,
-        env: options.auth,
-    })
-
-    return campaignURL(options)
-}
-
-export async function createCampaign(changes: CreatedChangeset[], options: CampaignOptions): Promise<string> {
+/**
+ * Create a new campaign from a set of changes.
+ */
+export async function createCampaign(changes: CreatedChangeset[], options: CampaignOptions): Promise<void> {
     // create a campaign spec
     const importChangesets = changes.map(change => ({
         repository: `github.com/${change.repository}`,
@@ -77,14 +78,17 @@ export async function createCampaign(changes: CreatedChangeset[], options: Campa
     )
 }
 
+/**
+ * Append changes to an existing campaign.
+ */
 export async function addToCampaign(
     changes: { repository: string; pullRequestNumber: number }[],
     options: CampaignOptions
-): Promise<string> {
-    const response = await fetch(`${options.auth.SRC_ENDPOINT}/.api/graphql`, {
+): Promise<void> {
+    const response = await fetch(`${options.cliConfig.SRC_ENDPOINT}/.api/graphql`, {
         method: 'POST',
         headers: {
-            Authorization: `token ${options.auth.SRC_ACCESS_TOKEN}`,
+            Authorization: `token ${options.cliConfig.SRC_ACCESS_TOKEN}`,
         },
         body: JSON.stringify({
             query: `query getCampaigns($namespace:String!) {
@@ -119,5 +123,26 @@ export async function addToCampaign(
     }))
     const newSpec = YAML.parse(campaign.currentSpec.originalInput) as CampaignSpec
     newSpec.importChangesets.push(...importChangesets)
-    return await applyCampaign(newSpec, options)
+    await applyCampaign(newSpec, options)
+}
+
+/**
+ * Subset of campaign spec: https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference
+ */
+interface CampaignSpec {
+    name: string
+    description: string
+    importChangesets: { repository: string; externalIDs: number[] }[]
+}
+
+async function applyCampaign(campaign: CampaignSpec, options: CampaignOptions): Promise<void> {
+    const campaignYAML = YAML.stringify(campaign)
+    console.log(`Rendered campaign spec:\n\n${campaignYAML}`)
+
+    // apply the campaign
+    await execa('src', ['campaign', 'apply', '-namespace', options.namespace, '-f', '-'], {
+        stdout: 'inherit',
+        input: campaignYAML,
+        env: options.cliConfig,
+    })
 }

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -89,7 +89,7 @@ export async function ensureTrackingIssue({
     return ensureIssue(
         octokit,
         {
-            title: trackingIssueTitle(version.major, version.minor),
+            title: trackingIssueTitle(version),
             owner: 'sourcegraph',
             repo: 'sourcegraph',
             assignees,
@@ -124,7 +124,7 @@ export async function ensurePatchReleaseIssue({
     return ensureIssue(
         octokit,
         {
-            title: `${version.version} patch release`,
+            title: trackingIssueTitle(version),
             owner: 'sourcegraph',
             repo: 'sourcegraph',
             assignees,
@@ -199,8 +199,11 @@ export async function listIssues(
     return (await octokit.search.issuesAndPullRequests({ per_page: 100, q: query })).data.items
 }
 
-export function trackingIssueTitle(major: number, minor: number): string {
-    return `${major}.${minor} release tracking issue`
+export function trackingIssueTitle(version: semver.SemVer): string {
+    if (!version.patch) {
+        return `${version.major}.${version.minor} release tracking issue`
+    }
+    return `${version.version} patch release tracking issue`
 }
 
 export async function getAuthenticatedGitHubClient(): Promise<Octokit> {

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -13,6 +13,24 @@ function dateMarkdown(date: Date, name: string): string {
     return `[${formatDate(date)}](${timezoneLink(date, name)})`
 }
 
+// Ensure these templates are up to date with the state of the tooling and release processes.
+const templates = {
+    releaseIssue: {
+        owner: 'sourcegraph',
+        repo: 'about',
+        path: 'handbook/engineering/releases/release_issue_template.md',
+    },
+    patchReleaseIssue: {
+        owner: 'sourcegraph',
+        repo: 'about',
+        path: 'handbook/engineering/releases/patch_release_issue_template.md',
+    },
+}
+
+/**
+ * Ensures a release ($MAJOR.$MINOR) tracking issue has been created with the given
+ * parameters using `templates.releaseIssue`.
+ */
 export async function ensureTrackingIssue({
     version,
     assignees,
@@ -31,11 +49,8 @@ export async function ensureTrackingIssue({
     dryRun: boolean
 }): Promise<{ url: string; created: boolean }> {
     const octokit = await getAuthenticatedGitHubClient()
-    const releaseIssueTemplate = await getContent(octokit, {
-        owner: 'sourcegraph',
-        repo: 'about',
-        path: 'handbook/engineering/releases/release_issue_template.md',
-    })
+    console.log(`Preparing issue from ${JSON.stringify(templates.releaseIssue)}`)
+    const releaseIssueTemplate = await getContent(octokit, templates.releaseIssue)
     const majorMinor = `${version.major}.${version.minor}`
     const releaseIssueBody = releaseIssueTemplate
         .replace(/\$MAJOR/g, version.major.toString())
@@ -86,6 +101,10 @@ export async function ensureTrackingIssue({
     )
 }
 
+/**
+ * Ensures a patch release ($MAJOR.$MINOR.PATCH) tracking issue has been created with the
+ * given parameters using `templates.releaseIssue`.
+ */
 export async function ensurePatchReleaseIssue({
     version,
     assignees,
@@ -96,11 +115,8 @@ export async function ensurePatchReleaseIssue({
     dryRun: boolean
 }): Promise<{ url: string; created: boolean }> {
     const octokit = await getAuthenticatedGitHubClient()
-    const issueTemplate = await getContent(octokit, {
-        owner: 'sourcegraph',
-        repo: 'about',
-        path: 'handbook/engineering/releases/patch_release_issue_template.md',
-    })
+    console.log(`Preparing issue from ${JSON.stringify(templates.patchReleaseIssue)}`)
+    const issueTemplate = await getContent(octokit, templates.patchReleaseIssue)
     const issueBody = issueTemplate
         .replace(/\$MAJOR/g, version.major.toString())
         .replace(/\$MINOR/g, version.minor.toString())

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -252,13 +252,21 @@ export async function createChangesets(options: ChangesetsOptions): Promise<Crea
     // Generate changes
     const results: CreatedChangeset[] = []
     for (const change of options.changes) {
+        const repository = `${change.owner}/${change.repo}`
+        console.log(`Preparing change for ${repository} on '${change.base}' to '${change.head}'
+
+Title: ${change.title}
+Body: ${change.body || 'none'}
+Dryrun: ${options.dryRun || false}`)
         await createBranchWithChanges(octokit, { ...change, dryRun: options.dryRun })
+
         let pullRequest: { url: string; number: number } = { url: '', number: -1 }
         if (!options.dryRun) {
             pullRequest = await createPR(octokit, change)
         }
+
         results.push({
-            repository: `${change.owner}/${change.repo}`,
+            repository,
             branch: change.base,
             pullRequestURL: pullRequest.url,
             pullRequestNumber: pullRequest.number,

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -269,13 +269,14 @@ const steps: Step[] = [
 
             // Announce issue if issue does not already exist
             if (created) {
+                const patchRequestTemplate = `https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=${release.version}%3A+`
                 await postMessage(
                     `:mega: *${release.version} Patch Release*
 
 :captain: Release captain: @${captainSlackUsername}
 :pencil: Tracking issue: ${url}
 
-If you have changes that should go into this patch release, *please add the relevant commits to the checklist in the tracking issue, or it will not be included*.`,
+If you have changes that should go into this patch release, <${patchRequestTemplate}|please *file a patch request issue*>, or it will not be included.`,
                     slackAnnounceChannel
                 )
                 console.log(`Posted to Slack channel ${slackAnnounceChannel}`)

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -411,7 +411,7 @@ ${issueCategories
             )
             const defaultPRMessage = `release: sourcegraph@${release.version}`
             const prBody = (actionItems: string[]): string => {
-                const defaultText = `Follow the ${release.version} Sourcegraph release in the [release campaign](${campaignURL}).`
+                const defaultText = `Follow the Sourcegraph ${release.version} release in the [release campaign](${campaignURL}).`
                 if (!actionItems || actionItems.length === 0) {
                     return defaultText
                 }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -479,7 +479,7 @@ cc @${config.captainGitHubUsername}
                                 } else {
                                     items.push(
                                         'Update the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) to include all the changes included in this patch',
-                                        'If any specific upgrade steps are required, update `doc/admin/updates`'
+                                        'If any specific upgrade steps are required, update the upgrade guides in `doc/admin/updates`'
                                     )
                                 }
                                 items.push(
@@ -508,7 +508,9 @@ cc @${config.captainGitHubUsername}
                         title: defaultPRMessage,
                         edits: [`tools/update-docker-tags.sh ${release.version}`],
                         ...prBodyAndDraftState([
-                            'Follow the [release guide](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md) to complete this PR (`pure-docker` release is optional for patch releases)',
+                            `Follow the [release guide](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md) to complete this PR ${
+                                isPatchRelease ? '(note: `pure-docker` release is optional for patch releases)' : ''
+                            }`,
                         ]),
                     },
                     {


### PR DESCRIPTION
* Update patch release announcements with more emphasis on requiring developers to list their commits in the patch tracking issue (closes https://github.com/sourcegraph/sourcegraph/issues/15293 maybe?)
   * Template has been updated with stronger wording too: https://github.com/sourcegraph/about/pull/1881
* For patch releases, have the CHANGELOG update process be a part of the release-publishing PR instead of a separate step
* Create helper function for generating PR bodies and draft state from action items
* Documents steps for requesting patches as part of announcements: https://github.com/sourcegraph/sourcegraph/pull/15550
* Some cleanup of campaigns code

Closes https://github.com/sourcegraph/sourcegraph/issues/15293