### PR TITLE
github: add issue template for requesting a patch release

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -35,4 +35,13 @@ I have read [when and why we perform patch releases](https://about.sourcegraph.c
 
 > Patch releases are a signal we can do something better to improve the quality of Sourcegraph. Have you already scheduled a call (or created a google doc) to perform a [retrospective](https://about.sourcegraph.com/retrospectives) and identify ways we can improve?
 
-**ANSWER THIS**
+<!-- **ANSWER THIS** -->
+
+---
+
+_For the release captain_: after reviewing and approving this request:
+* If there is [already an upcoming patch release](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Arelease-tracker+), add the listed commits alongside a link in this issue
+* If there is no upcoming patch release, create a new one:
+	* Update `dev/release/config.json` with the patch release in `upcomingRelease`
+	* `cd dev/release && yarn run release tracking:patch-issue`
+	* Add the listed commits alongside a link in this issue

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -21,7 +21,7 @@ I have read [when and why we perform patch releases](https://about.sourcegraph.c
 
 > Are the changes extremely minimal, well-tested, and low risk such that not testing as we do in a full release is OK?
 
-**ANSWER THIS, explain in detail**
+<!-- **ANSWER THIS, explain in detail** -->
 
 > Is there some functionality completely broken that warrants redacting the prior release of Sourcegraph and advising users wait for the patch release?
 

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -17,7 +17,7 @@ I have read [when and why we perform patch releases](https://about.sourcegraph.c
 
 > Are users/customers actively asking us for these changes and cannot wait until the next full release?
 
-**ANSWER THIS, include links to customer issue tracker**
+<!-- ANSWER THIS, include links to customer issue tracker -->
 
 > Are the changes extremely minimal, well-tested, and low risk such that not testing as we do in a full release is OK?
 

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -9,6 +9,8 @@ assignees: ''
 
 @sourcegraph/distribution I am requesting the following commits be included in a patch release. They are already merged into `main`:
 
+The intent of the questions below is to ensure we keep Sourcegraph high quality and [only create patch releases based on a strict criteria.](https://about.sourcegraph.com/handbook/engineering/releases#when-are-patch-releases-performed) If you can answer yes to many or most of these questions, we will be happy to create the patch release.
+
 - **LINK TO EXACT MERGED COMMITS HERE**
 
 I have read [when and why we perform patch releases](https://about.sourcegraph.com/handbook/engineering/releases#when-are-patch-releases-performed) and answer the questions as follows:
@@ -29,4 +31,8 @@ I have read [when and why we perform patch releases](https://about.sourcegraph.c
 >
 > Do you believe the changes are important enough to warrant this?
 
-**ANSER THIS, yes/no**
+**ANSWER THIS, yes/no**
+
+> Patch releases are a signal we can do something better to improve the quality of Sourcegraph. Have you already scheduled a call (or created a google doc) to perform a [retrospective](https://about.sourcegraph.com/retrospectives) and identify ways we can improve?
+
+**ANSWER THIS**

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -25,7 +25,7 @@ I have read [when and why we perform patch releases](https://about.sourcegraph.c
 
 > Is there some functionality completely broken that warrants redacting the prior release of Sourcegraph and advising users wait for the patch release?
 
-**ANSWER THIS, explain if needed**
+<!-- **ANSWER THIS, explain if needed** -->
 
 > This will interrupt our regular planned work and release cycle, taking 3-6 hours of our time, and will take up all of our site admin's valuable time by asking them to upgrade or producing noise for them if they don't need to upgrade.
 >

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -11,7 +11,7 @@ assignees: ''
 
 The intent of the questions below is to ensure we keep Sourcegraph high quality and [only create patch releases based on a strict criteria.](https://about.sourcegraph.com/handbook/engineering/releases#when-are-patch-releases-performed) If you can answer yes to many or most of these questions, we will be happy to create the patch release.
 
-- **LINK TO EXACT MERGED COMMITS HERE**
+- <!-- LINK TO EXACT MERGED COMMITS HERE -->
 
 I have read [when and why we perform patch releases](https://about.sourcegraph.com/handbook/engineering/releases#when-are-patch-releases-performed) and answer the questions as follows:
 

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -1,0 +1,32 @@
+---
+name: Request patch release
+about: Sourcegraph teams, use this issue to request the Distribution team perform a patch release or include your changes in a patch release..
+title: ''
+labels: 'team/distribution'
+assignees: ''
+
+---
+
+@sourcegraph/distribution I am requesting the following commits be included in a patch release. They are already merged into `main`:
+
+- **LINK TO EXACT MERGED COMMITS HERE**
+
+I have read [when and why we perform patch releases](https://about.sourcegraph.com/handbook/engineering/releases#when-are-patch-releases-performed) and answer the questions as follows:
+
+> Are users/customers actively asking us for these changes and cannot wait until the next full release?
+
+**ANSWER THIS, include links to customer issue tracker**
+
+> Are the changes extremely minimal, well-tested, and low risk such that not testing as we do in a full release is OK?
+
+**ANSWER THIS, explain in detail**
+
+> Is there some functionality completely broken that warrants redacting the prior release of Sourcegraph and advising users wait for the patch release?
+
+**ANSWER THIS, explain if needed**
+
+> This will interrupt our regular planned work and release cycle, taking 3-6 hours of our time, and will take up all of our site admin's valuable time by asking them to upgrade or producing noise for them if they don't need to upgrade.
+>
+> Do you believe the changes are important enough to warrant this?
+
+**ANSER THIS, yes/no**

--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -31,7 +31,7 @@ I have read [when and why we perform patch releases](https://about.sourcegraph.c
 >
 > Do you believe the changes are important enough to warrant this?
 
-**ANSWER THIS, yes/no**
+<!-- **ANSWER THIS, yes/no** -->
 
 > Patch releases are a signal we can do something better to improve the quality of Sourcegraph. Have you already scheduled a call (or created a google doc) to perform a [retrospective](https://about.sourcegraph.com/retrospectives) and identify ways we can improve?
 


### PR DESCRIPTION
This adds an issue template for requesting a patch release from the Distribution team.

My thinking is that anyone who requests we perform a patch release, or anyone that requests their changes be included in a patch release (or cherry-pick'd into an ongoing major release if we're in the process of doing the monthly 20th release) will use this template to explain their changes and why.

My goal here is to ensure we keep Sourcegraph high-quality and do not get in the habit of thinking "we released a patch" means "users have the fix", because a majority of the time that is not true as customers take 1-6 months to upgrade.

I have created this template based on our existing criteria for patch releases in https://about.sourcegraph.com/handbook/engineering/releases#when-are-patch-releases-performed

This would help to fix https://github.com/sourcegraph/sourcegraph/issues/15294 I believe, because it introduces much more explicit communication about what and why.