### PR TITLE
search frontend: rename parser -> scanner

### DIFF
--- a/client/shared/src/search/parser/completion.test.ts
+++ b/client/shared/src/search/parser/completion.test.ts
@@ -1,6 +1,6 @@
 import * as Monaco from 'monaco-editor'
 import { getCompletionItems, repositoryCompletionItemKind } from './completion'
-import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
 import { NEVER, of } from 'rxjs'
 import { SearchSuggestion } from '../../graphql/schema'
 
@@ -9,7 +9,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('re') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('re') as ScanSuccess<Sequence>).token,
                     { column: 3 },
                     of([
                         {
@@ -71,7 +71,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('reposi') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('reposi') as ScanSuccess<Sequence>).token,
                     { column: 7 },
                     of([
                         {
@@ -135,7 +135,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('') as ScanSuccess<Sequence>).token,
                     { column: 1 },
                     NEVER,
                     false
@@ -180,7 +180,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('a ') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('a ') as ScanSuccess<Sequence>).token,
                     { column: 3 },
                     of([
                         {
@@ -231,7 +231,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('rE') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('rE') as ScanSuccess<Sequence>).token,
                     { column: 3 },
                     of([]),
                     false
@@ -276,7 +276,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('case:y') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('case:y') as ScanSuccess<Sequence>).token,
                     { column: 7 },
                     NEVER,
                     false
@@ -289,7 +289,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('lang:') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('lang:') as ScanSuccess<Sequence>).token,
                     {
                         column: 6,
                     },
@@ -327,7 +327,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('file:c') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('file:c') as ScanSuccess<Sequence>).token,
                     { column: 7 },
                     of([
                         {
@@ -349,7 +349,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('jsonrpc') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('jsonrpc') as ScanSuccess<Sequence>).token,
                     { column: 8 },
                     of([
                         {
@@ -380,7 +380,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('f:^jsonrpc') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('f:^jsonrpc') as ScanSuccess<Sequence>).token,
                     { column: 11 },
                     of([
                         {
@@ -402,7 +402,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('main.go') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('main.go') as ScanSuccess<Sequence>).token,
                     { column: 7 },
                     of([
                         {
@@ -426,7 +426,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (parseSearchQuery('f:') as ParseSuccess<Sequence>).token,
+                    (scanSearchQuery('f:') as ScanSuccess<Sequence>).token,
                     { column: 2 },
                     of([
                         {

--- a/client/shared/src/search/parser/completion.ts
+++ b/client/shared/src/search/parser/completion.ts
@@ -1,7 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { escapeRegExp, startCase } from 'lodash'
 import { FILTERS, resolveFilter } from './filters'
-import { Sequence, toMonacoRange } from './parser'
+import { Sequence, toMonacoRange } from './scanner'
 import { Omit } from 'utility-types'
 import { Observable } from 'rxjs'
 import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup } from '../../graphql/schema'

--- a/client/shared/src/search/parser/diagnostics.test.ts
+++ b/client/shared/src/search/parser/diagnostics.test.ts
@@ -1,12 +1,12 @@
 import { getDiagnostics } from './diagnostics'
-import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
 import { SearchPatternType } from '../../graphql-operations'
 
 describe('getDiagnostics()', () => {
     test('do not raise invalid filter type', () => {
         expect(
             getDiagnostics(
-                (parseSearchQuery('repos:^github.com/sourcegraph') as ParseSuccess<Sequence>).token,
+                (scanSearchQuery('repos:^github.com/sourcegraph') as ScanSuccess<Sequence>).token,
                 SearchPatternType.literal
             )
         ).toStrictEqual([])
@@ -14,7 +14,7 @@ describe('getDiagnostics()', () => {
 
     test('invalid filter value', () => {
         expect(
-            getDiagnostics((parseSearchQuery('case:maybe') as ParseSuccess<Sequence>).token, SearchPatternType.literal)
+            getDiagnostics((scanSearchQuery('case:maybe') as ScanSuccess<Sequence>).token, SearchPatternType.literal)
         ).toStrictEqual([
             {
                 endColumn: 5,
@@ -30,7 +30,7 @@ describe('getDiagnostics()', () => {
     test('search query containing colon, literal pattern type, do not raise error', () => {
         expect(
             getDiagnostics(
-                (parseSearchQuery('Configuration::doStuff(...)') as ParseSuccess<Sequence>).token,
+                (scanSearchQuery('Configuration::doStuff(...)') as ScanSuccess<Sequence>).token,
                 SearchPatternType.literal
             )
         ).toStrictEqual([])
@@ -39,7 +39,7 @@ describe('getDiagnostics()', () => {
     test('search query containing quoted token, regexp pattern type', () => {
         expect(
             getDiagnostics(
-                (parseSearchQuery('"Configuration::doStuff(...)"') as ParseSuccess<Sequence>).token,
+                (scanSearchQuery('"Configuration::doStuff(...)"') as ScanSuccess<Sequence>).token,
                 SearchPatternType.regexp
             )
         ).toStrictEqual([])
@@ -48,7 +48,7 @@ describe('getDiagnostics()', () => {
     test('search query containing parenthesized parameterss', () => {
         expect(
             getDiagnostics(
-                (parseSearchQuery('repo:a (file:b and c)') as ParseSuccess<Sequence>).token,
+                (scanSearchQuery('repo:a (file:b and c)') as ScanSuccess<Sequence>).token,
                 SearchPatternType.regexp
             )
         ).toStrictEqual([])
@@ -57,7 +57,7 @@ describe('getDiagnostics()', () => {
     test('search query containing quoted token, literal pattern type', () => {
         expect(
             getDiagnostics(
-                (parseSearchQuery('"Configuration::doStuff(...)"') as ParseSuccess<Sequence>).token,
+                (scanSearchQuery('"Configuration::doStuff(...)"') as ScanSuccess<Sequence>).token,
                 SearchPatternType.literal
             )
         ).toStrictEqual([

--- a/client/shared/src/search/parser/diagnostics.ts
+++ b/client/shared/src/search/parser/diagnostics.ts
@@ -1,10 +1,10 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence, toMonacoRange } from './parser'
+import { Sequence, toMonacoRange } from './scanner'
 import { validateFilter } from './filters'
 import { SearchPatternType } from '../../graphql-operations'
 
 /**
- * Returns the diagnostics for a parsed search query to be displayed in the Monaco query input.
+ * Returns the diagnostics for a scanned search query to be displayed in the Monaco query input.
  */
 export function getDiagnostics(
     { members }: Pick<Sequence, 'members'>,

--- a/client/shared/src/search/parser/filters.test.ts
+++ b/client/shared/src/search/parser/filters.test.ts
@@ -1,5 +1,5 @@
 import { validateFilter } from './filters'
-import { Literal, Quoted } from './parser'
+import { Literal, Quoted } from './scanner'
 
 describe('validateFilter()', () => {
     interface TestCase {

--- a/client/shared/src/search/parser/filters.ts
+++ b/client/shared/src/search/parser/filters.ts
@@ -1,4 +1,4 @@
-import { Filter } from './parser'
+import { Filter } from './scanner'
 import { SearchSuggestion } from '../suggestions'
 import {
     FilterType,

--- a/client/shared/src/search/parser/hover.test.ts
+++ b/client/shared/src/search/parser/hover.test.ts
@@ -1,10 +1,9 @@
 import { getHoverResult } from './hover'
-import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
 
 describe('getHoverResult()', () => {
     test('returns hover contents for filters', () => {
-        const parsedQuery = (parseSearchQuery('repo:sourcegraph file:code_intelligence') as ParseSuccess<Sequence>)
-            .token
+        const parsedQuery = (scanSearchQuery('repo:sourcegraph file:code_intelligence') as ScanSuccess<Sequence>).token
         expect(getHoverResult(parsedQuery, { column: 4 })).toStrictEqual({
             contents: [
                 {

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -1,5 +1,5 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence, toMonacoRange } from './parser'
+import { Sequence, toMonacoRange } from './scanner'
 import { resolveFilter } from './filters'
 
 /**

--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -1,6 +1,6 @@
 import * as Monaco from 'monaco-editor'
 import { Observable, fromEventPattern, of } from 'rxjs'
-import { parseSearchQuery } from './parser'
+import { scanSearchQuery } from './scanner'
 import { map, first, takeUntil, publishReplay, refCount, switchMap, debounceTime, share } from 'rxjs/operators'
 import { getMonacoTokens } from './tokens'
 import { getDiagnostics } from './diagnostics'
@@ -17,10 +17,10 @@ interface SearchFieldProviders {
 }
 
 /**
- * A dummy parsing state, required for the token provider.
+ * A dummy scanner state, required for the token provider.
  */
-const PARSER_STATE: Monaco.languages.IState = {
-    clone: () => ({ ...PARSER_STATE }),
+const SCANNER_STATE: Monaco.languages.IState = {
+    clone: () => ({ ...SCANNER_STATE }),
     equals: () => false,
 }
 
@@ -40,10 +40,10 @@ export function getProviders(
         interpretComments?: boolean
     }
 ): SearchFieldProviders {
-    const parsedQueries = searchQueries.pipe(
+    const scannedQueries = searchQueries.pipe(
         map(rawQuery => {
-            const parsed = parseSearchQuery(rawQuery, options.interpretComments ?? false)
-            return { rawQuery, parsed }
+            const scanned = scanSearchQuery(rawQuery, options.interpretComments ?? false)
+            return { rawQuery, scanned }
         }),
         publishReplay(1),
         refCount()
@@ -53,24 +53,26 @@ export function getProviders(
 
     return {
         tokens: {
-            getInitialState: () => PARSER_STATE,
+            getInitialState: () => SCANNER_STATE,
             tokenize: line => {
-                const result = parseSearchQuery(line, options.interpretComments ?? false)
+                const result = scanSearchQuery(line, options.interpretComments ?? false)
                 if (result.type === 'success') {
                     return {
                         tokens: getMonacoTokens(result.token),
-                        endState: PARSER_STATE,
+                        endState: SCANNER_STATE,
                     }
                 }
-                return { endState: PARSER_STATE, tokens: [] }
+                return { endState: SCANNER_STATE, tokens: [] }
             },
         },
         hover: {
             provideHover: (textModel, position, token) =>
-                parsedQueries
+                scannedQueries
                     .pipe(
                         first(),
-                        map(({ parsed }) => (parsed.type === 'error' ? null : getHoverResult(parsed.token, position))),
+                        map(({ scanned }) =>
+                            scanned.type === 'error' ? null : getHoverResult(scanned.token, position)
+                        ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )
                     .toPromise(),
@@ -79,14 +81,14 @@ export function getProviders(
             // An explicit list of trigger characters is needed for the Monaco editor to show completions.
             triggerCharacters: [...printable, ...latin1Alpha],
             provideCompletionItems: (textModel, position, context, token) =>
-                parsedQueries
+                scannedQueries
                     .pipe(
                         first(),
-                        switchMap(parsedQuery =>
-                            parsedQuery.parsed.type === 'error'
+                        switchMap(scannedQuery =>
+                            scannedQuery.scanned.type === 'error'
                                 ? of(null)
                                 : getCompletionItems(
-                                      parsedQuery.parsed.token,
+                                      scannedQuery.scanned.token,
                                       position,
                                       debouncedDynamicSuggestions,
                                       options.globbing
@@ -96,8 +98,8 @@ export function getProviders(
                     )
                     .toPromise(),
         },
-        diagnostics: parsedQueries.pipe(
-            map(({ parsed }) => (parsed.type === 'success' ? getDiagnostics(parsed.token, options.patternType) : []))
+        diagnostics: scannedQueries.pipe(
+            map(({ scanned }) => (scanned.type === 'success' ? getDiagnostics(scanned.token, options.patternType) : []))
         ),
     }
 }

--- a/client/shared/src/search/parser/scanner.test.ts
+++ b/client/shared/src/search/parser/scanner.test.ts
@@ -1,4 +1,4 @@
-import { parseSearchQuery, scanBalancedPattern, PatternKind } from './parser'
+import { scanSearchQuery, scanBalancedPattern, PatternKind } from './scanner'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value),
@@ -68,99 +68,99 @@ describe('scanBalancedPattern()', () => {
     })
 })
 
-describe('parseSearchQuery() for literal search', () => {
+describe('scanSearchQuery() for literal search', () => {
     test('empty', () =>
-        expect(parseSearchQuery('')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[],"range":{"start":0,"end":1}}}'
         ))
 
     test('whitespace', () =>
-        expect(parseSearchQuery('  ')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('  ')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"whitespace","range":{"start":0,"end":2}}],"range":{"start":0,"end":2}}}'
         ))
 
     test('literal', () =>
-        expect(parseSearchQuery('a')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('a')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":1},"kind":1,"value":"a"}],"range":{"start":0,"end":1}}}'
         ))
 
     test('triple quotes', () => {
-        expect(parseSearchQuery('"""')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('"""')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"\\"\\"\\""}],"range":{"start":0,"end":3}}}'
         )
     })
 
     test('filter', () =>
-        expect(parseSearchQuery('f:b')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('f:b')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"b","range":{"start":2,"end":3}},"negated":false}],"range":{"start":0,"end":3}}}'
         ))
 
     test('negated filter', () =>
-        expect(parseSearchQuery('-f:b')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('-f:b')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"filterValue":{"type":"literal","value":"b","range":{"start":3,"end":4}},"negated":true}],"range":{"start":0,"end":4}}}'
         ))
 
     test('filter with quoted value', () => {
-        expect(parseSearchQuery('f:"b"')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('f:"b"')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":5},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"quoted","quotedValue":"b","range":{"start":2,"end":5}},"negated":false}],"range":{"start":0,"end":5}}}'
         )
     })
 
     test('filter with a value ending with a colon', () => {
-        expect(parseSearchQuery('f:a:')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}],"range":{"start":0,"end":4}}}'
         )
     })
 
     test('filter where the value is a colon', () => {
-        expect(parseSearchQuery('f:a:')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}],"range":{"start":0,"end":4}}}'
         )
     })
 
     test('quoted, double quotes', () =>
-        expect(parseSearchQuery('"a:b"')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('"a:b"')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}],"range":{"start":0,"end":5}}}'
         ))
 
     test('quoted, single quotes', () =>
-        expect(parseSearchQuery("'a:b'")).toMatchInlineSnapshot(
+        expect(scanSearchQuery("'a:b'")).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}],"range":{"start":0,"end":5}}}'
         ))
 
     test('quoted (escaped quotes)', () =>
-        expect(parseSearchQuery('"-\\"a\\":b"')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('"-\\"a\\":b"')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"quoted","quotedValue":"-\\\\\\"a\\\\\\":b","range":{"start":0,"end":10}}],"range":{"start":0,"end":10}}}'
         ))
 
     test('complex query', () =>
-        expect(parseSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":30},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"filterType":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"filterValue":{"type":"literal","value":"go","range":{"start":36,"end":38}},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"filterType":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"filterValue":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}],"range":{"start":0,"end":58}}}'
         ))
 
     test('parenthesized parameters', () => {
-        expect(parseSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"operator","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}],"range":{"start":0,"end":21}}}'
         )
     })
 
     test('nested parenthesized parameters', () => {
-        expect(parseSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":2},"kind":1,"value":"a"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"operator","value":"and","range":{"start":3,"end":6},"kind":"and"},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"pattern","range":{"start":8,"end":9},"kind":1,"value":"b"},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"operator","value":"or","range":{"start":10,"end":12},"kind":"or"},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"pattern","range":{"start":13,"end":14},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"operator","value":"and","range":{"start":16,"end":19},"kind":"and"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"pattern","range":{"start":20,"end":21},"kind":1,"value":"d"},{"type":"closingParen","range":{"start":21,"end":22}}],"range":{"start":0,"end":22}}}'
         )
     })
 
     test('do not treat links as filters', () => {
-        expect(parseSearchQuery('http://example.com repo:a')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('http://example.com repo:a')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"filterType":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"filterValue":{"type":"literal","value":"a","range":{"start":24,"end":25}},"negated":false}],"range":{"start":0,"end":25}}}'
         )
     })
 })
 
-describe('parseSearchQuery() for regexp', () => {
+describe('scanSearchQuery() for regexp', () => {
     test('interpret regexp pattern with match groups', () => {
         expect(
-            parseSearchQuery('((sauce|graph)(\\s)?)is best(g*r*a*p*h*)', false, PatternKind.Regexp)
+            scanSearchQuery('((sauce|graph)(\\s)?)is best(g*r*a*p*h*)', false, PatternKind.Regexp)
         ).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":22},"kind":2,"value":"((sauce|graph)(\\\\s)?)is"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":39},"kind":2,"value":"best(g*r*a*p*h*)"}],"range":{"start":0,"end":39}}}'
         )
@@ -168,32 +168,32 @@ describe('parseSearchQuery() for regexp', () => {
 
     test('interpret regexp pattern with match groups between operators', () => {
         expect(
-            parseSearchQuery('(((sauce|graph)\\s?) or (best)) and (gr|aph)', false, PatternKind.Regexp)
+            scanSearchQuery('(((sauce|graph)\\s?) or (best)) and (gr|aph)', false, PatternKind.Regexp)
         ).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":19},"kind":2,"value":"((sauce|graph)\\\\s?)"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"operator","value":"or","range":{"start":20,"end":22},"kind":"or"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":29},"kind":2,"value":"(best)"},{"type":"closingParen","range":{"start":29,"end":30}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"operator","value":"and","range":{"start":31,"end":34},"kind":"and"},{"type":"whitespace","range":{"start":34,"end":35}},{"type":"pattern","range":{"start":35,"end":43},"kind":2,"value":"(gr|aph)"}],"range":{"start":0,"end":43}}}'
         )
     })
 
     test('interpret regexp slash quotes', () => {
-        expect(parseSearchQuery('r:a /a regexp \\ pattern/', false, PatternKind.Regexp)).toMatchInlineSnapshot(
+        expect(scanSearchQuery('r:a /a regexp \\ pattern/', false, PatternKind.Regexp)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"r","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a","range":{"start":2,"end":3}},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}],"range":{"start":0,"end":24}}}'
         )
     })
 })
 
-describe('parseSearchQuery() with comments', () => {
+describe('scanSearchQuery() with comments', () => {
     test('interpret C-style comments', () => {
         const query = `// saucegraph is best graph
 repo:sourcegraph
 // search for thing
 thing`
-        expect(parseSearchQuery(query, true)).toMatchInlineSnapshot(
+        expect(scanSearchQuery(query, true)).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"filterType":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"filterValue":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}],"range":{"start":0,"end":70}}}'
         )
     })
 
     test('do not interpret C-style comments', () => {
-        expect(parseSearchQuery('// thing')).toMatchInlineSnapshot(
+        expect(scanSearchQuery('// thing')).toMatchInlineSnapshot(
             '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":2},"kind":1,"value":"//"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"pattern","range":{"start":3,"end":8},"kind":1,"value":"thing"}],"range":{"start":0,"end":8}}}'
         )
     })

--- a/client/shared/src/search/parser/scanner.ts
+++ b/client/shared/src/search/parser/scanner.ts
@@ -132,14 +132,14 @@ export type Token = Whitespace | OpeningParen | ClosingParen | Operator | Commen
 export type Term = Token | Sequence
 
 /**
- * Represents the failed result of running a {@link Parser} on a search query.
+ * Represents the failed result of running a {@link Scanner} on a search query.
  */
-interface ParseError {
+interface ScanError {
     type: 'error'
 
     /**
      * A string representing the token that would have been expected
-     * for successful parsing at {@link ParseError#at}.
+     * for successful scanning at {@link ScannerError#at}.
      */
     expected: string
 
@@ -150,9 +150,9 @@ interface ParseError {
 }
 
 /**
- * Represents the successful result of running a {@link Parser} on a search query.
+ * Represents the successful result of running a {@link Scannerer} on a search query.
  */
-export interface ParseSuccess<T = Term> {
+export interface ScanSuccess<T = Term> {
     type: 'success'
 
     /**
@@ -162,22 +162,22 @@ export interface ParseSuccess<T = Term> {
 }
 
 /**
- * Represents the result of running a {@link Parser} on a search query.
+ * Represents the result of running a {@link Scanner} on a search query.
  */
-export type ParserResult<T = Term> = ParseError | ParseSuccess<T>
+export type ScanResult<T = Term> = ScanError | ScanSuccess<T>
 
-type Parser<T = Term> = (input: string, start: number) => ParserResult<T>
+type Scanner<T = Term> = (input: string, start: number) => ScanResult<T>
 
 /**
- * Returns a {@link Parser} that succeeds if zero or more tokens parsed
- * by the given `parseToken` parsers are found in a search query.
+ * Returns a {@link Scanner} that succeeds if zero or more tokens are scanned
+ * by the given `scanToken` scanners.
  */
-const zeroOrMore = (parseToken: Parser<Term>): Parser<Sequence> => (input, start) => {
+const zeroOrMore = (scanToken: Scanner<Term>): Scanner<Sequence> => (input, start) => {
     const members: Token[] = []
     let adjustedStart = start
     let end = start + 1
     while (input[adjustedStart] !== undefined) {
-        const result = parseToken(input, adjustedStart)
+        const result = scanToken(input, adjustedStart)
         if (result.type === 'error') {
             return result
         }
@@ -198,12 +198,12 @@ const zeroOrMore = (parseToken: Parser<Term>): Parser<Sequence> => (input, start
 }
 
 /**
- * Returns a {@link Parser} that succeeds if any of the given parsers succeeds.
+ * Returns a {@link Scanner} that succeeds if any of the given scanner succeeds.
  */
-const oneOf = <T>(...parsers: Parser<T>[]): Parser<T> => (input, start) => {
+const oneOf = <T>(...scanners: Scanner<T>[]): Scanner<T> => (input, start) => {
     const expected: string[] = []
-    for (const parser of parsers) {
-        const result = parser(input, start)
+    for (const scanner of scanners) {
+        const result = scanner(input, start)
         if (result.type === 'success') {
             return result
         }
@@ -217,10 +217,10 @@ const oneOf = <T>(...parsers: Parser<T>[]): Parser<T> => (input, start) => {
 }
 
 /**
- * A {@link Parser} that will attempt to parse delimited strings for an arbitrary
+ * A {@link Scanner} that will attempt to scan delimited strings for an arbitrary
  * delimiter. `\` is treated as an escape character for the delimited string.
  */
-const quoted = (delimiter: string): Parser<Quoted> => (input, start) => {
+const quoted = (delimiter: string): Scanner<Quoted> => (input, start) => {
     if (input[start] !== delimiter) {
         return { type: 'error', expected: delimiter, at: start }
     }
@@ -239,10 +239,10 @@ const quoted = (delimiter: string): Parser<Quoted> => (input, start) => {
 }
 
 /**
- * Returns a {@link Parser} that will attempt to parse tokens matching
+ * Returns a {@link Scanner} that will attempt to scan tokens matching
  * the given character in a search query.
  */
-const character = (character: string): Parser<Literal> => (input, start) => {
+const character = (character: string): Scanner<Literal> => (input, start) => {
     if (input[start] !== character) {
         return { type: 'error', expected: character, at: start }
     }
@@ -253,14 +253,14 @@ const character = (character: string): Parser<Literal> => (input, start) => {
 }
 
 /**
- * Returns a {@link Parser} that will attempt to parse
+ * Returns a {@link Scanner} that will attempt to scan
  * tokens matching the given RegExp pattern in a search query.
  */
 const scanToken = <T extends Term = Literal>(
     regexp: RegExp,
     output?: T | ((input: string, range: CharacterRange) => T),
     expected?: string
-): Parser<T> => {
+): Scanner<T> => {
     if (!regexp.source.startsWith('^')) {
         regexp = new RegExp(`^${regexp.source}`, regexp.flags)
     }
@@ -331,19 +331,19 @@ const openingParen = scanToken(/\(/, (_input, range): OpeningParen => ({ type: '
 const closingParen = scanToken(/\)/, (_input, range): ClosingParen => ({ type: 'closingParen', range }))
 
 /**
- * Returns a {@link Parser} that succeeds if a token parsed by `parseToken`,
+ * Returns a {@link Scanner} that succeeds if a token scanned by `scanToken`,
  * followed by whitespace or EOF, is found in the search query.
  */
-const followedBy = (parseToken: Parser<Token>, parseNext: Parser<Token>): Parser<Sequence> => (input, start) => {
+const followedBy = (scanToken: Scanner<Token>, scanNext: Scanner<Token>): Scanner<Sequence> => (input, start) => {
     const members: Token[] = []
-    const tokenResult = parseToken(input, start)
+    const tokenResult = scanToken(input, start)
     if (tokenResult.type === 'error') {
         return tokenResult
     }
     members.push(tokenResult.token)
     let { end } = tokenResult.token.range
     if (input[end] !== undefined) {
-        const separatorResult = parseNext(input, end)
+        const separatorResult = scanNext(input, end)
         if (separatorResult.type === 'error') {
             return separatorResult
         }
@@ -357,39 +357,39 @@ const followedBy = (parseToken: Parser<Token>, parseNext: Parser<Token>): Parser
 }
 
 /**
- * A {@link Parser} that will attempt to parse {@link Filter} tokens
+ * A {@link Scanner} that will attempt to scan {@link Filter} tokens
  * (consisting a of a filter type and a filter value, separated by a colon)
  * in a search query.
  */
-const filter: Parser<Filter> = (input, start) => {
-    const parsedKeyword = filterKeyword(input, start)
-    if (parsedKeyword.type === 'error') {
-        return parsedKeyword
+const filter: Scanner<Filter> = (input, start) => {
+    const scannedKeyword = filterKeyword(input, start)
+    if (scannedKeyword.type === 'error') {
+        return scannedKeyword
     }
-    const parsedDelimiter = filterDelimiter(input, parsedKeyword.token.range.end)
-    if (parsedDelimiter.type === 'error') {
-        return parsedDelimiter
+    const scannedDelimiter = filterDelimiter(input, scannedKeyword.token.range.end)
+    if (scannedDelimiter.type === 'error') {
+        return scannedDelimiter
     }
-    const parsedValue =
-        input[parsedDelimiter.token.range.end] === undefined
+    const scannedValue =
+        input[scannedDelimiter.token.range.end] === undefined
             ? undefined
-            : filterValue(input, parsedDelimiter.token.range.end)
-    if (parsedValue && parsedValue.type === 'error') {
-        return parsedValue
+            : filterValue(input, scannedDelimiter.token.range.end)
+    if (scannedValue && scannedValue.type === 'error') {
+        return scannedValue
     }
     return {
         type: 'success',
         token: {
             type: 'filter',
-            range: { start, end: parsedValue ? parsedValue.token.range.end : parsedDelimiter.token.range.end },
-            filterType: parsedKeyword.token,
-            filterValue: parsedValue?.token,
-            negated: parsedKeyword.token.value.startsWith('-'),
+            range: { start, end: scannedValue ? scannedValue.token.range.end : scannedDelimiter.token.range.end },
+            filterType: scannedKeyword.token,
+            filterValue: scannedValue?.token,
+            negated: scannedKeyword.token.value.startsWith('-'),
         },
     }
 }
 
-const createPattern = (value: string, range: CharacterRange, kind: PatternKind): ParseSuccess<Pattern> => ({
+const createPattern = (value: string, range: CharacterRange, kind: PatternKind): ScanSuccess<Pattern> => ({
     type: 'success',
     token: {
         type: 'pattern',
@@ -423,7 +423,7 @@ const keepScanning = (input: string, start: number): boolean => scanFilterOrOper
  * (foo or (bar and baz)) - a valid query with and/or expression groups in the query langugae
  * (repo:foo bar baz)     - a valid query containing a recognized repo: field. Here parentheses are interpreted as a group, not a pattern.
  */
-export const scanBalancedPattern = (kind = PatternKind.Literal): Parser<Pattern> => (input, start) => {
+export const scanBalancedPattern = (kind = PatternKind.Literal): Scanner<Pattern> => (input, start) => {
     let adjustedStart = start
     let balanced = 0
     let current = ''
@@ -502,7 +502,7 @@ export const scanBalancedPattern = (kind = PatternKind.Literal): Parser<Pattern>
     return createPattern(result.join(''), { start, end: adjustedStart }, kind)
 }
 
-const scanPattern = (kind: PatternKind): Parser<Pattern> => (input, start) => {
+const scanPattern = (kind: PatternKind): Scanner<Pattern> => (input, start) => {
     const balancedPattern = scanBalancedPattern(kind)(input, start)
     if (balancedPattern.type === 'success') {
         return createPattern(balancedPattern.token.value, balancedPattern.token.range, kind)
@@ -519,16 +519,16 @@ const scanPattern = (kind: PatternKind): Parser<Pattern> => (input, start) => {
 const whitespaceOrClosingParen = oneOf<Whitespace | ClosingParen>(whitespace, closingParen)
 
 /**
- * A {@link Parser} for a Sourcegraph search query, interpreting patterns for {@link PatternKind}.
+ * A {@link Scanner} for a Sourcegraph search query, interpreting patterns for {@link PatternKind}.
  *
  * @param interpretComments Interpets C-style line comments for multiline queries.
  */
-const createParser = (kind: PatternKind, interpretComments?: boolean): Parser<Sequence> => {
+const createScanner = (kind: PatternKind, interpretComments?: boolean): Scanner<Sequence> => {
     const baseQuotedScanner = [quoted('"'), quoted("'")]
     const quotedScanner = kind === PatternKind.Regexp ? [quoted('/'), ...baseQuotedScanner] : baseQuotedScanner
 
     const baseScanner = [operator, filter, ...quotedScanner, scanPattern(kind)]
-    const tokenScanner: Parser<Token>[] = interpretComments ? [comment, ...baseScanner] : baseScanner
+    const tokenScanner: Scanner<Token>[] = interpretComments ? [comment, ...baseScanner] : baseScanner
 
     const baseEarlyPatternScanner = [...quotedScanner, scanBalancedPattern(kind)]
     const earlyPatternScanner = interpretComments ? [comment, ...baseEarlyPatternScanner] : baseEarlyPatternScanner
@@ -545,13 +545,13 @@ const createParser = (kind: PatternKind, interpretComments?: boolean): Parser<Se
 }
 
 /**
- * Parses a search query string.
+ * Scans a search query string.
  */
-export const parseSearchQuery = (
+export const scanSearchQuery = (
     query: string,
     interpretComments?: boolean,
     kind = PatternKind.Literal
-): ParserResult<Sequence> => {
-    const scanner = createParser(kind, interpretComments)
+): ScanResult<Sequence> => {
+    const scanner = createScanner(kind, interpretComments)
     return scanner(query, 0)
 }

--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -1,11 +1,11 @@
 import { getMonacoTokens } from './tokens'
-import { parseSearchQuery, ParseSuccess, Sequence } from './parser'
+import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
 
 describe('getMonacoTokens()', () => {
     test('returns the tokens for a parsed search query', () => {
         expect(
             getMonacoTokens(
-                (parseSearchQuery('r:^github.com/sourcegraph f:code_intelligence trackViews') as ParseSuccess<Sequence>)
+                (scanSearchQuery('r:^github.com/sourcegraph f:code_intelligence trackViews') as ScanSuccess<Sequence>)
                     .token
             )
         ).toStrictEqual([
@@ -41,7 +41,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('search query containing parenthesized parameters', () => {
-        expect(getMonacoTokens((parseSearchQuery('r:a (f:b and c)') as ParseSuccess<Sequence>).token)).toStrictEqual([
+        expect(getMonacoTokens((scanSearchQuery('r:a (f:b and c)') as ScanSuccess<Sequence>).token)).toStrictEqual([
             {
                 scopes: 'keyword',
                 startIndex: 0,

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -1,12 +1,12 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence } from './parser'
+import { Sequence } from './scanner'
 
 /**
- * Returns the tokens in a parsed search query displayed in the Monaco query input.
+ * Returns the tokens in a scanned search query displayed in the Monaco query input.
  */
-export function getMonacoTokens(parsedQuery: Pick<Sequence, 'members'>): Monaco.languages.IToken[] {
+export function getMonacoTokens(scannedQuery: Pick<Sequence, 'members'>): Monaco.languages.IToken[] {
     const tokens: Monaco.languages.IToken[] = []
-    for (const token of parsedQuery.members) {
+    for (const token of scannedQuery.members) {
         switch (token.type) {
             case 'filter':
                 {

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -2,7 +2,7 @@ import { Position, Range, Selection } from '@sourcegraph/extension-api-types'
 import { WorkspaceRootWithMetadata } from '../api/client/services/workspaceService'
 import { FiltersToTypeAndValue } from '../search/interactive/util'
 import { isEmpty } from 'lodash'
-import { parseSearchQuery, CharacterRange } from '../search/parser/parser'
+import { scanSearchQuery, CharacterRange } from '../search/parser/scanner'
 import { replaceRange } from './strings'
 import { discreteValueAliases } from '../search/parser/filters'
 import { tryCatch } from './errors'
@@ -652,7 +652,7 @@ export function generateFiltersQuery(filtersInQuery: FiltersToTypeAndValue): str
 }
 
 export function parsePatternTypeFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
-    const parsedQuery = parseSearchQuery(query)
+    const parsedQuery = scanSearchQuery(query)
     if (parsedQuery.type === 'success') {
         for (const token of parsedQuery.token.members) {
             if (
@@ -672,7 +672,7 @@ export function parsePatternTypeFromQuery(query: string): { range: CharacterRang
 }
 
 export function parseCaseSensitivityFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
-    const parsedQuery = parseSearchQuery(query)
+    const parsedQuery = scanSearchQuery(query)
     if (parsedQuery.type === 'success') {
         for (const token of parsedQuery.token.members) {
             if (token.type === 'filter' && token.filterType.value.toLowerCase() === 'case' && token.filterValue) {

--- a/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -1,10 +1,10 @@
 import React, { Fragment, useMemo } from 'react'
-import { parseSearchQuery } from '../../../shared/src/search/parser/parser'
+import { scanSearchQuery } from '../../../shared/src/search/parser/scanner'
 
 // A read-only syntax highlighted search query
 export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: string }> = ({ query }) => {
     const tokens = useMemo(() => {
-        const parsedQuery = parseSearchQuery(query)
+        const parsedQuery = scanSearchQuery(query)
         return parsedQuery.type === 'success'
             ? parsedQuery.token.members.map(token => {
                   if (token.type === 'filter') {

--- a/client/web/src/search/input/helpers.ts
+++ b/client/web/src/search/input/helpers.ts
@@ -4,7 +4,7 @@ import {
     isNegatedFilter,
     resolveNegatedFilter,
 } from '../../../../shared/src/search/interactive/util'
-import { parseSearchQuery } from '../../../../shared/src/search/parser/parser'
+import { scanSearchQuery } from '../../../../shared/src/search/parser/scanner'
 import { uniqueId } from 'lodash'
 import { validateFilter, isSingularFilter } from '../../../../shared/src/search/parser/filters'
 
@@ -19,7 +19,7 @@ import { validateFilter, isSingularFilter } from '../../../../shared/src/search/
 export function convertPlainTextToInteractiveQuery(
     query: string
 ): { filtersInQuery: FiltersToTypeAndValue; navbarQuery: string } {
-    const parsedQuery = parseSearchQuery(query)
+    const parsedQuery = scanSearchQuery(query)
 
     const newFiltersInQuery: FiltersToTypeAndValue = {}
     let newNavbarQuery = ''

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -8,7 +8,7 @@ import { Link } from '../../../../shared/src/components/Link'
 import { LoadingPanelView } from './LoadingPanelView'
 import { Observable } from 'rxjs'
 import { PanelContainer } from './PanelContainer'
-import { parseSearchQuery } from '../../../../shared/src/search/parser/parser'
+import { scanSearchQuery } from '../../../../shared/src/search/parser/scanner'
 import { parseSearchURLQuery } from '..'
 import { ShowMoreButton } from './ShowMoreButton'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
@@ -127,7 +127,7 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
     for (const node of eventLogResult.nodes) {
         const url = new URL(node.url)
         const queryFromURL = parseSearchURLQuery(url.search)
-        const parsedQuery = parseSearchQuery(queryFromURL || '')
+        const parsedQuery = scanSearchQuery(queryFromURL || '')
         if (parsedQuery.type === 'success') {
             for (const token of parsedQuery.token.members) {
                 if (

--- a/client/web/src/search/queryTelemetry.tsx
+++ b/client/web/src/search/queryTelemetry.tsx
@@ -1,5 +1,5 @@
 import { count } from '../../../shared/src/util/strings'
-import { parseSearchQuery, ParserResult, Sequence } from '../../../shared/src/search/parser/parser'
+import { scanSearchQuery, ScanResult, Sequence } from '../../../shared/src/search/parser/scanner'
 import { resolveFilter } from '../../../shared/src/search/parser/filters'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -11,7 +11,7 @@ export function queryTelemetryData(query: string, caseSensitive: boolean) {
         empty: !query,
     }
 }
-function filterExistsInQuery(parsedQuery: ParserResult<Sequence>, filterToMatch: string): boolean {
+function filterExistsInQuery(parsedQuery: ScanResult<Sequence>, filterToMatch: string): boolean {
     if (parsedQuery.type === 'success') {
         const members = parsedQuery.token.members
         for (const token of members) {
@@ -29,7 +29,7 @@ function filterExistsInQuery(parsedQuery: ParserResult<Sequence>, filterToMatch:
 function queryStringTelemetryData(query: string, caseSensitive: boolean) {
     // 🚨 PRIVACY: never provide any private data in this function's return value.
     // This only takes ~1.7ms per call, so it does not need to be optimized.
-    const parsedQuery = parseSearchQuery(query)
+    const parsedQuery = scanSearchQuery(query)
     return {
         field_archived: filterExistsInQuery(parsedQuery, 'archived')
             ? {

--- a/client/web/src/search/results/SearchResultTab.tsx
+++ b/client/web/src/search/results/SearchResultTab.tsx
@@ -6,7 +6,7 @@ import { toggleSearchType } from '../helpers'
 import { buildSearchURLQuery, generateFiltersQuery } from '../../../../shared/src/util/url'
 import { constant } from 'lodash'
 import { PatternTypeProps, CaseSensitivityProps, parseSearchURLQuery, InteractiveSearchProps } from '..'
-import { parseSearchQuery } from '../../../../shared/src/search/parser/parser'
+import { scanSearchQuery } from '../../../../shared/src/search/parser/scanner'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 
 interface Props
@@ -41,7 +41,7 @@ export const SearchResultTabHeader: React.FunctionComponent<Props> = ({
     const builtURLQuery = buildSearchURLQuery(caseToggledQuery, patternType, caseSensitive, versionContext)
 
     const currentQuery = parseSearchURLQuery(location.search) || ''
-    const parsedQuery = parseSearchQuery(currentQuery)
+    const parsedQuery = scanSearchQuery(currentQuery)
     let typeInQuery: SearchType = null
 
     if (parsedQuery.type === 'success') {


### PR DESCRIPTION
Stacked on #15544.

It's now important to distinguish between scanning and scan results (generates a list of tokens) and parse result (generates a tree, and e.g., does some extra processing on tokens. This is to be added in next PR.

The `parser.ts` file becomes `scanner.ts`, and `parseSearchQuery` becomes `scanSearchQuery`. Where appropriate, I rename variables to be `scannedXXX` instead of `parsedXXX`, but I do not propagate the `parse` -> `scan` rename up all the way up all the callstacks outside of `search/parser`--this because I have plans to turn the scan result into simply a `Token[]`, and all variables/functions that rely on scanner results can become some variant of `tokens` rather than `parsedSearchQuery`. This change I will do in a separate PR.