### PR TITLE
Fix step 1 on setting up local development environment

### DIFF
--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -132,9 +132,9 @@ The following are two recommendations for installing these dependencies:
 3. Install dependencies:
 
     ```
-    sudo apt install -y make git-all postgresql postgresql-contrib redis-server nginx libpcre3-dev libsqlite3-dev pkg-config golang-go musl-tools docker-ce docker-ce-cli containerd.io yarn jq
+    sudo apt install -y make git-all postgresql postgresql-contrib redis-server nginx libpcre3-dev libsqlite3-dev pkg-config golang-go musl-tools docker-ce docker-ce-cli containerd.io yarn jq ca-certificates
 
-    # install golang-migrate (you must rename the extracted binary to `golang-migrate` and move the binary into your $PATH)
+    # install golang-migrate (you must rename the extracted binary to `migrate` and move the binary into your $PATH)
     curl -L https://github.com/golang-migrate/migrate/releases/download/v4.7.0/migrate.linux-amd64.tar.gz | tar xvz
 
     # install comby (you must rename the extracted binary to `comby` and move the binary into your $PATH)
@@ -177,7 +177,7 @@ The following are two recommendations for installing these dependencies:
     # $REDIS_DATA_DIR should be an absolute path to a folder where you intend to store Redis data
     ```
 
-    You need to have Redis running when you start the dev server later on. If you have issues running Docker, try [adding your user to the docker group][dockerGroup], and/or [updating the socket file persimissions][socketPermissions], or try running these commands under `sudo`.
+    You need to have Redis running when you start the dev server later on. If you have issues running Docker, try [adding your user to the docker group][dockerGroup], and/or [updating the socket file permissions][socketPermissions], or try running these commands under `sudo`.
 
     [dockerGroup]: https://stackoverflow.com/a/48957722
     [socketPermissions]: https://stackoverflow.com/a/51362528


### PR DESCRIPTION
Hi Sourcegraph team! Hope this message finds you all well 😄 

I was setting up my machine for Sourcegraph local development environment and found few things that need to be tweaked first before it can run the local Sourcegraph instance as expected. 
These changes was based on my own experience and might not cater to the general step-by-step thus feel free to decline if you folks think that this might not be advantageous to others 😁 

1. Turns out my machine hasn't installed `ca-certificates` yet (which was needed) and might be useful to add it to the list of the apt packages installed.
2. I think that the binary should be named `migrate` since the [bash script](https://github.com/sourcegraph/sourcegraph/blob/main/dev/db/migrate.sh) for migration also used the `migrate` command instead of `golang-migrate`. Tried to rename the binary to `golang-migrate` and the migration didn't work (as expected).
3. Tiny typo on `permissions`. 

Thank you lots in advance!