### PR TITLE
search frontend: rename token operator -> keyword

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -94,8 +94,8 @@ $text-muted: var(--text-muted);
     --border-color: #{$gray-04};
     --border-color-2: #{$gray-02};
     --sourcegraph-logo-text-color: #242427;
-    --search-keyword-color: #1c7cd6;
-    --search-operator-color: #{$oc-grape-7};
+    --search-filter-keyword-color: #1c7cd6;
+    --search-keyword-color: #{$oc-grape-7};
 }
 .theme-dark {
     // Affects default browser styles
@@ -118,6 +118,6 @@ $text-muted: var(--text-muted);
     --link-active-color: #{$gray-02};
     --link-hover-color: #ffffff;
     --sourcegraph-logo-text-color: #ffffff;
-    --search-keyword-color: #329af0;
-    --search-operator-color: #{$oc-grape-4};
+    --search-filter-keyword-color: #329af0;
+    --search-keyword-color: #{$oc-grape-4};
 }

--- a/client/branded/src/global-styles/web-content.scss
+++ b/client/branded/src/global-styles/web-content.scss
@@ -50,12 +50,12 @@
         }
     }
 
-    .search-keyword {
-        color: var(--search-keyword-color);
+    .search-filter-keyword {
+        color: var(--search-filter-keyword-color);
     }
 
-    .search-operator {
-        color: var(--search-operator-color);
+    .search-keyword {
+        color: var(--search-keyword-color);
     }
 
     // Search examples that link to the results page should use this class.

--- a/client/shared/src/search/parser/scanner.test.ts
+++ b/client/shared/src/search/parser/scanner.test.ts
@@ -25,33 +25,33 @@ describe('scanBalancedPattern()', () => {
         )
     })
 
-    test('not recognized, contains not operator', () => {
+    test('not recognized, contains not keyword', () => {
         expect(scanLiteralBalancedPattern('(foo not bar)', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"no recognized filter or operator","at":5}'
+            '{"type":"error","expected":"no recognized filter or keyword","at":5}'
         )
     })
 
-    test('not recognized, starts with a not operator', () => {
+    test('not recognized, starts with a not keyword', () => {
         expect(scanLiteralBalancedPattern('(not chocolate)', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"no recognized filter or operator","at":1}'
+            '{"type":"error","expected":"no recognized filter or keyword","at":1}'
         )
     })
 
-    test('not recognized, contains an or operator', () => {
+    test('not recognized, contains an or keyword', () => {
         expect(scanLiteralBalancedPattern('(foo OR bar)', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"no recognized filter or operator","at":5}'
+            '{"type":"error","expected":"no recognized filter or keyword","at":5}'
         )
     })
 
-    test('not recognized, contains an and operator', () => {
+    test('not recognized, contains an and keyword', () => {
         expect(scanLiteralBalancedPattern('repo:foo AND bar', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"no recognized filter or operator","at":0}'
+            '{"type":"error","expected":"no recognized filter or keyword","at":0}'
         )
     })
 
     test('not recognized, contains a recognized repo field', () => {
         expect(scanLiteralBalancedPattern('repo:foo bar', 0)).toMatchInlineSnapshot(
-            '{"type":"error","expected":"no recognized filter or operator","at":0}'
+            '{"type":"error","expected":"no recognized filter or keyword","at":0}'
         )
     })
 
@@ -140,13 +140,13 @@ describe('scanSearchQuery() for literal search', () => {
 
     test('parenthesized parameters', () => {
         expect(scanSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"operator","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}],"range":{"start":0,"end":21}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}],"range":{"start":0,"end":21}}}'
         )
     })
 
     test('nested parenthesized parameters', () => {
         expect(scanSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":2},"kind":1,"value":"a"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"operator","value":"and","range":{"start":3,"end":6},"kind":"and"},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"pattern","range":{"start":8,"end":9},"kind":1,"value":"b"},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"operator","value":"or","range":{"start":10,"end":12},"kind":"or"},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"pattern","range":{"start":13,"end":14},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"operator","value":"and","range":{"start":16,"end":19},"kind":"and"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"pattern","range":{"start":20,"end":21},"kind":1,"value":"d"},{"type":"closingParen","range":{"start":21,"end":22}}],"range":{"start":0,"end":22}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":2},"kind":1,"value":"a"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"keyword","value":"and","range":{"start":3,"end":6},"kind":"and"},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"pattern","range":{"start":8,"end":9},"kind":1,"value":"b"},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"keyword","value":"or","range":{"start":10,"end":12},"kind":"or"},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"pattern","range":{"start":13,"end":14},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"keyword","value":"and","range":{"start":16,"end":19},"kind":"and"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"pattern","range":{"start":20,"end":21},"kind":1,"value":"d"},{"type":"closingParen","range":{"start":21,"end":22}}],"range":{"start":0,"end":22}}}'
         )
     })
 
@@ -166,11 +166,11 @@ describe('scanSearchQuery() for regexp', () => {
         )
     })
 
-    test('interpret regexp pattern with match groups between operators', () => {
+    test('interpret regexp pattern with match groups between keywords', () => {
         expect(
             scanSearchQuery('(((sauce|graph)\\s?) or (best)) and (gr|aph)', false, PatternKind.Regexp)
         ).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":19},"kind":2,"value":"((sauce|graph)\\\\s?)"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"operator","value":"or","range":{"start":20,"end":22},"kind":"or"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":29},"kind":2,"value":"(best)"},{"type":"closingParen","range":{"start":29,"end":30}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"operator","value":"and","range":{"start":31,"end":34},"kind":"and"},{"type":"whitespace","range":{"start":34,"end":35}},{"type":"pattern","range":{"start":35,"end":43},"kind":2,"value":"(gr|aph)"}],"range":{"start":0,"end":43}}}'
+            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":19},"kind":2,"value":"((sauce|graph)\\\\s?)"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"keyword","value":"or","range":{"start":20,"end":22},"kind":"or"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":29},"kind":2,"value":"(best)"},{"type":"closingParen","range":{"start":29,"end":30}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"keyword","value":"and","range":{"start":31,"end":34},"kind":"and"},{"type":"whitespace","range":{"start":34,"end":35}},{"type":"pattern","range":{"start":35,"end":43},"kind":2,"value":"(gr|aph)"}],"range":{"start":0,"end":43}}}'
         )
     })
 

--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -10,7 +10,7 @@ describe('getMonacoTokens()', () => {
             )
         ).toStrictEqual([
             {
-                scopes: 'keyword',
+                scopes: 'filterKeyword',
                 startIndex: 0,
             },
             {
@@ -22,7 +22,7 @@ describe('getMonacoTokens()', () => {
                 startIndex: 25,
             },
             {
-                scopes: 'keyword',
+                scopes: 'filterKeyword',
                 startIndex: 26,
             },
             {
@@ -43,7 +43,7 @@ describe('getMonacoTokens()', () => {
     test('search query containing parenthesized parameters', () => {
         expect(getMonacoTokens((scanSearchQuery('r:a (f:b and c)') as ScanSuccess<Sequence>).token)).toStrictEqual([
             {
-                scopes: 'keyword',
+                scopes: 'filterKeyword',
                 startIndex: 0,
             },
             {
@@ -59,7 +59,7 @@ describe('getMonacoTokens()', () => {
                 startIndex: 4,
             },
             {
-                scopes: 'keyword',
+                scopes: 'filterKeyword',
                 startIndex: 5,
             },
             {
@@ -71,7 +71,7 @@ describe('getMonacoTokens()', () => {
                 startIndex: 8,
             },
             {
-                scopes: 'operator',
+                scopes: 'keyword',
                 startIndex: 9,
             },
             {

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -12,7 +12,7 @@ export function getMonacoTokens(scannedQuery: Pick<Sequence, 'members'>): Monaco
                 {
                     tokens.push({
                         startIndex: token.filterType.range.start,
-                        scopes: 'keyword',
+                        scopes: 'filterKeyword',
                     })
                     if (token.filterValue) {
                         tokens.push({
@@ -23,7 +23,7 @@ export function getMonacoTokens(scannedQuery: Pick<Sequence, 'members'>): Monaco
                 }
                 break
             case 'whitespace':
-            case 'operator':
+            case 'keyword':
             case 'comment':
                 tokens.push({
                     startIndex: token.range.start,

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -32,8 +32,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
     },
     rules: [
         { token: 'identifier', foreground: '#f2f4f8' },
-        { token: 'keyword', foreground: '#569cd6' },
-        { token: 'operator', foreground: '#da77f2' },
+        { token: 'filterKeyword', foreground: '#569cd6' },
+        { token: 'keyword', foreground: '#da77f2' },
         { token: 'comment', foreground: '#ffa94d' },
     ],
 })
@@ -58,8 +58,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
     },
     rules: [
         { token: 'identifier', foreground: '#2b3750' },
-        { token: 'keyword', foreground: '#268bd2' },
-        { token: 'operator', foreground: '#ae3ec9' },
+        { token: 'filterKeyword', foreground: '#268bd2' },
+        { token: 'keyword', foreground: '#ae3ec9' },
         { token: 'comment', foreground: '#d9480f' },
     ],
 })

--- a/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -10,7 +10,7 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: stri
                   if (token.type === 'filter') {
                       return (
                           <Fragment key={token.range.start}>
-                              <span className="search-keyword">
+                              <span className="search-filter-keyword">
                                   {query.slice(token.filterType.range.start, token.filterType.range.end)}:
                               </span>
                               {token.filterValue ? (
@@ -19,9 +19,9 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: stri
                           </Fragment>
                       )
                   }
-                  if (token.type === 'operator') {
+                  if (token.type === 'keyword') {
                       return (
-                          <span className="search-operator" key={token.range.start}>
+                          <span className="search-keyword" key={token.range.start}>
                               {query.slice(token.range.start, token.range.end)}
                           </span>
                       )

--- a/client/web/src/components/__snapshots__/SyntaxHighlightedSearchQuery.test.tsx.snap
+++ b/client/web/src/components/__snapshots__/SyntaxHighlightedSearchQuery.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter 1`] = `
     className="text-monospace search-query-link"
   >
     <span
-      className="search-keyword"
+      className="search-filter-keyword"
     >
       repo
       :
@@ -16,7 +16,7 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter 1`] = `
     sourcegraph
      
     <span
-      className="search-keyword"
+      className="search-filter-keyword"
     >
       lang
       :
@@ -34,7 +34,7 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter and operato
     className="text-monospace search-query-link"
   >
     <span
-      className="search-keyword"
+      className="search-filter-keyword"
     >
       repo
       :
@@ -44,7 +44,7 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter and operato
     test
      
     <span
-      className="search-operator"
+      className="search-keyword"
       key="22"
     >
       and
@@ -63,7 +63,7 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight negated filter 1`]
     className="text-monospace search-query-link"
   >
     <span
-      className="search-keyword"
+      className="search-filter-keyword"
     >
       -lang
       :
@@ -85,7 +85,7 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight operator 1`] = `
     test
      
     <span
-      className="search-operator"
+      className="search-keyword"
       key="5"
     >
       or

--- a/client/web/src/repogroups/RepogroupPage.tsx
+++ b/client/web/src/repogroups/RepogroupPage.tsx
@@ -103,7 +103,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                     <>{props.repogroupMetadata.description}</>
                 ) : (
                     <span className="text-monospace">
-                        <span className="search-keyword">repogroup:</span>
+                        <span className="search-filter-keyword">repogroup:</span>
                         {props.repogroupMetadata.name}
                     </span>
                 )}
@@ -164,7 +164,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                                 <p>
                                     Using the syntax{' '}
                                     <code>
-                                        <span className="search-keyword ">repogroup:</span>
+                                        <span className="search-filter-keyword ">repogroup:</span>
                                         {props.repogroupMetadata.name}
                                     </code>{' '}
                                     in a query will search these repositories:
@@ -204,7 +204,7 @@ const RepoLink: React.FunctionComponent<{ repo: string }> = ({ repo }) => (
                 <a href={`https://${repo}`} target="_blank" rel="noopener noreferrer" onClick={RepoLinkClicked(repo)}>
                     <GithubIcon className="icon-inline repogroup-page__repo-list-icon" />
                 </a>
-                <Link to={`/${repo}`} className="text-monospace search-keyword">
+                <Link to={`/${repo}`} className="text-monospace search-filter-keyword">
                     {displayRepoName(repo)}
                 </Link>
             </>
@@ -214,7 +214,7 @@ const RepoLink: React.FunctionComponent<{ repo: string }> = ({ repo }) => (
                 <a href={`https://${repo}`} target="_blank" rel="noopener noreferrer" onClick={RepoLinkClicked(repo)}>
                     <GitlabIcon className="icon-inline repogroup-page__repo-list-icon" />
                 </a>
-                <Link to={`/${repo}`} className="text-monospace search-keyword">
+                <Link to={`/${repo}`} className="text-monospace search-filter-keyword">
                     {displayRepoName(repo)}
                 </Link>
             </>
@@ -224,7 +224,7 @@ const RepoLink: React.FunctionComponent<{ repo: string }> = ({ repo }) => (
                 <a href={`https://${repo}`} target="_blank" rel="noopener noreferrer" onClick={RepoLinkClicked(repo)}>
                     <BitbucketIcon className="icon-inline repogroup-page__repo-list-icon" />
                 </a>
-                <Link to={`/${repo}`} className="text-monospace search-keyword">
+                <Link to={`/${repo}`} className="text-monospace search-filter-keyword">
                     {displayRepoName(repo)}
                 </Link>
             </>

--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -120,7 +120,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                             <div className="d-flex align-items-baseline mb-3">
                                 <h3 className="search-page__help-content-header mr-2">Search in repository groups</h3>
                                 <small className="text-monospace font-weight-normal small">
-                                    <span className="search-keyword">repogroup:</span>
+                                    <span className="search-filter-keyword">repogroup:</span>
                                     <i>name</i>
                                 </small>
                             </div>
@@ -214,7 +214,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                                         <h3 className="search-page__help-content-header">
                                             Search a language{' '}
                                             <small className="text-monospace font-weight-normal">
-                                                <span className="search-keyword ml-1">lang:</span>
+                                                <span className="search-filter-keyword ml-1">lang:</span>
                                                 <i>name</i>
                                             </small>
                                         </h3>
@@ -225,7 +225,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                                                 .slice(0, Math.ceil(homepageLanguageList.length / 2))
                                                 .map(language => (
                                                     <Link
-                                                        className="search-keyword search-page__lang-link text-monospace mb-3"
+                                                        className="search-filter-keyword search-page__lang-link text-monospace mb-3"
                                                         to={`/search?q=lang:${language.filterName}`}
                                                         key={language.name}
                                                     >
@@ -241,7 +241,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                                                 )
                                                 .map(language => (
                                                     <Link
-                                                        className="search-keyword search-page__lang-link text-monospace mb-3"
+                                                        className="search-filter-keyword search-page__lang-link text-monospace mb-3"
                                                         to={`/search?q=lang:${language.filterName}`}
                                                         key={language.name}
                                                         onClick={LanguageExampleClicked(language.filterName)}

--- a/client/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
@@ -262,7 +262,7 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                           className="text-monospace search-query-link"
                         >
                           <span
-                            className="search-keyword"
+                            className="search-filter-keyword"
                           >
                             r
                             :
@@ -624,7 +624,7 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                           className="text-monospace search-query-link"
                         >
                           <span
-                            className="search-keyword"
+                            className="search-filter-keyword"
                           >
                             r
                             :
@@ -718,7 +718,7 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                           className="text-monospace search-query-link"
                         >
                           <span
-                            className="search-keyword"
+                            className="search-filter-keyword"
                           >
                             r
                             :
@@ -1013,7 +1013,7 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                           className="text-monospace search-query-link"
                         >
                           <span
-                            className="search-keyword"
+                            className="search-filter-keyword"
                           >
                             r
                             :

--- a/client/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -182,7 +182,7 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -369,7 +369,7 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -401,7 +401,7 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -433,7 +433,7 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -675,7 +675,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -707,7 +707,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -739,7 +739,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -771,7 +771,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -803,7 +803,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -835,7 +835,7 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -1004,7 +1004,7 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :
@@ -1036,7 +1036,7 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
                       className="text-monospace search-query-link"
                     >
                       <span
-                        className="search-keyword"
+                        className="search-filter-keyword"
                       >
                         repo
                         :


### PR DESCRIPTION
Stacked on #15551.

This renames `operator` tokens and `OperatorKind` to `keyword` resp. `KeywordKind`. Reason is, in the parser, I want to create the `OperatorKind` enum as:

```
enum OperatorKind {
    Or = 'OR',
    And = 'AND',
    Concat = 'CONCAT',
}
```
`NOT` isn't really an 'operator', at least, it doesn't deserve to be part of `OperatorKind`, because we simply use it as a keyword to apply negation to a leaf node ("filter" AKA parameter or pattern). We may introduce more keywords which are not operators later (e.g., `WHERE`, or something like that). There may come a time where we distinguish different keywords (`OperatorKeyword` versus something else), but we don't need that fidelity right now.

Separately, we have a notion of concatenating terms in the tree (e.g., `foo bar or baz` is technically a tree 

`(or (concat (foo bar) baz)`, 

where concat is a placeholder that decides what to substitute for whitespace between patterns. There is no corresponding syntax "keyword" for concat, it comes down to the ordering of whitespace-separated patterns.

 To separate our syntax from tree definition, I find it clear to just refer to these tokens as keywords in the scanner, and operators in parser for now.

We do have an existing use of `keyword` which refers to the `repo` part of `repo:foo`. See [inline-comment](https://github.com/sourcegraph/sourcegraph/pull/15558#discussion_r519315113).