### PR TITLE
Update active viewer when all viewers are removed

### DIFF
--- a/client/shared/src/api/client/services/viewerService.ts
+++ b/client/shared/src/api/client/services/viewerService.ts
@@ -234,6 +234,8 @@ export function createViewerService(modelService: Pick<ModelService, 'removeMode
             const updates: ViewerUpdate[] = [...viewers.keys()].map(viewerId => ({ type: 'deleted', viewerId }))
             viewers.clear()
             viewerUpdates.next(updates)
+            // The active viewer will have been removed
+            activeViewerUpdates.next(undefined)
         },
     }
 }


### PR DESCRIPTION
Fix #15065

We emitted `activeViewerUpdates` when individual viewers were removed, but not when all viewers were removed. `BlobPage` calls `removeAllViewers`, so context was computed with the last `CodeEditor`'s document.