### PR TITLE
search: add mutation createCodeMonitor

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -108,6 +108,24 @@ type ListActionArgs struct {
 type CreateCodeMonitorArgs struct {
 	Namespace   graphql.ID
 	Description string
+	Enabled     bool
+	Trigger     *CreateTriggerArgs
+	Actions     []*CreateActionArgs
+}
+
+type CreateTriggerArgs struct {
+	Query string
+}
+
+type CreateActionArgs struct {
+	Email *CreateActionEmailArgs
+}
+
+type CreateActionEmailArgs struct {
+	Enabled    bool
+	Priority   string
+	Recipients []graphql.ID
+	Header     string
 }
 
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -9,7 +9,8 @@ import (
 )
 
 type CodeMonitorsResolver interface {
-	Monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
+	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
+	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -104,6 +105,11 @@ type ListActionArgs struct {
 	After *string
 }
 
+type CreateCodeMonitorArgs struct {
+	Namespace   graphql.ID
+	Description string
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -111,6 +117,10 @@ var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available 
 type defaultCodeMonitorsResolver struct {
 }
 
-func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3269,7 +3269,7 @@ input MonitorEmailInput {
     """
     priority: MonitorEmailPriority!
     """
-    The recipients of the email.
+    A list of users or orgs which will receive the email.
     """
     recipients: [ID!]!
     """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -744,14 +744,26 @@ type Mutation {
     """
     createCodeMonitor(
         """
-        The namepsace represents the owener of the code monitor.
-        Owners can either be users or organziations.
+        The namespace represents the owner of the code monitor.
+        Owners can either be users or organizations.
         """
         namespace: ID!
         """
         A meaningful description of the code monitor.
         """
         description: String!
+        """
+        Whether the code monitor is enabled or not.
+        """
+        enabled: Boolean!
+        """
+        A trigger.
+        """
+        trigger: MonitorTriggerInput!
+        """
+        A list of actions.
+        """
+        actions: [MonitorActionInput!]!
     ): Monitor!
 }
 
@@ -3222,6 +3234,48 @@ enum EventStatus {
     PENDING
     SUCCESS
     ERROR
+}
+
+"""
+The input required to create a trigger.
+"""
+input MonitorTriggerInput {
+    """
+    The query string.
+    """
+    query: String!
+    }
+
+"""
+The input required to create an action.
+"""
+input MonitorActionInput {
+    """
+    An email action.
+    """
+    email: MonitorEmailInput
+}
+
+"""
+The input required to create an email action.
+"""
+input MonitorEmailInput {
+    """
+    Whether the email action is enabled or not.
+    """
+    enabled:    Boolean!
+    """
+    The priority of the email.
+    """
+    priority:   MonitorEmailPriority!
+    """
+    The recipients of the email.
+    """
+    recipients:  [ID!]!
+    """
+    Use header to automatically approve the message in a read-only or moderated mailing list.
+    """
+    header:     String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -739,6 +739,20 @@ type Mutation {
         """
         level: String!
     ): EmptyResponse!
+    """
+    Create a code monitor.
+    """
+    createCodeMonitor(
+        """
+        The namepsace represents the owener of the code monitor.
+        Owners can either be users or organziations.
+        """
+        namespace: ID!
+        """
+        A meaningful description of the code monitor.
+        """
+        description: String!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3244,7 +3244,7 @@ input MonitorTriggerInput {
     The query string.
     """
     query: String!
-    }
+}
 
 """
 The input required to create an action.
@@ -3263,19 +3263,19 @@ input MonitorEmailInput {
     """
     Whether the email action is enabled or not.
     """
-    enabled:    Boolean!
+    enabled: Boolean!
     """
     The priority of the email.
     """
-    priority:   MonitorEmailPriority!
+    priority: MonitorEmailPriority!
     """
     The recipients of the email.
     """
-    recipients:  [ID!]!
+    recipients: [ID!]!
     """
     Use header to automatically approve the message in a read-only or moderated mailing list.
     """
-    header:     String!
+    header: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -732,6 +732,20 @@ type Mutation {
         """
         level: String!
     ): EmptyResponse!
+    """
+    Create a code monitor.
+    """
+    createCodeMonitor(
+        """
+        The namepsace represents the owener of the code monitor.
+        Owners can either be users or organziations.
+        """
+        namespace: ID!
+        """
+        A meaningful description of the code monitor.
+        """
+        description: String!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -737,14 +737,26 @@ type Mutation {
     """
     createCodeMonitor(
         """
-        The namepsace represents the owener of the code monitor.
-        Owners can either be users or organziations.
+        The namespace represents the owner of the code monitor.
+        Owners can either be users or organizations.
         """
         namespace: ID!
         """
         A meaningful description of the code monitor.
         """
         description: String!
+        """
+        Whether the code monitor is enabled or not.
+        """
+        enabled: Boolean!
+        """
+        A trigger.
+        """
+        trigger: MonitorTriggerInput!
+        """
+        A list of actions.
+        """
+        actions: [MonitorActionInput!]!
     ): Monitor!
 }
 
@@ -3215,6 +3227,48 @@ enum EventStatus {
     PENDING
     SUCCESS
     ERROR
+}
+
+"""
+The input required to create a trigger.
+"""
+input MonitorTriggerInput {
+    """
+    The query string.
+    """
+    query: String!
+    }
+
+"""
+The input required to create an action.
+"""
+input MonitorActionInput {
+    """
+    An email action.
+    """
+    email: MonitorEmailInput
+}
+
+"""
+The input required to create an email action.
+"""
+input MonitorEmailInput {
+    """
+    Whether the email action is enabled or not.
+    """
+    enabled:    Boolean!
+    """
+    The priority of the email.
+    """
+    priority:   MonitorEmailPriority!
+    """
+    The recipients of the email.
+    """
+    recipients:  [ID!]!
+    """
+    Use header to automatically approve the message in a read-only or moderated mailing list.
+    """
+    header:     String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3262,7 +3262,7 @@ input MonitorEmailInput {
     """
     priority: MonitorEmailPriority!
     """
-    The recipients of the email.
+    A list of users or orgs which will receive the email.
     """
     recipients: [ID!]!
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3237,7 +3237,7 @@ input MonitorTriggerInput {
     The query string.
     """
     query: String!
-    }
+}
 
 """
 The input required to create an action.
@@ -3256,19 +3256,19 @@ input MonitorEmailInput {
     """
     Whether the email action is enabled or not.
     """
-    enabled:    Boolean!
+    enabled: Boolean!
     """
     The priority of the email.
     """
-    priority:   MonitorEmailPriority!
+    priority: MonitorEmailPriority!
     """
     The recipients of the email.
     """
-    recipients:  [ID!]!
+    recipients: [ID!]!
     """
     Use header to automatically approve the message in a read-only or moderated mailing list.
     """
-    header:     String!
+    header: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -350,5 +350,5 @@ func (r *UserResolver) Monitors(ctx context.Context, args *ListMonitorsArgs) (Mo
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
 		return nil, err
 	}
-	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.ID(), args)
+	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.user.ID, args)
 }

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
 func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	enterpriseServices.CodeMonitorsResolver = &resolvers.Resolver{}
+	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(dbconn.Global)
 	return nil
 }

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -13,15 +13,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 // NewResolver returns a new Resolver that uses the given db
-func NewResolver(db *sql.DB) graphqlbackend.CodeMonitorsResolver {
+func NewResolver(db dbutil.DB) graphqlbackend.CodeMonitorsResolver {
 	return &Resolver{db: basestore.NewWithDB(db, sql.TxOptions{}), clock: func() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }}
 }
 
 // newResolverWithClock is used in tests to set the clock manually.
-func newResolverWithClock(db *sql.DB, clock func() time.Time) graphqlbackend.CodeMonitorsResolver {
+func newResolverWithClock(db dbutil.DB, clock func() time.Time) graphqlbackend.CodeMonitorsResolver {
 	return &Resolver{db: basestore.NewWithDB(db, sql.TxOptions{}), clock: clock}
 }
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -64,7 +64,8 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 	defer func() { err = tx.db.Done(err) }()
 
 	// create code monitor
-	q, err := tx.createCodeMonitorQuery(ctx, args)
+	var q *sqlf.Query
+	q, err = tx.createCodeMonitorQuery(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +87,12 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 	// create actions
 	for i, action := range args.Actions {
 		if action.Email != nil {
-			q, err := tx.createActionEmailQuery(ctx, m.(*monitor).id, action.Email)
+			q, err = tx.createActionEmailQuery(ctx, m.(*monitor).id, action.Email)
 			if err != nil {
 				return nil, err
 			}
-			e, err := tx.runEmailQuery(ctx, q)
+			var e graphqlbackend.MonitorEmailResolver
+			e, err = tx.runEmailQuery(ctx, q)
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -1,0 +1,82 @@
+package resolvers
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestCreateCodeMonitor(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	username := "code-monitors-resolver-user"
+	userID := insertTestUser(t, dbconn.Global, username, true)
+	_, err := db.Orgs.Create(ctx, "test-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+	r := Resolver{
+		db:    dbconn.Global,
+		clock: clock,
+	}
+
+	want := &monitor{
+		id:              1,
+		createdBy:       userID,
+		createdAt:       clock(),
+		changedBy:       userID,
+		changedAt:       clock(),
+		description:     "banana",
+		enabled:         true,
+		namespaceUserID: &userID,
+		namespaceOrgID:  nil,
+	}
+
+	// Create a monitor
+	ctx = actor.WithActor(ctx, actor.FromUser(userID))
+	ns := relay.MarshalID("User", userID)
+	got, err := r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
+		Namespace:   ns,
+		Description: "banana",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, got.(*monitor)) {
+		t.Fatalf("\ngot %+v,\nwant %+v", got, want)
+	}
+}
+
+func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
+
+	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return userID
+}

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func TestCreateCodeMonitor(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	t.Skip()
+	//if testing.Short() {
+	//}
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -17,10 +17,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
+func init() {
+	dbtesting.DBNameSuffix = "codemonitorsdb"
+}
+
 func TestCreateCodeMonitor(t *testing.T) {
-	t.Skip()
-	//if testing.Short() {
-	//}
+	if testing.Short() {
+		t.Skip()
+	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)


### PR DESCRIPTION
This PR adds the first mutation for code monitors. I also updated the query to return real data for monitors instead of dummy data. I borrowed a lot of ideas from campaigns (clocked resolver, test setup, ...) which saved me a lot of time. 

Next up: mutations for delete, toggle, and edit code monitors.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
