### PR TITLE
licensing: enforce site admin roles

### DIFF
--- a/enterprise/cmd/frontend/internal/licensing/enforcement/main_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/main_test.go
@@ -1,0 +1,17 @@
+package enforcement
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/inconshreveable/log15"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
+	}
+	os.Exit(m.Run())
+}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -59,7 +59,7 @@ func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 	}
 }
 
-// NewAfterCreateUserHook returns a AfterCreateUserHook closure with the given UsersStore.
+// NewAfterCreateUserHook returns a AfterCreateUserHook closure.
 func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) error {
 	// 🚨 SECURITY: To be extra safe that we never prompt any new user to be site admin on Sourcegraph Cloud.
 	if !licensing.EnforceTiers || envvar.SourcegraphDotComMode() {
@@ -87,7 +87,7 @@ func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) erro
 	}
 }
 
-// NewPreCreateUserHook returns a PreCreateUserHook closure with the given UsersStore.
+// NewPreSetUserIsSiteAdmin returns a PreSetUserIsSiteAdmin closure.
 func NewPreSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
 	return func(isSiteAdmin bool) error {
 		if isSiteAdmin {

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -13,8 +13,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
-// NewPreCreateUserHook returns a PreCreateUserHook closure with the given UsersStore.
-func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
+// NewBeforeCreateUserHook returns a BeforeCreateUserHook closure with the given UsersStore
+// that determines whether new user is allowed to be created.
+func NewBeforeCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 	return func(ctx context.Context) error {
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {
@@ -59,7 +60,8 @@ func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 	}
 }
 
-// NewAfterCreateUserHook returns a AfterCreateUserHook closure.
+// NewAfterCreateUserHook returns a AfterCreateUserHook closure that determines whether
+// a new user should be promoted to site admin based on the product license.
 func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) error {
 	// 🚨 SECURITY: To be extra safe that we never promote any new user to be site admin on Sourcegraph Cloud.
 	if !licensing.EnforceTiers || envvar.SourcegraphDotComMode() {
@@ -87,8 +89,9 @@ func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) erro
 	}
 }
 
-// NewPreSetUserIsSiteAdmin returns a PreSetUserIsSiteAdmin closure.
-func NewPreSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
+// NewBeforeSetUserIsSiteAdmin returns a BeforeSetUserIsSiteAdmin closure that determines whether
+// non-site admin roles are allowed (i.e. revoke site admins) based on the product license.
+func NewBeforeSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
 	if !licensing.EnforceTiers {
 		return nil
 	}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -23,8 +23,8 @@ func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 		var licensedUserCount int32
 		if info != nil {
 			// We prevent creating new users when the license is expired because we do not want
-			// all new users to be prompted as site admins automatically until the customer decides
-			// to downgrade to Free tier.
+			// all new users to be promoted as site admins automatically until the customer
+			// decides to downgrade to Free tier.
 			if licensing.EnforceTiers && info.IsExpired() {
 				return errcode.NewPresentationError("Unable to create user account: Sourcegraph license expired! No new users can be created. Update the license key in the [**site configuration**](/site-admin/configuration) or downgrade to only using Sourcegraph Free features.")
 			}
@@ -61,7 +61,7 @@ func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 
 // NewAfterCreateUserHook returns a AfterCreateUserHook closure.
 func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) error {
-	// 🚨 SECURITY: To be extra safe that we never prompt any new user to be site admin on Sourcegraph Cloud.
+	// 🚨 SECURITY: To be extra safe that we never promote any new user to be site admin on Sourcegraph Cloud.
 	if !licensing.EnforceTiers || envvar.SourcegraphDotComMode() {
 		return nil
 	}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
-// NewPreCreateUserHook returns a PreCreateUserHook closure with
-// the given UsersStore.
+// NewPreCreateUserHook returns a PreCreateUserHook closure with the given UsersStore.
 func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 	return func(ctx context.Context) error {
 		info, err := licensing.GetConfiguredProductLicenseInfo()
@@ -20,6 +22,12 @@ func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 		}
 		var licensedUserCount int32
 		if info != nil {
+			// We prevent creating new users when the license is expired because we do not want
+			// all new users to be prompted as site admins automatically until the customer decides
+			// to downgrade to Free tier.
+			if licensing.EnforceTiers && info.IsExpired() {
+				return errcode.NewPresentationError("Unable to create user account: Sourcegraph license expired! No new users can be created. Update the license key in the [**site configuration**](/site-admin/configuration) or downgrade to only using Sourcegraph Free features.")
+			}
 			licensedUserCount = int32(info.UserCount)
 		} else {
 			licensedUserCount = licensing.NoLicenseMaximumAllowedUserCount
@@ -48,5 +56,53 @@ func NewPreCreateUserHook(s licensing.UsersStore) func(context.Context) error {
 		}
 
 		return nil
+	}
+}
+
+// NewAfterCreateUserHook returns a AfterCreateUserHook closure with the given UsersStore.
+func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) error {
+	// 🚨 SECURITY: To be extra safe that we never prompt any new user to be site admin on Sourcegraph Cloud.
+	if !licensing.EnforceTiers || envvar.SourcegraphDotComMode() {
+		return nil
+	}
+
+	return func(ctx context.Context, tx dbutil.DB, user *types.User) error {
+		info, err := licensing.GetConfiguredProductLicenseInfo()
+		if err != nil {
+			return err
+		}
+
+		// Nil info indicates no license, thus Free tier
+		if info == nil {
+			user.SiteAdmin = true
+			// TODO: Use db.Users.SetIsSiteAdmin when it migrated to have `*basestore.Store`
+			//  and support `With` method.
+			_, err := tx.ExecContext(ctx, "UPDATE users SET site_admin=$1 WHERE id=$2", user.SiteAdmin, user.ID)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// NewPreCreateUserHook returns a PreCreateUserHook closure with the given UsersStore.
+func NewPreSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
+	return func(isSiteAdmin bool) error {
+		if isSiteAdmin {
+			return nil
+		}
+
+		info, err := licensing.GetConfiguredProductLicenseInfo()
+		if err != nil {
+			return err
+		}
+
+		if info != nil {
+			return nil
+		}
+
+		return licensing.NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", "non-site admin roles"))
 	}
 }

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -89,6 +89,10 @@ func NewAfterCreateUserHook() func(context.Context, dbutil.DB, *types.User) erro
 
 // NewPreSetUserIsSiteAdmin returns a PreSetUserIsSiteAdmin closure.
 func NewPreSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
+	if !licensing.EnforceTiers {
+		return nil
+	}
+
 	return func(isSiteAdmin bool) error {
 		if isSiteAdmin {
 			return nil

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -206,7 +206,7 @@ func TestEnforcement_PreSetUserIsSiteAdmin(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "prompt to site admin is OK",
+			name:        "promote to site admin is OK",
 			isSiteAdmin: true,
 			wantErr:     false,
 		},

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -89,7 +89,7 @@ func TestEnforcement_PreCreateUser(t *testing.T) {
 			}
 			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 			store := fakeStore{count: test.activeUserCount}
-			err := NewPreCreateUserHook(store)(context.Background())
+			err := NewBeforeCreateUserHook(store)(context.Background())
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("got error %v, want %v", gotErr, test.wantErr)
 			}
@@ -228,7 +228,7 @@ func TestEnforcement_PreSetUserIsSiteAdmin(t *testing.T) {
 				return test.license, "test-signature", nil
 			}
 			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
-			err := NewPreSetUserIsSiteAdmin()(test.isSiteAdmin)
+			err := NewBeforeSetUserIsSiteAdmin()(test.isSiteAdmin)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("got error %v, want %v", gotErr, test.wantErr)
 			}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -2,14 +2,24 @@ package enforcement
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 )
 
-func TestEnforcementPreCreateUser(t *testing.T) {
+func TestEnforcement_PreCreateUser(t *testing.T) {
+	if !licensing.EnforceTiers {
+		licensing.EnforceTiers = true
+		defer func() { licensing.EnforceTiers = false }()
+	}
+
+	expiresAt := time.Now().Add(time.Hour)
 	tests := []struct {
 		license         *license.Info
 		activeUserCount int
@@ -17,53 +27,59 @@ func TestEnforcementPreCreateUser(t *testing.T) {
 	}{
 		// See the impl for why we treat UserCount == 0 as unlimited.
 		{
-			license:         &license.Info{UserCount: 0},
+			license:         &license.Info{UserCount: 0, ExpiresAt: expiresAt},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 
 		// Non-true-up licenses.
 		{
-			license:         &license.Info{UserCount: 10},
+			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 0,
 			wantErr:         false,
 		},
 		{
-			license:         &license.Info{UserCount: 10},
+			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 		{
-			license:         &license.Info{UserCount: 10},
+			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 9,
 			wantErr:         false,
 		},
 		{
-			license:         &license.Info{UserCount: 10},
+			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 10,
 			wantErr:         true,
 		},
 		{
-			license:         &license.Info{UserCount: 10},
+			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 11,
 			wantErr:         true,
 		},
 		{
-			license:         &license.Info{UserCount: 10},
+			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 12,
 			wantErr:         true,
 		},
 
 		// True-up licenses.
 		{
-			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10},
+			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 		{
-			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10},
+			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 15,
 			wantErr:         false,
+		},
+
+		// License expired
+		{
+			license: &license.Info{ExpiresAt: time.Now().Add(-1 * time.Minute)},
+			wantErr: true,
 		},
 	}
 	for _, test := range tests {
@@ -85,4 +101,94 @@ type fakeStore struct{ count int }
 
 func (s fakeStore) Count(context.Context) (int, error) {
 	return s.count, nil
+}
+
+func TestEnforcement_AfterCreateUser(t *testing.T) {
+	if !licensing.EnforceTiers {
+		licensing.EnforceTiers = true
+		defer func() { licensing.EnforceTiers = false }()
+	}
+
+	tests := []struct {
+		name                  string
+		setup                 func(t *testing.T)
+		license               *license.Info
+		wantCalledExecContext bool
+		wantSiteAdmin         bool
+	}{
+		{
+			name:                  "with a valid license",
+			license:               &license.Info{UserCount: 10},
+			wantCalledExecContext: false,
+			wantSiteAdmin:         false,
+		},
+		{
+			name: "dotcom mode should always do nothing",
+			setup: func(t *testing.T) {
+				orig := envvar.SourcegraphDotComMode()
+				envvar.MockSourcegraphDotComMode(true)
+				t.Cleanup(func() {
+					envvar.MockSourcegraphDotComMode(orig)
+				})
+			},
+			wantCalledExecContext: false,
+			wantSiteAdmin:         false,
+		},
+		{
+			name:                  "no license sets new user to be site admin",
+			wantCalledExecContext: true,
+			wantSiteAdmin:         true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+
+			licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+				return test.license, "test-signature", nil
+			}
+			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
+
+			calledExecContext := false
+			db := &fakeDB{
+				execContext: func(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+					calledExecContext = true
+					return nil, nil
+				},
+			}
+			user := new(types.User)
+
+			hook := NewAfterCreateUserHook()
+			if hook != nil {
+				err := NewAfterCreateUserHook()(context.Background(), db, user)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if test.wantCalledExecContext != calledExecContext {
+				t.Fatalf("calledExecContext: want %v but got %v", test.wantCalledExecContext, calledExecContext)
+			} else if test.wantSiteAdmin != user.SiteAdmin {
+				t.Fatalf("siteAdmin: want %v but got %v", test.wantSiteAdmin, user.SiteAdmin)
+			}
+		})
+	}
+}
+
+type fakeDB struct {
+	execContext func(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
+func (db *fakeDB) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
+	panic("implement me")
+}
+
+func (db *fakeDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return db.execContext(ctx, query, args...)
+}
+
+func (db *fakeDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	panic("implement me")
 }

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -24,11 +24,11 @@ import (
 func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
-	db.Users.PreCreateUser = enforcement.NewPreCreateUserHook(&usersStore{})
+	db.Users.BeforeCreateUser = enforcement.NewBeforeCreateUserHook(&usersStore{})
 
 	// Enforce non-site admin roles in Free tier.
 	db.Users.AfterCreateUser = enforcement.NewAfterCreateUserHook()
-	db.Users.PreSetUserIsSiteAdmin = enforcement.NewPreSetUserIsSiteAdmin()
+	db.Users.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
 
 	// Enforce the license's max external service count by preventing the creation of new external
 	// services when the max is reached.

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -26,6 +26,10 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 	// reached.
 	db.Users.PreCreateUser = enforcement.NewPreCreateUserHook(&usersStore{})
 
+	// Enforce non-site admin roles in Free tier.
+	db.Users.AfterCreateUser = enforcement.NewAfterCreateUserHook()
+	db.Users.PreSetUserIsSiteAdmin = enforcement.NewPreSetUserIsSiteAdmin()
+
 	// Enforce the license's max external service count by preventing the creation of new external
 	// services when the max is reached.
 	db.ExternalServices.PreCreateExternalService = enforcement.NewPreCreateExternalServiceHook(&externalServicesStore{})

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -36,7 +36,7 @@ func Check(feature Feature) error {
 
 func checkFeature(info *Info, feature Feature) error {
 	if info == nil {
-		return newFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", feature))
+		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", feature))
 	}
 
 	// Check if the feature is explicitly allowed via license tag.
@@ -49,7 +49,7 @@ func checkFeature(info *Info, feature Feature) error {
 		return false
 	}
 	if !info.Plan().HasFeature(feature) && !hasFeature(feature) {
-		return newFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", feature))
+		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", feature))
 	}
 	return nil // feature is activated for current license
 }
@@ -66,7 +66,7 @@ func TestingSkipFeatureChecks() func() {
 	return func() { MockCheckFeature = nil }
 }
 
-func newFeatureNotActivatedError(message string) featureNotActivatedError {
+func NewFeatureNotActivatedError(message string) featureNotActivatedError {
 	e := errcode.NewPresentationError(message).(errcode.PresentationError)
 	return featureNotActivatedError{e}
 }

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -27,16 +27,16 @@ import (
 //
 // For a detailed overview of the schema, see schema.md.
 type users struct {
-	// PreCreateUser (if set) is a hook called before creating a new user in the DB by any means
+	// BeforeCreateUser (if set) is a hook called before creating a new user in the DB by any means
 	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
-	PreCreateUser func(context.Context) error
+	BeforeCreateUser func(context.Context) error
 	// AfterCreateUser (if set) is a hook called after creating a new user in the DB by any means
 	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
 	// Whatever this hook mutates in database should be reflected on the `user` argument as well.
 	AfterCreateUser func(ctx context.Context, tx dbutil.DB, user *types.User) error
-	// PreSetUserIsSiteAdmin (if set) is a hook called before promoting/revoking a user to be a
+	// BeforeSetUserIsSiteAdmin (if set) is a hook called before promoting/revoking a user to be a
 	// site admin.
-	PreSetUserIsSiteAdmin func(isSiteAdmin bool) error
+	BeforeSetUserIsSiteAdmin func(isSiteAdmin bool) error
 }
 
 // userNotFoundErr is the error that is returned when a user is not found.
@@ -226,9 +226,9 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		return nil, errCannotCreateUser{"site_already_initialized"}
 	}
 
-	// Run PreCreateUser hook.
-	if u.PreCreateUser != nil {
-		if err := u.PreCreateUser(ctx); err != nil {
+	// Run BeforeCreateUser hook.
+	if u.BeforeCreateUser != nil {
+		if err := u.BeforeCreateUser(ctx); err != nil {
 			return nil, errors.Wrap(err, "pre create user hook")
 		}
 	}
@@ -541,8 +541,8 @@ func (u *users) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bool) 
 		return Mocks.Users.SetIsSiteAdmin(id, isSiteAdmin)
 	}
 
-	if u.PreSetUserIsSiteAdmin != nil {
-		if err := u.PreSetUserIsSiteAdmin(isSiteAdmin); err != nil {
+	if u.BeforeSetUserIsSiteAdmin != nil {
+		if err := u.BeforeSetUserIsSiteAdmin(isSiteAdmin); err != nil {
 			return err
 		}
 	}

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 	"unicode/utf8"
@@ -12,6 +11,8 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -29,6 +30,12 @@ type users struct {
 	// PreCreateUser (if set) is a hook called before creating a new user in the DB by any means
 	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
 	PreCreateUser func(context.Context) error
+	// AfterCreateUser (if set) is a hook called after creating a new user in the DB by any means
+	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
+	// Whatever this hook mutates in database should be reflected on the `user` argument as well.
+	AfterCreateUser func(ctx context.Context, tx dbutil.DB, user *types.User) error
+	// PreSetUserIsSiteAdmin (if set) is a hook called before (un)prompting a user to be a site admin.
+	PreSetUserIsSiteAdmin func(isSiteAdmin bool) error
 }
 
 // userNotFoundErr is the error that is returned when a user is not found.
@@ -221,7 +228,7 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 	// Run PreCreateUser hook.
 	if u.PreCreateUser != nil {
 		if err := u.PreCreateUser(ctx); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "pre create user hook")
 		}
 	}
 
@@ -269,6 +276,17 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		}
 	}
 
+	user := &types.User{
+		ID:                    id,
+		Username:              info.Username,
+		DisplayName:           info.DisplayName,
+		AvatarURL:             info.AvatarURL,
+		CreatedAt:             createdAt,
+		UpdatedAt:             updatedAt,
+		SiteAdmin:             siteAdmin,
+		BuiltinAuth:           info.Password != "",
+		InvalidatedSessionsAt: invalidatedSessionsAt,
+	}
 	{
 		// Run hooks.
 		//
@@ -283,19 +301,16 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		if err := OrgMembers.CreateMembershipInOrgsForAllUsers(ctx, tx, orgs); err != nil {
 			return nil, err
 		}
+
+		// Run AfterCreateUser hook
+		if u.AfterCreateUser != nil {
+			if err := u.AfterCreateUser(ctx, tx, user); err != nil {
+				return nil, errors.Wrap(err, "after create user hook")
+			}
+		}
 	}
 
-	return &types.User{
-		ID:                    id,
-		Username:              info.Username,
-		DisplayName:           info.DisplayName,
-		AvatarURL:             info.AvatarURL,
-		CreatedAt:             createdAt,
-		UpdatedAt:             updatedAt,
-		SiteAdmin:             siteAdmin,
-		BuiltinAuth:           info.Password != "",
-		InvalidatedSessionsAt: invalidatedSessionsAt,
-	}, nil
+	return user, nil
 }
 
 // orgsForAllUsersToJoin returns the list of org names that all users should be joined to. The second return value
@@ -519,10 +534,18 @@ func (u *users) HardDelete(ctx context.Context, id int32) error {
 	return nil
 }
 
+// SetIsSiteAdmin sets the the user with given ID to be or not to be the site admin.
 func (u *users) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bool) error {
 	if Mocks.Users.SetIsSiteAdmin != nil {
 		return Mocks.Users.SetIsSiteAdmin(id, isSiteAdmin)
 	}
+
+	if u.PreSetUserIsSiteAdmin != nil {
+		if err := u.PreSetUserIsSiteAdmin(isSiteAdmin); err != nil {
+			return err
+		}
+	}
+
 	_, err := dbconn.Global.ExecContext(ctx, "UPDATE users SET site_admin=$1 WHERE id=$2", isSiteAdmin, id)
 	return err
 }

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -34,7 +34,8 @@ type users struct {
 	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
 	// Whatever this hook mutates in database should be reflected on the `user` argument as well.
 	AfterCreateUser func(ctx context.Context, tx dbutil.DB, user *types.User) error
-	// PreSetUserIsSiteAdmin (if set) is a hook called before (un)prompting a user to be a site admin.
+	// PreSetUserIsSiteAdmin (if set) is a hook called before promoting/revoking a user to be a
+	// site admin.
 	PreSetUserIsSiteAdmin func(isSiteAdmin bool) error
 }
 


### PR DESCRIPTION
Non-site admins are not allowed in Free tier.

- All new users are promoted to be side admins in Free tier
- Prevent user creation with a malformed/expired license
- Prevent revoking site admins
- Dotcom: no new users can be promoted to site admin automatically

Unit tests are added and tested end-to-end.

Fixes #14023