### PR TITLE
Add username and improve formatting of email verification emails

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -125,8 +125,13 @@ func (userEmails) Add(ctx context.Context, userID int32, email string) error {
 	}
 
 	if conf.EmailVerificationRequired() && !emailAlreadyExistsAndIsVerified {
+		usr, err := db.Users.GetByID(ctx, userID)
+		if err != nil {
+			return err
+		}
+
 		// Send email verification email.
-		if err := SendUserEmailVerificationEmail(ctx, email, *code); err != nil {
+		if err := SendUserEmailVerificationEmail(ctx, usr.Username, email, *code); err != nil {
 			return errors.Wrap(err, "SendUserEmailVerificationEmail")
 		} else if err = db.UserEmails.SetLastVerificationSentAt(ctx, userID, email); err != nil {
 			return errors.Wrap(err, "SetLastVerificationSentAt")
@@ -147,7 +152,7 @@ func MakeEmailVerificationCode() (string, error) {
 
 // SendUserEmailVerificationEmail sends an email to the user to verify the email address. The code
 // is the verification code that the user must provide to verify their access to the email address.
-func SendUserEmailVerificationEmail(ctx context.Context, email, code string) error {
+func SendUserEmailVerificationEmail(ctx context.Context, username, email, code string) error {
 	q := make(url.Values)
 	q.Set("code", code)
 	q.Set("email", email)
@@ -156,11 +161,11 @@ func SendUserEmailVerificationEmail(ctx context.Context, email, code string) err
 		To:       []string{email},
 		Template: verifyEmailTemplates,
 		Data: struct {
-			Email string
-			URL   string
-			Host  string
+			Username string
+			URL      string
+			Host     string
 		}{
-			Email: email,
+			Username: username,
 			URL: globals.ExternalURL().ResolveReference(&url.URL{
 				Path:     verifyEmailPath.Path,
 				RawQuery: q.Encode(),
@@ -172,13 +177,15 @@ func SendUserEmailVerificationEmail(ctx context.Context, email, code string) err
 
 var verifyEmailTemplates = txemail.MustValidate(txtypes.Templates{
 	Subject: `Verify your email on Sourcegraph ({{.Host}})`,
-	Text: `
-Verify your email address {{printf "%q" .Email}} on Sourcegraph by following this link:
+	Text: `Hi {{.Username}},
 
-  {{.URL}}
+Please verify your email address on Sourcegraph ({{.Host}}) by clicking this link:
+
+{{.URL}}
 `,
-	HTML: `
-<p>Verify your email address {{printf "%q" .Email}} on Sourcegraph by following this link:</p>
+	HTML: `<p>Hi {{.Username}},</p>
+
+<p>Please verify your email address on Sourcegraph ({{.Host}}) by clicking this link:</p>
 
 <p><strong><a href="{{.URL}}">Verify email address</a></p>
 `,

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -134,7 +134,7 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 	}
 	defer func() { txemail.MockSend = nil }()
 
-	if err := SendUserEmailVerificationEmail(context.Background(), "a@example.com", "c"); err != nil {
+	if err := SendUserEmailVerificationEmail(context.Background(), "Alan Johnson", "a@example.com", "c"); err != nil {
 		t.Fatal(err)
 	}
 	if sent == nil {
@@ -145,13 +145,13 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 		To:       []string{"a@example.com"},
 		Template: verifyEmailTemplates,
 		Data: struct {
-			Email string
-			URL   string
-			Host  string
+			Username string
+			URL      string
+			Host     string
 		}{
-			Email: "a@example.com",
-			URL:   "http://example.com/-/verify-email?code=c&email=a%40example.com",
-			Host:  "example.com",
+			Username: "Alan Johnson",
+			URL:      "http://example.com/-/verify-email?code=c&email=a%40example.com",
+			Host:     "example.com",
 		},
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -170,7 +170,7 @@ func handleSignUp(w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInit
 	}
 
 	if conf.EmailVerificationRequired() && !newUserData.EmailIsVerified {
-		if err := backend.SendUserEmailVerificationEmail(r.Context(), creds.Email, newUserData.EmailVerificationCode); err != nil {
+		if err := backend.SendUserEmailVerificationEmail(r.Context(), usr.Username, creds.Email, newUserData.EmailVerificationCode); err != nil {
 			log15.Error("failed to send email verification (continuing, user's email will be unverified)", "email", creds.Email, "err", err)
 		} else if err = db.UserEmails.SetLastVerificationSentAt(r.Context(), usr.ID, creds.Email); err != nil {
 			log15.Error("failed to set email last verification sent at (user's email is verified)", "email", creds.Email, "err", err)


### PR DESCRIPTION
This PR fixes #10411 

I've added the username to these emails in place of the email address, and updated the copy based on @quinnkeast's suggestions.

preview:

![Screenshot 2020-11-09 at 10 18 31](https://user-images.githubusercontent.com/5236823/98529036-0aa47480-2275-11eb-82de-bac4cbdd84d3.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
