### PR TITLE
search: add mutations to delete, toggle, and edit code monitors

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -9,7 +9,8 @@ import (
 )
 
 type CodeMonitorsResolver interface {
-	Monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
+	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
+	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -104,6 +105,11 @@ type ListActionArgs struct {
 	After *string
 }
 
+type CreateCodeMonitorArgs struct {
+	Namespace   graphql.ID
+	Description string
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -111,6 +117,10 @@ var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available 
 type defaultCodeMonitorsResolver struct {
 }
 
-func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID graphql.ID, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -11,6 +11,9 @@ import (
 type CodeMonitorsResolver interface {
 	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
+	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)
+	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
+	EditCodeMonitor(ctx context.Context, args *EditCodeMonitorArgs) (MonitorResolver, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -110,6 +113,22 @@ type CreateCodeMonitorArgs struct {
 	Description string
 }
 
+type DeleteCodeMonitorArgs struct {
+	Id graphql.ID
+}
+
+type ToggleCodeMonitorArgs struct {
+	Id      graphql.ID
+	Enabled bool
+}
+
+type EditCodeMonitorArgs struct {
+	Id          graphql.ID
+	Namespace   graphql.ID
+	Description string
+	Enabled     bool
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -122,5 +141,17 @@ func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID int32,
 }
 
 func (d defaultCodeMonitorsResolver) CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) EditCodeMonitor(ctx context.Context, args *EditCodeMonitorArgs) (MonitorResolver, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -775,6 +775,28 @@ type Mutation {
         """
         enabled: Boolean!
     ): Monitor!
+    """
+    Edit a code monitor.
+    """
+    editCodeMonitor(
+        """
+        The ID of the code monitor.
+        """
+        id: ID!
+        """
+        A meaningful description of the code monitor.
+        """
+        description: String!
+        """
+        Whether the code monitor should be enabled or not.
+        """
+        enabled: Boolean!
+        """
+        The namepsace represents the owener of the code monitor.
+        Owners can either be users or organziations.
+        """
+        namespace: ID!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -753,6 +753,28 @@ type Mutation {
         """
         description: String!
     ): Monitor!
+    """
+    Delete a code monitor.
+    """
+    deleteCodeMonitor(
+        """
+        The ID of the code monitor.
+        """
+        id: ID!
+    ): EmptyResponse!
+    """
+    Toggle the state of a code monitor between enabled/disabled.
+    """
+    toggleCodeMonitor(
+        """
+        The ID of the code monitor.
+        """
+        id: ID!
+        """
+        Whether the code monitor should be enabled or not.
+        """
+        enabled: Boolean!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -739,6 +739,20 @@ type Mutation {
         """
         level: String!
     ): EmptyResponse!
+    """
+    Create a code monitor.
+    """
+    createCodeMonitor(
+        """
+        The namepsace represents the owener of the code monitor.
+        Owners can either be users or organziations.
+        """
+        namespace: ID!
+        """
+        A meaningful description of the code monitor.
+        """
+        description: String!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -732,6 +732,20 @@ type Mutation {
         """
         level: String!
     ): EmptyResponse!
+    """
+    Create a code monitor.
+    """
+    createCodeMonitor(
+        """
+        The namepsace represents the owener of the code monitor.
+        Owners can either be users or organziations.
+        """
+        namespace: ID!
+        """
+        A meaningful description of the code monitor.
+        """
+        description: String!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -746,6 +746,50 @@ type Mutation {
         """
         description: String!
     ): Monitor!
+    """
+    Delete a code monitor.
+    """
+    deleteCodeMonitor(
+        """
+        The ID of the code monitor.
+        """
+        id: ID!
+    ): EmptyResponse!
+    """
+    Toggle the state of a code monitor between enabled/disabled.
+    """
+    toggleCodeMonitor(
+        """
+        The ID of the code monitor.
+        """
+        id: ID!
+        """
+        Whether the code monitor should be enabled or not.
+        """
+        enabled: Boolean!
+    ): Monitor!
+    """
+    Edit a code monitor.
+    """
+    editCodeMonitor(
+        """
+        The ID of the code monitor.
+        """
+        id: ID!
+        """
+        A meaningful description of the code monitor.
+        """
+        description: String!
+        """
+        Whether the code monitor should be enabled or not.
+        """
+        enabled: Boolean!
+        """
+        The namepsace represents the owener of the code monitor.
+        Owners can either be users or organziations.
+        """
+        namespace: ID!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -350,5 +350,5 @@ func (r *UserResolver) Monitors(ctx context.Context, args *ListMonitorsArgs) (Mo
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
 		return nil, err
 	}
-	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.ID(), args)
+	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.user.ID, args)
 }

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
 func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	enterpriseServices.CodeMonitorsResolver = &resolvers.Resolver{}
+	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(dbconn.Global)
 	return nil
 }

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -100,8 +100,8 @@ func (r *Resolver) EditCodeMonitor(ctx context.Context, args *graphqlbackend.Edi
 
 func (r *Resolver) monitorForID(ctx context.Context, id graphql.ID) (graphqlbackend.MonitorResolver, error) {
 	monitorForIdQuery := `
-select * from cm_monitors
-where id = %s
+SELECT * FROM cm_monitors
+WHERE id = %s
 `
 	var monitorId int64
 	err := relay.UnmarshalSpec(id, &monitorId)

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -289,7 +289,7 @@ RETURNING %s;
 }
 
 func ownerForId32Query(ctx context.Context, monitorId int32) (*sqlf.Query, error) {
-	const ownerForId32Query = `SELECT namespace_user_id, namespace_org_id FROM cm_monitors where id = %s`
+	const ownerForId32Query = `SELECT namespace_user_id, namespace_org_id FROM cm_monitors WHERE id = %s`
 	return sqlf.Sprintf(
 		ownerForId32Query,
 		monitorId,
@@ -312,11 +312,11 @@ func deleteCodeMonitorQuery(ctx context.Context, args *graphqlbackend.DeleteCode
 func (r *Resolver) toggleCodeMonitorQuery(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*sqlf.Query, error) {
 	toggleCodeMonitorQuery := `
 UPDATE cm_monitors
-set enabled = %s,
+SET enabled = %s,
 	changed_by = %s,
 	changed_at = %s
-where id = %s
-returning %s 
+WHERE id = %s
+RETURNING %s 
 `
 	var monitorID int64
 	err := relay.UnmarshalSpec(args.Id, &monitorID)
@@ -338,14 +338,14 @@ returning %s
 func (r *Resolver) editCodeMonitorQuery(ctx context.Context, args *graphqlbackend.EditCodeMonitorArgs) (*sqlf.Query, error) {
 	editCodeMonitorQuery := `
 UPDATE cm_monitors
-set description = %s,
+SET description = %s,
 	enabled = %s,
 	namespace_user_id = %s,
 	namespace_org_id = %s,
 	changed_by = %s,
 	changed_at = %s
-where id = %s
-returning %s 
+WHERE id = %s
+RETURNING %s 
 `
 	var userID int32
 	var orgID int32

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -1,0 +1,82 @@
+package resolvers
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func TestCreateCodeMonitor(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+
+	username := "code-monitors-resolver-user"
+	userID := insertTestUser(t, dbconn.Global, username, true)
+	_, err := db.Orgs.Create(ctx, "test-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+	r := Resolver{
+		db:    dbconn.Global,
+		clock: clock,
+	}
+
+	want := &monitor{
+		id:              1,
+		createdBy:       userID,
+		createdAt:       clock(),
+		changedBy:       userID,
+		changedAt:       clock(),
+		description:     "banana",
+		enabled:         true,
+		namespaceUserID: &userID,
+		namespaceOrgID:  nil,
+	}
+
+	// Create a monitor
+	ctx = actor.WithActor(ctx, actor.FromUser(userID))
+	ns := relay.MarshalID("User", userID)
+	got, err := r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
+		Namespace:   ns,
+		Description: "banana",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, got.(*monitor)) {
+		t.Fatalf("\ngot %+v,\nwant %+v", got, want)
+	}
+}
+
+func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
+
+	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return userID
+}

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func TestCreateCodeMonitor(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	t.Skip()
+	//if testing.Short() {
+	//}
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -17,10 +17,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
+func init() {
+	dbtesting.DBNameSuffix = "codemonitorsdb"
+}
+
 func TestCreateCodeMonitor(t *testing.T) {
-	t.Skip()
-	//if testing.Short() {
-	//}
+	if testing.Short() {
+		t.Skip()
+	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)


### PR DESCRIPTION
stacked on top of #15569 

This PR completes the mutations for the table `cm_monitors`. 

The updated test is pretty long because it tests the flow `create->toggle->edit->delete->delete again`. Usually, I would prefer to split the test into several smaller tests, however, the setup is expensive so I decided to trade execution time against readability/maintainability.

Next up: mutations for actions

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
