### PR TITLE
Create basic code monitor creation page

### DIFF
--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -35,3 +35,4 @@
 @import './enterprise/productSubscription/TrueUpStatusSummary';
 @import './enterprise/user/productSubscriptions/PaymentTokenFormControl';
 @import './enterprise/codeintel/index';
+@import './enterprise/code-monitoring/index';

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,43 +1,28 @@
 import * as H from 'history'
-import React, { useMemo } from 'react'
+import React from 'react'
 import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
-import { Breadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
+import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageHeader } from '../../components/PageHeader'
 import { PageTitle } from '../../components/PageTitle'
 
-interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters {
+export interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters {
     location: H.Location
 }
 
-export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => {
-    props.useBreadcrumb(
-        useMemo(
-            () => ({
-                key: 'Code Monitoring',
-                element: <>Code Monitoring</>,
-            }),
-            []
-        )
-    )
-
-    return (
-        <div className="w-100">
-            <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
-            <div className="container mt-3 web-content">
-                <PageTitle title="Code Monitoring" />
-                <PageHeader
-                    title={
-                        <>
-                            Code Monitoring{' '}
-                            <sup>
-                                <span className="badge badge-info text-uppercase">Prototype</span>
-                            </sup>
-                        </>
-                    }
-                    icon={VideoInputAntennaIcon}
-                />
-                <div>Hello world</div>
-            </div>
-        </div>
-    )
-}
+export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => (
+    <div className="container mt-3 web-content">
+        <PageTitle title="Code Monitoring" />
+        <PageHeader
+            title={
+                <>
+                    Code Monitoring{' '}
+                    <sup>
+                        <span className="badge badge-info text-uppercase">Prototype</span>
+                    </sup>
+                </>
+            }
+            icon={VideoInputAntennaIcon}
+        />
+        <div>Hello world</div>
+    </div>
+)

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
@@ -7,4 +7,8 @@
             top: 1rem;
         }
     }
+
+    code {
+        background: $gray-10;
+    }
 }

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
@@ -1,0 +1,1 @@
+.create-monitor-page

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
@@ -1,1 +1,10 @@
-.create-monitor-page
+.create-monitor-page {
+    &__query-input {
+        position: relative;
+        &-preview-link {
+            position: absolute;
+            right: 0.375rem;
+            top: 1rem;
+        }
+    }
+}

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
@@ -7,8 +7,4 @@
             top: 1rem;
         }
     }
-
-    code {
-        background: $gray-10;
-    }
 }

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CodeMonitoringPage } from './CodeMonitoringPage'
+import { CreateCodeMonitoriPage } from './CreateCodeMonitoriPage'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
 

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { CodeMonitoringPage } from './CodeMonitoringPage'
+import { storiesOf } from '@storybook/react'
+import { WebStory } from '../../components/WebStory'
+
+const { add } = storiesOf('web/enterprise/code-monitoring/CreateCodeMonitorPage', module)
+
+add('Example', () => <WebStory>{props => <CodeMonitoringPage {...props} />}</WebStory>, {
+    design: {
+        type: 'figma',
+        url:
+            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+    },
+})

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -5,7 +5,7 @@ import { WebStory } from '../../components/WebStory'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CreateCodeMonitorPage', module)
 
-add('Example', () => <WebStory>{props => <CodeMonitoringPage {...props} />}</WebStory>, {
+add('Example', () => <WebStory>{props => <CreateCodeMonitoriPage {...props} />}</WebStory>, {
     design: {
         type: 'figma',
         url:

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { CreateCodeMonitoriPage } from './CreateCodeMonitoriPage'
+import { CreateCodeMonitorPage } from './CreateCodeMonitorPage'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CreateCodeMonitorPage', module)
 
-add('Example', () => <WebStory>{props => <CreateCodeMonitoriPage {...props} />}</WebStory>, {
+add('Example', () => <WebStory>{props => <CreateCodeMonitorPage {...props} />}</WebStory>, {
     design: {
         type: 'figma',
         url:

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -2,13 +2,30 @@ import React from 'react'
 import { CreateCodeMonitorPage } from './CreateCodeMonitorPage'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
+import { AuthenticatedUser } from '../../auth'
+import { boolean } from '@storybook/addon-knobs'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CreateCodeMonitorPage', module)
 
-add('Example', () => <WebStory>{props => <CreateCodeMonitorPage {...props} />}</WebStory>, {
-    design: {
-        type: 'figma',
-        url:
-            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
-    },
-})
+add(
+    'Example',
+    () => (
+        <WebStory>
+            {props => (
+                <CreateCodeMonitorPage
+                    {...props}
+                    authenticatedUser={
+                        boolean('isAuthenticated', false) ? ({ username: 'alice' } as AuthenticatedUser) : null
+                    }
+                />
+            )}
+        </WebStory>
+    ),
+    {
+        design: {
+            type: 'figma',
+            url:
+                'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+        },
+    }
+)

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -1,0 +1,157 @@
+import * as H from 'history'
+import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
+import React, { useCallback, useMemo, useState } from 'react'
+import { Form } from '../../../../branded/src/components/Form'
+import { Toggle } from '../../../../branded/src/components/Toggle'
+import { AuthenticatedUser } from '../../auth'
+import { Breadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
+import { PageHeader } from '../../components/PageHeader'
+import { PageTitle } from '../../components/PageTitle'
+
+interface Props extends BreadcrumbsProps, BreadcrumbSetters {
+    location: H.Location
+    authenticatedUser: AuthenticatedUser | null
+}
+export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
+    props.useBreadcrumb(
+        useMemo(
+            () => ({
+                key: 'Create Code Monitor',
+                element: <>Create new code monitor</>,
+            }),
+            []
+        )
+    )
+
+    const [showQueryForm, setShowQueryForm] = useState(false)
+    const toggleQueryForm: React.MouseEventHandler = useCallback(event => {
+        event.preventDefault()
+        setShowQueryForm(show => !show)
+    }, [])
+
+    const [showEmailNotificationForm, setShowEmailNotificationForm] = useState(false)
+    const toggleEmailNotificationForm: React.MouseEventHandler = useCallback(event => {
+        event.preventDefault()
+        setShowEmailNotificationForm(show => !show)
+    }, [])
+
+    const [active, setActive] = useState(false)
+    const toggleActive: (active: boolean) => void = useCallback(active => {
+        setActive(active)
+    }, [])
+
+    const [emailNotificationEnabled, setEmailNotificationEnabled] = useState(false)
+    const toggleEmailNotificationEnabled: (value: boolean) => void = useCallback(enabled => {
+        setEmailNotificationEnabled(enabled)
+    }, [])
+
+    return (
+        <div className="w-100">
+            <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
+            <div className="container mt-3 web-content">
+                <PageTitle title="Create new code monitor" />
+                <PageHeader title="Create new code monitor" icon={VideoInputAntennaIcon} />
+                Code monitors watch your code for specific triggers and run actions in response. Learn more.
+                <Form className="my-4">
+                    <div className="flex mb-4">
+                        Name
+                        <input type="text" className="form-control my-2" />
+                        <small className="text-muted">
+                            Give it a short, descriptive name to reference events on Sourcegraph and in notifications.
+                            Do not include confidential information.
+                        </small>
+                    </div>
+                    <div className="flex">
+                        Owner
+                        <select className="form-control my-2 w-auto" disabled={true}>
+                            <option value={props.authenticatedUser?.displayName || props.authenticatedUser?.username}>
+                                {props.authenticatedUser?.username}
+                            </option>
+                        </select>
+                        <small className="text-muted">Event history and configuration will not be shared.</small>
+                    </div>
+                    <hr className="my-4" />
+                    <h3>Trigger</h3>
+                    <div className="card p-3 my-3">
+                        <a href="" onClick={toggleQueryForm} className="font-weight-bold">
+                            When there are new search results
+                        </a>
+                        <span className="text-muted">
+                            This trigger will fire when new search results are found for a given search query.
+                        </span>
+                        {showQueryForm && (
+                            <>
+                                <input type="text" className="form-control my-2" />
+                            </>
+                        )}
+                    </div>
+                    <h3>Actions</h3>
+                    <p>Run any number of actions in response to an event</p>
+                    <div className="card p-3 my-3">
+                        {/* This should be its own component when you can add multiple email actions */}
+                        <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
+                            Send email notifications
+                        </a>
+                        <span className="text-muted">
+                            Deliver email notifications to specified recipients. Can customize delivery schedule and
+                            priority.
+                        </span>
+                        {showEmailNotificationForm && (
+                            <Form>
+                                <div className="mt-4">
+                                    Recipients
+                                    <input
+                                        type="text"
+                                        className="form-control my-2"
+                                        value={`${props.authenticatedUser?.email || ''} (you)`}
+                                        disabled={true}
+                                    />
+                                    <small className="text-muted">
+                                        Code monitors are currently limited to sending emails to your primary email
+                                        address.
+                                    </small>
+                                </div>
+                                <div className="mt-4">
+                                    Approved header
+                                    <input type="text" className="form-control my-2" />
+                                    <small className="text-muted">
+                                        Use the approved header to automatically approve the message in a read-only or
+                                        moderated mailing list.
+                                    </small>
+                                </div>
+                                <div className="flex my-4">
+                                    <Toggle
+                                        title="Enabled"
+                                        value={emailNotificationEnabled}
+                                        onToggle={toggleEmailNotificationEnabled}
+                                        className="mr-2"
+                                    />
+                                    Enabled
+                                </div>
+                                <div>
+                                    <button type="button" className="btn btn-outline-secondary">
+                                        Done
+                                    </button>
+                                    <button type="button" className="btn btn-outline-secondary">
+                                        Cancel
+                                    </button>
+                                </div>
+                            </Form>
+                        )}
+                    </div>
+                    <div className="flex my-4">
+                        <Toggle title="Active" value={active} onToggle={toggleActive} className="mr-2" /> Active
+                    </div>
+                    <div className="flex my-4">
+                        <button type="button" className="btn btn-primary">
+                            Create code monitor
+                        </button>
+                        <button type="button" className="btn btn-outline-secondary">
+                            Cancel
+                        </button>
+                    </div>
+                </Form>
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -1,4 +1,5 @@
 import * as H from 'history'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 import { Form } from '../../../../branded/src/components/Form'
@@ -51,7 +52,12 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
             <div className="container mt-3 web-content">
                 <PageTitle title="Create new code monitor" />
                 <PageHeader title="Create new code monitor" icon={VideoInputAntennaIcon} />
-                Code monitors watch your code for specific triggers and run actions in response. Learn more.
+                Code monitors watch your code for specific triggers and run actions in response.{' '}
+                <a href="" target="_blank" rel="noopener">
+                    {/* TODO: populate link */}
+                    Learn more
+                </a>
+                .
                 <Form className="my-4">
                     <div className="flex mb-4">
                         Name
@@ -60,8 +66,9 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                         </div>
                         <small className="text-muted">
                             Give it a short, descriptive name to reference events on Sourcegraph and in notifications.
-                            Do not include{' '}
+                            Do not include:{' '}
                             <a href="" target="_blank" rel="noopener">
+                                {/* TODO: populate link */}
                                 confidential information
                             </a>
                             .
@@ -96,11 +103,13 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                                             rel="noopener noreferrer"
                                             className="create-monitor-page__query-input-preview-link"
                                         >
-                                            Preview results
+                                            {/* TODO: populate link */}
+                                            Preview results <OpenInNewIcon />
                                         </a>
                                     </div>
                                     <small className="text-muted mb-4">
-                                        Code monitors only support type:diff and type:commit search queries.
+                                        Code monitors only support <code className="bg-code">type:diff</code> and{' '}
+                                        <code className="bg-code">type:commit</code> search queries.
                                     </small>
                                     <div>
                                         <button type="button" className="btn btn-outline-secondary mr-1">
@@ -116,8 +125,9 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                         {!showQueryForm && (
                             <small className="text-muted">
                                 {' '}
-                                What other events would you like to monitor?{' '}
+                                What other events would you like to monitor? {/* TODO: populate link */}
                                 <a href="" target="_blank" rel="noopener">
+                                    {/* TODO: populate link */}
                                     Share feedback.
                                 </a>
                             </small>
@@ -131,10 +141,6 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                             <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
                                 Send email notifications
                             </a>
-                            <span className="text-muted">
-                                Deliver email notifications to specified recipients. Can customize delivery schedule and
-                                priority.
-                            </span>
                             {showEmailNotificationForm && (
                                 <>
                                     <div className="mt-4">
@@ -148,14 +154,6 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                                         <small className="text-muted">
                                             Code monitors are currently limited to sending emails to your primary email
                                             address.
-                                        </small>
-                                    </div>
-                                    <div className="mt-4">
-                                        Approved header
-                                        <input type="text" className="form-control my-2" />
-                                        <small className="text-muted">
-                                            Use the approved header to automatically approve the message in a read-only
-                                            or moderated mailing list.
                                         </small>
                                     </div>
                                     <div className="flex my-4">
@@ -179,17 +177,24 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                             )}
                         </div>
                         <small className="text-muted">
-                            What other actions would you like to do?{' '}
+                            What other actions would you like to do?
                             <a href="" target="_blank" rel="noopener">
+                                {/* TODO: populate link */}
                                 Share feedback.
                             </a>
                         </small>
                     </div>
-                    <div className="flex my-4">
-                        <Toggle title="Active" value={active} onToggle={toggleActive} className="mr-2" /> Active
+                    <div className="d-flex my-4">
+                        <div>
+                            <Toggle title="Active" value={active} onToggle={toggleActive} className="mr-2" />{' '}
+                        </div>
+                        <div className="flex-column">
+                            <div>Active</div>
+                            <div className="text-muted">We will watch for the trigger and run actions in response</div>
+                        </div>
                     </div>
                     <div className="flex my-4">
-                        <button type="button" className="btn btn-primary">
+                        <button type="button" className="btn btn-primary mr-2">
                             Create code monitor
                         </button>
                         <button type="button" className="btn btn-outline-secondary">

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -35,14 +35,14 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
         setShowEmailNotificationForm(show => !show)
     }, [])
 
-    const [active, setActive] = useState(false)
-    const toggleActive: (active: boolean) => void = useCallback(active => {
-        setActive(active)
-    }, [])
-
-    const [emailNotificationEnabled, setEmailNotificationEnabled] = useState(false)
+    const [emailNotificationEnabled, setEmailNotificationEnabled] = useState(true)
     const toggleEmailNotificationEnabled: (value: boolean) => void = useCallback(enabled => {
         setEmailNotificationEnabled(enabled)
+    }, [])
+
+    const [active, setActive] = useState(true)
+    const toggleActive: (active: boolean) => void = useCallback(active => {
+        setActive(active)
     }, [])
 
     return (
@@ -55,10 +55,16 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                 <Form className="my-4">
                     <div className="flex mb-4">
                         Name
-                        <input type="text" className="form-control my-2" />
+                        <div>
+                            <input type="text" className="form-control my-2" />
+                        </div>
                         <small className="text-muted">
                             Give it a short, descriptive name to reference events on Sourcegraph and in notifications.
-                            Do not include confidential information.
+                            Do not include{' '}
+                            <a href="" target="_blank" rel="noopener">
+                                confidential information
+                            </a>
+                            .
                         </small>
                     </div>
                     <div className="flex">
@@ -71,73 +77,113 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                         <small className="text-muted">Event history and configuration will not be shared.</small>
                     </div>
                     <hr className="my-4" />
-                    <h3>Trigger</h3>
-                    <div className="card p-3 my-3">
-                        <a href="" onClick={toggleQueryForm} className="font-weight-bold">
-                            When there are new search results
-                        </a>
-                        <span className="text-muted">
-                            This trigger will fire when new search results are found for a given search query.
-                        </span>
-                        {showQueryForm && (
-                            <>
-                                <input type="text" className="form-control my-2" />
-                            </>
+                    <div className="mb-4">
+                        <h3>Trigger</h3>
+                        <div className="card p-3 my-3">
+                            <a href="" onClick={toggleQueryForm} className="font-weight-bold">
+                                When there are new search results
+                            </a>
+                            <span className="text-muted">
+                                This trigger will fire when new search results are found for a given search query.
+                            </span>
+                            {showQueryForm && (
+                                <>
+                                    <div className="create-monitor-page__query-input">
+                                        <input type="text" className="form-control my-2" />
+                                        <a
+                                            href=""
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="create-monitor-page__query-input-preview-link"
+                                        >
+                                            Preview results
+                                        </a>
+                                    </div>
+                                    <small className="text-muted mb-4">
+                                        Code monitors only support type:diff and type:commit search queries.
+                                    </small>
+                                    <div>
+                                        <button type="button" className="btn btn-outline-secondary mr-1">
+                                            Continue
+                                        </button>
+                                        <button type="button" className="btn btn-outline-secondary">
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                        {!showQueryForm && (
+                            <small className="text-muted">
+                                {' '}
+                                What other events would you like to monitor?{' '}
+                                <a href="" target="_blank" rel="noopener">
+                                    Share feedback.
+                                </a>
+                            </small>
                         )}
                     </div>
-                    <h3>Actions</h3>
-                    <p>Run any number of actions in response to an event</p>
-                    <div className="card p-3 my-3">
-                        {/* This should be its own component when you can add multiple email actions */}
-                        <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
-                            Send email notifications
-                        </a>
-                        <span className="text-muted">
-                            Deliver email notifications to specified recipients. Can customize delivery schedule and
-                            priority.
-                        </span>
-                        {showEmailNotificationForm && (
-                            <Form>
-                                <div className="mt-4">
-                                    Recipients
-                                    <input
-                                        type="text"
-                                        className="form-control my-2"
-                                        value={`${props.authenticatedUser?.email || ''} (you)`}
-                                        disabled={true}
-                                    />
-                                    <small className="text-muted">
-                                        Code monitors are currently limited to sending emails to your primary email
-                                        address.
-                                    </small>
-                                </div>
-                                <div className="mt-4">
-                                    Approved header
-                                    <input type="text" className="form-control my-2" />
-                                    <small className="text-muted">
-                                        Use the approved header to automatically approve the message in a read-only or
-                                        moderated mailing list.
-                                    </small>
-                                </div>
-                                <div className="flex my-4">
-                                    <Toggle
-                                        title="Enabled"
-                                        value={emailNotificationEnabled}
-                                        onToggle={toggleEmailNotificationEnabled}
-                                        className="mr-2"
-                                    />
-                                    Enabled
-                                </div>
-                                <div>
-                                    <button type="button" className="btn btn-outline-secondary">
-                                        Done
-                                    </button>
-                                    <button type="button" className="btn btn-outline-secondary">
-                                        Cancel
-                                    </button>
-                                </div>
-                            </Form>
-                        )}
+                    <div>
+                        <h3>Actions</h3>
+                        <p>Run any number of actions in response to an event</p>
+                        <div className="card p-3 my-3">
+                            {/* This should be its own component when you can add multiple email actions */}
+                            <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
+                                Send email notifications
+                            </a>
+                            <span className="text-muted">
+                                Deliver email notifications to specified recipients. Can customize delivery schedule and
+                                priority.
+                            </span>
+                            {showEmailNotificationForm && (
+                                <>
+                                    <div className="mt-4">
+                                        Recipients
+                                        <input
+                                            type="text"
+                                            className="form-control my-2"
+                                            value={`${props.authenticatedUser?.email || ''} (you)`}
+                                            disabled={true}
+                                        />
+                                        <small className="text-muted">
+                                            Code monitors are currently limited to sending emails to your primary email
+                                            address.
+                                        </small>
+                                    </div>
+                                    <div className="mt-4">
+                                        Approved header
+                                        <input type="text" className="form-control my-2" />
+                                        <small className="text-muted">
+                                            Use the approved header to automatically approve the message in a read-only
+                                            or moderated mailing list.
+                                        </small>
+                                    </div>
+                                    <div className="flex my-4">
+                                        <Toggle
+                                            title="Enabled"
+                                            value={emailNotificationEnabled}
+                                            onToggle={toggleEmailNotificationEnabled}
+                                            className="mr-2"
+                                        />
+                                        Enabled
+                                    </div>
+                                    <div>
+                                        <button type="button" className="btn btn-outline-secondary mr-1">
+                                            Done
+                                        </button>
+                                        <button type="button" className="btn btn-outline-secondary">
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                        <small className="text-muted">
+                            What other events would you like to monitor?{' '}
+                            <a href="" target="_blank" rel="noopener">
+                                Share feedback.
+                            </a>
+                        </small>
                     </div>
                     <div className="flex my-4">
                         <Toggle title="Active" value={active} onToggle={toggleActive} className="mr-2" /> Active

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -179,7 +179,7 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                             )}
                         </div>
                         <small className="text-muted">
-                            What other events would you like to monitor?{' '}
+                            What other actions would you like to do?{' '}
                             <a href="" target="_blank" rel="noopener">
                                 Share feedback.
                             </a>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -5,15 +5,15 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { Form } from '../../../../branded/src/components/Form'
 import { Toggle } from '../../../../branded/src/components/Toggle'
 import { AuthenticatedUser } from '../../auth'
-import { Breadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
+import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageHeader } from '../../components/PageHeader'
 import { PageTitle } from '../../components/PageTitle'
 
-interface Props extends BreadcrumbsProps, BreadcrumbSetters {
+export interface CreateCodeMonitorPageProps extends BreadcrumbsProps, BreadcrumbSetters {
     location: H.Location
     authenticatedUser: AuthenticatedUser | null
 }
-export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
+export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPageProps> = props => {
     props.useBreadcrumb(
         useMemo(
             () => ({
@@ -47,142 +47,195 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
     }, [])
 
     return (
-        <div className="w-100">
-            <Breadcrumbs breadcrumbs={props.breadcrumbs} location={props.location} />
-            <div className="container mt-3 web-content">
-                <PageTitle title="Create new code monitor" />
-                <PageHeader title="Create new code monitor" icon={VideoInputAntennaIcon} />
-                Code monitors watch your code for specific triggers and run actions in response.{' '}
-                <a href="" target="_blank" rel="noopener">
-                    {/* TODO: populate link */}
-                    Learn more
-                </a>
-                .
-                <Form className="my-4">
-                    <div className="flex mb-4">
-                        Name
-                        <div>
-                            <input type="text" className="form-control my-2" />
-                        </div>
-                        <small className="text-muted">
-                            Give it a short, descriptive name to reference events on Sourcegraph and in notifications.
-                            Do not include:{' '}
-                            <a href="" target="_blank" rel="noopener">
-                                {/* TODO: populate link */}
-                                confidential information
-                            </a>
-                            .
-                        </small>
+        <div className="container mt-3 web-content">
+            <PageTitle title="Create new code monitor" />
+            <PageHeader title="Create new code monitor" icon={VideoInputAntennaIcon} />
+            Code monitors watch your code for specific triggers and run actions in response.{' '}
+            <a href="" target="_blank" rel="noopener">
+                {/* TODO: populate link */}
+                Learn more
+            </a>
+            .
+            <Form className="my-4">
+                <div className="flex mb-4">
+                    Name
+                    <div>
+                        <input type="text" className="form-control my-2" />
                     </div>
-                    <div className="flex">
-                        Owner
-                        <select className="form-control my-2 w-auto" disabled={true}>
-                            <option value={props.authenticatedUser?.displayName || props.authenticatedUser?.username}>
-                                {props.authenticatedUser?.username}
-                            </option>
-                        </select>
-                        <small className="text-muted">Event history and configuration will not be shared.</small>
-                    </div>
-                    <hr className="my-4" />
-                    <div className="mb-4">
-                        <h3>Trigger</h3>
-                        <div className="card p-3 my-3">
-                            <a href="" onClick={toggleQueryForm} className="font-weight-bold">
-                                When there are new search results
-                            </a>
-                            <span className="text-muted">
-                                This trigger will fire when new search results are found for a given search query.
-                            </span>
-                            {showQueryForm && (
-                                <>
-                                    <div className="create-monitor-page__query-input">
-                                        <input type="text" className="form-control my-2" />
-                                        <a
-                                            href=""
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="create-monitor-page__query-input-preview-link"
-                                        >
-                                            {/* TODO: populate link */}
-                                            Preview results <OpenInNewIcon />
-                                        </a>
-                                    </div>
-                                    <small className="text-muted mb-4">
-                                        Code monitors only support <code className="bg-code">type:diff</code> and{' '}
-                                        <code className="bg-code">type:commit</code> search queries.
-                                    </small>
-                                    <div>
-                                        <button type="button" className="btn btn-outline-secondary mr-1">
-                                            Continue
-                                        </button>
-                                        <button type="button" className="btn btn-outline-secondary">
-                                            Cancel
-                                        </button>
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                        {!showQueryForm && (
-                            <small className="text-muted">
-                                {' '}
-                                What other events would you like to monitor? {/* TODO: populate link */}
-                                <a href="" target="_blank" rel="noopener">
-                                    {/* TODO: populate link */}
-                                    Share feedback.
-                                </a>
-                            </small>
+                    <small className="text-muted">
+                        Give it a short, descriptive name to reference events on Sourcegraph and in notifications. Do
+                        not include:{' '}
+                        <a href="" target="_blank" rel="noopener">
+                            {/* TODO: populate link */}
+                            confidential information
+                        </a>
+                        .
+                    </small>
+                </div>
+                <div className="flex">
+                    Owner
+                    <select className="form-control my-2 w-auto" disabled={true}>
+                        <option value={props.authenticatedUser?.displayName || props.authenticatedUser?.username}>
+                            {props.authenticatedUser?.username}
+                        </option>
+                    </select>
+                    <small className="text-muted">Event history and configuration will not be shared.</small>
+                </div>
+                <hr className="my-4" />
+                <div className="mb-4">
+                    <h3>Trigger</h3>
+                    <div className="card p-3 my-3">
+                        <a href="" onClick={toggleQueryForm} className="font-weight-bold">
+                            When there are new search results
+                        </a>
+                        <span className="text-muted">
+                            This trigger will fire when new search results are found for a given search query.
+                        </span>
+                        {showQueryForm && (
+                            <>
+                                <div className="create-monitor-page__query-input">
+                                    <input type="text" className="form-control my-2" />
+                                    <a
+                                        href=""
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="create-monitor-page__query-input-preview-link"
+                                    >
+                                        {/* TODO: populate link */}
+                                        Preview results <OpenInNewIcon />
+                                    </a>
+                                </div>
+                                <small className="text-muted mb-4">
+                                    Code monitors only support <code className="bg-code">type:diff</code> and{' '}
+                                    <code className="bg-code">type:commit</code> search queries.
+                                </small>
+                                <div>
+                                    <button type="button" className="btn btn-outline-secondary mr-1">
+                                        Continue
+                                    </button>
+                                    <button type="button" className="btn btn-outline-secondary">
+                                        Cancel
+                                    </button>
+                                </div>
+                            </>
                         )}
                     </div>
-                    <div>
-                        <h3>Actions</h3>
-                        <p>Run any number of actions in response to an event</p>
-                        <div className="card p-3 my-3">
-                            {/* This should be its own component when you can add multiple email actions */}
-                            <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
-                                Send email notifications
-                            </a>
-                            {showEmailNotificationForm && (
-                                <>
-                                    <div className="mt-4">
-                                        Recipients
-                                        <input
-                                            type="text"
-                                            className="form-control my-2"
-                                            value={`${props.authenticatedUser?.email || ''} (you)`}
-                                            disabled={true}
-                                        />
-                                        <small className="text-muted">
-                                            Code monitors are currently limited to sending emails to your primary email
-                                            address.
-                                        </small>
-                                    </div>
-                                    <div className="flex my-4">
-                                        <Toggle
-                                            title="Enabled"
-                                            value={emailNotificationEnabled}
-                                            onToggle={toggleEmailNotificationEnabled}
-                                            className="mr-2"
-                                        />
-                                        Enabled
-                                    </div>
-                                    <div>
-                                        <button type="button" className="btn btn-outline-secondary mr-1">
-                                            Done
-                                        </button>
-                                        <button type="button" className="btn btn-outline-secondary">
-                                            Cancel
-                                        </button>
-                                    </div>
-                                </>
-                            )}
-                        </div>
+                    {!showQueryForm && (
                         <small className="text-muted">
-                            What other actions would you like to do?
+                            {' '}
+                            What other events would you like to monitor? {/* TODO: populate link */}
                             <a href="" target="_blank" rel="noopener">
                                 {/* TODO: populate link */}
                                 Share feedback.
                             </a>
                         </small>
+                    )}
+                </div>
+                <div>
+                    <h3>Actions</h3>
+                    <p>Run any number of actions in response to an event</p>
+                    <div className="card p-3 my-3">
+                        {/* This should be its own component when you can add multiple email actions */}
+                        <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
+                            Send email notifications
+                        </a>
+                        {showEmailNotificationForm && (
+                            <>
+                                <div className="mt-4">
+                                    Recipients
+                                    <input
+                                        type="text"
+                                        className="form-control my-2"
+                                        value={`${props.authenticatedUser?.email || ''} (you)`}
+                                        disabled={true}
+                                    />
+                                    <small className="text-muted">
+                                        Code monitors are currently limited to sending emails to your primary email
+                                        address.
+                                    </small>
+                                </div>
+                                <div className="flex my-4">
+                                    <Toggle
+                                        title="Enabled"
+                                        value={emailNotificationEnabled}
+                                        onToggle={toggleEmailNotificationEnabled}
+                                        className="mr-2"
+                                    />
+                                    Enabled
+                                </div>
+                                <div>
+                                    <button type="button" className="btn btn-outline-secondary mr-1">
+                                        Done
+                                    </button>
+                                    <button type="button" className="btn btn-outline-secondary">
+                                        Cancel
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                    <small className="text-muted">
+                        What other actions would you like to do?
+                        <a href="" target="_blank" rel="noopener">
+                            {/* TODO: populate link */}
+                            Share feedback.
+                        </a>
+                    </small>
+                </div>
+                <div>
+                    <h3>Actions</h3>
+                    <p>Run any number of actions in response to an event</p>
+                    <div className="card p-3 my-3">
+                        {/* This should be its own component when you can add multiple email actions */}
+                        <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
+                            Send email notifications
+                        </a>
+                        <span className="text-muted">
+                            Deliver email notifications to specified recipients. Can customize delivery schedule and
+                            priority.
+                        </span>
+                        {showEmailNotificationForm && (
+                            <>
+                                <div className="mt-4">
+                                    Recipients
+                                    <input
+                                        type="text"
+                                        className="form-control my-2"
+                                        value={`${props.authenticatedUser?.email || ''} (you)`}
+                                        disabled={true}
+                                    />
+                                    <small className="text-muted">
+                                        Code monitors are currently limited to sending emails to your primary email
+                                        address.
+                                    </small>
+                                </div>
+                                <div className="mt-4">
+                                    Approved header
+                                    <input type="text" className="form-control my-2" />
+                                    <small className="text-muted">
+                                        Use the approved header to automatically approve the message in a read-only or
+                                        moderated mailing list.
+                                    </small>
+                                </div>
+                                <div className="flex my-4">
+                                    <Toggle
+                                        title="Enabled"
+                                        value={emailNotificationEnabled}
+                                        onToggle={toggleEmailNotificationEnabled}
+                                        className="mr-2"
+                                    />
+                                    Enabled
+                                </div>
+                                <div>
+                                    <button type="button" className="btn btn-outline-secondary mr-1">
+                                        Done
+                                    </button>
+                                    <button type="button" className="btn btn-outline-secondary">
+                                        Cancel
+                                    </button>
+                                </div>
+                            </>
+                        )}
                     </div>
                     <div className="d-flex my-4">
                         <div>
@@ -201,8 +254,8 @@ export const CreateCodeMonitorPage: React.FunctionComponent<Props> = props => {
                             Cancel
                         </button>
                     </div>
-                </Form>
-            </div>
+                </div>
+            </Form>
         </div>
     )
 }

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -175,7 +175,7 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
                         )}
                     </div>
                     <small className="text-muted">
-                        What other actions would you like to do?
+                        What other actions would you like to do?{' '}
                         <a href="" target="_blank" rel="noopener">
                             {/* TODO: populate link */}
                             Share feedback.
@@ -183,60 +183,6 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
                     </small>
                 </div>
                 <div>
-                    <h3>Actions</h3>
-                    <p>Run any number of actions in response to an event</p>
-                    <div className="card p-3 my-3">
-                        {/* This should be its own component when you can add multiple email actions */}
-                        <a href="" onClick={toggleEmailNotificationForm} className="font-weight-bold">
-                            Send email notifications
-                        </a>
-                        <span className="text-muted">
-                            Deliver email notifications to specified recipients. Can customize delivery schedule and
-                            priority.
-                        </span>
-                        {showEmailNotificationForm && (
-                            <>
-                                <div className="mt-4">
-                                    Recipients
-                                    <input
-                                        type="text"
-                                        className="form-control my-2"
-                                        value={`${props.authenticatedUser?.email || ''} (you)`}
-                                        disabled={true}
-                                    />
-                                    <small className="text-muted">
-                                        Code monitors are currently limited to sending emails to your primary email
-                                        address.
-                                    </small>
-                                </div>
-                                <div className="mt-4">
-                                    Approved header
-                                    <input type="text" className="form-control my-2" />
-                                    <small className="text-muted">
-                                        Use the approved header to automatically approve the message in a read-only or
-                                        moderated mailing list.
-                                    </small>
-                                </div>
-                                <div className="flex my-4">
-                                    <Toggle
-                                        title="Enabled"
-                                        value={emailNotificationEnabled}
-                                        onToggle={toggleEmailNotificationEnabled}
-                                        className="mr-2"
-                                    />
-                                    Enabled
-                                </div>
-                                <div>
-                                    <button type="button" className="btn btn-outline-secondary mr-1">
-                                        Done
-                                    </button>
-                                    <button type="button" className="btn btn-outline-secondary">
-                                        Cancel
-                                    </button>
-                                </div>
-                            </>
-                        )}
-                    </div>
                     <div className="d-flex my-4">
                         <div>
                             <Toggle title="Active" value={active} onToggle={toggleActive} className="mr-2" />{' '}

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo } from 'react'
+import { Route, RouteComponentProps, Switch } from 'react-router'
+import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
+import { PlatformContextProps } from '../../../../../shared/src/platform/context'
+import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
+import { ThemeProps } from '../../../../../shared/src/theme'
+import { AuthenticatedUser } from '../../../auth'
+import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
+import { BreadcrumbsProps, BreadcrumbSetters, Breadcrumbs } from '../../../components/Breadcrumbs'
+import { lazyComponent } from '../../../util/lazyComponent'
+import { CodeMonitoringPageProps } from '../CodeMonitoringPage'
+import { CreateCodeMonitorPageProps } from '../CreateCodeMonitorPage'
+
+interface Props
+    extends RouteComponentProps<{}>,
+        ThemeProps,
+        ExtensionsControllerProps,
+        TelemetryProps,
+        PlatformContextProps,
+        BreadcrumbsProps,
+        BreadcrumbSetters {
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+}
+
+const CodeMonitoringPage = lazyComponent<CodeMonitoringPageProps, 'CodeMonitoringPage'>(
+    () => import('../CodeMonitoringPage'),
+    'CodeMonitoringPage'
+)
+const CreateCodeMonitorPage = lazyComponent<CreateCodeMonitorPageProps, 'CreateCodeMonitorPage'>(
+    () => import('../CreateCodeMonitorPage'),
+    'CreateCodeMonitorPage'
+)
+
+/**
+ * The global code monitoring area.
+ */
+export const GlobalCodeMonitoringArea: React.FunctionComponent<Props> = props => (
+    <AuthenticatedCodeMonitoringArea {...props} />
+)
+
+interface AuthenticatedProps extends Props {
+    authenticatedUser: AuthenticatedUser
+}
+
+export const AuthenticatedCodeMonitoringArea = withAuthenticatedUser<AuthenticatedProps>(({ match, ...outerProps }) => {
+    const breadcrumbSetters = outerProps.useBreadcrumb(
+        useMemo(
+            () => ({
+                key: 'Code Monitoring',
+                element: <>Code Monitoring</>,
+            }),
+            []
+        )
+    )
+
+    return (
+        <div className="w-100">
+            <Breadcrumbs breadcrumbs={outerProps.breadcrumbs} location={outerProps.location} />
+            <div className="container web-content">
+                {/* eslint-disable react/jsx-no-bind */}
+                <Switch>
+                    <Route
+                        render={props => <CodeMonitoringPage {...outerProps} {...props} {...breadcrumbSetters} />}
+                        path={match.url}
+                        exact={true}
+                    />
+                    <Route
+                        path={`${match.url}/new`}
+                        render={props => <CreateCodeMonitorPage {...outerProps} {...props} {...breadcrumbSetters} />}
+                        exact={true}
+                    />
+                </Switch>
+            </div>
+        </div>
+    )
+})

--- a/client/web/src/enterprise/code-monitoring/index.scss
+++ b/client/web/src/enterprise/code-monitoring/index.scss
@@ -1,0 +1,1 @@
+@import './CreateCodeMonitorPage';

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -46,5 +46,13 @@ export const enterpriseRoutes: readonly LayoutRouteProps<{}>[] = [
             !isErrorLike(props.settingsCascade.final) &&
             !!props.settingsCascade.final?.experimentalFeatures?.codeMonitoring,
     },
+    {
+        path: '/code-monitoring/new',
+        exact: true,
+        render: lazyComponent(() => import('./code-monitoring/CreateCodeMonitorPage'), 'CreateCodeMonitorPage'),
+        condition: props =>
+            !isErrorLike(props.settingsCascade.final) &&
+            !!props.settingsCascade.final?.experimentalFeatures?.codeMonitoring,
+    },
     ...routes,
 ]

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -40,16 +40,10 @@ export const enterpriseRoutes: readonly LayoutRouteProps<{}>[] = [
     },
     {
         path: '/code-monitoring',
-        exact: true,
-        render: lazyComponent(() => import('./code-monitoring/CodeMonitoringPage'), 'CodeMonitoringPage'),
-        condition: props =>
-            !isErrorLike(props.settingsCascade.final) &&
-            !!props.settingsCascade.final?.experimentalFeatures?.codeMonitoring,
-    },
-    {
-        path: '/code-monitoring/new',
-        exact: true,
-        render: lazyComponent(() => import('./code-monitoring/CreateCodeMonitorPage'), 'CreateCodeMonitorPage'),
+        render: lazyComponent(
+            () => import('./code-monitoring/global/GlobalCodeMonitoringArea'),
+            'GlobalCodeMonitoringArea'
+        ),
         condition: props =>
             !isErrorLike(props.settingsCascade.final) &&
             !!props.settingsCascade.final?.experimentalFeatures?.codeMonitoring,


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/issues/15415. This adds the basic create monitor page. It does not yet send the mutation to create a monitor (depends on https://github.com/sourcegraph/sourcegraph/pull/15569), nor does it advance the form based on form submissions yet. These will happen in stacked PRs.

Figma: https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93%C2%A0Code-monitoring-actions-%26-notifications?node-id=2116%3A70

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
