### PR TITLE
search frontend: refactor token types

### DIFF
--- a/client/shared/src/search/parser/completion.test.ts
+++ b/client/shared/src/search/parser/completion.test.ts
@@ -1,15 +1,17 @@
 import * as Monaco from 'monaco-editor'
 import { getCompletionItems, repositoryCompletionItemKind } from './completion'
-import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
+import { scanSearchQuery, ScanSuccess, ScanResult, Token } from './scanner'
 import { NEVER, of } from 'rxjs'
 import { SearchSuggestion } from '../../graphql/schema'
+
+const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
 describe('getCompletionItems()', () => {
     test('returns only static filter type completions when the token matches a known filter', async () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('re') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('re')),
                     { column: 3 },
                     of([
                         {
@@ -71,7 +73,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('reposi') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('reposi')),
                     { column: 7 },
                     of([
                         {
@@ -133,14 +135,9 @@ describe('getCompletionItems()', () => {
 
     test('returns suggestions for an empty query', async () => {
         expect(
-            (
-                await getCompletionItems(
-                    (scanSearchQuery('') as ScanSuccess<Sequence>).token,
-                    { column: 1 },
-                    NEVER,
-                    false
-                )
-            )?.suggestions.map(({ label }) => label)
+            (await getCompletionItems(toSuccess(scanSearchQuery('')), { column: 1 }, NEVER, false))?.suggestions.map(
+                ({ label }) => label
+            )
         ).toStrictEqual([
             'after',
             'archived',
@@ -180,7 +177,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('a ') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('a ')),
                     { column: 3 },
                     of([
                         {
@@ -229,14 +226,9 @@ describe('getCompletionItems()', () => {
 
     test('returns static filter type completions for case-insensitive query', async () => {
         expect(
-            (
-                await getCompletionItems(
-                    (scanSearchQuery('rE') as ScanSuccess<Sequence>).token,
-                    { column: 3 },
-                    of([]),
-                    false
-                )
-            )?.suggestions.map(({ label }) => label)
+            (await getCompletionItems(toSuccess(scanSearchQuery('rE')), { column: 3 }, of([]), false))?.suggestions.map(
+                ({ label }) => label
+            )
         ).toStrictEqual([
             'after',
             'archived',
@@ -275,12 +267,7 @@ describe('getCompletionItems()', () => {
     test('returns completions for filters with discrete values', async () => {
         expect(
             (
-                await getCompletionItems(
-                    (scanSearchQuery('case:y') as ScanSuccess<Sequence>).token,
-                    { column: 7 },
-                    NEVER,
-                    false
-                )
+                await getCompletionItems(toSuccess(scanSearchQuery('case:y')), { column: 7 }, NEVER, false)
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual(['yes', 'no'])
     })
@@ -289,7 +276,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('lang:') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('lang:')),
                     {
                         column: 6,
                     },
@@ -327,7 +314,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('file:c') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('file:c')),
                     { column: 7 },
                     of([
                         {
@@ -349,7 +336,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('jsonrpc') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('jsonrpc')),
                     { column: 8 },
                     of([
                         {
@@ -380,7 +367,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('f:^jsonrpc') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('f:^jsonrpc')),
                     { column: 11 },
                     of([
                         {
@@ -402,7 +389,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('main.go') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('main.go')),
                     { column: 7 },
                     of([
                         {
@@ -426,7 +413,7 @@ describe('getCompletionItems()', () => {
         expect(
             (
                 await getCompletionItems(
-                    (scanSearchQuery('f:') as ScanSuccess<Sequence>).token,
+                    toSuccess(scanSearchQuery('f:')),
                     { column: 2 },
                     of([
                         {

--- a/client/shared/src/search/parser/completion.ts
+++ b/client/shared/src/search/parser/completion.ts
@@ -1,7 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { escapeRegExp, startCase } from 'lodash'
 import { FILTERS, resolveFilter } from './filters'
-import { Sequence, toMonacoRange } from './scanner'
+import { Token, toMonacoRange } from './scanner'
 import { Omit } from 'utility-types'
 import { Observable } from 'rxjs'
 import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup } from '../../graphql/schema'
@@ -185,7 +185,7 @@ const TRIGGER_SUGGESTIONS: Monaco.languages.Command = {
  * including both static and dynamically fetched suggestions.
  */
 export async function getCompletionItems(
-    { members }: Pick<Sequence, 'members'>,
+    tokens: Token[],
     { column }: Pick<Monaco.Position, 'column'>,
     dynamicSuggestions: Observable<SearchSuggestion[]>,
     globbing: boolean
@@ -209,7 +209,7 @@ export async function getCompletionItems(
             ),
         }
     }
-    const tokenAtColumn = members.find(({ range }) => range.start + 1 <= column && range.end + 1 >= column)
+    const tokenAtColumn = tokens.find(({ range }) => range.start + 1 <= column && range.end + 1 >= column)
     if (!tokenAtColumn) {
         throw new Error('getCompletionItems: no token at column')
     }

--- a/client/shared/src/search/parser/diagnostics.test.ts
+++ b/client/shared/src/search/parser/diagnostics.test.ts
@@ -1,21 +1,18 @@
 import { getDiagnostics } from './diagnostics'
-import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
+import { scanSearchQuery, ScanSuccess, ScanResult, Token } from './scanner'
 import { SearchPatternType } from '../../graphql-operations'
+
+const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
 describe('getDiagnostics()', () => {
     test('do not raise invalid filter type', () => {
         expect(
-            getDiagnostics(
-                (scanSearchQuery('repos:^github.com/sourcegraph') as ScanSuccess<Sequence>).token,
-                SearchPatternType.literal
-            )
+            getDiagnostics(toSuccess(scanSearchQuery('repos:^github.com/sourcegraph')), SearchPatternType.literal)
         ).toStrictEqual([])
     })
 
     test('invalid filter value', () => {
-        expect(
-            getDiagnostics((scanSearchQuery('case:maybe') as ScanSuccess<Sequence>).token, SearchPatternType.literal)
-        ).toStrictEqual([
+        expect(getDiagnostics(toSuccess(scanSearchQuery('case:maybe')), SearchPatternType.literal)).toStrictEqual([
             {
                 endColumn: 5,
                 endLineNumber: 1,
@@ -29,37 +26,25 @@ describe('getDiagnostics()', () => {
 
     test('search query containing colon, literal pattern type, do not raise error', () => {
         expect(
-            getDiagnostics(
-                (scanSearchQuery('Configuration::doStuff(...)') as ScanSuccess<Sequence>).token,
-                SearchPatternType.literal
-            )
+            getDiagnostics(toSuccess(scanSearchQuery('Configuration::doStuff(...)')), SearchPatternType.literal)
         ).toStrictEqual([])
     })
 
     test('search query containing quoted token, regexp pattern type', () => {
         expect(
-            getDiagnostics(
-                (scanSearchQuery('"Configuration::doStuff(...)"') as ScanSuccess<Sequence>).token,
-                SearchPatternType.regexp
-            )
+            getDiagnostics(toSuccess(scanSearchQuery('"Configuration::doStuff(...)"')), SearchPatternType.regexp)
         ).toStrictEqual([])
     })
 
     test('search query containing parenthesized parameterss', () => {
         expect(
-            getDiagnostics(
-                (scanSearchQuery('repo:a (file:b and c)') as ScanSuccess<Sequence>).token,
-                SearchPatternType.regexp
-            )
+            getDiagnostics(toSuccess(scanSearchQuery('repo:a (file:b and c)')), SearchPatternType.regexp)
         ).toStrictEqual([])
     })
 
     test('search query containing quoted token, literal pattern type', () => {
         expect(
-            getDiagnostics(
-                (scanSearchQuery('"Configuration::doStuff(...)"') as ScanSuccess<Sequence>).token,
-                SearchPatternType.literal
-            )
+            getDiagnostics(toSuccess(scanSearchQuery('"Configuration::doStuff(...)"')), SearchPatternType.literal)
         ).toStrictEqual([
             {
                 endColumn: 30,

--- a/client/shared/src/search/parser/diagnostics.ts
+++ b/client/shared/src/search/parser/diagnostics.ts
@@ -1,17 +1,14 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence, toMonacoRange } from './scanner'
+import { Token, toMonacoRange } from './scanner'
 import { validateFilter } from './filters'
 import { SearchPatternType } from '../../graphql-operations'
 
 /**
  * Returns the diagnostics for a scanned search query to be displayed in the Monaco query input.
  */
-export function getDiagnostics(
-    { members }: Pick<Sequence, 'members'>,
-    patternType: SearchPatternType
-): Monaco.editor.IMarkerData[] {
+export function getDiagnostics(tokens: Token[], patternType: SearchPatternType): Monaco.editor.IMarkerData[] {
     const diagnostics: Monaco.editor.IMarkerData[] = []
-    for (const token of members) {
+    for (const token of tokens) {
         if (token.type === 'filter') {
             const { filterType, filterValue } = token
             const validationResult = validateFilter(filterType.value, filterValue)

--- a/client/shared/src/search/parser/hover.test.ts
+++ b/client/shared/src/search/parser/hover.test.ts
@@ -1,10 +1,12 @@
 import { getHoverResult } from './hover'
-import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
+import { scanSearchQuery, ScanSuccess, Token, ScanResult } from './scanner'
+
+const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
 describe('getHoverResult()', () => {
     test('returns hover contents for filters', () => {
-        const parsedQuery = (scanSearchQuery('repo:sourcegraph file:code_intelligence') as ScanSuccess<Sequence>).token
-        expect(getHoverResult(parsedQuery, { column: 4 })).toStrictEqual({
+        const scannedQuery = toSuccess(scanSearchQuery('repo:sourcegraph file:code_intelligence'))
+        expect(getHoverResult(scannedQuery, { column: 4 })).toStrictEqual({
             contents: [
                 {
                     value: 'Include only results from repositories matching the given search pattern.',
@@ -17,7 +19,7 @@ describe('getHoverResult()', () => {
                 startLineNumber: 1,
             },
         })
-        expect(getHoverResult(parsedQuery, { column: 18 })).toStrictEqual({
+        expect(getHoverResult(scannedQuery, { column: 18 })).toStrictEqual({
             contents: [
                 {
                     value: 'Include only results from files matching the given search pattern.',
@@ -30,7 +32,7 @@ describe('getHoverResult()', () => {
                 startLineNumber: 1,
             },
         })
-        expect(getHoverResult(parsedQuery, { column: 30 })).toStrictEqual({
+        expect(getHoverResult(scannedQuery, { column: 30 })).toStrictEqual({
             contents: [
                 {
                     value: 'Include only results from files matching the given search pattern.',

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -1,15 +1,15 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence, toMonacoRange } from './scanner'
+import { Token, toMonacoRange } from './scanner'
 import { resolveFilter } from './filters'
 
 /**
  * Returns the hover result for a hovered search token in the Monaco query input.
  */
 export const getHoverResult = (
-    { members }: Pick<Sequence, 'members'>,
+    tokens: Token[],
     { column }: Pick<Monaco.Position, 'column'>
 ): Monaco.languages.Hover | null => {
-    const tokenAtColumn = members.find(({ range }) => range.start + 1 <= column && range.end >= column)
+    const tokenAtColumn = tokens.find(({ range }) => range.start + 1 <= column && range.end >= column)
     if (!tokenAtColumn || tokenAtColumn.type !== 'filter') {
         return null
     }

--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -58,7 +58,7 @@ export function getProviders(
                 const result = scanSearchQuery(line, options.interpretComments ?? false)
                 if (result.type === 'success') {
                     return {
-                        tokens: getMonacoTokens(result.token),
+                        tokens: getMonacoTokens(result.term),
                         endState: SCANNER_STATE,
                     }
                 }
@@ -71,7 +71,7 @@ export function getProviders(
                     .pipe(
                         first(),
                         map(({ scanned }) =>
-                            scanned.type === 'error' ? null : getHoverResult(scanned.token, position)
+                            scanned.type === 'error' ? null : getHoverResult(scanned.term, position)
                         ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )
@@ -88,7 +88,7 @@ export function getProviders(
                             scannedQuery.scanned.type === 'error'
                                 ? of(null)
                                 : getCompletionItems(
-                                      scannedQuery.scanned.token,
+                                      scannedQuery.scanned.term,
                                       position,
                                       debouncedDynamicSuggestions,
                                       options.globbing
@@ -99,7 +99,7 @@ export function getProviders(
                     .toPromise(),
         },
         diagnostics: scannedQueries.pipe(
-            map(({ scanned }) => (scanned.type === 'success' ? getDiagnostics(scanned.token, options.patternType) : []))
+            map(({ scanned }) => (scanned.type === 'success' ? getDiagnostics(scanned.term, options.patternType) : []))
         ),
     }
 }

--- a/client/shared/src/search/parser/scanner.test.ts
+++ b/client/shared/src/search/parser/scanner.test.ts
@@ -9,19 +9,19 @@ describe('scanBalancedPattern()', () => {
     const scanLiteralBalancedPattern = scanBalancedPattern()
     test('balanced, scans up to whitespace', () => {
         expect(scanLiteralBalancedPattern('foo OR bar', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"foo"}}'
+            '{"type":"success","term":{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"foo"}}'
         )
     })
 
     test('balanced, consumes spaces', () => {
         expect(scanLiteralBalancedPattern('(hello there)', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":13},"kind":1,"value":"(hello there)"}}'
+            '{"type":"success","term":{"type":"pattern","range":{"start":0,"end":13},"kind":1,"value":"(hello there)"}}'
         )
     })
 
     test('balanced, consumes unrecognized filter-like value', () => {
         expect(scanLiteralBalancedPattern('( general:kenobi )', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"( general:kenobi )"}}'
+            '{"type":"success","term":{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"( general:kenobi )"}}'
         )
     })
 
@@ -57,7 +57,7 @@ describe('scanBalancedPattern()', () => {
 
     test('balanced, no conflicting tokens', () => {
         expect(scanLiteralBalancedPattern('(bor band )', 0)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"pattern","range":{"start":0,"end":11},"kind":1,"value":"(bor band )"}}'
+            '{"type":"success","term":{"type":"pattern","range":{"start":0,"end":11},"kind":1,"value":"(bor band )"}}'
         )
     })
 
@@ -69,90 +69,87 @@ describe('scanBalancedPattern()', () => {
 })
 
 describe('scanSearchQuery() for literal search', () => {
-    test('empty', () =>
-        expect(scanSearchQuery('')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[],"range":{"start":0,"end":1}}}'
-        ))
+    test('empty', () => expect(scanSearchQuery('')).toMatchInlineSnapshot('{"type":"success","term":[]}'))
 
     test('whitespace', () =>
         expect(scanSearchQuery('  ')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"whitespace","range":{"start":0,"end":2}}],"range":{"start":0,"end":2}}}'
+            '{"type":"success","term":[{"type":"whitespace","range":{"start":0,"end":2}}]}'
         ))
 
     test('literal', () =>
         expect(scanSearchQuery('a')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":1},"kind":1,"value":"a"}],"range":{"start":0,"end":1}}}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":1},"kind":1,"value":"a"}]}'
         ))
 
     test('triple quotes', () => {
         expect(scanSearchQuery('"""')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"\\"\\"\\""}],"range":{"start":0,"end":3}}}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":3},"kind":1,"value":"\\"\\"\\""}]}'
         )
     })
 
     test('filter', () =>
         expect(scanSearchQuery('f:b')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"b","range":{"start":2,"end":3}},"negated":false}],"range":{"start":0,"end":3}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"b","range":{"start":2,"end":3}},"negated":false}]}'
         ))
 
     test('negated filter', () =>
         expect(scanSearchQuery('-f:b')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"filterValue":{"type":"literal","value":"b","range":{"start":3,"end":4}},"negated":true}],"range":{"start":0,"end":4}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"filterValue":{"type":"literal","value":"b","range":{"start":3,"end":4}},"negated":true}]}'
         ))
 
     test('filter with quoted value', () => {
         expect(scanSearchQuery('f:"b"')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":5},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"quoted","quotedValue":"b","range":{"start":2,"end":5}},"negated":false}],"range":{"start":0,"end":5}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":5},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"quoted","quotedValue":"b","range":{"start":2,"end":5}},"negated":false}]}'
         )
     })
 
     test('filter with a value ending with a colon', () => {
         expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}],"range":{"start":0,"end":4}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
         )
     })
 
     test('filter where the value is a colon', () => {
         expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}],"range":{"start":0,"end":4}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
         )
     })
 
     test('quoted, double quotes', () =>
         expect(scanSearchQuery('"a:b"')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}],"range":{"start":0,"end":5}}}'
+            '{"type":"success","term":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}]}'
         ))
 
     test('quoted, single quotes', () =>
         expect(scanSearchQuery("'a:b'")).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}],"range":{"start":0,"end":5}}}'
+            '{"type":"success","term":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}]}'
         ))
 
     test('quoted (escaped quotes)', () =>
         expect(scanSearchQuery('"-\\"a\\":b"')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"quoted","quotedValue":"-\\\\\\"a\\\\\\":b","range":{"start":0,"end":10}}],"range":{"start":0,"end":10}}}'
+            '{"type":"success","term":[{"type":"quoted","quotedValue":"-\\\\\\"a\\\\\\":b","range":{"start":0,"end":10}}]}'
         ))
 
     test('complex query', () =>
         expect(scanSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":30},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"filterType":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"filterValue":{"type":"literal","value":"go","range":{"start":36,"end":38}},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"filterType":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"filterValue":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}],"range":{"start":0,"end":58}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":30},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"filterType":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"filterValue":{"type":"literal","value":"go","range":{"start":36,"end":38}},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"filterType":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"filterValue":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}]}'
         ))
 
     test('parenthesized parameters', () => {
         expect(scanSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}],"range":{"start":0,"end":21}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}]}'
         )
     })
 
     test('nested parenthesized parameters', () => {
         expect(scanSearchQuery('(a and (b or c) and d)')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":2},"kind":1,"value":"a"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"keyword","value":"and","range":{"start":3,"end":6},"kind":"and"},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"pattern","range":{"start":8,"end":9},"kind":1,"value":"b"},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"keyword","value":"or","range":{"start":10,"end":12},"kind":"or"},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"pattern","range":{"start":13,"end":14},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"keyword","value":"and","range":{"start":16,"end":19},"kind":"and"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"pattern","range":{"start":20,"end":21},"kind":1,"value":"d"},{"type":"closingParen","range":{"start":21,"end":22}}],"range":{"start":0,"end":22}}}'
+            '{"type":"success","term":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":2},"kind":1,"value":"a"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"keyword","value":"and","range":{"start":3,"end":6},"kind":"and"},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"pattern","range":{"start":8,"end":9},"kind":1,"value":"b"},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"keyword","value":"or","range":{"start":10,"end":12},"kind":"or"},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"pattern","range":{"start":13,"end":14},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":14,"end":15}},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"keyword","value":"and","range":{"start":16,"end":19},"kind":"and"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"pattern","range":{"start":20,"end":21},"kind":1,"value":"d"},{"type":"closingParen","range":{"start":21,"end":22}}]}'
         )
     })
 
     test('do not treat links as filters', () => {
         expect(scanSearchQuery('http://example.com repo:a')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"filterType":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"filterValue":{"type":"literal","value":"a","range":{"start":24,"end":25}},"negated":false}],"range":{"start":0,"end":25}}}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"filterType":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"filterValue":{"type":"literal","value":"a","range":{"start":24,"end":25}},"negated":false}]}'
         )
     })
 })
@@ -162,7 +159,7 @@ describe('scanSearchQuery() for regexp', () => {
         expect(
             scanSearchQuery('((sauce|graph)(\\s)?)is best(g*r*a*p*h*)', false, PatternKind.Regexp)
         ).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":22},"kind":2,"value":"((sauce|graph)(\\\\s)?)is"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":39},"kind":2,"value":"best(g*r*a*p*h*)"}],"range":{"start":0,"end":39}}}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":22},"kind":2,"value":"((sauce|graph)(\\\\s)?)is"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":39},"kind":2,"value":"best(g*r*a*p*h*)"}]}'
         )
     })
 
@@ -170,13 +167,13 @@ describe('scanSearchQuery() for regexp', () => {
         expect(
             scanSearchQuery('(((sauce|graph)\\s?) or (best)) and (gr|aph)', false, PatternKind.Regexp)
         ).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":19},"kind":2,"value":"((sauce|graph)\\\\s?)"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"keyword","value":"or","range":{"start":20,"end":22},"kind":"or"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":29},"kind":2,"value":"(best)"},{"type":"closingParen","range":{"start":29,"end":30}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"keyword","value":"and","range":{"start":31,"end":34},"kind":"and"},{"type":"whitespace","range":{"start":34,"end":35}},{"type":"pattern","range":{"start":35,"end":43},"kind":2,"value":"(gr|aph)"}],"range":{"start":0,"end":43}}}'
+            '{"type":"success","term":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"pattern","range":{"start":1,"end":19},"kind":2,"value":"((sauce|graph)\\\\s?)"},{"type":"whitespace","range":{"start":19,"end":20}},{"type":"keyword","value":"or","range":{"start":20,"end":22},"kind":"or"},{"type":"whitespace","range":{"start":22,"end":23}},{"type":"pattern","range":{"start":23,"end":29},"kind":2,"value":"(best)"},{"type":"closingParen","range":{"start":29,"end":30}},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"keyword","value":"and","range":{"start":31,"end":34},"kind":"and"},{"type":"whitespace","range":{"start":34,"end":35}},{"type":"pattern","range":{"start":35,"end":43},"kind":2,"value":"(gr|aph)"}]}'
         )
     })
 
     test('interpret regexp slash quotes', () => {
         expect(scanSearchQuery('r:a /a regexp \\ pattern/', false, PatternKind.Regexp)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"r","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a","range":{"start":2,"end":3}},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}],"range":{"start":0,"end":24}}}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"r","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a","range":{"start":2,"end":3}},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}]}'
         )
     })
 })
@@ -188,13 +185,13 @@ repo:sourcegraph
 // search for thing
 thing`
         expect(scanSearchQuery(query, true)).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"filterType":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"filterValue":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}],"range":{"start":0,"end":70}}}'
+            '{"type":"success","term":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"filterType":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"filterValue":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}]}'
         )
     })
 
     test('do not interpret C-style comments', () => {
         expect(scanSearchQuery('// thing')).toMatchInlineSnapshot(
-            '{"type":"success","token":{"type":"sequence","members":[{"type":"pattern","range":{"start":0,"end":2},"kind":1,"value":"//"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"pattern","range":{"start":3,"end":8},"kind":1,"value":"thing"}],"range":{"start":0,"end":8}}}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":2},"kind":1,"value":"//"},{"type":"whitespace","range":{"start":2,"end":3}},{"type":"pattern","range":{"start":3,"end":8},"kind":1,"value":"thing"}]}'
         )
     })
 })

--- a/client/shared/src/search/parser/scanner.ts
+++ b/client/shared/src/search/parser/scanner.ts
@@ -82,15 +82,6 @@ export interface Keyword {
 }
 
 /**
- * Represents a sequence of tokens in a search query.
- */
-export interface Sequence {
-    type: 'sequence'
-    range: CharacterRange
-    members: Token[]
-}
-
-/**
  * Represents a quoted string in a search query.
  *
  * Example: "Conn".

--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -1,13 +1,12 @@
 import { getMonacoTokens } from './tokens'
-import { scanSearchQuery, ScanSuccess, Sequence } from './scanner'
+import { scanSearchQuery, ScanSuccess, Token, ScanResult } from './scanner'
+
+const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
 describe('getMonacoTokens()', () => {
     test('returns the tokens for a parsed search query', () => {
         expect(
-            getMonacoTokens(
-                (scanSearchQuery('r:^github.com/sourcegraph f:code_intelligence trackViews') as ScanSuccess<Sequence>)
-                    .token
-            )
+            getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com/sourcegraph f:code_intelligence trackViews')))
         ).toStrictEqual([
             {
                 scopes: 'filterKeyword',
@@ -41,7 +40,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('search query containing parenthesized parameters', () => {
-        expect(getMonacoTokens((scanSearchQuery('r:a (f:b and c)') as ScanSuccess<Sequence>).token)).toStrictEqual([
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:a (f:b and c)')))).toStrictEqual([
             {
                 scopes: 'filterKeyword',
                 startIndex: 0,

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -1,21 +1,21 @@
 import * as Monaco from 'monaco-editor'
-import { Sequence } from './scanner'
+import { Token } from './scanner'
 
 /**
  * Returns the tokens in a scanned search query displayed in the Monaco query input.
  */
-export function getMonacoTokens(scannedQuery: Pick<Sequence, 'members'>): Monaco.languages.IToken[] {
-    const tokens: Monaco.languages.IToken[] = []
-    for (const token of scannedQuery.members) {
+export function getMonacoTokens(tokens: Token[]): Monaco.languages.IToken[] {
+    const monacoTokens: Monaco.languages.IToken[] = []
+    for (const token of tokens) {
         switch (token.type) {
             case 'filter':
                 {
-                    tokens.push({
+                    monacoTokens.push({
                         startIndex: token.filterType.range.start,
                         scopes: 'filterKeyword',
                     })
                     if (token.filterValue) {
-                        tokens.push({
+                        monacoTokens.push({
                             startIndex: token.filterValue.range.start,
                             scopes: 'identifier',
                         })
@@ -25,18 +25,18 @@ export function getMonacoTokens(scannedQuery: Pick<Sequence, 'members'>): Monaco
             case 'whitespace':
             case 'keyword':
             case 'comment':
-                tokens.push({
+                monacoTokens.push({
                     startIndex: token.range.start,
                     scopes: token.type,
                 })
                 break
             default:
-                tokens.push({
+                monacoTokens.push({
                     startIndex: token.range.start,
                     scopes: 'identifier',
                 })
                 break
         }
     }
-    return tokens
+    return monacoTokens
 }

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -652,9 +652,9 @@ export function generateFiltersQuery(filtersInQuery: FiltersToTypeAndValue): str
 }
 
 export function parsePatternTypeFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
-    const parsedQuery = scanSearchQuery(query)
-    if (parsedQuery.type === 'success') {
-        for (const token of parsedQuery.token.members) {
+    const scannedQuery = scanSearchQuery(query)
+    if (scannedQuery.type === 'success') {
+        for (const token of scannedQuery.term) {
             if (
                 token.type === 'filter' &&
                 token.filterType.value.toLowerCase() === 'patterntype' &&
@@ -672,9 +672,9 @@ export function parsePatternTypeFromQuery(query: string): { range: CharacterRang
 }
 
 export function parseCaseSensitivityFromQuery(query: string): { range: CharacterRange; value: string } | undefined {
-    const parsedQuery = scanSearchQuery(query)
-    if (parsedQuery.type === 'success') {
-        for (const token of parsedQuery.token.members) {
+    const scannedQuery = scanSearchQuery(query)
+    if (scannedQuery.type === 'success') {
+        for (const token of scannedQuery.term) {
             if (token.type === 'filter' && token.filterType.value.toLowerCase() === 'case' && token.filterValue) {
                 return {
                     range: { start: token.filterType.range.start, end: token.filterValue.range.end },

--- a/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -4,9 +4,9 @@ import { scanSearchQuery } from '../../../shared/src/search/parser/scanner'
 // A read-only syntax highlighted search query
 export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: string }> = ({ query }) => {
     const tokens = useMemo(() => {
-        const parsedQuery = scanSearchQuery(query)
-        return parsedQuery.type === 'success'
-            ? parsedQuery.token.members.map(token => {
+        const scannedQuery = scanSearchQuery(query)
+        return scannedQuery.type === 'success'
+            ? scannedQuery.term.map(token => {
                   if (token.type === 'filter') {
                       return (
                           <Fragment key={token.range.start}>

--- a/client/web/src/search/input/helpers.ts
+++ b/client/web/src/search/input/helpers.ts
@@ -19,13 +19,13 @@ import { validateFilter, isSingularFilter } from '../../../../shared/src/search/
 export function convertPlainTextToInteractiveQuery(
     query: string
 ): { filtersInQuery: FiltersToTypeAndValue; navbarQuery: string } {
-    const parsedQuery = scanSearchQuery(query)
+    const scannedQuery = scanSearchQuery(query)
 
     const newFiltersInQuery: FiltersToTypeAndValue = {}
     let newNavbarQuery = ''
 
-    if (parsedQuery.type === 'success') {
-        for (const token of parsedQuery.token.members) {
+    if (scannedQuery.type === 'success') {
+        for (const token of scannedQuery.term) {
             if (
                 token.type === 'filter' &&
                 token.filterValue &&

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -127,9 +127,9 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
     for (const node of eventLogResult.nodes) {
         const url = new URL(node.url)
         const queryFromURL = parseSearchURLQuery(url.search)
-        const parsedQuery = scanSearchQuery(queryFromURL || '')
-        if (parsedQuery.type === 'success') {
-            for (const token of parsedQuery.token.members) {
+        const scannedQuery = scanSearchQuery(queryFromURL || '')
+        if (scannedQuery.type === 'success') {
+            for (const token of scannedQuery.term) {
                 if (
                     token.type === 'filter' &&
                     (token.filterType.value === FilterType.repo ||

--- a/client/web/src/search/queryTelemetry.tsx
+++ b/client/web/src/search/queryTelemetry.tsx
@@ -1,5 +1,5 @@
 import { count } from '../../../shared/src/util/strings'
-import { scanSearchQuery, ScanResult, Sequence } from '../../../shared/src/search/parser/scanner'
+import { scanSearchQuery, ScanResult, Token } from '../../../shared/src/search/parser/scanner'
 import { resolveFilter } from '../../../shared/src/search/parser/filters'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -11,10 +11,10 @@ export function queryTelemetryData(query: string, caseSensitive: boolean) {
         empty: !query,
     }
 }
-function filterExistsInQuery(parsedQuery: ScanResult<Sequence>, filterToMatch: string): boolean {
+function filterExistsInQuery(parsedQuery: ScanResult<Token[]>, filterToMatch: string): boolean {
     if (parsedQuery.type === 'success') {
-        const members = parsedQuery.token.members
-        for (const token of members) {
+        const tokens = parsedQuery.term
+        for (const token of tokens) {
             if (token.type === 'filter') {
                 const resolvedFilter = resolveFilter(token.filterType.value)
                 if (resolvedFilter !== undefined && resolvedFilter.type === filterToMatch) {

--- a/client/web/src/search/results/SearchResultTab.tsx
+++ b/client/web/src/search/results/SearchResultTab.tsx
@@ -41,13 +41,13 @@ export const SearchResultTabHeader: React.FunctionComponent<Props> = ({
     const builtURLQuery = buildSearchURLQuery(caseToggledQuery, patternType, caseSensitive, versionContext)
 
     const currentQuery = parseSearchURLQuery(location.search) || ''
-    const parsedQuery = scanSearchQuery(currentQuery)
+    const scannedQuery = scanSearchQuery(currentQuery)
     let typeInQuery: SearchType = null
 
-    if (parsedQuery.type === 'success') {
+    if (scannedQuery.type === 'success') {
         // Parse any `type:` filter that exists in a query so
         // we can check whether this tab should be active.
-        for (const token of parsedQuery.token.members) {
+        for (const token of scannedQuery.term) {
             if (token.type === 'filter' && token.filterType.value === 'type' && token.filterValue) {
                 typeInQuery =
                     token.filterValue.type === 'literal'


### PR DESCRIPTION
There are only two small changes, by commit:

(1) `fdd3e55` This commit is the main change. It removes `Sequence` as a token type. Previously:

`export type Term = Token | Sequence`

Now:

`export type Term = Token | Token[]`

Why is this useful? 

- `Sequence` is essentially a wrapper of `Token[]`, and adds a level of indirection (accessing `members`) in external uses, which is guaranteed to always be a `Token[]`. The type of `Sequence` prior, however, could imply that it has nested lists (it never does, as a function of a scanner result). This change removes a level of indirection and reveals that the underlying type can (only) be a `Token[]`, and not, potentially, nested lists.

- The providers (hover, highlighters) now receive a `Token[]` to iterate over. I want to extend the `Token` type to a `DecoratedToken` for contextual highlighting hovers (thing regexp patterns versus structural, etc). It's easier to deal with changing the interfaces/function params to accept `DecoratedToken` than accessing structural elements (e.g., `members`) of this `Sequence` type.

What do we 'lose'?

- The only 'extra' thing `Sequence` contains is the aggregate range of the token list it contains. This aggregate range is not used anywhere in code where the scanned tokens are used. It was used in one case internal to the scanner, which we can subsume by using the end range of the last token. The aggregate range can also be fully calculated from a `Token[]`, if needed, so no real information is lost.

(2) `7e39643` This commit renames ` token: T` -> `term: T` in `TokenSuccess`. It was previously a bit of a misnomer to call `Sequence` a `token`. Now that `Sequence` is effectively `Token[]`, it is especially a misnomer to call `Token[]` a `token`. `Term` better communicates that this value can be either a `Token` or `Token` list.

(3) `92d1e7e` Propagates the above changes to callers and tests. I rename `parsedQuery` to `scannedQuery` where appropriate.