### PR TITLE
search frontend: add feature flag for smart query highlighting/hovers

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -130,6 +130,7 @@ export interface LayoutProps
     globbing: boolean
     showMultilineSearchConsole: boolean
     showQueryBuilder: boolean
+    enableSmartQuery: boolean
     isSourcegraphDotCom: boolean
     showCampaigns: boolean
     fetchSavedSearches: () => Observable<GQL.ISavedSearch[]>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -190,6 +190,11 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
      * Whether we show the mulitiline editor at /search/query-builder
      */
     showQueryBuilder: boolean
+
+    /**
+     * Wether to enable enable contextual syntax highlighting and hovers for search queries
+     */
+    enableSmartQuery: boolean
 }
 
 const notificationClassNames = {
@@ -275,6 +280,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             globbing: false,
             showMultilineSearchConsole: false,
             showQueryBuilder: false,
+            enableSmartQuery: false,
         }
     }
 
@@ -452,6 +458,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     globbing={this.state.globbing}
                                     showMultilineSearchConsole={this.state.showMultilineSearchConsole}
                                     showQueryBuilder={this.state.showQueryBuilder}
+                                    enableSmartQuery={this.state.enableSmartQuery}
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -55,6 +55,7 @@ export function experimentalFeaturesFromSettings(
     showEnterpriseHomePanels: boolean
     showMultilineSearchConsole: boolean
     showQueryBuilder: boolean
+    enableSmartQuery: boolean
 } {
     const experimentalFeatures: SettingsExperimentalFeatures =
         (settingsCascade.final && !isErrorLike(settingsCascade.final) && settingsCascade.final.experimentalFeatures) ||
@@ -69,6 +70,7 @@ export function experimentalFeaturesFromSettings(
         showEnterpriseHomePanels = true, // Default to true if not set
         showMultilineSearchConsole = false,
         showQueryBuilder = false,
+        enableSmartQuery = false,
     } = experimentalFeatures
 
     return {
@@ -80,5 +82,6 @@ export function experimentalFeaturesFromSettings(
         showEnterpriseHomePanels,
         showMultilineSearchConsole,
         showQueryBuilder,
+        enableSmartQuery,
     }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1099,6 +1099,8 @@ type SettingsExperimentalFeatures struct {
 	CodeMonitoring *bool `json:"codeMonitoring,omitempty"`
 	// CopyQueryButton description: Enables displaying the copy query button in the search bar when hovering over the global navigation bar.
 	CopyQueryButton *bool `json:"copyQueryButton,omitempty"`
+	// EnableSmartQuery description: Enables contextual syntax highlighting and hovers for search queries in the web app
+	EnableSmartQuery *bool `json:"enableSmartQuery,omitempty"`
 	// SearchStats description: Enables a new page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`
 	// SearchStreaming description: Enables experimental streaming support.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -83,6 +83,12 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "enableSmartQuery": {
+          "description": "Enables contextual syntax highlighting and hovers for search queries in the web app",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -88,6 +88,12 @@ const SettingsSchemaJSON = `{
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "enableSmartQuery": {
+          "description": "Enables contextual syntax highlighting and hovers for search queries in the web app",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
This PR just creates a feature flag to activate the work I've been doing on query highlighting/hovers for regex and other query expressions. It'd be nice to ship things without a flag, but I want to work on this incrementally, and we can enable it for the Sourcegraph org so long. 

I'll stack my work on top of this PR, just wanted to get the boiler out of the way.