### PR TITLE
db: add authzQueryConds helper

### DIFF
--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -131,15 +131,18 @@ func ProvidersFromConfig(
 
 	// 🚨 SECURITY: Warn the admin when both code host authz provider and the permissions user mapping are configured.
 	if cfg.SiteConfiguration.PermissionsUserMapping != nil &&
-		cfg.SiteConfiguration.PermissionsUserMapping.Enabled && len(providers) > 0 {
-		serviceTypes := make([]string, len(providers))
-		for i := range providers {
-			serviceTypes[i] = strconv.Quote(providers[i].ServiceType())
+		cfg.SiteConfiguration.PermissionsUserMapping.Enabled {
+		allowAccessByDefault = false
+		if len(providers) > 0 {
+			serviceTypes := make([]string, len(providers))
+			for i := range providers {
+				serviceTypes[i] = strconv.Quote(providers[i].ServiceType())
+			}
+			msg := fmt.Sprintf(
+				"The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when %s authorization providers are in use. Blocking access to all repositories until the conflict is resolved.",
+				strings.Join(serviceTypes, ", "))
+			seriousProblems = append(seriousProblems, msg)
 		}
-		msg := fmt.Sprintf(
-			"The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when %s authorization providers are in use. Blocking access to all repositories until the conflict is resolved.",
-			strings.Join(serviceTypes, ", "))
-		seriousProblems = append(seriousProblems, msg)
 	}
 
 	return allowAccessByDefault, providers, seriousProblems, warnings

--- a/internal/db/repos_perm.go
+++ b/internal/db/repos_perm.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+	"github.com/keegancsmith/sqlf"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -254,6 +255,74 @@ func authzFilter(ctx context.Context, repos []*types.Repo, p authz.Perms) (filte
 	}
 
 	return append(filtered, verified...), nil
+}
+
+const authzQueryCondsFmtstr = `(
+    %s                            -- TRUE or FALSE to indicate whether to bypass the check
+OR  (
+	NOT %s                        -- Disregard unrestricted state when permissions user mapping is enabled
+	AND (
+		NOT repo.private          -- Happy path of non-private repositories
+		OR  EXISTS (              -- Each external service defines if repositories are unrestricted
+			SELECT
+			FROM external_services AS es
+			JOIN external_service_repos AS esr ON (
+					esr.external_service_id = es.id
+				AND esr.repo_id = repo.id
+				AND es.unrestricted = TRUE
+				AND es.deleted_at IS NULL
+			)
+			LIMIT 1
+		)
+	)
+) OR (                             -- Restricted repositories require checking permissions
+	SELECT object_ids_ints @> INTSET(repo.id)
+	FROM user_permissions
+	WHERE
+		user_id = %s
+	AND permission = %s
+	AND object_type = 'repos'
+)
+)
+`
+
+// authzQueryConds returns a query clause for enforcing repository permissions.
+// It uses `repo` as the table name to filter out repository IDs and should be
+// used as an AND condition in a complete SQL query.
+func authzQueryConds(ctx context.Context) (*sqlf.Query, error) {
+	authzAllowByDefault, authzProviders := authz.GetProviders()
+	usePermissionsUserMapping := globals.PermissionsUserMapping().Enabled
+
+	// 🚨 SECURITY: Blocking access to all repositories if both code host authz provider(s) and permissions user mapping
+	// are configured.
+	if usePermissionsUserMapping {
+		if len(authzProviders) > 0 {
+			return nil, errors.New("The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it.")
+		}
+		authzAllowByDefault = false
+	}
+
+	authenticatedUserID := int32(0)
+
+	// Authz is bypassed when the request is coming from an internal actor or
+	// there is no authz provider configured and access to all repositories are allowed by default.
+	bypassAuthz := isInternalActor(ctx) || (authzAllowByDefault && len(authzProviders) == 0)
+	if !bypassAuthz && actor.FromContext(ctx).IsAuthenticated() {
+		currentUser, err := Users.GetByCurrentAuthUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		authenticatedUserID = currentUser.ID
+		bypassAuthz = currentUser.SiteAdmin
+	}
+
+	q := sqlf.Sprintf(authzQueryCondsFmtstr,
+		bypassAuthz,
+		usePermissionsUserMapping,
+		authenticatedUserID,
+		authz.Read.String(), // Note: We currently only support read for repository permissions.
+	)
+	return q, nil
 }
 
 // isInternalActor returns true if the actor represents an internal agent (i.e., non-user-bound

--- a/internal/db/repos_perm.go
+++ b/internal/db/repos_perm.go
@@ -286,6 +286,8 @@ OR  (
 )
 `
 
+var errPermissionsUserMappingConflict = errors.New("The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it.")
+
 // authzQueryConds returns a query clause for enforcing repository permissions.
 // It uses `repo` as the table name to filter out repository IDs and should be
 // used as an AND condition in a complete SQL query.
@@ -297,7 +299,7 @@ func authzQueryConds(ctx context.Context) (*sqlf.Query, error) {
 	// are configured.
 	if usePermissionsUserMapping {
 		if len(authzProviders) > 0 {
-			return nil, errors.New("The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it.")
+			return nil, errPermissionsUserMappingConflict
 		}
 		authzAllowByDefault = false
 	}

--- a/internal/db/repos_perm_test.go
+++ b/internal/db/repos_perm_test.go
@@ -160,9 +160,8 @@ func TestAuthzQueryConds(t *testing.T) {
 		defer authz.SetProviders(true, nil)
 
 		_, err := authzQueryConds(context.Background())
-		wantErr := "The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it."
 		gotErr := fmt.Sprintf("%v", err)
-		if diff := cmp.Diff(wantErr, gotErr); diff != "" {
+		if diff := cmp.Diff(errPermissionsUserMappingConflict.Error(), gotErr); diff != "" {
 			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
 	})

--- a/internal/db/repos_perm_test.go
+++ b/internal/db/repos_perm_test.go
@@ -2,16 +2,21 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func Benchmark_authzFilter(b *testing.B) {
@@ -140,6 +145,112 @@ func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsv
 
 func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {
 	return nil, nil
+}
+
+// 🚨 SECURITY: Tests are necessary to ensure security.
+func TestAuthzQueryConds(t *testing.T) {
+	cmpOpts := cmp.AllowUnexported(sqlf.Query{})
+
+	t.Run("Conflict with permissions user mapping", func(t *testing.T) {
+		before := globals.PermissionsUserMapping()
+		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
+		defer globals.SetPermissionsUserMapping(before)
+
+		authz.SetProviders(false, []authz.Provider{&fakeProvider{}})
+		defer authz.SetProviders(true, nil)
+
+		_, err := authzQueryConds(context.Background())
+		wantErr := "The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it."
+		gotErr := fmt.Sprintf("%v", err)
+		if diff := cmp.Diff(wantErr, gotErr); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("When permissions user mapping is enabled", func(t *testing.T) {
+		before := globals.PermissionsUserMapping()
+		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
+		defer globals.SetPermissionsUserMapping(before)
+
+		got, err := authzQueryConds(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := sqlf.Sprintf(authzQueryCondsFmtstr, false, true, int32(0), authz.Read.String())
+		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	defer func() {
+		Mocks.Users.GetByCurrentAuthUser = nil
+	}()
+	tests := []struct {
+		name                string
+		setup               func() context.Context
+		authzAllowByDefault bool
+		wantQuery           *sqlf.Query
+	}{
+		{
+			name: "internal actor bypass checks",
+			setup: func() context.Context {
+				return actor.WithInternalActor(context.Background())
+			},
+			wantQuery: sqlf.Sprintf(authzQueryCondsFmtstr, true, false, int32(0), authz.Read.String()),
+		},
+
+		{
+			name: "no authz provider and not allow by default",
+			setup: func() context.Context {
+				return context.Background()
+			},
+			wantQuery: sqlf.Sprintf(authzQueryCondsFmtstr, false, false, int32(0), authz.Read.String()),
+		},
+		{
+			name: "no authz provider but allow by default",
+			setup: func() context.Context {
+				return context.Background()
+			},
+			authzAllowByDefault: true,
+			wantQuery:           sqlf.Sprintf(authzQueryCondsFmtstr, true, false, int32(0), authz.Read.String()),
+		},
+
+		{
+			name: "authenticated user is a site admin",
+			setup: func() context.Context {
+				Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+					return &types.User{ID: 1, SiteAdmin: true}, nil
+				}
+				return actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+			},
+			wantQuery: sqlf.Sprintf(authzQueryCondsFmtstr, true, false, int32(1), authz.Read.String()),
+		},
+		{
+			name: "authenticated user is not a site admin",
+			setup: func() context.Context {
+				Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+					return &types.User{ID: 1}, nil
+				}
+				return actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+			},
+			wantQuery: sqlf.Sprintf(authzQueryCondsFmtstr, false, false, int32(1), authz.Read.String()),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authz.SetProviders(test.authzAllowByDefault, nil)
+			defer authz.SetProviders(true, nil)
+
+			q, err := authzQueryConds(test.setup())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(test.wantQuery, q, cmpOpts); diff != "" {
+				t.Fatalf("Mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 // 🚨 SECURITY: test necessary to ensure security


### PR DESCRIPTION
This PR is a subset of #13708, which introduces `authzQueryConds` helper for composing an AND condition in a SQL query to enforce repository permissions at SQL-level.

This helper is not yet used alone in this PR, please see #13708 with full design and detail.

Part of #11767