### PR TITLE
secret: read base64-encoded encryption keys from secret file

### DIFF
--- a/internal/secret/encryptor_test.go
+++ b/internal/secret/encryptor_test.go
@@ -195,6 +195,9 @@ func TestGatherKeys(t *testing.T) {
 	primaryKeyStr := base64.StdEncoding.EncodeToString(primaryKey)
 	secondaryKeyStr := base64.StdEncoding.EncodeToString(secondaryKey)
 
+	tooShortKey := primaryKey[:5]
+	tooShortKeyStr := base64.StdEncoding.EncodeToString(tooShortKey)
+
 	tests := []struct {
 		name             string
 		data             []byte
@@ -227,6 +230,13 @@ func TestGatherKeys(t *testing.T) {
 		{
 			name:             "has bad encoded keys",
 			data:             []byte("look mom, I am a key"),
+			wantPrimaryKey:   nil,
+			wantSecondaryKey: nil,
+			wantErr:          true,
+		},
+		{
+			name:             "key length is below requirement",
+			data:             []byte(tooShortKeyStr),
 			wantPrimaryKey:   nil,
 			wantSecondaryKey: nil,
 			wantErr:          true,

--- a/internal/secret/encryptor_test.go
+++ b/internal/secret/encryptor_test.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"bytes"
+	"encoding/base64"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -189,6 +190,11 @@ func TestAESGCMEncodedEncrytor_BadKeysFailToDecrypt(t *testing.T) {
 }
 
 func TestGatherKeys(t *testing.T) {
+	primaryKey := mustGenerateRandomAESKey()
+	secondaryKey := mustGenerateRandomAESKey()
+	primaryKeyStr := base64.StdEncoding.EncodeToString(primaryKey)
+	secondaryKeyStr := base64.StdEncoding.EncodeToString(secondaryKey)
+
 	tests := []struct {
 		name             string
 		data             []byte
@@ -197,22 +203,30 @@ func TestGatherKeys(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name:             "base-case",
-			data:             []byte("key123,key345"),
-			wantPrimaryKey:   []byte("key123"),
-			wantSecondaryKey: []byte("key345"),
+			name:             "has both primary and secondary keys",
+			data:             []byte(primaryKeyStr + "," + secondaryKeyStr),
+			wantPrimaryKey:   primaryKey,
+			wantSecondaryKey: secondaryKey,
 			wantErr:          false,
 		},
 		{
-			name:             "no key set",
-			data:             []byte("key123"),
-			wantPrimaryKey:   []byte("key123"),
+			name:             "only has primary key",
+			data:             []byte(primaryKeyStr),
+			wantPrimaryKey:   primaryKey,
 			wantSecondaryKey: nil,
 			wantErr:          false,
 		},
+
 		{
-			name:             "3 key err case",
+			name:             "has more than two keys",
 			data:             []byte("look mom, I am a key, me too"),
+			wantPrimaryKey:   nil,
+			wantSecondaryKey: nil,
+			wantErr:          true,
+		},
+		{
+			name:             "has bad encoded keys",
+			data:             []byte("look mom, I am a key"),
 			wantPrimaryKey:   nil,
 			wantSecondaryKey: nil,
 			wantErr:          true,
@@ -222,14 +236,14 @@ func TestGatherKeys(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotPrimaryKey, gotSecondaryKey, err := gatherKeys(tt.data)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("gatherKeys() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if !bytes.Equal(gotPrimaryKey, tt.wantPrimaryKey) {
-				t.Errorf("gatherKeys() oOldKey = %s, want %s", gotSecondaryKey, tt.wantPrimaryKey)
+				t.Errorf("gotPrimaryKey = %v, want %v", gotPrimaryKey, tt.wantPrimaryKey)
 			}
 			if !bytes.Equal(gotSecondaryKey, tt.wantSecondaryKey) {
-				t.Errorf("gathrKeys() gotPrimaryKey = %s, want %s", gotPrimaryKey, tt.wantSecondaryKey)
+				t.Errorf("gotSecondaryKey = %v, want %v", gotSecondaryKey, tt.wantSecondaryKey)
 			}
 		})
 	}

--- a/internal/secret/init.go
+++ b/internal/secret/init.go
@@ -26,12 +26,16 @@ func gatherKeys(data []byte) (primaryKey, secondaryKey []byte, err error) {
 	primaryKey, err = base64.StdEncoding.DecodeString(parts[0])
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "decode primary key")
+	} else if len(primaryKey) < requiredKeyLength {
+		return nil, nil, errors.Errorf("primary key length of %d bytes is required", requiredKeyLength)
 	}
 
 	if len(parts) == 2 {
 		secondaryKey, err = base64.StdEncoding.DecodeString(parts[1])
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "decode secondary key")
+		} else if len(primaryKey) < requiredKeyLength {
+			return nil, nil, errors.Errorf("secondary key length of %d bytes is required", requiredKeyLength)
 		}
 	}
 
@@ -91,9 +95,6 @@ func initDefaultEncryptor() error {
 	encryptionKeys, err := ioutil.ReadFile(secretFile)
 	if err != nil {
 		return errors.Wrapf(err, "read file %q", secretFile)
-	}
-	if len(encryptionKeys) < requiredKeyLength {
-		return errors.Errorf("key length of %d characters is required", requiredKeyLength)
 	}
 
 	primaryKey, secondaryKey, err := gatherKeys(encryptionKeys)

--- a/internal/secret/init.go
+++ b/internal/secret/init.go
@@ -1,10 +1,11 @@
 package secret
 
 import (
-	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/inconshreveable/log15"
@@ -15,15 +16,26 @@ import (
 
 // gatherKeys splits the comma-separated encryption data into its potential two components:
 // primary and secondary keys, where the first key is assumed to be the primary key.
+// Each key is expected to be base64-encoded separately.
 func gatherKeys(data []byte) (primaryKey, secondaryKey []byte, err error) {
-	parts := bytes.Split(data, []byte(","))
+	parts := strings.Split(string(data), ",")
 	if len(parts) > 2 {
 		return nil, nil, errors.Errorf("expect at most two encryption keys but got %d", len(parts))
 	}
-	if len(parts) == 1 {
-		return parts[0], nil, nil
+
+	primaryKey, err = base64.StdEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "decode primary key")
 	}
-	return parts[0], parts[1], nil
+
+	if len(parts) == 2 {
+		secondaryKey, err = base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "decode secondary key")
+		}
+	}
+
+	return primaryKey, secondaryKey, nil
 }
 
 var initErr error
@@ -76,15 +88,15 @@ func initDefaultEncryptor() error {
 		return errors.New("key file permissions are not 0400")
 	}
 
-	encryptionKey, err := ioutil.ReadFile(secretFile)
+	encryptionKeys, err := ioutil.ReadFile(secretFile)
 	if err != nil {
 		return errors.Wrapf(err, "read file %q", secretFile)
 	}
-	if len(encryptionKey) < requiredKeyLength {
+	if len(encryptionKeys) < requiredKeyLength {
 		return errors.Errorf("key length of %d characters is required", requiredKeyLength)
 	}
 
-	primaryKey, secondaryKey, err := gatherKeys(encryptionKey)
+	primaryKey, secondaryKey, err := gatherKeys(encryptionKeys)
 	if err != nil {
 		return errors.Wrap(err, "gather keys")
 	}


### PR DESCRIPTION
Quoting problem statement from #14661:

>Editing raw bytes for the secret key file is a strange experience, especially if we also want admin to "join" two arrays of bytes with a ASCII comma.
>
>Instead, base64-encoded string is a good "container" for secrets, and much easier to deal with when we expect admin to do some editing with it.

Fixes #14661