### PR TITLE
graphqlbackend: split searchCommitsInRepo

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -93,20 +93,10 @@ func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevis
 	})
 }
 
-func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
-	tr, ctx := trace.New(ctx, "searchCommitsInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v", op.RepoRevs, op.PatternInfo))
-	defer func() {
-		tr.LazyPrintf("%d results, limitHit=%v, timedOut=%v", len(results), limitHit, timedOut)
-		tr.SetError(err)
-		tr.Finish()
-	}()
-
-	repo := op.RepoRevs.Repo
-	maxResults := int(op.PatternInfo.FileMatchLimit)
-
+func commitParametersToDiffParameters(ctx context.Context, op *search.CommitParameters) (*search.DiffParameters, error) {
 	args := []string{
 		"--no-prefix",
-		"--max-count=" + strconv.Itoa(maxResults+1),
+		"--max-count=" + strconv.Itoa(int(op.PatternInfo.FileMatchLimit)+1),
 	}
 	if op.Diff {
 		args = append(args,
@@ -129,7 +119,7 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 				// against a allowlist, but it could cause unexpected errors by (e.g.)
 				// changing the format of `git log` to a format that our parser doesn't
 				// expect.
-				return nil, false, false, fmt.Errorf("invalid revspec: %q", rev.RevSpec)
+				return nil, fmt.Errorf("invalid revspec: %q", rev.RevSpec)
 			}
 			args = append(args, rev.RevSpec)
 
@@ -196,13 +186,13 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 		return nil
 	}
 	if err := addGrepLikeFlags(&args, "--grep", query.FieldMessage, op.ExtraMessageValues, false); err != nil {
-		return nil, false, false, err
+		return nil, err
 	}
 	if err := addGrepLikeFlags(&args, "--author", query.FieldAuthor, nil, true); err != nil {
-		return nil, false, false, err
+		return nil, err
 	}
 	if err := addGrepLikeFlags(&args, "--committer", query.FieldCommitter, nil, true); err != nil {
-		return nil, false, false, err
+		return nil, err
 	}
 
 	textSearchOptions := git.TextSearchOptions{
@@ -210,7 +200,7 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 		IsRegExp:        op.PatternInfo.IsRegExp,
 		IsCaseSensitive: op.PatternInfo.IsCaseSensitive,
 	}
-	diffParameters := search.DiffParameters{
+	return &search.DiffParameters{
 		Repo: op.RepoRevs.GitserverRepo(),
 		Options: git.RawLogDiffSearchOptions{
 			Query: textSearchOptions,
@@ -224,6 +214,20 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 			OnlyMatchingHunks: true,
 			Args:              args,
 		},
+	}, nil
+}
+
+func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
+	tr, ctx := trace.New(ctx, "searchCommitsInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v", op.RepoRevs, op.PatternInfo))
+	defer func() {
+		tr.LazyPrintf("%d results, limitHit=%v, timedOut=%v", len(results), limitHit, timedOut)
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	diffParameters, err := commitParametersToDiffParameters(ctx, &op)
+	if err != nil {
+		return nil, false, false, err
 	}
 
 	rawResults, complete, err := git.RawLogDiffSearch(ctx, diffParameters.Repo, diffParameters.Options)
@@ -233,12 +237,12 @@ func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (resul
 
 	// if the result is incomplete, git log timed out and the client should be notified of that
 	timedOut = !complete
-	if len(rawResults) > maxResults {
+	if len(rawResults) > int(op.PatternInfo.FileMatchLimit) {
 		limitHit = true
-		rawResults = rawResults[:maxResults]
+		rawResults = rawResults[:op.PatternInfo.FileMatchLimit]
 	}
 
-	repoResolver := &RepositoryResolver{repo: repo}
+	repoResolver := &RepositoryResolver{repo: op.RepoRevs.Repo}
 	results = make([]*CommitSearchResultResolver, len(rawResults))
 	for i, rawResult := range rawResults {
 		commit := rawResult.Commit


### PR DESCRIPTION
We factor out argument construction and resolver creation in searchCommitsInRepo. This is to make it more amenable to streaming.

This is a pure refactoring (no functionality changes).