### PR TITLE
bump syntect_server: add TOML, Zig, DreamMaker + update Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
-- GraphQL syntax highlighting is now back (special thanks to @rvantonder) [#13935](https://github.com/sourcegraph/sourcegraph/issues/13935)
+- GraphQL and TOML syntax highlighting is now back (special thanks to @rvantonder) [#13935](https://github.com/sourcegraph/sourcegraph/issues/13935)
+- Zig and DreamMaker syntax highlighting.
 - Campaigns now support publishing GitHub draft PRs and GitLab WIP MRs. [#7998](https://github.com/sourcegraph/sourcegraph/issues/7998)
 - `indexed-searcher`'s watchdog can be configured and has additional instrumentation. This is useful when diagnosing [zoekt-webserver is restarting due to watchdog](https://docs.sourcegraph.com/admin/observability/troubleshooting#scenario-zoekt-webserver-is-restarting-due-to-watchdog). [#15148](https://github.com/sourcegraph/sourcegraph/pull/15148)
 - Pings now contain Redis & Postgres server versions. [14405](https://github.com/sourcegraph/sourcegraph/14405)
@@ -40,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed an issue where hover pop-ups would not show on the first character of a valid hover range in search queries. [#15410](https://github.com/sourcegraph/sourcegraph/pull/15410)
 - Fixed an issue where submodules configured with a relative URL resulted in non-functional hyperlinks in the file tree UI. [#15286](https://github.com/sourcegraph/sourcegraph/issues/15286)
 - Pushing commits to public GitLab repositories with campaigns now works, since we use the configured token even if the repository is public. [#15536](https://github.com/sourcegraph/sourcegraph/pull/15536)
+- `.kts` is now highlighted properly as Kotlin code, fixed various other issues in Kotlin syntax highlighting.
 
 ### Removed
 

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:67fa4c1@sha256:e50ed88f971f7b08698abbc87a10fe18f2f8bbb6472766a15677621c59ca5185 /syntect_server /usr/local/bin/
+COPY --from=sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe
 
 # install postgres 11
 # hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe
+COPY --from=sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9
 
 # install postgres 11
 # hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9
+COPY --from=sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9 /syntect_server /usr/local/bin/
 
 # install postgres 11
 # hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add --no-cache \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9 /syntect_server /usr/local/bin/
+COPY --from=sourcegraph/syntect_server:9089f98@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de /syntect_server /usr/local/bin/
 
 # install postgres 11
 # hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035

--- a/dev/syntect_server.sh
+++ b/dev/syntect_server.sh
@@ -23,4 +23,4 @@ if [[ "${INSECURE_DEV:-}" == '1' ]]; then
 fi
 
 docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server
-exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:67fa4c1@sha256:e50ed88f971f7b08698abbc87a10fe18f2f8bbb6472766a15677621c59ca5185
+exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe

--- a/dev/syntect_server.sh
+++ b/dev/syntect_server.sh
@@ -23,4 +23,4 @@ if [[ "${INSECURE_DEV:-}" == '1' ]]; then
 fi
 
 docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server
-exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe
+exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9

--- a/dev/syntect_server.sh
+++ b/dev/syntect_server.sh
@@ -23,4 +23,4 @@ if [[ "${INSECURE_DEV:-}" == '1' ]]; then
 fi
 
 docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server
-exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9
+exec docker run --name=syntect_server --rm -p9238:9238 "${addr[@]}" sourcegraph/syntect_server:9089f98@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de

--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/syntect_server:67fa4c1@sha256:e50ed88f971f7b08698abbc87a10fe18f2f8bbb6472766a15677621c59ca5185
-docker tag index.docker.io/sourcegraph/syntect_server:67fa4c1@sha256:e50ed88f971f7b08698abbc87a10fe18f2f8bbb6472766a15677621c59ca5185 "$IMAGE"
+docker pull index.docker.io/sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe
+docker tag index.docker.io/sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe "$IMAGE"

--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9
-docker tag index.docker.io/sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9 "$IMAGE"
+docker pull index.docker.io/sourcegraph/syntect_server:9089f98@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+docker tag index.docker.io/sourcegraph/syntect_server:9089f98@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de "$IMAGE"

--- a/docker-images/syntax-highlighter/build.sh
+++ b/docker-images/syntax-highlighter/build.sh
@@ -6,5 +6,5 @@ set -ex
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe
-docker tag index.docker.io/sourcegraph/syntect_server:b55ad2b@sha256:3e34d4996f046df081f5f9b726d992c73724ab1611ea55b104a937304faefdbe "$IMAGE"
+docker pull index.docker.io/sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9
+docker tag index.docker.io/sourcegraph/syntect_server:1c72add@sha256:17851d7da26f86e9f21725ac461b3ce6066bdb95731da09bed07045c03661fe9 "$IMAGE"


### PR DESCRIPTION
Thanks to @rvantonder we get TOML and Zig syntax highlighting on Sourcegraph
now: https://github.com/slimsag/Packages/pull/5

Thanks to @Strum355 we get updated Kotlin syntax highlighting (and support for `.kts` file extension) plus support for DreamMaker https://github.com/slimsag/Packages/pull/6 https://github.com/slimsag/Packages/pull/7

(I am just updating a dependency here)

Fixes #13937