### PR TITLE
Display banner when user is missing some credentials on preview page

### DIFF
--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.story.tsx
@@ -51,7 +51,7 @@ const campaignSpec: CampaignSpecFields = {
         url: '/users/alice',
     },
     viewerCanAdminister: boolean('viewerCanAdminister', true),
-    viewerMissingCodeHostCredentials: {
+    viewerCampaignsCodeHosts: {
         totalCount: 0,
         nodes: [],
     },
@@ -62,7 +62,7 @@ const fetchCampaignSpecCreate: typeof fetchCampaignSpecById = () => of(campaignS
 const fetchCampaignSpecMissingCredentials: typeof fetchCampaignSpecById = () =>
     of({
         ...campaignSpec,
-        viewerMissingCodeHostCredentials: {
+        viewerCampaignsCodeHosts: {
             totalCount: 2,
             nodes: [
                 {

--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.story.tsx
@@ -3,7 +3,12 @@ import { boolean } from '@storybook/addon-knobs'
 import React from 'react'
 import { CampaignApplyPage } from './CampaignApplyPage'
 import { of, Observable } from 'rxjs'
-import { CampaignSpecChangesetSpecsResult, ChangesetSpecFields, CampaignSpecFields } from '../../../graphql-operations'
+import {
+    CampaignSpecChangesetSpecsResult,
+    ChangesetSpecFields,
+    CampaignSpecFields,
+    ExternalServiceKind,
+} from '../../../graphql-operations'
 import { visibleChangesetSpecStories } from './VisibleChangesetSpecNode.story'
 import { hiddenChangesetSpecStories } from './HiddenChangesetSpecNode.story'
 import { fetchCampaignSpecById } from './backend'
@@ -46,9 +51,31 @@ const campaignSpec: CampaignSpecFields = {
         url: '/users/alice',
     },
     viewerCanAdminister: boolean('viewerCanAdminister', true),
+    viewerMissingCodeHostCredentials: {
+        totalCount: 0,
+        nodes: [],
+    },
 }
 
 const fetchCampaignSpecCreate: typeof fetchCampaignSpecById = () => of(campaignSpec)
+
+const fetchCampaignSpecMissingCredentials: typeof fetchCampaignSpecById = () =>
+    of({
+        ...campaignSpec,
+        viewerMissingCodeHostCredentials: {
+            totalCount: 2,
+            nodes: [
+                {
+                    externalServiceKind: ExternalServiceKind.GITHUB,
+                    externalServiceURL: 'https://github.com/',
+                },
+                {
+                    externalServiceKind: ExternalServiceKind.GITLAB,
+                    externalServiceURL: 'https://gitlab.com/',
+                },
+            ],
+        },
+    })
 
 const fetchCampaignSpecUpdate: typeof fetchCampaignSpecById = () =>
     of({
@@ -97,6 +124,7 @@ add('Create', () => (
                 fetchCampaignSpecById={fetchCampaignSpecCreate}
                 queryChangesetSpecs={queryChangesetSpecs}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                authenticatedUser={{ url: '/users/alice' }}
             />
         )}
     </EnterpriseWebStory>
@@ -112,6 +140,23 @@ add('Update', () => (
                 fetchCampaignSpecById={fetchCampaignSpecUpdate}
                 queryChangesetSpecs={queryChangesetSpecs}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                authenticatedUser={{ url: '/users/alice' }}
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
+add('Missing credentials', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CampaignApplyPage
+                {...props}
+                expandChangesetDescriptions={true}
+                specID="123123"
+                fetchCampaignSpecById={fetchCampaignSpecMissingCredentials}
+                queryChangesetSpecs={queryChangesetSpecs}
+                queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                authenticatedUser={{ url: '/users/alice' }}
             />
         )}
     </EnterpriseWebStory>
@@ -127,6 +172,7 @@ add('No changesets', () => (
                 fetchCampaignSpecById={fetchCampaignSpecCreate}
                 queryChangesetSpecs={queryEmptyChangesetSpecs}
                 queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                authenticatedUser={{ url: '/users/alice' }}
             />
         )}
     </EnterpriseWebStory>

--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
@@ -77,23 +77,19 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
                 className="test-campaign-apply-page"
             />
             <CampaignSpecInfoByline createdAt={spec.createdAt} creator={spec.creator} className="mb-3" />
-            {spec.viewerMissingCodeHostCredentials.totalCount > 0 && (
+            {spec.viewerCampaignsCodeHosts.totalCount > 0 && (
                 <div className="alert alert-warning">
                     <p className="alert-title">
                         You don't have credentials configured for{' '}
-                        {pluralize(
-                            'this code host',
-                            spec.viewerMissingCodeHostCredentials.totalCount,
-                            'these code hosts'
-                        )}
+                        {pluralize('this code host', spec.viewerCampaignsCodeHosts.totalCount, 'these code hosts')}
                     </p>
                     <ul>
-                        {spec.viewerMissingCodeHostCredentials.nodes.map(node => (
+                        {spec.viewerCampaignsCodeHosts.nodes.map(node => (
                             <MissingCodeHost {...node} key={node.externalServiceKind + node.externalServiceURL} />
                         ))}
                     </ul>
                     <p className="mb-0">
-                        Configure {pluralize('it', spec.viewerMissingCodeHostCredentials.totalCount, 'them')} in your{' '}
+                        Configure {pluralize('it', spec.viewerCampaignsCodeHosts.totalCount, 'them')} in your{' '}
                         <Link to={`${authenticatedUser.url}/settings/campaigns`} target="_blank" rel="noopener">
                             campaigns user settings
                         </Link>{' '}

--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
@@ -17,11 +17,8 @@ import { HeroPage } from '../../../components/HeroPage'
 import { CampaignDescription } from '../detail/CampaignDescription'
 import { CampaignSpecInfoByline } from './CampaignSpecInfoByline'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
-import { Link } from '../../../../../shared/src/components/Link'
 import { AuthenticatedUser } from '../../../auth'
-import { ExternalServiceKind } from '../../../graphql-operations'
-import { defaultExternalServices } from '../../../components/externalServices/externalServices'
-import { pluralize } from '../../../../../shared/src/util/strings'
+import { CampaignSpecMissingCredentialsAlert } from './CampaignSpecMissingCredentialsAlert'
 
 export interface CampaignApplyPageProps extends ThemeProps, TelemetryProps {
     specID: string
@@ -77,26 +74,10 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
                 className="test-campaign-apply-page"
             />
             <CampaignSpecInfoByline createdAt={spec.createdAt} creator={spec.creator} className="mb-3" />
-            {spec.viewerCampaignsCodeHosts.totalCount > 0 && (
-                <div className="alert alert-warning">
-                    <p className="alert-title">
-                        You don't have credentials configured for{' '}
-                        {pluralize('this code host', spec.viewerCampaignsCodeHosts.totalCount, 'these code hosts')}
-                    </p>
-                    <ul>
-                        {spec.viewerCampaignsCodeHosts.nodes.map(node => (
-                            <MissingCodeHost {...node} key={node.externalServiceKind + node.externalServiceURL} />
-                        ))}
-                    </ul>
-                    <p className="mb-0">
-                        Configure {pluralize('it', spec.viewerCampaignsCodeHosts.totalCount, 'them')} in your{' '}
-                        <Link to={`${authenticatedUser.url}/settings/campaigns`} target="_blank" rel="noopener">
-                            campaigns user settings
-                        </Link>{' '}
-                        to apply this spec.
-                    </p>
-                </div>
-            )}
+            <CampaignSpecMissingCredentialsAlert
+                authenticatedUser={authenticatedUser}
+                viewerCampaignsCodeHosts={spec.viewerCampaignsCodeHosts}
+            />
             <CreateUpdateCampaignAlert
                 history={history}
                 specID={spec.id}
@@ -115,18 +96,5 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
                 expandChangesetDescriptions={expandChangesetDescriptions}
             />
         </>
-    )
-}
-
-const MissingCodeHost: React.FunctionComponent<{
-    externalServiceKind: ExternalServiceKind
-    externalServiceURL: string
-}> = ({ externalServiceKind, externalServiceURL }) => {
-    const Icon = defaultExternalServices[externalServiceKind].icon
-    return (
-        <li>
-            <Icon className="icon-inline mr-2" />
-            {externalServiceURL}
-        </li>
     )
 }

--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
@@ -21,6 +21,7 @@ import { Link } from '../../../../../shared/src/components/Link'
 import { AuthenticatedUser } from '../../../auth'
 import { ExternalServiceKind } from '../../../graphql-operations'
 import { defaultExternalServices } from '../../../components/externalServices/externalServices'
+import { pluralize } from '../../../../../shared/src/util/strings'
 
 export interface CampaignApplyPageProps extends ThemeProps, TelemetryProps {
     specID: string
@@ -79,14 +80,25 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
             {spec.viewerMissingCodeHostCredentials.totalCount > 0 && (
                 <div className="alert alert-warning">
                     <p className="alert-title">
-                        Some credentials are missing to apply this campaign.{' '}
-                        <Link to={`${authenticatedUser.url}/settings/campaigns`}>Configure them here</Link>.
+                        You don't have credentials configured for{' '}
+                        {pluralize(
+                            'this code host',
+                            spec.viewerMissingCodeHostCredentials.totalCount,
+                            'these code hosts'
+                        )}
                     </p>
                     <ul>
                         {spec.viewerMissingCodeHostCredentials.nodes.map(node => (
                             <MissingCodeHost {...node} key={node.externalServiceKind + node.externalServiceURL} />
                         ))}
                     </ul>
+                    <p className="mb-0">
+                        Configure {pluralize('it', spec.viewerMissingCodeHostCredentials.totalCount, 'them')} in your{' '}
+                        <Link to={`${authenticatedUser.url}/settings/campaigns`} target="_blank" rel="noopener">
+                            campaigns user settings
+                        </Link>{' '}
+                        to apply this spec.
+                    </p>
                 </div>
             )}
             <CreateUpdateCampaignAlert
@@ -117,7 +129,7 @@ const MissingCodeHost: React.FunctionComponent<{
     const Icon = defaultExternalServices[externalServiceKind].icon
     return (
         <li>
-            <Icon className="icon-inline" />
+            <Icon className="icon-inline mr-2" />
             {externalServiceURL}
         </li>
     )

--- a/client/web/src/enterprise/campaigns/apply/CampaignSpecMissingCredentialsAlert.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignSpecMissingCredentialsAlert.tsx
@@ -19,17 +19,19 @@ export const CampaignSpecMissingCredentialsAlert: React.FunctionComponent<Campai
     }
     return (
         <div className="alert alert-warning">
-            <h4 className="alert-heading">
-                You don't have credentials configured for{' '}
-                {pluralize('this code host', viewerCampaignsCodeHosts.totalCount, 'these code hosts')}
-            </h4>
+            <p>
+                <strong>
+                    You don't have credentials configured for{' '}
+                    {pluralize('this code host', viewerCampaignsCodeHosts.totalCount, 'these code hosts')}
+                </strong>
+            </p>
             <ul>
                 {viewerCampaignsCodeHosts.nodes.map(node => (
                     <MissingCodeHost {...node} key={node.externalServiceKind + node.externalServiceURL} />
                 ))}
             </ul>
             <p className="mb-0">
-                Configure {pluralize('it', viewerCampaignsCodeHosts.totalCount, 'them')} in your{' '}
+                Credentials are required to publish changesets on code hosts. Configure them in your{' '}
                 <Link to={`${authenticatedUser.url}/settings/campaigns`} target="_blank" rel="noopener">
                     campaigns user settings
                 </Link>{' '}

--- a/client/web/src/enterprise/campaigns/apply/CampaignSpecMissingCredentialsAlert.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignSpecMissingCredentialsAlert.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Link } from '../../../../../shared/src/components/Link'
+import { pluralize } from '../../../../../shared/src/util/strings'
+import { AuthenticatedUser } from '../../../auth'
+import { defaultExternalServices } from '../../../components/externalServices/externalServices'
+import { ViewerCampaignsCodeHostsFields } from '../../../graphql-operations'
+
+export interface CampaignSpecMissingCredentialsAlertProps {
+    viewerCampaignsCodeHosts: ViewerCampaignsCodeHostsFields
+    authenticatedUser: Pick<AuthenticatedUser, 'url'>
+}
+
+export const CampaignSpecMissingCredentialsAlert: React.FunctionComponent<CampaignSpecMissingCredentialsAlertProps> = ({
+    viewerCampaignsCodeHosts,
+    authenticatedUser,
+}) => {
+    if (viewerCampaignsCodeHosts.totalCount === 0) {
+        return <></>
+    }
+    return (
+        <div className="alert alert-warning">
+            <h4 className="alert-heading">
+                You don't have credentials configured for{' '}
+                {pluralize('this code host', viewerCampaignsCodeHosts.totalCount, 'these code hosts')}
+            </h4>
+            <ul>
+                {viewerCampaignsCodeHosts.nodes.map(node => (
+                    <MissingCodeHost {...node} key={node.externalServiceKind + node.externalServiceURL} />
+                ))}
+            </ul>
+            <p className="mb-0">
+                Configure {pluralize('it', viewerCampaignsCodeHosts.totalCount, 'them')} in your{' '}
+                <Link to={`${authenticatedUser.url}/settings/campaigns`} target="_blank" rel="noopener">
+                    campaigns user settings
+                </Link>{' '}
+                to apply this spec.
+            </p>
+        </div>
+    )
+}
+
+const MissingCodeHost: React.FunctionComponent<ViewerCampaignsCodeHostsFields['nodes'][0]> = ({
+    externalServiceKind,
+    externalServiceURL,
+}) => {
+    const Icon = defaultExternalServices[externalServiceKind].icon
+    return (
+        <li>
+            <Icon className="icon-inline mr-2" />
+            {externalServiceURL}
+        </li>
+    )
+}

--- a/client/web/src/enterprise/campaigns/apply/backend.ts
+++ b/client/web/src/enterprise/campaigns/apply/backend.ts
@@ -45,7 +45,7 @@ export const campaignSpecFragment = gql`
         diffStat {
             ...DiffStatFields
         }
-        viewerMissingCodeHostCredentials {
+        viewerCampaignsCodeHosts(onlyWithoutCredential: true) {
             totalCount
             nodes {
                 externalServiceURL

--- a/client/web/src/enterprise/campaigns/apply/backend.ts
+++ b/client/web/src/enterprise/campaigns/apply/backend.ts
@@ -45,6 +45,13 @@ export const campaignSpecFragment = gql`
         diffStat {
             ...DiffStatFields
         }
+        viewerMissingCodeHostCredentials {
+            totalCount
+            nodes {
+                externalServiceURL
+                externalServiceKind
+            }
+        }
     }
 
     ${diffStatFields}

--- a/client/web/src/enterprise/campaigns/apply/backend.ts
+++ b/client/web/src/enterprise/campaigns/apply/backend.ts
@@ -19,6 +19,16 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { requestGraphQL } from '../../../backend/graphql'
 
+export const viewerCampaignsCodeHostsFragment = gql`
+    fragment ViewerCampaignsCodeHostsFields on CampaignsCodeHostConnection {
+        totalCount
+        nodes {
+            externalServiceURL
+            externalServiceKind
+        }
+    }
+`
+
 export const campaignSpecFragment = gql`
     fragment CampaignSpecFields on CampaignSpec {
         id
@@ -46,13 +56,11 @@ export const campaignSpecFragment = gql`
             ...DiffStatFields
         }
         viewerCampaignsCodeHosts(onlyWithoutCredential: true) {
-            totalCount
-            nodes {
-                externalServiceURL
-                externalServiceKind
-            }
+            ...ViewerCampaignsCodeHostsFields
         }
     }
+
+    ${viewerCampaignsCodeHostsFragment}
 
     ${diffStatFields}
 `

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -534,7 +534,7 @@ describe('Campaigns', () => {
                                           url: '/organizations/test-org',
                                       },
                             viewerCanAdminister: true,
-                            viewerMissingCodeHostCredentials: {
+                            viewerCampaignsCodeHosts: {
                                 totalCount: 0,
                                 nodes: [],
                             },

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -534,6 +534,10 @@ describe('Campaigns', () => {
                                           url: '/organizations/test-org',
                                       },
                             viewerCanAdminister: true,
+                            viewerMissingCodeHostCredentials: {
+                                totalCount: 0,
+                                nodes: [],
+                            },
                         },
                     }),
                     CampaignSpecChangesetSpecs: () => ({

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -90,6 +90,12 @@ type ListCampaignsCodeHostsArgs struct {
 	UserID int32
 }
 
+type ListViewerCampaignsCodeHostsArgs struct {
+	First                 int32
+	After                 *string
+	OnlyWithoutCredential bool
+}
+
 type CampaignsResolver interface {
 	// Mutations
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (CampaignResolver, error)
@@ -139,7 +145,7 @@ type CampaignSpecResolver interface {
 
 	AppliesToCampaign(ctx context.Context) (CampaignResolver, error)
 
-	ViewerMissingCodeHostCredentials(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
+	ViewerCampaignsCodeHosts(ctx context.Context, args *ListViewerCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 }
 
 type CampaignDescriptionResolver interface {

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -138,6 +138,8 @@ type CampaignSpecResolver interface {
 	DiffStat(ctx context.Context) (*DiffStat, error)
 
 	AppliesToCampaign(ctx context.Context) (CampaignResolver, error)
+
+	ViewerMissingCodeHostCredentials(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 }
 
 type CampaignDescriptionResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1186,7 +1186,23 @@ type CampaignSpec implements Node {
     """
     appliesToCampaign: Campaign
 
-    viewerMissingCodeHostCredentials(first: Int = 50, after: String): CampaignsCodeHostConnection!
+    """
+    The code host connections required for applying this spec. Includes the credentials of the current user.
+    """
+    viewerCampaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only returns the code hosts for which the viewer doesn't have credentials.
+        """
+        onlyWithoutCredential: Boolean = false
+    ): CampaignsCodeHostConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1186,7 +1186,7 @@ type CampaignSpec implements Node {
     """
     appliesToCampaign: Campaign
 
-    viewerMissingCodeHostCredentials(first: Int! = 50, after: String): CampaignsCodeHostConnection!
+    viewerMissingCodeHostCredentials(first: Int = 50, after: String): CampaignsCodeHostConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1185,6 +1185,8 @@ type CampaignSpec implements Node {
     campaign doesn't yet exist.
     """
     appliesToCampaign: Campaign
+
+    viewerMissingCodeHostCredentials(first: Int! = 50, after: String): CampaignsCodeHostConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1179,7 +1179,23 @@ type CampaignSpec implements Node {
     """
     appliesToCampaign: Campaign
 
-    viewerMissingCodeHostCredentials(first: Int = 50, after: String): CampaignsCodeHostConnection!
+    """
+    The code host connections required for applying this spec. Includes the credentials of the current user.
+    """
+    viewerCampaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only returns the code hosts for which the viewer doesn't have credentials.
+        """
+        onlyWithoutCredential: Boolean = false
+    ): CampaignsCodeHostConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1178,6 +1178,8 @@ type CampaignSpec implements Node {
     campaign doesn't yet exist.
     """
     appliesToCampaign: Campaign
+
+    viewerMissingCodeHostCredentials(first: Int! = 50, after: String): CampaignsCodeHostConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1179,7 +1179,7 @@ type CampaignSpec implements Node {
     """
     appliesToCampaign: Campaign
 
-    viewerMissingCodeHostCredentials(first: Int! = 50, after: String): CampaignsCodeHostConnection!
+    viewerMissingCodeHostCredentials(first: Int = 50, after: String): CampaignsCodeHostConnection!
 }
 
 """

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -203,6 +203,12 @@ type CampaignSpec struct {
 
 	AppliesToCampaign Campaign
 
+	ViewerCampaignsCodeHosts CampaignsCodeHostsConnection
+	// Alias for the above.
+	AllCodeHosts CampaignsCodeHostsConnection
+	// Alias for the above.
+	OnlyWithoutCredential CampaignsCodeHostsConnection
+
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -214,12 +214,7 @@ func (r *campaignSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, arg
 	if args.OnlyWithoutCredential {
 		if authErr := backend.CheckCurrentUserIsSiteAdmin(ctx); authErr == nil {
 			// For site-admins never return anything
-			return &campaignsCodeHostConnectionResolver{
-				store: r.store,
-				customCompute: func(ctx context.Context) (all []*campaigns.CodeHost, page []*campaigns.CodeHost, credsByIDType map[idType]*db.UserCredential, err error) {
-					return []*campaigns.CodeHost{}, []*campaigns.CodeHost{}, nil, nil
-				},
-			}, nil
+			return &emptyCampaignsCodeHostConnectionResolver{}, nil
 		} else if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
 			return nil, authErr
 		}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -212,6 +212,7 @@ func (r *campaignSpecResolver) ViewerMissingCodeHostCredentials(ctx context.Cont
 	if authErr := backend.CheckCurrentUserIsSiteAdmin(ctx); authErr == nil {
 		// For site-admins never return anything
 		return &campaignsCodeHostConnectionResolver{
+			store: r.store,
 			customCompute: func(ctx context.Context) (all []*campaigns.CodeHost, page []*campaigns.CodeHost, credsByIDType map[idType]*db.UserCredential, err error) {
 				return []*campaigns.CodeHost{}, []*campaigns.CodeHost{}, nil, nil
 			},
@@ -233,6 +234,7 @@ func (r *campaignSpecResolver) ViewerMissingCodeHostCredentials(ctx context.Cont
 	return &campaignsCodeHostConnectionResolver{
 		userID:                actor.UID,
 		onlyWithoutCredential: true,
+		store:                 r.store,
 		opts: ee.ListCodeHostsOpts{
 			RepoIDs: specs.RepoIDs(),
 		},

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -220,7 +220,7 @@ func (r *campaignSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, arg
 					return []*campaigns.CodeHost{}, []*campaigns.CodeHost{}, nil, nil
 				},
 			}, nil
-		} else if authErr != backend.ErrMustBeSiteAdmin {
+		} else if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
 			return nil, authErr
 		}
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -209,6 +209,16 @@ func (r *campaignSpecResolver) ViewerMissingCodeHostCredentials(ctx context.Cont
 	if !actor.IsAuthenticated() {
 		return nil, backend.ErrNotAuthenticated
 	}
+	if authErr := backend.CheckCurrentUserIsSiteAdmin(ctx); authErr == nil {
+		// For site-admins never return anything
+		return &campaignsCodeHostConnectionResolver{
+			customCompute: func(ctx context.Context) (all []*campaigns.CodeHost, page []*campaigns.CodeHost, credsByIDType map[idType]*db.UserCredential, err error) {
+				return []*campaigns.CodeHost{}, []*campaigns.CodeHost{}, nil, nil
+			},
+		}, nil
+	} else if authErr != backend.ErrMustBeSiteAdmin {
+		return nil, authErr
+	}
 	specs, _, err := r.store.ListChangesetSpecs(ctx, ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID})
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -8,9 +8,12 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
@@ -198,5 +201,34 @@ func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlba
 		store:       r.store,
 		httpFactory: r.httpFactory,
 		Campaign:    campaign,
+	}, nil
+}
+
+func (r *campaignSpecResolver) ViewerMissingCodeHostCredentials(ctx context.Context, args *graphqlbackend.ListCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {
+	actor := actor.FromContext(ctx)
+	if !actor.IsAuthenticated() {
+		return nil, backend.ErrNotAuthenticated
+	}
+	specs, _, err := r.store.ListChangesetSpecs(ctx, ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID})
+	if err != nil {
+		return nil, err
+	}
+	offset := 0
+	if args.After != nil {
+		offset, err = strconv.Atoi(*args.After)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &campaignsCodeHostConnectionResolver{
+		userID:                actor.UID,
+		onlyWithoutCredential: true,
+		opts: ee.ListCodeHostsOpts{
+			RepoIDs: specs.RepoIDs(),
+		},
+		limitOffset: db.LimitOffset{
+			Limit:  int(args.First),
+			Offset: offset,
+		},
 	}, nil
 }

--- a/enterprise/internal/campaigns/resolvers/code_host_connection.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection.go
@@ -14,20 +14,23 @@ import (
 )
 
 type campaignsCodeHostConnectionResolver struct {
-	userID      int32
-	limitOffset db.LimitOffset
-	store       *ee.Store
+	userID                int32
+	onlyWithoutCredential bool
+	opts                  ee.ListCodeHostsOpts
+	limitOffset           db.LimitOffset
+	store                 *ee.Store
 
-	once    sync.Once
-	chs     []*campaigns.CodeHost
-	chsPage []*campaigns.CodeHost
-	chsErr  error
+	once          sync.Once
+	chs           []*campaigns.CodeHost
+	chsPage       []*campaigns.CodeHost
+	credsByIDType map[idType]*db.UserCredential
+	chsErr        error
 }
 
 var _ graphqlbackend.CampaignsCodeHostConnectionResolver = &campaignsCodeHostConnectionResolver{}
 
 func (c *campaignsCodeHostConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	chs, _, err := c.compute(ctx)
+	chs, _, _, err := c.compute(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -35,7 +38,7 @@ func (c *campaignsCodeHostConnectionResolver) TotalCount(ctx context.Context) (i
 }
 
 func (c *campaignsCodeHostConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	chs, _, err := c.compute(ctx)
+	chs, _, _, err := c.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,42 +52,58 @@ func (c *campaignsCodeHostConnectionResolver) PageInfo(ctx context.Context) (*gr
 }
 
 func (c *campaignsCodeHostConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.CampaignsCodeHostResolver, error) {
-	_, page, err := c.compute(ctx)
+	_, page, credsByIDType, err := c.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Fetch all user credentials to avoid N+1 per credential resolver.
-	creds, _, err := db.UserCredentials.List(ctx, db.UserCredentialsListOpts{Scope: db.UserCredentialScope{Domain: db.UserCredentialDomainCampaigns, UserID: c.userID}})
-	if err != nil {
-		return nil, err
-	}
-
-	credsByIDType := make(map[idType]*db.UserCredential)
-	for _, cred := range creds {
-		t := idType{
-			externalServiceID:   cred.ExternalServiceID,
-			externalServiceType: cred.ExternalServiceType,
-		}
-		credsByIDType[t] = cred
-	}
-
-	nodes := make([]graphqlbackend.CampaignsCodeHostResolver, len(page))
-	for i, ch := range page {
+	nodes := make([]graphqlbackend.CampaignsCodeHostResolver, 0)
+	for _, ch := range page {
 		t := idType{
 			externalServiceID:   ch.ExternalServiceID,
 			externalServiceType: ch.ExternalServiceType,
 		}
-		nodes[i] = &campaignsCodeHostResolver{externalServiceKind: extsvc.TypeToKind(ch.ExternalServiceType), externalServiceURL: ch.ExternalServiceID, credential: credsByIDType[t]}
+		cred := credsByIDType[t]
+		nodes = append(nodes, &campaignsCodeHostResolver{externalServiceKind: extsvc.TypeToKind(ch.ExternalServiceType), externalServiceURL: ch.ExternalServiceID, credential: cred})
 	}
 
 	return nodes, nil
 }
 
-func (c *campaignsCodeHostConnectionResolver) compute(ctx context.Context) (all, page []*campaigns.CodeHost, err error) {
+func (c *campaignsCodeHostConnectionResolver) compute(ctx context.Context) (all, page []*campaigns.CodeHost, credsByIDType map[idType]*db.UserCredential, err error) {
 	c.once.Do(func() {
 		// Don't pass c.limitOffset here, as we want all code hosts for the totalCount anyways.
-		c.chs, c.chsErr = c.store.ListCodeHosts(ctx)
+		c.chs, c.chsErr = c.store.ListCodeHosts(ctx, c.opts)
+
+		// Fetch all user credentials to avoid N+1 per credential resolver.
+		creds, _, err := db.UserCredentials.List(ctx, db.UserCredentialsListOpts{Scope: db.UserCredentialScope{Domain: db.UserCredentialDomainCampaigns, UserID: c.userID}})
+		if err != nil {
+			c.chsErr = err
+			return
+		}
+
+		c.credsByIDType = make(map[idType]*db.UserCredential)
+		for _, cred := range creds {
+			t := idType{
+				externalServiceID:   cred.ExternalServiceID,
+				externalServiceType: cred.ExternalServiceType,
+			}
+			c.credsByIDType[t] = cred
+		}
+
+		if c.onlyWithoutCredential {
+			chs := make([]*campaigns.CodeHost, 0)
+			for _, ch := range c.chs {
+				t := idType{
+					externalServiceID:   ch.ExternalServiceID,
+					externalServiceType: ch.ExternalServiceType,
+				}
+				if _, ok := credsByIDType[t]; !ok {
+					chs = append(chs, ch)
+				}
+			}
+			c.chs = chs
+		}
 
 		afterIdx := c.limitOffset.Offset
 
@@ -106,7 +125,7 @@ func (c *campaignsCodeHostConnectionResolver) compute(ctx context.Context) (all,
 		}
 		c.chsPage = c.chs[afterIdx : limit+afterIdx]
 	})
-	return c.chs, c.chsPage, c.chsErr
+	return c.chs, c.chsPage, c.credsByIDType, c.chsErr
 }
 
 type idType struct {

--- a/enterprise/internal/campaigns/resolvers/code_host_connection.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection.go
@@ -58,14 +58,14 @@ func (c *campaignsCodeHostConnectionResolver) Nodes(ctx context.Context) ([]grap
 		return nil, err
 	}
 
-	nodes := make([]graphqlbackend.CampaignsCodeHostResolver, 0)
-	for _, ch := range page {
+	nodes := make([]graphqlbackend.CampaignsCodeHostResolver, len(page))
+	for i, ch := range page {
 		t := idType{
 			externalServiceID:   ch.ExternalServiceID,
 			externalServiceType: ch.ExternalServiceType,
 		}
 		cred := credsByIDType[t]
-		nodes = append(nodes, &campaignsCodeHostResolver{externalServiceKind: extsvc.TypeToKind(ch.ExternalServiceType), externalServiceURL: ch.ExternalServiceID, credential: cred})
+		nodes[i] = &campaignsCodeHostResolver{externalServiceKind: extsvc.TypeToKind(ch.ExternalServiceType), externalServiceURL: ch.ExternalServiceID, credential: cred}
 	}
 
 	return nodes, nil
@@ -82,6 +82,9 @@ func (c *campaignsCodeHostConnectionResolver) defaultCompute(ctx context.Context
 	c.once.Do(func() {
 		// Don't pass c.limitOffset here, as we want all code hosts for the totalCount anyways.
 		c.chs, c.chsErr = c.store.ListCodeHosts(ctx, c.opts)
+		if c.chsErr != nil {
+			return
+		}
 
 		// Fetch all user credentials to avoid N+1 per credential resolver.
 		creds, _, err := db.UserCredentials.List(ctx, db.UserCredentialsListOpts{Scope: db.UserCredentialScope{Domain: db.UserCredentialDomainCampaigns, UserID: c.userID}})

--- a/enterprise/internal/campaigns/resolvers/code_host_connection.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection.go
@@ -106,7 +106,7 @@ func (c *campaignsCodeHostConnectionResolver) defaultCompute(ctx context.Context
 					externalServiceID:   ch.ExternalServiceID,
 					externalServiceType: ch.ExternalServiceType,
 				}
-				if _, ok := credsByIDType[t]; !ok {
+				if _, ok := c.credsByIDType[t]; !ok {
 					chs = append(chs, ch)
 				}
 			}

--- a/enterprise/internal/campaigns/store_codehost_test.go
+++ b/enterprise/internal/campaigns/store_codehost_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
@@ -27,27 +28,45 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, reposStore r
 	}
 
 	t.Run("ListCodeHosts", func(t *testing.T) {
-		have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := []*campaigns.CodeHost{
-			{
-				ExternalServiceType: extsvc.TypeBitbucketServer,
-				ExternalServiceID:   "https://bitbucketserver.com/",
-			},
-			{
-				ExternalServiceType: extsvc.TypeGitHub,
-				ExternalServiceID:   "https://github.com/",
-			},
-			{
-				ExternalServiceType: extsvc.TypeGitLab,
-				ExternalServiceID:   "https://gitlab.com/",
-			},
-		}
-		if diff := cmp.Diff(have, want); diff != "" {
-			t.Fatalf("Invalid code hosts returned. %s", diff)
-		}
+		t.Run("List all", func(t *testing.T) {
+			have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []*campaigns.CodeHost{
+				{
+					ExternalServiceType: extsvc.TypeBitbucketServer,
+					ExternalServiceID:   "https://bitbucketserver.com/",
+				},
+				{
+					ExternalServiceType: extsvc.TypeGitHub,
+					ExternalServiceID:   "https://github.com/",
+				},
+				{
+					ExternalServiceType: extsvc.TypeGitLab,
+					ExternalServiceID:   "https://gitlab.com/",
+				},
+			}
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatalf("Invalid code hosts returned. %s", diff)
+			}
+		})
+		t.Run("By RepoIDs", func(t *testing.T) {
+			have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{RepoIDs: []api.RepoID{repo.ID}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []*campaigns.CodeHost{
+				{
+					ExternalServiceType: extsvc.TypeGitHub,
+					ExternalServiceID:   "https://github.com/",
+				},
+			}
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatalf("Invalid code hosts returned. %s", diff)
+			}
+
+		})
 	})
 
 	t.Run("GetExternalServiceID", func(t *testing.T) {

--- a/enterprise/internal/campaigns/store_codehost_test.go
+++ b/enterprise/internal/campaigns/store_codehost_test.go
@@ -27,7 +27,7 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, reposStore r
 	}
 
 	t.Run("ListCodeHosts", func(t *testing.T) {
-		have, err := s.ListCodeHosts(ctx)
+		have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Implements a list of code host connection with the ability to filter by only those where no credentials are set. Then in the UI we use that to display a warning which code hosts are missing.

![image](https://user-images.githubusercontent.com/19534377/98856617-1acb7800-245e-11eb-9bc6-d8c04c6f51a0.png)

Closes https://github.com/sourcegraph/sourcegraph/issues/14991.