### PR TITLE
Move internal package content to shared

### DIFF
--- a/cmd/repo-updater/shared/observability.go
+++ b/cmd/repo-updater/shared/observability.go
@@ -1,4 +1,4 @@
-package internal
+package shared
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/cmd/repo-updater/shared/store.go
+++ b/cmd/repo-updater/shared/store.go
@@ -1,4 +1,4 @@
-package internal
+package shared
 
 import (
 	"context"

--- a/cmd/repo-updater/shared/sync_job.go
+++ b/cmd/repo-updater/shared/sync_job.go
@@ -1,4 +1,4 @@
-package internal
+package shared
 
 import "database/sql"
 


### PR DESCRIPTION
This PR is part of #15082. The new store code needs to be accessed by `enterprise/cmd/repo-updater` and thus cannot reside in `cmd/repo-updater/internal`. It has been moved to `cmd/repo-updater/shared` instead. 
The content of that package will only be imported by repo-updater.