### PR TITLE
search: add mutation toggle- and deleteCodeMonitor

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -11,6 +11,7 @@ import (
 type CodeMonitorsResolver interface {
 	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
+	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -128,6 +129,11 @@ type CreateActionEmailArgs struct {
 	Header     string
 }
 
+type ToggleCodeMonitorArgs struct {
+	Id      graphql.ID
+	Enabled bool
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -140,5 +146,9 @@ func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID int32,
 }
 
 func (d defaultCodeMonitorsResolver) CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -12,6 +12,7 @@ type CodeMonitorsResolver interface {
 	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
 	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
+	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -134,6 +135,10 @@ type ToggleCodeMonitorArgs struct {
 	Enabled bool
 }
 
+type DeleteCodeMonitorArgs struct {
+	Id graphql.ID
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -150,5 +155,9 @@ func (d defaultCodeMonitorsResolver) CreateCodeMonitor(ctx context.Context, args
 }
 
 func (d defaultCodeMonitorsResolver) ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -765,6 +765,19 @@ type Mutation {
         """
         actions: [MonitorActionInput!]!
     ): Monitor!
+    """
+    Set a code monitor to active/inactive.
+    """
+    toggleCodeMonitor(
+        """
+        The id of a code monitor.
+        """
+        id: ID!
+        """
+        Whether the code monitor should be enabled or not.
+        """
+        enabled: Boolean!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -778,6 +778,15 @@ type Mutation {
         """
         enabled: Boolean!
     ): Monitor!
+    """
+    Delete a code monitor.
+    """
+    deleteCodeMonitor(
+        """
+        The id of a code monitor.
+        """
+        id: ID!
+    ): EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -758,6 +758,19 @@ type Mutation {
         """
         actions: [MonitorActionInput!]!
     ): Monitor!
+    """
+    Set a code monitor to active/inactive.
+    """
+    toggleCodeMonitor(
+        """
+        The id of a code monitor.
+        """
+        id: ID!
+        """
+        Whether the code monitor should be enabled or not.
+        """
+        enabled: Boolean!
+    ): Monitor!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -771,6 +771,15 @@ type Mutation {
         """
         enabled: Boolean!
     ): Monitor!
+    """
+    Delete a code monitor.
+    """
+    deleteCodeMonitor(
+        """
+        The id of a code monitor.
+        """
+        id: ID!
+    ): EmptyResponse!
 }
 
 """

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -113,6 +114,18 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 		}
 	}
 	return m, nil
+}
+
+func (r *Resolver) ToggleCodeMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (graphqlbackend.MonitorResolver, error) {
+	err := r.isAllowedToEdit(ctx, args.Id)
+	if err != nil {
+		return nil, fmt.Errorf("ToggleCodeMonitor: %w", err)
+	}
+	q, err := r.toggleCodeMonitorQuery(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return r.runMonitorQuery(ctx, q)
 }
 
 func (r *Resolver) runMonitorQuery(ctx context.Context, q *sqlf.Query) (graphqlbackend.MonitorResolver, error) {
@@ -380,6 +393,106 @@ RETURNING %s;
 		nilOrInt32(userID),
 		nilOrInt32(orgID),
 		sqlf.Join(recipientsColumns, ", "),
+	), nil
+}
+
+func (r *Resolver) toggleCodeMonitorQuery(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*sqlf.Query, error) {
+	toggleCodeMonitorQuery := `
+UPDATE cm_monitors
+SET enabled = %s,
+	changed_by = %s,
+	changed_at = %s
+WHERE id = %s
+RETURNING %s
+`
+	var monitorID int64
+	err := relay.UnmarshalSpec(args.Id, &monitorID)
+	if err != nil {
+		return nil, err
+	}
+	actorUID := actor.FromContext(ctx).UID
+	query := sqlf.Sprintf(
+		toggleCodeMonitorQuery,
+		args.Enabled,
+		actorUID,
+		r.clock(),
+		monitorID,
+		sqlf.Join(monitorColumns, ", "),
+	)
+	return query, nil
+}
+
+// isAllowedToEdit compares the owner of a monitor (user or org) to the actor of
+// the request. A user can edit a monitor if either of the following statements
+// is true:
+// - she is the owner
+// - she is a member of the organization which is the owner of the monitor
+// - she is a site-admin
+func (r *Resolver) isAllowedToEdit(ctx context.Context, id graphql.ID) error {
+	var monitorId int32
+	err := relay.UnmarshalSpec(id, &monitorId)
+	if err != nil {
+		return err
+	}
+	userId, orgID, err := r.ownerForId32(ctx, monitorId)
+	if err != nil {
+		return err
+	}
+	if userId == nil && orgID == nil {
+		return fmt.Errorf("monitor does not exist")
+	}
+	if orgID != nil {
+		if err := backend.CheckOrgAccess(ctx, *orgID); err != nil {
+			return fmt.Errorf("user is not a member of the organization which owns the code monitor")
+		}
+		return nil
+	}
+	if err := backend.CheckSiteAdminOrSameUser(ctx, *userId); err != nil {
+		return fmt.Errorf("user not allowed to edit")
+	}
+	return nil
+}
+
+func (r *Resolver) ownerForId32(ctx context.Context, monitorId int32) (userId *int32, orgId *int32, err error) {
+	var (
+		q    *sqlf.Query
+		rows *sql.Rows
+	)
+	q, err = ownerForId32Query(ctx, monitorId)
+	if err != nil {
+		return nil, nil, err
+	}
+	rows, err = r.db.Query(ctx, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err = rows.Scan(
+			&userId,
+			&orgId,
+		); err != nil {
+			return nil, nil, err
+		}
+	}
+	err = rows.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Rows.Err will report the last error encountered by Rows.Scan.
+	if err = rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return userId, orgId, nil
+}
+
+func ownerForId32Query(ctx context.Context, monitorId int32) (*sqlf.Query, error) {
+	const ownerForId32Query = `SELECT namespace_user_id, namespace_org_id FROM cm_monitors WHERE id = %s`
+	return sqlf.Sprintf(
+		ownerForId32Query,
+		monitorId,
 	), nil
 }
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -29,27 +30,17 @@ func TestCreateCodeMonitor(t *testing.T) {
 
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
+	r := newTestResolver(t)
 
-	username := "code-monitors-resolver-user"
-	userID := insertTestUser(t, dbconn.Global, username, true)
-	_, err := db.Orgs.Create(ctx, "test-org", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
-	r := newResolverWithClock(dbconn.Global, clock)
+	userID := insertTestUser(t, dbconn.Global, "cm-user1", true)
 
 	want := &monitor{
 		id:              1,
 		createdBy:       userID,
-		createdAt:       clock(),
+		createdAt:       r.clock(),
 		changedBy:       userID,
-		changedAt:       clock(),
-		description:     "banana",
+		changedAt:       r.clock(),
+		description:     "test monitor",
 		enabled:         true,
 		namespaceUserID: &userID,
 		namespaceOrgID:  nil,
@@ -58,24 +49,80 @@ func TestCreateCodeMonitor(t *testing.T) {
 	// Create a monitor
 	ctx = actor.WithActor(ctx, actor.FromUser(userID))
 	ns := relay.MarshalID("User", userID)
-	got, err := r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
-		Namespace:   ns,
-		Description: "banana",
-		Enabled:     true,
-		Trigger:     &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
-		Actions: []*graphqlbackend.CreateActionArgs{
-			{Email: &graphqlbackend.CreateActionEmailArgs{
-				Enabled:    false,
-				Priority:   "NORMAL",
-				Recipients: []graphql.ID{ns},
-				Header:     "test header",
-			}}},
-	})
+	got, err := r.insertTestMonitor(ctx, t, ns)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(want, got.(*monitor)) {
 		t.Fatalf("\ngot:\t %+v,\nwant:\t %+v", got, want)
+	}
+
+	// Toggle field enabled from true to false
+	got, err = r.ToggleCodeMonitor(ctx, &graphqlbackend.ToggleCodeMonitorArgs{
+		Id:      relay.MarshalID(monitorKind, got.(*monitor).id),
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(*monitor).enabled {
+		t.Fatalf("got enabled=%T, want enabled=%T", got.(*monitor).enabled, false)
+	}
+
+}
+
+func TestIsAllowedToEdit(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	dbtesting.SetupGlobalTestDB(t)
+
+	// Setup users and org
+	member := insertTestUser(t, dbconn.Global, "cm-user1", false)
+	notMember := insertTestUser(t, dbconn.Global, "cm-user2", false)
+	siteAdmin := insertTestUser(t, dbconn.Global, "cm-user3", true)
+
+	admContext := actor.WithActor(context.Background(), actor.FromUser(siteAdmin))
+	org, err := db.Orgs.Create(admContext, "cm-test-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addUserToOrg(t, dbconn.Global, member, org.ID)
+
+	r := newTestResolver(t)
+
+	// Create a monitor and set org as owner.
+	ns := relay.MarshalID("Org", org.ID)
+	m, err := r.insertTestMonitor(admContext, t, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		user    int32
+		allowed bool
+	}{
+		{
+			user:    member,
+			allowed: true,
+		},
+		{
+			user:    notMember,
+			allowed: false,
+		},
+		{
+			user:    siteAdmin,
+			allowed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("user %d", tt.user), func(t *testing.T) {
+			ctx := actor.WithActor(context.Background(), actor.FromUser(tt.user))
+			if err := r.isAllowedToEdit(ctx, m.ID()); (err != nil) == tt.allowed {
+				t.Fatalf("unexpected permissions for user %d", tt.user)
+			}
+		})
 	}
 }
 
@@ -90,4 +137,43 @@ func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID
 	}
 
 	return userID
+}
+
+func addUserToOrg(t *testing.T, db *sql.DB, userID int32, orgID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO org_members (org_id, user_id) VALUES (%s, %s)", orgID, userID)
+
+	_, err := db.Exec(q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (r *Resolver) insertTestMonitor(ctx context.Context, t *testing.T, owner graphql.ID) (graphqlbackend.MonitorResolver, error) {
+	t.Helper()
+
+	return r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
+		Namespace:   owner,
+		Description: "test monitor",
+		Enabled:     true,
+		Trigger:     &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
+		Actions: []*graphqlbackend.CreateActionArgs{
+			{Email: &graphqlbackend.CreateActionEmailArgs{
+				Enabled:    true,
+				Priority:   "NORMAL",
+				Recipients: []graphql.ID{owner},
+				Header:     "test header",
+			}}},
+	})
+}
+
+func newTestResolver(t *testing.T) *Resolver {
+	t.Helper()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+	return newResolverWithClock(dbconn.Global, clock).(*Resolver)
 }


### PR DESCRIPTION
Adds the mutation `toggleCodeMonitor`. Its purpose is to allow to toggle the state (`enabled=true/false`) of a monitor as we can see on this design
![image](https://user-images.githubusercontent.com/26413131/98786905-1459e380-23ff-11eb-963d-a2a2ab8c4788.png)

As a by-product, I introduce the first authorization logic `isAllowedToEdit` which will be used in many mutations down the line.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
