### PR TITLE
Bump src-cli version and update docs to reflect new version

### DIFF
--- a/doc/dev/background-information/campaigns/index.md
+++ b/doc/dev/background-information/campaigns/index.md
@@ -79,11 +79,27 @@ Here is a short description of what `src-cli` does when you run with `src campai
 
 ### 1. Download archive and prepare
 
-1. Download archive of repository (what it does is equivalent to: `curl -L -v -X GET -H 'Accept: application/zip' -H 'Authorization: token <THE_SRC_TOKEN>' 'http://sourcegraph.example.com/github.com/my-org/my-repo@refs/heads/master/-/raw' --output ~/tmp/my-repo.zip
-`)
+1. Download archive of repository. What it does is equivalent to:
+
+    ```
+    curl -L -v -X GET -H 'Accept: application/zip' \
+      -H 'Authorization: token <THE_SRC_TOKEN>' \
+      'http://sourcegraph.example.com/github.com/my-org/my-repo@refs/heads/master/-/raw' \
+      --output ~/tmp/my-repo.zip
+    ```
 2. Unzip archive, e.g. into `~/Library/Caches/sourcegraph/campaigns` (see `src campaign preview -h` for default value of cache dir, overwrite with `-cache`)
 3. `cd` into unzipped archive
 4. In the unzipped archive directory, create a git repository:
+	- Configure `git` to not use local config (see [the code for explanations on what each varable does](https://github.com/sourcegraph/src-cli/blob/038180005c9ebf5c0f9e8d3b2eda63c109cea904/internal/campaigns/run_steps.go#L31-L44)):
+
+    ```
+    export GIT_CONFIG_NOSYSTEM=1 \
+           GIT_CONFIG=/dev/null \
+           GIT_AUTHOR_NAME=Sourcegraph \
+           GIT_AUTHOR_EMAIL=campaigns@sourcegraph.com \
+           GIT_COMMITTER_NAME=Sourcegraph \
+           GIT_COMMITTER_EMAIL=campaigns@sourcegraph.com
+    ```
   - Run `git init`
   - Run `git config --local user.name Sourcegraph`
   - Run `git config --local user.email campaigns@sourcegraph.com`
@@ -97,7 +113,14 @@ For each step:
 1. Probe container image to see whether it has `bin/sh` or `bin/bash`
 2. Write `steps.run` to a temp file, e.g. `/tmp-script`
 3. Run `chmod 644 /tmp-script`
-4. Run `docker run --rm --init --workdir /work --mount type=bind,source=/unzipped-archive-locally,target=/work --mount type=bind,source=/tmp-script,target=/tmp-file-in-container --entrypoint /bin/bash -- <IMAGE> /tmp-file-in-container`
+4. Run the Docker container:
+
+    ```
+    docker run --rm --init --workdir /work \
+      --mount type=bind,source=/unzipped-archive-locally,target=/work \
+      --mount type=bind,source=/tmp-script,target=/tmp-file-in-container \
+      --entrypoint /bin/bash -- <IMAGE> /tmp-file-in-container
+    ```
 5. Add all the changes, run: `git add --all`
 
 ### 3. Create final diff

--- a/doc/dev/background-information/campaigns/index.md
+++ b/doc/dev/background-information/campaigns/index.md
@@ -90,7 +90,7 @@ Here is a short description of what `src-cli` does when you run with `src campai
 2. Unzip archive, e.g. into `~/Library/Caches/sourcegraph/campaigns` (see `src campaign preview -h` for default value of cache dir, overwrite with `-cache`)
 3. `cd` into unzipped archive
 4. In the unzipped archive directory, create a git repository:
-	- Configure `git` to not use local config (see [the code for explanations on what each varable does](https://github.com/sourcegraph/src-cli/blob/038180005c9ebf5c0f9e8d3b2eda63c109cea904/internal/campaigns/run_steps.go#L31-L44)):
+	- Configure `git` to not use local config (see [the code for explanations on what each variable does](https://github.com/sourcegraph/src-cli/blob/038180005c9ebf5c0f9e8d3b2eda63c109cea904/internal/campaigns/run_steps.go#L31-L44)):
 
     ```
     export GIT_CONFIG_NOSYSTEM=1 \

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.21.5"
+const MinimumVersion = "3.21.8"


### PR DESCRIPTION
This bumps the src-cli version and updates the docs I added yesterday to reflect the new behaviour added in https://github.com/sourcegraph/src-cli/pull/373