### PR TITLE
search: add mutation deleteCodeMonitor

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -12,6 +12,7 @@ type CodeMonitorsResolver interface {
 	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
 	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
+	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -134,6 +135,10 @@ type ToggleCodeMonitorArgs struct {
 	Enabled bool
 }
 
+type DeleteCodeMonitorArgs struct {
+	Id graphql.ID
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -150,5 +155,9 @@ func (d defaultCodeMonitorsResolver) CreateCodeMonitor(ctx context.Context, args
 }
 
 func (d defaultCodeMonitorsResolver) ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -778,6 +778,15 @@ type Mutation {
         """
         enabled: Boolean!
     ): Monitor!
+    """
+    Delete a code monitor.
+    """
+    deleteCodeMonitor(
+        """
+        The id of a code monitor.
+        """
+        id: ID!
+    ): EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -771,6 +771,15 @@ type Mutation {
         """
         enabled: Boolean!
     ): Monitor!
+    """
+    Delete a code monitor.
+    """
+    deleteCodeMonitor(
+        """
+        The id of a code monitor.
+        """
+        id: ID!
+    ): EmptyResponse!
 }
 
 """


### PR DESCRIPTION
This PR adds the mutation `deleteCodeMonitor`. Deletion of a code
monitor triggers the deletion of all related triggers and actions.

I added a test to the existing test for `createCodeMonitor` to increase
speed of execution

[Link to Figma frame](https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=2160%3A55)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
