### PR TITLE
graphql: Record queries that trigger getCommit calls

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -54,6 +54,8 @@ func (prometheusTracer) TraceQuery(ctx context.Context, queryString string, oper
 		ctx, finish = trace.OpenTracingTracer{}.TraceQuery(ctx, queryString, operationName, variables, varTypes)
 	}
 
+	ctx = context.WithValue(ctx, "graphql-query", queryString)
+
 	_, disableLog := os.LookupEnv("NO_GRAPHQL_LOG")
 
 	// Note: We don't care about the error here, we just extract the username if


### PR DESCRIPTION
This is an attempt to debug #15392 and find what GraphQL queries trigger
the `getCommit` codepath, which leads to a spike of git log calls in git
server, that triggers that alert.

In the future, we should invest in working tracing, rather than only
per-request activated tracing, which doesn't allow us to retroactively
debug situations like these.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
