### PR TITLE
Code monitor creation page: Focus form fields

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -95,6 +95,7 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
                             onChange={event => {
                                 onNameChange(event.target.value)
                             }}
+                            autoFocus={true}
                         />
                     </div>
                     <small className="text-muted">
@@ -233,6 +234,7 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                 }}
                                 value={query}
                                 required={true}
+                                autoFocus={true}
                             />
                             <a
                                 href=""
@@ -358,6 +360,7 @@ const ActionArea: React.FunctionComponent<ActionAreaProps> = ({
                                 className="form-control my-2"
                                 value={`${authenticatedUser.email || ''} (you)`}
                                 disabled={true}
+                                autoFocus={true}
                             />
                             <small className="text-muted">
                                 Code monitors are currently limited to sending emails to your primary email address.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/15652. Autofocuses the name input, and autofocuses the inputs in the trigger and action areas when opened.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
