### PR TITLE
Lazily init upload store to not block frontend bootup

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -36,7 +36,7 @@ var once sync.Once
 func initServices(ctx context.Context) error {
 	once.Do(func() {
 		if err := config.UploadStoreConfig.Validate(); err != nil {
-			services.err = fmt.Errorf("Failed to load config: %s", err)
+			services.err = fmt.Errorf("failed to load config: %s", err)
 			return
 		}
 
@@ -54,7 +54,7 @@ func initServices(ctx context.Context) error {
 		dbStore := store.NewWithDB(dbconn.Global, observationContext)
 		lsifStore := lsifstore.NewStore(codeIntelDB, observationContext)
 
-		uploadStore, err := uploadstore.Create(context.Background(), config.UploadStoreConfig, observationContext)
+		uploadStore, err := uploadstore.CreateLazy(context.Background(), config.UploadStoreConfig, observationContext)
 		if err != nil {
 			log.Fatalf("Failed to initialize upload store: %s", err)
 		}

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
@@ -18,7 +18,7 @@ func TestGCSInit(t *testing.T) {
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.AttrsFunc.SetDefaultReturn(nil, storage.ErrBucketNotExist)
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, true, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -44,7 +44,7 @@ func TestGCSInitBucketExists(t *testing.T) {
 	bucketHandle := NewMockGcsBucketHandle()
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, true, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -69,7 +69,7 @@ func TestGCSUnmanagedInit(t *testing.T) {
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.AttrsFunc.SetDefaultReturn(nil, storage.ErrBucketNotExist)
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, false)
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -93,7 +93,7 @@ func TestGCSGet(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 	rc, err := client.Get(context.Background(), "test-key", 0)
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
@@ -132,7 +132,7 @@ func TestGCSGetSkipBytes(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 	rc, err := client.Get(context.Background(), "test-key", 20)
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
@@ -174,7 +174,7 @@ func TestGCSUpload(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewWriterFunc.SetDefaultReturn(nopCloser{buf})
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 
 	size, err := client.Upload(context.Background(), "test-key", bytes.NewReader([]byte("TEST PAYLOAD")))
 	if err != nil {
@@ -219,7 +219,7 @@ func TestGCSCombine(t *testing.T) {
 		}[name]
 	})
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 
 	size, err := client.Compose(context.Background(), "test-key", "test-src1", "test-src2", "test-src3")
 	if err != nil {
@@ -274,7 +274,7 @@ func TestGCSDelete(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := newGCSWithClient(gcsClient, "test-bucket", time.Hour*24, false, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := testGCSClient(gcsClient, true)
 	if err := client.Delete(context.Background(), "test-key"); err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
@@ -291,7 +291,7 @@ func TestGCSDelete(t *testing.T) {
 }
 
 func TestGCSLifecycle(t *testing.T) {
-	client := newGCSWithClient(nil, "test-bucket", time.Hour*24*3, true, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+	client := rawGCSClient(nil, true)
 
 	if lifecycle := client.lifecycle(); len(lifecycle.Rules) != 1 {
 		t.Fatalf("unexpected lifecycle rules")
@@ -300,8 +300,13 @@ func TestGCSLifecycle(t *testing.T) {
 	}
 }
 
-//
-//
+func testGCSClient(client gcsAPI, manageBucket bool) Store {
+	return newLazyStorerawGCSClient(client, manageBucket)
+}
+
+func rawGCSClient(client gcsAPI, manageBucket bool) *gcsStore {
+	return newGCSWithClient(client, "test-bucket", time.Hour*24*3, manageBucket, GCSConfig{ProjectID: "pid"}, makeOperations(&observation.TestContext))
+}
 
 type nopCloser struct {
 	io.Writer

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
@@ -93,7 +93,7 @@ func TestGCSGet(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := testGCSClient(gcsClient, true)
+	client := testGCSClient(gcsClient, false)
 	rc, err := client.Get(context.Background(), "test-key", 0)
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
@@ -132,7 +132,7 @@ func TestGCSGetSkipBytes(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := testGCSClient(gcsClient, true)
+	client := testGCSClient(gcsClient, false)
 	rc, err := client.Get(context.Background(), "test-key", 20)
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
@@ -174,7 +174,7 @@ func TestGCSUpload(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewWriterFunc.SetDefaultReturn(nopCloser{buf})
 
-	client := testGCSClient(gcsClient, true)
+	client := testGCSClient(gcsClient, false)
 
 	size, err := client.Upload(context.Background(), "test-key", bytes.NewReader([]byte("TEST PAYLOAD")))
 	if err != nil {
@@ -219,7 +219,7 @@ func TestGCSCombine(t *testing.T) {
 		}[name]
 	})
 
-	client := testGCSClient(gcsClient, true)
+	client := testGCSClient(gcsClient, false)
 
 	size, err := client.Compose(context.Background(), "test-key", "test-src1", "test-src2", "test-src3")
 	if err != nil {
@@ -274,7 +274,7 @@ func TestGCSDelete(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
-	client := testGCSClient(gcsClient, true)
+	client := testGCSClient(gcsClient, false)
 	if err := client.Delete(context.Background(), "test-key"); err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
@@ -301,7 +301,7 @@ func TestGCSLifecycle(t *testing.T) {
 }
 
 func testGCSClient(client gcsAPI, manageBucket bool) Store {
-	return newLazyStorerawGCSClient(client, manageBucket)
+	return newLazyStore(rawGCSClient(client, manageBucket))
 }
 
 func rawGCSClient(client gcsAPI, manageBucket bool) *gcsStore {

--- a/enterprise/internal/codeintel/stores/uploadstore/lazy_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/lazy_client.go
@@ -1,0 +1,80 @@
+package uploadstore
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+type lazyStore struct {
+	store       Store
+	m           sync.RWMutex
+	initialized bool
+}
+
+var _ Store = &gcsStore{}
+
+func newLazyStore(store Store) Store {
+	return &lazyStore{store: store}
+}
+
+func (s *lazyStore) Init(ctx context.Context) error {
+	return s.initOnce(ctx)
+}
+
+func (s *lazyStore) Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error) {
+	if err := s.initOnce(ctx); err != nil {
+		return nil, err
+	}
+
+	return s.store.Get(ctx, key, skipBytes)
+}
+
+func (s *lazyStore) Upload(ctx context.Context, key string, r io.Reader) (int64, error) {
+	if err := s.initOnce(ctx); err != nil {
+		return 0, err
+	}
+
+	return s.store.Upload(ctx, key, r)
+}
+
+func (s *lazyStore) Compose(ctx context.Context, destination string, sources ...string) (int64, error) {
+	if err := s.initOnce(ctx); err != nil {
+		return 0, err
+	}
+
+	return s.store.Compose(ctx, destination, sources...)
+}
+
+func (s *lazyStore) Delete(ctx context.Context, key string) error {
+	if err := s.initOnce(ctx); err != nil {
+		return err
+	}
+
+	return s.store.Delete(ctx, key)
+}
+
+// initOnce serializes access to the underlying store's Init method. If the
+// Init method completes successfully, all future calls to this function will
+// no-op.
+func (s *lazyStore) initOnce(ctx context.Context) error {
+	s.m.RLock()
+	initialized := s.initialized
+	s.m.RUnlock()
+	if initialized {
+		return nil
+	}
+
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.initialized {
+		return nil
+	}
+
+	if err := s.store.Init(ctx); err != nil {
+		return err
+	}
+
+	s.initialized = true
+	return nil
+}

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
@@ -77,30 +77,12 @@ func (s *s3Store) Init(ctx context.Context) error {
 		return nil
 	}
 
-	//
-	// TODO - rewrite, test
-
-	tryCreate := func() error {
-		if err := s.create(ctx); err != nil {
-			return errors.Wrap(err, "failed to create bucket")
-		}
-
-		if err := s.update(ctx); err != nil {
-			return errors.Wrap(err, "failed to update bucket attributes")
-		}
-
-		return nil
+	if err := s.create(ctx); err != nil {
+		return errors.Wrap(err, "failed to create bucket")
 	}
 
-	var err error
-	for i := 0; i < 20; i++ {
-		if i > 0 {
-			<-time.After(time.Second)
-		}
-
-		if err = tryCreate(); err == nil {
-			break
-		}
+	if err := s.update(ctx); err != nil {
+		return errors.Wrap(err, "failed to update bucket attributes")
 	}
 
 	return nil

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
@@ -351,7 +351,7 @@ func TestS3Lifecycle(t *testing.T) {
 }
 
 func testS3Client(client s3API, uploader s3Uploader) Store {
-	return newLazyStore(rawS3Client(client, uploader)
+	return newLazyStore(rawS3Client(client, uploader))
 }
 
 func rawS3Client(client s3API, uploader s3Uploader) *s3Store {

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestS3Init(t *testing.T) {
 	s3Client := NewMockS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, true, makeOperations(&observation.TestContext))
+	client := testS3Client(s3Client, nil)
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err.Error())
 	}
@@ -42,7 +42,7 @@ func TestS3InitBucketExists(t *testing.T) {
 		s3Client := NewMockS3API()
 		s3Client.CreateBucketFunc.SetDefaultReturn(nil, awserr.New(code, "", nil))
 
-		client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, true, makeOperations(&observation.TestContext))
+		client := testS3Client(s3Client, nil)
 		if err := client.Init(context.Background()); err != nil {
 			t.Fatalf("unexpected error initializing client: %s", err.Error())
 		}
@@ -161,7 +161,7 @@ func TestS3Upload(t *testing.T) {
 		return nil
 	})
 
-	client := newS3WithClients(s3Client, uploaderClient, "test-bucket", time.Hour*24, false, makeOperations(&observation.TestContext))
+	client := testS3Client(s3Client, uploaderClient)
 
 	size, err := client.Upload(context.Background(), "test-key", bytes.NewReader([]byte("TEST PAYLOAD")))
 	if err != nil {
@@ -197,7 +197,7 @@ func TestS3Combine(t *testing.T) {
 
 	s3Client.HeadObjectFunc.SetDefaultReturn(&s3.HeadObjectOutput{ContentLength: aws.Int64(42)}, nil)
 
-	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, false, makeOperations(&observation.TestContext))
+	client := testS3Client(s3Client, nil)
 
 	size, err := client.Compose(context.Background(), "test-key", "test-src1", "test-src2", "test-src3")
 	if err != nil {
@@ -299,7 +299,7 @@ func TestS3Delete(t *testing.T) {
 		Body: ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
 	}, nil)
 
-	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, false, makeOperations(&observation.TestContext))
+	client := testS3Client(s3Client, nil)
 	if err := client.Delete(context.Background(), "test-key"); err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
@@ -315,7 +315,7 @@ func TestS3Delete(t *testing.T) {
 
 func TestS3Lifecycle(t *testing.T) {
 	s3Client := NewMockS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24*3, true, makeOperations(&observation.TestContext))
+	client := rawS3Client(s3Client, nil)
 
 	if lifecycle := client.lifecycle(); lifecycle == nil || len(lifecycle.Rules) != 2 {
 		t.Fatalf("unexpected lifecycle rules")
@@ -348,4 +348,12 @@ func TestS3Lifecycle(t *testing.T) {
 			t.Errorf("unexpected ttl for multipart upload expiration. want=%d have=%d", 3, *multipartExpiration)
 		}
 	}
+}
+
+func testS3Client(client s3API, uploader s3Uploader) Store {
+	return newLazyStore(rawS3Client(client, uploader)
+}
+
+func rawS3Client(client s3API, uploader s3Uploader) *s3Store {
+	return newS3WithClients(client, uploader, "test-bucket", time.Hour*24*3, true, makeOperations(&observation.TestContext))
 }

--- a/enterprise/internal/codeintel/stores/uploadstore/store.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/store.go
@@ -39,6 +39,32 @@ var storeConstructors = map[string]func(ctx context.Context, config *Config, ope
 
 // Create initialize a new store from the given configuration.
 func Create(ctx context.Context, config *Config, observationContext *observation.Context) (Store, error) {
+	store, err := create(ctx, config, observationContext)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := store.Init(ctx); err != nil {
+		return nil, err
+	}
+
+	return store, err
+}
+
+// CreateLazy initialize a new store from the given configuration that is initialized
+// on it first method call. If initialization fails, all methods calls will return a
+// the initialization error.
+func CreateLazy(ctx context.Context, config *Config, observationContext *observation.Context) (Store, error) {
+	store, err := create(ctx, config, observationContext)
+	if err != nil {
+		return nil, err
+	}
+
+	return newLazyStore(store), nil
+}
+
+// create creates but does not initialize a new store from the given configuration.
+func create(ctx context.Context, config *Config, observationContext *observation.Context) (Store, error) {
 	newStore, ok := storeConstructors[config.Backend]
 	if !ok {
 		return nil, fmt.Errorf("unknown upload store backend '%s'", config.Backend)
@@ -49,9 +75,5 @@ func Create(ctx context.Context, config *Config, observationContext *observation
 		return nil, err
 	}
 
-	if err := store.Init(ctx); err != nil {
-		return nil, err
-	}
-
-	return store, err
+	return store, nil
 }


### PR DESCRIPTION
This Slack thread has more information: https://sourcegraph.slack.com/archives/C07KZF47K/p1605097556396300

Short version: when `./enterprise/dev/start.sh` was started `frontend`
initialized the bucket on `minio`, even when the code-intel services
weren't started.

And if `minio` hasn't booted up yet, `frontend` would wait for `minio`
to boot up. And other services, waiting for `frontend`, would also wait.

This could take between 1 and 25 seconds. 1-3 if `minio` was up, 3-25 if
`minio` needed to be started.

Since I (nor @tsenart who I was pairing with) don't know much about
code-intel architecture, this is just a rough attempt.

It does fix the problem, but might not be the proper thing in the
context of code intel.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
