### PR TITLE
fix: Fix frontend shutdown

### DIFF
--- a/internal/processrestart/processrestart.go
+++ b/internal/processrestart/processrestart.go
@@ -19,6 +19,3 @@ func Restart() error {
 	}
 	return errors.New("unable to restart processes")
 }
-
-// WillRestart is a channel that is closed when the process will imminently restart.
-var WillRestart = make(chan struct{})


### PR DESCRIPTION
Stop listening on a channel that's never closed/written. Graefully begin to shutdown the frontend on a signal.