### PR TITLE
git: Send actual repo.Name to Honeycomb

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -76,7 +76,7 @@ func getCommit(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (s
 		defer func() {
 			ev := honey.Event("getCommit")
 			ev.SampleRate = 10 // 1 in 10
-			ev.AddField("repo", repo)
+			ev.AddField("repo", repo.Name)
 			ev.AddField("commit", id)
 			ev.AddField("no_ensure_revision", opt.NoEnsureRevision)
 			ev.AddField("actor", actor.FromContext(ctx).UIDString())


### PR DESCRIPTION
We were sending struct string representations like
`{"Name":"github.com/kubernetes/kubernetes","URL":"https://github.com/kubernetes/kubernetes.git"}`

