### PR TITLE
event_logs: Collect codeintel and search data separately

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -178,25 +178,26 @@ func getAndMarshalSearchOnboardingJSON(ctx context.Context) (_ json.RawMessage, 
 	return json.Marshal(searchOnboarding)
 }
 
-func getAndMarshalAggregatedUsageJSON(ctx context.Context) (_ json.RawMessage, _ json.RawMessage, err error) {
-	defer recordOperation("getAndMarshalAggregatedUsageJSON")(&err)
+func getAndMarshalAggregatedCodeIntelUsageJSON(ctx context.Context) (_ json.RawMessage, err error) {
+	defer recordOperation("getAndMarshalAggregatedCodeIntelUsageJSON")(&err)
 
-	codeIntelUsage, searchUsage, err := usagestats.GetAggregatedStats(ctx)
+	codeIntelUsage, err := usagestats.GetAggregatedCodeIntelStats(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	serializedCodeIntelUsage, err := json.Marshal(codeIntelUsage)
+	return json.Marshal(codeIntelUsage)
+}
+
+func getAndMarshalAggregatedSearchUsageJSON(ctx context.Context) (_ json.RawMessage, err error) {
+	defer recordOperation("getAndMarshalAggregatedSearchUsageJSON")(&err)
+
+	searchUsage, err := usagestats.GetAggregatedSearchStats(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	serializedSearchUsage, err := json.Marshal(searchUsage)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return serializedCodeIntelUsage, serializedSearchUsage, nil
+	return json.Marshal(searchUsage)
 }
 
 func getDependencyVersions(ctx context.Context, logFunc func(string, ...interface{})) (json.RawMessage, error) {
@@ -376,11 +377,21 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r.CodeIntelUsage, r.SearchUsage, err = getAndMarshalAggregatedUsageJSON(ctx)
+			r.CodeIntelUsage, err = getAndMarshalAggregatedCodeIntelUsageJSON(ctx)
 			if err != nil {
-				logFunc("telemetry: updatecheck.getAndMarshalAggregatedUsageJSON failed", "error", err)
+				logFunc("telemetry: updatecheck.getAndMarshalAggregatedCodeIntelUsageJSON failed", "error", err)
 			}
 		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.SearchUsage, err = getAndMarshalAggregatedSearchUsageJSON(ctx)
+			if err != nil {
+				logFunc("telemetry: updatecheck.getAndMarshalAggregatedSearchUsageJSON failed", "error", err)
+			}
+		}()
+
 		wg.Wait()
 	} else {
 		r.Activity, err = getAndMarshalSiteActivityJSON(ctx, true)

--- a/internal/db/event_logs_test.go
+++ b/internal/db/event_logs_test.go
@@ -276,14 +276,14 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 	}
 }
 
-func TestEventLogs_AggregatedEvents(t *testing.T) {
+func TestEventLogs_AggregatedCodeIntelEvents(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	names := []string{"codeintel.searchHover", "search.latencies.literal", "unknown event"}
+	names := []string{"codeintel.lsifReferences", "codeintel.searchHover", "unknown event"}
 	users := []uint32{1, 2}
 	durations := []int{40, 65, 72}
 
@@ -332,14 +332,14 @@ func TestEventLogs_AggregatedEvents(t *testing.T) {
 		}
 	}
 
-	events, err := EventLogs.aggregatedEvents(ctx, now)
+	events, err := EventLogs.aggregatedCodeIntelEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expectedEvents := []types.AggregatedEvent{
 		{
-			Name:           "codeintel.searchHover",
+			Name:           "codeintel.lsifReferences",
 			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
 			Week:           now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
 			Day:            now.Truncate(time.Hour * 24),
@@ -354,7 +354,7 @@ func TestEventLogs_AggregatedEvents(t *testing.T) {
 			LatenciesDay:   []float64{894, 1732.1, 1745.51},
 		},
 		{
-			Name:           "search.latencies.literal",
+			Name:           "codeintel.searchHover",
 			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
 			Week:           now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
 			Day:            now.Truncate(time.Hour * 24),
@@ -374,7 +374,7 @@ func TestEventLogs_AggregatedEvents(t *testing.T) {
 	}
 }
 
-func TestEventLogs_AggregatedEventsSparseEvents(t *testing.T) {
+func TestEventLogs_AggregatedSparseCodeIntelEvents(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -405,7 +405,7 @@ func TestEventLogs_AggregatedEventsSparseEvents(t *testing.T) {
 		}
 	}
 
-	events, err := EventLogs.aggregatedEvents(ctx, now)
+	events, err := EventLogs.aggregatedCodeIntelEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -413,6 +413,162 @@ func TestEventLogs_AggregatedEventsSparseEvents(t *testing.T) {
 	expectedEvents := []types.AggregatedEvent{
 		{
 			Name:           "codeintel.searchHover",
+			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
+			Week:           now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
+			Day:            now.Truncate(time.Hour * 24),
+			TotalMonth:     5,
+			TotalWeek:      0,
+			TotalDay:       0,
+			UniquesMonth:   1,
+			UniquesWeek:    0,
+			UniquesDay:     0,
+			LatenciesMonth: []float64{50, 50, 50},
+			LatenciesWeek:  nil,
+			LatenciesDay:   nil,
+		},
+	}
+	if diff := cmp.Diff(expectedEvents, events); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	names := []string{"search.latencies.literal", "search.latencies.structural", "unknown event"}
+	users := []uint32{1, 2}
+	durations := []int{40, 65, 72}
+
+	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
+	// be a consistent value so that the tests don't fail when someone runs it at some particular
+	// time that falls too near the edge of a week.
+	now := time.Unix(1589581800, 0).UTC()
+
+	days := []time.Time{
+		now,                           // Today
+		now.Add(-time.Hour * 24 * 3),  // This week
+		now.Add(-time.Hour * 24 * 4),  // This week
+		now.Add(-time.Hour * 24 * 6),  // This month
+		now.Add(-time.Hour * 24 * 12), // This month
+		now.Add(-time.Hour * 24 * 40), // Previous month
+	}
+
+	durationOffset := 0
+	for _, user := range users {
+		for _, name := range names {
+			for _, duration := range durations {
+				for _, day := range days {
+					for i := 0; i < 25; i++ {
+						durationOffset++
+
+						e := &Event{
+							UserID: user,
+							Name:   name,
+							URL:    "test",
+							Source: "test",
+							// Make durations non-uniform to test percent_cont. The values
+							// in this test were hand-checked before being added to the assertion.
+							// Adding additional events or changing parameters will require these
+							// values to be checked again.
+							Argument: json.RawMessage(fmt.Sprintf(`{"durationMs": %d}`, duration+durationOffset)),
+							// Jitter current time +/- 30 minutes
+							Timestamp: day.Add(time.Minute * time.Duration(rand.Intn(60)-30)),
+						}
+
+						if err := EventLogs.Insert(ctx, e); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	events, err := EventLogs.aggregatedSearchEvents(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedEvents := []types.AggregatedEvent{
+		{
+			Name:           "search.latencies.literal",
+			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
+			Week:           now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
+			Day:            now.Truncate(time.Hour * 24),
+			TotalMonth:     int32(len(users) * len(durations) * 25 * 5), // 5 days in month
+			TotalWeek:      int32(len(users) * len(durations) * 25 * 3), // 3 days in week
+			TotalDay:       int32(len(users) * len(durations) * 25),
+			UniquesMonth:   2,
+			UniquesWeek:    2,
+			UniquesDay:     2,
+			LatenciesMonth: []float64{944, 1772.1, 1839.51},
+			LatenciesWeek:  []float64{919, 1752.1, 1792.51},
+			LatenciesDay:   []float64{894, 1732.1, 1745.51},
+		},
+		{
+			Name:           "search.latencies.structural",
+			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
+			Week:           now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
+			Day:            now.Truncate(time.Hour * 24),
+			TotalMonth:     int32(len(users) * len(durations) * 25 * 5), // 5 days in month
+			TotalWeek:      int32(len(users) * len(durations) * 25 * 3), // 3 days in week
+			TotalDay:       int32(len(users) * len(durations) * 25),
+			UniquesMonth:   2,
+			UniquesWeek:    2,
+			UniquesDay:     2,
+			LatenciesMonth: []float64{1394, 2222.1, 2289.51},
+			LatenciesWeek:  []float64{1369, 2202.1, 2242.51},
+			LatenciesDay:   []float64{1344, 2182.1, 2195.51},
+		},
+	}
+	if diff := cmp.Diff(expectedEvents, events); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestEventLogs_AggregatedSparseSearchEvents(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
+	// be a consistent value so that the tests don't fail when someone runs it at some particular
+	// time that falls too near the edge of a week.
+	now := time.Unix(1589581800, 0).UTC()
+
+	for i := 0; i < 5; i++ {
+		e := &Event{
+			UserID: 1,
+			Name:   "search.latencies.structural",
+			URL:    "test",
+			Source: "test",
+			// Make durations non-uniform to test percent_cont. The values
+			// in this test were hand-checked before being added to the assertion.
+			// Adding additional events or changing parameters will require these
+			// values to be checked again.
+			Argument:  json.RawMessage(fmt.Sprintf(`{"durationMs": %d}`, 50)),
+			Timestamp: now.Add(-time.Hour * 24 * 6), // This month
+		}
+
+		if err := EventLogs.Insert(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	events, err := EventLogs.aggregatedSearchEvents(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedEvents := []types.AggregatedEvent{
+		{
+			Name:           "search.latencies.structural",
 			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
 			Week:           now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
 			Day:            now.Truncate(time.Hour * 24),

--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -56,15 +56,44 @@ func groupSiteUsageStats(summary types.SiteUsageSummary, monthsOnly bool) *types
 	return stats
 }
 
-// GetAggregatedStats returns aggregates statistics for code intel and search usage.
-func GetAggregatedStats(ctx context.Context) (*types.CodeIntelUsageStatistics, *types.SearchUsageStatistics, error) {
-	events, err := db.EventLogs.AggregatedEvents(ctx)
+// GetAggregatedCodeIntelStats returns aggregates statistics for code intel usage.
+func GetAggregatedCodeIntelStats(ctx context.Context) (*types.CodeIntelUsageStatistics, error) {
+	events, err := db.EventLogs.AggregatedCodeIntelEvents(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	codeIntelStats, searchStats := groupAggreatedStats(events)
-	return codeIntelStats, searchStats, nil
+	codeIntelUsageStats := &types.CodeIntelUsageStatistics{
+		Daily:   []*types.CodeIntelUsagePeriod{newCodeIntelUsagePeriod()},
+		Weekly:  []*types.CodeIntelUsagePeriod{newCodeIntelUsagePeriod()},
+		Monthly: []*types.CodeIntelUsagePeriod{newCodeIntelUsagePeriod()},
+	}
+
+	for _, event := range events {
+		insertCodeIntelEventStatistics(event, codeIntelUsageStats)
+	}
+
+	return codeIntelUsageStats, nil
+}
+
+// GetAggregatedSearchStats returns aggregates statistics for search usage.
+func GetAggregatedSearchStats(ctx context.Context) (*types.SearchUsageStatistics, error) {
+	events, err := db.EventLogs.AggregatedSearchEvents(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	searchUsageStats := &types.SearchUsageStatistics{
+		Daily:   []*types.SearchUsagePeriod{newSearchUsagePeriod()},
+		Weekly:  []*types.SearchUsagePeriod{newSearchUsagePeriod()},
+		Monthly: []*types.SearchUsagePeriod{newSearchUsagePeriod()},
+	}
+
+	for _, event := range events {
+		insertSearchEventStatistics(event, searchUsageStats)
+	}
+
+	return searchUsageStats, nil
 }
 
 func groupAggreatedStats(events []types.AggregatedEvent) (*types.CodeIntelUsageStatistics, *types.SearchUsageStatistics) {


### PR DESCRIPTION
This is another refactor pass that splits the code intel and search usage stats so we'll get a smaller, more concentrated diff once we change the code intel stats.