### PR TITLE
search frontend: highlight paren groups (with smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -205,4 +205,48 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('decorate paren groups', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('((a) or b)', false, SearchPatternType.regexp)), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "openingParen"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "keyword"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "closingParen"
+              }
+            ]
+        `)
+    })
 })

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -160,6 +160,8 @@ const fromDecoratedTokens = (tokens: DecoratedToken[]): Monaco.languages.IToken[
             case 'whitespace':
             case 'keyword':
             case 'comment':
+            case 'openingParen':
+            case 'closingParen':
                 monacoTokens.push({
                     startIndex: token.range.start,
                     scopes: token.type,

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -34,6 +34,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'identifier', foreground: '#f2f4f8' },
         { token: 'filterKeyword', foreground: '#569cd6' },
         { token: 'keyword', foreground: '#da77f2' },
+        { token: 'openingParen', foreground: '#da77f2' },
+        { token: 'closingParen', foreground: '#da77f2' },
         { token: 'comment', foreground: '#ffa94d' },
         // Regexp pattern highlighting
         { token: 'regexpMetaDelimited', foreground: '#ff6b6b' },
@@ -65,6 +67,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'identifier', foreground: '#2b3750' },
         { token: 'filterKeyword', foreground: '#268bd2' },
         { token: 'keyword', foreground: '#ae3ec9' },
+        { token: 'openingParen', foreground: '#ae3ec9' },
+        { token: 'closingParen', foreground: '#ae3ec9' },
         { token: 'comment', foreground: '#d9480f' },
         // Regexp pattern highlighting
         { token: 'regexpMetaDelimited', foreground: '#c92a2a' },


### PR DESCRIPTION
Feature flagged: Highlights parentheses that refer to groups in expressions, e.g., the surrounding purple ones in this query:

<img width="173" alt="Screen Shot 2020-11-11 at 3 48 08 PM" src="https://user-images.githubusercontent.com/888624/98873289-59007180-2435-11eb-9a79-c400b1f593e3.png">


