### PR TITLE
search frontend: highlight regexp char classes (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -249,4 +249,36 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('decorate character classes', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('([a-z])', false, SearchPatternType.regexp)), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "regexpMetaDelimited"
+              }
+            ]
+        `)
+    })
 })

--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -267,6 +267,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "identifier"
               },
               {
+                "startIndex": 3,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
                 "startIndex": 4,
                 "scopes": "identifier"
               },
@@ -277,6 +281,74 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 6,
                 "scopes": "regexpMetaDelimited"
+              }
+            ]
+        `)
+    })
+
+    test('decorate character classes', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('[a-z][--z][--z]', false, SearchPatternType.regexp)), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "regexpMetaCharacterClass"
               }
             ]
         `)

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -1,7 +1,15 @@
 import * as Monaco from 'monaco-editor'
 import { Token, Pattern, CharacterRange, PatternKind } from './scanner'
 import { RegExpParser, visitRegExpAST } from 'regexpp'
-import { Character, CharacterClass, CharacterSet, CapturingGroup, Assertion, Quantifier } from 'regexpp/ast'
+import {
+    Character,
+    CharacterClass,
+    CharacterClassRange,
+    CharacterSet,
+    CapturingGroup,
+    Assertion,
+    Quantifier,
+} from 'regexpp/ast'
 
 export enum RegexpMetaKind {
     Delimited = 'Delimited', // like ( or )
@@ -84,6 +92,17 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                     type: 'regexpMeta',
                     range: { start: offset + node.end - 1, end: offset + node.end },
                     value: ']',
+                    kind: RegexpMetaKind.CharacterClass,
+                })
+            },
+            onCharacterClassRangeEnter(node: CharacterClassRange) {
+                // highlight the '-' in [a-z]. Take care to use node.min.end, because we
+                // don't want to highlight the first '-' in [--z], nor an escaped '-' with a
+                // two-character offset as in [\--z].
+                tokens.push({
+                    type: 'regexpMeta',
+                    range: { start: offset + node.min.end, end: offset + node.min.end + 1 },
+                    value: '-',
                     kind: RegexpMetaKind.CharacterClass,
                 })
             },

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -41,6 +41,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'regexpMetaDelimited', foreground: '#ff6b6b' },
         { token: 'regexpMetaAssertion', foreground: '#ff6b6b' },
         { token: 'regexpMetaCharacterSet', foreground: '#3bc9db' },
+        { token: 'regexpMetaCharacterClass', foreground: '#3bc9db' },
         { token: 'regexpMetaQuantifier', foreground: '#3bc9db' },
     ],
 })
@@ -74,6 +75,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'regexpMetaDelimited', foreground: '#c92a2a' },
         { token: 'regexpMetaAssertion', foreground: '#c92a2a' },
         { token: 'regexpMetaCharacterSet', foreground: '#1098ad' },
+        { token: 'regexpMetaCharacterClass', foreground: '#1098ad' },
         { token: 'regexpMetaQuantifier', foreground: '#1098ad' },
     ],
 })


### PR DESCRIPTION
Highlights the `[`...`]` brackets in character classes. ~Would like to also highlight the hyphen `-` but it's tricky, so skipping that for now.~ Never mind I figured out how accurately highlight the hyphens too.


<img width="157" alt="Screen Shot 2020-11-11 at 4 04 42 PM" src="https://user-images.githubusercontent.com/888624/98874531-ab429200-2437-11eb-94ab-5fbc54930c68.png">

<img width="284" alt="Screen Shot 2020-11-11 at 4 26 43 PM" src="https://user-images.githubusercontent.com/888624/98876079-ba770f00-243a-11eb-8e11-39f621e88786.png">
