### PR TITLE
search frontend: highlight regexp for field values (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -353,4 +353,49 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('decorate regexp field values', () => {
+        expect(
+            getMonacoTokens(toSuccess(scanSearchQuery('repo:^foo$ count:.*', false, SearchPatternType.regexp)), true)
+        ).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "regexpMetaAssertion"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "regexpMetaAssertion"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "identifier"
+              }
+            ]
+        `)
+    })
 })


### PR DESCRIPTION
Stacked on #15672. Highlights field values that are regular expressions:

<img width="677" alt="Screen Shot 2020-11-11 at 5 32 08 PM" src="https://user-images.githubusercontent.com/888624/98879979-f2368480-2443-11eb-8656-caa0b5f42004.png">
