### PR TITLE
Deprecate DisableTLS field, add noVerifyTLS in email.smtp config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Campaigns now have a fancy new icon. [#14740](https://github.com/sourcegraph/sourcegraph/pull/14740)
 - Search queries with an unbalanced closing paren `)` are now invalid, since this likely indicates an error. Previously, patterns with dangling `)` were valid in some cases. Note that patterns with dangling `)` can still be searched, but should be quoted via `content:"foo)"`. [#15042](https://github.com/sourcegraph/sourcegraph/pull/15042)
 - Extension providers can now return AsyncIterables, enabling dynamic provider results without dependencies. [#15042](https://github.com/sourcegraph/sourcegraph/issues/15061)
+- Deprecated the disableTLS email.smtp config option, this field has been replaced by noVerifyTLS [#15682](https://github.com/sourcegraph/sourcegraph/pull/15682)
 
 ### Fixed
 

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -117,7 +117,8 @@ func Send(ctx context.Context, message Message) error {
 		return fmt.Errorf("invalid SMTP authentication type %q", conf.EmailSmtp.Authentication)
 	}
 
-	if conf.EmailSmtp.DisableTLS {
+	// TODO: 2020/11/12 @arussellsaw, after next release delete DisableTLS option
+	if conf.EmailSmtp.DisableTLS || conf.EmailSmtp.NoVerifyTLS {
 		return m.SendWithStartTLS(
 			net.JoinHostPort(conf.EmailSmtp.Host, strconv.Itoa(conf.EmailSmtp.Port)),
 			smtpAuth,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -985,12 +985,14 @@ type SAMLAuthProvider struct {
 type SMTPServerConfig struct {
 	// Authentication description: The type of authentication to use for the SMTP server.
 	Authentication string `json:"authentication"`
-	// DisableTLS description: Disable TLS verification
+	// DisableTLS description: DEPRECATED: use noVerifyTLS instead, this field will be removed in a future release
 	DisableTLS bool `json:"disableTLS,omitempty"`
 	// Domain description: The HELO domain to provide to the SMTP server (if needed).
 	Domain string `json:"domain,omitempty"`
 	// Host description: The SMTP server host.
 	Host string `json:"host"`
+	// NoVerifyTLS description: Disable TLS verification
+	NoVerifyTLS bool `json:"noVerifyTLS,omitempty"`
 	// Password description: The password to use when communicating with the SMTP server.
 	Password string `json:"password,omitempty"`
 	// Port description: The SMTP server port.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -525,6 +525,10 @@
           "type": "string"
         },
         "disableTLS": {
+          "description": "DEPRECATED: use noVerifyTLS instead, this field will be removed in a future release",
+          "type": "boolean"
+        },
+        "noVerifyTLS": {
           "description": "Disable TLS verification",
           "type": "boolean"
         }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -530,6 +530,10 @@ const SiteSchemaJSON = `{
           "type": "string"
         },
         "disableTLS": {
+          "description": "DEPRECATED: use noVerifyTLS instead, this field will be removed in a future release",
+          "type": "boolean"
+        },
+        "noVerifyTLS": {
           "description": "Disable TLS verification",
           "type": "boolean"
         }


### PR DESCRIPTION
This PR fixes https://github.com/sourcegraph/sourcegraph/issues/13043

❓  There also seems to be typescript files generated from the json schema, but i couldn't work out how to generate them, does that need doing in this PR?

todo:
- [x] add changelog entry


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
