### PR TITLE
graphqlbackend: Add searchCommitsInRepoStream

### DIFF
--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -277,6 +277,7 @@ func doLogDiffSearchStream(ctx context.Context, repo gitserver.Repo, opt RawLogD
 				Complete: true,
 			}
 			empty = false
+			resultCount += len(results)
 		}
 
 		if err != nil {


### PR DESCRIPTION
This is `searchCommitsInRepo`, but returning a channel which streams out results. `searchCommitsInRepo` is what is responsible for calling our commit search backend (`git.RawLogDiffSearch`) and converting those results into graphql resolvers.

This PR is very similiar to https://github.com/sourcegraph/sourcegraph/pull/15616 which added `git.RawLogDiffSearchStream`. It is broken into multiple commits to separate out the mechanical refactoring from the logic changes.

The next few PRs will be introducing streaming in our search aggregator type, and then wiring that up to our streaming rest endpoint.