### PR TITLE
search: change schema of MonitorActionEmail

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -71,12 +71,18 @@ type MonitorEmailResolver interface {
 	Enabled() bool
 	Priority() string
 	Header() string
-	Recipient(ctx context.Context) (MonitorEmailRecipient, error)
+	Recipients(ctx context.Context, args *ListRecipientsArgs) (MonitorActionEmailRecipientsConnectionResolver, error)
 	Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
 }
 
 type MonitorEmailRecipient interface {
 	ToUser() (*UserResolver, bool)
+}
+
+type MonitorActionEmailRecipientsConnectionResolver interface {
+	Nodes(ctx context.Context) ([]NamespaceResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
 type MonitorActionEventConnectionResolver interface {
@@ -103,6 +109,11 @@ type ListMonitorsArgs struct {
 }
 
 type ListActionArgs struct {
+	First int32
+	After *string
+}
+
+type ListRecipientsArgs struct {
 	First int32
 	After *string
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3178,9 +3178,18 @@ type MonitorEmail implements Node {
     """
     header: String!
     """
-    The recipients of the email.
+    A list of recipients of the email.
     """
-    recipient: MonitorEmailRecipient!
+    recipients(
+        """
+        Returns the first n recipients from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEmailRecipientsConnection!
     """
     A list of events.
     """
@@ -3205,9 +3214,22 @@ enum MonitorEmailPriority {
 }
 
 """
-Supported types of recipients for email actions.
+A list of events.
 """
-union MonitorEmailRecipient = User
+type MonitorActionEmailRecipientsConnection {
+    """
+    A list of recipients.
+    """
+    nodes: [Namespace!]!
+    """
+    The total number of recipients in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
 
 """
 A list of events.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3171,9 +3171,18 @@ type MonitorEmail implements Node {
     """
     header: String!
     """
-    The recipients of the email.
+    A list of recipients of the email.
     """
-    recipient: MonitorEmailRecipient!
+    recipients(
+        """
+        Returns the first n recipients from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEmailRecipientsConnection!
     """
     A list of events.
     """
@@ -3198,9 +3207,22 @@ enum MonitorEmailPriority {
 }
 
 """
-Supported types of recipients for email actions.
+A list of events.
 """
-union MonitorEmailRecipient = User
+type MonitorActionEmailRecipientsConnection {
+    """
+    A list of recipients.
+    """
+    nodes: [Namespace!]!
+    """
+    The total number of recipients in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
 
 """
 A list of events.

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -751,11 +751,16 @@ type monitorEmail struct {
 	triggerEventID *graphql.ID
 }
 
-func (m *monitorEmail) Recipient(ctx context.Context) (graphqlbackend.MonitorEmailRecipient, error) {
-	user, err := graphqlbackend.UserByIDInt32(ctx, actor.FromContext(ctx).UID)
-	return &monitorEmailRecipient{
-		user: user,
-	}, err
+func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.ListRecipientsArgs) (c graphqlbackend.MonitorActionEmailRecipientsConnectionResolver, err error) {
+	n := graphqlbackend.NamespaceResolver{}
+	// dummy data
+	n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, actor.FromContext(ctx).UID)
+	if err != nil {
+		return nil, err
+	}
+	return &monitorActionEmailRecipientConnection{
+		recipients: []graphqlbackend.NamespaceResolver{n},
+	}, nil
 }
 
 func (m *monitorEmail) Enabled() bool {
@@ -779,18 +784,22 @@ func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEven
 }
 
 //
-// MonitorEmailRecipient <<UNION>>
+// MonitorActionEmailRecipientConnection
 //
-type MonitorEmailRecipient interface {
-	ToUser() (*graphqlbackend.UserResolver, bool)
+type monitorActionEmailRecipientConnection struct {
+	recipients []graphqlbackend.NamespaceResolver
 }
 
-type monitorEmailRecipient struct {
-	user *graphqlbackend.UserResolver
+func (a *monitorActionEmailRecipientConnection) Nodes(ctx context.Context) ([]graphqlbackend.NamespaceResolver, error) {
+	return a.recipients, nil
 }
 
-func (o *monitorEmailRecipient) ToUser() (*graphqlbackend.UserResolver, bool) {
-	return o.user, o.user != nil
+func (a *monitorActionEmailRecipientConnection) TotalCount(ctx context.Context) (int32, error) {
+	return 1, nil
+}
+
+func (a *monitorActionEmailRecipientConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(false), nil
 }
 
 //


### PR DESCRIPTION
Mistakenly, the current schema returns only a single email recipient. This is not enough
for our use case, hence we change it to return a connection which in
turn returns a list of namespaces.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
