### PR TITLE
graphqlbackend: factor out searchCommitsInRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -418,16 +418,18 @@ func highlightMatches(pattern *regexp.Regexp, data []byte) *highlightedString {
 	return hls
 }
 
-var mockSearchCommitDiffsInRepos func(args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error)
+type searchCommitsInReposParameters struct {
+	TraceName string
 
-// searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
-	if mockSearchCommitDiffsInRepos != nil {
-		return mockSearchCommitDiffsInRepos(args)
-	}
+	ErrorName string
 
+	// Search does a commit search for repoRev.
+	Search func(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error)
+}
+
+func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
 	var err error
-	tr, ctx := trace.New(ctx, "searchCommitDiffsInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
+	tr, ctx := trace.New(ctx, params.TraceName, fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -450,13 +452,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {
 			defer wg.Done()
-			commitParams := search.CommitParameters{
-				RepoRevs:    repoRev,
-				PatternInfo: args.PatternInfo,
-				Query:       args.Query,
-				Diff:        true,
-			}
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitsInRepo(ctx, commitParams)
+			results, repoLimitHit, repoTimedOut, searchErr := params.Search(ctx, repoRev, args)
 			if ctx.Err() == context.Canceled {
 				// Our request has been canceled (either because another one of args.repos had a
 				// fatal error, or otherwise), so we can just ignore these results.
@@ -464,12 +460,12 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 			}
 			repoTimedOut = repoTimedOut || ctx.Err() == context.DeadlineExceeded
 			if searchErr != nil {
-				tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("searchErr", searchErr.Error()), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)))
+				tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("searchErr", searchErr.Error()), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)))
 			}
 			mu.Lock()
 			defer mu.Unlock()
 			if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, repoTimedOut, searchErr); fatalErr != nil {
-				err = errors.Wrapf(searchErr, "failed to search commit diffs %s", repoRev.String())
+				err = errors.Wrapf(searchErr, "failed to search commit %s %s", params.ErrorName, repoRev.String())
 				cancel()
 			}
 			if len(results) > 0 {
@@ -489,6 +485,35 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
+func commitDiffSearcher(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) ([]*CommitSearchResultResolver, bool, bool, error) {
+	commitParams := search.CommitParameters{
+		RepoRevs:    repoRev,
+		PatternInfo: args.PatternInfo,
+		Query:       args.Query,
+		Diff:        true,
+	}
+	return searchCommitsInRepo(ctx, commitParams)
+}
+
+var mockSearchCommitDiffsInRepos func(args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error)
+
+// searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
+func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+	if mockSearchCommitDiffsInRepos != nil {
+		return mockSearchCommitDiffsInRepos(args)
+	}
+
+	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
+		TraceName: "searchCommitDiffsInRepos",
+		ErrorName: "diffs",
+		Search:    commitDiffSearcher,
+	})
+}
+
+func commitLogSearcher(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) ([]*CommitSearchResultResolver, bool, bool, error) {
+	return searchCommitLogInRepo(ctx, repoRev, args.PatternInfo, args.Query)
+}
+
 var mockSearchCommitLogInRepos func(args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error)
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
@@ -497,61 +522,11 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 		return mockSearchCommitLogInRepos(args)
 	}
 
-	var err error
-	tr, ctx := trace.New(ctx, "searchCommitLogInRepos", fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	var (
-		wg          sync.WaitGroup
-		mu          sync.Mutex
-		unflattened [][]*CommitSearchResultResolver
-		common      = &searchResultsCommon{}
-	)
-	common.repos = make([]*types.Repo, len(args.Repos))
-	for i, repo := range args.Repos {
-		common.repos[i] = repo.Repo
-	}
-	for _, repoRev := range args.Repos {
-		wg.Add(1)
-		go func(repoRev *search.RepositoryRevisions) {
-			defer wg.Done()
-			results, repoLimitHit, repoTimedOut, searchErr := searchCommitLogInRepo(ctx, repoRev, args.PatternInfo, args.Query)
-			if ctx.Err() == context.Canceled {
-				// Our request has been canceled (either because another one of args.repos had a
-				// fatal error, or otherwise), so we can just ignore these results.
-				return
-			}
-			repoTimedOut = repoTimedOut || ctx.Err() == context.DeadlineExceeded
-			if searchErr != nil {
-				tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("searchErr", searchErr.Error()), otlog.Bool("timeout", errcode.IsTimeout(searchErr)), otlog.Bool("temporary", errcode.IsTemporary(searchErr)))
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, repoTimedOut, searchErr); fatalErr != nil {
-				err = errors.Wrapf(searchErr, "failed to search commit log %s", repoRev.String())
-				cancel()
-			}
-			if len(results) > 0 {
-				unflattened = append(unflattened, results)
-			}
-		}(repoRev)
-	}
-	wg.Wait()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var flattened []*CommitSearchResultResolver
-	for _, results := range unflattened {
-		flattened = append(flattened, results...)
-	}
-	return commitSearchResultsToSearchResults(flattened), common, nil
+	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
+		TraceName: "searchCommitLogsInRepos",
+		ErrorName: "commits",
+		Search:    commitLogSearcher,
+	})
 }
 
 func commitSearchResultsToSearchResults(results []*CommitSearchResultResolver) []SearchResultResolver {


### PR DESCRIPTION
The functions searchCommitLogInRepos and searchCommitDiffInRepos are
identical, except for which function they call out and some naming used
in tracing/errors. This commit factors out the common functionality and
passes into it the differences between the two.

This is motivated by reducing the amount of work we need to do for
streaming as well as just removing silly duplication.