### PR TITLE
Create code monitor when submitting form

### DIFF
--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -1,0 +1,44 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { dataOrThrowErrors, gql } from '../../../../shared/src/graphql/graphql'
+import { requestGraphQL } from '../../backend/graphql'
+import { CreateCodeMonitorResult, CreateCodeMonitorVariables } from '../../graphql-operations'
+
+export const createCodeMonitor = ({
+    namespace,
+    description,
+    enabled,
+    trigger,
+    actions,
+}: CreateCodeMonitorVariables): Observable<CreateCodeMonitorResult['createCodeMonitor']> => {
+    const query = gql`
+        mutation CreateCodeMonitor(
+            $namespace: ID!
+            $description: String!
+            $enabled: Boolean!
+            $trigger: MonitorTriggerInput!
+            $actions: [MonitorActionInput!]!
+        ) {
+            createCodeMonitor(
+                namespace: $namespace
+                description: $description
+                enabled: $enabled
+                trigger: $trigger
+                actions: $actions
+            ) {
+                description
+            }
+        }
+    `
+
+    return requestGraphQL<CreateCodeMonitorResult, CreateCodeMonitorVariables>(query, {
+        namespace,
+        description,
+        enabled,
+        trigger,
+        actions,
+    }).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.createCodeMonitor)
+    )
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/15652. Adds functionality to create the code monitor in the backend when submitting the form on the create code monitor page.