### PR TITLE
search frontend: add query visitor

### DIFF
--- a/client/shared/src/search/parser/visitor.test.ts
+++ b/client/shared/src/search/parser/visitor.test.ts
@@ -1,0 +1,83 @@
+import { visit, Visitors } from './visitor'
+import { parseSearchQuery, ParseSuccess, Node, OperatorKind } from './parser'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value, null, 2),
+    test: () => true,
+})
+
+/**
+ * A function that defines a simple visitor to collect visited nodes
+ * in a query string, and returns the string result.
+ *
+ * @param input The input query string.
+ */
+const collect = (input: string): Node[] => {
+    const nodes: Node[] = []
+    const visitors: Visitors = {
+        visitOperator(operands: Node[], kind: OperatorKind) {
+            nodes.push({ type: 'operator', operands, kind })
+        },
+        visitParameter(field, value, negated) {
+            nodes.push({ type: 'parameter', field, value, negated })
+        },
+        visitPattern(value, kind, negated, quoted) {
+            nodes.push({ type: 'pattern', value, kind, negated, quoted })
+        },
+    }
+    visit((parseSearchQuery(input) as ParseSuccess).nodes, visitors)
+    return nodes
+}
+
+describe('visit()', () => {
+    test('basic visit', () => {
+        expect(collect('repo:foo pattern-bar or file:baz')).toMatchInlineSnapshot(`
+            [
+              {
+                "type": "operator",
+                "operands": [
+                  {
+                    "type": "parameter",
+                    "field": "repo",
+                    "value": "foo",
+                    "negated": false
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "pattern-bar",
+                    "quoted": false,
+                    "negated": false
+                  },
+                  {
+                    "type": "parameter",
+                    "field": "file",
+                    "value": "baz",
+                    "negated": false
+                  }
+                ],
+                "kind": "OR"
+              },
+              {
+                "type": "parameter",
+                "field": "repo",
+                "value": "foo",
+                "negated": false
+              },
+              {
+                "type": "pattern",
+                "value": "pattern-bar",
+                "kind": 1,
+                "negated": false,
+                "quoted": false
+              },
+              {
+                "type": "parameter",
+                "field": "file",
+                "value": "baz",
+                "negated": false
+              }
+            ]
+        `)
+    })
+})

--- a/client/shared/src/search/parser/visitor.ts
+++ b/client/shared/src/search/parser/visitor.ts
@@ -1,0 +1,66 @@
+import { Node, Operator, Parameter, Pattern, OperatorKind } from './parser'
+import { PatternKind } from './scanner'
+
+export class Visitor {
+    /**
+     * Set up this visitor with visit callback functions.
+     *
+     * @param visitors the visitor callback functions.
+     */
+    constructor(private readonly _visitors: Visitors) {}
+
+    /**
+     * Top-level visit function.
+     *
+     * @param nodes Top-level nodes of the tree.
+     */
+    public visit(nodes: Node[]): void {
+        for (const node of nodes) {
+            switch (node.type) {
+                case 'operator':
+                    this.visitOperator(node)
+                    break
+                case 'parameter':
+                    this.visitParameter(node)
+                    break
+                case 'pattern':
+                    this.visitPattern(node)
+                    break
+            }
+        }
+    }
+
+    private visitOperator(node: Operator): void {
+        if (this._visitors.visitOperator) {
+            this._visitors.visitOperator(node.operands, node.kind)
+        }
+        this.visit(node.operands)
+    }
+
+    private visitParameter(node: Parameter): void {
+        if (this._visitors.visitParameter) {
+            this._visitors.visitParameter(node.field, node.value, node.negated)
+        }
+    }
+
+    private visitPattern(node: Pattern): void {
+        if (this._visitors.visitPattern) {
+            this._visitors.visitPattern(node.value, node.kind, node.negated, node.quoted)
+        }
+    }
+}
+
+export interface Visitors {
+    visitOperator?(operands: Node[], kind: OperatorKind): void
+    visitParameter?(field: string, value: string, negated: boolean): void
+    visitPattern?(value: string, kind: PatternKind, negated: boolean, quoted: boolean): void
+}
+
+/**
+ *
+ * @param tree A list of nodes that represent the top-level of a parse tree.
+ * @param visitors the visitor callback functions defined by {@link Visitors}.
+ */
+export const visit = (tree: Node[], visitors: Visitors): void => {
+    new Visitor(visitors).visit(tree)
+}


### PR DESCRIPTION
Adds a visitor for parsed queries. We need this to write validators for queries.

There is more than one way to expose members of a visited node, for example, you can make the interface something like:

```typescript
export interface Visitors {
    visitOperator?(node: Operand): void
    visitParameter?(node: Parameter): void
    visitPattern?(node: Pattern): void
}
```

I generally find visitors that unbox their members in a callback more convenient. Matter of taste, but basically, with this second version you don't have to look up the interface of `Operand` or whatnot above, and it might bring to your attention some things that would be hidden like realizing "oh this node is negatable, I should handle that case" when it's part of the signature. So instead I implement that version:

```typescript
export interface Visitors {
    visitOperator?(operands: Node[], kind: OperatorKind): void
    visitParameter?(field: string, value: string, negated: boolean): void
    visitPattern?(value: string, kind: PatternKind, negated: boolean, quoted: boolean): void
}
```
