### PR TITLE
Add private code feature flag

### DIFF
--- a/cmd/frontend/backend/users.go
+++ b/cmd/frontend/backend/users.go
@@ -54,5 +54,6 @@ func CheckActorHasTag(ctx context.Context, tag string) error {
 }
 
 const (
-	TagAllowUserExternalServicePublic = "AllowUserExternalServicePublic"
+	TagAllowUserExternalServicePublic  = "AllowUserExternalServicePublic"
+	TagAllowUserExternalServicePrivate = "AllowUserExternalServicePrivate"
 )

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -39,14 +39,22 @@ type addExternalServiceInput struct {
 
 func currentUserAllowedExternalServices(ctx context.Context) string {
 	mode := conf.ExternalServiceUserMode()
-	if mode == "disabled" {
-		// The user may have a tag that opts them in
-		err := backend.CheckActorHasTag(ctx, backend.TagAllowUserExternalServicePublic)
-		if err == nil {
-			mode = "all"
-		}
+	if mode != "disabled" {
+		return mode
 	}
-	return mode
+
+	// The user may have a tag that opts them in
+	err := backend.CheckActorHasTag(ctx, backend.TagAllowUserExternalServicePrivate)
+	if err == nil {
+		return "all"
+	}
+
+	err = backend.CheckActorHasTag(ctx, backend.TagAllowUserExternalServicePublic)
+	if err == nil {
+		return "public"
+	}
+
+	return "disabled"
 }
 
 func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExternalServiceArgs) (*externalServiceResolver, error) {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -37,24 +37,24 @@ type addExternalServiceInput struct {
 	Namespace   *graphql.ID
 }
 
-func currentUserAllowedExternalServices(ctx context.Context) string {
+func currentUserAllowedExternalServices(ctx context.Context) conf.ExternalServiceMode {
 	mode := conf.ExternalServiceUserMode()
-	if mode != "disabled" {
+	if mode != conf.ExternalServiceModeDisabled {
 		return mode
 	}
 
 	// The user may have a tag that opts them in
 	err := backend.CheckActorHasTag(ctx, backend.TagAllowUserExternalServicePrivate)
 	if err == nil {
-		return "all"
+		return conf.ExternalServiceModeAll
 	}
 
 	err = backend.CheckActorHasTag(ctx, backend.TagAllowUserExternalServicePublic)
 	if err == nil {
-		return "public"
+		return conf.ExternalServiceModePublic
 	}
 
-	return "disabled"
+	return conf.ExternalServiceModeDisabled
 }
 
 func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExternalServiceArgs) (*externalServiceResolver, error) {
@@ -67,7 +67,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 	isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
 	allowUserExternalServices := currentUserAllowedExternalServices(ctx)
 	if args.Input.Namespace != nil {
-		if allowUserExternalServices == "disabled" {
+		if allowUserExternalServices == conf.ExternalServiceModeDisabled {
 			return nil, errors.New("allow users to add external services is not enabled")
 		}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -405,7 +405,7 @@ func resolveRepoGroups(ctx context.Context, settings *schema.Settings) (groups m
 		groups[name] = repos
 	}
 
-	if !currentUserAllowedExternalServices(ctx) {
+	if currentUserAllowedExternalServices(ctx) == "disabled" {
 		return groups, nil
 	}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -405,7 +405,7 @@ func resolveRepoGroups(ctx context.Context, settings *schema.Settings) (groups m
 		groups[name] = repos
 	}
 
-	if currentUserAllowedExternalServices(ctx) == "disabled" {
+	if currentUserAllowedExternalServices(ctx) == conf.ExternalServiceModeDisabled {
 		return groups, nil
 	}
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -169,7 +169,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		ResetPasswordEnabled: userpasswd.ResetPasswordEnabled(),
 
-		ExternalServicesUserModeEnabled: conf.ExternalServiceUserMode(),
+		ExternalServicesUserModeEnabled: conf.ExternalServiceUserMode() != "disabled",
 
 		AllowSignup: conf.AuthAllowSignup(),
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -169,7 +169,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		ResetPasswordEnabled: userpasswd.ResetPasswordEnabled(),
 
-		ExternalServicesUserModeEnabled: conf.ExternalServiceUserMode() != "disabled",
+		ExternalServicesUserModeEnabled: conf.ExternalServiceUserMode() != conf.ExternalServiceModeDisabled,
 
 		AllowSignup: conf.AuthAllowSignup(),
 

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -237,7 +237,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 		return errors.Wrap(err, "syncer.sync.sourced")
 	}
 
-	// User added external services should only sync public code
+	// Unless explicitly specified with "all", user added external services should only sync public code
 	if isUserOwned && conf.ExternalServiceUserMode() != conf.ExternalServiceModeAll {
 		sourced = sourced.Filter(func(r *Repo) bool { return !r.Private })
 	}

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -238,7 +238,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 	}
 
 	// User added external services should only sync public code
-	if isUserOwned && conf.ExternalServiceUserMode() != "all" {
+	if isUserOwned && conf.ExternalServiceUserMode() != conf.ExternalServiceModeAll {
 		sourced = sourced.Filter(func(r *Repo) bool { return !r.Private })
 	}
 

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
@@ -237,7 +238,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 	}
 
 	// User added external services should only sync public code
-	if isUserOwned {
+	if isUserOwned && conf.ExternalServiceUserMode() != "all" {
 		sourced = sourced.Filter(func(r *Repo) bool { return !r.Private })
 	}
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -306,12 +306,23 @@ func AuthMinPasswordLength() int {
 	return val
 }
 
+type ExternalServiceMode int
+
+const (
+	ExternalServiceModeDisabled ExternalServiceMode = 0
+	ExternalServiceModePublic   ExternalServiceMode = 1
+	ExternalServiceModeAll      ExternalServiceMode = 2
+)
+
 // ExternalServiceUserMode returns the mode describing if users are allowed to add external services
 // for public and private repositories.
-func ExternalServiceUserMode() string {
-	val := Get().ExternalServiceUserMode
-	if val == "" {
-		return "disabled"
+func ExternalServiceUserMode() ExternalServiceMode {
+	switch Get().ExternalServiceUserMode {
+	case "public":
+		return ExternalServiceModePublic
+	case "all":
+		return ExternalServiceModeAll
+	default:
+		return ExternalServiceModeDisabled
 	}
-	return val
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -306,9 +306,12 @@ func AuthMinPasswordLength() int {
 	return val
 }
 
-// ExternalServiceUserMode returns true if users are allowed to add external services
-// for public repositories.
-func ExternalServiceUserMode() bool {
+// ExternalServiceUserMode returns the mode describing if users are allowed to add external services
+// for public and private repositories.
+func ExternalServiceUserMode() string {
 	val := Get().ExternalServiceUserMode
-	return val == "public"
+	if val == "" {
+		return "disabled"
+	}
+	return val
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1185,7 +1185,7 @@ type SiteConfiguration struct {
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: Configures Sourcegraph extensions.
 	Extensions *Extensions `json:"extensions,omitempty"`
-	// ExternalServiceUserMode description: Enable to allow users to add external services for public repositories to the Sourcegraph instance.
+	// ExternalServiceUserMode description: Enable to allow users to add external services for public and private repositories to the Sourcegraph instance.
 	ExternalServiceUserMode string `json:"externalService.userMode,omitempty"`
 	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
 	ExternalURL string `json:"externalURL,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -421,9 +421,9 @@
       "group": "Security"
     },
     "externalService.userMode": {
-      "description": "Enable to allow users to add external services for public repositories to the Sourcegraph instance.",
+      "description": "Enable to allow users to add external services for public and private repositories to the Sourcegraph instance.",
       "type": "string",
-      "enum": ["public", "disabled"],
+      "enum": ["public", "disabled", "all"],
       "default": "disabled"
     },
     "permissions.userMapping": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -426,9 +426,9 @@ const SiteSchemaJSON = `{
       "group": "Security"
     },
     "externalService.userMode": {
-      "description": "Enable to allow users to add external services for public repositories to the Sourcegraph instance.",
+      "description": "Enable to allow users to add external services for public and private repositories to the Sourcegraph instance.",
       "type": "string",
-      "enum": ["public", "disabled"],
+      "enum": ["public", "disabled", "all"],
       "default": "disabled"
     },
     "permissions.userMapping": {


### PR DESCRIPTION
This PR adds a new mode for the `externalService.userMode` feature flag: `all`.
This allows users to sync both private and public code in their external services.

QA done:
- Enabled the flag
- Added an external service with private code
- Code got synced
- Disabled the flag
- Next sync removed the private code

Fixes #15322 