### PR TITLE
search: connect action resolvers to db

### DIFF
--- a/enterprise/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/internal/codemonitors/resolvers/apitest/types.go
@@ -1,0 +1,65 @@
+// Package apitest provided types used in testing.
+package apitest
+
+type Response struct {
+	User User
+}
+
+type User struct {
+	Monitors MonitorConnection
+}
+
+type MonitorConnection struct {
+	Nodes      []Monitor
+	TotalCount int
+	PageInfo   PageInfo
+}
+
+type Monitor struct {
+	Id          string
+	Description string
+	Enabled     bool
+	Owner       UserOrg
+	CreatedBy   UserOrg
+	CreatedAt   string
+	Trigger     Trigger
+	Actions     ActionConnection
+}
+
+type UserOrg struct {
+	Name string `json:"username" json:"name"`
+}
+
+type PageInfo struct {
+	HasNextPage bool
+	EndCursor   *string
+}
+
+type ActionConnection struct {
+	Nodes      []Action
+	TotalCount int
+	PageInfo   PageInfo
+}
+
+type Action struct {
+	ActionEmail
+}
+
+type ActionEmail struct {
+	Id         string
+	Enabled    bool
+	Priority   string
+	Recipients RecipientsConnection
+	Header     string
+}
+
+type RecipientsConnection struct {
+	Nodes      []UserOrg
+	TotalCount int
+	PageInfo   PageInfo
+}
+
+type Trigger struct {
+	Id    string
+	Query string
+}

--- a/enterprise/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/internal/codemonitors/resolvers/main_test.go
@@ -1,0 +1,90 @@
+package resolvers
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+)
+
+func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
+
+	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return userID
+}
+
+func addUserToOrg(t *testing.T, db *sql.DB, userID int32, orgID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO org_members (org_id, user_id) VALUES (%s, %s)", orgID, userID)
+
+	_, err := db.Exec(q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (r *Resolver) insertTestMonitor(ctx context.Context, t *testing.T, owner graphql.ID) (graphqlbackend.MonitorResolver, error) {
+	t.Helper()
+
+	return r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
+		Namespace:   owner,
+		Description: "test monitor",
+		Enabled:     true,
+		Trigger:     &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
+		Actions: []*graphqlbackend.CreateActionArgs{
+			{Email: &graphqlbackend.CreateActionEmailArgs{
+				Enabled:    true,
+				Priority:   "NORMAL",
+				Recipients: []graphql.ID{owner},
+				Header:     "test header",
+			}},
+		},
+	})
+}
+
+// newTestResolver returns a Resolver with stopped clock, which is useful to
+// compare input and outputs in tests.
+func newTestResolver(t *testing.T) *Resolver {
+	t.Helper()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time {
+		return now.UTC().Truncate(time.Microsecond)
+	}
+	return newResolverWithClock(dbconn.Global, clock).(*Resolver)
+}
+
+func (r *Resolver) monitorForIDInt32(ctx context.Context, t *testing.T, monitorId int64) (graphqlbackend.MonitorResolver, error) {
+	t.Helper()
+
+	q := sqlf.Sprintf("SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id FROM cm_monitors WHERE id = %s", monitorId)
+	return r.runMonitorQuery(ctx, q)
+}
+
+func marshalDateTime(t testing.TB, ts time.Time) string {
+	t.Helper()
+
+	dt := graphqlbackend.DateTime{Time: ts}
+
+	bs, err := dt.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unquote the date time.
+	return strings.ReplaceAll(string(bs), "\"", "")
+}

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -283,6 +283,37 @@ func scanQueries(rows *sql.Rows) ([]graphqlbackend.MonitorQueryResolver, error) 
 	return ms, nil
 }
 
+type recipient struct {
+	id              int64
+	email           int64
+	namespaceUserID *int32
+	namespaceOrgID  *int32
+}
+
+func scanRecipients(rows *sql.Rows) (ms []*recipient, err error) {
+	for rows.Next() {
+		m := &recipient{}
+		if err := rows.Scan(
+			&m.id,
+			&m.email,
+			&m.namespaceUserID,
+			&m.namespaceOrgID,
+		); err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	err = rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	// Rows.Err will report the last error encountered by Rows.Scan.
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ms, nil
+}
+
 func nilOrInt32(n int32) *int32 {
 	if n == 0 {
 		return nil
@@ -309,16 +340,11 @@ FROM cm_monitors
 WHERE namespace_user_id = %s
 AND id > %s
 ORDER BY id ASC
-LIMIT %S
+LIMIT %s
 `
-	var after int64
-	if args.After == nil {
-		after = 0
-	} else {
-		err := relay.UnmarshalSpec(graphql.ID(*args.After), &after)
-		if err != nil {
-			return nil, err
-		}
+	after, err := unmarshallAfter(args.After)
+	if err != nil {
+		return nil, err
 	}
 	query := sqlf.Sprintf(
 		SelectMonitorsByOwner,
@@ -449,6 +475,18 @@ var recipientsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_recipients.namespace_org_id"),
 }
 
+func (r *Resolver) readActionEmailQuery(ctx context.Context, monitorId int64, args *graphqlbackend.ListActionArgs) (*sqlf.Query, error) {
+	const readActionEmailQuery = `
+SELECT id, monitor, enabled, priority, header, created_by, created_at, changed_by, changed_at
+FROM cm_emails
+WHERE monitor = %s;
+`
+	return sqlf.Sprintf(
+		readActionEmailQuery,
+		monitorId,
+	), nil
+}
+
 func (r *Resolver) createRecipientQuery(ctx context.Context, emailId int64, namespace graphql.ID) (*sqlf.Query, error) {
 	const insertRecipientQuery = `
 INSERT INTO cm_recipients
@@ -468,6 +506,27 @@ RETURNING %s;
 		nilOrInt32(userID),
 		nilOrInt32(orgID),
 		sqlf.Join(recipientsColumns, ", "),
+	), nil
+}
+
+func (r *Resolver) readRecipientQuery(ctx context.Context, emailId int64, args *graphqlbackend.ListRecipientsArgs) (*sqlf.Query, error) {
+	const readRecipientQuery = `
+SELECT id, email, namespace_user_id, namespace_org_id
+FROM cm_recipients
+WHERE email = %s
+AND id > %s
+ORDER BY id ASC
+LIMIT %s;
+`
+	after, err := unmarshallAfter(args.After)
+	if err != nil {
+		return nil, err
+	}
+	return sqlf.Sprintf(
+		readRecipientQuery,
+		emailId,
+		after,
+		args.First,
 	), nil
 }
 
@@ -625,8 +684,11 @@ type monitor struct {
 }
 
 const (
-	monitorKind = "CodeMonitor"
-	triggerKind = "CodeMonitorTrigger"
+	monitorKind                     = "CodeMonitor"
+	monitorTriggerQueryKind         = "CodeMonitorTriggerQuery"
+	monitorTriggerEventKind         = "CodeMonitorTriggerEvent"
+	monitorActionEmailKind          = "CodeMonitorActionEmail"
+	monitorActionEmailRecipientKind = "CodeMonitorActionEmailRecipient"
 )
 
 func (m *monitor) ID() graphql.ID {
@@ -673,10 +735,38 @@ func (m *monitor) Trigger(ctx context.Context) (graphqlbackend.MonitorTrigger, e
 }
 
 func (m *monitor) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
+	return m.actionConnectionResolverWithTriggerID(ctx, nil, m.id, args)
+}
+
+func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int64, monitorID int64, args *graphqlbackend.ListActionArgs) (c graphqlbackend.MonitorActionConnectionResolver, err error) {
+	// For now, we only support emails as actions. Once we add other actions such as
+	// webhooks, we have to query those tables here too.
+	var q *sqlf.Query
+	q, err = r.readActionEmailQuery(ctx, monitorID, args)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.db.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	es, err := scanEmails(rows)
+	if err != nil {
+		return nil, err
+	}
+	actions := make([]graphqlbackend.MonitorAction, 0, len(es))
+	for _, e := range es {
+		// Hydrate action with resolver.
+		e.(*monitorEmail).Resolver = r
+		actions = append(actions, &action{
+			email: e,
+		})
+	}
 	return &monitorActionConnection{
-			monitorID: m.ID(),
-			userID:    m.ID()},
-		nil
+		actions:        actions,
+		triggerEventID: triggerEventID,
+	}, nil
 }
 
 //
@@ -705,7 +795,7 @@ type monitorQuery struct {
 }
 
 func (q *monitorQuery) ID() graphql.ID {
-	return relay.MarshalID(triggerKind, q.id)
+	return relay.MarshalID(monitorTriggerQueryKind, q.id)
 }
 
 func (q *monitorQuery) Query() string {
@@ -720,13 +810,15 @@ func (q *monitorQuery) Events(ctx context.Context, args *graphqlbackend.ListEven
 // MonitorTriggerEventConnection
 //
 type monitorTriggerEventConnection struct {
+	*Resolver
 	monitorID graphql.ID
 	userID    graphql.ID // TODO: remove this. Just for stub implementation
 }
 
 func (a *monitorTriggerEventConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorTriggerEventResolver, error) {
 	return []graphqlbackend.MonitorTriggerEventResolver{&monitorTriggerEvent{
-		id:        "42",
+		Resolver:  a.Resolver,
+		id:        42,
 		status:    "SUCCESS",
 		message:   nil,
 		timestamp: graphqlbackend.DateTime{Time: time.Now()},
@@ -747,7 +839,8 @@ func (a *monitorTriggerEventConnection) PageInfo(ctx context.Context) (*graphqlu
 // MonitorTriggerEvent
 //
 type monitorTriggerEvent struct {
-	id        graphql.ID
+	*Resolver
+	id        int64
 	status    string
 	message   *string
 	timestamp graphqlbackend.DateTime
@@ -757,7 +850,7 @@ type monitorTriggerEvent struct {
 }
 
 func (m *monitorTriggerEvent) ID() graphql.ID {
-	return m.id
+	return relay.MarshalID(monitorTriggerEventKind, m.id)
 }
 
 func (m *monitorTriggerEvent) Status() string {
@@ -773,29 +866,35 @@ func (m *monitorTriggerEvent) Timestamp() graphqlbackend.DateTime {
 }
 
 func (m *monitorTriggerEvent) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
-	return graphqlbackend.MonitorActionConnectionResolver(&monitorActionConnection{userID: m.userID, monitorID: m.monitorID, triggerEventID: &m.id}), nil
+	return m.actionConnectionResolverWithTriggerID(ctx, &m.id, m.id, args)
 }
 
 // ActionConnection
 //
 type monitorActionConnection struct {
-	userID    graphql.ID //  TODO: remove this. This is just for the stub implementation.
-	monitorID graphql.ID
+	actions []graphqlbackend.MonitorAction
 
 	// triggerEventID is used to link action events to a trigger event
-	triggerEventID *graphql.ID
+	triggerEventID *int64
 }
 
 func (a *monitorActionConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorAction, error) {
-	return []graphqlbackend.MonitorAction{&action{email: &monitorEmail{id: 42}}}, nil
+	return a.actions, nil
 }
 
 func (a *monitorActionConnection) TotalCount(ctx context.Context) (int32, error) {
-	return 1, nil
+	return int32(len(a.actions)), nil
 }
 
 func (a *monitorActionConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
+	if len(a.actions) == 0 {
+		return graphqlutil.HasNextPage(false), nil
+	}
+	last := a.actions[len(a.actions)-1]
+	if email, ok := last.ToMonitorEmail(); ok {
+		return graphqlutil.NextPageCursor(string(email.ID())), nil
+	}
+	return nil, fmt.Errorf("we only support email actions for now")
 }
 
 //
@@ -813,6 +912,7 @@ func (a *action) ToMonitorEmail() (graphqlbackend.MonitorEmailResolver, bool) {
 // Email
 //
 type monitorEmail struct {
+	*Resolver
 	id        int64
 	monitor   int64
 	enabled   bool
@@ -830,31 +930,54 @@ type monitorEmail struct {
 }
 
 func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.ListRecipientsArgs) (c graphqlbackend.MonitorActionEmailRecipientsConnectionResolver, err error) {
-	n := graphqlbackend.NamespaceResolver{}
-	// dummy data
-	n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, actor.FromContext(ctx).UID)
+	q, err := m.readRecipientQuery(ctx, m.id, args)
 	if err != nil {
 		return nil, err
 	}
-	return &monitorActionEmailRecipientConnection{
-		recipients: []graphqlbackend.NamespaceResolver{n},
-	}, nil
+	rows, err := m.db.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ms, err := scanRecipients(rows)
+	if err != nil {
+		return nil, err
+	}
+	var ns []graphqlbackend.NamespaceResolver
+	for _, r := range ms {
+		n := graphqlbackend.NamespaceResolver{}
+		if r.namespaceOrgID == nil {
+			n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, *r.namespaceUserID)
+		} else {
+			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, *r.namespaceOrgID)
+		}
+		ns = append(ns, n)
+	}
+
+	// Since recipients can either be a user or an org it would be very tedious to
+	// use the user-id or org-id of the last entry as a cursor for the next page. It
+	// is easier to just use the id of the recipients table.
+	var nextPageCursor string
+	if len(ms) > 0 {
+		nextPageCursor = string(relay.MarshalID(monitorActionEmailRecipientKind, ms[len(ms)-1].id))
+	}
+	return &monitorActionEmailRecipientsConnection{ns, nextPageCursor}, nil
 }
 
 func (m *monitorEmail) Enabled() bool {
-	return true
+	return m.enabled
 }
 
 func (m *monitorEmail) Priority() string {
-	return "NORMAL"
+	return m.priority
 }
 
 func (m *monitorEmail) Header() string {
-	return "Header not implemented"
+	return m.header
 }
 
 func (m *monitorEmail) ID() graphql.ID {
-	return "monitorEmail ID not implemented"
+	return relay.MarshalID(monitorActionEmailKind, m.id)
 }
 
 func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEventsArgs) (graphqlbackend.MonitorActionEventConnectionResolver, error) {
@@ -864,20 +987,24 @@ func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEven
 //
 // MonitorActionEmailRecipientConnection
 //
-type monitorActionEmailRecipientConnection struct {
-	recipients []graphqlbackend.NamespaceResolver
+type monitorActionEmailRecipientsConnection struct {
+	recipients     []graphqlbackend.NamespaceResolver
+	nextPageCursor string
 }
 
-func (a *monitorActionEmailRecipientConnection) Nodes(ctx context.Context) ([]graphqlbackend.NamespaceResolver, error) {
+func (a *monitorActionEmailRecipientsConnection) Nodes(ctx context.Context) ([]graphqlbackend.NamespaceResolver, error) {
 	return a.recipients, nil
 }
 
-func (a *monitorActionEmailRecipientConnection) TotalCount(ctx context.Context) (int32, error) {
-	return 1, nil
+func (a *monitorActionEmailRecipientsConnection) TotalCount(ctx context.Context) (int32, error) {
+	return int32(len(a.recipients)), nil
 }
 
-func (a *monitorActionEmailRecipientConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
+func (a *monitorActionEmailRecipientsConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	if len(a.recipients) == 0 {
+		return graphqlutil.HasNextPage(false), nil
+	}
+	return graphqlutil.NextPageCursor(a.nextPageCursor), nil
 }
 
 //
@@ -927,4 +1054,17 @@ func (m *monitorActionEvent) Message() *string {
 
 func (m *monitorActionEvent) Timestamp() graphqlbackend.DateTime {
 	return m.timestamp
+}
+
+func unmarshallAfter(after *string) (int64, error) {
+	var a int64
+	if after == nil {
+		a = 0
+	} else {
+		err := relay.UnmarshalSpec(graphql.ID(*after), &a)
+		if err != nil {
+			return -1, err
+		}
+	}
+	return a, nil
 }


### PR DESCRIPTION
This PR replaces stub resolvers for monitor actions with resolvers
that are actually connected to the database.

All changes related to the resolvers are contained in `resolvers.go`.

I also thought it was a good time to raise the test coverage. 
Most of the changes in this PR are related to a new test,
`TestQueryMonitor`, which covers monitor, trigger, and action resolvers.
With `TestQueryMonitor` we reach a coverage of >71% for code
monitoring. 

Like before, I shamelessly copied a lot of ideas and structure
from campaigns, EG I factored out types used in tests to
the `apitest` package, as well general purpose test helpers to
`main_test.go`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
