### PR TITLE
search: add stub for UpdateCodeMonitor

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -13,6 +13,7 @@ type CodeMonitorsResolver interface {
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
 	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
 	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)
+	UpdateCodeMonitor(ctx context.Context, args *UpdateCodeMonitorArgs) (MonitorResolver, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -150,6 +151,38 @@ type DeleteCodeMonitorArgs struct {
 	Id graphql.ID
 }
 
+type MonitorArgs struct {
+	Namespace   graphql.ID
+	Description string
+	Enabled     bool
+}
+
+type EditActionEmailArgs struct {
+	Id     graphql.ID
+	Update *CreateActionEmailArgs
+}
+
+type EditActionArgs struct {
+	Email *EditActionEmailArgs
+}
+
+type EditTriggerArgs struct {
+	Id     graphql.ID
+	Update *CreateTriggerArgs
+}
+
+type EditMonitorArgs struct {
+	Id     graphql.ID
+	Update *MonitorArgs
+}
+
+type UpdateCodeMonitorArgs struct {
+	Id      graphql.ID
+	Monitor *EditMonitorArgs
+	Trigger *EditTriggerArgs
+	Actions []*EditActionArgs
+}
+
 var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
@@ -170,5 +203,9 @@ func (d defaultCodeMonitorsResolver) ToggleCodeMonitor(ctx context.Context, args
 }
 
 func (d defaultCodeMonitorsResolver) DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) UpdateCodeMonitor(ctx context.Context, args *UpdateCodeMonitorArgs) (MonitorResolver, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -177,7 +177,6 @@ type EditMonitorArgs struct {
 }
 
 type UpdateCodeMonitorArgs struct {
-	Id      graphql.ID
 	Monitor *EditMonitorArgs
 	Trigger *EditTriggerArgs
 	Actions []*EditActionArgs

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -793,6 +793,27 @@ type Mutation {
         """
         id: ID!
     ): EmptyResponse!
+    """
+    Update a code monitor. Objects in the db will be overwritten with the objects in the request. Objects
+    which are not contained in the request remain unchanged. If the request contains objects that have
+    no corresponding entry in the db, an error is returned.
+    """
+    updateCodeMonitor(
+        """
+        The input required to edit a monitor.
+        """
+        monitor: MonitorEditInput!
+        """
+        The input required to edit the trigger of a monitor. You can only edit triggers that are
+        associated with the monitor (value of field monitor).
+        """
+        trigger: MonitorEditTriggerInput!
+        """
+        The input required to edit the actions of a monitor. You can only edit actions that are
+        associated with the monitor (value of field monitor).
+        """
+        actions: [MonitorEditActionInput!]!
+    ): Monitor!
 }
 
 """
@@ -3305,6 +3326,39 @@ enum EventStatus {
 }
 
 """
+The input required to create a code monitor.
+"""
+input MonitorInput {
+    """
+    The namespace represents the owner of the code monitor.
+    Owners can either be users or organizations.
+    """
+    namespace: ID!
+    """
+    A meaningful description of the code monitor.
+    """
+    description: String!
+    """
+    Whether the code monitor is enabled or not.
+    """
+    enabled: Boolean!
+}
+
+"""
+The input required to edit a code monitor.
+"""
+input MonitorEditInput {
+    """
+    The id of the monitor.
+    """
+    id: ID!
+    """
+    The desired state after the udpate.
+    """
+    update: MonitorInput!
+}
+
+"""
 The input required to create a trigger.
 """
 input MonitorTriggerInput {
@@ -3312,6 +3366,20 @@ input MonitorTriggerInput {
     The query string.
     """
     query: String!
+}
+
+"""
+The input required to edit a trigger.
+"""
+input MonitorEditTriggerInput {
+    """
+    The id of the Trigger.
+    """
+    id: ID!
+    """
+    The desired state after the udpate.
+    """
+    update: MonitorTriggerInput!
 }
 
 """
@@ -3344,6 +3412,29 @@ input MonitorEmailInput {
     Use header to automatically approve the message in a read-only or moderated mailing list.
     """
     header: String!
+}
+"""
+The input required to edit an action.
+"""
+input MonitorEditActionInput {
+    """
+    An email action.
+    """
+    email: MonitorEditEmailInput
+}
+
+"""
+The input required to edit an email action.
+"""
+input MonitorEditEmailInput {
+    """
+    The id of an email action.
+    """
+    id: ID!
+    """
+    The desired state after the update.
+    """
+    update: MonitorEmailInput!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -786,6 +786,27 @@ type Mutation {
         """
         id: ID!
     ): EmptyResponse!
+    """
+    Update a code monitor. Objects in the db will be overwritten with the objects in the request. Objects
+    which are not contained in the request remain unchanged. If the request contains objects that have
+    no corresponding entry in the db, an error is returned.
+    """
+    updateCodeMonitor(
+        """
+        The input required to edit a monitor.
+        """
+        monitor: MonitorEditInput!
+        """
+        The input required to edit the trigger of a monitor. You can only edit triggers that are
+        associated with the monitor (value of field monitor).
+        """
+        trigger: MonitorEditTriggerInput!
+        """
+        The input required to edit the actions of a monitor. You can only edit actions that are
+        associated with the monitor (value of field monitor).
+        """
+        actions: [MonitorEditActionInput!]!
+    ): Monitor!
 }
 
 """
@@ -3298,6 +3319,39 @@ enum EventStatus {
 }
 
 """
+The input required to create a code monitor.
+"""
+input MonitorInput {
+    """
+    The namespace represents the owner of the code monitor.
+    Owners can either be users or organizations.
+    """
+    namespace: ID!
+    """
+    A meaningful description of the code monitor.
+    """
+    description: String!
+    """
+    Whether the code monitor is enabled or not.
+    """
+    enabled: Boolean!
+}
+
+"""
+The input required to edit a code monitor.
+"""
+input MonitorEditInput {
+    """
+    The id of the monitor.
+    """
+    id: ID!
+    """
+    The desired state after the udpate.
+    """
+    update: MonitorInput!
+}
+
+"""
 The input required to create a trigger.
 """
 input MonitorTriggerInput {
@@ -3305,6 +3359,20 @@ input MonitorTriggerInput {
     The query string.
     """
     query: String!
+}
+
+"""
+The input required to edit a trigger.
+"""
+input MonitorEditTriggerInput {
+    """
+    The id of the Trigger.
+    """
+    id: ID!
+    """
+    The desired state after the udpate.
+    """
+    update: MonitorTriggerInput!
 }
 
 """
@@ -3337,6 +3405,29 @@ input MonitorEmailInput {
     Use header to automatically approve the message in a read-only or moderated mailing list.
     """
     header: String!
+}
+"""
+The input required to edit an action.
+"""
+input MonitorEditActionInput {
+    """
+    An email action.
+    """
+    email: MonitorEditEmailInput
+}
+
+"""
+The input required to edit an email action.
+"""
+input MonitorEditEmailInput {
+    """
+    The id of an email action.
+    """
+    id: ID!
+    """
+    The desired state after the update.
+    """
+    update: MonitorEmailInput!
 }
 
 """

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -147,6 +147,10 @@ func (r *Resolver) DeleteCodeMonitor(ctx context.Context, args *graphqlbackend.D
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
+func (r Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (graphqlbackend.MonitorResolver, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (r *Resolver) runMonitorQuery(ctx context.Context, q *sqlf.Query) (graphqlbackend.MonitorResolver, error) {
 	rows, err := r.db.Query(ctx, q)
 	if err != nil {


### PR DESCRIPTION
This PR adds a stub for `UpdateCodeMonitor`. Once we align on the schema
I will remove the stub in a follow-up PR.

Note that the signature of `CreateCodeMonitor` is slightly different from the
signature of `UpdateCodeMonitor`. I think it might be a good idea to
align both, IE we should change the signature of `CreateCodeMonitor` and
nest the meta-fields (description, enabled, owner) of a code monitor on the
same level as trigger and actions. This way we could reuse the types in
the schema which makes the whole thing less brittle.