### PR TITLE
monitoring: Allow Observables without alerts

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2400,24 +2400,6 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <br />
-## repo-updater: sched_manual_fetch
-
-<p class="subtitle">cloud: repositories scheduled due to user traffic</p>**Descriptions:**
-
-- _repo-updater: less than 0 repositories scheduled due to user traffic for 9h0m0s_
-
-**Possible solutions:**
-
-- Check repo-updater logs. This is expected to fire if there are no user added code hosts
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_sched_manual_fetch"
-]
-```
-
-<br />
 ## repo-updater: sched_known_repos
 
 <p class="subtitle">cloud: repositories managed by the scheduler</p>**Descriptions:**

--- a/monitoring/generator.go
+++ b/monitoring/generator.go
@@ -185,7 +185,7 @@ type Observable struct {
 	//
 	// See README.md for why it is intentionally impossible to create a dashboard to monitor
 	// something without at least a warning alert being defined.
-	Warning, Critical alertDefinition
+	Warning, Critical *alertDefinition
 
 	// PossibleSolutions is Markdown describing possible solutions in the event that the alert is
 	// firing. If there is no clear potential resolution, "none" must be explicitly stated.
@@ -225,15 +225,14 @@ func (o Observable) validate() error {
 	if v := string([]rune(o.Description)[0]); v != strings.ToLower(v) {
 		return fmt.Errorf("Observable.Description must be lowercase; found \"%s\"", o.Description)
 	}
-	if o.Warning.isEmpty() && o.Critical.isEmpty() {
-		return fmt.Errorf("%s: a Warning or Critical alert MUST be defined", o.Name)
+
+	if o.Warning != nil && o.Warning.isEmpty() {
+		return fmt.Errorf("Observable.Warning was set, but is empty")
 	}
-	if err := o.Warning.validate(); err != nil && !o.Warning.isEmpty() {
-		return fmt.Errorf("warning: %v", err)
+	if o.Critical != nil && o.Critical.isEmpty() {
+		return fmt.Errorf("Observable.Critical was set, but is empty")
 	}
-	if err := o.Critical.validate(); err != nil && !o.Critical.isEmpty() {
-		return fmt.Errorf("critical: %v", err)
-	}
+
 	if l := strings.ToLower(o.PossibleSolutions); strings.Contains(l, "contact support") || strings.Contains(l, "contact us") {
 		return fmt.Errorf("PossibleSolutions: should not include mentions of contacting support")
 	}
@@ -250,8 +249,8 @@ func (o Observable) validate() error {
 	return nil
 }
 
-func Alert() alertDefinition {
-	return alertDefinition{}
+func Alert() *alertDefinition {
+	return &alertDefinition{}
 }
 
 // alertDefinition defines when an alert would be considered firing.
@@ -269,30 +268,23 @@ type alertDefinition struct {
 	duration time.Duration
 }
 
-func (a alertDefinition) GreaterOrEqual(f float64) alertDefinition {
+func (a *alertDefinition) GreaterOrEqual(f float64) *alertDefinition {
 	a.greaterOrEqual = &f
 	return a
 }
 
-func (a alertDefinition) LessOrEqual(f float64) alertDefinition {
+func (a *alertDefinition) LessOrEqual(f float64) *alertDefinition {
 	a.lessOrEqual = &f
 	return a
 }
 
-func (a alertDefinition) For(d time.Duration) alertDefinition {
+func (a *alertDefinition) For(d time.Duration) *alertDefinition {
 	a.duration = d
 	return a
 }
 
-func (a alertDefinition) isEmpty() bool {
-	return a == alertDefinition{} || (a.greaterOrEqual == nil && a.lessOrEqual == nil)
-}
-
-func (a alertDefinition) validate() error {
-	if a.isEmpty() {
-		return errors.New("empty")
-	}
-	return nil
+func (a *alertDefinition) isEmpty() bool {
+	return a == nil || (*a == alertDefinition{}) || (a.greaterOrEqual == nil && a.lessOrEqual == nil)
 }
 
 // UnitType for controlling the unit type display on graphs.
@@ -569,7 +561,7 @@ func (c *Container) dashboard() *sdk.Board {
 					Show:     true,
 				}
 
-				if o.Warning.greaterOrEqual != nil {
+				if o.Warning != nil && o.Warning.greaterOrEqual != nil {
 					// Warning threshold
 					panel.GraphPanel.Thresholds = append(panel.GraphPanel.Thresholds, sdk.Threshold{
 						Value:     float32(*o.Warning.greaterOrEqual),
@@ -580,7 +572,7 @@ func (c *Container) dashboard() *sdk.Board {
 						FillColor: "rgba(255, 73, 53, 0.8)",
 					})
 				}
-				if o.Critical.greaterOrEqual != nil {
+				if o.Critical != nil && o.Critical.greaterOrEqual != nil {
 					// Critical threshold
 					panel.GraphPanel.Thresholds = append(panel.GraphPanel.Thresholds, sdk.Threshold{
 						Value:     float32(*o.Critical.greaterOrEqual),
@@ -591,7 +583,7 @@ func (c *Container) dashboard() *sdk.Board {
 						FillColor: "rgba(255, 17, 36, 0.8)",
 					})
 				}
-				if o.Warning.lessOrEqual != nil {
+				if o.Warning != nil && o.Warning.lessOrEqual != nil {
 					// Warning threshold
 					panel.GraphPanel.Thresholds = append(panel.GraphPanel.Thresholds, sdk.Threshold{
 						Value:     float32(*o.Warning.lessOrEqual),
@@ -602,7 +594,7 @@ func (c *Container) dashboard() *sdk.Board {
 						FillColor: "rgba(255, 73, 53, 0.8)",
 					})
 				}
-				if o.Critical.lessOrEqual != nil {
+				if o.Critical != nil && o.Critical.lessOrEqual != nil {
 					// Critical threshold
 					panel.GraphPanel.Thresholds = append(panel.GraphPanel.Thresholds, sdk.Threshold{
 						Value:     float32(*o.Critical.lessOrEqual),
@@ -645,7 +637,7 @@ func (c *Container) dashboard() *sdk.Board {
 }
 
 // alertDescription generates an alert description for the specified coontainer's alert.
-func (c *Container) alertDescription(o Observable, alert alertDefinition) string {
+func (c *Container) alertDescription(o Observable, alert *alertDefinition) string {
 	if alert.isEmpty() {
 		panic("never here")
 	}
@@ -684,7 +676,7 @@ func (c *Container) promAlertsFile() *promRulesFile {
 	for _, g := range c.Groups {
 		for _, r := range g.Rows {
 			for _, o := range r {
-				for level, a := range map[string]alertDefinition{
+				for level, a := range map[string]*alertDefinition{
 					"warning":  o.Warning,
 					"critical": o.Critical,
 				} {
@@ -700,11 +692,11 @@ func (c *Container) promAlertsFile() *promRulesFile {
 							// make sure the prometheus alert description only describes one bound
 							name = fmt.Sprintf("%s_%s", o.Name, bound)
 							if bound == "high" {
-								description = c.alertDescription(o, alertDefinition{
+								description = c.alertDescription(o, &alertDefinition{
 									greaterOrEqual: a.greaterOrEqual,
 								})
 							} else if bound == "low" {
-								description = c.alertDescription(o, alertDefinition{
+								description = c.alertDescription(o, &alertDefinition{
 									lessOrEqual: a.lessOrEqual,
 								})
 							} else {
@@ -837,6 +829,10 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 		for _, g := range c.Groups {
 			for _, r := range g.Rows {
 				for _, o := range r {
+					if o.Warning == nil && o.Critical == nil {
+						continue
+					}
+
 					fmt.Fprintf(&b, "## %s: %s\n\n", c.Name, o.Name)
 					fmt.Fprintf(&b, `<p class="subtitle">%s: %s</p>`, o.Owner, o.Description)
 
@@ -845,7 +841,7 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 					var prometheusAlertNames []string
 					for _, alert := range []struct {
 						level     string
-						threshold alertDefinition
+						threshold *alertDefinition
 					}{
 						{level: "warning", threshold: o.Warning},
 						{level: "critical", threshold: o.Critical},

--- a/monitoring/repo_updater.go
+++ b/monitoring/repo_updater.go
@@ -148,7 +148,6 @@ func RepoUpdater() *Container {
 							Description:       "repositories scheduled due to user traffic",
 							Query:             `sum(rate(src_repoupdater_sched_manual_fetch[1m]))`,
 							DataMayNotExist:   true,
-							Warning:           Alert().LessOrEqual(0).For(syncDurationThreshold),
 							PanelOptions:      PanelOptions().Unit(Number),
 							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "Check repo-updater logs. This is expected to fire if there are no user added code hosts",


### PR DESCRIPTION
This commit allows teams to define Observables without alerts, and
removes one Warning alert from the current repo-updater dashboard to
exemplify it.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
