### PR TITLE
graphqlbackend: Lazy load git commit for each hunk

### DIFF
--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -47,13 +46,5 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	cachedRepo, err := backend.CachedGitRepo(ctx, r.repo.repo)
-	if err != nil {
-		return nil, err
-	}
-	commit, err := git.GetCommit(ctx, *cachedRepo, nil, r.hunk.CommitID, git.ResolveRevisionOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return toGitCommitResolver(r.repo, commit), nil
+	return toGitCommitResolver(r.repo, &git.Commit{ID: r.hunk.CommitID}), nil
 }


### PR DESCRIPTION
This change makes it so `hunkResolver` lazy loads the `git.Commit` of a
hunk from gitserver, instead of eagerly doing it for all hunks.

This functionality was already built in `GitCommitResolver`, we were
just not using it. Additionally, for use cases where only the commit URL
is requested, that resolver doesn't call out to gitserver, which fixes
the current problem with the git blame queries coming from https://github.com/sourcegraph/sourcegraph-git-extras

**However**, the moment any client asks for other fields that require talking to gitserver, we'll get back to the same issue. While we could introduce a commit cache shared between `GitCommitResolver` instances, that would only accrue small benefits, compared to having a longer lived cache of commits, which is mostly immutable data, that doesn't require talking to gitserver and do expensive `git log` calls.

@keegancsmith: This is hinting again at storing commits in Postgres (or somewhere else, like Redis). Would you be open for us to experiment with that too in the course of us now writing data to Postgres from gitserver?

Fixes #15392
