### PR TITLE
Fix user viewing admin profile fails with permission error

### DIFF
--- a/client/web/src/user/settings/profile/EditUserProfileForm.test.tsx
+++ b/client/web/src/user/settings/profile/EditUserProfileForm.test.tsx
@@ -9,7 +9,8 @@ describe('EditUserProfileForm', () => {
         expect(
             mount(
                 <EditUserProfileForm
-                    user={{ id: 'x', siteAdmin: false, viewerCanChangeUsername: true }}
+                    authenticatedUser={{ siteAdmin: false }}
+                    user={{ id: 'x', viewerCanChangeUsername: true }}
                     initialValue={{ username: 'u', displayName: 'd', avatarURL: 'https://example.com/image.jpg' }}
                     onUpdate={() => {}}
                     after="AFTER"

--- a/client/web/src/user/settings/profile/EditUserProfileForm.tsx
+++ b/client/web/src/user/settings/profile/EditUserProfileForm.tsx
@@ -9,9 +9,11 @@ import { UserProfileFormFields, UserProfileFormFieldsValue } from './UserProfile
 import * as GQL from '../../../../../shared/src/graphql/schema'
 import { UserAreaGQLFragment } from '../../area/UserArea'
 import { Form } from '../../../../../branded/src/components/Form'
+import { AuthenticatedUser } from '../../../auth'
 
 interface Props {
-    user: Pick<GQL.IUser, 'id' | 'viewerCanChangeUsername' | 'siteAdmin'>
+    authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'>
+    user: Pick<GQL.IUser, 'id' | 'viewerCanChangeUsername'>
 
     initialValue: UserProfileFormFieldsValue
 
@@ -24,7 +26,13 @@ interface Props {
 /**
  * A form to edit a user's profile.
  */
-export const EditUserProfileForm: React.FunctionComponent<Props> = ({ user, initialValue, onUpdate, after }) => {
+export const EditUserProfileForm: React.FunctionComponent<Props> = ({
+    user,
+    authenticatedUser,
+    initialValue,
+    onUpdate,
+    after,
+}) => {
     const [value, setValue] = useState<UserProfileFormFieldsValue>(initialValue)
     const onChange = useCallback<React.ComponentProps<typeof UserProfileFormFields>['onChange']>(
         newValue => setValue(previous => ({ ...previous, ...newValue })),
@@ -59,7 +67,7 @@ export const EditUserProfileForm: React.FunctionComponent<Props> = ({ user, init
                         }
                         ${UserAreaGQLFragment}
                     `,
-                    { ...value, user: user.id, siteAdmin: user.siteAdmin }
+                    { ...value, user: user.id, siteAdmin: authenticatedUser.siteAdmin }
                 )
                     .pipe(
                         map(dataOrThrowErrors),
@@ -74,7 +82,7 @@ export const EditUserProfileForm: React.FunctionComponent<Props> = ({ user, init
                 setOpState(error)
             }
         },
-        [onUpdate, user.id, user.siteAdmin, value]
+        [onUpdate, user.id, authenticatedUser.siteAdmin, value]
     )
 
     return (

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -7,9 +7,9 @@ import { isErrorLike } from '../../../../../shared/src/util/errors'
 import { refreshAuthenticatedUser } from '../../../auth'
 import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
-import { UserAreaRouteContext } from '../../area/UserArea'
 import { EditUserProfilePage as EditUserProfilePageFragment } from '../../../graphql-operations'
 import { EditUserProfileForm } from './EditUserProfileForm'
+import { UserSettingsAreaRouteContext } from '../UserSettingsArea'
 
 export const EditUserProfilePageGQLFragment = gql`
     fragment EditUserProfilePage on User {
@@ -18,11 +18,10 @@ export const EditUserProfilePageGQLFragment = gql`
         displayName
         avatarURL
         viewerCanChangeUsername
-        siteAdmin
     }
 `
 
-interface Props extends Pick<UserAreaRouteContext, 'onUserUpdate' | 'activation'> {
+interface Props extends Pick<UserSettingsAreaRouteContext, 'onUserUpdate' | 'activation' | 'authenticatedUser'> {
     user: EditUserProfilePageFragment
 
     history: H.History
@@ -31,6 +30,7 @@ interface Props extends Pick<UserAreaRouteContext, 'onUserUpdate' | 'activation'
 
 export const UserSettingsProfilePage: React.FunctionComponent<Props> = ({
     user,
+    authenticatedUser,
     onUserUpdate: parentOnUpdate,
     ...props
 }) => {
@@ -75,6 +75,7 @@ export const UserSettingsProfilePage: React.FunctionComponent<Props> = ({
             {user && !isErrorLike(user) && (
                 <EditUserProfileForm
                     user={user}
+                    authenticatedUser={authenticatedUser}
                     initialValue={user}
                     onUpdate={onUpdate}
                     after={

--- a/client/web/src/user/settings/profile/__snapshots__/EditUserProfileForm.test.tsx.snap
+++ b/client/web/src/user/settings/profile/__snapshots__/EditUserProfileForm.test.tsx.snap
@@ -3,6 +3,11 @@
 exports[`EditUserProfileForm simple 1`] = `
 <EditUserProfileForm
   after="AFTER"
+  authenticatedUser={
+    Object {
+      "siteAdmin": false,
+    }
+  }
   initialValue={
     Object {
       "avatarURL": "https://example.com/image.jpg",
@@ -14,7 +19,6 @@ exports[`EditUserProfileForm simple 1`] = `
   user={
     Object {
       "id": "x",
-      "siteAdmin": false,
       "viewerCanChangeUsername": true,
     }
   }


### PR DESCRIPTION
The root cause was that our directives that don't request admin only fields listened on the viewed user, not the viewING user.
