### PR TITLE
cloud: Explicitly set global external service

### DIFF
--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -164,6 +164,12 @@
       "description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the `auth.providers` field of type \"github\" with the same `url` field as specified in this `GitHubConnection`.",
       "type": "object",
       "properties": {}
+    },
+    "cloudGlobal": {
+      "title": "CloudGlobal",
+      "description": "When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -169,6 +169,12 @@ const GitHubSchemaJSON = `{
       "description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the ` + "`" + `auth.providers` + "`" + ` field of type \"github\" with the same ` + "`" + `url` + "`" + ` field as specified in this ` + "`" + `GitHubConnection` + "`" + `.",
       "type": "object",
       "properties": {}
+    },
+    "cloudGlobal": {
+      "title": "CloudGlobal",
+      "description": "When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -193,6 +193,12 @@
           }
         }
       }
+    },
+    "cloudGlobal": {
+      "title": "CloudGlobal",
+      "description": "When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
+      "type": "boolean",
+      "default": false
     }
   },
   "definitions": {

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -198,6 +198,12 @@ const GitLabSchemaJSON = `{
           }
         }
       }
+    },
+    "cloudGlobal": {
+      "title": "CloudGlobal",
+      "description": "When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
+      "type": "boolean",
+      "default": false
     }
   },
   "definitions": {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -508,6 +508,8 @@ type GitHubConnection struct {
 	Authorization *GitHubAuthorization `json:"authorization,omitempty"`
 	// Certificate description: TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	Certificate string `json:"certificate,omitempty"`
+	// CloudGlobal description: When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.
+	CloudGlobal bool `json:"cloudGlobal,omitempty"`
 	// Exclude description: A list of repositories to never mirror from this GitHub instance. Takes precedence over "orgs", "repos", and "repositoryQuery" configuration.
 	//
 	// Supports excluding by name ({"name": "owner/name"}) or by ID ({"id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="}).
@@ -597,6 +599,8 @@ type GitLabConnection struct {
 	Authorization *GitLabAuthorization `json:"authorization,omitempty"`
 	// Certificate description: TLS certificate of the GitLab instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	Certificate string `json:"certificate,omitempty"`
+	// CloudGlobal description: When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.
+	CloudGlobal bool `json:"cloudGlobal,omitempty"`
 	// Exclude description: A list of projects to never mirror from this GitLab instance. Takes precedence over "projects" and "projectQuery" configuration. Supports excluding by name ({"name": "group/name"}) or by ID ({"id": 42}).
 	Exclude []*ExcludedGitLabProject `json:"exclude,omitempty"`
 	// GitURLType description: The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.


### PR DESCRIPTION
Add CloudGlobal flag to GitHub and GitLab external services

Validate that only one site admin owned service on cloud can have this flag set as true.

A followup PR will use these values one this PR has been deployed and the appropriate external services have been flagged.

Part of: https://github.com/sourcegraph/sourcegraph/issues/14985
