### PR TITLE
graphqlbackend: Proper lazy loading in GitCommitResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -1,6 +1,110 @@
 package graphqlbackend
 
-import "testing"
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+func TestGitCommitResolver(t *testing.T) {
+	ctx := context.Background()
+
+	commit := &git.Commit{
+		ID:      "c1",
+		Message: "subject: Changes things\nBody of changes",
+		Parents: []api.CommitID{"p1", "p2"},
+		Author: git.Signature{
+			Name:  "Bob",
+			Email: "bob@alice.com",
+			Date:  time.Now(),
+		},
+		Committer: &git.Signature{
+			Name:  "Alice",
+			Email: "alice@bob.com",
+			Date:  time.Now(),
+		},
+	}
+
+	t.Run("Lazy loading", func(t *testing.T) {
+		git.Mocks.GetCommit = func(api.CommitID) (*git.Commit, error) {
+			return commit, nil
+		}
+		t.Cleanup(func() {
+			git.Mocks.GetCommit = nil
+		})
+
+		for _, tc := range []struct {
+			name string
+			want interface{}
+			have func(*GitCommitResolver) (interface{}, error)
+		}{{
+			name: "author",
+			want: toSignatureResolver(&commit.Author, true),
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.Author(ctx)
+			},
+		}, {
+			name: "committer",
+			want: toSignatureResolver(commit.Committer, true),
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.Committer(ctx)
+			},
+		}, {
+			name: "message",
+			want: commit.Message,
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.Message(ctx)
+			},
+		}, {
+			name: "subject",
+			want: "subject: Changes things",
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.Subject(ctx)
+			},
+		}, {
+			name: "body",
+			want: "Body of changes",
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.Body(ctx)
+			},
+		}, {
+			name: "url",
+			want: "/bob-repo/-/commit/c1",
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.URL()
+			},
+		}, {
+			name: "canonical-url",
+			want: "/bob-repo/-/commit/c1",
+			have: func(r *GitCommitResolver) (interface{}, error) {
+				return r.CanonicalURL()
+			},
+		}} {
+			t.Run(tc.name, func(t *testing.T) {
+				repo := NewRepositoryResolver(&types.Repo{Name: "bob-repo"})
+				// We pass no commit here to test that it gets lazy loaded via
+				// the git.GetCommit mock above.
+				r := toGitCommitResolver(repo, "c1", nil)
+
+				have, err := tc.have(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(have, tc.want) {
+					t.Errorf("\nhave: %s\nwant: %s", spew.Sprint(have), spew.Sprint(tc.want))
+				}
+			})
+		}
+	})
+}
 
 func TestGitCommitBody(t *testing.T) {
 	tests := map[string]string{

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -72,7 +72,8 @@ func TestGitCommitResolver(t *testing.T) {
 			name: "body",
 			want: "Body of changes",
 			have: func(r *GitCommitResolver) (interface{}, error) {
-				return r.Body(ctx)
+				s, err := r.Body(ctx)
+				return *s, err
 			},
 		}, {
 			name: "url",

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -80,7 +80,7 @@ func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*GitCommitRe
 
 	resolvers := make([]*GitCommitResolver, len(commits))
 	for i, commit := range commits {
-		resolvers[i] = toGitCommitResolver(r.repo, commit)
+		resolvers[i] = toGitCommitResolver(r.repo, commit.ID, commit)
 	}
 
 	return resolvers, nil

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -46,5 +46,5 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return toGitCommitResolver(r.repo, &git.Commit{ID: r.hunk.CommitID}), nil
+	return toGitCommitResolver(r.repo, r.hunk.CommitID, nil), nil
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -167,7 +167,7 @@ func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *RepositoryC
 		return nil, err
 	}
 
-	resolver := toGitCommitResolver(r, commit)
+	resolver := toGitCommitResolver(r, commitID, commit)
 	if args.InputRevspec != nil {
 		resolver.inputRev = args.InputRevspec
 	} else {

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -82,7 +82,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 		// Optimistically fetch using revspec
 		commit, err := git.GetCommit(ctx, repo, nil, api.CommitID(revspec), opt)
 		if err == nil {
-			return toGitCommitResolver(r, commit), nil
+			return toGitCommitResolver(r, commit.ID, commit), nil
 		}
 
 		// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't
@@ -96,7 +96,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 		if err != nil {
 			return nil, err
 		}
-		return toGitCommitResolver(r, commit), nil
+		return toGitCommitResolver(r, commit.ID, commit), nil
 	}
 
 	grepo, err := backend.CachedGitRepo(ctx, r.repo)

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -251,7 +251,7 @@ func logCommitSearchResultsToResolvers(ctx context.Context, op *search.CommitPar
 	results := make([]*CommitSearchResultResolver, len(rawResults))
 	for i, rawResult := range rawResults {
 		commit := rawResult.Commit
-		commitResolver := toGitCommitResolver(repoResolver, &commit)
+		commitResolver := toGitCommitResolver(repoResolver, commit.ID, &commit)
 		results[i] = &CommitSearchResultResolver{commit: commitResolver}
 
 		addRefs := func(dst *[]*GitRefResolver, src []string) {
@@ -546,7 +546,7 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 func commitSearchResultsToSearchResults(results []*CommitSearchResultResolver) []SearchResultResolver {
 	// Show most recent commits first.
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].commit.author.Date() > results[j].commit.author.Date()
+		return results[i].commit.commit.Author.Date.After(results[j].commit.commit.Author.Date)
 	})
 
 	results2 := make([]SearchResultResolver, len(results))

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -65,17 +65,15 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantCommit := GitCommitResolver{
-		repoResolver:    &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
-		oid:             "c1",
-		author:          *toSignatureResolver(&gitSignatureWithDate, true),
-		includeUserInfo: true,
-	}
-	wantCommit.once.Do(func() {}) // mark as done
+	wantCommit := toGitCommitResolver(
+		&RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
+		"c1",
+		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
+	)
 
 	if want := []*CommitSearchResultResolver{
 		{
-			commit:      &wantCommit,
+			commit:      wantCommit,
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
 			icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
 			label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -500,7 +500,7 @@ loop:
 			continue
 		case *CommitSearchResultResolver:
 			// Diff searches are cheap, because we implicitly have author date info.
-			addPoint(m.commit.author.date)
+			addPoint(m.commit.commit.Author.Date)
 		case *FileMatchResolver:
 			// File match searches are more expensive, because we must blame the
 			// (first) line in order to know its placement in our sparkline.

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -22,11 +22,12 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	}
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
-	commit := &GitCommitResolver{
-		repoResolver: &RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
-		oid:          "c1",
-		author:       *toSignatureResolver(&gitSignatureWithDate, false),
-	}
+
+	commit := toGitCommitResolver(
+		&RepositoryResolver{repo: &types.Repo{ID: 1, Name: "repo"}},
+		"c1",
+		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
+	)
 	sr := &searchSymbolResult{symbol, baseURI, "go", commit}
 
 	tests := []struct {


### PR DESCRIPTION
This fixes a bug I introduced in #15746 where not all fields of the
commit would be lazy loaded.

It makes the constructor of the resolver take in a commit ID and a
commit, separately, so that it's clear when we instantiate a resolver
with a pre-loaded commit, vs without one (so that it gets lazy loaded).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
