### PR TITLE
authz: Register authz providers in code intel worker

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -11,12 +11,16 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	eauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/worker"
+	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -111,6 +115,24 @@ func mustInitializeDB() *sql.DB {
 	if err := dbconn.SetupGlobalConnection(postgresDSN); err != nil {
 		log.Fatalf("Failed to connect to frontend database: %s", err)
 	}
+
+	//
+	// START FLAILING
+
+	// TODO(efritz) - rearrange the authz packages so we don't have to import from frontend
+	ctx := context.Background()
+	var msResolutionClock = func() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }
+	eauthz.Init(dbconn.Global, msResolutionClock)
+
+	go func() {
+		for range time.NewTicker(5 * time.Second).C {
+			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices)
+			authz.SetProviders(allowAccessByDefault, authzProviders)
+		}
+	}()
+
+	// END FLAILING
+	//
 
 	return dbconn.Global
 }


### PR DESCRIPTION
The code intel worker database queries lock up because there are no providers registered on startup. This copies the same code required to register authz in the enterprise frontend. Needs work, but the cloud environment is currently failing to process any code intel uploads.

Adds additional state required by https://github.com/sourcegraph/sourcegraph/pull/13708.