### PR TITLE
Faster compute of burndown charts

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -201,7 +201,7 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 		end = args.To.Time.UTC()
 	}
 
-	eventsOpts := ee.ListChangesetEventsOpts{ChangesetIDs: cs.IDs()}
+	eventsOpts := ee.ListChangesetEventsOpts{ChangesetIDs: cs.IDs(), Kinds: ee.RequiredEventTypesForHistory}
 	es, _, err := r.store.ListChangesetEvents(ctx, eventsOpts)
 	if err != nil {
 		return resolvers, err

--- a/enterprise/internal/campaigns/store_changeset_events.go
+++ b/enterprise/internal/campaigns/store_changeset_events.go
@@ -78,6 +78,7 @@ func getChangesetEventQuery(opts *GetChangesetEventOpts) *sqlf.Query {
 type ListChangesetEventsOpts struct {
 	LimitOpts
 	ChangesetIDs []int64
+	Kinds        []campaigns.ChangesetEventKind
 	Cursor       int64
 }
 
@@ -132,6 +133,14 @@ func listChangesetEventsQuery(opts *ListChangesetEventsOpts) *sqlf.Query {
 		}
 		preds = append(preds,
 			sqlf.Sprintf("changeset_id IN (%s)", sqlf.Join(ids, ",")))
+	}
+
+	if len(opts.Kinds) > 0 {
+		kinds := make([]*sqlf.Query, 0, len(opts.Kinds))
+		for _, kind := range opts.Kinds {
+			kinds = append(kinds, sqlf.Sprintf("%s", kind))
+		}
+		preds = append(preds, sqlf.Sprintf("kind IN (%s)", sqlf.Join(kinds, ",")))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store_changeset_events_test.go
+++ b/enterprise/internal/campaigns/store_changeset_events_test.go
@@ -49,7 +49,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 		}
 
 		// Verify that no duplicates are introduced and no error is returned.
-		for i := 0; i < len(events); i++ {
+		for i := 0; i < 2; i++ {
 			err := s.UpsertChangesetEvents(ctx, events...)
 			if err != nil {
 				t.Fatal(err)

--- a/enterprise/internal/campaigns/store_changeset_events_test.go
+++ b/enterprise/internal/campaigns/store_changeset_events_test.go
@@ -29,12 +29,17 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 	}
 
 	events := make([]*cmpgn.ChangesetEvent, 0, 3)
+	kinds := []cmpgn.ChangesetEventKind{
+		cmpgn.ChangesetEventKindGitHubCommented,
+		cmpgn.ChangesetEventKindGitHubClosed,
+		cmpgn.ChangesetEventKindGitHubAssigned,
+	}
 
 	t.Run("Upsert", func(t *testing.T) {
-		for i := 1; i < cap(events); i++ {
+		for i := 0; i < cap(events); i++ {
 			e := &cmpgn.ChangesetEvent{
-				ChangesetID: int64(i),
-				Kind:        cmpgn.ChangesetEventKindGitHubCommented,
+				ChangesetID: int64(i + 1),
+				Kind:        kinds[i],
 				Key:         issueComment.Key(),
 				CreatedAt:   clock.now(),
 				Metadata:    issueComment,
@@ -44,7 +49,7 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 		}
 
 		// Verify that no duplicates are introduced and no error is returned.
-		for i := 0; i < 2; i++ {
+		for i := 0; i < len(events); i++ {
 			err := s.UpsertChangesetEvents(ctx, events...)
 			if err != nil {
 				t.Fatal(err)
@@ -162,6 +167,51 @@ func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ rep
 
 				for i := 1; i <= len(events); i++ {
 					opts.ChangesetIDs = append(opts.ChangesetIDs, int64(i))
+				}
+
+				ts, next, err := s.ListChangesetEvents(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := next, int64(0); have != want {
+					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+				}
+
+				have, want := ts, events
+				if len(have) != len(want) {
+					t.Fatalf("listed %d events, want: %d", len(have), len(want))
+				}
+			}
+		})
+
+		t.Run("ByKinds", func(t *testing.T) {
+			for _, k := range kinds {
+				opts := ListChangesetEventsOpts{Kinds: []cmpgn.ChangesetEventKind{k}}
+
+				ts, next, err := s.ListChangesetEvents(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if have, want := next, int64(0); have != want {
+					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
+				}
+
+				if have, want := len(ts), 1; have != want {
+					t.Fatalf("listed %d events for %q, want: %d", have, k, want)
+				}
+
+				if have, want := ts[0].Kind, k; have != want {
+					t.Fatalf("listed %q events, want of kind: %q", have, want)
+				}
+			}
+
+			{
+				opts := ListChangesetEventsOpts{Kinds: []cmpgn.ChangesetEventKind{}}
+
+				for _, e := range events {
+					opts.Kinds = append(opts.Kinds, e.Kind)
 				}
 
 				ts, next, err := s.ListChangesetEvents(ctx, opts)


### PR DESCRIPTION
Turns out for the burndown chart we really don't need all events in the PR timelines. Given that, we can add a filter by kind and sometimes drastically reduce the amount of events that need to be processed. In case of my 9k changesets campaign this reduces it to ~30% of the initial amount of events.

Before:
Required changesets: 9045, events: 106843, request duration: 5.34s

After:
Required changesets: 9045, events: 31752, request duration: 4.10s