### PR TITLE
codeintel: fix panic if there are no usage events

### DIFF
--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -62,6 +62,8 @@ func GetAggregatedCodeIntelStats(ctx context.Context) (*types.NewCodeIntelUsageS
 	codeIntelEvents, err := db.EventLogs.AggregatedCodeIntelEvents(ctx)
 	if err != nil {
 		return nil, err
+	} else if len(codeIntelEvents) == 0 {
+		return nil, nil
 	}
 	stats := groupAggreatedCodeIntelStats(codeIntelEvents)
 


### PR DESCRIPTION
If the aggregation function has no events to look at, then we get a frontend panic (included below), since the first event is used to define the aggregation window without a check for whether there are any events.

It looks like the usage gathering can deal with a `nil` return, so let's just do that. (Obviously the correct fix here is for me to use code intel more, though!)

The panic I saw:

```
11:25:33                  frontend | panic: runtime error: index out of range [0] with length 0
11:25:33                  frontend | goroutine 396 [running]:
11:25:33                  frontend | github.com/sourcegraph/sourcegraph/internal/usagestats.groupAggreatedCodeIntelStats(0x0, 0x0, 0x0, 0x0)
11:25:33                  frontend | 	/home/adam/trees/sourcegraph/sourcegraph/internal/usagestats/aggregated.go:122 +0x506
11:25:33                  frontend | github.com/sourcegraph/sourcegraph/internal/usagestats.GetAggregatedCodeIntelStats(0x2f28580, 0xc001816960, 0x0, 0x0, 0x0)
11:25:33                  frontend | 	/home/adam/trees/sourcegraph/sourcegraph/internal/usagestats/aggregated.go:66 +0x173
11:25:33                  frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck.getAndMarshalAggregatedCodeIntelUsageJSON(0x2f28580, 0xc001816960, 0x0, 0x0, 0x0, 0xc00111efa8, 0xab3e68)
11:25:33                  frontend | 	/home/adam/trees/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck/client.go:184 +0x117
11:25:33                  frontend | github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck.updateBody.func2(0xc001b628a0, 0x2f28580, 0xc001816960, 0xc001158ea0, 0xc001852a60, 0x2c50360)
11:25:33                  frontend | 	/home/adam/trees/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck/client.go:381 +0xbb
11:25:33                  frontend | created by github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck.updateBody
11:25:33                  frontend | 	/home/adam/trees/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck/client.go:379 +0x2e07
```