### PR TITLE
codeintel: fix typos in function names

### DIFF
--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -57,13 +57,13 @@ func groupSiteUsageStats(summary types.SiteUsageSummary, monthsOnly bool) *types
 	return stats
 }
 
-// GetAggregateCodeIntelStats returns aggregates statistics for code intelligence usage.
+// GetAggregatedCodeIntelStats returns aggregated statistics for code intelligence usage.
 func GetAggregatedCodeIntelStats(ctx context.Context) (*types.NewCodeIntelUsageStatistics, error) {
 	codeIntelEvents, err := db.EventLogs.AggregatedCodeIntelEvents(ctx)
 	if err != nil {
 		return nil, err
 	}
-	stats := groupAggreatedCodeIntelStats(codeIntelEvents)
+	stats := groupAggregatedCodeIntelStats(codeIntelEvents)
 
 	usersCount, err := db.EventLogs.CodeIntelligenceCombinedWAU(ctx)
 	if err != nil {
@@ -100,7 +100,7 @@ var sourceMap = map[string]types.CodeIntelSource{
 	"codeintel.searchReferences.xrepo":  types.SearchSource,
 }
 
-func groupAggreatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *types.NewCodeIntelUsageStatistics {
+func groupAggregatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *types.NewCodeIntelUsageStatistics {
 	var eventSummaries []types.CodeIntelEventSummary
 	for _, event := range rawEvents {
 		languageID := ""
@@ -131,10 +131,10 @@ func GetAggregatedSearchStats(ctx context.Context) (*types.SearchUsageStatistics
 		return nil, err
 	}
 
-	return groupAggreatedSearchStats(events), nil
+	return groupAggregatedSearchStats(events), nil
 }
 
-func groupAggreatedSearchStats(events []types.AggregatedEvent) *types.SearchUsageStatistics {
+func groupAggregatedSearchStats(events []types.AggregatedEvent) *types.SearchUsageStatistics {
 	searchUsageStats := &types.SearchUsageStatistics{
 		Daily:   []*types.SearchUsagePeriod{newSearchEventPeriod()},
 		Weekly:  []*types.SearchUsagePeriod{newSearchEventPeriod()},

--- a/internal/usagestats/aggregated_test.go
+++ b/internal/usagestats/aggregated_test.go
@@ -123,7 +123,7 @@ func TestGroupAggregateSearchStats(t *testing.T) {
 	t2 := t1.Add(time.Hour)
 	t3 := t2.Add(time.Hour)
 
-	searchStats := groupAggreatedSearchStats([]types.AggregatedEvent{
+	searchStats := groupAggregatedSearchStats([]types.AggregatedEvent{
 		{
 			Name:           "search.latencies.structural",
 			Month:          t1,
@@ -292,7 +292,7 @@ func TestGroupAggregatedCodeIntelStats(t *testing.T) {
 	lang2 := "typescript"
 	t1 := time.Now().UTC().Add(time.Hour)
 
-	codeIntelStats := groupAggreatedCodeIntelStats([]types.CodeIntelAggregatedEvent{
+	codeIntelStats := groupAggregatedCodeIntelStats([]types.CodeIntelAggregatedEvent{
 		{Name: "codeintel.lsifHover", Week: t1, TotalWeek: 10, UniquesWeek: 1},
 		{Name: "codeintel.searchDefinitions", Week: t1, TotalWeek: 20, UniquesWeek: 2, LanguageID: &lang1},
 		{Name: "codeintel.lsifDefinitions", Week: t1, TotalWeek: 30, UniquesWeek: 3},


### PR DESCRIPTION
Noticed this while creating #15764: this is obviously massively
unimportant, but while I'm here... :shrug:
