### PR TITLE
campaigns: add site setting to restrict users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Pings now contain Redis & Postgres server versions. [14405](https://github.com/sourcegraph/sourcegraph/14405)
 - Aggregated usage data of the search onboarding tour is now included in pings. The data tracked are: total number of views of the onboarding tour, total number of views of each step in the onboarding tour, total number of tours closed. [#15113](https://github.com/sourcegraph/sourcegraph/pull/15113)
 - Users can now specify credentials for code hosts to enable campaigns for non site-admin users. [#15506](https://github.com/sourcegraph/sourcegraph/pull/15506)
-- A `campaigns.restrictToAdmins` site configuration option has been added to prevent non site-admin users from using campaigns.
+- A `campaigns.restrictToAdmins` site configuration option has been added to prevent non site-admin users from using campaigns. [#15785](https://github.com/sourcegraph/sourcegraph/pull/15785)
 - Number of page views on campaign apply page, page views on campaign details page after create/update, closed campaigns, created campaign specs and changesets specs and the sum of changeset diff stats will be sent back in pings. [#15279](https://github.com/sourcegraph/sourcegraph/pull/15279)
 - Users can now explicitly set their primary email address. [#15683](https://github.com/sourcegraph/sourcegraph/pull/15683)
 - "[Why code search is still needed for monorepos](https://docs.sourcegraph.com/adopt/code_search_in_monorepos)" doc page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Pings now contain Redis & Postgres server versions. [14405](https://github.com/sourcegraph/sourcegraph/14405)
 - Aggregated usage data of the search onboarding tour is now included in pings. The data tracked are: total number of views of the onboarding tour, total number of views of each step in the onboarding tour, total number of tours closed. [#15113](https://github.com/sourcegraph/sourcegraph/pull/15113)
 - Users can now specify credentials for code hosts to enable campaigns for non site-admin users. [#15506](https://github.com/sourcegraph/sourcegraph/pull/15506)
+- A `campaigns.restrictToAdmins` site configuration option has been added to prevent non site-admin users from using campaigns.
 - Number of page views on campaign apply page, page views on campaign details page after create/update, closed campaigns, created campaign specs and changesets specs and the sum of changeset diff stats will be sent back in pings. [#15279](https://github.com/sourcegraph/sourcegraph/pull/15279)
 - Users can now explicitly set their primary email address. [#15683](https://github.com/sourcegraph/sourcegraph/pull/15683)
 - "[Why code search is still needed for monorepos](https://docs.sourcegraph.com/adopt/code_search_in_monorepos)" doc page

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/csrf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -133,6 +134,12 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		sentryDSN = &siteConfig.Log.Sentry.Dsn
 	}
 
+	// Check if campaigns are enabled for this user.
+	campaignsEnabled := conf.CampaignsEnabled()
+	if conf.Get().CampaignsRestrictToAdmins && backend.CheckCurrentUserIsSiteAdmin(req.Context()) != nil {
+		campaignsEnabled = false
+	}
+
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private
 	// server. Including secret fields here is OK if it is based on the user's
@@ -177,7 +184,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		Branding: globals.Branding(),
 
-		CampaignsEnabled: conf.CampaignsEnabled(),
+		CampaignsEnabled: campaignsEnabled,
 
 		ExperimentalFeatures: conf.ExperimentalFeatures(),
 	}

--- a/doc/campaigns/explanations/permissions_in_campaigns.md
+++ b/doc/campaigns/explanations/permissions_in_campaigns.md
@@ -84,3 +84,7 @@ If you are not permitted to view a repository on Sourcegraph, then you won't be 
 ## Disabling campaigns
 
 A site admin can disable campaigns for the entire site by setting the [site configuration](../../../admin/config/site_config.md) property `"campaigns.enabled"` to `false`.
+
+### Disabling campaigns for non-site-admin users
+
+A site admin can disable campaigns for normal users by setting the [site configuration](../../../admin/config/site_config.md) property `"campaigns.restrictToAdmins"` to `true`.

--- a/doc/campaigns/explanations/permissions_in_campaigns.md
+++ b/doc/campaigns/explanations/permissions_in_campaigns.md
@@ -85,6 +85,6 @@ If you are not permitted to view a repository on Sourcegraph, then you won't be 
 
 A site admin can disable campaigns for the entire site by setting the [site configuration](../../../admin/config/site_config.md) property `"campaigns.enabled"` to `false`.
 
-### Disabling campaigns for non-site-admin users
+## Disabling campaigns for non-site-admin users
 
 A site admin can disable campaigns for normal users by setting the [site configuration](../../../admin/config/site_config.md) property `"campaigns.restrictToAdmins"` to `true`.

--- a/doc/campaigns/how-tos/site_admin_configuration.md
+++ b/doc/campaigns/how-tos/site_admin_configuration.md
@@ -6,5 +6,5 @@ Site admins can also:
 
 - [Allow users to authenticate via the code host](../../../admin/auth/index.md#github), which makes it easier for users to authorize [code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
 - [Configure repository permissions](../../../admin/repo/permissions.md), which campaigns will respect.
-- [Disable campaigns for all users](../explanations/permissions_in_campaigns.md#disabling-campaigns-for-all-users).
-
+- [Disable campaigns](../explanations/permissions_in_campaigns.md#disabling-campaigns).
+- [Disable campaigns for non-site-admin users](../explanations/permissions_in_campaigns.md#disabling-campaigns-for-non-site-admin-users).

--- a/enterprise/internal/campaigns/resolvers/errors.go
+++ b/enterprise/internal/campaigns/resolvers/errors.go
@@ -20,6 +20,16 @@ func (e ErrCampaignsDisabled) Extensions() map[string]interface{} {
 	return map[string]interface{}{"code": "ErrCampaignsDisabled"}
 }
 
+type ErrCampaignsDisabledForUser struct{}
+
+func (e ErrCampaignsDisabledForUser) Error() string {
+	return "campaigns are disabled for non-site-admin users"
+}
+
+func (e ErrCampaignsDisabledForUser) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrCampaignsDisabledForUser"}
+}
+
 type ErrCampaignsDotCom struct{}
 
 func (e ErrCampaignsDotCom) Error() string {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -36,13 +36,16 @@ func NewResolver(db *sql.DB) graphqlbackend.CampaignsResolver {
 	return &Resolver{store: ee.NewStore(db)}
 }
 
-func campaignsEnabled() error {
+func campaignsEnabled(ctx context.Context) error {
 	// On Sourcegraph.com nobody can read/create campaign entities
 	if envvar.SourcegraphDotComMode() {
 		return ErrCampaignsDotCom{}
 	}
 
 	if enabled := conf.CampaignsEnabled(); enabled {
+		if conf.Get().CampaignsRestrictToAdmins && backend.CheckCurrentUserIsSiteAdmin(ctx) != nil {
+			return ErrCampaignsDisabledForUser{}
+		}
 		return nil
 	}
 
@@ -65,7 +68,7 @@ func campaignsCreateAccess(ctx context.Context) error {
 }
 
 func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbackend.ChangesetResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +100,7 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 }
 
 func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +125,7 @@ func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlback
 }
 
 func (r *Resolver) Campaign(ctx context.Context, args *graphqlbackend.CampaignArgs) (graphqlbackend.CampaignResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +148,7 @@ func (r *Resolver) Campaign(ctx context.Context, args *graphqlbackend.CampaignAr
 }
 
 func (r *Resolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignSpecResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -171,7 +174,7 @@ func (r *Resolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (graphql
 }
 
 func (r *Resolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (graphqlbackend.ChangesetSpecResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -202,7 +205,7 @@ func (r *Resolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (graphq
 }
 
 func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignsCredentialResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -234,7 +237,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		tr.Finish()
 	}()
 
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -276,7 +279,7 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		tr.Finish()
 	}()
 
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -324,7 +327,7 @@ func (r *Resolver) CreateCampaignSpec(ctx context.Context, args *graphqlbackend.
 		tr.Finish()
 	}()
 
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -392,7 +395,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 		tr.Finish()
 	}()
 
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -428,7 +431,7 @@ func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCa
 		tr.Finish()
 	}()
 
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -470,7 +473,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -490,7 +493,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 }
 
 func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignsArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -540,7 +543,7 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 }
 
 func (r *Resolver) CampaignsCodeHosts(ctx context.Context, args *graphqlbackend.ListCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -656,7 +659,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		tr.Finish()
 	}()
 
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -685,7 +688,7 @@ func (r *Resolver) SyncChangeset(ctx context.Context, args *graphqlbackend.SyncC
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -713,7 +716,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 
@@ -777,7 +780,7 @@ func (r *Resolver) DeleteCampaignsCredential(ctx context.Context, args *graphqlb
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if err := campaignsEnabled(); err != nil {
+	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1165,6 +1165,8 @@ type SiteConfiguration struct {
 	CampaignsEnabled *bool `json:"campaigns.enabled,omitempty"`
 	// CampaignsReadAccessEnabled description: DEPRECATED: Enables read-only access to campaigns for non-site-admin users. This doesn't have an effect anymore.
 	CampaignsReadAccessEnabled *bool `json:"campaigns.readAccess.enabled,omitempty"`
+	// CampaignsRestrictToAdmins description: When enabled, only site admins can create and apply campaigns.
+	CampaignsRestrictToAdmins bool `json:"campaigns.restrictToAdmins,omitempty"`
 	// CorsOrigin description: Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
 	CorsOrigin string `json:"corsOrigin,omitempty"`
 	// DebugSearchSymbolsParallelism description: (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -266,6 +266,12 @@
       "!go": { "pointer": true },
       "group": "Campaigns"
     },
+    "campaigns.restrictToAdmins": {
+      "description": "When enabled, only site admins can create and apply campaigns.",
+      "type": "boolean",
+      "group": "Campaigns",
+      "default": false
+    },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -271,6 +271,12 @@ const SiteSchemaJSON = `{
       "!go": { "pointer": true },
       "group": "Campaigns"
     },
+    "campaigns.restrictToAdmins": {
+      "description": "When enabled, only site admins can create and apply campaigns.",
+      "type": "boolean",
+      "group": "Campaigns",
+      "default": false
+    },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",


### PR DESCRIPTION
This disables all campaign and user token functionality for regular users if the new `campaigns.restrictToAdmins` setting is enabled.

This may be _too_ heavy handed right now, as it essentially shuts down all the campaign resolvers and removes the campaigns UI for regular users when this switch is enabled. However, it's a starting point, and it at least gets us in the direction we need to go before branch cut.

The test changes are going to conflict pretty nastily with #15775, so that'll be fun to fix.

Closes #15780.