### PR TITLE
search: add mutation updateCodeMonitors

### DIFF
--- a/enterprise/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/internal/codemonitors/resolvers/apitest/types.go
@@ -5,6 +5,10 @@ type Response struct {
 	User User
 }
 
+type UpdateCodeMonitorResponse struct {
+	UpdateCodeMonitor Monitor
+}
+
 type User struct {
 	Monitors MonitorConnection
 }


### PR DESCRIPTION
Stacked on top of #15741

This PR adds the mutation `updateCodeMonitors`. Following the design of `createCodeMonitors` we update the monitor, the trigger, and actions all at once. 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
