### PR TITLE
Code monitoring: fix validation of filters on create page

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -21,6 +21,7 @@ import { SearchPatternType } from '../../../../shared/src/graphql-operations'
 import { deriveInputClassName, useInputValidation } from '../../../../shared/src/util/useInputValidation'
 import { scanSearchQuery } from '../../../../shared/src/search/parser/scanner'
 import { FilterType } from '../../../../shared/src/search/interactive/util'
+import { resolveFilter } from '../../../../shared/src/search/parser/filters'
 
 export interface CreateCodeMonitorPageProps extends BreadcrumbsProps, BreadcrumbSetters {
     location: H.Location
@@ -276,7 +277,7 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                             const typeFilters = filters.filter(
                                 filter =>
                                     filter.type === 'filter' &&
-                                    filter.filterType.value === FilterType.type &&
+                                    resolveFilter(filter.filterType.value)?.type === FilterType.type &&
                                     ((filter.filterValue?.type === 'literal' &&
                                         filter.filterValue &&
                                         isDiffOrCommit(filter.filterValue.value)) ||
@@ -287,7 +288,7 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                             const patternTypeFilters = filters.filter(
                                 filter =>
                                     (filter.type === 'filter' &&
-                                        filter.filterType.value === FilterType.patterntype &&
+                                        resolveFilter(filter.filterType.value)?.type === FilterType.patterntype &&
                                         filter.filterValue?.type === 'literal' &&
                                         filter.filterValue &&
                                         isValidPatternType(filter.filterValue.value)) ||

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -240,6 +240,8 @@ interface TriggerAreaProps {
     setTriggerCompleted: () => void
 }
 
+const isDiffOrCommit = (value: string): boolean => value === 'diff' || value === 'commit'
+
 const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
     query,
     onQueryChange,
@@ -264,7 +266,6 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
     const [queryState, nextQueryFieldChange, queryInputReference] = useInputValidation(
         useMemo(
             () => ({
-                initialValue: query,
                 synchronousValidators: [
                     (value: string) => {
                         const tokens = scanSearchQuery(value)
@@ -274,8 +275,12 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                 filter =>
                                     filter.type === 'filter' &&
                                     resolveFilter(filter.filterType.value)?.type === FilterType.type &&
-                                    filter.filterValue &&
-                                    validateFilter(filter.filterType.value, filter.filterValue)
+                                    ((filter.filterValue?.type === 'literal' &&
+                                        filter.filterValue &&
+                                        isDiffOrCommit(filter.filterValue.value)) ||
+                                        (filter.filterValue?.type === 'quoted' &&
+                                            filter.filterValue &&
+                                            isDiffOrCommit(filter.filterValue.quotedValue)))
                             )
                             const hasPatternTypeFilter = filters.some(
                                 filter =>
@@ -298,7 +303,7 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     },
                 ],
             }),
-            [query]
+            []
         )
     )
 


### PR DESCRIPTION
Properly resolves filter values for queries in the trigger area of the code monitoring create page. Ensures that filters and filter values are detected case insensitively. Brought up by @tjkandala in https://github.com/sourcegraph/sourcegraph/pull/15659#discussion_r522600505.  

Also uses `.some()` as suggested by @felixfbecker in https://github.com/sourcegraph/sourcegraph/pull/15659#discussion_r523182504.