### PR TITLE
Bump src-cli MinimumVersion to 3.22.0

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.21.9"
+const MinimumVersion = "3.22.0"


### PR DESCRIPTION
Better to get this in before the release branch is cut :)

Release is here: https://github.com/sourcegraph/src-cli/releases/tag/3.22.0