### PR TITLE
Fix console warning about wrong language

### DIFF
--- a/client/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
+++ b/client/web/src/enterprise/campaigns/create/CreateCampaignPage.tsx
@@ -88,11 +88,7 @@ export const CreateCampaignPage: React.FunctionComponent<CreateCampaignPageProps
                     </a>{' '}
                     to preview the commits and changesets that your campaign will make:
                 </p>
-                <CodeSnippet
-                    code={`src campaign preview -f ${selectedSample.name}`}
-                    language="shell"
-                    className="mb-3"
-                />
+                <CodeSnippet code={`src campaign preview -f ${selectedSample.name}`} language="bash" className="mb-3" />
                 <p>
                     Follow the URL printed in your terminal to see the preview and (when you're ready) create the
                     campaign.


### PR DESCRIPTION
This didn't do harm put it prints an ugly warning message to the console.
