### PR TITLE
search: add mutation createCodeMonitorAction

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -14,6 +14,7 @@ type CodeMonitorsResolver interface {
 	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
 	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)
 	UpdateCodeMonitor(ctx context.Context, args *UpdateCodeMonitorArgs) (MonitorResolver, error)
+	CreateCodeMonitorAction(ctx context.Context, args *CreateActionForMonitorArgs) (MonitorAction, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -131,6 +132,11 @@ type CreateTriggerArgs struct {
 	Query string
 }
 
+type CreateActionForMonitorArgs struct {
+	Id     graphql.ID
+	Action *CreateActionArgs
+}
+
 type CreateActionArgs struct {
 	Email *CreateActionEmailArgs
 }
@@ -207,4 +213,8 @@ func (d defaultCodeMonitorsResolver) DeleteCodeMonitor(ctx context.Context, args
 
 func (d defaultCodeMonitorsResolver) UpdateCodeMonitor(ctx context.Context, args *UpdateCodeMonitorArgs) (MonitorResolver, error) {
 	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) CreateCodeMonitorAction(ctx context.Context, args *CreateActionForMonitorArgs) (MonitorAction, error) {
+	panic("implement me")
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -808,6 +808,19 @@ type Mutation {
         """
         actions: [MonitorEditActionInput!]!
     ): Monitor!
+    """
+    Add an action to an existing code monitor.
+    """
+    createCodeMonitorAction(
+        """
+        The id of the monitor.
+        """
+        id: ID!
+        """
+        The input needed to create an action.
+        """
+        action: MonitorActionInput!
+    ): MonitorAction!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -801,6 +801,19 @@ type Mutation {
         """
         actions: [MonitorEditActionInput!]!
     ): Monitor!
+    """
+    Add an action to an existing code monitor.
+    """
+    createCodeMonitorAction(
+        """
+        The id of the monitor.
+        """
+        id: ID!
+        """
+        The input needed to create an action.
+        """
+        action: MonitorActionInput!
+    ): MonitorAction!
 }
 
 """


### PR DESCRIPTION
Stacked on top of #15792 

This PR adds the mutation `createCodeMonitorAction`.

The mutation allows adding an additional action to an already existing monitor. The mutation returns the created action.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
