### PR TITLE
codeintel: Add feature flags for auto-indexing

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/background/commit_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commit_updater.go
@@ -70,14 +70,14 @@ func (u *CommitUpdater) tryUpdate(ctx context.Context, repositoryID, dirtyToken 
 		err = unlock(err)
 	}()
 
-	graph, err := u.gitserverClient.CommitGraph(ctx, repositoryID, gitserver.CommitGraphOptions{})
-	if err != nil {
-		return errors.Wrap(err, "gitserver.CommitGraph")
-	}
-
 	tipCommit, err := u.gitserverClient.Head(ctx, repositoryID)
 	if err != nil {
 		return errors.Wrap(err, "gitserver.Head")
+	}
+
+	graph, err := u.gitserverClient.CommitGraph(ctx, repositoryID, gitserver.CommitGraphOptions{})
+	if err != nil {
+		return errors.Wrap(err, "gitserver.CommitGraph")
 	}
 
 	if err := u.dbStore.CalculateVisibleUploads(ctx, repositoryID, graph, tipCommit, dirtyToken); err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -10,17 +10,19 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	UploadStoreConfig *uploadstore.Config
-
-	HunkCacheSize               int
-	BackgroundTaskInterval      time.Duration
-	IndexBatchSize              int
-	MinimumTimeSinceLastEnqueue time.Duration
-	MinimumSearchCount          int
-	MinimumSearchRatio          int
-	MinimumPreciseCount         int
-	UploadTimeout               time.Duration
-	DataTTL                     time.Duration
+	UploadStoreConfig             *uploadstore.Config
+	CommitGraphUpdateTaskInterval time.Duration
+	CleanupTaskInterval           time.Duration
+	AutoIndexingTaskInterval      time.Duration
+	HunkCacheSize                 int
+	DataTTL                       time.Duration
+	UploadTimeout                 time.Duration
+	EnableAutoIndexing            bool
+	IndexBatchSize                int
+	MinimumTimeSinceLastEnqueue   time.Duration
+	MinimumSearchCount            int
+	MinimumSearchRatio            int
+	MinimumPreciseCount           int
 }
 
 var config = &Config{}
@@ -31,12 +33,15 @@ func init() {
 	config.UploadStoreConfig = uploadStoreConfig
 
 	config.HunkCacheSize = config.GetInt("PRECISE_CODE_INTEL_HUNK_CACHE_SIZE", "1000", "The capacity of the git diff hunk cache.")
-	config.BackgroundTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_BACKGROUND_TASK_INTERVAL", "1m", "The frequency with which to run periodic codeintel background tasks.")
+	config.DataTTL = config.GetInterval("PRECISE_CODE_INTEL_DATA_TTL", "720h", "The maximum time an non-critical index can live in the database.")
+	config.UploadTimeout = config.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TIMEOUT", "24h", "The maximum time an upload can be in the 'uploading' state.")
+	config.CommitGraphUpdateTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_COMMIT_GRAPH_UPDATE_TASK_INTERVAL", "10s", "The frequency with which to run periodic codeintel commit graph update tasks.")
+	config.CleanupTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic codeintel cleanup tasks.")
+	config.AutoIndexingTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL", "10m", "The frequency with which to run periodic codeintel auto-indexing tasks.")
+	config.EnableAutoIndexing = config.GetBool("PRECISE_CODE_INTEL_ENABLE_AUTO_INDEXING", "false", "Whether to enable scheduling of auto-indexing tasks.")
 	config.IndexBatchSize = config.GetInt("PRECISE_CODE_INTEL_INDEX_BATCH_SIZE", "100", "The number of indexable repositories to schedule at a time.")
 	config.MinimumTimeSinceLastEnqueue = config.GetInterval("PRECISE_CODE_INTEL_MINIMUM_TIME_SINCE_LAST_ENQUEUE", "24h", "The minimum time between auto-index enqueues for the same repository.")
 	config.MinimumSearchCount = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_SEARCH_COUNT", "50", "The minimum number of search-based code intel events that triggers auto-indexing on a repository.")
 	config.MinimumSearchRatio = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_SEARCH_RATIO", "50", "The minimum ratio of search-based to total code intel events that triggers auto-indexing on a repository.")
 	config.MinimumPreciseCount = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_PRECISE_COUNT", "1", "The minimum number of precise code intel events that triggers auto-indexing on a repository.")
-	config.UploadTimeout = config.GetInterval("PRECISE_CODE_INTEL_UPLOAD_TIMEOUT", "24h", "The maximum time an upload can be in the 'uploading' state.")
-	config.DataTTL = config.GetInterval("PRECISE_CODE_INTEL_DATA_TTL", "720h", "The maximum time an non-critical index can live in the database.")
 }

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -108,15 +108,25 @@ func newBackgroundRoutines() ([]goroutine.BackgroundRoutine, error) {
 	metrics := background.NewMetrics(observationContext.Registerer)
 
 	routines := []goroutine.BackgroundRoutine{
-		background.NewAbandonedUploadJanitor(dbStoreShim, config.UploadTimeout, config.BackgroundTaskInterval, metrics),
-		background.NewDeletedRepositoryJanitor(dbStoreShim, config.BackgroundTaskInterval, metrics),
-		background.NewHardDeleter(dbStoreShim, lsifStoreShim, config.BackgroundTaskInterval, metrics),
-		background.NewIndexScheduler(dbStoreShim, gitserverClient, config.IndexBatchSize, config.MinimumTimeSinceLastEnqueue, config.MinimumSearchCount, float64(config.MinimumSearchRatio)/100, config.MinimumPreciseCount, config.BackgroundTaskInterval, metrics),
-		background.NewIndexabilityUpdater(dbStoreShim, gitserverClient, config.MinimumSearchCount, float64(config.MinimumSearchRatio)/100, config.MinimumPreciseCount, config.BackgroundTaskInterval, metrics),
-		background.NewRecordExpirer(dbStoreShim, config.DataTTL, config.BackgroundTaskInterval, metrics),
-		background.NewUploadResetter(dbStoreShim, config.BackgroundTaskInterval, metrics),
-		background.NewIndexResetter(dbStoreShim, config.BackgroundTaskInterval, metrics),
-		background.NewCommitUpdater(dbStoreShim, gitserverClient, config.BackgroundTaskInterval),
+		// Commit graph updater
+		background.NewCommitUpdater(dbStoreShim, gitserverClient, config.CommitGraphUpdateTaskInterval),
+
+		// Cleanup
+		background.NewAbandonedUploadJanitor(dbStoreShim, config.UploadTimeout, config.CleanupTaskInterval, metrics),
+		background.NewDeletedRepositoryJanitor(dbStoreShim, config.CleanupTaskInterval, metrics),
+		background.NewHardDeleter(dbStoreShim, lsifStoreShim, config.CleanupTaskInterval, metrics),
+		background.NewRecordExpirer(dbStoreShim, config.DataTTL, config.CleanupTaskInterval, metrics),
+		background.NewUploadResetter(dbStoreShim, config.CleanupTaskInterval, metrics),
+		background.NewIndexResetter(dbStoreShim, config.CleanupTaskInterval, metrics),
+	}
+
+	if config.EnableAutoIndexing {
+		// Auto indexing
+		routines = append(
+			routines,
+			background.NewIndexScheduler(dbStoreShim, gitserverClient, config.IndexBatchSize, config.MinimumTimeSinceLastEnqueue, config.MinimumSearchCount, float64(config.MinimumSearchRatio)/100, config.MinimumPreciseCount, config.AutoIndexingTaskInterval, metrics),
+			background.NewIndexabilityUpdater(dbStoreShim, gitserverClient, config.MinimumSearchCount, float64(config.MinimumSearchRatio)/100, config.MinimumPreciseCount, config.AutoIndexingTaskInterval, metrics),
+		)
 	}
 
 	return routines, nil

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -36,6 +36,7 @@ fi
 SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat "$DEV_PRIVATE_PATH"/enterprise/dev/test-license-generation-key.pem)
 export SOURCEGRAPH_LICENSE_GENERATION_KEY
 
+export PRECISE_CODE_INTEL_ENABLE_AUTO_INDEXING=true
 export PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT=http://localhost:9000
 export DISABLE_CNCF=notonmybox
 


### PR DESCRIPTION
We moved background routines for scheduling indexing tasks from a dedicated indexer service (only deployed on cloud) into the frontend. To stop from adding useless records into the database on a loop, feature flag these background routines (default: off).

Drive-by: Also made separate intervals for different types of tasks (indexing, cleanup, commit graph updates).