### PR TITLE
Add tabs to campaign list pages to reach getting started

### DIFF
--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.story.tsx
@@ -4,6 +4,7 @@ import { CampaignListPage } from './CampaignListPage'
 import { nodes } from './CampaignNode.story'
 import { of } from 'rxjs'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { useCallback } from '@storybook/addons'
 
 const { add } = storiesOf('web/campaigns/CampaignListPage', module)
     .addDecorator(story => <div className="p-3 container web-content">{story()}</div>)
@@ -27,25 +28,48 @@ add('List of campaigns', () => (
     <EnterpriseWebStory>{props => <CampaignListPage {...props} queryCampaigns={queryCampaigns} />}</EnterpriseWebStory>
 ))
 
-add('No campaigns', () => (
-    <EnterpriseWebStory>
-        {props => (
-            <CampaignListPage
-                {...props}
-                queryCampaigns={() =>
-                    of({
-                        campaigns: {
-                            totalCount: 0,
-                            nodes: [],
-                            pageInfo: {
-                                endCursor: null,
-                                hasNextPage: false,
-                            },
-                        },
-                        totalCount: 0,
-                    })
-                }
-            />
-        )}
-    </EnterpriseWebStory>
-))
+add('No campaigns', () => {
+    const queryCampaigns = useCallback(
+        () =>
+            of({
+                campaigns: {
+                    totalCount: 0,
+                    nodes: [],
+                    pageInfo: {
+                        endCursor: null,
+                        hasNextPage: false,
+                    },
+                },
+                totalCount: 0,
+            }),
+        []
+    )
+    return (
+        <EnterpriseWebStory>
+            {props => <CampaignListPage {...props} queryCampaigns={queryCampaigns} />}
+        </EnterpriseWebStory>
+    )
+})
+
+add('All campaigns tab empty', () => {
+    const queryCampaigns = useCallback(
+        () =>
+            of({
+                campaigns: {
+                    totalCount: 0,
+                    nodes: [],
+                    pageInfo: {
+                        endCursor: null,
+                        hasNextPage: false,
+                    },
+                },
+                totalCount: 0,
+            }),
+        []
+    )
+    return (
+        <EnterpriseWebStory>
+            {props => <CampaignListPage {...props} queryCampaigns={queryCampaigns} openTab="campaigns" />}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from 'react'
+import React, { useEffect, useCallback, useState, useMemo } from 'react'
 import { queryCampaigns as _queryCampaigns, queryCampaignsByNamespace } from './backend'
 import { RouteComponentProps } from 'react-router'
 import { FilteredConnection, FilteredConnectionFilter } from '../../../components/FilteredConnection'
@@ -18,12 +18,16 @@ import { PageHeader } from '../../../components/PageHeader'
 import { CampaignsIconFlushLeft } from '../icons'
 import { CampaignsListEmpty } from './CampaignsListEmpty'
 import { CampaignListIntro } from './CampaignListIntro'
-import { filter, map, tap } from 'rxjs/operators'
-import { Observable } from 'rxjs'
+import { filter, map, tap, withLatestFrom } from 'rxjs/operators'
+import { Observable, ReplaySubject } from 'rxjs'
+import classNames from 'classnames'
 
 export interface CampaignListPageProps extends TelemetryProps, Pick<RouteComponentProps, 'history' | 'location'> {
     displayNamespace?: boolean
+    /** For testing only. */
     queryCampaigns?: typeof _queryCampaigns
+    /** For testing only. */
+    openTab?: SelectedTab
 }
 
 const FILTERS: FilteredConnectionFilter[] = [
@@ -47,6 +51,8 @@ const FILTERS: FilteredConnectionFilter[] = [
     },
 ]
 
+type SelectedTab = 'campaigns' | 'gettingStarted'
+
 /**
  * A list of all campaigns on the Sourcegraph instance.
  */
@@ -54,39 +60,54 @@ export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = 
     queryCampaigns = _queryCampaigns,
     displayNamespace = true,
     location,
+    openTab,
     ...props
 }) => {
     useEffect(() => props.telemetryService.logViewEvent('CampaignsListPage'), [props.telemetryService])
-    const [totalCampaignsCount, setTotalCampaignsCount] = useState<number>()
+
+    /*
+     * Tracks whether this is the first fetch since this page has been rendered the first time.
+     * Used to only switch to the "Getting started" tab if the user didn't select the tab manually.
+     */
+    const isFirstFetch = useMemo(() => {
+        const subject = new ReplaySubject(1)
+        subject.next(true)
+        return subject
+    }, [])
+    const [selectedTab, setSelectedTab] = useState<SelectedTab>(openTab ?? 'campaigns')
     const query = useCallback<(args: Partial<CampaignsVariables>) => Observable<CampaignsResult['campaigns']>>(
         args =>
             queryCampaigns(args).pipe(
-                tap(response => {
-                    setTotalCampaignsCount(response.totalCount)
+                withLatestFrom(isFirstFetch),
+                tap(([response, isFirst]) => {
+                    if (isFirst) {
+                        isFirstFetch.next(false)
+                        if (!openTab && response.totalCount === 0) {
+                            setSelectedTab('gettingStarted')
+                        }
+                    }
                 }),
-                filter(response => response.totalCount > 0),
-                map(response => response.campaigns)
+                filter(([response, isFirst]) => openTab === undefined || !isFirst || response.totalCount > 0),
+                map(([response]) => response.campaigns)
             ),
-        [queryCampaigns]
+        [queryCampaigns, isFirstFetch, openTab]
     )
+
     return (
         <>
             <PageHeader
                 icon={CampaignsIconFlushLeft}
                 title="Campaigns"
                 className="justify-content-end test-campaign-list-page"
-                actions={
-                    <Link to={`${location.pathname}/create`} className="btn btn-primary">
-                        <PlusIcon className="icon-inline" /> New campaign
-                    </Link>
-                }
+                actions={<NewCampaignButton location={location} />}
             />
             <p className="text-muted">
                 Run custom code over hundreds of repositories and manage the resulting changesets
             </p>
             <CampaignListIntro />
-            {totalCampaignsCount === 0 && <CampaignsListEmpty />}
-            {totalCampaignsCount !== 0 && (
+            <CampaignListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
+            {selectedTab === 'gettingStarted' && <CampaignsListEmpty />}
+            {selectedTab === 'campaigns' && (
                 <FilteredConnection<ListCampaign, Omit<CampaignNodeProps, 'node'>>
                     {...props}
                     location={location}
@@ -103,6 +124,7 @@ export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = 
                     className="mb-3"
                     cursorPaging={true}
                     noSummaryIfAllNodesVisible={true}
+                    emptyElement={<CampaignListEmptyElement location={location} />}
                 />
             )}
         </>
@@ -133,4 +155,67 @@ export const NamespaceCampaignListPage: React.FunctionComponent<NamespaceCampaig
         [namespaceID]
     )
     return <CampaignListPage {...props} displayNamespace={false} queryCampaigns={queryConnection} />
+}
+
+interface CampaignListEmptyElementProps extends Pick<RouteComponentProps, 'location'> {}
+
+const CampaignListEmptyElement: React.FunctionComponent<CampaignListEmptyElementProps> = ({ location }) => (
+    <div className="w-100 py-5 text-center">
+        <p>
+            <strong>No campaigns have been created</strong>
+        </p>
+        <NewCampaignButton location={location} />
+    </div>
+)
+
+interface NewCampaignButtonProps extends Pick<RouteComponentProps, 'location'> {}
+
+const NewCampaignButton: React.FunctionComponent<NewCampaignButtonProps> = ({ location }) => (
+    <Link to={`${location.pathname}/create`} className="btn btn-primary">
+        <PlusIcon className="icon-inline" /> New campaign
+    </Link>
+)
+
+const CampaignListTabHeader: React.FunctionComponent<{
+    selectedTab: SelectedTab
+    setSelectedTab: (selectedTab: SelectedTab) => void
+}> = ({ selectedTab, setSelectedTab }) => {
+    const onSelectCampaigns = useCallback<React.MouseEventHandler>(
+        event => {
+            event.preventDefault()
+            setSelectedTab('campaigns')
+        },
+        [setSelectedTab]
+    )
+    const onSelectGettingStarted = useCallback<React.MouseEventHandler>(
+        event => {
+            event.preventDefault()
+            setSelectedTab('gettingStarted')
+        },
+        [setSelectedTab]
+    )
+    return (
+        <div className="overflow-auto mb-2">
+            <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">
+                <li className="nav-item">
+                    <a
+                        href=""
+                        onClick={onSelectCampaigns}
+                        className={classNames('nav-link', selectedTab === 'campaigns' && 'active')}
+                    >
+                        All campaigns
+                    </a>
+                </li>
+                <li className="nav-item">
+                    <a
+                        href=""
+                        onClick={onSelectGettingStarted}
+                        className={classNames('nav-link', selectedTab === 'gettingStarted' && 'active')}
+                    >
+                        Getting started
+                    </a>
+                </li>
+            </ul>
+        </div>
+    )
 }

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
@@ -87,7 +87,12 @@ export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = 
                         }
                     }
                 }),
-                filter(([response, isFirst]) => openTab === undefined || !isFirst || response.totalCount > 0),
+                // Don't emit when we are switching to the getting started tab right away to prevent a costly render.
+                // Only if:
+                //  - We don't fetch for the first time (the user clicked a tab) OR
+                //  - There are more than 0 changesets in the namespace OR
+                //  - A test forces us to display a specific tab
+                filter(([response, isFirst]) => !isFirst || openTab !== undefined || response.totalCount > 0),
                 map(([response]) => response.campaigns)
             ),
         [queryCampaigns, isFirstFetch, openTab]

--- a/client/web/src/enterprise/campaigns/list/CampaignsListEmpty.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignsListEmpty.tsx
@@ -6,7 +6,7 @@ export interface CampaignsListEmptyProps {
 
 export const CampaignsListEmpty: React.FunctionComponent<CampaignsListEmptyProps> = () => (
     <div className="web-content">
-        <h2 className="my-5">Get started with campaigns</h2>
+        <h2 className="mb-5">Get started with campaigns</h2>
         <h3 className="mb-3">Tutorials to help with your first campaign</h3>
         <div className="row">
             <div className="col-12 col-md-6 mb-2">

--- a/client/web/src/enterprise/campaigns/list/__snapshots__/CampaignListPage.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/list/__snapshots__/CampaignListPage.test.tsx.snap
@@ -4,15 +4,9 @@ exports[`CampaignListPage renders for non-siteadmin and totalCount: 0 1`] = `
 <Fragment>
   <PageHeader
     actions={
-      <AnchorLink
-        className="btn btn-primary"
-        to="//create"
-      >
-        <Memo(PlusIcon)
-          className="icon-inline"
-        />
-         New campaign
-      </AnchorLink>
+      <NewCampaignButton
+        location="[Location path=/]"
+      />
     }
     className="justify-content-end test-campaign-list-page"
     icon={[Function]}
@@ -24,10 +18,19 @@ exports[`CampaignListPage renders for non-siteadmin and totalCount: 0 1`] = `
     Run custom code over hundreds of repositories and manage the resulting changesets
   </p>
   <CampaignListIntro />
+  <CampaignListTabHeader
+    selectedTab="campaigns"
+    setSelectedTab={[Function]}
+  />
   <FilteredConnection
     className="mb-3"
     cursorPaging={true}
     defaultFirst={15}
+    emptyElement={
+      <CampaignListEmptyElement
+        location="[Location path=/]"
+      />
+    }
     filters={
       Array [
         Object {
@@ -85,15 +88,9 @@ exports[`CampaignListPage renders for non-siteadmin and totalCount: 1 1`] = `
 <Fragment>
   <PageHeader
     actions={
-      <AnchorLink
-        className="btn btn-primary"
-        to="//create"
-      >
-        <Memo(PlusIcon)
-          className="icon-inline"
-        />
-         New campaign
-      </AnchorLink>
+      <NewCampaignButton
+        location="[Location path=/]"
+      />
     }
     className="justify-content-end test-campaign-list-page"
     icon={[Function]}
@@ -105,10 +102,19 @@ exports[`CampaignListPage renders for non-siteadmin and totalCount: 1 1`] = `
     Run custom code over hundreds of repositories and manage the resulting changesets
   </p>
   <CampaignListIntro />
+  <CampaignListTabHeader
+    selectedTab="campaigns"
+    setSelectedTab={[Function]}
+  />
   <FilteredConnection
     className="mb-3"
     cursorPaging={true}
     defaultFirst={15}
+    emptyElement={
+      <CampaignListEmptyElement
+        location="[Location path=/]"
+      />
+    }
     filters={
       Array [
         Object {
@@ -166,15 +172,9 @@ exports[`CampaignListPage renders for siteadmin and totalCount: 0 1`] = `
 <Fragment>
   <PageHeader
     actions={
-      <AnchorLink
-        className="btn btn-primary"
-        to="//create"
-      >
-        <Memo(PlusIcon)
-          className="icon-inline"
-        />
-         New campaign
-      </AnchorLink>
+      <NewCampaignButton
+        location="[Location path=/]"
+      />
     }
     className="justify-content-end test-campaign-list-page"
     icon={[Function]}
@@ -186,10 +186,19 @@ exports[`CampaignListPage renders for siteadmin and totalCount: 0 1`] = `
     Run custom code over hundreds of repositories and manage the resulting changesets
   </p>
   <CampaignListIntro />
+  <CampaignListTabHeader
+    selectedTab="campaigns"
+    setSelectedTab={[Function]}
+  />
   <FilteredConnection
     className="mb-3"
     cursorPaging={true}
     defaultFirst={15}
+    emptyElement={
+      <CampaignListEmptyElement
+        location="[Location path=/]"
+      />
+    }
     filters={
       Array [
         Object {
@@ -247,15 +256,9 @@ exports[`CampaignListPage renders for siteadmin and totalCount: 1 1`] = `
 <Fragment>
   <PageHeader
     actions={
-      <AnchorLink
-        className="btn btn-primary"
-        to="//create"
-      >
-        <Memo(PlusIcon)
-          className="icon-inline"
-        />
-         New campaign
-      </AnchorLink>
+      <NewCampaignButton
+        location="[Location path=/]"
+      />
     }
     className="justify-content-end test-campaign-list-page"
     icon={[Function]}
@@ -267,10 +270,19 @@ exports[`CampaignListPage renders for siteadmin and totalCount: 1 1`] = `
     Run custom code over hundreds of repositories and manage the resulting changesets
   </p>
   <CampaignListIntro />
+  <CampaignListTabHeader
+    selectedTab="campaigns"
+    setSelectedTab={[Function]}
+  />
   <FilteredConnection
     className="mb-3"
     cursorPaging={true}
     defaultFirst={15}
+    emptyElement={
+      <CampaignListEmptyElement
+        location="[Location path=/]"
+      />
+    }
     filters={
       Array [
         Object {


### PR DESCRIPTION
Implements the design request by @rrhyne in https://www.figma.com/file/LDJVqbqJK7iasFXsswsW6N/Campaigns-empty-state-15341?node-id=30%3A1145.

