### PR TITLE
codeintel: Retry pulling upload from MinIO

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -181,7 +181,7 @@ func withUploadData(ctx context.Context, uploadStore uploadstore.Store, id int, 
 	uploadFilename := fmt.Sprintf("upload-%d.lsif.gz", id)
 
 	// Pull raw uploaded data from bucket
-	rc, err := uploadStore.Get(ctx, uploadFilename, 0)
+	rc, err := uploadStore.Get(ctx, uploadFilename)
 	if err != nil {
 		return errors.Wrap(err, "uploadStore.Get")
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler_test.go
@@ -223,7 +223,7 @@ func TestHandleCloneInProgress(t *testing.T) {
 //
 //
 
-func copyTestDump(ctx context.Context, key string, offsetBytes int64) (io.ReadCloser, error) {
+func copyTestDump(ctx context.Context, key string) (io.ReadCloser, error) {
 	return os.Open("../../testdata/dump1.lsif.gz")
 }
 

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client.go
@@ -87,14 +87,13 @@ func (s *gcsStore) Init(ctx context.Context) error {
 	return nil
 }
 
-func (s *gcsStore) Get(ctx context.Context, key string, skipBytes int64) (_ io.ReadCloser, err error) {
+func (s *gcsStore) Get(ctx context.Context, key string) (_ io.ReadCloser, err error) {
 	ctx, endObservation := s.operations.get.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("key", key),
-		log.Int64("skipBytes", skipBytes),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	rc, err := s.client.Bucket(s.bucket).Object(key).NewRangeReader(ctx, skipBytes, -1)
+	rc, err := s.client.Bucket(s.bucket).Object(key).NewRangeReader(ctx, 0, -1)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get object")
 	}

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
@@ -94,7 +94,7 @@ func TestGCSGet(t *testing.T) {
 	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
 	client := testGCSClient(gcsClient, false)
-	rc, err := client.Get(context.Background(), "test-key", 0)
+	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
@@ -119,45 +119,6 @@ func TestGCSGet(t *testing.T) {
 		t.Fatalf("unexpected number of NewRangeReader calls. want=%d have=%d", 1, len(calls))
 	} else if value := calls[0].Arg1; value != 0 {
 		t.Errorf("unexpected offset argument. want=%d have=%d", 0, value)
-	} else if value := calls[0].Arg2; value != -1 {
-		t.Errorf("unexpected length argument. want=%d have=%d", -1, value)
-	}
-}
-
-func TestGCSGetSkipBytes(t *testing.T) {
-	gcsClient := NewMockGcsAPI()
-	bucketHandle := NewMockGcsBucketHandle()
-	objectHandle := NewMockGcsObjectHandle()
-	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
-	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
-	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
-
-	client := testGCSClient(gcsClient, false)
-	rc, err := client.Get(context.Background(), "test-key", 20)
-	if err != nil {
-		t.Fatalf("unexpected error getting key: %s", err.Error())
-	}
-
-	defer rc.Close()
-	contents, err := ioutil.ReadAll(rc)
-	if err != nil {
-		t.Fatalf("unexpected error reading object: %s", err.Error())
-	}
-
-	if string(contents) != "TEST PAYLOAD" {
-		t.Fatalf("unexpected contents. want=%s have=%s", "TEST PAYLOAD", contents)
-	}
-
-	if calls := gcsClient.BucketFunc.History(); len(calls) != 1 {
-		t.Fatalf("unexpected number of Bucket calls. want=%d have=%d", 1, len(calls))
-	} else if value := calls[0].Arg0; value != "test-bucket" {
-		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
-	}
-
-	if calls := objectHandle.NewRangeReaderFunc.History(); len(calls) != 1 {
-		t.Fatalf("unexpected number of NewRangeReader calls. want=%d have=%d", 1, len(calls))
-	} else if value := calls[0].Arg1; value != 20 {
-		t.Errorf("unexpected offset argument. want=%d have=%d", 20, value)
 	} else if value := calls[0].Arg2; value != -1 {
 		t.Errorf("unexpected length argument. want=%d have=%d", -1, value)
 	}

--- a/enterprise/internal/codeintel/stores/uploadstore/lazy_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/lazy_client.go
@@ -22,12 +22,12 @@ func (s *lazyStore) Init(ctx context.Context) error {
 	return s.initOnce(ctx)
 }
 
-func (s *lazyStore) Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error) {
+func (s *lazyStore) Get(ctx context.Context, key string) (io.ReadCloser, error) {
 	if err := s.initOnce(ctx); err != nil {
 		return nil, err
 	}
 
-	return s.store.Get(ctx, key, skipBytes)
+	return s.store.Get(ctx, key)
 }
 
 func (s *lazyStore) Upload(ctx context.Context, key string, r io.Reader) (int64, error) {

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
@@ -115,7 +115,7 @@ func (s *s3Store) Get(ctx context.Context, key string) (_ io.ReadCloser, err err
 			}
 
 			byteOffset += n
-			log15.Warn("Transient error while reading payload", "error", err)
+			log15.Warn("Transient error while reading payload", "key", key, "error", err)
 
 			if n == 0 {
 				zeroReads++

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 	"sync"
 	"time"
@@ -89,16 +90,58 @@ func (s *s3Store) Init(ctx context.Context) error {
 	return nil
 }
 
-func (s *s3Store) Get(ctx context.Context, key string, skipBytes int64) (_ io.ReadCloser, err error) {
+// maxZeroReads is the maximum number of no-progress iterations (due to connection reset errors)
+// in Get that can occur in a row before returning an error.
+const maxZeroReads = 3
+
+// errNoDownloadProgress is returned from Get after multiple connection reset errors occur
+// in a row.
+var errNoDownloadProgress = errors.New("no download progress")
+
+func (s *s3Store) Get(ctx context.Context, key string) (_ io.ReadCloser, err error) {
 	ctx, endObservation := s.operations.get.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("key", key),
-		log.Int64("skipBytes", skipBytes),
 	}})
 	defer endObservation(1, observation.Args{})
 
+	reader := writeToPipe(func(w io.Writer) error {
+		zeroReads := 0
+		byteOffset := int64(0)
+
+		for {
+			n, err := s.readObjectInto(ctx, w, key, byteOffset)
+			if err == nil || !isConnectionResetError(err) {
+				return err
+			}
+
+			byteOffset += n
+			log15.Warn("Transient error while reading payload", "error", err)
+
+			if n == 0 {
+				zeroReads++
+
+				if zeroReads > maxZeroReads {
+					return errNoDownloadProgress
+				}
+			} else {
+				zeroReads = 0
+			}
+		}
+	})
+
+	return ioutil.NopCloser(reader), nil
+}
+
+// ioCopyHook is a pointer to io.Copy. This function is replaced in unit tests so that we can
+// easily inject errors when reading from the backing S3 store.
+var ioCopyHook = io.Copy
+
+// readObjectInto reads the content of the given key starting at the given byte offset into the
+// given writer. The number of bytes read is returned. On successful read, the error value is nil.
+func (s *s3Store) readObjectInto(ctx context.Context, w io.Writer, key string, byteOffset int64) (int64, error) {
 	var bytesRange *string
-	if skipBytes > 0 {
-		bytesRange = aws.String(fmt.Sprintf("bytes=%d-", skipBytes))
+	if byteOffset > 0 {
+		bytesRange = aws.String(fmt.Sprintf("bytes=%d-", byteOffset))
 	}
 
 	resp, err := s.client.GetObject(ctx, &s3.GetObjectInput{
@@ -107,10 +150,11 @@ func (s *s3Store) Get(ctx context.Context, key string, skipBytes int64) (_ io.Re
 		Range:  bytesRange,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get object")
+		return 0, errors.Wrap(err, "failed to get object")
 	}
+	defer resp.Body.Close()
 
-	return resp.Body, nil
+	return ioCopyHook(w, resp.Body)
 }
 
 func (s *s3Store) Upload(ctx context.Context, key string, r io.Reader) (_ int64, err error) {
@@ -298,6 +342,8 @@ func (s *s3Store) deleteSources(ctx context.Context, bucket string, sources []st
 	})
 }
 
+// countingReader is an io.Reader that counts the number of bytes sent
+// back to the caller.
 type countingReader struct {
 	r io.Reader
 	n int
@@ -327,4 +373,20 @@ func s3SessionOptions(backend string, config S3Config) session.Options {
 	}
 
 	return session.Options{Config: awsConfig}
+}
+
+// writeToPipe invokes the given function with a pipe writer in a goroutine
+// and returns the associated pipe reader.
+func writeToPipe(fn func(w io.Writer) error) io.Reader {
+	pr, pw := io.Pipe()
+	go func() { _ = pw.CloseWithError(fn(pw)) }()
+	return pr
+}
+
+func isConnectionResetError(err error) bool {
+	if err != nil && strings.Contains(err.Error(), "read: connection reset by peer") {
+		return true
+	}
+
+	return false
 }

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"regexp"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -83,12 +87,12 @@ func TestS3Get(t *testing.T) {
 	}, nil)
 
 	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, false, makeOperations(&observation.TestContext))
-	rc, err := client.Get(context.Background(), "test-key", 0)
+	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
-
 	defer rc.Close()
+
 	contents, err := ioutil.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("unexpected error reading object: %s", err.Error())
@@ -109,37 +113,100 @@ func TestS3Get(t *testing.T) {
 	}
 }
 
-func TestS3GetSkipBytes(t *testing.T) {
-	s3Client := NewMockS3API()
-	s3Client.GetObjectFunc.SetDefaultReturn(&s3.GetObjectOutput{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
-	}, nil)
+var bytesPattern = regexp.MustCompile(`bytes=(\d+)-`)
 
+func TestS3GetTransientErrors(t *testing.T) {
+	// read 50 bytes then return a connection reset error
+	ioCopyHook = func(w io.Writer, r io.Reader) (int64, error) {
+		var buf bytes.Buffer
+		_, readErr := io.CopyN(&buf, r, 50)
+		if readErr != nil && readErr != io.EOF {
+			return 0, readErr
+		}
+
+		n, writeErr := io.Copy(w, bytes.NewReader(buf.Bytes()))
+		if writeErr != nil {
+			return 0, writeErr
+		}
+
+		if readErr == io.EOF {
+			readErr = nil
+		} else {
+			readErr = errors.New("read: connection reset by peer")
+		}
+		return n, readErr
+	}
+
+	s3Client := fullContentsS3API()
 	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, false, makeOperations(&observation.TestContext))
-	rc, err := client.Get(context.Background(), "test-key", 20)
+	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err.Error())
 	}
-
 	defer rc.Close()
+
 	contents, err := ioutil.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("unexpected error reading object: %s", err.Error())
 	}
 
-	if string(contents) != "TEST PAYLOAD" {
-		t.Fatalf("unexpected contents. want=%s have=%s", "TEST PAYLOAD", contents)
+	if diff := cmp.Diff(fullContents, contents); diff != "" {
+		t.Errorf("unexpected payload (-want +got):\n%s", diff)
 	}
 
-	if calls := s3Client.GetObjectFunc.History(); len(calls) != 1 {
-		t.Fatalf("unexpected number of GetObject calls. want=%d have=%d", 1, len(calls))
-	} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
-		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
-	} else if value := *calls[0].Arg1.Key; value != "test-key" {
-		t.Errorf("unexpected key argument. want=%s have=%s", "test-key", value)
-	} else if value := *calls[0].Arg1.Range; value != "bytes=20-" {
-		t.Errorf("unexpected range argument. want=%s have=%s", "", value)
+	expectedGetObjectCalls := len(fullContents)/50 + 1
+	if calls := s3Client.GetObjectFunc.History(); len(calls) != expectedGetObjectCalls {
+		t.Fatalf("unexpected number of GetObject calls. want=%d have=%d", expectedGetObjectCalls, len(calls))
 	}
+}
+
+func TestS3GetReadNothingLoop(t *testing.T) {
+	// read nothing then return a connection reset error
+	ioCopyHook = func(w io.Writer, r io.Reader) (int64, error) {
+		return 0, errors.New("read: connection reset by peer")
+	}
+
+	s3Client := fullContentsS3API()
+	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, false, makeOperations(&observation.TestContext))
+	rc, err := client.Get(context.Background(), "test-key")
+	if err != nil {
+		t.Fatalf("unexpected error getting key: %s", err.Error())
+	}
+	defer rc.Close()
+
+	if _, err := ioutil.ReadAll(rc); err != errNoDownloadProgress {
+		t.Fatalf("unexpected error reading object. want=%q have=%q", errNoDownloadProgress, err.Error())
+	}
+}
+
+var fullContents = func() []byte {
+	var fullContents []byte
+	for i := 0; i < 1000; i++ {
+		fullContents = append(fullContents, []byte(fmt.Sprintf("payload %d\n", i))...)
+	}
+
+	return fullContents
+}()
+
+func fullContentsS3API() *MockS3API {
+	s3Client := NewMockS3API()
+	s3Client.GetObjectFunc.SetDefaultHook(func(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+		offset := 0
+		if input.Range != nil {
+			match := bytesPattern.FindStringSubmatch(*input.Range)
+			if len(match) != 0 {
+				offset, _ = strconv.Atoi(match[1])
+			}
+		}
+
+		out := &s3.GetObjectOutput{
+			Body: ioutil.NopCloser(bytes.NewReader(fullContents[offset:])),
+		}
+
+		return out, nil
+	})
+
+	return s3Client
 }
 
 func TestS3Upload(t *testing.T) {

--- a/enterprise/internal/codeintel/stores/uploadstore/store.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/store.go
@@ -15,9 +15,7 @@ type Store interface {
 	Init(ctx context.Context) error
 
 	// Get returns a reader that streams the content of the object at the given key.
-	// If a positive skipBytes is supplied, the reader will begin reading at that byte
-	// offset.
-	Get(ctx context.Context, key string, skipBytes int64) (io.ReadCloser, error)
+	Get(ctx context.Context, key string) (io.ReadCloser, error)
 
 	// Upload writes the content in the given reader to the object at the given key.
 	Upload(ctx context.Context, key string, r io.Reader) (int64, error)

--- a/enterprise/internal/codeintel/stores/uploadstore/store_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/store_test.go
@@ -1,0 +1,17 @@
+package uploadstore
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/inconshreveable/log15"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Previously in the cloud environment we were seeing a lot of transient "connection reset" errors when transferring uploads within the same k8s cluster (worker <-> bundle manager).

We've since moved to reading from S3/GCS, but the default is to use an S3-compatible MinIO instance. This could likely result in the same types of transient network errors and will cause flaky LSIF upload processing errors.

I'm putting back the retry logic that worked around the issue between the previous services. The store interface was also able to be simplified, so I did that as a drive-by.