### PR TITLE
campaigns: link user credential changelog

### DIFF
--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -34,8 +34,11 @@ export const CampaignListIntro: React.FunctionComponent = () => (
                         <ul className="text-muted mb-0 pl-3">
                             <li>Users can now create campaigns</li>
                             <li>
-                                Changeset are published using the configured code host tokens of the user applying the
-                                campaign
+                                Changeset are published using the{' '}
+                                <a href="https://docs.sourcegraph.com/campaigns/how-tos/configuring_user_credentials">
+                                    configured code host tokens
+                                </a>{' '}
+                                of the user applying the campaign
                             </li>
                             <li>
                                 Template variables such as <code>search_result_paths</code> and{' '}

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -1,0 +1,5 @@
+# Configuring user credentials
+
+Sourcegraph 3.22 adds the ability for non-site-admin users to create and manage campaigns.
+
+More information on doing this is coming soon!

--- a/doc/campaigns/how-tos/index.md
+++ b/doc/campaigns/how-tos/index.md
@@ -9,3 +9,4 @@ The following is a list of how-tos that show how to use [Sourcegraph campaigns](
 - [Tracking existing changesets](tracking_existing_changesets.md)
 - [Closing or deleting a campaign](closing_or_deleting_a_campaign.md)
 - [Site admin configuration for campaigns](site_admin_configuration.md)
+- [Configuring user credentials for campaigns](configuring_user_credentials.md)


### PR DESCRIPTION
This adds a placeholder for a user credential how-to, which I'll be fleshing out this afternoon as part of #15312.