### PR TITLE
search: remove GraphQL dependencies from SearchResultsFilterBars

### DIFF
--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -27,7 +27,7 @@ import { ThemeProps } from '../../../../shared/src/theme'
 import { EventLogger } from '../../tracking/eventLogger'
 import { isSearchResults, submitSearch, toggleSearchFilter, getSearchTypeFromQuery, QueryState } from '../helpers'
 import { queryTelemetryData } from '../queryTelemetry'
-import { SearchResultsFilterBars, SearchFilterData } from './SearchResultsFilterBars'
+import { SearchResultsFilterBars, DynamicSearchFilter } from './SearchResultsFilterBars'
 import { SearchResultsList } from './SearchResultsList'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { VersionContextProps } from '../../../../shared/src/search/util'
@@ -302,11 +302,11 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                 {!this.props.interactiveSearchMode && (
                     <SearchResultsFilterBars
                         navbarSearchQuery={this.props.navbarSearchQueryState.query}
-                        resultsFound={isSearchResults(this.state.resultsOrError)}
+                        searchSucceeded={isSearchResults(this.state.resultsOrError)}
                         resultsLimitHit={
                             isSearchResults(this.state.resultsOrError) && this.state.resultsOrError.limitHit
                         }
-                        filters={filters}
+                        genericFilters={filters}
                         extensionFilters={extensionFilters}
                         repoFilters={repoFilters}
                         quickLinks={quickLinks}
@@ -347,8 +347,8 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
     }
 
     /** Combines dynamic filters and search scopes into a list de-duplicated by value. */
-    private getFilters(): SearchFilterData[] {
-        const filters = new Map<string, SearchFilterData>()
+    private getFilters(): DynamicSearchFilter[] {
+        const filters = new Map<string, DynamicSearchFilter>()
 
         if (isSearchResults(this.state.resultsOrError) && this.state.resultsOrError.dynamicFilters) {
             let dynamicFilters = this.state.resultsOrError.dynamicFilters
@@ -383,7 +383,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         return [...filters.values()]
     }
 
-    private getRepoFilters(): SearchFilterData[] | undefined {
+    private getRepoFilters(): DynamicSearchFilter[] | undefined {
         if (isSearchResults(this.state.resultsOrError) && this.state.resultsOrError.dynamicFilters) {
             return this.state.resultsOrError.dynamicFilters
                 .filter(filter => filter.kind === 'repo' && filter.value !== '')

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -27,7 +27,7 @@ import { ThemeProps } from '../../../../shared/src/theme'
 import { EventLogger } from '../../tracking/eventLogger'
 import { isSearchResults, submitSearch, toggleSearchFilter, getSearchTypeFromQuery, QueryState } from '../helpers'
 import { queryTelemetryData } from '../queryTelemetry'
-import { SearchResultsFilterBars, SearchScopeWithOptionalName } from './SearchResultsFilterBars'
+import { SearchResultsFilterBars, SearchFilterData } from './SearchResultsFilterBars'
 import { SearchResultsList } from './SearchResultsList'
 import { buildSearchURLQuery } from '../../../../shared/src/util/url'
 import { VersionContextProps } from '../../../../shared/src/search/util'
@@ -290,6 +290,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
     public render(): JSX.Element | null {
         const query = parseSearchURLQuery(this.props.location.search)
         const filters = this.getFilters()
+        const repoFilters = this.getRepoFilters()
         const extensionFilters = this.state.contributions?.searchFilters
 
         const quickLinks =
@@ -301,9 +302,13 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                 {!this.props.interactiveSearchMode && (
                     <SearchResultsFilterBars
                         navbarSearchQuery={this.props.navbarSearchQueryState.query}
-                        results={this.state.resultsOrError}
+                        resultsFound={isSearchResults(this.state.resultsOrError)}
+                        resultsLimitHit={
+                            isSearchResults(this.state.resultsOrError) && this.state.resultsOrError.limitHit
+                        }
                         filters={filters}
                         extensionFilters={extensionFilters}
+                        repoFilters={repoFilters}
                         quickLinks={quickLinks}
                         onFilterClick={this.onDynamicFilterClicked}
                         onShowMoreResultsClick={this.showMoreResults}
@@ -342,8 +347,8 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
     }
 
     /** Combines dynamic filters and search scopes into a list de-duplicated by value. */
-    private getFilters(): SearchScopeWithOptionalName[] {
-        const filters = new Map<string, SearchScopeWithOptionalName>()
+    private getFilters(): SearchFilterData[] {
+        const filters = new Map<string, SearchFilterData>()
 
         if (isSearchResults(this.state.resultsOrError) && this.state.resultsOrError.dynamicFilters) {
             let dynamicFilters = this.state.resultsOrError.dynamicFilters
@@ -377,6 +382,21 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
 
         return [...filters.values()]
     }
+
+    private getRepoFilters(): SearchFilterData[] | undefined {
+        if (isSearchResults(this.state.resultsOrError) && this.state.resultsOrError.dynamicFilters) {
+            return this.state.resultsOrError.dynamicFilters
+                .filter(filter => filter.kind === 'repo' && filter.value !== '')
+                .map(filter => ({
+                    name: filter.label,
+                    value: filter.value,
+                    count: filter.count,
+                    limitHit: filter.limitHit,
+                }))
+        }
+        return undefined
+    }
+
     private showMoreResults = (): void => {
         // Requery with an increased max result count.
         const parameters = new URLSearchParams(this.props.location.search)

--- a/client/web/src/search/results/SearchResultsFilterBars.story.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.story.tsx
@@ -110,6 +110,27 @@ add('filters with quicklinks', () => {
     )
 })
 
+add('some filters selected', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }, { value: 'repogroup:my', name: 'My Repos' }]
+    const repoFilters: DynamicSearchFilter[] = [
+        { value: 'archive:yes', count: 5, limitHit: true },
+        { value: 'repo:sourcegraph', count: 3, limitHit: false },
+    ]
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsFilterBars
+                    {...defaultProps}
+                    navbarSearchQuery="repo:sourcegraph lang:c"
+                    resultsLimitHit={true}
+                    genericFilters={genericFilters}
+                    repoFilters={repoFilters}
+                />
+            )}
+        </WebStory>
+    )
+})
+
 add('search error, display only quicklinks', () => {
     const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }]
     const repoFilters: DynamicSearchFilter[] = [{ value: 'archive:yes' }]

--- a/client/web/src/search/results/SearchResultsFilterBars.story.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.story.tsx
@@ -1,0 +1,131 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { SearchFilters } from '../../../../shared/src/api/protocol'
+import { WebStory } from '../../components/WebStory'
+import { QuickLink } from '../../schema/settings.schema'
+import { DynamicSearchFilter, SearchResultsFilterBars, SearchResultsFilterBarsProps } from './SearchResultsFilterBars'
+
+const defaultProps: SearchResultsFilterBarsProps = {
+    navbarSearchQuery: 'test',
+    searchSucceeded: true,
+    resultsLimitHit: false,
+    genericFilters: [],
+    extensionFilters: [],
+    repoFilters: [],
+    quickLinks: [],
+    onFilterClick: () => {},
+    onShowMoreResultsClick: () => {},
+    calculateShowMoreResultsCount: () => 0,
+}
+
+const { add } = storiesOf('web/search/results/SearchResultsFilterBars', module).addParameters({
+    chromatic: { viewports: [993] },
+})
+
+add('empty filters', () => <WebStory>{() => <SearchResultsFilterBars {...defaultProps} />}</WebStory>)
+
+add('some generic filters', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }, { value: 'repogroup:my', name: 'My Repos' }]
+    return <WebStory>{() => <SearchResultsFilterBars {...defaultProps} genericFilters={genericFilters} />}</WebStory>
+})
+
+add('some generic and extension filters', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }, { value: 'repogroup:my', name: 'My Repos' }]
+    const extensionFilters: SearchFilters[] = [{ name: 'Extension filter', value: 'repo:test' }]
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsFilterBars
+                    {...defaultProps}
+                    genericFilters={genericFilters}
+                    extensionFilters={extensionFilters}
+                />
+            )}
+        </WebStory>
+    )
+})
+
+add('some generic, extension, and repo filters', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }, { value: 'repogroup:my', name: 'My Repos' }]
+    const extensionFilters: SearchFilters[] = [{ name: 'Extension filter', value: 'repo:test' }]
+    const repoFilters: DynamicSearchFilter[] = [{ value: 'archive:yes' }, { value: 'repo:sourcegraph' }]
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsFilterBars
+                    {...defaultProps}
+                    genericFilters={genericFilters}
+                    extensionFilters={extensionFilters}
+                    repoFilters={repoFilters}
+                />
+            )}
+        </WebStory>
+    )
+})
+
+add('some repo filters', () => {
+    const repoFilters: DynamicSearchFilter[] = [
+        { value: 'archive:yes', count: 5, limitHit: true },
+        { value: 'repo:sourcegraph', count: 3, limitHit: false },
+    ]
+    return <WebStory>{() => <SearchResultsFilterBars {...defaultProps} repoFilters={repoFilters} />}</WebStory>
+})
+
+add('result limit hit, render Show More', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }, { value: 'repogroup:my', name: 'My Repos' }]
+    const repoFilters: DynamicSearchFilter[] = [
+        { value: 'archive:yes', count: 5, limitHit: true },
+        { value: 'repo:sourcegraph', count: 3, limitHit: false },
+    ]
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsFilterBars
+                    {...defaultProps}
+                    resultsLimitHit={true}
+                    genericFilters={genericFilters}
+                    repoFilters={repoFilters}
+                />
+            )}
+        </WebStory>
+    )
+})
+
+add('filters with quicklinks', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }]
+    const repoFilters: DynamicSearchFilter[] = [{ value: 'archive:yes' }]
+    const quicklinks: QuickLink[] = [{ name: 'Home', url: '/' }]
+
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsFilterBars
+                    {...defaultProps}
+                    genericFilters={genericFilters}
+                    repoFilters={repoFilters}
+                    quickLinks={quicklinks}
+                />
+            )}
+        </WebStory>
+    )
+})
+
+add('search error, display only quicklinks', () => {
+    const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }]
+    const repoFilters: DynamicSearchFilter[] = [{ value: 'archive:yes' }]
+    const quicklinks: QuickLink[] = [{ name: 'Home', url: '/' }]
+
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsFilterBars
+                    {...defaultProps}
+                    searchSucceeded={false}
+                    genericFilters={genericFilters}
+                    repoFilters={repoFilters}
+                    quickLinks={quicklinks}
+                />
+            )}
+        </WebStory>
+    )
+})

--- a/client/web/src/search/results/SearchResultsFilterBars.test.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.test.tsx
@@ -1,5 +1,93 @@
-describe('SearchResultsFilterBars', () => {
-    it('should call onFilterClick when filter is clicked', () => {})
+import { mount } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+import { SearchFilters } from '../../../../shared/src/api/protocol'
+import { FilterChip } from '../FilterChip'
+import { DynamicSearchFilter, SearchResultsFilterBars, SearchResultsFilterBarsProps } from './SearchResultsFilterBars'
 
-    it('should call onShowMoreResultsClick when Show More is clicked', () => {})
+describe('SearchResultsFilterBars', () => {
+    const defaultProps: SearchResultsFilterBarsProps = {
+        navbarSearchQuery: 'test',
+        searchSucceeded: true,
+        resultsLimitHit: false,
+        genericFilters: [],
+        extensionFilters: [],
+        repoFilters: [],
+        quickLinks: [],
+        onFilterClick: () => {},
+        onShowMoreResultsClick: () => {},
+        calculateShowMoreResultsCount: () => 0,
+    }
+
+    it('should call onFilterClick when filter is clicked on generic filter', () => {
+        const onFilterClickSpy = sinon.spy((value: string) => {})
+        const genericFilters: DynamicSearchFilter[] = [{ value: 'lang:c' }]
+        const element = mount(
+            <SearchResultsFilterBars
+                {...defaultProps}
+                genericFilters={genericFilters}
+                onFilterClick={onFilterClickSpy}
+            />
+        )
+
+        const filterChip = element.find(FilterChip)
+        filterChip.simulate('click')
+
+        sinon.assert.calledOnce(onFilterClickSpy)
+        sinon.assert.calledWith(onFilterClickSpy, 'lang:c')
+    })
+
+    it('should call onFilterClick when filter is clicked on extension filter', () => {
+        const onFilterClickSpy = sinon.spy((value: string) => {})
+        const extensionFilters: SearchFilters[] = [{ name: 'Extension filter', value: 'repo:test' }]
+        const element = mount(
+            <SearchResultsFilterBars
+                {...defaultProps}
+                extensionFilters={extensionFilters}
+                onFilterClick={onFilterClickSpy}
+            />
+        )
+
+        const filterChip = element.find(FilterChip)
+        filterChip.simulate('click')
+
+        sinon.assert.calledOnce(onFilterClickSpy)
+        sinon.assert.calledWith(onFilterClickSpy, 'repo:test')
+    })
+
+    it('should call onFilterClick when filter is clicked on repo filter', () => {
+        const onFilterClickSpy = sinon.spy((value: string) => {})
+        const repoFilters: DynamicSearchFilter[] = [{ value: 'archive:yes' }]
+        const element = mount(
+            <SearchResultsFilterBars {...defaultProps} repoFilters={repoFilters} onFilterClick={onFilterClickSpy} />
+        )
+
+        const filterChip = element.find(FilterChip)
+        filterChip.simulate('click')
+
+        sinon.assert.calledOnce(onFilterClickSpy)
+        sinon.assert.calledWith(onFilterClickSpy, 'archive:yes')
+    })
+
+    it('should call onShowMoreResultsClick when Show More is clicked', () => {
+        const calculateShowMoreResultsCount = () => 5
+        const onShowMoreResultsClick = sinon.spy((value: string) => {})
+
+        const repoFilters: DynamicSearchFilter[] = [{ value: 'archive:yes' }]
+        const element = mount(
+            <SearchResultsFilterBars
+                {...defaultProps}
+                resultsLimitHit={true}
+                repoFilters={repoFilters}
+                calculateShowMoreResultsCount={calculateShowMoreResultsCount}
+                onShowMoreResultsClick={onShowMoreResultsClick}
+            />
+        )
+
+        const filterChip = element.find(FilterChip).last()
+        filterChip.simulate('click')
+
+        sinon.assert.calledOnce(onShowMoreResultsClick)
+        sinon.assert.calledWith(onShowMoreResultsClick, 'count:5')
+    })
 })

--- a/client/web/src/search/results/SearchResultsFilterBars.test.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.test.tsx
@@ -1,0 +1,5 @@
+describe('SearchResultsFilterBars', () => {
+    it('should call onFilterClick when filter is clicked', () => {})
+
+    it('should call onShowMoreResultsClick when Show More is clicked', () => {})
+})

--- a/client/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.tsx
@@ -4,7 +4,7 @@ import { QuickLink } from '../../schema/settings.schema'
 import { FilterChip } from '../FilterChip'
 import { QuickLinks } from '../QuickLinks'
 
-export interface SearchFilterData {
+export interface DynamicSearchFilter {
     name?: string
 
     value: string
@@ -13,22 +13,24 @@ export interface SearchFilterData {
     limitHit?: boolean
 }
 
-export const SearchResultsFilterBars: React.FunctionComponent<{
+export interface SearchResultsFilterBarsProps {
     navbarSearchQuery: string
-    resultsFound: boolean
+    searchSucceeded: boolean
     resultsLimitHit: boolean
-    filters: SearchFilterData[]
+    genericFilters: DynamicSearchFilter[]
     extensionFilters: SearchFilters[] | undefined
-    repoFilters: SearchFilterData[] | undefined
+    repoFilters?: DynamicSearchFilter[] | undefined
     quickLinks?: QuickLink[] | undefined
     onFilterClick: (value: string) => void
     onShowMoreResultsClick: (value: string) => void
     calculateShowMoreResultsCount: () => number
-}> = ({
+}
+
+export const SearchResultsFilterBars: React.FunctionComponent<SearchResultsFilterBarsProps> = ({
     navbarSearchQuery,
-    resultsFound,
+    searchSucceeded: resultsFound,
     resultsLimitHit,
-    filters,
+    genericFilters: filters,
     extensionFilters,
     repoFilters,
     quickLinks,
@@ -37,7 +39,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
     calculateShowMoreResultsCount,
 }) => (
     <div className="search-results-filter-bars">
-        {((resultsFound && filters.length > 0) || extensionFilters) && (
+        {((resultsFound && filters.length > 0) || (extensionFilters && extensionFilters.length > 0)) && (
             <div className="search-results-filter-bars__row" data-testid="filters-bar">
                 Filters:
                 <div className="search-results-filter-bars__filters">
@@ -61,6 +63,8 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                                 key={String(filter.name) + filter.value}
                                 value={filter.value}
                                 name={filter.name}
+                                count={filter.count}
+                                limitHit={filter.limitHit}
                             />
                         ))}
                 </div>

--- a/client/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.tsx
@@ -1,37 +1,43 @@
 import React from 'react'
 import { SearchFilters } from '../../../../shared/src/api/protocol'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { QuickLink } from '../../schema/settings.schema'
 import { FilterChip } from '../FilterChip'
-import { isSearchResults } from '../helpers'
 import { QuickLinks } from '../QuickLinks'
 
-export interface SearchScopeWithOptionalName {
+export interface SearchFilterData {
     name?: string
+
     value: string
+
+    count?: number
+    limitHit?: boolean
 }
 
 export const SearchResultsFilterBars: React.FunctionComponent<{
     navbarSearchQuery: string
-    results?: GQL.ISearchResults
-    filters: SearchScopeWithOptionalName[]
+    resultsFound: boolean
+    resultsLimitHit: boolean
+    filters: SearchFilterData[]
     extensionFilters: SearchFilters[] | undefined
+    repoFilters: SearchFilterData[] | undefined
     quickLinks?: QuickLink[] | undefined
     onFilterClick: (value: string) => void
     onShowMoreResultsClick: (value: string) => void
     calculateShowMoreResultsCount: () => number
 }> = ({
     navbarSearchQuery,
-    results,
+    resultsFound,
+    resultsLimitHit,
     filters,
     extensionFilters,
+    repoFilters,
     quickLinks,
     onFilterClick,
     onShowMoreResultsClick,
     calculateShowMoreResultsCount,
 }) => (
     <div className="search-results-filter-bars">
-        {((isSearchResults(results) && filters.length > 0) || extensionFilters) && (
+        {((resultsFound && filters.length > 0) || extensionFilters) && (
             <div className="search-results-filter-bars__row" data-testid="filters-bar">
                 Filters:
                 <div className="search-results-filter-bars__filters">
@@ -60,24 +66,22 @@ export const SearchResultsFilterBars: React.FunctionComponent<{
                 </div>
             </div>
         )}
-        {isSearchResults(results) && results.dynamicFilters.filter(filter => filter.kind === 'repo').length > 0 && (
+        {resultsFound && repoFilters && repoFilters.length > 0 && (
             <div className="search-results-filter-bars__row" data-testid="repo-filters-bar">
                 Repositories:
                 <div className="search-results-filter-bars__filters">
-                    {results.dynamicFilters
-                        .filter(filter => filter.kind === 'repo' && filter.value !== '')
-                        .map(filter => (
-                            <FilterChip
-                                name={filter.label}
-                                query={navbarSearchQuery}
-                                onFilterChosen={onFilterClick}
-                                key={filter.value}
-                                value={filter.value}
-                                count={filter.count}
-                                limitHit={filter.limitHit}
-                            />
-                        ))}
-                    {results.limitHit && !/\brepo:/.test(navbarSearchQuery) && (
+                    {repoFilters.map(filter => (
+                        <FilterChip
+                            name={filter.name}
+                            query={navbarSearchQuery}
+                            onFilterChosen={onFilterClick}
+                            key={filter.value}
+                            value={filter.value}
+                            count={filter.count}
+                            limitHit={filter.limitHit}
+                        />
+                    ))}
+                    {resultsLimitHit && !/\brepo:/.test(navbarSearchQuery) && (
                         <FilterChip
                             name="Show more"
                             query={navbarSearchQuery}

--- a/client/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.tsx
@@ -28,9 +28,9 @@ export interface SearchResultsFilterBarsProps {
 
 export const SearchResultsFilterBars: React.FunctionComponent<SearchResultsFilterBarsProps> = ({
     navbarSearchQuery,
-    searchSucceeded: resultsFound,
+    searchSucceeded,
     resultsLimitHit,
-    genericFilters: filters,
+    genericFilters,
     extensionFilters,
     repoFilters,
     quickLinks,
@@ -39,7 +39,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<SearchResultsFilte
     calculateShowMoreResultsCount,
 }) => (
     <div className="search-results-filter-bars">
-        {((resultsFound && filters.length > 0) || (extensionFilters && extensionFilters.length > 0)) && (
+        {((searchSucceeded && genericFilters.length > 0) || (extensionFilters && extensionFilters.length > 0)) && (
             <div className="search-results-filter-bars__row" data-testid="filters-bar">
                 Filters:
                 <div className="search-results-filter-bars__filters">
@@ -54,7 +54,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<SearchResultsFilte
                                 name={filter.name}
                             />
                         ))}
-                    {filters
+                    {genericFilters
                         .filter(filter => filter.value !== '')
                         .map(filter => (
                             <FilterChip
@@ -70,7 +70,7 @@ export const SearchResultsFilterBars: React.FunctionComponent<SearchResultsFilte
                 </div>
             </div>
         )}
-        {resultsFound && repoFilters && repoFilters.length > 0 && (
+        {searchSucceeded && repoFilters && repoFilters.length > 0 && (
             <div className="search-results-filter-bars__row" data-testid="repo-filters-bar">
                 Repositories:
                 <div className="search-results-filter-bars__filters">


### PR DESCRIPTION
We need to remove any GraphQL dependencies so the component can work for both GraphQL searches and streaming searches.
