### PR TITLE
codeintel: Add additional metrics around resolver layer

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -393,6 +393,40 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 ```
 
 <br />
+## frontend: codeintel_resolvers_99th_percentile_duration
+
+<p class="subtitle">code-intel: 99th percentile successful resolvers operation duration over 5m</p>**Descriptions:**
+
+- _frontend: 20s+ 99th percentile successful resolvers operation duration over 5m_
+
+**Possible solutions:**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_codeintel_resolvers_99th_percentile_duration"
+]
+```
+
+<br />
+## frontend: codeintel_resolvers_errors
+
+<p class="subtitle">code-intel: resolvers errors every 5m</p>**Descriptions:**
+
+- _frontend: 20+ resolvers errors every 5m_
+
+**Possible solutions:**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_codeintel_resolvers_errors"
+]
+```
+
+<br />
 ## frontend: codeintel_api_99th_percentile_duration
 
 <p class="subtitle">code-intel: 99th percentile successful api operation duration over 5m</p>**Descriptions:**
@@ -613,57 +647,6 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 ```json
 "observability.silenceAlerts": [
   "warning_frontend_internal_api_error_responses"
-]
-```
-
-<br />
-## frontend: 99th_percentile_precise_code_intel_bundle_manager_query_duration
-
-<p class="subtitle">code-intel: 99th percentile successful precise-code-intel-bundle-manager query duration over 5m</p>**Descriptions:**
-
-- _frontend: 20s+ 99th percentile successful precise-code-intel-bundle-manager query duration over 5m_
-
-**Possible solutions:**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_frontend_99th_percentile_precise_code_intel_bundle_manager_query_duration"
-]
-```
-
-<br />
-## frontend: 99th_percentile_precise_code_intel_bundle_manager_transfer_duration
-
-<p class="subtitle">code-intel: 99th percentile successful precise-code-intel-bundle-manager data transfer duration over 5m</p>**Descriptions:**
-
-- _frontend: 300s+ 99th percentile successful precise-code-intel-bundle-manager data transfer duration over 5m_
-
-**Possible solutions:**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_frontend_99th_percentile_precise_code_intel_bundle_manager_transfer_duration"
-]
-```
-
-<br />
-## frontend: precise_code_intel_bundle_manager_error_responses
-
-<p class="subtitle">code-intel: precise-code-intel-bundle-manager error responses every 5m</p>**Descriptions:**
-
-- _frontend: 5%+ precise-code-intel-bundle-manager error responses every 5m for 15m0s_
-
-**Possible solutions:**
-
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_frontend_precise_code_intel_bundle_manager_error_responses"
 ]
 ```
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -1,0 +1,107 @@
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/honey"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	queryResolver *observation.Operation
+	definitions   *observation.Operation
+	diagnostics   *observation.Operation
+	hover         *observation.Operation
+	ranges        *observation.Operation
+	references    *observation.Operation
+}
+
+func makeOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewOperationMetrics(
+		observationContext.Registerer,
+		"codeintel_resolvers",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of resolver invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:         fmt.Sprintf("codeintel.resolvers.%s", name),
+			MetricLabels: []string{name},
+			Metrics:      metrics,
+		})
+	}
+
+	return &operations{
+		queryResolver: op("QueryResolver"),
+		definitions:   op("Definitions"),
+		diagnostics:   op("Diagnostics"),
+		hover:         op("Hover"),
+		ranges:        op("Ranges"),
+		references:    op("References"),
+	}
+}
+
+func observeResolver(
+	ctx context.Context,
+	err *error,
+	name string,
+	operation *observation.Operation,
+	threshold time.Duration,
+	observationArgs observation.Args,
+) (context.Context, func()) {
+	start := time.Now()
+	ctx, endObservation := operation.With(ctx, err, observationArgs)
+
+	return ctx, func() {
+		duration := time.Since(start)
+		endObservation(1, observation.Args{})
+
+		if duration >= threshold {
+			lowSlowRequest(name, duration, err, observationArgs)
+		}
+		if honey.Enabled() {
+			sendHoneyEvent(name, duration, err, observationArgs)
+		}
+	}
+}
+
+func lowSlowRequest(name string, duration time.Duration, err *error, observationArgs observation.Args) {
+	pairs := append(
+		logFieldToPairs(observationArgs),
+		"type", name,
+		"duration_ms", duration.Milliseconds(),
+	)
+	if err != nil && *err != nil {
+		pairs = append(pairs, "error", (*err).Error())
+	}
+
+	log15.Warn("Slow codeintel request", pairs...)
+}
+
+func logFieldToPairs(observationArgs observation.Args) []interface{} {
+	pairs := make([]interface{}, 0, len(observationArgs.LogFields)*2)
+	for _, field := range observationArgs.LogFields {
+		pairs = append(pairs, field.Key(), field.Value())
+	}
+
+	return pairs
+}
+
+func sendHoneyEvent(name string, duration time.Duration, err *error, observationArgs observation.Args) {
+	ev := honey.Event("codeintel")
+	for _, field := range observationArgs.LogFields {
+		ev.AddField(field.Key(), field.Value())
+	}
+	ev.AddField("type", name)
+	ev.AddField("duration_ms", duration.Milliseconds())
+	if err != nil && *err != nil {
+		ev.AddField("error", (*err).Error())
+	}
+
+	_ = ev.Send()
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -3,10 +3,15 @@ package resolvers
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/opentracing/opentracing-go/log"
 	codeintelapi "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/api"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // AdjustedLocation is similar to a codeintelapi.ResolvedLocation, but with fields denoting
@@ -57,6 +62,7 @@ type queryResolver struct {
 	commit           string
 	path             string
 	uploads          []store.Dump
+	operations       *operations
 }
 
 // NewQueryResolver create a new query resolver with the given services. The methods of this
@@ -71,12 +77,14 @@ func NewQueryResolver(
 	commit string,
 	path string,
 	uploads []store.Dump,
+	operations *operations,
 ) QueryResolver {
 	return &queryResolver{
 		dbStore:          dbStore,
 		lsifStore:        lsifStore,
 		codeIntelAPI:     codeIntelAPI,
 		positionAdjuster: positionAdjuster,
+		operations:       operations,
 		repositoryID:     repositoryID,
 		commit:           commit,
 		path:             path,
@@ -84,10 +92,24 @@ func NewQueryResolver(
 	}
 }
 
+const slowRangesRequestThreshold = time.Second
+
 // Ranges returns code intelligence for the ranges that fall within the given range of lines. These
 // results are partial and do not include references outside the current file, or any location that
 // requires cross-linking of bundles (cross-repo or cross-root).
-func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) ([]AdjustedCodeIntelligenceRange, error) {
+func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) (_ []AdjustedCodeIntelligenceRange, err error) {
+	ctx, endObservation := observeResolver(ctx, &err, "Ranges", r.operations.ranges, slowRangesRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.String("uploadIDs", strings.Join(r.uploadIDs(), ", ")),
+			log.Int("startLine", startLine),
+			log.Int("endLine", endLine),
+		},
+	})
+	defer endObservation()
+
 	var adjustedRanges []AdjustedCodeIntelligenceRange
 	for i := range r.uploads {
 		adjustedPath, ok, err := r.positionAdjuster.AdjustPath(ctx, r.uploads[i].Commit, r.path, false)
@@ -132,11 +154,25 @@ func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) ([]A
 	return adjustedRanges, nil
 }
 
+const slowDefinitionsRequestThreshold = time.Second
+
 // Definitions returns the list of source locations that define the symbol at the given position.
 // This may include remote definitions if the remote repository is also indexed. If there are multiple
 // bundles associated with this resolver, the definitions from the first bundle with any results will
 // be returned.
-func (r *queryResolver) Definitions(ctx context.Context, line, character int) ([]AdjustedLocation, error) {
+func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_ []AdjustedLocation, err error) {
+	ctx, endObservation := observeResolver(ctx, &err, "Definitions", r.operations.definitions, slowDefinitionsRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.String("uploadIDs", strings.Join(r.uploadIDs(), ", ")),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
+	defer endObservation()
+
 	position := lsifstore.Position{Line: line, Character: character}
 
 	for i := range r.uploads {
@@ -162,10 +198,24 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) ([
 	return nil, nil
 }
 
+const slowReferencesRequestThreshold = time.Second
+
 // References returns the list of source locations that reference the symbol at the given position.
 // This may include references from other dumps and repositories. If there are multiple bundles
 // associated with this resolver, results from all bundles will be concatenated and returned.
-func (r *queryResolver) References(ctx context.Context, line, character, limit int, rawCursor string) ([]AdjustedLocation, string, error) {
+func (r *queryResolver) References(ctx context.Context, line, character, limit int, rawCursor string) (_ []AdjustedLocation, _ string, err error) {
+	ctx, endObservation := observeResolver(ctx, &err, "References", r.operations.references, slowReferencesRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.String("uploadIDs", strings.Join(r.uploadIDs(), ", ")),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
+	defer endObservation()
+
 	position := lsifstore.Position{Line: line, Character: character}
 
 	// Decode a map of upload ids to the next url that serves
@@ -231,10 +281,24 @@ func (r *queryResolver) References(ctx context.Context, line, character, limit i
 	return adjustedLocations, endCursor, nil
 }
 
+const slowHoverRequestThreshold = time.Second
+
 // Hover returns the hover text and range for the symbol at the given position. If there are
 // multiple bundles associated with this resolver, the hover text and range from the first
 // bundle with any results will be returned.
-func (r *queryResolver) Hover(ctx context.Context, line, character int) (string, lsifstore.Range, bool, error) {
+func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ string, _ lsifstore.Range, _ bool, err error) {
+	ctx, endObservation := observeResolver(ctx, &err, "Hover", r.operations.hover, slowHoverRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.String("uploadIDs", strings.Join(r.uploadIDs(), ", ")),
+			log.Int("line", line),
+			log.Int("character", character),
+		},
+	})
+	defer endObservation()
+
 	position := lsifstore.Position{Line: line, Character: character}
 
 	for i := range r.uploads {
@@ -271,10 +335,23 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (string,
 	return "", lsifstore.Range{}, false, nil
 }
 
+const slowDiagnosticsRequestThreshold = time.Second
+
 // Diagnostics returns the diagnostics for documents with the given path prefix. If there are
 // multiple bundles associated with this resolver, results from all bundles will be concatenated
 // and returned.
-func (r *queryResolver) Diagnostics(ctx context.Context, limit int) ([]AdjustedDiagnostic, int, error) {
+func (r *queryResolver) Diagnostics(ctx context.Context, limit int) (_ []AdjustedDiagnostic, _ int, err error) {
+	ctx, endObservation := observeResolver(ctx, &err, "Diagnostics", r.operations.diagnostics, slowDiagnosticsRequestThreshold, observation.Args{
+		LogFields: []log.Field{
+			log.Int("repositoryID", r.repositoryID),
+			log.String("commit", r.commit),
+			log.String("path", r.path),
+			log.String("uploadIDs", strings.Join(r.uploadIDs(), ", ")),
+			log.Int("limit", limit),
+		},
+	})
+	defer endObservation()
+
 	totalCount := 0
 	var allDiagnostics []codeintelapi.ResolvedDiagnostic
 	for i := range r.uploads {
@@ -321,6 +398,16 @@ func (r *queryResolver) Diagnostics(ctx context.Context, limit int) ([]AdjustedD
 	}
 
 	return adjustedDiagnostics, totalCount, nil
+}
+
+// uploadIDs returns a slice of this query's matched upload identifiers.
+func (r *queryResolver) uploadIDs() []string {
+	uploadIDs := make([]string, 0, len(r.uploads))
+	for i := range r.uploads {
+		uploadIDs = append(uploadIDs, strconv.FormatInt(int64(r.uploads[i].ID), 10))
+	}
+
+	return uploadIDs
 }
 
 // adjustLocations translates a list of resolved locations (relative to the indexed commit) into a list of

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -404,7 +404,7 @@ func (r *queryResolver) Diagnostics(ctx context.Context, limit int) (_ []Adjuste
 func (r *queryResolver) uploadIDs() []string {
 	uploadIDs := make([]string, 0, len(r.uploads))
 	for i := range r.uploads {
-		uploadIDs = append(uploadIDs, strconv.FormatInt(int64(r.uploads[i].ID), 10))
+		uploadIDs = append(uploadIDs, strconv.Itoa(r.uploads[i].ID))
 	}
 
 	return uploadIDs

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_test.go
@@ -8,6 +8,7 @@ import (
 	codeintelapi "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/api"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestRanges(t *testing.T) {
@@ -68,6 +69,7 @@ func TestRanges(t *testing.T) {
 			{ID: 44, RepositoryID: 50, Commit: "deadbeef1"},
 			{ID: 45, RepositoryID: 50, Commit: "deadbeef1"},
 		},
+		makeOperations(&observation.TestContext),
 	)
 
 	ranges, err := queryResolver.Ranges(context.Background(), 10, 20)
@@ -205,6 +207,7 @@ func TestDefinitions(t *testing.T) {
 			{ID: 44, RepositoryID: 50, Commit: "deadbeef1"},
 			{ID: 45, RepositoryID: 50, Commit: "deadbeef1"},
 		},
+		makeOperations(&observation.TestContext),
 	)
 
 	definitions, err := queryResolver.Definitions(context.Background(), 10, 15)
@@ -334,6 +337,7 @@ func TestReferences(t *testing.T) {
 			{ID: 45, RepositoryID: 50, Commit: "deadbeef1"},
 			{ID: 46, RepositoryID: 50, Commit: "deadbeef1"},
 		},
+		makeOperations(&observation.TestContext),
 	)
 
 	cursor, err := makeCursor(map[int]string{
@@ -461,6 +465,7 @@ func TestHover(t *testing.T) {
 			{ID: 44, RepositoryID: 50, Commit: "deadbeef1"},
 			{ID: 45, RepositoryID: 50, Commit: "deadbeef1"},
 		},
+		makeOperations(&observation.TestContext),
 	)
 
 	text, r, ok, err := queryResolver.Hover(context.Background(), 10, 15)
@@ -576,6 +581,7 @@ func TestDiagnostics(t *testing.T) {
 			{ID: 44, RepositoryID: 50, Commit: "deadbeef1"},
 			{ID: 45, RepositoryID: 50, Commit: "deadbeef1"},
 		},
+		makeOperations(&observation.TestContext),
 	)
 
 	diagnostics, totalCount, err := queryResolver.Diagnostics(context.Background(), 3)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
@@ -7,6 +7,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestQueryResolver(t *testing.T) {
@@ -14,7 +15,7 @@ func TestQueryResolver(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockCodeIntelAPI := NewMockCodeIntelAPI() // returns no dumps
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockCodeIntelAPI, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockCodeIntelAPI, nil, &observation.TestContext)
 	queryResolver, err := resolver.QueryResolver(context.Background(), &gql.GitBlobLSIFDataArgs{
 		Repo:      &types.Repo{ID: 50},
 		Commit:    api.CommitID("deadbeef"),

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -50,8 +50,8 @@ type CommitGraphOptions struct {
 func (c *Client) CommitGraph(ctx context.Context, repositoryID int, opts CommitGraphOptions) (_ map[string][]string, err error) {
 	ctx, endObservation := c.operations.commitGraph.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
-		log.String("opts.Commit", opts.Commit),
-		log.Int("opts.Limit", opts.Limit),
+		log.String("commit", opts.Commit),
+		log.Int("limit", opts.Limit),
 	}})
 	defer endObservation(1, observation.Args{})
 

--- a/enterprise/internal/codeintel/stores/dbstore/indexable_repos.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexable_repos.go
@@ -70,11 +70,11 @@ func scanIndexableRepositories(rows *sql.Rows, queryErr error) (_ []IndexableRep
 // IndexableRepositories returns the metadata of all indexable repositories.
 func (s *Store) IndexableRepositories(ctx context.Context, opts IndexableRepositoryQueryOptions) (_ []IndexableRepository, err error) {
 	ctx, endObservation := s.operations.indexableRepositories.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("opts.Limit", opts.Limit),
-		log.Int("opts.MinimumSearchCount", opts.MinimumSearchCount),
-		log.Float64("opts.MinimumSearchRatio", opts.MinimumSearchRatio),
-		log.Int("opts.MinimumPreciseCount", opts.MinimumPreciseCount),
-		log.String("opts.MinimumTimeSinceLastEnqueue", fmt.Sprintf("%s", opts.MinimumTimeSinceLastEnqueue)),
+		log.Int("limit", opts.Limit),
+		log.Int("minimumSearchCount", opts.MinimumSearchCount),
+		log.Float64("minimumSearchRatio", opts.MinimumSearchRatio),
+		log.Int("minimumPreciseCount", opts.MinimumPreciseCount),
+		log.String("minimumTimeSinceLastEnqueue", fmt.Sprintf("%s", opts.MinimumTimeSinceLastEnqueue)),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -133,7 +133,7 @@ func (s *Store) IndexableRepositories(ctx context.Context, opts IndexableReposit
 // already marked as indexable, a new record will be created.
 func (s *Store) UpdateIndexableRepository(ctx context.Context, indexableRepository UpdateableIndexableRepository, now time.Time) (err error) {
 	ctx, endObservation := s.operations.updateIndexableRepository.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("indexableRepository.RepositoryID", indexableRepository.RepositoryID),
+		log.Int("repositoryID", indexableRepository.RepositoryID),
 	}})
 	defer endObservation(1, observation.Args{})
 

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -150,11 +150,11 @@ type GetIndexesOptions struct {
 // GetIndexes returns a list of indexes and the total count of records matching the given conditions.
 func (s *Store) GetIndexes(ctx context.Context, opts GetIndexesOptions) (_ []Index, _ int, err error) {
 	ctx, endObservation := s.operations.getIndexes.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("opts.RepositoryID", opts.RepositoryID),
-		log.String("opts.State", opts.State),
-		log.String("opts.Term", opts.Term),
-		log.Int("opts.Limit", opts.Limit),
-		log.Int("opts.Offset", opts.Offset),
+		log.Int("repositoryID", opts.RepositoryID),
+		log.String("state", opts.State),
+		log.String("term", opts.Term),
+		log.Int("limit", opts.Limit),
+		log.Int("offset", opts.Offset),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -279,7 +279,7 @@ func (s *Store) IsQueued(ctx context.Context, repositoryID int, commit string) (
 // InsertIndex inserts a new index and returns its identifier.
 func (s *Store) InsertIndex(ctx context.Context, index Index) (_ int, err error) {
 	ctx, endObservation := s.operations.insertIndex.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("index.ID", index.ID),
+		log.Int("indexID", index.ID),
 	}})
 	defer endObservation(1, observation.Args{})
 

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -204,13 +204,13 @@ func (s *Store) DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore 
 // GetUploads returns a list of uploads and the total count of records matching the given conditions.
 func (s *Store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upload, _ int, err error) {
 	ctx, endObservation := s.operations.getUploads.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("opts.RepositoryID", opts.RepositoryID),
-		log.String("opts.State", opts.State),
-		log.String("opts.Term", opts.Term),
-		log.Bool("opts.VisibleAtTip", opts.VisibleAtTip),
+		log.Int("repositoryID", opts.RepositoryID),
+		log.String("state", opts.State),
+		log.String("term", opts.Term),
+		log.Bool("visibleAtTip", opts.VisibleAtTip),
 		// TODO(efritz) - opts.UploadedBefore should be a duration
-		log.Int("opts.Limit", opts.Limit),
-		log.Int("opts.Offset", opts.Offset),
+		log.Int("limit", opts.Limit),
+		log.Int("offset", opts.Offset),
 	}})
 	defer endObservation(1, observation.Args{})
 

--- a/monitoring/frontend.go
+++ b/monitoring/frontend.go
@@ -314,6 +314,28 @@ func Frontend() *Container {
 				Rows: []Row{
 					{
 						{
+							Name:              "codeintel_resolvers_99th_percentile_duration",
+							Description:       "99th percentile successful resolvers operation duration over 5m",
+							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_codeintel_resolvers_duration_seconds_bucket{job="sourcegraph-frontend"}[5m])))`,
+							DataMayNotExist:   true,
+							Warning:           Alert().GreaterOrEqual(20),
+							PanelOptions:      PanelOptions().LegendFormat("resolvers operation").Unit(Seconds),
+							Owner:             ObservableOwnerCodeIntel,
+							PossibleSolutions: "none",
+						},
+						{
+							Name:              "codeintel_resolvers_errors",
+							Description:       "resolvers errors every 5m",
+							Query:             `sum(increase(src_codeintel_resolvers_errors_total{job="sourcegraph-frontend"}[5m]))`,
+							DataMayNotExist:   true,
+							Warning:           Alert().GreaterOrEqual(20),
+							PanelOptions:      PanelOptions().LegendFormat("error"),
+							Owner:             ObservableOwnerCodeIntel,
+							PossibleSolutions: "none",
+						},
+					},
+					{
+						{
 							Name:              "codeintel_api_99th_percentile_duration",
 							Description:       "99th percentile successful api operation duration over 5m",
 							Query:             `histogram_quantile(0.99, sum by (le)(rate(src_codeintel_api_duration_seconds_bucket{job="sourcegraph-frontend"}[5m])))`,
@@ -464,38 +486,6 @@ func Frontend() *Container {
 							PossibleSolutions: `
 								- May not be a substantial issue, check the 'frontend' logs for potential causes.
 							`,
-						},
-					},
-					{
-						{
-							Name:              "99th_percentile_precise_code_intel_bundle_manager_query_duration",
-							Description:       "99th percentile successful precise-code-intel-bundle-manager query duration over 5m",
-							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_precise_code_intel_bundle_manager_request_duration_seconds_bucket{job="sourcegraph-frontend",category!="transfer"}[5m])))`,
-							DataMayNotExist:   true,
-							Warning:           Alert().GreaterOrEqual(20),
-							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
-							Owner:             ObservableOwnerCodeIntel,
-							PossibleSolutions: "none",
-						},
-						{
-							Name:              "99th_percentile_precise_code_intel_bundle_manager_transfer_duration",
-							Description:       "99th percentile successful precise-code-intel-bundle-manager data transfer duration over 5m",
-							Query:             `histogram_quantile(0.99, sum by (le,category)(rate(src_precise_code_intel_bundle_manager_request_duration_seconds_bucket{job="sourcegraph-frontend",category="transfer"}[5m])))`,
-							DataMayNotExist:   true,
-							Warning:           Alert().GreaterOrEqual(300),
-							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Seconds),
-							Owner:             ObservableOwnerCodeIntel,
-							PossibleSolutions: "none",
-						},
-						{
-							Name:              "precise_code_intel_bundle_manager_error_responses",
-							Description:       "precise-code-intel-bundle-manager error responses every 5m",
-							Query:             `sum by(category) (increase(src_precise_code_intel_bundle_manager_request_duration_seconds_count{job="sourcegraph-frontend",code!~"2.."}[5m]))  / ignoring(code) group_left sum by(category) (increase(src_precise_code_intel_bundle_manager_request_duration_seconds_count{job="sourcegraph-frontend"}[5m])) * 100`,
-							DataMayNotExist:   true,
-							Warning:           Alert().GreaterOrEqual(5).For(15 * time.Minute),
-							PanelOptions:      PanelOptions().LegendFormat("{{category}}").Unit(Percentage),
-							Owner:             ObservableOwnerCodeIntel,
-							PossibleSolutions: "none",
 						},
 					},
 					{


### PR DESCRIPTION
Add metrics, honeycomb events, and slow request logging to all codeintel query resolvers.