### PR TITLE
frontend: Reduce number of external services queried

### DIFF
--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -66,6 +66,11 @@ func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType stri
 	//
 	// This fails for private repositories, which require authentication in the URL userinfo.
 
+	r := &gitserver.Repo{Name: repo, URL: "https://" + string(repo) + ".git"}
+	if envvar.SourcegraphDotComMode() {
+		return r, nil
+	}
+
 	lowerRepo := strings.ToLower(string(repo))
 	var hasToken func(context.Context) (bool, error)
 	switch {
@@ -75,11 +80,6 @@ func quickGitserverRepo(ctx context.Context, repo api.RepoName, serviceType stri
 		hasToken = hasGitLabDotComToken
 	default:
 		return nil, nil
-	}
-
-	r := &gitserver.Repo{Name: repo, URL: "https://" + string(repo) + ".git"}
-	if envvar.SourcegraphDotComMode() {
-		return r, nil
 	}
 
 	ok, err := hasToken(ctx)
@@ -102,6 +102,7 @@ func hasGitHubDotComToken(ctx context.Context) (hasToken bool, _ error) {
 		LimitOffset: &db.LimitOffset{
 			Limit: 500, // The number is randomly chosen
 		},
+		NoNamespace: true, // Only include site owned external services
 	}
 	for {
 		svcs, err := db.ExternalServices.List(ctx, opt)
@@ -153,6 +154,7 @@ func hasGitLabDotComToken(ctx context.Context) (bool, error) {
 		LimitOffset: &db.LimitOffset{
 			Limit: 500, // The number is randomly chosen
 		},
+		NoNamespace: true, // Only include site owned external services
 	}
 	for {
 		svcs, err := db.ExternalServices.List(ctx, opt)


### PR DESCRIPTION
In quickGitserverRepo we check all external services to see if they have
a token for GitLab or GitHub. We should only be checking site level
repos, not user owned.

Also, moved a block of code until after the SourcegraphDotComMode check
since it only runs there.
