### PR TITLE
chore(automerge): run on status changes

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,6 +17,7 @@ on:
   check_suite:
     types:
       - completed
+  status: {}
 
 jobs:
   automerge:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           MERGE_LABELS: automerge
           MERGE_METHOD: squash
+          MERGE_RETRIES: 1
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           args: "--trace"


### PR DESCRIPTION
I think this might be needed to trigger automerge runs on Buildkite completions: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#status

For https://github.com/sourcegraph/sourcegraph/issues/14766 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
