### PR TITLE
graphqlbackend: stream to frontend for diff search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -610,18 +610,31 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 	return commitSearchResultsToSearchResults(flattened), common, nil
 }
 
-func commitDiffSearcher(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) ([]*CommitSearchResultResolver, bool, bool, error) {
-	commitParams := search.CommitParameters{
-		RepoRevs:    repoRev,
-		PatternInfo: args.PatternInfo,
-		Query:       args.Query,
-		Diff:        true,
-	}
-	return searchCommitsInRepo(ctx, commitParams)
-}
-
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel chan<- []SearchResultResolver) ([]SearchResultResolver, *searchResultsCommon, error) {
+	commitDiffSearcher := func(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
+		commitParams := search.CommitParameters{
+			RepoRevs:    repoRev,
+			PatternInfo: args.PatternInfo,
+			Query:       args.Query,
+			Diff:        true,
+		}
+
+		// We use the stream so we can optionally send down resultChannel.
+		for event := range searchCommitsInRepoStream(ctx, commitParams) {
+			if len(event.Results) > 0 && resultChannel != nil {
+				resultChannel <- commitSearchResultsToSearchResults(event.Results)
+			}
+
+			results = append(results, event.Results...)
+			limitHit = event.LimitHit
+			timedOut = event.TimedOut
+			err = event.Error
+		}
+
+		return
+	}
+
 	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
 		TraceName: "searchCommitDiffsInRepos",
 		ErrorName: "diffs",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1644,11 +1644,18 @@ func (a *aggregator) get() ([]SearchResultResolver, searchResultsCommon, *multie
 	return a.results, a.common, a.multiErr
 }
 
+// report sends results down resultChannel and collects the results.
 func (a *aggregator) report(ctx context.Context, results []SearchResultResolver, common *searchResultsCommon, err error) {
 	if a.resultChannel != nil {
 		a.resultChannel <- results
 	}
 
+	a.collect(ctx, results, common, err)
+}
+
+// collect the results. This doesn't send down resultChannel. Should only be
+// used by non-streaming supported backends.
+func (a *aggregator) collect(ctx context.Context, results []SearchResultResolver, common *searchResultsCommon, err error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	// Timeouts are reported through searchResultsCommon so don't report an error for them
@@ -1738,8 +1745,9 @@ func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters
 		return
 	}
 
-	diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, args)
-	a.report(ctx, diffResults, diffCommon, errors.Wrap(err, "diff search failed"))
+	// searchCommitDiffsInRepos supports streamings, so we use a.collect.
+	diffResults, diffCommon, err := searchCommitDiffsInRepos(ctx, args, a.resultChannel)
+	a.collect(ctx, diffResults, diffCommon, errors.Wrap(err, "diff search failed"))
 }
 
 func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParameters) {


### PR DESCRIPTION
We introduce our first end to end use of streaming. This will stream
results for type:diff searches all the way to the browser. We use the
recently introduced ResultChannel to send up results.

Note: There is still some unexpected buffering. From local testing a
search should be streaming results within 200ms is only showing up after
2s. That will be tackled in later commits.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/15837