### PR TITLE
Extend documentation for updating campaigns

### DIFF
--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -16,7 +16,6 @@ ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e
   ':(exclude)doc/admin/updates/docker_compose.md' \
   ':(exclude)docker-images/README.md' \
   ':(exclude)docker-images/alpine' \
-  ':(exclude)doc/dev/campaigns_design.md' \
   ':(exclude)doc/campaigns/' \
   ':(exclude)web/src/enterprise/campaigns/create/CreateCampaignPage.tsx' \
   ':(exclude)vendor' \

--- a/doc/campaigns/explanations/campaigns_design.md
+++ b/doc/campaigns/explanations/campaigns_design.md
@@ -1,4 +1,4 @@
-# Campaigns design doc
+# Campaigns design
 
 Why are [campaigns](../../../campaigns/index.md) designed the way they are?
 

--- a/doc/campaigns/explanations/index.md
+++ b/doc/campaigns/explanations/index.md
@@ -4,3 +4,4 @@ The following articles explain different parts of [Sourcegraph campaigns](../ind
 
 - [Introduction to campaigns](introduction_to_campaigns.md)
 - [Permissions in campaigns](permissions_in_campaigns.md)
+- [Campaigns design](campaigns_design.md)

--- a/doc/campaigns/how-tos/updating_a_campaign.md
+++ b/doc/campaigns/how-tos/updating_a_campaign.md
@@ -1,25 +1,114 @@
 # Updating a campaign
 
-Campaigns are identified by their name. It must be unique within a single namespace (your user account on Sourcegraph, or an organization you are a member of).
+Updating a campaign works by applying a campaign spec to an **existing** campaign in the same namespace.
 
-Updating a campaign works by targeting an **existing** campaign in the namespace by specifying the name in the spec. If the name matches an existing campaign, it will update the campaign. (Otherwise, a new campaign will be created.)
+Since campaigns are uniquely identified by their name (the `name` property in the campaign spec) and the namespace in which they were created, you can edit any other part of a campaign spec and apply it again.
 
-You can edit a the campaign's description, and any other part of its campaign spec at any time.
+When a new campaign spec is applied to an existing campaign the existing campaign is updated and its changesets are updated to match the new desired state.
 
-To update a campaign, you need [admin access to the campaign](../explanations/permissions_in_campaigns.md#campaign-access-for-each-permission-level), and [write access to all affected repositories](../explanations/permissions_in_campaigns.md#repository-permissions-for-campaigns) with published changesets.
+## Requirements 
 
-1. Update the [campaign spec](../explanations/introduction_to_campaigns.md#concepts) to include the changes you want to make to the campaign. For example, change the `description` of the campaign or change the commit message in the `changesetTemplate`.
-1. In your terminal, run the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) command shown. The command will execute your campaign spec to generate changes and then upload them to the campaign for you to preview and accept.
+To update a campaign, you need [admin access to the campaign](../explanations/permissions_in_campaigns.md#campaign-access-for-each-permission-level), and, if you want to [publish changesets](publishing_changesets.md) in the campaign, [write access to all affected repositories](../explanations/permissions_in_campaigns.md#repository-permissions-for-campaigns) with published changesets.
+
+## Preview and apply a new campaign spec
+
+In order to update a campaign after previewing the changes, do the following:
+
+1. Edit the [campaign spec](../references/campaign_spec_yaml_reference.md) with which you created the campaign to include the changes you want to make to the campaign. For example, change the [`description`](../references/campaign_spec_yaml_reference.md#description) of the campaign or change [the commit message in the `changesetTemplate`](../references/campaign_spec_yaml_reference.md#changesettemplate-commit-message).
+1. Use the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) to execute and upload the campaign spec.
 
     <pre><code>src campaign preview -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
-
-    > **Don't worry!** Before any branches or changesets are modified, you will see a preview of all changes and can confirm before proceeding.
-
-1. Open the preview URL that the command printed out.
-1. Examine the preview. Confirm that the changes are what you intended. If not, edit your campaign spec and then rerun the command above.
-1. Click the **Update campaign** button.
+1. Open on the URL that's printed to preview the changes that will be made by applying the new campaign spec.
+1. Click **Apply spec** to update the campaign.
 
 All of the changesets on your code host will be updated to the desired state that was shown in the preview.
 
-> NOTE: If you are sure about the changes you want to make and don't need to preview them, you can run `src campaign apply` to apply the campaign spec directly:
-> <pre><code>src campaign <em>apply</em> -f YOUR_CAMPAIGN_SPEC.campaign.yaml</code></pre>
+## Apply a new campaign spec directly
+
+In order to update a campaign directly, without preview, do the following:
+
+1. Edit the [campaign spec](../references/campaign_spec_yaml_reference.md) with which you created the campaign to include the changes you want to make to the campaign.
+1. Use the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) to execute, upload, and the campaign spec.
+
+    <pre><code>src campaign apply -f <em>YOUR_CAMPAIGN_SPEC.campaign.yaml</em></code></pre>
+
+The new campaign spec will be applied directly and the campaign and its changesets will be updated.
+
+## How campaign updates are processed
+
+Changes in the campaign spec that that affect campaign itself, such as the [`description`](../references/campaign_spec_yaml_reference.md#description), are applied directly when you apply the new campaign spec.
+
+Changes that affect the changesets are processed asynchronously to update the changeset to its new desired state. Different fields are processed differently.
+
+Here are some examples:
+
+- When the diff or attributes that affect the resulting commit of a changeset directly (such as the [`changesetTemplate.commit.message`](../references/campaign_spec_yaml_reference.md#changesettemplate-commit-message) or the [`changesetTemplate.commit.author`](../references/campaign_spec_yaml_reference.md#changesettemplate-commit-author)) and the changeset has been published, the commit on the code host will be overwritten by a new commit that includes the updated diff.
+- When the the [`changesetTemplate.title`](../references/campaign_spec_yaml_reference.md#changesettemplate-title) or the [`changesetTemplate.body`](../references/campaign_spec_yaml_reference.md#changesettemplate-commit-author) are changed and the changeset has been published, the changeset on the code host will be updated accordingly.
+- When the [`changesetTemplate.branch`](../references/campaign_spec_yaml_reference.md#changesettemplate-title) is changed after the changeset has been published on the code host, the existing changeset will be closed on the code host and new one, with the new branch, will be created.
+- When the campaign spec is changed in such a way that no diff is produced in a repository in which the campaign already created and published a changeset, the existing changeset will be closed on the code host and detached from the campaign.
+
+See the "[Campaigns design](../explanations/campaigns_design.md)" doc for more information on the declarative nature of the campaigns system.
+
+## Updating a campaign to change its scope
+
+### Increasing the number of changesets
+
+You can gradually increase the number of repositories to which a campaign applies by modifying the entries in the [`on`](../references/campaign_spec_yaml_reference.md#on) property of the campaign spec.
+
+That means you can start with an `on` property like this in your campaign spec:
+
+```yaml
+# [...]
+
+# Find all repositories that contain a README.md file, in the GitHub my-company org.
+on:
+  - repositoriesMatchingQuery: file:README.md repo:github.com/my-company
+
+# [...]
+```
+
+After you applied that campaign spec, you can extend the scope of campaign by changing the `on` property to result in more repositories:
+
+```yaml
+# [...]
+
+# Find all repositories that contain a README.md file, in the GitHub my-company and my-company-ci org.
+on:
+  - repositoriesMatchingQuery: file:README.md repo:github.com/my-company|github.com/my-company-ci
+
+# [...]
+```
+
+The updated [`repo:` keyword](../../code_search/reference/queries.md#keywords-all-searches) in the search query will result in more repositories being returned by the search.
+
+If you apply the updated campaign spec new changesets will be created for each additional repository.
+
+### Decreasing the number of changesets
+
+You can also decrease the number of repositories to which a campaign applies the by modifying the entries in the [`on`](../references/campaign_spec_yaml_reference.md#on) property.
+
+If you, for example, started with this campaign spec
+
+```yaml
+# [...]
+
+# Find all repositories that contain a README.md file, in the GitHub my-company org.
+on:
+  - repositoriesMatchingQuery: file:README.md repo:github.com/my-company
+
+# [...]
+```
+
+and applied it and [published changesets](publishing_changesets.md) and then change it to this
+
+```yaml
+# [...]
+
+# Find all repositories that contain a README.md file, in the GitHub my-company org.
+on:
+  - repositoriesMatchingQuery: file:README.md repo:github.com/my-company/my-one-repository
+
+# [...]
+```
+
+and apply it, then all the changesets that were published in repositories other than `my-one-repository` _will be closed on the code host and detached from the campaign_.

--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -75,6 +75,7 @@ Create a campaign by specifying a search query to get a list of repositories and
 
 - [Introduction to campaigns](explanations/introduction_to_campaigns.md)
 - [Permissions in campaigns](explanations/permissions_in_campaigns.md)
+- [Campaigns design](explanations/campaigns_design.md)
 
 ## How-tos
 

--- a/doc/dev/background-information/campaigns/index.md
+++ b/doc/dev/background-information/campaigns/index.md
@@ -6,10 +6,7 @@ Before diving into the technical part of campaigns, make sure to read up on what
 
 1. Start by looking at the [campaigns description on about.sourcegraph.com](https://about.sourcegraph.com).
 1. Read through the [campaigns documentation](../../../campaigns/index.md).
-
-## [Campaigns design doc](campaigns_design.md)
-
-See "[Campaigns design doc](campaigns_design.md)".
+	- Especially: "[Campaigns design doc](../../../campaigns/explanations/campaigns_design.md)".
 
 ## Starting up your environment
 


### PR DESCRIPTION
This is the follow-up to https://github.com/sourcegraph/sourcegraph/pull/15807 and does two things:

1. It updates the "Updating a campaign" documentation to explain how to update a campaign with or without preview, how updates are processed (this should probably be moved to the "Explanations" section in the future), how to increase/decrease the scope of a campaign.
2. It moves the "campaigns design doc" to the user-facing documentation, because I think it's valuable to have it in there.

