### PR TITLE
monitoring: Remove alert for 'time since last sync'

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2214,24 +2214,6 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 ```
 
 <br />
-## repo-updater: syncer_sync_last_time
-
-<p class="subtitle">cloud: time since last sync</p>**Descriptions:**
-
-- _repo-updater: 3600s+ time since last sync for 5m0s_
-
-**Possible solutions:**
-
-- Make sure there are external services added with valid tokens
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_syncer_sync_last_time"
-]
-```
-
-<br />
 ## repo-updater: src_repoupdater_max_sync_backoff
 
 <p class="subtitle">cloud: time since oldest sync</p>**Descriptions:**

--- a/monitoring/repo_updater.go
+++ b/monitoring/repo_updater.go
@@ -31,6 +31,7 @@ func RepoUpdater() *Container {
 							Description:       "time since last sync",
 							Query:             `max(timestamp(vector(time()))) - max(src_repoupdater_syncer_sync_last_time)`,
 							DataMayNotExist:   true,
+							NoAlert:           true,
 							PanelOptions:      PanelOptions().Unit(Seconds),
 							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "Make sure there are external services added with valid tokens",

--- a/monitoring/repo_updater.go
+++ b/monitoring/repo_updater.go
@@ -31,7 +31,6 @@ func RepoUpdater() *Container {
 							Description:       "time since last sync",
 							Query:             `max(timestamp(vector(time()))) - max(src_repoupdater_syncer_sync_last_time)`,
 							DataMayNotExist:   true,
-							Warning:           Alert().GreaterOrEqual(time.Hour.Seconds()).For(5 * time.Minute),
 							PanelOptions:      PanelOptions().Unit(Seconds),
 							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "Make sure there are external services added with valid tokens",


### PR DESCRIPTION
It's difficult to set a number for this as it depends on the number of
external services configured and how often repo data changes.

We already have an alert to on 'time since oldest' sync which would
catch issues in overall sync progress.
