### PR TITLE
test: exit on error

### DIFF
--- a/test/code-intel/test.sh
+++ b/test/code-intel/test.sh
@@ -4,7 +4,7 @@
 source /root/.profile
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
 
-set -x
+set -ex
 
 test/setup-deps.sh
 

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -4,7 +4,7 @@
 source /root/.profile
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
 
-set -x
+set -ex
 
 test/setup-deps.sh
 test/setup-display.sh

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -4,7 +4,7 @@
 source /root/.profile
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
 
-set -x
+set -ex
 
 test/setup-deps.sh
 test/setup-display.sh

--- a/test/upgrade/test.sh
+++ b/test/upgrade/test.sh
@@ -4,7 +4,7 @@
 source /root/.profile
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
 
-set -x
+set -ex
 
 test/setup-deps.sh
 test/setup-display.sh


### PR DESCRIPTION
Not doing so makes it hard to diagnose when a setup step fails (e.g. [github flake (?)](https://buildkite.com/sourcegraph/qa/builds/474#d3cbe344-5c49-4dab-89dd-9f1b8173de27/33-167) and misleadingly passes these tests, or allows them to continue to steps where more confusing, unrelated errors show up. If we want to force passes should probably add a `|| true` to the pipeline file where the test scripts are called instead

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
