### PR TITLE
search backend fix: repohasfile honored for global search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1750,8 +1750,8 @@ func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParamete
 	a.report(ctx, commitResults, commitCommon, errors.Wrap(err, "commit search failed"))
 }
 
-// isGlobalSearch returns true if the query contains the filters repo or
-// repogroup. For structural queries and queries with version context
+// isGlobalSearch returns true if the query does not contain repo, repogroup, or
+// repohasfile filters. For structural queries and queries with version context
 // isGlobalSearch always return false.
 func (r *searchResolver) isGlobalSearch() bool {
 	if r.patternType == query.SearchTypeStructural {
@@ -1760,7 +1760,7 @@ func (r *searchResolver) isGlobalSearch() bool {
 	if r.versionContext != nil && *r.versionContext != "" {
 		return false
 	}
-	return len(r.query.Values(query.FieldRepo)) == 0 && len(r.query.Values(query.FieldRepoGroup)) == 0
+	return len(r.query.Values(query.FieldRepo)) == 0 && len(r.query.Values(query.FieldRepoGroup)) == 0 && len(r.query.Values(query.FieldRepoHasFile)) == 0
 }
 
 // doResults is one of the highest level search functions that handles finding results.

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -308,6 +308,10 @@ func TestSearch(t *testing.T) {
 				minMatchCount: 1001,
 			},
 			{
+				name:  "repohasfile returns results for global search",
+				query: "repohasfile:README",
+			},
+			{
 				name:  "regular expression without indexed search",
 				query: "index:no patterntype:regexp ^func.*$",
 			},


### PR DESCRIPTION
Fixes #15178.

https://github.com/sourcegraph/sourcegraph/pull/14093 introduced a regression where a query with `repohasfile` would no longer search all repos, because it bypasses the logic that handles `repohasfile` by optimizing for a global search. 

Ideally we should be able to use the optimization for `repohasfile`, but because that logic is embedded deeply into other search code, I am simply deactivating this optimization when `repohasfile` is specified.

My overall diagnosis: This was avoidable if we had better coverage of our search functionality, repohasfile had no integration test and we would have surely picked it up at the time had we coverage. That said, repohasfile is more obscure than our other filters, so, consider this a win as in "Yay we are covering this functionality in our integration tests".

Side concern: I find the code around this global optimization confusing and we need to do something better. For example, we should know, basically right after we parse a query, how we are going to evaluate it and convert it to a type that evaluates that kind of query on a specific code path (global versus non global versus "we are on Sourcegraph.com", etc). None of this mixed-in logic that becomes impossible to follow. We need to push this environment/search mode/optimization logic up our search stack. I'm partially guilty of this problem myself (mixing in structural search logic in v0), so what I'm saying is we should start taking this problem seriously ASAP.

I will merge this when build is green because it is release blocking.