### PR TITLE
search frontend: highlight '|' regex metachar (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -398,4 +398,143 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('decorate regexp | operator, single pattern', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('[|]\\|((a|b)|d)|e', false, SearchPatternType.regexp)), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "identifier"
+              }
+            ]
+        `)
+    })
+
+    test('decorate regexp | operator, multiple patterns', () => {
+        expect(
+            getMonacoTokens(toSuccess(scanSearchQuery('repo:(a|b) (c|d) (e|f)', false, SearchPatternType.regexp)), true)
+        ).toMatchInlineSnapshot(
+            `
+            [
+              {
+                "startIndex": 0,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "closingParen"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 20,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 21,
+                "scopes": "regexpMetaDelimited"
+              }
+            ]
+        `
+        )
+    })
 })

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -43,6 +43,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'regexpMetaCharacterSet', foreground: '#3bc9db' },
         { token: 'regexpMetaCharacterClass', foreground: '#3bc9db' },
         { token: 'regexpMetaQuantifier', foreground: '#3bc9db' },
+        { token: 'regexpMetaAlternative', foreground: '#3bc9db' },
     ],
 })
 
@@ -77,6 +78,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'regexpMetaCharacterSet', foreground: '#1098ad' },
         { token: 'regexpMetaCharacterClass', foreground: '#1098ad' },
         { token: 'regexpMetaQuantifier', foreground: '#1098ad' },
+        { token: 'regexpMetaAlternative', foreground: '#1098ad' },
     ],
 })
 


### PR DESCRIPTION
This one was actually tricky because we have to figure out where legitimate `|` are without being told by the parsed tree. Code ended up being simple though.

<img width="503" alt="Screen Shot 2020-11-17 at 10 01 16 PM" src="https://user-images.githubusercontent.com/888624/99485940-a2166100-2920-11eb-8fc6-e279a7b7f9d6.png">
