### PR TITLE
search frontend: highlight escaped regex chars (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -152,7 +152,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 3,
-                "scopes": "identifier"
+                "scopes": "regexpMetaEscapedCharacter"
               },
               {
                 "startIndex": 5,
@@ -417,7 +417,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 3,
-                "scopes": "identifier"
+                "scopes": "regexpMetaEscapedCharacter"
               },
               {
                 "startIndex": 5,
@@ -470,8 +470,7 @@ describe('getMonacoTokens()', () => {
     test('decorate regexp | operator, multiple patterns', () => {
         expect(
             getMonacoTokens(toSuccess(scanSearchQuery('repo:(a|b) (c|d) (e|f)', false, SearchPatternType.regexp)), true)
-        ).toMatchInlineSnapshot(
-            `
+        ).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -532,6 +531,71 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 21,
                 "scopes": "regexpMetaDelimited"
+              }
+            ]
+        `)
+    })
+
+    test('decorate escaped characters', () => {
+        expect(
+            getMonacoTokens(
+                toSuccess(scanSearchQuery('[\\--\\abc] \\|\\.|\\(\\)', false, SearchPatternType.regexp)),
+                true
+            )
+        ).toMatchInlineSnapshot(
+            `
+            [
+              {
+                "startIndex": 0,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "regexpMetaEscapedCharacter"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "regexpMetaEscapedCharacter"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "regexpMetaCharacterClass"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "regexpMetaEscapedCharacter"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "regexpMetaEscapedCharacter"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "regexpMetaEscapedCharacter"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "regexpMetaEscapedCharacter"
               }
             ]
         `

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -16,6 +16,7 @@ export enum RegexpMetaKind {
     Assertion = 'Assertion', // like ^ or \b
     Alternative = 'Alternative', // like |
     Delimited = 'Delimited', // like ( or )
+    EscapedCharacter = 'EscapedCharacter', // like \(
     CharacterSet = 'CharacterSet', // like \s
     CharacterClass = 'CharacterClass', // like [a-z]
     Quantifier = 'Quantifier', // like +
@@ -146,6 +147,16 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                 }
             },
             onCharacterEnter(node: Character) {
+                if (node.end - node.start > 1 && node.raw.startsWith('\\')) {
+                    // This is an escaped value like `\.`, `\u0065`, `\x65`.
+                    tokens.push({
+                        type: 'regexpMeta',
+                        range: { start: offset + node.start, end: offset + node.end },
+                        value: node.raw,
+                        kind: RegexpMetaKind.EscapedCharacter,
+                    })
+                    return
+                }
                 tokens.push({
                     type: 'pattern',
                     range: { start: offset + node.start, end: offset + node.end },

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -40,6 +40,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         // Regexp pattern highlighting
         { token: 'regexpMetaDelimited', foreground: '#ff6b6b' },
         { token: 'regexpMetaAssertion', foreground: '#ff6b6b' },
+        { token: 'regexpMetaEscapedCharacter', foreground: '#ffa8a8' },
         { token: 'regexpMetaCharacterSet', foreground: '#3bc9db' },
         { token: 'regexpMetaCharacterClass', foreground: '#3bc9db' },
         { token: 'regexpMetaQuantifier', foreground: '#3bc9db' },
@@ -75,6 +76,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         // Regexp pattern highlighting
         { token: 'regexpMetaDelimited', foreground: '#c92a2a' },
         { token: 'regexpMetaAssertion', foreground: '#c92a2a' },
+        { token: 'regexpMetaEscapedCharacter', foreground: '#af5200' },
         { token: 'regexpMetaCharacterSet', foreground: '#1098ad' },
         { token: 'regexpMetaCharacterClass', foreground: '#1098ad' },
         { token: 'regexpMetaQuantifier', foreground: '#1098ad' },


### PR DESCRIPTION
Stacked on #15902. 

Decided it's an improvement to highlight escaped chars. 

I'm deviating a bit from [open color scheme](https://yeun.github.io/open-color/), because I wanted colors that are not so in-your-face for escaped chars, they should be "quieter", and didn't find any I liked. We can debate more on this later, let's get feature-flagged code checked in :-)

<img width="712" alt="Screen Shot 2020-11-17 at 10 23 07 PM" src="https://user-images.githubusercontent.com/888624/99487718-36ce8e00-2924-11eb-92c1-0aedba94e3be.png">
<img width="730" alt="Screen Shot 2020-11-17 at 10 22 56 PM" src="https://user-images.githubusercontent.com/888624/99487723-39c97e80-2924-11eb-991c-fa8123e42ddf.png">

