### PR TITLE
search frontend: split regexp range and lazy quantifiers

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -184,7 +184,11 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 1,
-                "scopes": "regexpMetaQuantifier"
+                "scopes": "regexpMetaRangeQuantifier"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "regexpMetaLazyQuantifier"
               },
               {
                 "startIndex": 3,
@@ -200,7 +204,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 6,
-                "scopes": "regexpMetaQuantifier"
+                "scopes": "regexpMetaRangeQuantifier"
               }
             ]
         `)
@@ -216,7 +220,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 1,
-                "scopes": "regexpMetaQuantifier"
+                "scopes": "regexpMetaRangeQuantifier"
               },
               {
                 "startIndex": 4,
@@ -228,7 +232,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 6,
-                "scopes": "regexpMetaQuantifier"
+                "scopes": "regexpMetaRangeQuantifier"
               },
               {
                 "startIndex": 11,
@@ -240,17 +244,19 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 13,
-                "scopes": "regexpMetaQuantifier"
+                "scopes": "regexpMetaRangeQuantifier"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "regexpMetaLazyQuantifier"
               }
             ]
         `)
     })
 
     test('decorate paren groups', () => {
-        expect(
-            getMonacoTokens(toSuccess(scanSearchQuery('((a) or b)', false, SearchPatternType.regexp)), true)
-        ).toMatchInlineSnapshot(
-            `
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('((a) or b)', false, SearchPatternType.regexp)), true))
+            .toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -289,8 +295,7 @@ describe('getMonacoTokens()', () => {
                 "scopes": "closingParen"
               }
             ]
-        `
-        )
+        `)
     })
 
     test('decorate character classes', () => {

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -40,10 +40,11 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         // Regexp pattern highlighting
         { token: 'regexpMetaDelimited', foreground: '#ff6b6b' },
         { token: 'regexpMetaAssertion', foreground: '#ff6b6b' },
+        { token: 'regexpMetaLazyQuantifier', foreground: '#ff6b6b' },
         { token: 'regexpMetaEscapedCharacter', foreground: '#ffa8a8' },
         { token: 'regexpMetaCharacterSet', foreground: '#da77f2' },
         { token: 'regexpMetaCharacterClass', foreground: '#da77f2' },
-        { token: 'regexpMetaQuantifier', foreground: '#3bc9db' },
+        { token: 'regexpMetaRangeQuantifier', foreground: '#3bc9db' },
         { token: 'regexpMetaAlternative', foreground: '#3bc9db' },
     ],
 })
@@ -76,10 +77,11 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         // Regexp pattern highlighting
         { token: 'regexpMetaDelimited', foreground: '#c92a2a' },
         { token: 'regexpMetaAssertion', foreground: '#c92a2a' },
+        { token: 'regexpMetaLazyQuantifier', foreground: '#c92a2a' },
         { token: 'regexpMetaEscapedCharacter', foreground: '#af5200' },
         { token: 'regexpMetaCharacterSet', foreground: '#ae3ec9' },
         { token: 'regexpMetaCharacterClass', foreground: '#ae3ec9' },
-        { token: 'regexpMetaQuantifier', foreground: '#1098ad' },
+        { token: 'regexpMetaRangeQuantifier', foreground: '#1098ad' },
         { token: 'regexpMetaAlternative', foreground: '#1098ad' },
     ],
 })


### PR DESCRIPTION
Stacked on #15907.

I decided it's worth highlighting a `?` that refers to the lazy quantifier, as in `.*?` different to the range (AKA optional) quantifier `a?`. Since these are both fairly commonly used, but way different meaning in context. 

<img width="190" alt="Screen Shot 2020-11-18 at 12 53 56 AM" src="https://user-images.githubusercontent.com/888624/99501120-8e76f480-2938-11eb-91fb-0afdaad45977.png">

With this PR, regexp highlighting is feature-complete.
