### PR TITLE
ci: refactor image builds and tags for clarity

### DIFF
--- a/enterprise/dev/ci/ci/images.go
+++ b/enterprise/dev/ci/ci/images.go
@@ -1,0 +1,62 @@
+package ci
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	// SourcegraphDockerDevRegistry is a private registry for dev images, and requires authentication to pull from.
+	SourcegraphDockerDevRegistry = "us.gcr.io/sourcegraph-dev"
+	// SourcegraphDockerPublishRegistry is a public registry for final iamges, and does not require authentication to pull from.
+	SourcegraphDockerPublishRegistry = "index.docker.io/sourcegraph"
+)
+
+// SourcegraphDockerImages is a list of all images published by Sourcegraph.
+//
+// In general:
+//
+// - dev images (candidates - see `candidateImageTag`) are published to `SourcegraphDockerDevRegistry`
+// - final images (releases, `insiders`) are published to `SourcegraphDockerPublishRegistry`
+//
+// The `addDockerImages` pipeline step determines what images are built and published.
+var SourcegraphDockerImages = []string{
+	// Slow images first for faster CI
+	"server",
+	"frontend",
+	"grafana",
+	"prometheus",
+	"ignite-ubuntu",
+
+	"github-proxy",
+	"gitserver",
+	"query-runner",
+	"repo-updater",
+	"searcher",
+	"symbols",
+	"precise-code-intel-worker",
+	"executor-queue",
+	"executor",
+
+	// Images under docker-images/
+	"cadvisor",
+	"indexed-searcher",
+	"postgres-11.4",
+	"redis-cache",
+	"redis-store",
+	"search-indexer",
+	"syntax-highlighter",
+	"jaeger-agent",
+	"jaeger-all-in-one",
+	"codeintel-db",
+	"minio",
+}
+
+// candidateImageTag provides the tag for a candidate image built for this Buildkite run.
+//
+// Note that the availability of this image depends on whether a candidate gets built,
+// as determined in `addDockerImages()`.
+func candidateImageTag(c Config) string {
+	buildNumber := os.Getenv("BUILDKITE_BUILD_NUMBER")
+	return fmt.Sprintf("%s_%s_candidate", c.commit, buildNumber)
+}

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -9,38 +9,6 @@ import (
 	bk "github.com/sourcegraph/sourcegraph/internal/buildkite"
 )
 
-var allDockerImages = []string{
-	// Slow images first for faster CI
-	"server",
-	"frontend",
-	"grafana",
-	"prometheus",
-	"ignite-ubuntu",
-
-	"github-proxy",
-	"gitserver",
-	"query-runner",
-	"repo-updater",
-	"searcher",
-	"symbols",
-	"precise-code-intel-worker",
-	"executor-queue",
-	"executor",
-
-	// Images under docker-images/
-	"cadvisor",
-	"indexed-searcher",
-	"postgres-11.4",
-	"redis-cache",
-	"redis-store",
-	"search-indexer",
-	"syntax-highlighter",
-	"jaeger-agent",
-	"jaeger-all-in-one",
-	"codeintel-db",
-	"minio",
-}
-
 // Verifies the docs formatting and builds the `docsite` command.
 func addDocs(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":memo: Check and build docsite",
@@ -308,6 +276,11 @@ func copyEnv(keys ...string) map[string]string {
 // Build all relevant Docker images for Sourcegraph (for example, candidates and final
 // images), given the current CI case (e.g., "tagged release", "release branch",
 // "master branch", etc.)
+//
+// Notes:
+//
+// - Publishing of `insiders` implies deployment
+// - See `images.go` for more details on what images get built and where they get published
 func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 	addDockerImage := func(c Config, app string, insiders bool) func(*bk.Pipeline) {
 		if !final {
@@ -320,7 +293,7 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 		switch {
 		// build all images for tagged releases
 		case c.taggedRelease:
-			for _, dockerImage := range allDockerImages {
+			for _, dockerImage := range SourcegraphDockerImages {
 				addDockerImage(c, dockerImage, false)(pipeline)
 			}
 
@@ -330,19 +303,19 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 
 		// replicates `main` build but does not deploy `insiders` images
 		case c.isMasterDryRun:
-			for _, dockerImage := range allDockerImages {
+			for _, dockerImage := range SourcegraphDockerImages {
 				addDockerImage(c, dockerImage, false)(pipeline)
 			}
 
 		// deploy `insiders` images for `main`
 		case c.branch == "main":
-			for _, dockerImage := range allDockerImages {
+			for _, dockerImage := range SourcegraphDockerImages {
 				addDockerImage(c, dockerImage, true)(pipeline)
 			}
 
 		// ensure candidate images are available for testing
 		case c.shouldRunE2EandQA():
-			for _, dockerImage := range allDockerImages {
+			for _, dockerImage := range SourcegraphDockerImages {
 				addDockerImage(c, dockerImage, false)(pipeline)
 			}
 
@@ -358,13 +331,13 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 // tags once the e2e tests pass.
 func addCandidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-
-		baseImage := "sourcegraph/" + strings.ReplaceAll(app, "/", "-")
+		image := strings.ReplaceAll(app, "/", "-")
+		localImage := "sourcegraph/" + image + ":" + c.version
 
 		cmds := []bk.StepOpt{
 			bk.Cmd(fmt.Sprintf(`echo "Building candidate %s image..."`, app)),
 			bk.Env("DOCKER_BUILDKIT", "1"),
-			bk.Env("IMAGE", baseImage+":"+c.version),
+			bk.Env("IMAGE", localImage),
 			bk.Env("VERSION", c.version),
 			bk.Cmd("yes | gcloud auth configure-docker"),
 		}
@@ -388,11 +361,13 @@ func addCandidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 			cmds = append(cmds, bk.Cmd(cmdDir+"/build.sh"))
 		}
 
-		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
-		tag := candidateImageTag(c)
+		devImage := fmt.Sprintf("%s/%s", SourcegraphDockerDevRegistry, image)
+		devTag := candidateImageTag(c)
 		cmds = append(cmds,
-			bk.Cmd(fmt.Sprintf("docker tag %s:%s %s:%s", baseImage, c.version, gcrImage, tag)),
-			bk.Cmd(fmt.Sprintf("docker push %s:%s", gcrImage, tag)),
+			// Retag the local image for dev registry
+			bk.Cmd(fmt.Sprintf("docker tag %s %s:%s", localImage, devImage, devTag)),
+			// Publish tagged image
+			bk.Cmd(fmt.Sprintf("docker push %s:%s", devImage, devTag)),
 		)
 
 		pipeline.AddStep(fmt.Sprintf(":docker: :construction: %s", app), cmds...)
@@ -403,12 +378,12 @@ func addCandidateDockerImage(c Config, app string) func(*bk.Pipeline) {
 // after the e2e tests pass.
 func addFinalDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		baseImage := "sourcegraph/" + strings.ReplaceAll(app, "/", "-")
-		gcrImage := fmt.Sprintf("us.gcr.io/sourcegraph-dev/%s", strings.TrimPrefix(baseImage, "sourcegraph/"))
-		dockerHubImage := fmt.Sprintf("index.docker.io/%s", baseImage)
+		image := strings.ReplaceAll(app, "/", "-")
+		devImage := fmt.Sprintf("%s/%s", SourcegraphDockerDevRegistry, image)
+		publishImage := fmt.Sprintf("%s/%s", SourcegraphDockerPublishRegistry, image)
 
 		var images []string
-		for _, image := range []string{dockerHubImage, gcrImage} {
+		for _, image := range []string{publishImage, devImage} {
 			if app != "server" || c.taggedRelease || c.patch || c.patchNoTest {
 				images = append(images, fmt.Sprintf("%s:%s", image, c.version))
 			}
@@ -422,18 +397,9 @@ func addFinalDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline)
 			}
 		}
 
-		candidateImage := fmt.Sprintf("%s:%s", gcrImage, candidateImageTag(c))
+		candidateImage := fmt.Sprintf("%s:%s", devImage, candidateImageTag(c))
 		cmd := fmt.Sprintf("./dev/ci/docker-publish.sh %s %s", candidateImage, strings.Join(images, " "))
 
 		pipeline.AddStep(fmt.Sprintf(":docker: :white_check_mark: %s", app), bk.Cmd(cmd))
 	}
-}
-
-// candidateImageTag provides the tag for a candidate image built for this Buildkite run.
-//
-// Note that the availability of this image depends on whether a candidate gets built,
-// as determined in `addDockerImages()`.
-func candidateImageTag(c Config) string {
-	buildNumber := os.Getenv("BUILDKITE_BUILD_NUMBER")
-	return fmt.Sprintf("%s_%s_candidate", c.commit, buildNumber)
 }


### PR DESCRIPTION
Pairing on https://github.com/sourcegraph/sourcegraph/pull/15678 revealed that it is kind of hard to explain this stuff - when images get built, where they go, what gets built, etc.

This PR does some light renaming/moving-around/docstring-additions to hopefully make this more clear.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
