### PR TITLE
search frontend: highlight non-capturing groups (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -298,6 +298,38 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
+    test('decorate non-capturing paren groups', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('(?:a(?:b))', false, SearchPatternType.regexp)), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "regexpMetaDelimited"
+              }
+            ]
+        `)
+    })
+
     test('decorate character classes', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('([a-z])', false, SearchPatternType.regexp)), true))
             .toMatchInlineSnapshot(`

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -4,11 +4,12 @@ import { RegExpParser, visitRegExpAST } from 'regexpp'
 import {
     Alternative,
     Assertion,
+    CapturingGroup,
     Character,
     CharacterClass,
     CharacterClassRange,
     CharacterSet,
-    CapturingGroup,
+    Group,
     Quantifier,
 } from 'regexpp/ast'
 
@@ -71,6 +72,22 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                     range: { start: offset + node.start, end: offset + node.end },
                     value: node.raw,
                     kind: RegexpMetaKind.Assertion,
+                })
+            },
+            onGroupEnter(node: Group) {
+                // Push the leading '('
+                tokens.push({
+                    type: 'regexpMeta',
+                    range: { start: offset + node.start, end: offset + node.start + 1 },
+                    value: '(',
+                    kind: RegexpMetaKind.Delimited,
+                })
+                // Push the trailing ')'
+                tokens.push({
+                    type: 'regexpMeta',
+                    range: { start: offset + node.end - 1, end: offset + node.end },
+                    value: ')',
+                    kind: RegexpMetaKind.Delimited,
                 })
             },
             onCapturingGroupEnter(node: CapturingGroup) {


### PR DESCRIPTION
Stacked on #15908.

We need to handle non-capturing group syntax like `(?:foo)`, which is valid syntax in the frontend and backend. If we don't handle this in the highlighter, the groups (and therefore parentheses) will be labeled according to whatever we pushed in the Monaco token list before the non-capturing group, and so colored incorrectly (could be red, purple, whatever).