### PR TITLE
ci: move storybooks to async pipeline

### DIFF
--- a/.buildkite/pipeline.async.yml
+++ b/.buildkite/pipeline.async.yml
@@ -8,4 +8,4 @@ steps:
   - yarn run cover-storybook
   - yarn nyc report -r json
   - bash <(curl -s https://codecov.io/bash) -c -F typescript -F storybook
-  label: ':storybook::codecov: Code coverage'
+  label: ':storybook::codecov: Storybook coverage'

--- a/.buildkite/pipeline.async.yml
+++ b/.buildkite/pipeline.async.yml
@@ -1,0 +1,11 @@
+env:
+  ENTERPRISE: "1"
+  FORCE_COLOR: "3"
+
+steps:
+- command:
+  - COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-storybook
+  - yarn run cover-storybook
+  - yarn nyc report -r json
+  - bash <(curl -s https://codecov.io/bash) -c -F typescript -F storybook
+  label: ':storybook::codecov: Code coverage'

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -129,6 +129,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		//
 		// PERF: Try to order steps such that slower steps are first.
 		pipelineOperations = []func(*bk.Pipeline){
+			triggerAsync(c),               // triggers a slow pipeline, so do it first.
 			addBackendIntegrationTests(c), // ~11m
 			addDockerImages(c, false),     // ~8m (candidate images)
 			addLint,                       // ~4.5m


### PR DESCRIPTION
This is a slow step which doesn't block the build. So we create a new
pipeline and run it on that.

Fixes #14082 