### PR TITLE
search: extend updateCodeMonitor to handle edits of actions

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -9,7 +9,10 @@ import (
 )
 
 type CodeMonitorsResolver interface {
+	// Query
 	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
+
+	// Mutations
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
 	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
 	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -158,7 +158,7 @@ type MonitorArgs struct {
 }
 
 type EditActionEmailArgs struct {
-	Id     graphql.ID
+	Id     *graphql.ID
 	Update *CreateActionEmailArgs
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -794,8 +794,9 @@ type Mutation {
         id: ID!
     ): EmptyResponse!
     """
-    Update a code monitor. We assume that the request contains a complete code monitor.
-    Existing actions which are missing from the request will be deleted from DB. Actions
+    Update a code monitor. We assume that the request contains a complete code monitor,
+    including its trigger and all actions. Actions which are stored in the db,
+    but are missing from the request will be deleted from the database. Actions
     without an ID will be created.
     """
     updateCodeMonitor(

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -794,9 +794,9 @@ type Mutation {
         id: ID!
     ): EmptyResponse!
     """
-    Update a code monitor. Objects in the db will be overwritten with the objects in the request. Objects
-    which are not contained in the request remain unchanged. If the request contains objects that have
-    no corresponding entry in the db, an error is returned.
+    Update a code monitor. We assume that the request contains a complete code monitor.
+    Existing actions which are missing from the request will be deleted from DB. Actions
+    without an ID will be created.
     """
     updateCodeMonitor(
         """
@@ -3430,7 +3430,7 @@ input MonitorEditEmailInput {
     """
     The id of an email action.
     """
-    id: ID!
+    id: ID
     """
     The desired state after the update.
     """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -795,9 +795,9 @@ type Mutation {
     ): EmptyResponse!
     """
     Update a code monitor. We assume that the request contains a complete code monitor,
-    including its trigger and all actions. Actions which are stored in the db,
-    but are missing from the request will be deleted from the database. Actions
-    without an ID will be created.
+    including its trigger and all actions. Actions which are stored in the database,
+    but are missing from the request will be deleted from the database. Actions with id=null
+    will be created.
     """
     updateCodeMonitor(
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -787,9 +787,9 @@ type Mutation {
         id: ID!
     ): EmptyResponse!
     """
-    Update a code monitor. Objects in the db will be overwritten with the objects in the request. Objects
-    which are not contained in the request remain unchanged. If the request contains objects that have
-    no corresponding entry in the db, an error is returned.
+    Update a code monitor. We assume that the request contains a complete code monitor.
+    Existing actions which are missing from the request will be deleted from DB. Actions
+    without an ID will be created.
     """
     updateCodeMonitor(
         """
@@ -3423,7 +3423,7 @@ input MonitorEditEmailInput {
     """
     The id of an email action.
     """
-    id: ID!
+    id: ID
     """
     The desired state after the update.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -788,9 +788,9 @@ type Mutation {
     ): EmptyResponse!
     """
     Update a code monitor. We assume that the request contains a complete code monitor,
-    including its trigger and all actions. Actions which are stored in the db,
-    but are missing from the request will be deleted from the database. Actions
-    without an ID will be created.
+    including its trigger and all actions. Actions which are stored in the database,
+    but are missing from the request will be deleted from the database. Actions with id=null
+    will be created.
     """
     updateCodeMonitor(
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -787,8 +787,9 @@ type Mutation {
         id: ID!
     ): EmptyResponse!
     """
-    Update a code monitor. We assume that the request contains a complete code monitor.
-    Existing actions which are missing from the request will be deleted from DB. Actions
+    Update a code monitor. We assume that the request contains a complete code monitor,
+    including its trigger and all actions. Actions which are stored in the db,
+    but are missing from the request will be deleted from the database. Actions
     without an ID will be created.
     """
     updateCodeMonitor(

--- a/enterprise/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/internal/codemonitors/resolvers/main_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
@@ -37,22 +39,66 @@ func addUserToOrg(t *testing.T, db *sql.DB, userID int32, orgID int32) {
 	}
 }
 
-func (r *Resolver) insertTestMonitor(ctx context.Context, t *testing.T, owner graphql.ID) (graphqlbackend.MonitorResolver, error) {
+type Option interface {
+	apply(*options)
+}
+
+type options struct {
+	actions []*graphqlbackend.CreateActionArgs
+	owner   graphql.ID
+}
+
+type actionOption struct {
+	actions []*graphqlbackend.CreateActionArgs
+}
+
+func (a actionOption) apply(opts *options) {
+	opts.actions = a.actions
+}
+
+func WithActions(actions []*graphqlbackend.CreateActionArgs) Option {
+	return actionOption{actions: actions}
+}
+
+type ownerOption struct {
+	owner graphql.ID
+}
+
+func (o ownerOption) apply(opts *options) {
+	opts.owner = o.owner
+}
+
+func WithOwner(owner graphql.ID) Option {
+	return ownerOption{owner: owner}
+}
+
+// insertTestMonitorWithOpts is a test helper that creates monitors for test
+// purposes with sensible defaults. You can override the defaults by providing
+// (optional) opts.
+func (r *Resolver) insertTestMonitorWithOpts(ctx context.Context, t *testing.T, opts ...Option) (graphqlbackend.MonitorResolver, error) {
 	t.Helper()
 
+	defaultOwner := relay.MarshalID("User", actor.FromContext(ctx).UID)
+	defaultAction := []*graphqlbackend.CreateActionArgs{
+		{Email: &graphqlbackend.CreateActionEmailArgs{
+			Enabled:    true,
+			Priority:   "NORMAL",
+			Recipients: []graphql.ID{defaultOwner},
+			Header:     "test header"}}}
+
+	options := options{
+		actions: defaultAction,
+		owner:   defaultOwner,
+	}
+	for _, opt := range opts {
+		opt.apply(&options)
+	}
 	return r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
-		Namespace:   owner,
+		Namespace:   options.owner,
 		Description: "test monitor",
 		Enabled:     true,
 		Trigger:     &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
-		Actions: []*graphqlbackend.CreateActionArgs{
-			{Email: &graphqlbackend.CreateActionEmailArgs{
-				Enabled:    true,
-				Priority:   "NORMAL",
-				Recipients: []graphql.ID{owner},
-				Header:     "test header",
-			}},
-		},
+		Actions:     options.actions,
 	})
 }
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -198,18 +198,20 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 
 func (r *Resolver) actionIDsForMonitorIDInt64(ctx context.Context, monitorID int64) (actionIDs []graphql.ID, err error) {
 	limit := 50
-	var ids []graphql.ID
-	var after *string
-	var q *sqlf.Query
-	q, err = r.readActionEmailQuery(ctx, monitorID, &graphqlbackend.ListActionArgs{
-		First: int32(limit),
-		After: after,
-	})
-	if err != nil {
-		return nil, err
-	}
+	var (
+		ids   []graphql.ID
+		after *string
+		q     *sqlf.Query
+	)
 	// Paging.
 	for {
+		q, err = r.readActionEmailQuery(ctx, monitorID, &graphqlbackend.ListActionArgs{
+			First: int32(limit),
+			After: after,
+		})
+		if err != nil {
+			return nil, err
+		}
 		es, cur, err := r.actionIDsForMonitorIDINT64SinglePage(ctx, q, limit)
 		if err != nil {
 			return nil, err

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -305,6 +305,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		return m, nil
 	}
 	var emailID int64
+	var e graphqlbackend.MonitorEmailResolver
 	for i, action := range args.Actions {
 		if action.Email == nil {
 			return nil, fmt.Errorf("missing email object for action %d", i)
@@ -325,7 +326,6 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		if err != nil {
 			return nil, err
 		}
-		var e graphqlbackend.MonitorEmailResolver
 		e, err = r.runEmailQuery(ctx, q)
 		if err != nil {
 			return nil, err
@@ -345,6 +345,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 func (r *Resolver) createActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) (err error) {
 	var q *sqlf.Query
 	for _, a := range args {
+		// Insert actions.
 		q, err = r.createActionEmailQuery(ctx, monitorID, a.Email)
 		if err != nil {
 			return err
@@ -353,7 +354,7 @@ func (r *Resolver) createActions(ctx context.Context, args []*graphqlbackend.Cre
 		if err != nil {
 			return err
 		}
-		// insert recipients
+		// Insert recipients.
 		q, err = r.createRecipientsQuery(ctx, a.Email.Recipients, e.(*monitorEmail).id)
 		if err != nil {
 			return err

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -263,7 +263,7 @@ func splitActionIDs(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorA
 			continue
 		}
 		if _, ok := aMap[*a.Email.Id]; !ok {
-			return nil, nil, fmt.Errorf("unknown ID=%s for action", a.Email.Id)
+			return nil, nil, fmt.Errorf("unknown ID=%s for action", *a.Email.Id)
 		}
 		toUpdateActions = append(toUpdateActions, a)
 		delete(aMap, *a.Email.Id)

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -6,12 +6,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers/apitest"
-
+	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	campaignApitest "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -45,19 +45,19 @@ func TestCreateCodeMonitor(t *testing.T) {
 		namespaceOrgID:  nil,
 	}
 
-	// Create a monitor
+	// Create a monitor.
 	ctx = actor.WithActor(ctx, actor.FromUser(userID))
-	ns := relay.MarshalID("User", userID)
-	got, err := r.insertTestMonitor(ctx, t, ns)
+	got, err := r.insertTestMonitorWithOpts(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	want.Resolver = got.(*monitor).Resolver
 	if !reflect.DeepEqual(want, got.(*monitor)) {
 		t.Fatalf("\ngot:\t %+v,\nwant:\t %+v", got, want)
 	}
 
-	// Toggle field enabled from true to false
+	// Toggle field enabled from true to false.
 	got, err = r.ToggleCodeMonitor(ctx, &graphqlbackend.ToggleCodeMonitorArgs{
 		Id:      relay.MarshalID(monitorKind, got.(*monitor).id),
 		Enabled: false,
@@ -69,7 +69,7 @@ func TestCreateCodeMonitor(t *testing.T) {
 		t.Fatalf("got enabled=%T, want enabled=%T", got.(*monitor).enabled, false)
 	}
 
-	// Delete code monitor
+	// Delete code monitor.
 	_, err = r.DeleteCodeMonitor(ctx, &graphqlbackend.DeleteCodeMonitorArgs{Id: got.ID()})
 	if err != nil {
 		t.Fatal(err)
@@ -102,8 +102,8 @@ func TestIsAllowedToEdit(t *testing.T) {
 	r := newTestResolver(t)
 
 	// Create a monitor and set org as owner.
-	ns := relay.MarshalID("Org", org.ID)
-	m, err := r.insertTestMonitor(admContext, t, ns)
+	ownerOpt := WithOwner(relay.MarshalID("Org", org.ID))
+	m, err := r.insertTestMonitorWithOpts(admContext, t, ownerOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,8 +149,7 @@ func TestQueryMonitor(t *testing.T) {
 
 	// Create a monitor
 	ctx = actor.WithActor(ctx, actor.FromUser(userID))
-	ns := relay.MarshalID("User", userID)
-	_, err := r.insertTestMonitor(ctx, t, ns)
+	_, err := r.insertTestMonitorWithOpts(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,76 +262,106 @@ func TestEditCodeMonitor(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
 	r := newTestResolver(t)
-	userName := "cm-user1"
-	userID := insertTestUser(t, dbconn.Global, userName, true)
 
-	// Create a monitor.
-	ctx = actor.WithActor(ctx, actor.FromUser(userID))
-	ns := relay.MarshalID("User", userID)
-	_, err := r.insertTestMonitor(ctx, t, ns)
+	// Create 2 test users.
+	user1Name := "cm-user1"
+	user1ID := insertTestUser(t, dbconn.Global, user1Name, true)
+	ns1 := relay.MarshalID("User", user1ID)
+
+	user2Name := "cm-user2"
+	user2ID := insertTestUser(t, dbconn.Global, user2Name, true)
+	ns2 := relay.MarshalID("User", user2ID)
+
+	// Create a code monitor with 1 trigger and 2 actions.
+	ctx = actor.WithActor(ctx, actor.FromUser(user1ID))
+	actionOpt := WithActions([]*graphqlbackend.CreateActionArgs{
+		{
+			Email: &graphqlbackend.CreateActionEmailArgs{
+				Enabled:    true,
+				Priority:   "NORMAL",
+				Recipients: []graphql.ID{ns1},
+				Header:     "header action 1",
+			}},
+		{
+			Email: &graphqlbackend.CreateActionEmailArgs{
+				Enabled:    true,
+				Priority:   "NORMAL",
+				Recipients: []graphql.ID{ns1, ns2},
+				Header:     "header action 2",
+			},
+		},
+	})
+	_, err := r.insertTestMonitorWithOpts(ctx, t, actionOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+	// Update the code monitor.
+	// We update all fields, delete one action, and add a new action.
 	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Query the monitor we just inserted to get the IDs of the monitor, trigger, and
-	// action. We could use the output from insertTestMonitor instead, but going
-	// through the GraphQL server makes it much easier to retrieve the deeply nested IDs.
-	input := map[string]interface{}{
-		"userName": userName,
+	updateInput := map[string]interface{}{
+		"monitorID": string(relay.MarshalID(monitorKind, 1)),
+		"triggerID": string(relay.MarshalID(monitorTriggerQueryKind, 1)),
+		"actionID":  string(relay.MarshalID(monitorActionEmailKind, 1)),
+		"user1ID":   ns1,
+		"user2ID":   ns2,
 	}
-	queryResponse := apitest.Response{}
-	campaignApitest.MustExec(actorCtx, t, schema, input, &queryResponse, queryMonitor)
-	input = map[string]interface{}{
-		"monitorID": queryResponse.User.Monitors.Nodes[0].Id,
-		"triggerID": queryResponse.User.Monitors.Nodes[0].Trigger.Id,
-		"actionID":  queryResponse.User.Monitors.Nodes[0].Actions.Nodes[0].Id,
-		"userID":    relay.MarshalID("User", userID),
-	}
+	got := apitest.UpdateCodeMonitorResponse{}
+	campaignApitest.MustExec(ctx, t, schema, updateInput, &got, editMonitor)
 
 	want := apitest.UpdateCodeMonitorResponse{
 		UpdateCodeMonitor: apitest.Monitor{
-			Id:          queryResponse.User.Monitors.Nodes[0].Id,
+			Id:          string(relay.MarshalID(monitorKind, 1)),
 			Description: "updated test monitor",
 			Enabled:     false,
 			Owner: apitest.UserOrg{
-				Name: userName,
+				Name: user1Name,
 			},
 			CreatedBy: apitest.UserOrg{
-				Name: userName,
+				Name: user1Name,
 			},
 			CreatedAt: marshalDateTime(t, r.clock()),
 			Trigger: apitest.Trigger{
-				Id:    queryResponse.User.Monitors.Nodes[0].Trigger.Id,
+				Id:    string(relay.MarshalID(monitorTriggerQueryKind, 1)),
 				Query: "repo:bar",
 			},
 			Actions: apitest.ActionConnection{
 				Nodes: []apitest.Action{{
 					ActionEmail: apitest.ActionEmail{
-						Id:       queryResponse.User.Monitors.Nodes[0].Actions.Nodes[0].Id,
+						Id:       string(relay.MarshalID(monitorActionEmailKind, 1)),
 						Enabled:  false,
 						Priority: "CRITICAL",
 						Recipients: apitest.RecipientsConnection{
 							Nodes: []apitest.UserOrg{
 								{
-									Name: userName,
+									Name: user2Name,
 								},
 							},
 						},
-						Header: "updated test header",
+						Header: "updated header action 1",
+					}}, {
+					ActionEmail: apitest.ActionEmail{
+						Id:       string(relay.MarshalID(monitorActionEmailKind, 3)),
+						Enabled:  true,
+						Priority: "NORMAL",
+						Recipients: apitest.RecipientsConnection{
+							Nodes: []apitest.UserOrg{
+								{
+									Name: user1Name,
+								},
+								{
+									Name: user2Name,
+								},
+							},
+						},
+						Header: "header action 3",
 					}},
 				},
 			},
 		}}
-
-	// Update the code monitor.
-	got := apitest.UpdateCodeMonitorResponse{}
-	campaignApitest.MustExec(actorCtx, t, schema, input, &got, editMonitor)
 
 	if !reflect.DeepEqual(&got, &want) {
 		t.Fatalf("\ngot:\t%+v\nwant:\t%+v\n", got, want)
@@ -350,49 +379,57 @@ fragment o on Org {
   name
 }
 
-mutation ($monitorID: ID!, $triggerID: ID!, $actionID: ID!, $userID: ID!) {
-  updateCodeMonitor(monitor: {id: $monitorID, update: {description: "updated test monitor", enabled: false, namespace: $userID}}, trigger: {id: $triggerID, update: {query: "repo:bar"}}, actions: [{email: {id: $actionID, update: {enabled: false, priority: CRITICAL, recipients: [$userID], header: "updated test header"}}}]) {
-    id
-    description
-    enabled
-    owner {
-      ... on User {
-        ...u
-      }
-      ... on Org {
-        ...o
-      }
-    }
-    createdBy {
-      ...u
-    }
-    createdAt
-    trigger {
-      ... on MonitorQuery {
-        id
-        query
-      }
-    }
-    actions {
-      nodes {
-        ... on MonitorEmail {
-          id
-          enabled
-          priority
-          header
-          recipients {
-            nodes {
-              ... on User {
-                username
-              }
-              ... on Org {
-                name
-              }
-            }
-          }
-        }
-      }
-    }
+mutation ($monitorID: ID!, $triggerID: ID!, $actionID: ID!, $user1ID: ID!, $user2ID: ID!) {
+  updateCodeMonitor(
+    monitor: {id: $monitorID, update: {description: "updated test monitor", enabled: false, namespace: $user1ID}},
+	trigger: {id: $triggerID, update: {query: "repo:bar"}},
+	actions: [
+	  {email: {id: $actionID, update: {enabled: false, priority: CRITICAL, recipients: [$user2ID], header: "updated header action 1"}}}
+	  {email: {update: {enabled: true, priority: NORMAL, recipients: [$user1ID, $user2ID], header: "header action 3"}}}
+    ]
+  )
+  {
+	id
+	description
+	enabled
+	owner {
+	  ... on User {
+		...u
+	  }
+	  ... on Org {
+		...o
+	  }
+	}
+	createdBy {
+	  ...u
+	}
+	createdAt
+	trigger {
+	  ... on MonitorQuery {
+		id
+		query
+	  }
+	}
+	actions {
+	  nodes {
+		... on MonitorEmail {
+		  id
+		  enabled
+		  priority
+		  header
+		  recipients {
+			nodes {
+			  ... on User {
+				username
+			  }
+			  ... on Org {
+				name
+			  }
+			}
+		  }
+		}
+	  }
+	}
   }
 }
 `


### PR DESCRIPTION
This PR extends the capabilities of `updateCodeMonitor`: now it can also create and delete actions.

To allow both, updating and creating a new action, I made the action ID optional when updating a code monitor. 
```
"""
The input required to edit an email action.
"""
input MonitorEditEmailInput {
    """
    The id of an email action.
    """
    id: ID
    """
    The desired state after the update.
    """
    update: MonitorEmailInput!
}
```

Quoting from the docstring of `updateCodeMonitor`

>  Update a code monitor. We assume that the request contains a complete code monitor,
    including its trigger and all actions. Actions which are stored in the database,
    but are missing from the request will be deleted from the database. Actions with id=null
    will be created.

Other notable changes:
- I invested in building up more test infrastructure. `insertTestMonitorWithOpts` lets us create test data more flexibly, which was already quite helpful to test the new functionalities. 
- As part of the change I optimized how we update recipients. Before, recipients were inserted one by one (within a transaction), now they are inserted in bulk (within a transaction).

To understand how everything fits together, I recommend starting with `func (r *Resolver) UpdateCodeMonitor(...)`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
