### PR TITLE
e2e: do not mark builds as green

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -11,8 +11,7 @@ env:
 steps:
   - label: ':chromium: Sourcegraph E2E'
     artifact_paths: ./*.png;./*.mp4;./ffmpeg.log
-    # set commands to pass until tests are 100% confirmed as working, so as to avoid disruting dev workflow on main
     command:
-      - .buildkite/vagrant-run.sh sourcegraph-e2e || true
+      - .buildkite/vagrant-run.sh sourcegraph-e2e
     agents:
       queue: 'baremetal'


### PR DESCRIPTION
E2E seems to [currently failing before it even starts testing](https://buildkite.com/sourcegraph/e2e/builds/11335#a8d2b47d-5b37-4bb8-bdca-07446d30eedd/33-1287), but it's marked as green so misleadingly makes our testing look healthy. Since E2E and QA now runs async from the main pipeline, I think we can safely mark these as failing to help drive more action.

All QA builds already report errors properly.

Merging this should accompany a #dev-announce post about the state of these tests.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
