### PR TITLE
qa: allow all tests to run, error at end if one fails

### DIFF
--- a/test/code-intel/test.sh
+++ b/test/code-intel/test.sh
@@ -2,7 +2,8 @@
 
 # shellcheck disable=SC1091
 source /root/.profile
-cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
+root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
+cd "$root_dir" || exit
 
 set -ex
 

--- a/test/code-intel/test.sh
+++ b/test/code-intel/test.sh
@@ -30,6 +30,11 @@ set +x
 source /root/.profile
 set -x
 
+# TODO: we temporarily allow all the test commands to pass, to help teams identify if
+# their tests have been fixed. Remove this when all tests are green so we can identify
+# failures in the future.
+set +e
+
 echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz

--- a/test/code-intel/test.sh
+++ b/test/code-intel/test.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 source /root/.profile
 root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
-cd "$root_dir" || exit
+cd "$root_dir"
 
 set -ex
 
@@ -35,11 +35,11 @@ echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz
 echo "TEST: Running tests"
-pushd internal/cmd/precise-code-intel-tester || exit
+pushd internal/cmd/precise-code-intel-tester
 go build
 ./precise-code-intel-tester addrepos
 ./scripts/download.sh
 ./precise-code-intel-tester upload
 sleep 10
 ./precise-code-intel-tester query
-popd || exit
+popd

--- a/test/code-intel/test.sh
+++ b/test/code-intel/test.sh
@@ -42,5 +42,3 @@ go build
 sleep 10
 ./precise-code-intel-tester query
 popd || exit
-
-# ==========================

--- a/test/code-intel/test.sh
+++ b/test/code-intel/test.sh
@@ -30,11 +30,6 @@ set +x
 source /root/.profile
 set -x
 
-# TODO: we temporarily allow all the test commands to pass, to help teams identify if
-# their tests have been fixed. Remove this when all tests are green so we can identify
-# failures in the future.
-set +e
-
 echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -2,7 +2,8 @@
 
 # shellcheck disable=SC1091
 source /root/.profile
-cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
+root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
+cd "$root_dir" || exit
 
 set -ex
 
@@ -10,6 +11,7 @@ test/setup-deps.sh
 test/setup-display.sh
 
 cleanup() {
+  cd "$root_dir"
   test/cleanup-display.sh
 }
 trap cleanup EXIT

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -16,11 +16,6 @@ pushd enterprise || exit
 ./cmd/server/build.sh
 popd || exit
 
-# TODO: we temporarily allow all the test commands to pass, to help teams identify if
-# their tests have been fixed. Remove this when all tests are green so we can identify
-# failures in the future.
-set +e
-
 echo "TEST: Running E2E tests"
 ./dev/ci/e2e.sh
 docker image rm -f "${IMAGE}"

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -15,6 +15,13 @@ pushd enterprise || exit
 ./cmd/server/pre-build.sh
 ./cmd/server/build.sh
 popd || exit
+
+# TODO: we temporarily allow all the test commands to pass, to help teams identify if
+# their tests have been fixed. Remove this when all tests are green so we can identify
+# failures in the future.
+set +e
+
+echo "TEST: Running E2E tests"
 ./dev/ci/e2e.sh
 docker image rm -f "${IMAGE}"
 

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 source /root/.profile
 root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
-cd "$root_dir" || exit
+cd "$root_dir"
 
 set -ex
 
@@ -18,10 +18,10 @@ trap cleanup EXIT
 
 # ==========================
 
-pushd enterprise || exit
+pushd enterprise
 ./cmd/server/pre-build.sh
 ./cmd/server/build.sh
-popd || exit
+popd
 
 echo "TEST: Running E2E tests"
 ./dev/ci/e2e.sh

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -9,6 +9,11 @@ set -ex
 test/setup-deps.sh
 test/setup-display.sh
 
+cleanup() {
+  test/cleanup-display.sh
+}
+trap cleanup EXIT
+
 # ==========================
 
 pushd enterprise || exit
@@ -19,7 +24,3 @@ popd || exit
 echo "TEST: Running E2E tests"
 ./dev/ci/e2e.sh
 docker image rm -f "${IMAGE}"
-
-# ==========================
-
-test/cleanup-display.sh

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -31,21 +31,19 @@ set +x
 source /root/.profile
 set -x
 
-# TODO: we temporarily allow all the test commands to pass, to help teams identify if
-# their tests have been fixed. Remove this when all tests are green so we can identify
-# failures in the future.
-set +e
-
 echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz
 echo "TEST: Running tests"
 pushd client/web || exit
-yarn run test:regression:core
-yarn run test:regression:codeintel
-yarn run test:regression:config-settings
-yarn run test:regression:integrations
-yarn run test:regression:search
+# Run all tests, and error if one fails
+test_status=0
+yarn run test:regression:core || test_status=1
+yarn run test:regression:codeintel || test_status=1
+yarn run test:regression:config-settings || test_status=1
+yarn run test:regression:integrations || test_status=1
+yarn run test:regression:search || test_status=1
+exit $test_status
 popd || exit
 
 # ==========================

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -9,6 +9,11 @@ set -ex
 test/setup-deps.sh
 test/setup-display.sh
 
+cleanup() {
+  test/cleanup-display.sh
+}
+trap cleanup EXIT
+
 # ==========================
 
 CONTAINER=sourcegraph-server
@@ -45,7 +50,3 @@ yarn run test:regression:integrations || test_status=1
 yarn run test:regression:search || test_status=1
 exit $test_status
 popd || exit
-
-# ==========================
-
-test/cleanup-display.sh

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -2,7 +2,8 @@
 
 # shellcheck disable=SC1091
 source /root/.profile
-cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
+root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
+cd "$root_dir" || exit
 
 set -ex
 
@@ -10,6 +11,7 @@ test/setup-deps.sh
 test/setup-display.sh
 
 cleanup() {
+  cd "$root_dir"
   test/cleanup-display.sh
 }
 trap cleanup EXIT
@@ -40,13 +42,13 @@ echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz
 echo "TEST: Running tests"
-pushd client/web || exit
 # Run all tests, and error if one fails
 test_status=0
+pushd client/web
 yarn run test:regression:core || test_status=1
 yarn run test:regression:codeintel || test_status=1
 yarn run test:regression:config-settings || test_status=1
 yarn run test:regression:integrations || test_status=1
 yarn run test:regression:search || test_status=1
-exit $test_status
 popd || exit
+exit $test_status

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -31,6 +31,11 @@ set +x
 source /root/.profile
 set -x
 
+# TODO: we temporarily allow all the test commands to pass, to help teams identify if
+# their tests have been fixed. Remove this when all tests are green so we can identify
+# failures in the future.
+set +e
+
 echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 source /root/.profile
 root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
-cd "$root_dir" || exit
+cd "$root_dir"
 
 set -ex
 
@@ -50,5 +50,5 @@ yarn run test:regression:codeintel || test_status=1
 yarn run test:regression:config-settings || test_status=1
 yarn run test:regression:integrations || test_status=1
 yarn run test:regression:search || test_status=1
-popd || exit
+popd
 exit $test_status

--- a/test/upgrade/test.sh
+++ b/test/upgrade/test.sh
@@ -2,7 +2,8 @@
 
 # shellcheck disable=SC1091
 source /root/.profile
-cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit
+root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
+cd "$root_dir" || exit
 
 set -ex
 
@@ -10,6 +11,7 @@ test/setup-deps.sh
 test/setup-display.sh
 
 cleanup() {
+  cd "$root_dir"
   test/cleanup-display.sh
 }
 trap cleanup EXIT

--- a/test/upgrade/test.sh
+++ b/test/upgrade/test.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 source /root/.profile
 root_dir="$(dirname "${BASH_SOURCE[0]}")/../.."
-cd "$root_dir" || exit
+cd "$root_dir"
 
 set -ex
 
@@ -49,6 +49,6 @@ echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz
 echo "TEST: Running tests"
-pushd client/web || exit
+pushd client/web
 yarn run test:regression:core
-popd || exit
+popd

--- a/test/upgrade/test.sh
+++ b/test/upgrade/test.sh
@@ -9,6 +9,11 @@ set -ex
 test/setup-deps.sh
 test/setup-display.sh
 
+cleanup() {
+  test/cleanup-display.sh
+}
+trap cleanup EXIT
+
 # ==========================
 
 # Run and initialize an old Sourcegraph release
@@ -45,7 +50,3 @@ echo "TEST: Running tests"
 pushd client/web || exit
 yarn run test:regression:core
 popd || exit
-
-# ==========================
-
-test/cleanup-display.sh

--- a/test/upgrade/test.sh
+++ b/test/upgrade/test.sh
@@ -37,6 +37,11 @@ IMAGE=us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION CLEAN="false" ./dev/ru
 trap docker_logs exit
 sleep 15
 
+# TODO: we temporarily allow all the test commands to pass, to help teams identify if
+# their tests have been fixed. Remove this when all tests are green so we can identify
+# failures in the future.
+set +e
+
 # Run tests
 echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080

--- a/test/upgrade/test.sh
+++ b/test/upgrade/test.sh
@@ -37,11 +37,6 @@ IMAGE=us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION CLEAN="false" ./dev/ru
 trap docker_logs exit
 sleep 15
 
-# TODO: we temporarily allow all the test commands to pass, to help teams identify if
-# their tests have been fixed. Remove this when all tests are green so we can identify
-# failures in the future.
-set +e
-
 # Run tests
 echo "TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080


### PR DESCRIPTION
Currently, QA exits at the first failure, making it difficult to see if anything is going wrong in subsequent tests. Also standardize on a cleanup trap.