### PR TITLE
Fix GlobalNavbar erasing user edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed the `url` fields of repositories and trees in GraphQL returning URLs that were not %-encoded (e.g. when the repository name contained spaces). [#15667](https://github.com/sourcegraph/sourcegraph/issues/15667)
 - Fixed "Find references" showing errors in the references panel in place of the syntax-highlighted code for repositories with spaces in their name. [#15618](https://github.com/sourcegraph/sourcegraph/issues/15618)
 - Fixed an issue where specifying the `repohasfile` filter did not return results as expected unless `repo` was specified. [#15894](https://github.com/sourcegraph/sourcegraph/pull/15894)
+- Fixed an issue causing user input in the search query field to be erased in some cases. [#15921](https://github.com/sourcegraph/sourcegraph/issues/15921).
 
 ### Removed
 

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -128,6 +128,10 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         if (!query) {
             return
         }
+        // Do nothing if the query input contains a user-edited query
+        if (navbarSearchQueryState.fromUserInput) {
+            return
+        }
         // If the URL contains a query, update the query state to reflect it
         if (interactiveSearchMode) {
             let filtersInQuery: FiltersToTypeAndValue = {}
@@ -138,7 +142,15 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         } else {
             onNavbarQueryChange({ query, cursorPosition: query.length })
         }
-    }, [interactiveSearchMode, isSearchRelatedPage, location, onFiltersInQueryChange, onNavbarQueryChange, query])
+    }, [
+        interactiveSearchMode,
+        isSearchRelatedPage,
+        location,
+        onFiltersInQueryChange,
+        onNavbarQueryChange,
+        query,
+        navbarSearchQueryState.fromUserInput,
+    ])
 
     const logo = (
         <LinkOrSpan to={authRequired ? undefined : '/search'} className="global-navbar__logo-link">


### PR DESCRIPTION
Fixes #15921

This code is not covered by any existing unit tests 😞 Maybe integration tests would allow us to test this? The behaviour is racy though (user edits have to happen _before_ the `useEffect()` callback runs), so it would be tricky to write a Puppeteer test that is 100% accurate in this case. 