### PR TITLE
docs: fix markdown list style

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -212,6 +212,7 @@ An incremental sync is in fact a side effect of a complete sync because a user m
 Sourcegraph 3.22+ can speed up permissions syncing by receiving webhooks from GitHub for events related to user and repo permissions. To set up webhooks, follow the guide in the [GitHub Code Host Docs](../external_service/github.md#webhooks). These events will enqueue permissions syncs for the repositories or users mentioned, meaning things like publicising / privatising repos, or adding collaborators will be reflected in your Sourcegraph searches more quickly. For this to work the user must have logged in via the [GitHub OAuth provider](../auth.md#github) 
 
 The events we consume are:
+
 * [public](https://developer.github.com/webhooks/event-payloads/#public)
 * [repository](https://developer.github.com/webhooks/event-payloads/#repository)
 * [member](https://developer.github.com/webhooks/event-payloads/#member)


### PR DESCRIPTION
Follow up of https://github.com/sourcegraph/sourcegraph/pull/15915

Before:
<img width="771" alt="Screen Shot 2020-11-18 at 11 15 48 PM" src="https://user-images.githubusercontent.com/2946214/99548818-00f8da80-29f4-11eb-96c1-1689ef304835.png">

cc @arussellsaw Our markdown render for docs isn't great yet 😞 