### PR TITLE
Code monitors: basic listing page

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -65,6 +65,7 @@ import { SearchPatternType } from './graphql-operations'
 import { TelemetryProps } from '../../shared/src/telemetry/telemetryService'
 import { useObservable } from '../../shared/src/util/useObservable'
 import { useExtensionAlertAnimation } from './nav/UserNavItem'
+import { CodeMonitoringProps } from './enterprise/code-monitoring'
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,
@@ -84,7 +85,8 @@ export interface LayoutProps
         RepogroupHomepageProps,
         OnboardingTourProps,
         HomePanelsProps,
-        SearchStreamingProps {
+        SearchStreamingProps,
+        CodeMonitoringProps {
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
     extensionAreaHeaderNavItems: readonly ExtensionAreaHeaderNavItem[]
     extensionsAreaRoutes: readonly ExtensionsAreaRoute[]

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -69,6 +69,7 @@ import {
 } from './util/settings'
 import { SearchPatternType } from '../../shared/src/graphql-operations'
 import { HTTPStatusError } from '../../shared/src/backend/fetch'
+import { listUserCodeMonitors } from './enterprise/code-monitoring/backend'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
@@ -462,6 +463,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}
+                                    fetchUserCodeMonitors={listUserCodeMonitors}
                                 />
                             )}
                         />

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -4,27 +4,30 @@ import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
 import { AuthenticatedUser } from '../../auth'
 
+import { ListUserCodeMonitorsVariables } from '../../graphql-operations'
+import { of } from 'rxjs'
+
 const { add } = storiesOf('web/enterprise/code-monitoring/CodeMonitoringPage', module)
 
-add(
-    'Example',
-    () => (
-        <WebStory>
-            {props => (
-                <CodeMonitoringPage
-                    {...props}
-                    authenticatedUser={
-                        { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser
-                    }
-                />
-            )}
-        </WebStory>
-    ),
-    {
-        design: {
-            type: 'figma',
-            url:
-                'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
-        },
-    }
-)
+const additionalProps = {
+    authenticatedUser: { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser,
+    fetchUserCodeMonitors: ({ id, first, after }: ListUserCodeMonitorsVariables) =>
+        of({
+            nodes: [
+                {
+                    id: 'foobar',
+                    description: 'test code monitor',
+                    enabled: true,
+                    actions: { nodes: [{ enabled: true, recipients: { nodes: [{ id: 'baz' }] } }] },
+                },
+            ],
+        }),
+}
+
+add('Example', () => <WebStory>{props => <CodeMonitoringPage {...props} {...additionalProps} />}</WebStory>, {
+    design: {
+        type: 'figma',
+        url:
+            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+    },
+})

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -2,13 +2,29 @@ import React from 'react'
 import { CodeMonitoringPage } from './CodeMonitoringPage'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
+import { AuthenticatedUser } from '../../auth'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CodeMonitoringPage', module)
 
-add('Example', () => <WebStory>{props => <CodeMonitoringPage {...props} />}</WebStory>, {
-    design: {
-        type: 'figma',
-        url:
-            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
-    },
-})
+add(
+    'Example',
+    () => (
+        <WebStory>
+            {props => (
+                <CodeMonitoringPage
+                    {...props}
+                    authenticatedUser={
+                        { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser
+                    }
+                />
+            )}
+        </WebStory>
+    ),
+    {
+        design: {
+            type: 'figma',
+            url:
+                'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+        },
+    }
+)

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,28 +1,91 @@
 import * as H from 'history'
-import React from 'react'
+import React, { useCallback } from 'react'
 import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageHeader } from '../../components/PageHeader'
 import { PageTitle } from '../../components/PageTitle'
+import { listUserCodeMonitors } from './backend'
+import { AuthenticatedUser } from '../../auth'
+import { FilteredConnection } from '../../components/FilteredConnection'
+import { CodeMonitorFields, ListUserCodeMonitorsVariables } from '../../graphql-operations'
+import { Toggle } from '../../../../branded/src/components/Toggle'
 
 export interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters {
+    authenticatedUser: AuthenticatedUser
     location: H.Location
+    history: H.History
 }
 
-export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => (
-    <div className="container mt-3 web-content">
-        <PageTitle title="Code Monitoring" />
-        <PageHeader
-            title={
-                <>
-                    Code Monitoring{' '}
-                    <sup>
-                        <span className="badge badge-info text-uppercase">Prototype</span>
-                    </sup>
-                </>
-            }
-            icon={VideoInputAntennaIcon}
-        />
-        <div>Hello world</div>
+export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => {
+    const queryConnection = useCallback(
+        (args: Partial<ListUserCodeMonitorsVariables>) =>
+            listUserCodeMonitors({
+                id: props.authenticatedUser.id,
+                first: args.first ?? null,
+                after: args.after ?? null,
+            }),
+        [props.authenticatedUser]
+    )
+
+    return (
+        <div className="container mt-3 web-content">
+            <PageTitle title="Code Monitoring" />
+            <PageHeader
+                title={
+                    <>
+                        Code Monitoring{' '}
+                        <sup>
+                            <span className="badge badge-info text-uppercase">Prototype</span>
+                        </sup>
+                    </>
+                }
+                icon={VideoInputAntennaIcon}
+            />
+            <div>Hello world</div>
+            <div className="d-flex flex-column">
+                <div className="code-monitoring-page-tabs border-bottom mb-4">
+                    <div className="nav nav-tabs border-bottom-0">
+                        <div className="nav-item">
+                            <div className="nav-link active">Code monitors</div>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <h3 className="mb-2">Your code monitors</h3>
+                    <FilteredConnection<CodeMonitorFields>
+                        location={props.location}
+                        history={props.history}
+                        defaultFirst={10}
+                        queryConnection={queryConnection}
+                        hideSearch={true}
+                        nodeComponent={CodeMonitorNode}
+                        noun="code monitor"
+                        pluralNoun="code monitors"
+                        noSummaryIfAllNodesVisible={true}
+                        cursorPaging={true}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+interface CodeMonitorNodeProps {
+    node: CodeMonitorFields
+}
+
+const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({ node }: CodeMonitorNodeProps) => (
+    <div className="card p-3 mb-2">
+        <div className="d-flex justify-content-between align-items-center">
+            <div className="d-flex flex-column">
+                <div className="font-weight-bold">{node.description}</div>
+                {node.actions.nodes.length > 0 && (
+                    <div className="text-muted">New search result → Sends email notifications, delivers webhook</div>
+                )}
+            </div>
+            <div>
+                <Toggle value={node.enabled} />
+            </div>
+        </div>
     </div>
 )

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -4,27 +4,30 @@ import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageHeader } from '../../components/PageHeader'
 import { PageTitle } from '../../components/PageTitle'
-import { listUserCodeMonitors } from './backend'
 import { AuthenticatedUser } from '../../auth'
 import { FilteredConnection } from '../../components/FilteredConnection'
 import { CodeMonitorFields, ListUserCodeMonitorsVariables } from '../../graphql-operations'
 import { Toggle } from '../../../../branded/src/components/Toggle'
+import { Link } from '../../../../shared/src/components/Link'
+import { CodeMonitoringProps } from '.'
 
-export interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters {
+export interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters, CodeMonitoringProps {
     authenticatedUser: AuthenticatedUser
     location: H.Location
     history: H.History
 }
 
 export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => {
+    const { authenticatedUser, fetchUserCodeMonitors } = props
+
     const queryConnection = useCallback(
         (args: Partial<ListUserCodeMonitorsVariables>) =>
-            listUserCodeMonitors({
-                id: props.authenticatedUser.id,
+            fetchUserCodeMonitors({
+                id: authenticatedUser.id,
                 first: args.first ?? null,
                 after: args.after ?? null,
             }),
-        [props.authenticatedUser]
+        [authenticatedUser, fetchUserCodeMonitors]
     )
 
     return (
@@ -65,6 +68,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                     />
                 </div>
             </div>
+            <Link to="/code-monitoring/new">Add new code monitor</Link>
         </div>
     )
 }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -41,7 +41,6 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                 }
                 icon={VideoInputAntennaIcon}
             />
-            <div>Hello world</div>
             <div className="d-flex flex-column">
                 <div className="code-monitoring-page-tabs border-bottom mb-4">
                     <div className="nav nav-tabs border-bottom-0">

--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -2,7 +2,13 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { dataOrThrowErrors, gql } from '../../../../shared/src/graphql/graphql'
 import { requestGraphQL } from '../../backend/graphql'
-import { CreateCodeMonitorResult, CreateCodeMonitorVariables } from '../../graphql-operations'
+import {
+    CreateCodeMonitorResult,
+    CreateCodeMonitorVariables,
+    ListCodeMonitors,
+    ListUserCodeMonitorsResult,
+    ListUserCodeMonitorsVariables,
+} from '../../graphql-operations'
 
 export const createCodeMonitor = ({
     namespace,
@@ -40,5 +46,84 @@ export const createCodeMonitor = ({
     }).pipe(
         map(dataOrThrowErrors),
         map(data => data.createCodeMonitor)
+    )
+}
+
+const CodeMonitorFragment = gql`
+    fragment CodeMonitorFields on Monitor {
+        id
+        description
+        enabled
+        actions {
+            nodes {
+                ... on MonitorEmail {
+                    enabled
+                    recipients {
+                        nodes {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
+const ListCodeMonitorsFragment = gql`
+    fragment ListCodeMonitors on MonitorConnection {
+        nodes {
+            ...CodeMonitorFields
+        }
+    }
+    ${CodeMonitorFragment}
+`
+
+export interface ListCodeMonitorsResult {
+    monitors: ListCodeMonitors
+}
+
+export const listUserCodeMonitors = ({
+    id,
+    first,
+    after,
+}: ListUserCodeMonitorsVariables): Observable<ListCodeMonitorsResult['monitors']> => {
+    const query = gql`
+        query ListUserCodeMonitors($id: ID!, $first: Int, $after: String) {
+            node(id: $id) {
+                __typename
+                ... on User {
+                    monitors(first: $first, after: $after) {
+                        ...ListCodeMonitors
+                        totalCount
+                        pageInfo {
+                            endCursor
+                            hasNextPage
+                        }
+                    }
+                }
+            }
+        }
+        ${ListCodeMonitorsFragment}
+    `
+
+    return requestGraphQL<ListUserCodeMonitorsResult, ListUserCodeMonitorsVariables>(query, {
+        id,
+        first,
+        after,
+    }).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.node) {
+                throw new Error('namespace not found')
+            }
+
+            if (data.node.__typename !== 'User') {
+                throw new Error(`Requested node is a ${data.node.__typename}, not a User or Org`)
+            }
+
+            return {
+                nodes: data.node.monitors.nodes,
+            }
+        })
     )
 }

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import { Observable } from 'rxjs'
+import { CodeMonitoringProps } from '..'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
@@ -8,7 +8,6 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { AuthenticatedUser } from '../../../auth'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
 import { BreadcrumbsProps, BreadcrumbSetters, Breadcrumbs } from '../../../components/Breadcrumbs'
-import { ListUserCodeMonitorsVariables, ListCodeMonitors } from '../../../graphql-operations'
 import { lazyComponent } from '../../../util/lazyComponent'
 import { CodeMonitoringPageProps } from '../CodeMonitoringPage'
 import { CreateCodeMonitorPageProps } from '../CreateCodeMonitorPage'
@@ -20,10 +19,10 @@ interface Props
         TelemetryProps,
         PlatformContextProps,
         BreadcrumbsProps,
-        BreadcrumbSetters {
+        BreadcrumbSetters,
+        CodeMonitoringProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
-    userCodeMonitorsRequest: ({ id, first, after }: ListUserCodeMonitorsVariables) => Observable<ListCodeMonitors>
 }
 
 const CodeMonitoringPage = lazyComponent<CodeMonitoringPageProps, 'CodeMonitoringPage'>(

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
+import { Observable } from 'rxjs'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
@@ -7,6 +8,7 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { AuthenticatedUser } from '../../../auth'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
 import { BreadcrumbsProps, BreadcrumbSetters, Breadcrumbs } from '../../../components/Breadcrumbs'
+import { ListUserCodeMonitorsVariables, ListCodeMonitors } from '../../../graphql-operations'
 import { lazyComponent } from '../../../util/lazyComponent'
 import { CodeMonitoringPageProps } from '../CodeMonitoringPage'
 import { CreateCodeMonitorPageProps } from '../CreateCodeMonitorPage'
@@ -21,6 +23,7 @@ interface Props
         BreadcrumbSetters {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
+    userCodeMonitorsRequest: ({ id, first, after }: ListUserCodeMonitorsVariables) => Observable<ListCodeMonitors>
 }
 
 const CodeMonitoringPage = lazyComponent<CodeMonitoringPageProps, 'CodeMonitoringPage'>(

--- a/client/web/src/enterprise/code-monitoring/index.ts
+++ b/client/web/src/enterprise/code-monitoring/index.ts
@@ -1,0 +1,6 @@
+import { Observable } from 'rxjs'
+import { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-operations'
+
+export interface CodeMonitoringProps {
+    fetchUserCodeMonitors: ({ id, first, after }: ListUserCodeMonitorsVariables) => Observable<ListCodeMonitors>
+}


### PR DESCRIPTION
Lists a user's code monitors on the code monitor page. Bare minimum, just includes the GraphQL request, basic markup, and use of the `FilteredConnection` component. Will add styling and full information on the listings separately.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
