### PR TITLE
search: remove e2e tests covered by backend gqltest

### DIFF
--- a/client/web/src/regression/search.test.ts
+++ b/client/web/src/regression/search.test.ts
@@ -5,56 +5,17 @@ import { getConfig } from '../../../shared/src/testing/config'
 import { getTestTools } from './util/init'
 import * as GQL from '../../../shared/src/graphql/schema'
 import { GraphQLClient } from './util/GraphQlClient'
-import { ensureTestExternalService, search } from './util/api'
-import { ensureLoggedInOrCreateTestUser, editGlobalSettings } from './util/helpers'
+import { ensureTestExternalService } from './util/api'
+import { ensureLoggedInOrCreateTestUser } from './util/helpers'
 import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { TestResourceManager } from './util/TestResourceManager'
-import { setProperty } from '@sqs/jsonc-parser/lib/edit'
 import { Key } from 'ts-key-enum'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 import { editUserSettings } from './util/settings'
 import assert from 'assert'
 import delay from 'delay'
 
-/**
- * Reads the number of results from the text at the top of the results page
- */
-function getNumberOfResults() {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const matches = document.body.textContent!.match(/(\d+)\+?\sresults?/)
-    if (!matches || matches.length < 2) {
-        return null
-    }
-    const numberOfResults = parseInt(matches[1], 10)
-    return isNaN(numberOfResults) ? null : numberOfResults
-}
-
-/**
- * Returns true if "No results" message is present, throws an error if there are search results,
- * and returns false otherwise.
- */
-function hasNoResultsOrError(): boolean {
-    if (document.querySelectorAll('.test-search-result').length > 0) {
-        throw new Error('Expected "No results", but there were search results.')
-    }
-
-    const resultsElement = document.querySelector('.test-search-results')
-    if (!resultsElement) {
-        return false
-    }
-    const resultsText = (resultsElement as HTMLElement).textContent
-    if (!resultsText) {
-        return false
-    }
-    if (resultsText.includes('No results')) {
-        return true
-    }
-    return false
-}
-
 describe('Search regression test suite', () => {
-    const formattingOptions = { eol: '\n', insertSpaces: true, tabSize: 2 }
-
     /**
      * Test data
      */
@@ -193,16 +154,6 @@ describe('Search regression test suite', () => {
             }
         })
 
-        test('Global text search with 0 results.', async () => {
-            await driver.page.goto(
-                config.sourcegraphBaseUrl + '/search?q=asdfalksd+jflaksjdflkasjdf&patternType=literal'
-            )
-            await driver.page.waitForFunction(hasNoResultsOrError)
-        })
-        test('Global text search with double-quoted string constant ("error type:") with a few results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q="error+type:%5Cn"')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length >= 3)
-        })
         test('Global text search excluding repository ("error type:") with a few results.', async () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?q="error+type:%5Cn"+-repo:google')
             await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
@@ -217,79 +168,6 @@ describe('Search regression test suite', () => {
                 }
                 return true
             })
-        })
-        test('Global text search (error) with many results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=error')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-        })
-        test('Global text search (error count:>1000), expect many results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=error+count:1000')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-        })
-        test('Global text search (repohasfile:copying), expect many results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=repohasfile:copying')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length >= 2)
-        })
-        test('Global text search (repohascommitafter:"5 years ago")', async () => {
-            await driver.page.goto(
-                config.sourcegraphBaseUrl + '/search?q=repohascommitafter:"5+months+ago"+test&patternType=literal'
-            )
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length >= 10)
-        })
-        test('Global text search for something with more than 1000 results and use "count:1000".', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=.+count:1000')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-            await driver.page.addScriptTag({ content: getNumberOfResults.toString() })
-            await driver.page.waitForFunction(() => getNumberOfResults() !== null)
-            await driver.page.waitForFunction(
-                () => {
-                    const numberOfResults = getNumberOfResults()
-                    return numberOfResults && numberOfResults > 1000
-                },
-                { timeout: 500 }
-            )
-        })
-        test('Global text search for a regular expression without indexed search: (index:no ^func.*$), expect many results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=index:no+^func.*$')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-        })
-        test('Global text search for a regular expression with only indexed search: (index:only ^func.*$), expect many results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=index:only+^func.*$')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-        })
-        test('Search for a repository by name.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=repo:auth0/go-jwt-middleware$')
-            await driver.page.waitForFunction(() => {
-                const results = document.querySelectorAll('.test-search-result')
-                return results.length === 1 && (results.item(0).textContent || '').includes('go-jwt-middleware')
-            })
-        })
-        test('Single repository, case-sensitive search.', async () => {
-            await driver.page.goto(
-                config.sourcegraphBaseUrl +
-                    '/search?q=String+repo:%5Egithub.com/adjust/go-wrk%24+&patternType=regexp&case=yes'
-            )
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 3)
-        })
-        test('Global text search, fork:only, few results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=fork:only+router')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length >= 4)
-        })
-        test('Global text search, fork:only, 1 result', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=fork:only+FORK_SENTINEL')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 1)
-        })
-        test('Global text search, fork:no, 0 results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=fork:only+FORK_SENTINEL')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 0)
-        })
-        test('Text search non-master branch, large repository, many results', async () => {
-            // The string `var ExecutionEnvironment = require('ExecutionEnvironment');` occurs 10 times on this old branch, but 0 times in current master.
-            await driver.page.goto(
-                config.sourcegraphBaseUrl +
-                    '/search?q="var+ExecutionEnvironment+%3D+require%28%27ExecutionEnvironment%27%29%3B"+repo:%5Egithub%5C.com/facebook/react%24%400.3-stable&patternType=regexp'
-            )
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 10)
         })
         test('Global text search filtering by language', async () => {
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=%5Cbfunc%5Cb+lang:js')
@@ -311,86 +189,6 @@ describe('Search regression test suite', () => {
                 throw new Error('found Go results when filtering for JavaScript')
             }
         })
-        test('Global search for a filename with 0 results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=file:asdfasdf.go')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 0)
-        })
-        test('Global search for a filename with a few results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=file:router.go')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 5)
-        })
-        test('Global search for a filename with many results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=file:doc.go')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-            await driver.page.addScriptTag({ content: getNumberOfResults.toString() })
-            await driver.page.waitForFunction(() => getNumberOfResults() !== null)
-            await driver.page.waitForFunction(
-                () => {
-                    const numberResults = getNumberOfResults()
-                    return numberResults !== null && numberResults > 25
-                },
-                { timeout: 500 }
-            )
-        })
-        test('Global symbol search with many results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=type:symbol+test+count:100')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-            await driver.page.addScriptTag({ content: getNumberOfResults.toString() })
-            await driver.page.waitForFunction(() => (getNumberOfResults() || 0) >= 100)
-        })
-        test('Global symbol search with 0 results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=type:symbol+asdfasdf')
-            await driver.page.waitForFunction(hasNoResultsOrError)
-        })
-        test('Global symbol search ("type:symbol ^newroute count:100") with a few results', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=type:symbol+%5Enewroute+count:100')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Indexed multiline search, many results', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$ componentDidMount\\(\\) {\\n\\s*this',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-        })
-        test('Non-indexed multiline search, many results', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$ componentDidMount\\(\\) {\\n\\s*this index:no',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 10)
-        })
-        test('Indexed multiline search, 0 results', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$ componentDidMount\\(\\) {\\n\\s*this\\.props\\.sourcegraph\\(',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 0)
-        })
-        test('Non-indexed multiline search, 0 results', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$ componentDidMount\\(\\) {\\n\\s*this\\.props\\.sourcegraph\\( index:no',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 0)
-        })
-        test('Indexed-only structural search, one or more results', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$ index:only patterntype:structural toHaveYielded(:[args])',
-                GQL.SearchPatternType.structural,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
         test('Structural search, return repo results if pattern is empty', async () => {
             const urlQuery = buildSearchURLQuery(
                 'repo:^github\\.com/facebook/react$',
@@ -399,105 +197,6 @@ describe('Search regression test suite', () => {
             )
             await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
             await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Commit search, nonzero result', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$ type:commit hello world',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Diff search, nonzero result', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/sgtest/mux$ type:diff main',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Archived repos excluded by default', async () => {
-            const urlQuery = buildSearchURLQuery('type:repo facebookarchive', GQL.SearchPatternType.regexp, false)
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 0)
-        })
-        test('Archived repos included by archived option', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'type:repo facebookarchive archived:yes',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Single archived repo included if exact', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebookarchive/httpcontrol$ error',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Fork repos excluded by default', async () => {
-            const urlQuery = buildSearchURLQuery('type:repo sgtest/mux', GQL.SearchPatternType.regexp, false)
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length === 0)
-        })
-        test('Forked repos included by fork option', async () => {
-            const urlQuery = buildSearchURLQuery('type:repo sgtest/mux fork:yes', GQL.SearchPatternType.regexp, false)
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-        test('Single forked repo included if exact', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/sgtest/mux$ error',
-                GQL.SearchPatternType.regexp,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-        })
-
-        test('Search timeout', async function () {
-            this.timeout(2 * 1000)
-            const response = await search(gqlClient, 'router index:no timeout:1ns', 'V2', GQL.SearchPatternType.literal)
-            expect(response.results.matchCount).toBe(0)
-            expect(response.results.alert?.title).toBe('Timed out while searching')
-        })
-
-        test('Search repo group', async () => {
-            resourceManager.add(
-                'Global setting',
-                'search.repositoryGroups',
-                await editGlobalSettings(gqlClient, contents =>
-                    setProperty(
-                        contents,
-                        ['search.repositoryGroups'],
-                        {
-                            test_group: ['github.com/auth0/go-jwt-middleware'],
-                        },
-                        formattingOptions
-                    )
-                )
-            )
-
-            const response = await search(gqlClient, 'repogroup:test_group route', 'V2', GQL.SearchPatternType.literal)
-            expect(
-                response.results.results.length > 0 &&
-                    response.results.results.every(result => {
-                        switch (result.__typename) {
-                            case 'FileMatch':
-                                return result.repository.name === 'github.com/auth0/go-jwt-middleware'
-                            case 'Repository':
-                                return result.name === 'github.com/auth0/go-jwt-middleware'
-                            default:
-                                return false
-                        }
-                    })
-            ).toBeTruthy()
         })
 
         test('Search suggestions', async () => {


### PR DESCRIPTION
![trash-it](https://user-images.githubusercontent.com/888624/67820037-de0c2900-fa74-11e9-99e7-a1144172afb9.gif)

Did a pass on e2e tests and we functionally test for all of these behaviors in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/gqltest/search_test.go now. There are ~3 tests that are slightly stronger, that I'll port at a later stage.

Relates to #15178

