### PR TITLE
search: fix saved search modal background color

### DIFF
--- a/client/web/src/savedSearches/SavedSearchModal.scss
+++ b/client/web/src/savedSearches/SavedSearchModal.scss
@@ -1,6 +1,6 @@
 .saved-search-modal-form {
     padding: 1rem;
-    background: $white;
+    background: var(--color-bg-1);
     border: 1px solid var(--border-color);
     border-radius: 0.25rem;
     width: 20rem;


### PR DESCRIPTION
Background color was always white, even in dark mode

![image](https://user-images.githubusercontent.com/206864/99589416-cfa2ef00-29a0-11eb-8c7d-1d308ef2acd5.png)

![image](https://user-images.githubusercontent.com/206864/99589439-d893c080-29a0-11eb-8ef3-9f067ee21264.png)
