### PR TITLE
search: refactor and clean up SearchResultsInfoBar

### DIFF
--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -10,7 +10,7 @@ import { ErrorLike } from '../../../shared/src/util/errors'
 import { addSourcegraphSearchCodeIntelligence } from './input/MonacoQueryInput'
 import { BehaviorSubject, concat, NEVER, of } from 'rxjs'
 import { useObservable } from '../../../shared/src/util/useObservable'
-import { search } from './backend'
+import { search, shouldDisplayPerformanceWarning } from './backend'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { Omit } from 'utility-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
@@ -28,6 +28,7 @@ interface SearchConsolePageProps
             | 'onSavedQueryModalClose'
             | 'onDidCreateSavedQuery'
             | 'onSaveQueryClick'
+            | 'shouldDisplayPerformanceWarning'
         >,
         ExtensionsControllerProps<'executeCommand' | 'services' | 'extHostAPI'> {
     globbing: boolean
@@ -170,6 +171,7 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                                 onDidCreateSavedQuery={voidCallback}
                                 onSavedQueryModalClose={voidCallback}
                                 onSaveQueryClick={voidCallback}
+                                shouldDisplayPerformanceWarning={shouldDisplayPerformanceWarning}
                             />
                         ))}
                 </div>

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -39,6 +39,7 @@ import { FlatExtensionHostAPI } from '../../../../shared/src/api/contract'
 import { DeployType } from '../../jscontext'
 import { AuthenticatedUser } from '../../auth'
 import { SearchPatternType } from '../../../../shared/src/graphql-operations'
+import { shouldDisplayPerformanceWarning } from '../backend'
 
 export interface SearchResultsProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
@@ -341,6 +342,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                     onSavedQueryModalClose={this.onModalClose}
                     onDidCreateSavedQuery={this.onDidCreateSavedQuery}
                     didSave={this.state.didSaveQuery}
+                    shouldDisplayPerformanceWarning={shouldDisplayPerformanceWarning}
                 />
             </div>
         )

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    align-self: stretch;
     color: #93a9c8;
     padding: 0.25rem 0.5rem;
 
@@ -17,6 +18,7 @@
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
+        height: 100%;
 
         &-left {
             display: flex;

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -33,8 +33,5 @@
         display: flex;
         align-items: center;
         margin-right: 1rem;
-        &--no-results {
-            padding: 0.375rem 0.75rem 0 0.375rem;
-        }
     }
 }

--- a/client/web/src/search/results/SearchResultsList.story.tsx
+++ b/client/web/src/search/results/SearchResultsList.story.tsx
@@ -73,6 +73,33 @@ add('loading', () => <WebStory>{() => <SearchResultsList {...defaultProps} resul
 
 add('single result', () => <WebStory>{() => <SearchResultsList {...defaultProps} />}</WebStory>)
 
+add('no results with quote tip in infobar', () => {
+    const resultsOrError: ISearchResults = {
+        ...(defaultProps.resultsOrError as ISearchResults),
+        results: [],
+        matchCount: 0,
+        approximateResultCount: '0',
+    }
+
+    const location = {
+        ...history.location,
+        search: 'q="test"',
+    }
+
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsList
+                    {...defaultProps}
+                    resultsOrError={resultsOrError}
+                    patternType={SearchPatternType.literal}
+                    location={location}
+                />
+            )}
+        </WebStory>
+    )
+})
+
 add('error', () => (
     <WebStory>
         {() => <SearchResultsList {...defaultProps} resultsOrError={{ message: 'test error', name: 'TestError' }} />}

--- a/client/web/src/search/results/SearchResultsList.story.tsx
+++ b/client/web/src/search/results/SearchResultsList.story.tsx
@@ -9,10 +9,11 @@ import {
     SEARCH_REQUEST,
 } from '../../../../shared/src/util/searchTestHelpers'
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
-import { NEVER } from 'rxjs'
+import { NEVER, of } from 'rxjs'
 import { SearchPatternType } from '../../../../shared/src/graphql-operations'
 import { storiesOf } from '@storybook/react'
 import { WebStory } from '../../components/WebStory'
+import { ISearchResults } from '../../../../shared/src/graphql/schema'
 
 const history = createBrowserHistory()
 history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })
@@ -60,6 +61,8 @@ const defaultProps: SearchResultsListProps = {
 
     navbarSearchQueryState: { query: '', cursorPosition: 0 },
     searchStreaming: false,
+
+    shouldDisplayPerformanceWarning: () => of(false),
 }
 
 const { add } = storiesOf('web/search/results/SearchResultsList', module).addParameters({
@@ -75,3 +78,43 @@ add('error', () => (
         {() => <SearchResultsList {...defaultProps} resultsOrError={{ message: 'test error', name: 'TestError' }} />}
     </WebStory>
 ))
+
+add('show performance warning', () => {
+    const shouldDisplayPerformanceWarning = () => of(true)
+
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsList
+                    {...defaultProps}
+                    shouldDisplayPerformanceWarning={shouldDisplayPerformanceWarning}
+                />
+            )}
+        </WebStory>
+    )
+})
+
+add('show server side alert', () => {
+    const shouldDisplayPerformanceWarning = () => of(true)
+    const resultsOrError: ISearchResults = {
+        ...(defaultProps.resultsOrError as ISearchResults),
+        alert: {
+            __typename: 'SearchAlert',
+            description: 'This is a test alert',
+            proposedQueries: [{ __typename: 'SearchQueryDescription', description: 'Test query', query: 'test' }],
+            title: 'Test Alert',
+        },
+    }
+
+    return (
+        <WebStory>
+            {() => (
+                <SearchResultsList
+                    {...defaultProps}
+                    resultsOrError={resultsOrError}
+                    shouldDisplayPerformanceWarning={shouldDisplayPerformanceWarning}
+                />
+            )}
+        </WebStory>
+    )
+})

--- a/client/web/src/search/results/SearchResultsList.test.tsx
+++ b/client/web/src/search/results/SearchResultsList.test.tsx
@@ -15,7 +15,7 @@ import {
     SEARCH_REQUEST,
 } from '../../../../shared/src/util/searchTestHelpers'
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
-import { NEVER } from 'rxjs'
+import { NEVER, of } from 'rxjs'
 import { FiltersToTypeAndValue, FilterType } from '../../../../shared/src/search/interactive/util'
 import { SearchPatternType } from '../../../../shared/src/graphql-operations'
 
@@ -128,6 +128,8 @@ describe('SearchResultsList', () => {
 
         navbarSearchQueryState: { query: '', cursorPosition: 0 },
         searchStreaming: false,
+
+        shouldDisplayPerformanceWarning: () => of(false),
     }
 
     it('displays loading text when results is undefined', () => {

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -32,7 +32,6 @@ import { SearchResult } from '../../components/SearchResult'
 import { SavedSearchModal } from '../../savedSearches/SavedSearchModal'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { eventLogger } from '../../tracking/eventLogger'
-import { shouldDisplayPerformanceWarning } from '../backend'
 import { SearchResultsInfoBar } from './SearchResultsInfoBar'
 import { ErrorAlert } from '../../components/alerts'
 import { VersionContextProps } from '../../../../shared/src/search/util'
@@ -85,6 +84,7 @@ export interface SearchResultsListProps
     interactiveSearchMode: boolean
 
     fetchHighlightedFileLines: (parameters: FetchFileParameters, force?: boolean) => Observable<string[]>
+    shouldDisplayPerformanceWarning: (deployType: DeployType) => Observable<boolean>
 }
 
 interface State {
@@ -305,9 +305,9 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
         this.componentUpdates.next(this.props)
 
         this.subscriptions.add(
-            shouldDisplayPerformanceWarning(this.props.deployType).subscribe(displayPerformanceWarning =>
-                this.setState({ displayPerformanceWarning })
-            )
+            this.props
+                .shouldDisplayPerformanceWarning(this.props.deployType)
+                .subscribe(displayPerformanceWarning => this.setState({ displayPerformanceWarning }))
         )
     }
 

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -40,6 +40,7 @@ import { DeployType } from '../../jscontext'
 import { AuthenticatedUser } from '../../auth'
 import { SearchResultTypeTabs } from './SearchResultTypeTabs'
 import { QueryState } from '../helpers'
+import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 
 const isSearchResults = (value: unknown): value is GQL.ISearchResults =>
     typeof value === 'object' &&
@@ -378,10 +379,13 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                             query={parsedQuery}
                                             results={results}
                                             showDotComMarketing={this.props.isSourcegraphDotCom}
-                                            displayPerformanceWarning={this.state.displayPerformanceWarning}
                                             className="border-bottom flex-grow-1"
                                         />
                                     </div>
+
+                                    {!results.alert && this.state.displayPerformanceWarning && (
+                                        <PerformanceWarningAlert />
+                                    )}
 
                                     {/* Server-provided help message */}
                                     {results.alert && (

--- a/client/web/src/site/PerformanceWarningAlert.tsx
+++ b/client/web/src/site/PerformanceWarningAlert.tsx
@@ -11,7 +11,10 @@ const onClickCTA = (): void => {
  * An alert that explains the performance limitations of single-node Docker deployments.
  */
 export const PerformanceWarningAlert: React.FunctionComponent = () => (
-    <DismissibleAlert partialStorageKey="performanceWarningAlert" className="alert alert-warning align-items-center">
+    <DismissibleAlert
+        partialStorageKey="performanceWarningAlert"
+        className="alert alert-warning align-items-center m-2"
+    >
         <WarningIcon className="icon-inline mr-2 flex-shrink-0" />
         <div>
             Search performance and accuracy are limited on single-node Docker deployments. We recommend that instances


### PR DESCRIPTION
First step towards refactoring SearchResultsInfoBar to remove GraphQL dependencies, required for streaming search.

- Move performance warning alert out of the infobar
- Always render calculations, evens if no results
- Fix duplicated quote warning and fix padding on it
- Fix height of infobar when there are no buttons
- Add more storybook tests for SearchResultsList to test alerts and infobar state

![image](https://user-images.githubusercontent.com/206864/99593713-f3693380-29a6-11eb-830b-5f919134d1a2.png)

