### PR TITLE
quick plural + caps cleanup

### DIFF
--- a/doc/extensions/authoring/creating.md
+++ b/doc/extensions/authoring/creating.md
@@ -52,7 +52,7 @@ For code layout, a single TypeScript/JavaScript file is usually all you'll need.
 
 #### README.md
 
-The `README.md` is the content for your extension page in the [extensions registry](https://sourcegraph.com/extensions). See the [Codecov extension](https://sourcegraph.com/extensions/sourcegraph/codecov) for a great example.
+The `README.md` is the content for your extension page in the [extension registry](https://sourcegraph.com/extensions). See the [Codecov extension](https://sourcegraph.com/extensions/sourcegraph/codecov) for a great example.
 
 #### package.json
 

--- a/doc/extensions/index.md
+++ b/doc/extensions/index.md
@@ -17,19 +17,19 @@ Sourcegraph extensions are like editor extensions, but run anywhere you view cod
 
 <div class="getting-started">
    <a href="usage" class="btn">
-   <span>Using Extensions</span>
+   <span>Using extensions</span>
    </br>
    How to enable extensions on Sourcegraph.
   </a>
 
   <a href="https://sourcegraph.com/extensions" class="btn">
-   <span>Extensions Registry</span>
+   <span>Extension registry</span>
    </br>
    Browse popular extensions like git extras, link previews, open-in-editor, Codecov, or Sonarqube.
   </a>
 
   <a href="security" class="btn">
-   <span>Security and Privacy</span>
+   <span>Security and privacy</span>
    </br>
     All the ways we protect the privacy of your code. 
   </a>

--- a/doc/extensions/security.md
+++ b/doc/extensions/security.md
@@ -14,4 +14,4 @@ We designed Sourcegraph extensions with security and privacy in mind:
 
 ## Additional Admin security features
 
-We offer admins the option to only allow pre-approved extensions, disallow all Sourcegraph.com extensions, or host a private extensions registry: [Administration of Sourcegraph extensions and the extension registry](../admin/extensions/index.md).
+We offer admins the option to only allow pre-approved extensions, disallow all Sourcegraph.com extensions, or host a private extension registry: [Administration of Sourcegraph extensions and the extension registry](../admin/extensions/index.md).


### PR DESCRIPTION
Mistakenly used plural for "extension registry" + a few sentence case errors. 