### PR TITLE
qa: allow local run with insiders

### DIFF
--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -17,7 +17,11 @@ cleanup() {
 trap cleanup EXIT
 
 # ==========================
-
+if [ "$VAGRANT_RUN_ENV" = "CI" ]; then
+  IMAGE=us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION
+else
+  IMAGE=sourcegraph/server:insiders
+fi
 CONTAINER=sourcegraph-server
 
 docker_logs() {
@@ -26,13 +30,7 @@ docker_logs() {
   chmod 744 $CONTAINER.log
 }
 
-if [ $VAGRANT_RUN_ENV = "CI" ]; then
-  IMAGE=us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION
-else
-  IMAGE=sourcegraph/server:insiders
-fi
-
-./dev/run-server-image.sh -d --name $CONTAINER
+$IMAGE ./dev/run-server-image.sh -d --name $CONTAINER
 trap docker_logs exit
 sleep 15
 

--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -26,7 +26,13 @@ docker_logs() {
   chmod 744 $CONTAINER.log
 }
 
-IMAGE=us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION ./dev/run-server-image.sh -d --name $CONTAINER
+if [ $VAGRANT_RUN_ENV = "CI" ]; then
+  IMAGE=us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION
+else
+  IMAGE=sourcegraph/server:insiders
+fi
+
+./dev/run-server-image.sh -d --name $CONTAINER
 trap docker_logs exit
 sleep 15
 


### PR DESCRIPTION
Adding this logic as it may sometimes we be useful to run these "locally" in a clean state without waiting for them to get to master. 

I used this during the development of all of this and given we don't have candidate image locally and don't want to always build from scratch this might work. 

If you think it's better to compile then feel free to let me know. 