### PR TITLE
Don't assume row element exists in LineDecorator

### DIFF
--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -66,29 +66,31 @@ export const LineDecorator = React.memo<LineDecoratorProps>(
             // Code view ref should always be set at this point
             if (codeViewReference.current) {
                 const codeCell = getCodeElementFromLineNumber(codeViewReference.current, line)
-                const row = codeCell?.parentElement as HTMLTableRowElement
+                const row = codeCell?.parentElement as HTMLTableRowElement | undefined
 
-                for (const decoration of decorations) {
-                    let decorated = false
-                    const style = decorationStyleForTheme(decoration, isLightTheme)
-                    if (style.backgroundColor) {
-                        row.style.backgroundColor = style.backgroundColor
-                        decorated = true
-                    }
-                    if (style.border) {
-                        row.style.border = style.border
-                        decorated = true
-                    }
-                    if (style.borderColor) {
-                        row.style.borderColor = style.borderColor
-                        decorated = true
-                    }
-                    if (style.borderWidth) {
-                        row.style.borderWidth = style.borderWidth
-                        decorated = true
-                    }
-                    if (decorated) {
-                        decoratedElements.push(row)
+                if (row) {
+                    for (const decoration of decorations) {
+                        let decorated = false
+                        const style = decorationStyleForTheme(decoration, isLightTheme)
+                        if (style.backgroundColor) {
+                            row.style.backgroundColor = style.backgroundColor
+                            decorated = true
+                        }
+                        if (style.border) {
+                            row.style.border = style.border
+                            decorated = true
+                        }
+                        if (style.borderColor) {
+                            row.style.borderColor = style.borderColor
+                            decorated = true
+                        }
+                        if (style.borderWidth) {
+                            row.style.borderWidth = style.borderWidth
+                            decorated = true
+                        }
+                        if (decorated) {
+                            decoratedElements.push(row)
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
We used to be able to make this assumption for the `Blob` class component.

When you navigate from a longer file to a shorter file when both blobs have been memoized, we set decorations on nonexistent lines.

![Screenshot from 2020-11-18 21-52-32](https://user-images.githubusercontent.com/37420160/99614881-6515a180-29e8-11eb-8ece-483cafd8df93.png)

Root cause is that the decorations array isn't reset when the `blobInfo` prop changes, but rather after the the latest decorations are fetched. We could just not think about this problem by keying `Blob` by uri. However, I think the new `Hoverifier` component will fix bugs caused by logic badly ported from class components. We'd also lose line decoration animations if we keyed `Blob`.