### PR TITLE
doc: flesh out user credential documentation

### DIFF
--- a/doc/campaigns/explanations/introduction_to_campaigns.md
+++ b/doc/campaigns/explanations/introduction_to_campaigns.md
@@ -57,3 +57,4 @@ To learn about the internals of campaigns, see [Campaigns](../../../dev/backgrou
 - Campaign steps are run locally (in the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli)). Sourcegraph does not yet support executing campaign steps on the server. For this reason, the APIs for creating and updating a campaign require you to upload all of the changeset specs (which are produced by executing the campaign spec locally). {#server-execution}
 - It is not yet possible for multiple users to edit the same campaign that was created under an organization.
 - It is not yet possible to reuse a branch in a repository across multiple campaigns.
+- The only type of user credential supported by Sourcegraph right now is a personal access token. Further credential types may be supported in the future.

--- a/doc/campaigns/explanations/permissions_in_campaigns.md
+++ b/doc/campaigns/explanations/permissions_in_campaigns.md
@@ -59,7 +59,7 @@ See these code host specific pages for which permissions and scopes the tokens r
 
 > NOTE: Site admins will fall back to using the Sourcegraph token for the code host if they have not added a personal access token. This makes it easier to try out campaigns, but be aware that this may result in changesets being created or changed with different permissions to your normal code host user.
 >
-> This does not affect non-admin users, who are unable to apply campaigns without configuring access tokens.
+> Non-admin users are unable to apply campaigns without configuring access tokens.
 
 ## Repository permissions for campaigns
 

--- a/doc/campaigns/explanations/permissions_in_campaigns.md
+++ b/doc/campaigns/explanations/permissions_in_campaigns.md
@@ -57,9 +57,11 @@ See these code host specific pages for which permissions and scopes the tokens r
 - [GitLab](../../../admin/external_service/gitlab.md#access-token-scopes)
 - [Bitbucket Server](../../../admin/external_service/gitlab.md#access-token-permissions)
 
-> NOTE: Site admins will fall back to using the Sourcegraph token for the code host if they have not added a personal access token. This makes it easier to try out campaigns, but be aware that this may result in changesets being created or changed with different permissions to your normal code host user.
->
-> Non-admin users are unable to apply campaigns without configuring access tokens.
+### Site admins
+
+Site admins will fall back to using the Sourcegraph token for the code host if they have not added a personal access token. This makes it easier to try out campaigns, but be aware that this may result in changesets being created or changed with different permissions to your normal code host user.
+
+Non-admin users are unable to apply campaigns without configuring access tokens.
 
 ## Repository permissions for campaigns
 

--- a/doc/campaigns/explanations/permissions_in_campaigns.md
+++ b/doc/campaigns/explanations/permissions_in_campaigns.md
@@ -42,12 +42,14 @@ All users are automatically given read permissions to a campaign. Granular permi
 
 ## Code host interactions in campaigns
 
-All interactions with the code host are performed by Sourcegraph with the token with which you configured the code host. These operations include:
+Interactions with the code host are performed by Sourcegraph with your personal access token for that code host. These operations include:
 
 - Pushing a branch with the changes (the Git author and committer will be you, and the Git push will be authenticated with your credentials)
 - Creating a changeset (e.g., on GitHub, the pull request author will be you)
 - Updating a changeset
 - Closing a changeset
+
+For instructions on adding and managing your code host access tokens, please refer to "[Configuring user credentials](../how-tos/configuring_user_credentials.md)".
 
 See these code host specific pages for which permissions and scopes the tokens require:
 
@@ -55,7 +57,9 @@ See these code host specific pages for which permissions and scopes the tokens r
 - [GitLab](../../../admin/external_service/gitlab.md#access-token-scopes)
 - [Bitbucket Server](../../../admin/external_service/gitlab.md#access-token-permissions)
 
-In the future you'll be able to perform all code host interactions with a separate access token or your personal code host account.
+> NOTE: Site admins will fall back to using the Sourcegraph token for the code host if they have not added a personal access token. This makes it easier to try out campaigns, but be aware that this may result in changesets being created or changed with different permissions to your normal code host user.
+>
+> This does not affect non-admin users, who are unable to apply campaigns without configuring access tokens.
 
 ## Repository permissions for campaigns
 

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -31,7 +31,7 @@ To add a token for a code host, click on the **Add token** button next to its na
 
 To create a personal access token for a specific code host provider, please refer to the relevant section for "[GitHub](#github)", "[GitLab](#gitlab)", or "[Bitbucket Server](#bitbucket-server)". Once you have a token, you should paste it into the Sourcegraph input shown above, and click **Add token**.
 
-> NOTE: See ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
+> NOTE: See ["Code host interactions in campaigns"](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
 
 Once this is done, Sourcegraph should indicate that you have a token with a green tick:
 

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -12,7 +12,7 @@ In order to [publish changesets with campaigns](publishing_changesets.md), you n
 
 ## Adding a personal access token
 
-Adding personal access tokens is done through the the Campaigns section of your user settings. To access this page, follow these instructions (also shown in the video below):
+Adding personal access tokens is done through the the Campaigns section of your user settings:
 
 1. From any Sourcegraph page, click on your avatar at the top right of the page.
 1. Select **Settings** from the dropdown menu.

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -4,8 +4,6 @@
 
 In order to [publish changesets with campaigns](publishing_changesets.md), you need to add a personal access token for each code host that your campaigns interact with. These tokens are used by Sourcegraph to create and manage changesets as you, and with your specific permissions, on the code host.
 
-> NOTE: The only type of user credential supported by Sourcegraph right now is a personal access token. Further credential types may be supported in the future.
-
 ## Requirements
 
 - Sourcegraph instance with repositories in it. See the "[Quickstart](../../index.md#quickstart)" guide on how to setup a Sourcegraph instance.

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -2,7 +2,7 @@
 
 > NOTE: This page describes functionality added in Sourcegraph 3.22. Older Sourcegraph versions only allow campaigns to be applied and managed by site admins.
 
-Before using campaigns, you need to add a personal access token for each code host that your campaigns interact with. These tokens are used by Sourcegraph to create and manage changesets as you, and with your specific permissions.
+In order to [publish changesets with campaigns](publishing_changesets.md), you need to add a personal access token for each code host that your campaigns interact with. These tokens are used by Sourcegraph to create and manage changesets as you, and with your specific permissions, on the code host.
 
 > NOTE: The only type of user credential supported by Sourcegraph right now is a personal access token. Further credential types may be supported in the future.
 

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -1,5 +1,81 @@
 # Configuring user credentials
 
-Sourcegraph 3.22 adds the ability for non-site-admin users to create and manage campaigns.
+> NOTE: This page describes functionality added in Sourcegraph 3.22. Older Sourcegraph versions only allow campaigns to be applied and managed by site admins.
 
-More information on doing this is coming soon!
+Before using campaigns, you need to add a personal access token for each code host that your campaigns interact with. These tokens are used by Sourcegraph to create and manage changesets as you, and with your specific permissions.
+
+> NOTE: The only type of user credential supported by Sourcegraph right now is a personal access token. Further credential types may be supported in the future.
+
+## Requirements
+
+- Sourcegraph instance with repositories in it. See the "[Quickstart](../../index.md#quickstart)" guide on how to setup a Sourcegraph instance.
+
+## Adding a personal access token
+
+Adding personal access tokens is done through the the Campaigns section of your user settings. To access this page, follow these instructions (also shown in the video below):
+
+1. From any Sourcegraph page, click on your avatar at the top right of the page.
+1. Select **Settings** from the dropdown menu.
+1. Click **Campaigns** on the sidebar menu.
+
+You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them.
+
+<video width="1920" height="1080" autoplay loop muted playsinline controls style="width: 100%; height: auto; max-width: 50rem">
+  <source src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.webm" type="video/webm">
+  <sourec src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.mp4" type="video/mp4">
+</video>
+
+To add a token for a code host, click on the **Add token** button next to its name. This will display an input modal like the following:
+
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-token-input.png" alt="An input dialog, titled &quot;Github campaigns token for https://github.com&quot;, with an input box to type or paste a token and a list of scopes that must be enabled on the token, which are repo, read:org, and read:discussion">
+
+To create a personal access token for a specific code host provider, please refer to the relevant section for "[GitHub](#github)", "[GitLab](#gitlab)", or "[Bitbucket Server](#bitbucket-server)". Once you have a token, you should paste it into the Sourcegraph input shown above, and click **Add token**.
+
+> NOTE: See ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
+
+Once this is done, Sourcegraph should indicate that you have a token with a green tick:
+
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/one-token.png" alt="A list of code hosts, with GitHub indicating that it has a token and the other hosts indicating that they do not">
+
+### GitHub
+
+In addition to the below, you should refer to [GitHub's documentation on creating a personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token).
+
+Sourcegraph requires the `repo`, `read:org`, and `read:discussion` scopes to be enabled on the user token. This is done by selecting the relevant checkboxes when creating the token:
+
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/github-token.png" alt="The GitHub token creation page, with the repo scope selected">
+
+### GitLab
+
+In addition to the below, you should refer to [GitLab's documentation on creating a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token).
+
+Sourcegraph requires the `api`, `read_repository`, and `write_repository` scopes to be enabled on the user token. This is done by selecting the relevant checkboxes when creating the token:
+
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/gitlab-token.png" alt="The GitLab token creation page, with the api, read_repository, and write_repository scopes selected">
+
+### Bitbucket Server
+
+In addition to the below, you should refer to [Bitbucket Server's documentation on creating a personal access token](https://confluence.atlassian.com/bitbucketserver0516/personal-access-tokens-966061199.html?utm_campaign=in-app-help&utm_medium=in-app-help&utm_source=stash#Personalaccesstokens-Generatingpersonalaccesstokens).
+
+Sourcegraph requires the access token to have the `write` permission on both projects and repositories. This is done by selecting the **Write** level in the **Projects** dropdown, and letting it be inherited by repositories:
+
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/bb-token.png" alt="The Bitbucket Server token creation page, with Write permissions selected on both the Project and Repository dropdowns">
+
+## Removing a personal access token
+
+Removing personal access tokens is done through the the Campaigns section of your user settings. To access this page, follow these instructions (also shown in the video below):
+
+1. From any Sourcegraph page, click on your avatar at the top right of the page.
+1. Select **Settings** from the dropdown menu.
+1. Click **Campaigns** on the sidebar menu.
+
+You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them.
+
+<video width="1920" height="1080" autoplay loop muted playsinline controls style="width: 100%; height: auto; max-width: 50rem">
+  <source src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.webm" type="video/webm">
+  <sourec src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.mp4" type="video/mp4">
+</video>
+
+To remove a personal access token for a code host, click **Remove** next to that code host. The code host's indicator will change to an empty red circle to indicate that no token is configured for that code host:
+
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/no-tokens.png" alt="A list of code hosts, with all code hosts indicating that they do not have a token">

--- a/doc/campaigns/how-tos/creating_a_campaign.md
+++ b/doc/campaigns/how-tos/creating_a_campaign.md
@@ -6,6 +6,7 @@ Campaigns are created by writing a [campaign spec](../references/campaign_spec_y
 
 - Sourcegraph instance with repositories in it. See the "[Quickstart](../../index.md#quickstart)" guide on how to setup a Sourcegraph instance.
 - Installed and configured [Sourcegraph CLI](https://github.com/sourcegraph/src-cli) (see "[Install the Sourcegraph CLI](../quickstart.md#install-the-sourcegraph-cli)" in the campaigns quickstart for detailed instructions).
+- Configured user credentials for the code host(s) that you'll be creating changesets on. See "[Configuring user credentials](configuring_user_credentials.md)" for a guide on how to add and manage your user credentials.
 
 ## Writing a campaign spec
 

--- a/doc/campaigns/how-tos/publishing_changesets.md
+++ b/doc/campaigns/how-tos/publishing_changesets.md
@@ -8,10 +8,12 @@ In order to create these changesets on the code hosts, you need to publish them.
 
 ## Requirements
 
-To publish a changeset, you need [admin permissions for the campaign](../explanations/permissions_in_campaigns.md#permission-levels-for-campaigns) and write access to the changeset's repository (on the code host). For more information, see [Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
+To publish a changeset, you need
+1. [admin permissions for the campaign](../explanations/permissions_in_campaigns.md#permission-levels-for-campaigns).
+1. write access to the changeset's repository (on the code host).
+1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_user_credentials.md).  
 
-You also need a personal access token configured in Sourcegraph for your code host(s). For more information, see "[Configuring user credentials](configuring_user_credentials.md)".
-
+For more information, see [Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
 [Forking the repository](../explanations/introduction_to_campaigns.md#known-issues) is not yet supported.
 
 ## Publishing changesets

--- a/doc/campaigns/how-tos/publishing_changesets.md
+++ b/doc/campaigns/how-tos/publishing_changesets.md
@@ -10,6 +10,8 @@ In order to create these changesets on the code hosts, you need to publish them.
 
 To publish a changeset, you need [admin permissions for the campaign](../explanations/permissions_in_campaigns.md#permission-levels-for-campaigns) and write access to the changeset's repository (on the code host). For more information, see [Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
 
+You also need a personal access token configured in Sourcegraph for your code host(s). For more information, see "[Configuring user credentials](configuring_user_credentials.md)".
+
 [Forking the repository](../explanations/introduction_to_campaigns.md#known-issues) is not yet supported.
 
 ## Publishing changesets

--- a/doc/campaigns/how-tos/publishing_changesets.md
+++ b/doc/campaigns/how-tos/publishing_changesets.md
@@ -14,7 +14,7 @@ To publish a changeset, you need:
 1. write access to the changeset's repository (on the code host), and
 1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_user_credentials.md).  
 
-For more information, see [Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
+For more information, see "[Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns)".
 [Forking the repository](../explanations/introduction_to_campaigns.md#known-issues) is not yet supported.
 
 ## Publishing changesets

--- a/doc/campaigns/how-tos/publishing_changesets.md
+++ b/doc/campaigns/how-tos/publishing_changesets.md
@@ -8,9 +8,10 @@ In order to create these changesets on the code hosts, you need to publish them.
 
 ## Requirements
 
-To publish a changeset, you need
-1. [admin permissions for the campaign](../explanations/permissions_in_campaigns.md#permission-levels-for-campaigns).
-1. write access to the changeset's repository (on the code host).
+To publish a changeset, you need:
+
+1. [admin permissions for the campaign](../explanations/permissions_in_campaigns.md#permission-levels-for-campaigns),
+1. write access to the changeset's repository (on the code host), and
 1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_user_credentials.md).  
 
 For more information, see [Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).

--- a/doc/campaigns/how-tos/site_admin_configuration.md
+++ b/doc/campaigns/how-tos/site_admin_configuration.md
@@ -4,7 +4,6 @@ Using campaigns requires a [code host connection](../../../admin/external_servic
 
 Site admins can also:
 
-- [Allow users to authenticate via the code host](../../../admin/auth/index.md#github), which makes it easier for users to authorize [code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
 - [Configure repository permissions](../../../admin/repo/permissions.md), which campaigns will respect.
 - [Disable campaigns](../explanations/permissions_in_campaigns.md#disabling-campaigns).
 - [Disable campaigns for non-site-admin users](../explanations/permissions_in_campaigns.md#disabling-campaigns-for-non-site-admin-users).

--- a/doc/campaigns/how-tos/updating_a_campaign.md
+++ b/doc/campaigns/how-tos/updating_a_campaign.md
@@ -8,9 +8,13 @@ When a new campaign spec is applied to an existing campaign the existing campaig
 
 ## Requirements 
 
-To update a campaign, you need [admin access to the campaign](../explanations/permissions_in_campaigns.md#campaign-access-for-each-permission-level), and, if you want to [publish changesets](publishing_changesets.md) in the campaign, [write access to all affected repositories](../explanations/permissions_in_campaigns.md#repository-permissions-for-campaigns) with published changesets.
+To update a changeset, you need:
 
-You also need a personal access token configured in Sourcegraph for your code host(s). For more information, see "[Configuring user credentials](configuring_user_credentials.md)".
+1. [admin permissions for the campaign](../explanations/permissions_in_campaigns.md#permission-levels-for-campaigns),
+1. write access to the changeset's repository (on the code host), and
+1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_user_credentials.md).
+
+For more information, see [Code host interactions in campaigns](../explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns).
 
 ## Preview and apply a new campaign spec
 

--- a/doc/campaigns/how-tos/updating_a_campaign.md
+++ b/doc/campaigns/how-tos/updating_a_campaign.md
@@ -10,6 +10,8 @@ When a new campaign spec is applied to an existing campaign the existing campaig
 
 To update a campaign, you need [admin access to the campaign](../explanations/permissions_in_campaigns.md#campaign-access-for-each-permission-level), and, if you want to [publish changesets](publishing_changesets.md) in the campaign, [write access to all affected repositories](../explanations/permissions_in_campaigns.md#repository-permissions-for-campaigns) with published changesets.
 
+You also need a personal access token configured in Sourcegraph for your code host(s). For more information, see "[Configuring user credentials](configuring_user_credentials.md)".
+
 ## Preview and apply a new campaign spec
 
 In order to update a campaign after previewing the changes, do the following:

--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -86,6 +86,7 @@ Create a campaign by specifying a search query to get a list of repositories and
 - [Tracking existing changesets](how-tos/tracking_existing_changesets.md)
 - [Closing or deleting a campaign](how-tos/closing_or_deleting_a_campaign.md)
 - [Site admin configuration for campaigns](how-tos/site_admin_configuration.md)
+- [Configuring user credentials for campaigns](how-tos/configuring_user_credentials.md)
 
 ## Tutorials
 

--- a/doc/campaigns/quickstart.md
+++ b/doc/campaigns/quickstart.md
@@ -114,9 +114,9 @@ To add a personal access token:
 
 The red circle next to the code host will now change to a green tick. Sourcegraph has everything it needs to publish changesets to that code host!
 
-### Publishing a campaign
+### Publishing changesets
 
-Now that you have credentials set up, you can publish the campaign. On a real campaign, you would do the following:
+Now that you have credentials set up, you can publish the changesets in the campaign. On a real campaign, you would do the following:
 
 1. Change the `published: false` in `hello-world.campaign.yaml` to `published: true`.
     <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaign_publish_true.png" class="screenshot">

--- a/doc/campaigns/quickstart.md
+++ b/doc/campaigns/quickstart.md
@@ -10,23 +10,6 @@ The only requirement is a Sourcegraph instance with a some repositories in it. S
 
 For more information about campaigns see the ["Campaigns"](index.md) documentation and watch the [campaigns demo video](https://www.youtube.com/watch?v=EfKwKFzOs3E).
 
-## Configure code host credentials
-
-Campaigns need write permissions for the repositories in which you want to make changes. You'll need to add a personal access token for each code host you'll be publishing changesets on.
-
-See "[Configuring user credentials](how-tos/configuring_user_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
-
-To add a personal access token:
-
-1. From any Sourcegraph page, click on your avatar at the top right of the page.
-1. Select **Settings** from the dropdown menu.
-1. Click **Campaigns** on the sidebar menu.
-1. Click **Add token** next to the code host you want to configure.
-1. Go to the code host and create a personal access token with the exact scopes or permissions required, which are noted below the token text field. For more provider-specific detail, please refer to "[GitHub](how-tos/configuring_user_credentials.md#github)", "[GitLab](how-tos/configuring_user_credentials.md#gitlab)", or "[Bitbucket Server](how-tos/configuring_user_credentials.md#bitbucket-server)".
-1. Click **Add token** to save the token.
-
-The red circle next to the code host will now change to a green tick. Sourcegraph has everything it needs to publish changesets to that code host!
-
 ## Install the Sourcegraph CLI
 
 In order to create campaigns we need to [install the Sourcegraph CLI](https://github.com/sourcegraph/src-cli) (`src`).
@@ -114,7 +97,26 @@ Publishing causes commits, branches, and pull requests/merge requests to be crea
 
 _You probably don't want to publish these toy "Hello World" changesets to actively developed repositories, because that might confuse people ("Why did you add this line to our READMEs?")._
 
-On a real campaign, you would do the following:
+### Configure code host credentials
+
+Since campaigns need write permissions to open changesets, you'll need to add a personal access token for each code host you'll be publishing changesets on. This is a one time operation that you don't need to do for each campaign.
+
+See "[Configuring user credentials](how-tos/configuring_user_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
+
+To add a personal access token:
+
+1. From any Sourcegraph page, click on your avatar at the top right of the page.
+1. Select **Settings** from the dropdown menu.
+1. Click **Campaigns** on the sidebar menu.
+1. Click **Add token** next to the code host you want to configure.
+1. Go to the code host and create a personal access token with the exact scopes or permissions required, which are noted below the token text field. For more provider-specific detail, please refer to "[GitHub](how-tos/configuring_user_credentials.md#github)", "[GitLab](how-tos/configuring_user_credentials.md#gitlab)", or "[Bitbucket Server](how-tos/configuring_user_credentials.md#bitbucket-server)".
+1. Click **Add token** to save the token.
+
+The red circle next to the code host will now change to a green tick. Sourcegraph has everything it needs to publish changesets to that code host!
+
+### Publishing a campaign
+
+Now that you have credentials set up, you can publish the campaign. On a real campaign, you would do the following:
 
 1. Change the `published: false` in `hello-world.campaign.yaml` to `published: true`.
     <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaign_publish_true.png" class="screenshot">

--- a/doc/campaigns/quickstart.md
+++ b/doc/campaigns/quickstart.md
@@ -12,7 +12,7 @@ For more information about campaigns see the ["Campaigns"](index.md) documentati
 
 ## Configure code host credentials
 
-Campaigns need write permissions for the repositories in which you want to make changes. You'll need to add a personal access token for each code host you'll be creating changesets on.
+Campaigns need write permissions for the repositories in which you want to make changes. You'll need to add a personal access token for each code host you'll be publishing changesets on.
 
 See "[Configuring user credentials](how-tos/configuring_user_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
 

--- a/doc/campaigns/quickstart.md
+++ b/doc/campaigns/quickstart.md
@@ -10,17 +10,22 @@ The only requirement is a Sourcegraph instance with a some repositories in it. S
 
 For more information about campaigns see the ["Campaigns"](index.md) documentation and watch the [campaigns demo video](https://www.youtube.com/watch?v=EfKwKFzOs3E).
 
-## Configure code host connections
+## Configure code host credentials
 
-Campaigns need write permissions for the repositories in which you want to make changes.
+Campaigns need write permissions for the repositories in which you want to make changes. You'll need to add a personal access token for each code host you'll be creating changesets on.
 
-Configure your code host connections to have the right permissions for campaigns:
+See "[Configuring user credentials](how-tos/configuring_user_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
 
-- `repo`, `read:org`, and `read:discussion` (see [GitHub api token and access](../../admin/external_service/github.md#github-api-token-and-access) )
-- `api`, `read_repository`, `write_repository` (see [GitLab access token scopes](../../admin/external_service/gitlab.md#access-token-scopes))
-- **write** permissions on the project and repository level (see [Bitbucket Server access token permissions](../../admin/external_service/bitbucket_server.md#access-token-permissions))
+To add a personal access token:
 
-See ["Code host interactions in campaigns"](explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns) for details on what the permissions are used for.
+1. From any Sourcegraph page, click on your avatar at the top right of the page.
+1. Select **Settings** from the dropdown menu.
+1. Click **Campaigns** on the sidebar menu.
+1. Click **Add token** next to the code host you want to configure.
+1. Go to the code host and create a personal access token with the exact scopes or permissions required, which are noted below the token text field. For more provider-specific detail, please refer to "[GitHub](how-tos/configuring_user_credentials.md#github)", "[GitLab](how-tos/configuring_user_credentials.md#gitlab)", or "[Bitbucket Server](how-tos/configuring_user_credentials.md#bitbucket-server)".
+1. Click **Add token** to save the token.
+
+The red circle next to the code host will now change to a green tick. Sourcegraph has everything it needs to publish changesets to that code host!
 
 ## Install the Sourcegraph CLI
 


### PR DESCRIPTION
This PR adds documentation for creating and removing user credentials in Sourcegraph. I've also tried to plumb this through where it makes sense in the campaigns documentation, but I'm sure I've missed places.

The rendered documentation is at https://docs.sourcegraph.com/@aharvey-user-token-docs/. The most interesting page is probably the new https://docs.sourcegraph.com/@aharvey-user-token-docs/campaigns/how-tos/configuring_user_credentials, which is full of screenshots and videos. (Well, OK, the same video twice. Close enough.)

Fixes #15312.