### PR TITLE
search frontend: structural search highlighting (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/scanner.ts
+++ b/client/shared/src/search/parser/scanner.ts
@@ -550,7 +550,18 @@ export const scanSearchQuery = (
     interpretComments?: boolean,
     searchPatternType = SearchPatternType.literal
 ): ScanResult<Token[]> => {
-    const patternKind = searchPatternType === SearchPatternType.regexp ? PatternKind.Regexp : PatternKind.Literal
+    let patternKind
+    switch (searchPatternType) {
+        case SearchPatternType.literal:
+            patternKind = PatternKind.Literal
+            break
+        case SearchPatternType.regexp:
+            patternKind = PatternKind.Regexp
+            break
+        case SearchPatternType.structural:
+            patternKind = PatternKind.Structural
+            break
+    }
     const scanner = createScanner(patternKind, interpretComments)
     return scanner(query, 0)
 }

--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -679,4 +679,97 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('decorate structural holes', () => {
+        expect(
+            getMonacoTokens(
+                toSuccess(scanSearchQuery('r:foo Search(thing::[x], :[y])', false, SearchPatternType.structural)),
+                true
+            )
+        ).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 23,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 25,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 29,
+                "scopes": "identifier"
+              }
+            ]
+        `)
+    })
+
+    test('decorate structural holes with valid inlined regexp', () => {
+        expect(
+            getMonacoTokens(toSuccess(scanSearchQuery('r:foo a:[x~[\\]]]b', false, SearchPatternType.structural)), true)
+        ).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "identifier"
+              }
+            ]
+        `)
+    })
 })

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -46,6 +46,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'regexpMetaCharacterClass', foreground: '#da77f2' },
         { token: 'regexpMetaRangeQuantifier', foreground: '#3bc9db' },
         { token: 'regexpMetaAlternative', foreground: '#3bc9db' },
+        // Structural pattern highlighting
+        { token: 'structuralMetaHole', foreground: '#ff6b6b' },
     ],
 })
 
@@ -83,6 +85,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'regexpMetaCharacterClass', foreground: '#ae3ec9' },
         { token: 'regexpMetaRangeQuantifier', foreground: '#1098ad' },
         { token: 'regexpMetaAlternative', foreground: '#1098ad' },
+        // Structural pattern highlighting
+        { token: 'structuralMetaHole', foreground: '#c92a2a' },
     ],
 })
 


### PR DESCRIPTION
Adds the basic tokenzier and highlighting for structural search. I really wanted to do this recursively but (a) more than that I want this highlighting to ship and (b) it's kind of a pain if I can't pattern match on lists anyway. So instead I based this implementation off [a backend function that's already battle-tested](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_structural.go#L58), so feel good about it.

<img width="468" alt="Screen Shot 2020-11-18 at 9 32 08 PM" src="https://user-images.githubusercontent.com/888624/99621600-8d4fd100-29e5-11eb-93f1-0ed89d996290.png">

`tokens.ts` is getting large, I will split it into respective decorated patterns later.

More refinements to come.

