### PR TITLE
search frontend: structural ellipses highlighting (smartQuery flag)

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -772,4 +772,103 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('decorate structural hole ... alias', () => {
+        expect(
+            getMonacoTokens(
+                toSuccess(scanSearchQuery('r:foo a...b...c....', false, SearchPatternType.structural)),
+                true
+            )
+        ).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "identifier"
+              }
+            ]
+        `)
+    })
+    test('decorate structural hole ... alias', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:foo ...:...', false, SearchPatternType.structural)), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "filterKeyword"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "structuralMetaHole"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "structuralMetaHole"
+              }
+            ]
+        `)
+    })
 })


### PR DESCRIPTION
Stacked on #15958.

Highlights the `...`s

<img width="289" alt="Screen Shot 2020-11-18 at 11 29 52 PM" src="https://user-images.githubusercontent.com/888624/99629869-05be8e00-29f6-11eb-9542-836b07e218c8.png">
