### PR TITLE
code-intel-worker: remove unnecessary init for authz

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -114,6 +114,7 @@ func mustInitializeDB() *sql.DB {
 	//
 	// START FLAILING
 
+	ctx := context.Background()
 	go func() {
 		for range time.NewTicker(5 * time.Second).C {
 			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices)

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	eauthz "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/worker"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -115,11 +115,6 @@ func mustInitializeDB() *sql.DB {
 	//
 	// START FLAILING
 
-	// TODO(efritz) - rearrange the authz packages so we don't have to import from frontend
-	ctx := context.Background()
-	var msResolutionClock = func() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }
-	eauthz.Init(dbconn.Global, msResolutionClock)
-
 	go func() {
 		for range time.NewTicker(5 * time.Second).C {
 			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices)


### PR DESCRIPTION
These lines are only useful for frontend as they generate graphql-level alerts for site admins.

Follow up of #15755