### PR TITLE
search: align signatures of Create- & UpdateCodeMonitors

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -98,9 +98,11 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
                     tap(event => event.preventDefault()),
                     mergeMap(() =>
                         createCodeMonitor({
-                            namespace: props.authenticatedUser.id,
-                            description: codeMonitor.description,
-                            enabled: codeMonitor.enabled,
+                            monitor: {
+                                namespace: props.authenticatedUser.id,
+                                description: codeMonitor.description,
+                                enabled: codeMonitor.enabled,
+                            },
                             trigger: { query: codeMonitor.query },
                             actions: [
                                 {

--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -11,36 +11,24 @@ import {
 } from '../../graphql-operations'
 
 export const createCodeMonitor = ({
-    namespace,
-    description,
-    enabled,
+    monitor,
     trigger,
     actions,
 }: CreateCodeMonitorVariables): Observable<CreateCodeMonitorResult['createCodeMonitor']> => {
     const query = gql`
         mutation CreateCodeMonitor(
-            $namespace: ID!
-            $description: String!
-            $enabled: Boolean!
+            $monitor: MonitorInput!
             $trigger: MonitorTriggerInput!
             $actions: [MonitorActionInput!]!
         ) {
-            createCodeMonitor(
-                namespace: $namespace
-                description: $description
-                enabled: $enabled
-                trigger: $trigger
-                actions: $actions
-            ) {
+            createCodeMonitor(monitor: $monitor, trigger: $trigger, actions: $actions) {
                 description
             }
         }
     `
 
     return requestGraphQL<CreateCodeMonitorResult, CreateCodeMonitorVariables>(query, {
-        namespace,
-        description,
-        enabled,
+        monitor,
         trigger,
         actions,
     }).pipe(

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -123,11 +123,9 @@ type ListRecipientsArgs struct {
 }
 
 type CreateCodeMonitorArgs struct {
-	Namespace   graphql.ID
-	Description string
-	Enabled     bool
-	Trigger     *CreateTriggerArgs
-	Actions     []*CreateActionArgs
+	Monitor *CreateMonitorArgs
+	Trigger *CreateTriggerArgs
+	Actions []*CreateActionArgs
 }
 
 type CreateTriggerArgs struct {
@@ -154,7 +152,7 @@ type DeleteCodeMonitorArgs struct {
 	Id graphql.ID
 }
 
-type MonitorArgs struct {
+type CreateMonitorArgs struct {
 	Namespace   graphql.ID
 	Description string
 	Enabled     bool
@@ -176,7 +174,7 @@ type EditTriggerArgs struct {
 
 type EditMonitorArgs struct {
 	Id     graphql.ID
-	Update *MonitorArgs
+	Update *CreateMonitorArgs
 }
 
 type UpdateCodeMonitorArgs struct {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -750,18 +750,9 @@ type Mutation {
     """
     createCodeMonitor(
         """
-        The namespace represents the owner of the code monitor.
-        Owners can either be users or organizations.
+        A monitor.
         """
-        namespace: ID!
-        """
-        A meaningful description of the code monitor.
-        """
-        description: String!
-        """
-        Whether the code monitor is enabled or not.
-        """
-        enabled: Boolean!
+        monitor: MonitorInput!
         """
         A trigger.
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -743,18 +743,9 @@ type Mutation {
     """
     createCodeMonitor(
         """
-        The namespace represents the owner of the code monitor.
-        Owners can either be users or organizations.
+        A monitor.
         """
-        namespace: ID!
-        """
-        A meaningful description of the code monitor.
-        """
-        description: String!
-        """
-        Whether the code monitor is enabled or not.
-        """
-        enabled: Boolean!
+        monitor: MonitorInput!
         """
         A trigger.
         """

--- a/enterprise/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/internal/codemonitors/resolvers/main_test.go
@@ -94,11 +94,13 @@ func (r *Resolver) insertTestMonitorWithOpts(ctx context.Context, t *testing.T, 
 		opt.apply(&options)
 	}
 	return r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
-		Namespace:   options.owner,
-		Description: "test monitor",
-		Enabled:     true,
-		Trigger:     &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
-		Actions:     options.actions,
+		Monitor: &graphqlbackend.CreateMonitorArgs{
+			Namespace:   options.owner,
+			Description: "test monitor",
+			Enabled:     true,
+		},
+		Trigger: &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
+		Actions: options.actions,
 	})
 }
 


### PR DESCRIPTION
UpdateCodeMonitor has a much nicer signature than CreateCodeMonitor.
So, while it is still easy to do, we should change the signature of
CreateCodeMonitor and align it with that of UpdateCodeMonitor.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
