### PR TITLE
search: disable nginx buffering for streaming search

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -377,6 +377,12 @@ func newEventStreamWriter(w http.ResponseWriter) (*eventStreamWriter, error) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+
+	// This informs nginx to not buffer. With buffering search responses will
+	// be delayed until buffers get full, leading to worst case latency of the
+	// full time a search takes to complete.
+	w.Header().Set("X-Accel-Buffering", "no")
 
 	return &eventStreamWriter{
 		w:     w,


### PR DESCRIPTION
This was a fun one to track down. Nginx buffers responses before passing
them on. There is a header you can set on a response to disable this
behaviour. Before this change streaming search would often only see the
first result once the full search had been complete. Now results are
shown as soon as they are found.