### PR TITLE
search frontend: correct highlight for filter values with parens

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -558,11 +558,23 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 5,
+                "scopes": "regexpMetaDelimited"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "regexpMetaAlternative"
+              },
+              {
+                "startIndex": 8,
                 "scopes": "identifier"
               },
               {
                 "startIndex": 9,
-                "scopes": "closingParen"
+                "scopes": "regexpMetaDelimited"
               },
               {
                 "startIndex": 10,


### PR DESCRIPTION
Stacked on #15965.

Previously, highlighting borked for things like so:


<img width="390" alt="Screen Shot 2020-11-19 at 2 14 42 AM" src="https://user-images.githubusercontent.com/888624/99646227-76bd7000-2a0d-11eb-964c-362bf738c947.png">


This because we placed higher precedence on identifying parens as part of a group (purple parens) than a term like a regular expression group (red parens).

With this PR, the fix correctly highlights regexp filters like `repo` and `repohasfile` with paren values:

<img width="394" alt="Screen Shot 2020-11-19 at 2 13 58 AM" src="https://user-images.githubusercontent.com/888624/99646217-745b1600-2a0d-11eb-95b3-25c3e0b8e61d.png">

The fix is to put higher precedence on first identifying filter values as being, e.g., balanced regex expressions (we do the same in the backend). The motivation of the change in #15965 makes this fix straightforward: use the `scanBalancedLiteral` scanner for the values of filters. This is a one line change, the rest of the diff is just moving the function around (needed define before use) and updating an existing test to cover this behavior.