### PR TITLE
timeutil: add Now function to truncate microsecond

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -12,10 +12,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	eauthz.Init(dbconn.Global, msResolutionClock)
+	eauthz.Init(dbconn.Global, timeutil.Now)
 
 	go func() {
 		t := time.NewTicker(5 * time.Second)
@@ -26,9 +27,7 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		}
 	}()
 
-	enterpriseServices.AuthzResolver = resolvers.NewResolver(dbconn.Global, msResolutionClock)
+	enterpriseServices.AuthzResolver = resolvers.NewResolver(dbconn.Global, timeutil.Now)
 
 	return nil
 }
-
-var msResolutionClock = func() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/gqltesting"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -24,13 +25,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var now = time.Now().Truncate(time.Microsecond).UnixNano()
+var now = timeutil.Now().UnixNano()
 
 func clock() time.Time {
-	return time.Unix(0, atomic.LoadInt64(&now)).Truncate(time.Microsecond)
+	return time.Unix(0, atomic.LoadInt64(&now))
 }
 
 var (

--- a/enterprise/cmd/repo-updater/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/authz/integration_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	extsvcGitHub "github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 var updateRegex = flag.String("update", "", "Update testdata of tests matching the given regex")
@@ -69,15 +69,11 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	testDB := dbtest.NewDB(t, *dsn)
 	ctx := context.Background()
 
-	clock := func() time.Time {
-		return time.Now().UTC().Truncate(time.Microsecond)
-	}
-
 	reposStore := repos.NewDBStore(testDB, sql.TxOptions{})
 
 	svc := repos.ExternalService{
 		Kind:      extsvc.KindGitHub,
-		CreatedAt: clock(),
+		CreatedAt: timeutil.Now(),
 		Config:    `{"url": "https://github.com", "authorization": {}}`,
 	}
 	err = reposStore.UpsertExternalServices(ctx, &svc)
@@ -125,8 +121,8 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	permsStore := edb.NewPermsStore(testDB, clock)
-	syncer := NewPermsSyncer(reposStore, permsStore, clock, nil)
+	permsStore := edb.NewPermsStore(testDB, timeutil.Now)
+	syncer := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
 
 	err = syncer.syncRepoPerms(ctx, repo.ID, false)
 	if err != nil {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestPermsSyncer_ScheduleUsers(t *testing.T) {
@@ -137,11 +138,8 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 			return []*repos.Repo{{ID: 1}}, nil
 		},
 	}
-	clock := func() time.Time {
-		return time.Now().UTC().Truncate(time.Microsecond)
-	}
-	permsStore := edb.NewPermsStore(nil, clock)
-	s := NewPermsSyncer(reposStore, permsStore, clock, nil)
+	permsStore := edb.NewPermsStore(nil, timeutil.Now)
+	s := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
 
 	tests := []struct {
 		name     string
@@ -173,11 +171,8 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 }
 
 func TestPermsSyncer_syncRepoPerms(t *testing.T) {
-	clock := func() time.Time {
-		return time.Now().UTC().Truncate(time.Microsecond)
-	}
 	newPermsSyncer := func(reposStore repos.Store) *PermsSyncer {
-		return NewPermsSyncer(reposStore, edb.NewPermsStore(nil, clock), clock, nil)
+		return NewPermsSyncer(reposStore, edb.NewPermsStore(nil, timeutil.Now), timeutil.Now, nil)
 	}
 
 	t.Run("TouchRepoPermissions is called when no authz provider", func(t *testing.T) {

--- a/enterprise/internal/campaigns/counts_test.go
+++ b/enterprise/internal/campaigns/counts_test.go
@@ -5,16 +5,18 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestCalcCounts(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 	daysAgo := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
 	tests := []struct {

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
-
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -31,10 +32,8 @@ func TestReconcilerProcess(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := NewStoreWithClock(dbconn.Global, clock)
 
 	admin := createTestUser(ctx, t)
@@ -1192,10 +1191,8 @@ func TestDecorateChangesetBody(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := NewStoreWithClock(dbconn.Global, clock)
 
 	admin := createTestUser(ctx, t)

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
@@ -16,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestCampaignResolver(t *testing.T) {
@@ -33,10 +35,8 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := ee.NewStoreWithClock(dbconn.Global, clock)
 
 	campaignSpec := &campaigns.CampaignSpec{

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -18,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestChangesetEventConnectionResolver(t *testing.T) {
@@ -30,10 +32,8 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	userID := insertTestUser(t, dbconn.Global, "changeset-event-connection-resolver", true)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := ee.NewStoreWithClock(dbconn.Global, clock)
 	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -17,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestChangesetResolver(t *testing.T) {
@@ -29,8 +31,8 @@ func TestChangesetResolver(t *testing.T) {
 
 	userID := insertTestUser(t, dbconn.Global, "campaign-resolver", true)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time { return now.UTC().Truncate(time.Microsecond) }
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := ee.NewStoreWithClock(dbconn.Global, clock)
 	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/campaignutils/overridable"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
@@ -25,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestNullIDResilience(t *testing.T) {
@@ -275,10 +278,8 @@ func TestApplyCampaign(t *testing.T) {
 
 	userID := insertTestUser(t, dbconn.Global, "apply-campaign", true)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := ee.NewStoreWithClock(dbconn.Global, clock)
 	reposStore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 

--- a/enterprise/internal/campaigns/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service_apply_campaign_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestServiceApplyCampaign(t *testing.T) {
@@ -42,10 +43,8 @@ func TestServiceApplyCampaign(t *testing.T) {
 
 	repos, _ := ct.CreateTestRepos(t, ctx, dbconn.Global, 4)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	store := NewStoreWithClock(dbconn.Global, clock)
 	svc := NewService(store, httpcli.NewExternalHTTPClientFactory())
 

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
@@ -23,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func init() {
@@ -195,7 +197,7 @@ func TestService(t *testing.T) {
 		t.Fatal("user is admin, want non-admin")
 	}
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 	clock := func() time.Time { return now }
 
 	store := NewStoreWithClock(dbconn.Global, clock)

--- a/enterprise/internal/campaigns/state_test.go
+++ b/enterprise/internal/campaigns/state_test.go
@@ -6,16 +6,18 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestComputeGithubCheckState(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 	commitEvent := func(minutesSinceSync int, context, state string) *cmpgn.ChangesetEvent {
 		commit := &github.CommitStatus{
 			Context:    context,
@@ -161,7 +163,7 @@ func TestComputeGithubCheckState(t *testing.T) {
 }
 
 func TestComputeBitbucketBuildStatus(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 	sha := "abcdef"
 	statusEvent := func(minutesSinceSync int, key, state string) *cmpgn.ChangesetEvent {
 		commit := &bitbucketserver.CommitStatus{
@@ -400,7 +402,7 @@ func TestComputeGitLabCheckState(t *testing.T) {
 }
 
 func TestComputeReviewState(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 	daysAgo := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
 	tests := []struct {
@@ -545,7 +547,7 @@ func TestComputeReviewState(t *testing.T) {
 }
 
 func TestComputeExternalState(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 	daysAgo := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
 	tests := []struct {

--- a/enterprise/internal/campaigns/store.go
+++ b/enterprise/internal/campaigns/store.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 // seededRand is used to populate the RandID fields on CampaignSpec and
@@ -30,9 +32,7 @@ type Store struct {
 
 // NewStore returns a new Store backed by the given db.
 func NewStore(db dbutil.DB) *Store {
-	return NewStoreWithClock(db, func() time.Time {
-		return time.Now().UTC().Truncate(time.Microsecond)
-	})
+	return NewStoreWithClock(db, timeutil.Now)
 }
 
 // NewStoreWithClock returns a new Store backed by the given db and

--- a/enterprise/internal/campaigns/store_test.go
+++ b/enterprise/internal/campaigns/store_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 type clock interface {
@@ -28,7 +29,7 @@ type storeTestFunc func(*testing.T, context.Context, *Store, repos.Store, clock)
 // dependencies are set up and injected into the storeTestFunc.
 func storeTest(db *sql.DB, f storeTestFunc) func(*testing.T) {
 	return func(t *testing.T) {
-		c := &testClock{t: time.Now().UTC().Truncate(time.Microsecond)}
+		c := &testClock{t: timeutil.Now()}
 
 		// Store tests all run in a transaction that's rolled back at the end
 		// of the tests, so that foreign key constraints can be deferred and we

--- a/enterprise/internal/campaigns/webhooks_gitlab_test.go
+++ b/enterprise/internal/campaigns/webhooks_gitlab_test.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -842,7 +843,7 @@ func (nntx *noNestingTx) BeginTx(ctx context.Context, opts *sql.TxOptions) error
 // Any changes made to the stores will be rolled back after the test is
 // complete.
 func gitLabTestSetup(t *testing.T, db *sql.DB) (*Store, repos.Store, clock) {
-	c := &testClock{t: time.Now().UTC().Truncate(time.Microsecond)}
+	c := &testClock{t: timeutil.Now()}
 	tx := dbtest.NewTx(t, db)
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +21,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -29,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -37,7 +39,7 @@ var update = flag.Bool("update", false, "update testdata")
 // Run from integration_test.go
 func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 	return func(t *testing.T) {
-		now := time.Now().UTC().Truncate(time.Microsecond)
+		now := timeutil.Now()
 		clock := func() time.Time { return now }
 
 		ctx := context.Background()
@@ -210,7 +212,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 // Run from integration_test.go
 func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 	return func(t *testing.T) {
-		now := time.Now().UTC().Truncate(time.Microsecond)
+		now := timeutil.Now()
 		clock := func() time.Time { return now }
 
 		ctx := context.Background()

--- a/enterprise/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/internal/codemonitors/resolvers/main_test.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
@@ -61,10 +63,8 @@ func (r *Resolver) insertTestMonitor(ctx context.Context, t *testing.T, owner gr
 func newTestResolver(t *testing.T) *Resolver {
 	t.Helper()
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	clock := func() time.Time {
-		return now.UTC().Truncate(time.Microsecond)
-	}
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
 	return newResolverWithClock(dbconn.Global, clock).(*Resolver)
 }
 

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func cleanupPermsTables(t *testing.T, s *PermsStore) {
@@ -52,10 +53,10 @@ func toBitmap(ids ...uint32) *roaring.Bitmap {
 	return bm
 }
 
-var now = time.Now().Truncate(time.Microsecond).UnixNano()
+var now = timeutil.Now().UnixNano()
 
 func clock() time.Time {
-	return time.Unix(0, atomic.LoadInt64(&now)).Truncate(time.Microsecond)
+	return time.Unix(0, atomic.LoadInt64(&now))
 }
 
 func testPermsStore_LoadUserPermissions(db *sql.DB) func(*testing.T) {
@@ -648,9 +649,9 @@ func testPermsStore_SetRepoPermissions(db *sql.DB) func(*testing.T) {
 
 func testPermsStore_TouchRepoPermissions(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
-		now := time.Now().Truncate(time.Microsecond).Unix()
+		now := timeutil.Now().Unix()
 		s := NewPermsStore(db, func() time.Time {
-			return time.Unix(atomic.LoadInt64(&now), 0).Truncate(time.Microsecond)
+			return time.Unix(atomic.LoadInt64(&now), 0)
 		})
 		t.Cleanup(func() {
 			cleanupPermsTables(t, s)

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -8,12 +8,14 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -346,7 +348,7 @@ func (c *Changeset) Body() (string, error) {
 // SetDeleted sets the internal state of a Changeset so that its State is
 // ChangesetStateDeleted.
 func (c *Changeset) SetDeleted() {
-	c.ExternalDeletedAt = time.Now().UTC().Truncate(time.Microsecond)
+	c.ExternalDeletedAt = timeutil.Now()
 }
 
 // IsDeleted returns true when the Changeset's ExternalDeletedAt is a non-zero

--- a/internal/campaigns/changeset_test.go
+++ b/internal/campaigns/changeset_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestChangeset_DiffStat(t *testing.T) {
@@ -493,7 +495,7 @@ func TestChangeset_Labels(t *testing.T) {
 }
 
 func TestChangesetMetadata(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := timeutil.Now()
 
 	githubActor := github.Actor{
 		AvatarURL: "https://avatars2.githubusercontent.com/u/1185253",

--- a/internal/db/event_logs_test.go
+++ b/internal/db/event_logs_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/types"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
@@ -687,7 +688,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 
 	t.Run("with existing pings in database", func(t *testing.T) {
 		userID := int32(0)
-		timestamp := time.Now().UTC().Truncate(time.Microsecond)
+		timestamp := timeutil.Now()
 
 		ctx := context.Background()
 		events := []*Event{

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
@@ -26,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/secret"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -461,7 +461,7 @@ func (e *ExternalServiceStore) Create(ctx context.Context, confGet func() *conf.
 		return err
 	}
 
-	es.CreatedAt = time.Now().UTC().Truncate(time.Microsecond)
+	es.CreatedAt = timeutil.Now()
 	es.UpdatedAt = es.CreatedAt
 
 	// Prior to saving the record, run a validation hook.

--- a/internal/timeutil/clock.go
+++ b/internal/timeutil/clock.go
@@ -1,0 +1,13 @@
+package timeutil
+
+import (
+	"time"
+)
+
+// Now returns the current UTC time with time.Microsecond truncated
+// because Postgres 9.6 does not support saving microsecond. This is
+// particularly useful when trying to compare time values between Go
+// and what we get back from the Postgres.
+func Now() time.Time {
+	return time.Now().UTC().Truncate(time.Microsecond)
+}


### PR DESCRIPTION
Adds a `Now` function to our `internal/timeutil` package to return current UTC time with microsecond truncated to align time values we get back from the Postgres.

Fixes #11246