### PR TITLE
Add missing null-id check to CampaignsCredentialByID

### DIFF
--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -214,6 +214,10 @@ func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (
 		return nil, err
 	}
 
+	if dbID == 0 {
+		return nil, nil
+	}
+
 	cred, err := db.UserCredentials.GetByID(ctx, dbID)
 	if err != nil {
 		if errcode.IsNotFound(err) {


### PR DESCRIPTION
I ran into a panic when running `go test -short
./enterprise/internal/campaigns`, because something in
`db.UserCredentials` blows up when there's no state in the database.

That brought me to the null-id resilience test, which causes the panic.

Turns out that we don't do the 0 check here like in the other `*ByID`
resolvers.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
