### PR TITLE
Add test:regression:extensions to the QA tests

### DIFF
--- a/test/qa/test.sh
+++ b/test/qa/test.sh
@@ -49,6 +49,7 @@ yarn run test:regression:core || test_status=1
 yarn run test:regression:codeintel || test_status=1
 yarn run test:regression:config-settings || test_status=1
 yarn run test:regression:integrations || test_status=1
+yarn run test:regression:extensions || test_status=1
 yarn run test:regression:search || test_status=1
 popd
 exit $test_status


### PR DESCRIPTION
The test was fixed on https://github.com/sourcegraph/sourcegraph/pull/15973 and we should be able to run it again.