### PR TITLE
search: render filters for streaming search queries

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -70,7 +70,7 @@ import {
 import { SearchPatternType } from '../../shared/src/graphql-operations'
 import { HTTPStatusError } from '../../shared/src/backend/fetch'
 import { listUserCodeMonitors } from './enterprise/code-monitoring/backend'
-import { search as streamSearch } from './search/stream'
+import { aggregateStreamingSearch } from './search/stream'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
@@ -458,7 +458,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}
                                     fetchUserCodeMonitors={listUserCodeMonitors}
-                                    streamSearch={streamSearch}
+                                    streamSearch={aggregateStreamingSearch}
                                 />
                             )}
                         />

--- a/client/web/src/search/backend.tsx
+++ b/client/web/src/search/backend.tsx
@@ -11,7 +11,6 @@ import { FlatExtensionHostAPI } from '../../../shared/src/api/contract'
 import { wrapRemoteObservable } from '../../../shared/src/api/client/api/common'
 import { DeployType } from '../jscontext'
 import { SearchPatternType, EventLogsDataResult, EventLogsDataVariables } from '../graphql-operations'
-import * as SearchStream from './stream'
 
 export function search(
     query: string,
@@ -186,26 +185,6 @@ export function search(
                     return data.search.results
                 }),
                 catchError(error => [asError(error)])
-            )
-        )
-    )
-}
-
-export function searchStream(
-    query: string,
-    version: string,
-    patternType: SearchPatternType,
-    versionContext: string | undefined,
-    extensionHostPromise: Promise<Remote<FlatExtensionHostAPI>>
-): Observable<GQL.ISearchResults | ErrorLike> {
-    const transformedQuery = from(extensionHostPromise).pipe(
-        switchMap(extensionHost => wrapRemoteObservable(extensionHost.transformSearchQuery(query)))
-    )
-
-    return transformedQuery.pipe(
-        switchMap(query =>
-            SearchStream.search(query, version, patternType, versionContext).pipe(
-                SearchStream.switchToGQLISearchResults
             )
         )
     )

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -8,7 +8,7 @@ import { SearchPatternType } from '../../../shared/src/graphql-operations'
 import { Observable } from 'rxjs'
 import { ISavedSearch } from '../../../shared/src/graphql/schema'
 import { EventLogResult } from './backend'
-import { SearchEvent } from './stream'
+import { AggregateStreamingSearchResults } from './stream'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
@@ -187,7 +187,7 @@ export interface SearchStreamingProps {
         version: string,
         patternType: SearchPatternType,
         versionContext: string | undefined
-    ) => Observable<SearchEvent>
+    ) => Observable<AggregateStreamingSearchResults>
 }
 
 /**

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -95,7 +95,7 @@ export type SearchType = 'diff' | 'commit' | 'symbol' | 'repo' | 'path' | null
 // The latest supported version of our search syntax. Users should never be able to determine the search version.
 // The version is set based on the release tag of the instance. Anything before 3.9.0 will not pass a version parameter,
 // and will therefore default to V1.
-const LATEST_VERSION = 'V2'
+export const LATEST_VERSION = 'V2'
 
 export class SearchResults extends React.Component<SearchResultsProps, SearchResultsState> {
     public state: SearchResultsState = {

--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -1,0 +1,54 @@
+import { storiesOf } from '@storybook/react'
+import { createBrowserHistory } from 'history'
+import React from 'react'
+import { of } from 'rxjs'
+import sinon from 'sinon'
+import { SearchPatternType } from '../../../../../shared/src/graphql-operations'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
+import { extensionsController, MULTIPLE_SEARCH_RESULT } from '../../../../../shared/src/util/searchTestHelpers'
+import { WebStory } from '../../../components/WebStory'
+import { AggregateStreamingSearchResults } from '../../stream'
+import { StreamingSearchResults, StreamingSearchResultsProps } from './StreamingSearchResults'
+
+const history = createBrowserHistory()
+history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })
+
+const streamingSearchResult: AggregateStreamingSearchResults = {
+    results: MULTIPLE_SEARCH_RESULT.results,
+    filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
+    progress: {
+        done: true,
+        durationMs: 500,
+        matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
+        skipped: [],
+    },
+}
+
+const defaultProps: StreamingSearchResultsProps = {
+    caseSensitive: false,
+    setCaseSensitivity: sinon.spy(),
+    patternType: SearchPatternType.literal,
+    setPatternType: sinon.spy(),
+    versionContext: undefined,
+
+    extensionsController,
+    telemetryService: NOOP_TELEMETRY_SERVICE,
+
+    history,
+    location: history.location,
+
+    navbarSearchQueryState: { query: '', cursorPosition: 0 },
+
+    settingsCascade: {
+        subjects: null,
+        final: null,
+    },
+
+    streamSearch: () => of(streamingSearchResult),
+}
+
+const { add } = storiesOf('web/search/results/streaming/StreamingSearchResults', module).addParameters({
+    chromatic: { viewports: [769, 993] },
+})
+
+add('render', () => <WebStory>{() => <StreamingSearchResults {...defaultProps} />}</WebStory>)

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -1,6 +1,164 @@
-import React from 'react'
-import { SearchStreamingProps } from '../..'
+import * as H from 'history'
+import React, { useCallback, useEffect, useMemo } from 'react'
+import { CaseSensitivityProps, parseSearchURL, PatternTypeProps, SearchStreamingProps } from '../..'
+import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
+import { SearchPatternType } from '../../../../../shared/src/graphql-operations'
+import { VersionContextProps } from '../../../../../shared/src/search/util'
+import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
+import { useObservable } from '../../../../../shared/src/util/useObservable'
+import { PageTitle } from '../../../components/PageTitle'
+import { Settings } from '../../../schema/settings.schema'
+import { submitSearch, toggleSearchFilter, QueryState } from '../../helpers'
+import { Filter } from '../../stream'
+import { LATEST_VERSION } from '../SearchResults'
+import { DynamicSearchFilter, SearchResultsFilterBars } from '../SearchResultsFilterBars'
+import {
+    isSettingsValid,
+    SettingsCascadeOrError,
+    SettingsCascadeProps,
+} from '../../../../../shared/src/settings/settings'
 
-interface StreamingSearchResultsProps extends SearchStreamingProps {}
+interface StreamingSearchResultsProps
+    extends SearchStreamingProps,
+        PatternTypeProps,
+        VersionContextProps,
+        CaseSensitivityProps,
+        SettingsCascadeProps,
+        ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
+        TelemetryProps {
+    location: H.Location
+    history: H.History
+    navbarSearchQueryState: QueryState
+}
 
-export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResultsProps> = () => <></>
+export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResultsProps> = props => {
+    const {
+        patternType: currentPatternType,
+        setPatternType,
+        caseSensitive: currentCaseSensitive,
+        setCaseSensitivity,
+        versionContext,
+        streamSearch,
+        settingsCascade,
+        extensionsController,
+    } = props
+
+    const { query = '', patternType, caseSensitive } = parseSearchURL(props.location.search)
+
+    useEffect(() => {
+        if (patternType && patternType !== currentPatternType) {
+            setPatternType(patternType)
+        }
+    }, [patternType, currentPatternType, setPatternType])
+
+    useEffect(() => {
+        if (caseSensitive && caseSensitive !== currentCaseSensitive) {
+            setCaseSensitivity(caseSensitive)
+        }
+    }, [caseSensitive, currentCaseSensitive, setCaseSensitivity])
+
+    const results = useObservable(
+        useMemo(
+            () =>
+                streamSearch(
+                    caseSensitive ? `${query} case:yes` : query,
+                    LATEST_VERSION,
+                    patternType ?? SearchPatternType.literal,
+                    versionContext
+                ),
+            [streamSearch, caseSensitive, query, patternType, versionContext]
+        )
+    )
+
+    const contributions = useObservable(
+        useMemo(() => extensionsController.services.contribution.getContributions(), [extensionsController])
+    )
+    const filters = results?.filters
+    const quickLinks = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final.quicklinks) || []
+
+    const onDynamicFilterClicked = useCallback(
+        (value: string) => {
+            props.telemetryService.log('DynamicFilterClicked', {
+                search_filter: { value },
+            })
+
+            const newQuery = toggleSearchFilter(props.navbarSearchQueryState.query, value)
+
+            submitSearch({ ...props, query: newQuery, source: 'filter' })
+        },
+        [props]
+    )
+    const showMoreResults = useCallback(() => {}, [])
+    const calculateCount = useCallback(() => 0, [])
+
+    return (
+        <div className="test-search-results search-results d-flex flex-column w-100">
+            <PageTitle key="page-title" title={query} />
+            <SearchResultsFilterBars
+                navbarSearchQuery={props.navbarSearchQueryState.query}
+                searchSucceeded={!!results}
+                resultsLimitHit={
+                    !!results && results.progress.skipped.some(skipped => skipped.reason.includes('-limit'))
+                }
+                genericFilters={getFilters(filters, settingsCascade)}
+                extensionFilters={contributions?.searchFilters}
+                repoFilters={getRepoFilters(filters)}
+                quickLinks={quickLinks}
+                onFilterClick={onDynamicFilterClicked}
+                onShowMoreResultsClick={showMoreResults}
+                calculateShowMoreResultsCount={calculateCount}
+            />
+        </div>
+    )
+}
+
+/** Combines dynamic filters and search scopes into a list de-duplicated by value. */
+function getFilters(
+    resultFilters: Filter[] | undefined,
+    settingsCascade: SettingsCascadeOrError<Settings>
+): DynamicSearchFilter[] {
+    const filters = new Map<string, DynamicSearchFilter>()
+
+    if (resultFilters) {
+        const dynamicFilters = resultFilters.filter(filter => filter.kind !== 'repo')
+        for (const filter of dynamicFilters) {
+            filters.set(filter.value, filter)
+        }
+    }
+
+    const scopes = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final['search.scopes']) || []
+    if (resultFilters) {
+        for (const scope of scopes) {
+            if (!filters.has(scope.value)) {
+                filters.set(scope.value, scope)
+            }
+        }
+    } else {
+        for (const scope of scopes) {
+            // Check for if filter.value already exists and if so, overwrite with user's configured scope name.
+            const existingFilter = filters.get(scope.value)
+            // This works because user setting configs are the last to be processed after Global and Org.
+            // Thus, user set filters overwrite the equal valued existing filters.
+            if (existingFilter) {
+                existingFilter.name = scope.name || scope.value
+            }
+            filters.set(scope.value, existingFilter || scope)
+        }
+    }
+
+    return [...filters.values()]
+}
+
+function getRepoFilters(resultFilters: Filter[] | undefined): DynamicSearchFilter[] | undefined {
+    if (resultFilters) {
+        return resultFilters
+            .filter(filter => filter.kind === 'repo' && filter.value !== '')
+            .map(filter => ({
+                name: filter.label,
+                value: filter.value,
+                count: filter.count,
+                limitHit: filter.limitHit,
+            }))
+    }
+    return undefined
+}

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -1,24 +1,18 @@
 import * as H from 'history'
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { CaseSensitivityProps, parseSearchURL, PatternTypeProps, SearchStreamingProps } from '../..'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { SearchPatternType } from '../../../../../shared/src/graphql-operations'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
+import { SettingsCascadeProps } from '../../../../../shared/src/settings/settings'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
 import { PageTitle } from '../../../components/PageTitle'
-import { Settings } from '../../../schema/settings.schema'
-import { submitSearch, toggleSearchFilter, QueryState } from '../../helpers'
-import { Filter } from '../../stream'
+import { QueryState } from '../../helpers'
 import { LATEST_VERSION } from '../SearchResults'
-import { DynamicSearchFilter, SearchResultsFilterBars } from '../SearchResultsFilterBars'
-import {
-    isSettingsValid,
-    SettingsCascadeOrError,
-    SettingsCascadeProps,
-} from '../../../../../shared/src/settings/settings'
+import { StreamingSearchResultsFilterBars } from './StreamingSearchResultsFilterBars'
 
-interface StreamingSearchResultsProps
+export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
         PatternTypeProps,
         VersionContextProps,
@@ -39,8 +33,6 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         setCaseSensitivity,
         versionContext,
         streamSearch,
-        settingsCascade,
-        extensionsController,
     } = props
 
     const { query = '', patternType, caseSensitive } = parseSearchURL(props.location.search)
@@ -70,95 +62,10 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         )
     )
 
-    const contributions = useObservable(
-        useMemo(() => extensionsController.services.contribution.getContributions(), [extensionsController])
-    )
-    const filters = results?.filters
-    const quickLinks = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final.quicklinks) || []
-
-    const onDynamicFilterClicked = useCallback(
-        (value: string) => {
-            props.telemetryService.log('DynamicFilterClicked', {
-                search_filter: { value },
-            })
-
-            const newQuery = toggleSearchFilter(props.navbarSearchQueryState.query, value)
-
-            submitSearch({ ...props, query: newQuery, source: 'filter' })
-        },
-        [props]
-    )
-    const showMoreResults = useCallback(() => {}, [])
-    const calculateCount = useCallback(() => 0, [])
-
     return (
         <div className="test-search-results search-results d-flex flex-column w-100">
             <PageTitle key="page-title" title={query} />
-            <SearchResultsFilterBars
-                navbarSearchQuery={props.navbarSearchQueryState.query}
-                searchSucceeded={!!results}
-                resultsLimitHit={
-                    !!results && results.progress.skipped.some(skipped => skipped.reason.includes('-limit'))
-                }
-                genericFilters={getFilters(filters, settingsCascade)}
-                extensionFilters={contributions?.searchFilters}
-                repoFilters={getRepoFilters(filters)}
-                quickLinks={quickLinks}
-                onFilterClick={onDynamicFilterClicked}
-                onShowMoreResultsClick={showMoreResults}
-                calculateShowMoreResultsCount={calculateCount}
-            />
+            <StreamingSearchResultsFilterBars {...props} results={results} />
         </div>
     )
-}
-
-/** Combines dynamic filters and search scopes into a list de-duplicated by value. */
-function getFilters(
-    resultFilters: Filter[] | undefined,
-    settingsCascade: SettingsCascadeOrError<Settings>
-): DynamicSearchFilter[] {
-    const filters = new Map<string, DynamicSearchFilter>()
-
-    if (resultFilters) {
-        const dynamicFilters = resultFilters.filter(filter => filter.kind !== 'repo')
-        for (const filter of dynamicFilters) {
-            filters.set(filter.value, filter)
-        }
-    }
-
-    const scopes = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final['search.scopes']) || []
-    if (resultFilters) {
-        for (const scope of scopes) {
-            if (!filters.has(scope.value)) {
-                filters.set(scope.value, scope)
-            }
-        }
-    } else {
-        for (const scope of scopes) {
-            // Check for if filter.value already exists and if so, overwrite with user's configured scope name.
-            const existingFilter = filters.get(scope.value)
-            // This works because user setting configs are the last to be processed after Global and Org.
-            // Thus, user set filters overwrite the equal valued existing filters.
-            if (existingFilter) {
-                existingFilter.name = scope.name || scope.value
-            }
-            filters.set(scope.value, existingFilter || scope)
-        }
-    }
-
-    return [...filters.values()]
-}
-
-function getRepoFilters(resultFilters: Filter[] | undefined): DynamicSearchFilter[] | undefined {
-    if (resultFilters) {
-        return resultFilters
-            .filter(filter => filter.kind === 'repo' && filter.value !== '')
-            .map(filter => ({
-                name: filter.label,
-                value: filter.value,
-                count: filter.count,
-                limitHit: filter.limitHit,
-            }))
-    }
-    return undefined
 }

--- a/client/web/src/search/results/streaming/StreamingSearchResultsFilterBars.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsFilterBars.tsx
@@ -1,0 +1,122 @@
+import * as H from 'history'
+import React, { useCallback, useMemo } from 'react'
+import { CaseSensitivityProps, PatternTypeProps } from '../..'
+import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
+import { VersionContextProps } from '../../../../../shared/src/search/util'
+import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
+import { useObservable } from '../../../../../shared/src/util/useObservable'
+import { Settings } from '../../../schema/settings.schema'
+import { QueryState, submitSearch, toggleSearchFilter } from '../../helpers'
+import { AggregateStreamingSearchResults, Filter } from '../../stream'
+import { DynamicSearchFilter, SearchResultsFilterBars } from '../SearchResultsFilterBars'
+import {
+    isSettingsValid,
+    SettingsCascadeOrError,
+    SettingsCascadeProps,
+} from '../../../../../shared/src/settings/settings'
+
+interface Props
+    extends SettingsCascadeProps,
+        ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
+        TelemetryProps,
+        PatternTypeProps,
+        VersionContextProps,
+        CaseSensitivityProps {
+    location: H.Location
+    history: H.History
+
+    navbarSearchQueryState: QueryState
+
+    results?: AggregateStreamingSearchResults
+}
+
+export const StreamingSearchResultsFilterBars: React.FunctionComponent<Props> = props => {
+    const { extensionsController, results, settingsCascade } = props
+
+    const contributions = useObservable(
+        useMemo(() => extensionsController.services.contribution.getContributions(), [extensionsController])
+    )
+    const filters = props.results?.filters
+    const quickLinks = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final.quicklinks) || []
+
+    const onDynamicFilterClicked = useCallback(
+        (value: string) => {
+            props.telemetryService.log('DynamicFilterClicked', {
+                search_filter: { value },
+            })
+
+            const newQuery = toggleSearchFilter(props.navbarSearchQueryState.query, value)
+
+            submitSearch({ ...props, query: newQuery, source: 'filter' })
+        },
+        [props]
+    )
+    const showMoreResults = useCallback(() => {}, [])
+    const calculateCount = useCallback(() => 0, [])
+
+    return (
+        <SearchResultsFilterBars
+            navbarSearchQuery={props.navbarSearchQueryState.query}
+            searchSucceeded={!!results}
+            resultsLimitHit={!!results && results.progress.skipped.some(skipped => skipped.reason.includes('-limit'))}
+            genericFilters={getFilters(filters, settingsCascade)}
+            extensionFilters={contributions?.searchFilters}
+            repoFilters={getRepoFilters(filters)}
+            quickLinks={quickLinks}
+            onFilterClick={onDynamicFilterClicked}
+            onShowMoreResultsClick={showMoreResults}
+            calculateShowMoreResultsCount={calculateCount}
+        />
+    )
+}
+
+/** Combines dynamic filters and search scopes into a list de-duplicated by value. */
+function getFilters(
+    resultFilters: Filter[] | undefined,
+    settingsCascade: SettingsCascadeOrError<Settings>
+): DynamicSearchFilter[] {
+    const filters = new Map<string, DynamicSearchFilter>()
+
+    if (resultFilters) {
+        const dynamicFilters = resultFilters.filter(filter => filter.kind !== 'repo')
+        for (const filter of dynamicFilters) {
+            filters.set(filter.value, filter)
+        }
+    }
+
+    const scopes = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final['search.scopes']) || []
+    if (resultFilters) {
+        for (const scope of scopes) {
+            if (!filters.has(scope.value)) {
+                filters.set(scope.value, scope)
+            }
+        }
+    } else {
+        for (const scope of scopes) {
+            // Check for if filter.value already exists and if so, overwrite with user's configured scope name.
+            const existingFilter = filters.get(scope.value)
+            // This works because user setting configs are the last to be processed after Global and Org.
+            // Thus, user set filters overwrite the equal valued existing filters.
+            if (existingFilter) {
+                existingFilter.name = scope.name || scope.value
+            }
+            filters.set(scope.value, existingFilter || scope)
+        }
+    }
+
+    return [...filters.values()]
+}
+
+function getRepoFilters(resultFilters: Filter[] | undefined): DynamicSearchFilter[] | undefined {
+    if (resultFilters) {
+        return resultFilters
+            .filter(filter => filter.kind === 'repo' && filter.value !== '')
+            .map(filter => ({
+                name: filter.label,
+                value: filter.value,
+                count: filter.count,
+                limitHit: filter.limitHit,
+            }))
+    }
+    return undefined
+}


### PR DESCRIPTION
- Aggregates streaming search results (still uses some GQL conversion so we can detect the match type and render the result later on)
- Remove all unneeded streaming -> GQL conversion code
- Renders filter bar with streaming results dynamic filters, search scopes, and extension provided filters

![image](https://user-images.githubusercontent.com/206864/99739310-562efd80-2a81-11eb-84ef-13011ed99b04.png)

