### PR TITLE
search frontend: restructure token decoration

### DIFF
--- a/client/shared/src/search/parser/tokens.test.ts
+++ b/client/shared/src/search/parser/tokens.test.ts
@@ -15,7 +15,7 @@ describe('getMonacoTokens()', () => {
             getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com/sourcegraph f:code_intelligence trackViews')))
         ).toStrictEqual([
             {
-                scopes: 'filterKeyword',
+                scopes: 'field',
                 startIndex: 0,
             },
             {
@@ -27,7 +27,7 @@ describe('getMonacoTokens()', () => {
                 startIndex: 25,
             },
             {
-                scopes: 'filterKeyword',
+                scopes: 'field',
                 startIndex: 26,
             },
             {
@@ -48,7 +48,7 @@ describe('getMonacoTokens()', () => {
     test('search query containing parenthesized parameters', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('r:a (f:b and c)')))).toStrictEqual([
             {
-                scopes: 'filterKeyword',
+                scopes: 'field',
                 startIndex: 0,
             },
             {
@@ -64,7 +64,7 @@ describe('getMonacoTokens()', () => {
                 startIndex: 4,
             },
             {
-                scopes: 'filterKeyword',
+                scopes: 'field',
                 startIndex: 5,
             },
             {
@@ -436,12 +436,15 @@ describe('getMonacoTokens()', () => {
 
     test('decorate regexp field values', () => {
         expect(
-            getMonacoTokens(toSuccess(scanSearchQuery('repo:^foo$ count:.*', false, SearchPatternType.regexp)), true)
+            getMonacoTokens(
+                toSuccess(scanSearchQuery('repo:^foo$ count:10 file:.* fork:yes', false, SearchPatternType.regexp)),
+                true
+            )
         ).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 5,
@@ -469,10 +472,38 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 11,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 17,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 20,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 25,
+                "scopes": "regexpMetaCharacterSet"
+              },
+              {
+                "startIndex": 26,
+                "scopes": "regexpMetaRangeQuantifier"
+              },
+              {
+                "startIndex": 27,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 28,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 33,
                 "scopes": "identifier"
               }
             ]
@@ -554,7 +585,7 @@ describe('getMonacoTokens()', () => {
             [
               {
                 "startIndex": 0,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 5,
@@ -702,7 +733,7 @@ describe('getMonacoTokens()', () => {
             [
               {
                 "startIndex": 0,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 2,
@@ -751,7 +782,7 @@ describe('getMonacoTokens()', () => {
             [
               {
                 "startIndex": 0,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 2,
@@ -795,7 +826,7 @@ describe('getMonacoTokens()', () => {
             [
               {
                 "startIndex": 0,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 2,
@@ -850,7 +881,7 @@ describe('getMonacoTokens()', () => {
             [
               {
                 "startIndex": 0,
-                "scopes": "filterKeyword"
+                "scopes": "field"
               },
               {
                 "startIndex": 2,

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -42,9 +42,15 @@ export interface StructuralMeta {
     value: string
 }
 
+export interface Field {
+    type: 'field'
+    range: CharacterRange
+    value: string
+}
+
 export type MetaToken = RegexpMeta | StructuralMeta
 
-type DecoratedToken = Token | MetaToken
+type DecoratedToken = Token | Field | MetaToken
 
 const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
     const tokens: DecoratedToken[] = []
@@ -368,20 +374,50 @@ export const hasRegexpValue = (field: string): boolean => {
 const decorateTokens = (tokens: Token[]): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
     for (const token of tokens) {
-        if (token.type === 'pattern') {
-            switch (token.kind) {
-                case PatternKind.Regexp:
-                    decorated.push(...mapRegexpMeta(token))
-                    break
-                case PatternKind.Structural:
-                    decorated.push(...mapStructuralMeta(token))
-                    break
-                default:
-                    decorated.push(token)
+        switch (token.type) {
+            case 'pattern':
+                switch (token.kind) {
+                    case PatternKind.Regexp:
+                        decorated.push(...mapRegexpMeta(token))
+                        break
+                    case PatternKind.Structural:
+                        decorated.push(...mapStructuralMeta(token))
+                        break
+                    case PatternKind.Literal:
+                        decorated.push(token)
+                        break
+                }
+                break
+            case 'filter': {
+                decorated.push({
+                    type: 'field',
+                    range: token.range,
+                    value: token.filterType.value,
+                })
+                if (
+                    token.filterValue &&
+                    token.filterValue.type === 'literal' &&
+                    hasRegexpValue(token.filterType.value)
+                ) {
+                    // Highlight fields with regexp values.
+                    decorated.push(
+                        ...decorateTokens([
+                            {
+                                type: 'pattern',
+                                kind: PatternKind.Regexp,
+                                value: token.filterValue.value,
+                                range: token.filterValue.range,
+                            },
+                        ])
+                    )
+                } else if (token.filterValue) {
+                    decorated.push(token.filterValue)
+                }
+                break
             }
-            continue
+            default:
+                decorated.push(token)
         }
-        decorated.push(token)
     }
     return decorated
 }
@@ -390,36 +426,7 @@ const fromDecoratedTokens = (tokens: DecoratedToken[]): Monaco.languages.IToken[
     const monacoTokens: Monaco.languages.IToken[] = []
     for (const token of tokens) {
         switch (token.type) {
-            case 'filter':
-                {
-                    monacoTokens.push({
-                        startIndex: token.filterType.range.start,
-                        scopes: 'filterKeyword',
-                    })
-
-                    if (
-                        hasRegexpValue(token.filterType.value) &&
-                        token.filterValue &&
-                        token.filterValue.type === 'literal'
-                    ) {
-                        // Highlight fields with regexp values.
-                        const decoratedValue = decorateTokens([
-                            {
-                                type: 'pattern',
-                                kind: PatternKind.Regexp,
-                                value: token.filterValue.value,
-                                range: token.filterValue.range,
-                            },
-                        ])
-                        monacoTokens.push(...fromDecoratedTokens(decoratedValue))
-                    } else if (token.filterValue) {
-                        monacoTokens.push({
-                            startIndex: token.filterValue.range.start,
-                            scopes: 'identifier',
-                        })
-                    }
-                }
-                break
+            case 'field':
             case 'whitespace':
             case 'keyword':
             case 'comment':
@@ -459,7 +466,7 @@ const fromTokens = (tokens: Token[]): Monaco.languages.IToken[] => {
                 {
                     monacoTokens.push({
                         startIndex: token.filterType.range.start,
-                        scopes: 'filterKeyword',
+                        scopes: 'field',
                     })
                     if (token.filterValue) {
                         monacoTokens.push({

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -32,7 +32,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
     },
     rules: [
         { token: 'identifier', foreground: '#f2f4f8' },
-        { token: 'filterKeyword', foreground: '#569cd6' },
+        { token: 'field', foreground: '#569cd6' },
         { token: 'keyword', foreground: '#da77f2' },
         { token: 'openingParen', foreground: '#da77f2' },
         { token: 'closingParen', foreground: '#da77f2' },
@@ -71,7 +71,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
     },
     rules: [
         { token: 'identifier', foreground: '#2b3750' },
-        { token: 'filterKeyword', foreground: '#268bd2' },
+        { token: 'field', foreground: '#268bd2' },
         { token: 'keyword', foreground: '#ae3ec9' },
         { token: 'openingParen', foreground: '#ae3ec9' },
         { token: 'closingParen', foreground: '#ae3ec9' },


### PR DESCRIPTION
Stacked on #16001.

Preserves current highlighting. This just restructures things so that `decorateTokens` takes care to handle `field:value` cases (previously this was done by the same function that converts monaco tokens). I need the logic to b self-contained in `decorateTokens` to use it for hovers.

Also renames `filterKeyword` to `field` (consistent with backend terms).