### PR TITLE
authz: simplify PermsStore with intarray

### DIFF
--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -698,7 +698,7 @@ SET
 	updated_at = %s
 WHERE
 	id = ANY (%s)
-AND	permission = %s
+AND permission = %s
 AND object_type = %s
 `
 	if updatedAt.IsZero() {


### PR DESCRIPTION
Our permissions storage format in Postgres has been transitioned from roaring bitmap (`BYTEA`) to intarray (`[]INT`), it is now possible to perform many operations directly using SQLs.

I rely on our tests to ensure correctness, and tested end-to-end.

_Easier to be reviewed with split view_

Fixes #11768