### PR TITLE
search frontend: refactor renames filterType -> field

### DIFF
--- a/client/shared/src/search/parser/completion.ts
+++ b/client/shared/src/search/parser/completion.ts
@@ -254,12 +254,12 @@ export async function getCompletionItems(
         }
     }
     if (token.type === 'filter') {
-        const { filterValue } = token
-        const completingValue = !filterValue || filterValue.range.start + 1 <= column
+        const { value } = token
+        const completingValue = !value || value.range.start + 1 <= column
         if (!completingValue) {
             return null
         }
-        const resolvedFilter = resolveFilter(token.filterType.value)
+        const resolvedFilter = resolveFilter(token.field.value)
         if (!resolvedFilter) {
             return null
         }
@@ -270,7 +270,7 @@ export async function getCompletionItems(
                         label,
                         kind: Monaco.languages.CompletionItemKind.Text,
                         insertText: label,
-                        range: filterValue ? toMonacoRange(filterValue.range) : defaultRange,
+                        range: value ? toMonacoRange(value.range) : defaultRange,
                         command: COMPLETION_ITEM_SELECTED,
                     })),
                 }
@@ -288,10 +288,8 @@ export async function getCompletionItems(
                         // Set the current value as filterText, so that all dynamic suggestions
                         // returned by the server are displayed. otherwise, if the current filter value
                         // is a regex pattern, Monaco's filtering might hide some suggestions.
-                        filterText:
-                            filterValue &&
-                            (filterValue?.type === 'literal' ? filterValue.value : filterValue.quotedValue),
-                        range: filterValue ? toMonacoRange(filterValue.range) : defaultRange,
+                        filterText: value && (value?.type === 'literal' ? value.value : value.quotedValue),
+                        range: value ? toMonacoRange(value.range) : defaultRange,
                         command: COMPLETION_ITEM_SELECTED,
                     })),
             }
@@ -304,7 +302,7 @@ export async function getCompletionItems(
                         kind: Monaco.languages.CompletionItemKind.Value,
                         insertText: `${label} `,
                         filterText: label,
-                        range: filterValue ? toMonacoRange(filterValue.range) : defaultRange,
+                        range: value ? toMonacoRange(value.range) : defaultRange,
                         command: COMPLETION_ITEM_SELECTED,
                     })
                 ),

--- a/client/shared/src/search/parser/diagnostics.ts
+++ b/client/shared/src/search/parser/diagnostics.ts
@@ -10,15 +10,15 @@ export function getDiagnostics(tokens: Token[], patternType: SearchPatternType):
     const diagnostics: Monaco.editor.IMarkerData[] = []
     for (const token of tokens) {
         if (token.type === 'filter') {
-            const { filterType, filterValue } = token
-            const validationResult = validateFilter(filterType.value, filterValue)
+            const { field, value } = token
+            const validationResult = validateFilter(field.value, value)
             if (validationResult.valid) {
                 continue
             }
             diagnostics.push({
                 severity: Monaco.MarkerSeverity.Error,
                 message: validationResult.reason,
-                ...toMonacoRange(filterType.range),
+                ...toMonacoRange(field.range),
             })
         } else if (token.type === 'quoted') {
             if (patternType === SearchPatternType.literal) {

--- a/client/shared/src/search/parser/filters.ts
+++ b/client/shared/src/search/parser/filters.ts
@@ -244,23 +244,23 @@ const isValidDiscreteValue = (definition: NegatableFilterDefinition | BaseFilter
 }
 
 /**
- * Validates a filter given its type and value.
+ * Validates a filter given its field and value.
  */
 export const validateFilter = (
-    filterType: string,
-    filterValue: Filter['filterValue']
+    field: string,
+    value: Filter['value']
 ): { valid: true } | { valid: false; reason: string } => {
-    const typeAndDefinition = resolveFilter(filterType)
+    const typeAndDefinition = resolveFilter(field)
     if (!typeAndDefinition) {
         return { valid: false, reason: 'Invalid filter type.' }
     }
     const { definition } = typeAndDefinition
     if (
         definition.discreteValues &&
-        (!filterValue ||
-            (filterValue.type !== 'literal' && filterValue.type !== 'quoted') ||
-            (filterValue.type === 'literal' && !isValidDiscreteValue(definition, filterValue.value)) ||
-            (filterValue.type === 'quoted' && !isValidDiscreteValue(definition, filterValue.quotedValue)))
+        (!value ||
+            (value.type !== 'literal' && value.type !== 'quoted') ||
+            (value.type === 'literal' && !isValidDiscreteValue(definition, value.value)) ||
+            (value.type === 'quoted' && !isValidDiscreteValue(definition, value.quotedValue)))
     ) {
         return {
             valid: false,

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -18,7 +18,7 @@ export const getHoverResult = (
     tokensAtCursor.map(token => {
         switch (token.type) {
             case 'filter': {
-                const resolvedFilter = resolveFilter(token.filterType.value)
+                const resolvedFilter = resolveFilter(token.field.value)
                 if (resolvedFilter) {
                     values.push(
                         'negated' in resolvedFilter

--- a/client/shared/src/search/parser/parser.ts
+++ b/client/shared/src/search/parser/parser.ts
@@ -67,12 +67,12 @@ const tokenToLeafNode = (token: Token): ParseResult => {
         return createPattern(token.value, token.kind, false, false)
     }
     if (token.type === 'filter') {
-        const filterValue = token.filterValue
-            ? token.filterValue.type === 'literal'
-                ? token.filterValue.value
-                : token.filterValue.quotedValue
+        const filterValue = token.value
+            ? token.value.type === 'literal'
+                ? token.value.value
+                : token.value.quotedValue
             : ''
-        return createParameter(token.filterType.value, filterValue, token.negated)
+        return createParameter(token.field.value, filterValue, token.negated)
     }
     return { type: 'error', expected: 'a convertable token to tree node' }
 }

--- a/client/shared/src/search/parser/scanner.test.ts
+++ b/client/shared/src/search/parser/scanner.test.ts
@@ -90,29 +90,29 @@ describe('scanSearchQuery() for literal search', () => {
 
     test('filter', () =>
         expect(scanSearchQuery('f:b')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"b","range":{"start":2,"end":3}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"b","range":{"start":2,"end":3}},"negated":false}]}'
         ))
 
     test('negated filter', () =>
         expect(scanSearchQuery('-f:b')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"filterValue":{"type":"literal","value":"b","range":{"start":3,"end":4}},"negated":true}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"value":{"type":"literal","value":"b","range":{"start":3,"end":4}},"negated":true}]}'
         ))
 
     test('filter with quoted value', () => {
         expect(scanSearchQuery('f:"b"')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":5},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"quoted","quotedValue":"b","range":{"start":2,"end":5}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":5},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"quoted","quotedValue":"b","range":{"start":2,"end":5}},"negated":false}]}'
         )
     })
 
     test('filter with a value ending with a colon', () => {
         expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
         )
     })
 
     test('filter where the value is a colon', () => {
         expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"filterType":{"type":"literal","value":"f","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
         )
     })
 
@@ -133,12 +133,12 @@ describe('scanSearchQuery() for literal search', () => {
 
     test('complex query', () =>
         expect(scanSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":30},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"filterType":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"filterValue":{"type":"literal","value":"go","range":{"start":36,"end":38}},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"filterType":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"filterValue":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":30},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"field":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"value":{"type":"literal","value":"go","range":{"start":36,"end":38}},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"field":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"value":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}]}'
         ))
 
     test('parenthesized parameters', () => {
         expect(scanSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":6},"filterType":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"filterValue":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"filterType":{"type":"literal","value":"file","range":{"start":8,"end":12}},"filterValue":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":6},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"field":{"type":"literal","value":"file","range":{"start":8,"end":12}},"value":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}]}'
         )
     })
 
@@ -150,7 +150,7 @@ describe('scanSearchQuery() for literal search', () => {
 
     test('do not treat links as filters', () => {
         expect(scanSearchQuery('http://example.com repo:a')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"filterType":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"filterValue":{"type":"literal","value":"a","range":{"start":24,"end":25}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"field":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"value":{"type":"literal","value":"a","range":{"start":24,"end":25}},"negated":false}]}'
         )
     })
 })
@@ -174,7 +174,7 @@ describe('scanSearchQuery() for regexp', () => {
 
     test('interpret regexp slash quotes', () => {
         expect(scanSearchQuery('r:a /a regexp \\ pattern/', false, SearchPatternType.regexp)).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"filterType":{"type":"literal","value":"r","range":{"start":0,"end":1}},"filterValue":{"type":"literal","value":"a","range":{"start":2,"end":3}},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"field":{"type":"literal","value":"r","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a","range":{"start":2,"end":3}},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}]}'
         )
     })
 })
@@ -186,7 +186,7 @@ repo:sourcegraph
 // search for thing
 thing`
         expect(scanSearchQuery(query, true)).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"filterType":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"filterValue":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}]}'
+            '{"type":"success","term":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"field":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"value":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}]}'
         )
     })
 

--- a/client/shared/src/search/parser/scanner.ts
+++ b/client/shared/src/search/parser/scanner.ts
@@ -77,8 +77,8 @@ export interface Literal extends BaseToken {
  */
 export interface Filter extends BaseToken {
     type: 'filter'
-    filterType: Literal
-    filterValue: Quoted | Literal | undefined
+    field: Literal
+    value: Quoted | Literal | undefined
     negated: boolean
 }
 
@@ -487,8 +487,8 @@ const filter: Scanner<Filter> = (input, start) => {
         term: {
             type: 'filter',
             range: { start, end: scannedValue ? scannedValue.term.range.end : scannedDelimiter.term.range.end },
-            filterType: scannedKeyword.term,
-            filterValue: scannedValue?.term,
+            field: scannedKeyword.term,
+            value: scannedValue?.term,
             negated: scannedKeyword.term.value.startsWith('-'),
         },
     }

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -392,26 +392,22 @@ const decorateTokens = (tokens: Token[]): DecoratedToken[] => {
                 decorated.push({
                     type: 'field',
                     range: token.range,
-                    value: token.filterType.value,
+                    value: token.field.value,
                 })
-                if (
-                    token.filterValue &&
-                    token.filterValue.type === 'literal' &&
-                    hasRegexpValue(token.filterType.value)
-                ) {
+                if (token.value && token.value.type === 'literal' && hasRegexpValue(token.field.value)) {
                     // Highlight fields with regexp values.
                     decorated.push(
                         ...decorateTokens([
                             {
                                 type: 'pattern',
                                 kind: PatternKind.Regexp,
-                                value: token.filterValue.value,
-                                range: token.filterValue.range,
+                                value: token.value.value,
+                                range: token.value.range,
                             },
                         ])
                     )
-                } else if (token.filterValue) {
-                    decorated.push(token.filterValue)
+                } else if (token.value) {
+                    decorated.push(token.value)
                 }
                 break
             }
@@ -465,12 +461,12 @@ const fromTokens = (tokens: Token[]): Monaco.languages.IToken[] => {
             case 'filter':
                 {
                     monacoTokens.push({
-                        startIndex: token.filterType.range.start,
+                        startIndex: token.field.range.start,
                         scopes: 'field',
                     })
-                    if (token.filterValue) {
+                    if (token.value) {
                         monacoTokens.push({
-                            startIndex: token.filterValue.range.start,
+                            startIndex: token.value.range.start,
                             scopes: 'identifier',
                         })
                     }

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -659,14 +659,10 @@ export function parsePatternTypeFromQuery(query: string): { range: CharacterRang
     const scannedQuery = scanSearchQuery(query)
     if (scannedQuery.type === 'success') {
         for (const token of scannedQuery.term) {
-            if (
-                token.type === 'filter' &&
-                token.filterType.value.toLowerCase() === 'patterntype' &&
-                token.filterValue
-            ) {
+            if (token.type === 'filter' && token.field.value.toLowerCase() === 'patterntype' && token.value) {
                 return {
-                    range: { start: token.filterType.range.start, end: token.filterValue.range.end },
-                    value: query.slice(token.filterValue.range.start, token.filterValue.range.end),
+                    range: { start: token.field.range.start, end: token.value.range.end },
+                    value: query.slice(token.value.range.start, token.value.range.end),
                 }
             }
         }
@@ -679,10 +675,10 @@ export function parseCaseSensitivityFromQuery(query: string): { range: Character
     const scannedQuery = scanSearchQuery(query)
     if (scannedQuery.type === 'success') {
         for (const token of scannedQuery.term) {
-            if (token.type === 'filter' && token.filterType.value.toLowerCase() === 'case' && token.filterValue) {
+            if (token.type === 'filter' && token.field.value.toLowerCase() === 'case' && token.value) {
                 return {
-                    range: { start: token.filterType.range.start, end: token.filterValue.range.end },
-                    value: query.slice(token.filterValue.range.start, token.filterValue.range.end),
+                    range: { start: token.field.range.start, end: token.value.range.end },
+                    value: query.slice(token.value.range.start, token.value.range.end),
                 }
             }
         }

--- a/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -11,11 +11,9 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: stri
                       return (
                           <Fragment key={token.range.start}>
                               <span className="search-filter-keyword">
-                                  {query.slice(token.filterType.range.start, token.filterType.range.end)}:
+                                  {query.slice(token.field.range.start, token.field.range.end)}:
                               </span>
-                              {token.filterValue ? (
-                                  <>{query.slice(token.filterValue.range.start, token.filterValue.range.end)}</>
-                              ) : null}
+                              {token.value ? <>{query.slice(token.value.range.start, token.value.range.end)}</> : null}
                           </Fragment>
                       )
                   }

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -276,20 +276,20 @@ const TriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                             const hasTypeDiffOrCommitFilter = filters.some(
                                 filter =>
                                     filter.type === 'filter' &&
-                                    resolveFilter(filter.filterType.value)?.type === FilterType.type &&
-                                    ((filter.filterValue?.type === 'literal' &&
-                                        filter.filterValue &&
-                                        isDiffOrCommit(filter.filterValue.value)) ||
-                                        (filter.filterValue?.type === 'quoted' &&
-                                            filter.filterValue &&
-                                            isDiffOrCommit(filter.filterValue.quotedValue)))
+                                    resolveFilter(filter.field.value)?.type === FilterType.type &&
+                                    ((filter.value?.type === 'literal' &&
+                                        filter.value &&
+                                        isDiffOrCommit(filter.value.value)) ||
+                                        (filter.value?.type === 'quoted' &&
+                                            filter.value &&
+                                            isDiffOrCommit(filter.value.quotedValue)))
                             )
                             const hasPatternTypeFilter = filters.some(
                                 filter =>
                                     filter.type === 'filter' &&
-                                    resolveFilter(filter.filterType.value)?.type === FilterType.patterntype &&
-                                    filter.filterValue &&
-                                    validateFilter(filter.filterType.value, filter.filterValue)
+                                    resolveFilter(filter.field.value)?.type === FilterType.patterntype &&
+                                    filter.value &&
+                                    validateFilter(filter.field.value, filter.value)
                             )
                             if (hasTypeDiffOrCommitFilter && hasPatternTypeFilter) {
                                 return undefined

--- a/client/web/src/search/input/helpers.ts
+++ b/client/web/src/search/input/helpers.ts
@@ -26,21 +26,17 @@ export function convertPlainTextToInteractiveQuery(
 
     if (scannedQuery.type === 'success') {
         for (const token of scannedQuery.term) {
-            if (
-                token.type === 'filter' &&
-                token.filterValue &&
-                validateFilter(token.filterType.value, token.filterValue).valid
-            ) {
-                const filterType = token.filterType.value as FilterType
+            if (token.type === 'filter' && token.value && validateFilter(token.field.value, token.value).valid) {
+                const filterType = token.field.value as FilterType
                 newFiltersInQuery[isSingularFilter(filterType) ? filterType : uniqueId(filterType)] = {
                     type: isNegatedFilter(filterType) ? resolveNegatedFilter(filterType) : filterType,
-                    value: query.slice(token.filterValue.range.start, token.filterValue.range.end),
+                    value: query.slice(token.value.range.start, token.value.range.end),
                     editable: false,
                     negated: isNegatedFilter(filterType),
                 }
             } else if (
                 token.type !== 'filter' ||
-                (token.type === 'filter' && !validateFilter(token.filterType.value, token.filterValue).valid)
+                (token.type === 'filter' && !validateFilter(token.field.value, token.value).valid)
             ) {
                 newNavbarQuery = [newNavbarQuery, query.slice(token.range.start, token.range.end)]
                     .filter(query => query.length > 0)

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -132,20 +132,13 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
             for (const token of scannedQuery.term) {
                 if (
                     token.type === 'filter' &&
-                    (token.filterType.value === FilterType.repo ||
-                        token.filterType.value === FILTERS[FilterType.repo].alias)
+                    (token.field.value === FilterType.repo || token.field.value === FILTERS[FilterType.repo].alias)
                 ) {
-                    if (
-                        token.filterValue?.type === 'literal' &&
-                        !recentlySearchedRepos.includes(token.filterValue.value)
-                    ) {
-                        recentlySearchedRepos.push(token.filterValue.value)
+                    if (token.value?.type === 'literal' && !recentlySearchedRepos.includes(token.value.value)) {
+                        recentlySearchedRepos.push(token.value.value)
                     }
-                    if (
-                        token.filterValue?.type === 'quoted' &&
-                        !recentlySearchedRepos.includes(token.filterValue.quotedValue)
-                    ) {
-                        recentlySearchedRepos.push(token.filterValue.quotedValue)
+                    if (token.value?.type === 'quoted' && !recentlySearchedRepos.includes(token.value.quotedValue)) {
+                        recentlySearchedRepos.push(token.value.quotedValue)
                     }
                 }
             }

--- a/client/web/src/search/queryTelemetry.tsx
+++ b/client/web/src/search/queryTelemetry.tsx
@@ -16,7 +16,7 @@ function filterExistsInQuery(parsedQuery: ScanResult<Token[]>, filterToMatch: st
         const tokens = parsedQuery.term
         for (const token of tokens) {
             if (token.type === 'filter') {
-                const resolvedFilter = resolveFilter(token.filterType.value)
+                const resolvedFilter = resolveFilter(token.field.value)
                 if (resolvedFilter !== undefined && resolvedFilter.type === filterToMatch) {
                     return true
                 }

--- a/client/web/src/search/results/SearchResultTab.tsx
+++ b/client/web/src/search/results/SearchResultTab.tsx
@@ -48,11 +48,11 @@ export const SearchResultTabHeader: React.FunctionComponent<Props> = ({
         // Parse any `type:` filter that exists in a query so
         // we can check whether this tab should be active.
         for (const token of scannedQuery.term) {
-            if (token.type === 'filter' && token.filterType.value === 'type' && token.filterValue) {
+            if (token.type === 'filter' && token.field.value === 'type' && token.value) {
                 typeInQuery =
-                    token.filterValue.type === 'literal'
-                        ? (token.filterValue.value as SearchType)
-                        : (token.filterValue.quotedValue as SearchType)
+                    token.value.type === 'literal'
+                        ? (token.value.value as SearchType)
+                        : (token.value.quotedValue as SearchType)
             }
         }
     }


### PR DESCRIPTION
Stacked on #16004.

Basically:

```patch
export interface Filter extends BaseToken {
     type: 'filter'
-    filterType: Literal
-    filterValue: Quoted | Literal | undefined
+    field: Literal
+    value: Quoted | Literal | undefined
     negated: boolean
}
```

This is consistent with backend terms. The one place where readability stutters a little bit is when accessing a filter's `value.value` of a `Literal`. I think there are like 5 cases where this happens, and this is hardly the end of the world, we can avoid it with either (1) destructuring and assigning to a temp variable or (2) making this value a different type from `Literal` and renaming the member. 

I still need to go after `FilterType` in `util.ts`. but that's for another day.