### PR TITLE
Port search regression tests to integration

### DIFF
--- a/client/web/src/regression/search.test.ts
+++ b/client/web/src/regression/search.test.ts
@@ -6,7 +6,6 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { GraphQLClient } from './util/GraphQlClient'
 import { ensureTestExternalService } from './util/api'
 import { ensureLoggedInOrCreateTestUser } from './util/helpers'
-import { buildSearchURLQuery } from '../../../shared/src/util/url'
 import { TestResourceManager } from './util/TestResourceManager'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
 
@@ -19,79 +18,7 @@ describe('Search regression test suite', () => {
         kind: GQL.ExternalServiceKind.GITHUB,
         uniqueDisplayName: '[TEST] GitHub (search.test.ts)',
     }
-    const testRepoSlugs = [
-        'auth0/go-jwt-middleware',
-        'kyoshidajp/ghkw',
-        'PalmStoneGames/kube-cert-manager',
-        'adjust/go-wrk',
-        'P3GLEG/Whaler',
-        'sajari/docconv',
-        'marianogappa/chart',
-        'divan/gobenchui',
-        'tuna/tunasync',
-        'mthbernardes/GTRS',
-        'antonmedv/expr',
-        'ClickHouse/clickhouse-go',
-        'xwb1989/sqlparser',
-        'itcloudy/ERP',
-        'iovisor/kubectl-trace',
-        'minio/highwayhash',
-        'matryer/moq',
-        'vkuznecovas/mouthful',
-        'DirectXMan12/k8s-prometheus-adapter',
-        'stephens2424/php',
-        'ericchiang/k8s',
-        'jonmorehouse/terraform-provisioner-ansible',
-        'solo-io/gloo-mesh',
-        'xtaci/smux',
-        'MatchbookLab/local-persist',
-        'ossrs/go-oryx',
-        'yep/eth-tweet',
-        'deckarep/gosx-notifier',
-        'zentures/sequence',
-        'nishanths/license',
-        'beego/mux',
-        'status-im/status-go',
-        'antonmedv/countdown',
-        'lonng/nanoserver',
-        'vbauerster/mpb',
-        'evilsocket/sg1',
-        'zhenghaoz/gorse',
-        'nsf/godit',
-        '3xxx/engineercms',
-        'howtowhale/dvm',
-        'gosuri/uitable',
-        'github/vulcanizer',
-        'metaparticle-io/package',
-        'bwmarrin/snowflake',
-        'wyh267/FalconEngine',
-        'moul/sshportal',
-        'fogleman/fauxgl',
-        'DataDog/datadog-agent',
-        'line/line-bot-sdk-go',
-        'pinterest/bender',
-        'esimov/diagram',
-        'nytimes/openapi2proto',
-        'iris-contrib/examples',
-        'munnerz/kube-plex',
-        'inbucket/inbucket',
-        'golangci/awesome-go-linters',
-        'htcat/htcat',
-        'tidwall/pinhole',
-        'gocraft/health',
-        'ivpusic/grpool',
-        'Antonito/gfile',
-        'yinqiwen/gscan',
-        'facebookarchive/httpcontrol',
-        'josharian/impl',
-        'salihciftci/liman',
-        'kelseyhightower/konfd',
-        'mohanson/daze',
-        'google/ko',
-        'freedomofdevelopers/fod',
-        'sgtest/mux',
-        'facebook/react',
-    ]
+    const testRepoSlugs = ['sgtest/jsonrpc2', 'sgtest/go-diff']
     const config = getConfig(
         'sudoToken',
         'sudoUsername',
@@ -149,48 +76,8 @@ describe('Search regression test suite', () => {
             }
         })
 
-        test('Global text search excluding repository ("error type:") with a few results.', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q="error+type:%5Cn"+-repo:google')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-            await driver.page.waitForFunction(() => {
-                const results = [...document.querySelectorAll('.test-search-result')]
-                if (results.length === 0) {
-                    return false
-                }
-                const hasExcludedRepo = results.some(element => element.textContent?.includes('google'))
-                if (hasExcludedRepo) {
-                    throw new Error('Results contain excluded repository')
-                }
-                return true
-            })
-        })
-        test('Global text search filtering by language', async () => {
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=%5Cbfunc%5Cb+lang:js')
-            await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
-            const filenames: string[] = await driver.page.evaluate(
-                () =>
-                    [...document.querySelectorAll('.test-search-result')]
-                        .map(element => {
-                            const header = element.querySelector('[data-testid="result-container-header"')
-                            if (!header?.textContent) {
-                                return null
-                            }
-                            const components = header.textContent.split(/\s/)
-                            return components[components.length - 1]
-                        })
-                        .filter(element => element !== null) as string[]
-            )
-            if (!filenames.every(filename => filename.endsWith('.js'))) {
-                throw new Error('found Go results when filtering for JavaScript')
-            }
-        })
-        test('Structural search, return repo results if pattern is empty', async () => {
-            const urlQuery = buildSearchURLQuery(
-                'repo:^github\\.com/facebook/react$',
-                GQL.SearchPatternType.structural,
-                false
-            )
-            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)
+        test('Performs a search and displays results', async () => {
+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?q=fmt.Sprintf')
             await driver.page.waitForFunction(() => document.querySelectorAll('.test-search-result').length > 0)
         })
     })

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -39,6 +39,7 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 		query.FieldCase:               {},
 		query.FieldRepoHasFile:        {},
 		query.FieldRepoHasCommitAfter: {},
+		query.FieldPatternType:        {},
 	}
 	// Don't return repo results if the search contains fields that aren't on the allowlist.
 	// Matching repositories based whether they contain files at a certain path (etc.) is not yet implemented.

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -281,16 +281,16 @@ func TestSearch(t *testing.T) {
 				query: `repo:^github\.com/sgtest/mux$`,
 			},
 			{
-				name:  `Structural search returns repo results if pattern is empty`,
-				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ patterntype:structural`,
-			},
-			{
 				name:  `exclude counts for fork and archive`,
 				query: `repo:mux|archived|go-diff`,
 				wantMissing: []string{
 					"github.com/sgtest/archived",
 					"github.com/sgtest/mux",
 				},
+			},
+			{
+				name:  `Structural search returns repo results if patterntype set but pattern is empty`,
+				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ patterntype:structural`,
 			},
 		}
 		for _, test := range tests {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -122,6 +122,37 @@ func TestSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("lang: filter", func(t *testing.T) {
+		// On our test repositories, `function` has results for go, ts, python, html
+		results, err := client.SearchFiles("function lang:go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Make sure we only got .go files
+		for _, r := range results.Results {
+			if !strings.Contains(r.File.Name, ".go") {
+				t.Fatalf("Found file name does not end with .go: %s", r.File.Name)
+			}
+		}
+	})
+
+	t.Run("excluding repositories", func(t *testing.T) {
+		results, err := client.SearchFiles("fmt.Sprintf -repo:jsonrpc2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Make sure we got some results
+		if len(results.Results) == 0 {
+			t.Fatal("Want non-zero results but got 0")
+		}
+		// Make sure we got no results from the excluded repository
+		for _, r := range results.Results {
+			if strings.Contains(r.Repository.Name, "jsonrpc2") {
+				t.Fatal("Got results for excluded repository")
+			}
+		}
+	})
+
 	t.Run("multiple revisions per repository", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:sgtest/go-diff$@master:print-options:*refs/heads/ func NewHunksReader")
 		if err != nil {
@@ -248,6 +279,10 @@ func TestSearch(t *testing.T) {
 			{
 				name:  `fork included if exact without option, nonzero result`,
 				query: `repo:^github\.com/sgtest/mux$`,
+			},
+			{
+				name:  `Structural search returns repo results if pattern is empty`,
+				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ patterntype:structural`,
 			},
 			{
 				name:  `exclude counts for fork and archive`,


### PR DESCRIPTION
Ports the remaining search regression tests to the go integration test suite, and only keeps a single integration test validating a basic end-to-end success case.