### PR TITLE
release: fix markdown in generated release PR

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -355,7 +355,7 @@ If you have changes that should go into this patch release, <${patchRequestTempl
                 const defaultBody = `This pull request is part of the Sourcegraph ${release.version} release.
 
 * [Release campaign](${campaignURL})
-* ${trackingIssue ? `[Tracking issue](${trackingIssue.url}` : 'No tracking issue exists for this release'}`
+* ${trackingIssue ? `[Tracking issue](${trackingIssue.url})` : 'No tracking issue exists for this release'}`
                 if (!actionItems || actionItems.length === 0) {
                     return { draft: false, body: defaultBody }
                 }


### PR DESCRIPTION
The markdown was bad in the 3.22 release PRs: https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.22.0

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
