### PR TITLE
search backend: validate repohasfile in new query

### DIFF
--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -76,12 +77,16 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			input: "repo:foo author:rob@saucegraph.com",
 			want:  `your query contains the field 'author', which requires type:commit or type:diff in the query`,
 		},
+		{
+			input: "repohasfile:README type:symbol yolo",
+			want:  "repohasfile is not compatible for type:symbol. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4610 for updates",
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
 			_, err := ProcessAndOr(c.input, ParserOptions{c.searchType, false})
 			if err == nil {
-				t.Fatal("expected test to fail")
+				t.Fatal(fmt.Sprintf("expected test for %s to fail", c.input))
 			}
 			if diff := cmp.Diff(c.want, err.Error()); diff != "" {
 				t.Fatal(diff)


### PR DESCRIPTION
Stacked on #16045. 

@attfarhan I'll soon remove all validation code I see in `search_results.go` and elsewhere. This PR ports this validation to the new parser:

https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results.go#L2124-2129

It looks pretty low value though, because the tests only check that the query `repohasfile:thing type:symbol` raises error, but `repohasfile type:symbol something` is considered "valid": https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results_test.go#L856-876

The latter, I think, should not be valid, because we don't support it. For example, if I search for `repohasfile:glorglorglorglor type:symbol Search` today, it will return symbol results for `Search` and basically just ignore the `repohasfile` constraint. So, I am porting this validation function and making it stronger, saying it is just not compatible with `type:symbol`. 

I don't really care about what exactly we do here--I actually just want to get rid of validation code for old parser/clutter because I will soon remove all parts of the old parser.

For now I won't delete the old `repohasfile` validation function because that will make the `migrateParser = false` setting technically not behave like it would have before. But I do want to port it so I can clear out everything when I'm ready. When I remove everything, I will also deprecate the `migrateParser` setting.



