### PR TITLE
search: align frontend/backend structural syntax parsers

### DIFF
--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -280,24 +280,18 @@ const mapStructuralMeta = (pattern: Pattern): DecoratedToken[] => {
                     continue
                 }
                 if (pattern.value[start] !== undefined) {
-                    if (pattern.value[start] === ':') {
-                        // '::' case, so push the first ':' and continue.
-                        token.push(':')
-                        continue
-                    }
                     // Look ahead and see if this is the start of a hole.
-                    current = nextChar()
-                    if (current === '[') {
-                        // It is the start of a hole.
+                    if (pattern.value[start] === '[') {
+                        // It is the start of a hole, consume the '['.
+                        current = nextChar()
                         open = open + 1
                         // Persist the literal token scanned up to this point.
                         appendDecoratedToken(start - 2, PatternKind.Literal)
                         token.push(':[')
                         continue
                     }
-                    // Something else, push the ':' we saw, backtrack, and continue.
+                    // Something else, push the ':' we saw and continue.
                     token.push(':')
-                    start = start - 1
                     continue
                 }
                 // Trailing ':'.

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -188,7 +188,7 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 		{
 			Name:    "Not well-formed is undefined",
 			Pattern: ":[[",
-			Want:    `(.|\s)*?`,
+			Want:    `(:\[\[)`,
 		},
 		{
 			Name:    "Complex regex with character class",


### PR DESCRIPTION
Stacked on #16048. 

We have a structural syntax parser in the frontend and backend now. I'm making them align basically one-to-one, simplify things I've noticed, add the same comments, and use similar variable names. Most of the backend/Go changes are updated to align more closely with the comments in the TypeScript code: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/search/parser/tokens.ts#L258-349