### PR TITLE
Allow consumers to override useInputValidation state, use in AddUserEmailForm

### DIFF
--- a/client/shared/src/util/useInputValidation.ts
+++ b/client/shared/src/util/useInputValidation.ts
@@ -45,7 +45,7 @@ interface OverrideOptions {
     value: string
 
     /** Whether to validate the new value */
-    validate: boolean
+    validate?: boolean
 }
 
 /**
@@ -54,9 +54,6 @@ interface OverrideOptions {
  * and custom synchronous and asynchronous validators.
  *
  * @param options Config object that declares sync + async validators
- * @param initialValue
- *
- * @returns
  */
 export function useInputValidation(
     options: ValidationOptions
@@ -64,7 +61,7 @@ export function useInputValidation(
     InputValidationState,
     (change: React.ChangeEvent<HTMLInputElement>) => void,
     React.MutableRefObject<HTMLInputElement | null>,
-    (overrideOptions?: OverrideOptions) => void
+    (overrideOptions: OverrideOptions) => void
 ] {
     const inputReference = useRef<HTMLInputElement>(null)
 
@@ -81,7 +78,7 @@ export function useInputValidation(
 
     // TODO(tj): Move control of state to consumer
     const overrideState = useCallback(
-        (overrideOptions?: OverrideOptions) => {
+        (overrideOptions: OverrideOptions) => {
             // clear custom validity
             inputReference.current?.setCustomValidity('')
 
@@ -91,7 +88,7 @@ export function useInputValidation(
                 value: overrideOptions?.value ?? '',
             })
 
-            if (overrideOptions?.value) {
+            if (overrideOptions?.validate) {
                 nextInputChangeEvent({
                     preventDefault: noop,
                     target: { value: overrideOptions.value },

--- a/client/shared/src/util/useInputValidation.ts
+++ b/client/shared/src/util/useInputValidation.ts
@@ -1,5 +1,5 @@
-import { compact, head } from 'lodash'
-import { useMemo, useState, useRef } from 'react'
+import { compact, head, noop } from 'lodash'
+import { useMemo, useState, useRef, useCallback } from 'react'
 import { concat, EMPTY, Observable, of, zip } from 'rxjs'
 import { catchError, map, switchMap, tap, debounceTime } from 'rxjs/operators'
 import { useEventObservable } from './useObservable'
@@ -37,6 +37,18 @@ export type InputValidationState = { value: string } & (
 )
 
 /**
+ * Options for overriding input state programmatically. If `overrideState` is called without
+ * these options, the input will be cleared and not validated.
+ */
+interface OverrideOptions {
+    /** The value to set input state to */
+    value: string
+
+    /** Whether to validate the new value */
+    validate: boolean
+}
+
+/**
  * React hook to manage validation of a single form input field.
  * `useInputValidation` helps with coordinating the constraint validation API
  * and custom synchronous and asynchronous validators.
@@ -51,7 +63,8 @@ export function useInputValidation(
 ): [
     InputValidationState,
     (change: React.ChangeEvent<HTMLInputElement>) => void,
-    React.MutableRefObject<HTMLInputElement | null>
+    React.MutableRefObject<HTMLInputElement | null>,
+    (overrideOptions?: OverrideOptions) => void
 ] {
     const inputReference = useRef<HTMLInputElement>(null)
 
@@ -66,7 +79,29 @@ export function useInputValidation(
 
     const [nextInputChangeEvent] = useEventObservable(validationPipeline)
 
-    return [inputState, nextInputChangeEvent, inputReference]
+    // TODO(tj): Move control of state to consumer
+    const overrideState = useCallback(
+        (overrideOptions?: OverrideOptions) => {
+            // clear custom validity
+            inputReference.current?.setCustomValidity('')
+
+            // clear React state
+            setInputState({
+                kind: overrideOptions?.validate ? 'LOADING' : 'NOT_VALIDATED',
+                value: overrideOptions?.value ?? '',
+            })
+
+            if (overrideOptions?.value) {
+                nextInputChangeEvent({
+                    preventDefault: noop,
+                    target: { value: overrideOptions.value },
+                })
+            }
+        },
+        [nextInputChangeEvent]
+    )
+
+    return [inputState, nextInputChangeEvent, inputReference, overrideState]
 }
 
 /**

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -64,7 +64,7 @@ export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, on
             }
 
             eventLogger.log('NewUserEmailAddressAdded')
-            overrideEmailState()
+            overrideEmailState({ value: '' })
             setStatus({})
             if (onDidAdd) {
                 onDidAdd()

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -29,7 +29,7 @@ interface State {
 export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, onDidAdd, history }) => {
     const [status, setStatus] = useState<State>({})
 
-    const [emailState, nextEmailFieldChange, emailInputReference] = useInputValidation(
+    const [emailState, nextEmailFieldChange, emailInputReference, overrideEmailState] = useInputValidation(
         useMemo(
             () => ({
                 synchronousValidators: [],
@@ -64,6 +64,7 @@ export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, on
             }
 
             eventLogger.log('NewUserEmailAddressAdded')
+            overrideEmailState()
             setStatus({})
             if (onDidAdd) {
                 onDidAdd()

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -160,14 +160,7 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user, history
             )}
 
             {/* re-fetch emails on onDidAdd to guarantee correct state */}
-            {/* Note: key - is a workaround to clear state in useInputValidation hook when the email is added */}
-            <AddUserEmailForm
-                key={emails.length}
-                className="mt-4"
-                user={user.id}
-                onDidAdd={fetchEmails}
-                history={history}
-            />
+            <AddUserEmailForm className="mt-4" user={user.id} onDidAdd={fetchEmails} history={history} />
             <hr className="my-4" />
             {!status.loading && (
                 <SetUserPrimaryEmailForm


### PR DESCRIPTION
@felixfbecker I think that while `useInputValidation`'s return value is starting to get ugly, most consumers don't need to override state. Should we prioritize giving consumers control, or is this change sufficient for our use cases?