### PR TITLE
authz: utilize expired_at and last_valid_at columns of user_external_accounts

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -254,6 +254,8 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 					return errors.Wrapf(err, "set expired for external account %d", acct.ID)
 				}
 				log15.Debug("PermsSyncer.syncUserPerms.setExternalAccountExpired", "userID", user.ID, "id", acct.ID)
+
+				// We still want to continue processing other external accounts
 				continue
 			}
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -249,7 +249,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		if err != nil {
 			// The "401 Unauthorized" is returned by code hosts when the token is no longer valid
 			if errcode.IsUnauthorized(errors.Cause(err)) {
-				err = db.ExternalAccounts.SetExpired(ctx, acct.ID)
+				err = db.ExternalAccounts.TouchExpired(ctx, acct.ID)
 				if err != nil {
 					return errors.Wrapf(err, "set expired for external account %d", acct.ID)
 				}
@@ -265,7 +265,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			}
 			log15.Warn("PermsSyncer.syncUserPerms.proceedWithPartialResults", "userID", user.ID, "error", err)
 		} else {
-			err = db.ExternalAccounts.SetLastValid(ctx, acct.ID)
+			err = db.ExternalAccounts.TouchLastValid(ctx, acct.ID)
 			if err != nil {
 				return errors.Wrapf(err, "set last valid for external account %d", acct.ID)
 			}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -217,9 +217,9 @@ func TestPermsSyncer_syncUserPerms_invalidToken(t *testing.T) {
 	permsStore := edb.NewPermsStore(nil, timeutil.Now)
 	s := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
 
-	calledSetExpired := false
+	calledTouchExpired := false
 	db.Mocks.ExternalAccounts.TouchExpired = func(ctx context.Context, id int32) error {
-		calledSetExpired = true
+		calledTouchExpired = true
 		return nil
 	}
 
@@ -232,8 +232,8 @@ func TestPermsSyncer_syncUserPerms_invalidToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !calledSetExpired {
-		t.Fatal("!calledSetExpired")
+	if !calledTouchExpired {
+		t.Fatal("!calledTouchExpired")
 	}
 }
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
@@ -111,6 +113,9 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	db.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
 		return &types.User{ID: id}, nil
 	}
+	db.Mocks.ExternalAccounts.SetLastValid = func(ctx context.Context, id int32) error {
+		return nil
+	}
 	edb.Mocks.Perms.ListExternalAccounts = func(context.Context, int32) ([]*extsvc.Account, error) {
 		return []*extsvc.Account{&extAccount}, nil
 	}
@@ -127,6 +132,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	defer func() {
 		db.Mocks.Users = db.MockUsers{}
+		db.Mocks.ExternalAccounts = db.MockExternalAccounts{}
 		edb.Mocks.Perms = edb.MockPerms{}
 	}()
 
@@ -167,6 +173,67 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestPermsSyncer_syncUserPerms_invalidToken(t *testing.T) {
+	p := &mockProvider{
+		serviceType: extsvc.TypeGitLab,
+		serviceID:   "https://gitlab.com/",
+	}
+	authz.SetProviders(false, []authz.Provider{p})
+	defer authz.SetProviders(true, nil)
+
+	extAccount := extsvc.Account{
+		AccountSpec: extsvc.AccountSpec{
+			ServiceType: p.ServiceType(),
+			ServiceID:   p.ServiceID(),
+		},
+	}
+
+	db.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+		return &types.User{ID: id}, nil
+	}
+	edb.Mocks.Perms.ListExternalAccounts = func(context.Context, int32) ([]*extsvc.Account, error) {
+		return []*extsvc.Account{&extAccount}, nil
+	}
+	edb.Mocks.Perms.SetUserPermissions = func(_ context.Context, p *authz.UserPermissions) error {
+		return nil
+	}
+	defer func() {
+		db.Mocks.Users = db.MockUsers{}
+		db.Mocks.ExternalAccounts = db.MockExternalAccounts{}
+		edb.Mocks.Perms = edb.MockPerms{}
+	}()
+
+	reposStore := &mockReposStore{
+		listRepos: func(_ context.Context, args repos.StoreListReposArgs) ([]*repos.Repo, error) {
+			if !args.PrivateOnly {
+				return nil, errors.New("PrivateOnly want true but got false")
+			}
+			return []*repos.Repo{{ID: 1}}, nil
+		},
+	}
+	permsStore := edb.NewPermsStore(nil, timeutil.Now)
+	s := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
+
+	calledSetExpired := false
+	db.Mocks.ExternalAccounts.SetExpired = func(ctx context.Context, id int32) error {
+		calledSetExpired = true
+		return nil
+	}
+
+	p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
+		return nil, &github.APIError{Code: http.StatusUnauthorized}
+	}
+
+	err := s.syncUserPerms(context.Background(), 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !calledSetExpired {
+		t.Fatal("!calledSetExpired")
 	}
 }
 

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -113,7 +113,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	db.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
 		return &types.User{ID: id}, nil
 	}
-	db.Mocks.ExternalAccounts.SetLastValid = func(ctx context.Context, id int32) error {
+	db.Mocks.ExternalAccounts.TouchLastValid = func(ctx context.Context, id int32) error {
 		return nil
 	}
 	edb.Mocks.Perms.ListExternalAccounts = func(context.Context, int32) ([]*extsvc.Account, error) {
@@ -218,7 +218,7 @@ func TestPermsSyncer_syncUserPerms_invalidToken(t *testing.T) {
 	s := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
 
 	calledSetExpired := false
-	db.Mocks.ExternalAccounts.SetExpired = func(ctx context.Context, id int32) error {
+	db.Mocks.ExternalAccounts.TouchExpired = func(ctx context.Context, id int32) error {
 		calledSetExpired = true
 		return nil
 	}

--- a/enterprise/internal/db/perms_store.go
+++ b/enterprise/internal/db/perms_store.go
@@ -1310,6 +1310,7 @@ FROM user_external_accounts
 WHERE
     user_id = %s
 AND deleted_at IS NULL
+AND expired_at IS NULL
 ORDER BY id ASC
 `, userID)
 	rows, err := s.db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)

--- a/enterprise/internal/db/perms_store_test.go
+++ b/enterprise/internal/db/perms_store_test.go
@@ -1937,18 +1937,19 @@ func testPermsStore_ListExternalAccounts(db *sql.DB) func(*testing.T) {
 		// Set up test users and external accounts
 		extSQL := `
 INSERT INTO
-	user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at)
+	user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at, expired_at)
 VALUES
-	(%s, %s, %s, %s, %s, %s, %s, %s)
+	(%s, %s, %s, %s, %s, %s, %s, %s, %s)
 `
 		qs := []*sqlf.Query{
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`), // ID=1
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),   // ID=2
 
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil), // ID=1
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitHub, "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock(), nil), // ID=2
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock(), nil),     // ID=3
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitHub, "https://github.com/", "bob_github", "bob_github_client_id", clock(), clock(), clock()), // ID=4
+			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil, nil), // ID=1
+			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitHub, "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock(), nil, nil), // ID=2
+			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock(), nil, nil),     // ID=3
+			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitHub, "https://github.com/", "bob_github", "bob_github_client_id", clock(), clock(), clock(), nil), // ID=4
+			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitHub, "https://github.com/", "expired", "expired_client_id", clock(), clock(), nil, clock()),       // ID=5
 		}
 		for _, q := range qs {
 			if err := s.execute(ctx, q); err != nil {

--- a/internal/db/external_accounts.go
+++ b/internal/db/external_accounts.go
@@ -207,14 +207,14 @@ VALUES ($1, $2, $3, $4, $5, $6, $7)
 	return err
 }
 
-// SetExpired sets the given user external account to be expired now.
-func (*userExternalAccounts) SetExpired(ctx context.Context, id int32) error {
+// TouchExpired sets the given user external account to be expired now.
+func (*userExternalAccounts) TouchExpired(ctx context.Context, id int32) error {
 	if Mocks.ExternalAccounts.SetExpired != nil {
 		return Mocks.ExternalAccounts.SetExpired(ctx, id)
 	}
 
 	_, err := dbconn.Global.ExecContext(ctx, `
--- source: internal/db/external_accounts.go:userExternalAccounts.SetExpired
+-- source: internal/db/external_accounts.go:userExternalAccounts.TouchExpired
 UPDATE user_external_accounts
 SET expired_at = now()
 WHERE id = $1
@@ -222,14 +222,14 @@ WHERE id = $1
 	return err
 }
 
-// SetLastValid sets last valid time of the given user external account to be now.
-func (*userExternalAccounts) SetLastValid(ctx context.Context, id int32) error {
+// TouchLastValid sets last valid time of the given user external account to be now.
+func (*userExternalAccounts) TouchLastValid(ctx context.Context, id int32) error {
 	if Mocks.ExternalAccounts.SetLastValid != nil {
 		return Mocks.ExternalAccounts.SetLastValid(ctx, id)
 	}
 
 	_, err := dbconn.Global.ExecContext(ctx, `
--- source: internal/db/external_accounts.go:userExternalAccounts.SetLastValid
+-- source: internal/db/external_accounts.go:userExternalAccounts.TouchLastValid
 UPDATE user_external_accounts
 SET
 	expired_at = NULL,

--- a/internal/db/external_accounts.go
+++ b/internal/db/external_accounts.go
@@ -209,6 +209,10 @@ VALUES ($1, $2, $3, $4, $5, $6, $7)
 
 // SetExpired sets the given user external account to be expired now.
 func (*userExternalAccounts) SetExpired(ctx context.Context, id int32) error {
+	if Mocks.ExternalAccounts.SetExpired != nil {
+		return Mocks.ExternalAccounts.SetExpired(ctx, id)
+	}
+
 	_, err := dbconn.Global.ExecContext(ctx, `
 -- source: internal/db/external_accounts.go:userExternalAccounts.SetExpired
 UPDATE user_external_accounts
@@ -220,6 +224,10 @@ WHERE id = $1
 
 // SetLastValid sets last valid time of the given user external account to be now.
 func (*userExternalAccounts) SetLastValid(ctx context.Context, id int32) error {
+	if Mocks.ExternalAccounts.SetLastValid != nil {
+		return Mocks.ExternalAccounts.SetLastValid(ctx, id)
+	}
+
 	_, err := dbconn.Global.ExecContext(ctx, `
 -- source: internal/db/external_accounts.go:userExternalAccounts.SetLastValid
 UPDATE user_external_accounts
@@ -408,4 +416,6 @@ type MockExternalAccounts struct {
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)
+	SetExpired           func(ctx context.Context, id int32) error
+	SetLastValid         func(ctx context.Context, id int32) error
 }

--- a/internal/db/external_accounts.go
+++ b/internal/db/external_accounts.go
@@ -209,8 +209,8 @@ VALUES ($1, $2, $3, $4, $5, $6, $7)
 
 // TouchExpired sets the given user external account to be expired now.
 func (*userExternalAccounts) TouchExpired(ctx context.Context, id int32) error {
-	if Mocks.ExternalAccounts.SetExpired != nil {
-		return Mocks.ExternalAccounts.SetExpired(ctx, id)
+	if Mocks.ExternalAccounts.TouchExpired != nil {
+		return Mocks.ExternalAccounts.TouchExpired(ctx, id)
 	}
 
 	_, err := dbconn.Global.ExecContext(ctx, `
@@ -224,8 +224,8 @@ WHERE id = $1
 
 // TouchLastValid sets last valid time of the given user external account to be now.
 func (*userExternalAccounts) TouchLastValid(ctx context.Context, id int32) error {
-	if Mocks.ExternalAccounts.SetLastValid != nil {
-		return Mocks.ExternalAccounts.SetLastValid(ctx, id)
+	if Mocks.ExternalAccounts.TouchLastValid != nil {
+		return Mocks.ExternalAccounts.TouchLastValid(ctx, id)
 	}
 
 	_, err := dbconn.Global.ExecContext(ctx, `
@@ -416,6 +416,6 @@ type MockExternalAccounts struct {
 	Delete               func(id int32) error
 	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count                func(ExternalAccountsListOptions) (int, error)
-	SetExpired           func(ctx context.Context, id int32) error
-	SetLastValid         func(ctx context.Context, id int32) error
+	TouchExpired         func(ctx context.Context, id int32) error
+	TouchLastValid       func(ctx context.Context, id int32) error
 }

--- a/internal/db/external_accounts_test.go
+++ b/internal/db/external_accounts_test.go
@@ -342,6 +342,10 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		if len(accts) > 0 {
 			t.Fatalf("Want no external accounts but got %d", len(accts))
 		}
@@ -362,6 +366,10 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		if len(accts) != 1 {
 			t.Fatalf("Want 1 external accounts but got %d", len(accts))
 		}
@@ -382,6 +390,10 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		if len(accts) != 1 {
 			t.Fatalf("Want 1 external accounts but got %d", len(accts))
 		}

--- a/internal/db/external_accounts_test.go
+++ b/internal/db/external_accounts_test.go
@@ -305,3 +305,105 @@ func simplifyExternalAccount(account *extsvc.Account) {
 	account.CreatedAt = time.Time{}
 	account.UpdatedAt = time.Time{}
 }
+
+func TestExternalAccounts_expiredAt(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+
+	spec := extsvc.AccountSpec{
+		ServiceType: "xa",
+		ServiceID:   "xb",
+		ClientID:    "xc",
+		AccountID:   "xd",
+	}
+	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{UserID: userID})
+	if err != nil {
+		t.Fatal(err)
+	} else if len(accts) != 1 {
+		t.Fatalf("Want 1 external accounts but got %d", len(accts))
+	}
+	acct := accts[0]
+
+	t.Run("Exclude expired", func(t *testing.T) {
+		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+			UserID:         userID,
+			ExcludeExpired: true,
+		})
+		if len(accts) > 0 {
+			t.Fatalf("Want no external accounts but got %d", len(accts))
+		}
+	})
+
+	t.Run("LookupUserAndSave should set expired_at to NULL", func(t *testing.T) {
+		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.AccountData{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+			UserID:         userID,
+			ExcludeExpired: true,
+		})
+		if len(accts) != 1 {
+			t.Fatalf("Want 1 external accounts but got %d", len(accts))
+		}
+	})
+
+	t.Run("AssociateUserAndSave should set expired_at to NULL", func(t *testing.T) {
+		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ExternalAccounts.AssociateUserAndSave(ctx, userID, spec, extsvc.AccountData{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+			UserID:         userID,
+			ExcludeExpired: true,
+		})
+		if len(accts) != 1 {
+			t.Fatalf("Want 1 external accounts but got %d", len(accts))
+		}
+	})
+
+	t.Run("SetLastValid should set expired_at to NULL", func(t *testing.T) {
+		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ExternalAccounts.SetLastValid(ctx, acct.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+			UserID:         userID,
+			ExcludeExpired: true,
+		})
+		if len(accts) != 1 {
+			t.Fatalf("Want 1 external accounts but got %d", len(accts))
+		}
+	})
+}

--- a/internal/db/external_accounts_test.go
+++ b/internal/db/external_accounts_test.go
@@ -333,7 +333,7 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	acct := accts[0]
 
 	t.Run("Exclude expired", func(t *testing.T) {
-		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -348,7 +348,7 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("LookupUserAndSave should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -368,7 +368,7 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("AssociateUserAndSave should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -387,13 +387,13 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 		}
 	})
 
-	t.Run("SetLastValid should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts.SetExpired(ctx, acct.ID)
+	t.Run("TouchLastValid should set expired_at to NULL", func(t *testing.T) {
+		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ExternalAccounts.SetLastValid(ctx, acct.ID)
+		err = ExternalAccounts.TouchLastValid(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -173,6 +173,10 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("request to %s returned status %d: %s", e.URL, e.Code, e.Message)
 }
 
+func (e *APIError) Unauthorized() bool {
+	return e.Code == http.StatusUnauthorized
+}
+
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from
 // this package. Otherwise it returns 0.
 func HTTPErrorCode(err error) int {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -268,6 +268,10 @@ func (err HTTPError) Error() string {
 	return fmt.Sprintf("HTTP error status %d", err)
 }
 
+func (err HTTPError) Unauthorized() bool {
+	return err == http.StatusUnauthorized
+}
+
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from
 // this package. Otherwise it returns 0.
 func HTTPErrorCode(err error) int {


### PR DESCRIPTION
This PR does two things in the PermsSyncer:

- When successfully used a token from `user_external_accounts`, we update the `last_valid_at` column.
- Otherwise, update the `expired_at` column.

Part of #14899

### TODOs

- [x] Implements `errcode.IsUnauthorized` for GitHub and GitLab errors
- [x] Add tests for `db.ExternalAccounts`
- [x] Add tests for `PermsSyncer`