### PR TITLE
gitserver: Avoid double HTTP response header writing

### DIFF
--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -105,7 +105,7 @@ func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cmd.Stdout = flowrateWriter(w)
 	cmd.Stdin = body
 	if err := cmd.Run(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log15.Error("gitservice.ServeHTTP", "svc", svc, "repo", repo, "protocol", r.Header.Get("Git-Protocol"), "duration", time.Since(start), "error", err.Error())
 	}
 }
 


### PR DESCRIPTION
Avoids errors like `http: superfluous response.WriteHeader call from github.com/sourcegraph/sourcegraph/cmd/gitserver/server.(*gitServiceHandler).ServeHTTP (gitservice.go:108)`
