### PR TITLE
monitoring: Change syntect_server owner to Cloud team

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3390,7 +3390,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: syntax_highlighting_errors
 
-<p class="subtitle">code-intel: syntax highlighting errors every 5m</p>**Descriptions:**
+<p class="subtitle">cloud: syntax highlighting errors every 5m</p>**Descriptions:**
 
 - _syntect-server: 5%+ syntax highlighting errors every 5m for 5m0s_
 
@@ -3407,7 +3407,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: syntax_highlighting_timeouts
 
-<p class="subtitle">code-intel: syntax highlighting timeouts every 5m</p>**Descriptions:**
+<p class="subtitle">cloud: syntax highlighting timeouts every 5m</p>**Descriptions:**
 
 - _syntect-server: 5%+ syntax highlighting timeouts every 5m for 5m0s_
 
@@ -3424,7 +3424,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: syntax_highlighting_panics
 
-<p class="subtitle">code-intel: syntax highlighting panics every 5m</p>**Descriptions:**
+<p class="subtitle">cloud: syntax highlighting panics every 5m</p>**Descriptions:**
 
 - _syntect-server: 5+ syntax highlighting panics every 5m_
 
@@ -3441,7 +3441,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: syntax_highlighting_worker_deaths
 
-<p class="subtitle">code-intel: syntax highlighter worker deaths every 5m</p>**Descriptions:**
+<p class="subtitle">cloud: syntax highlighter worker deaths every 5m</p>**Descriptions:**
 
 - _syntect-server: 1+ syntax highlighter worker deaths every 5m_
 
@@ -3458,7 +3458,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: container_cpu_usage
 
-<p class="subtitle">code-intel: container cpu usage total (1m average) across all cores by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container cpu usage total (1m average) across all cores by instance</p>**Descriptions:**
 
 - _syntect-server: 99%+ container cpu usage total (1m average) across all cores by instance_
 
@@ -3477,7 +3477,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: container_memory_usage
 
-<p class="subtitle">code-intel: container memory usage by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container memory usage by instance</p>**Descriptions:**
 
 - _syntect-server: 99%+ container memory usage by instance_
 
@@ -3496,7 +3496,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: container_restarts
 
-<p class="subtitle">code-intel: container restarts every 5m by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container restarts every 5m by instance</p>**Descriptions:**
 
 - _syntect-server: 1+ container restarts every 5m by instance_
 
@@ -3519,7 +3519,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: fs_inodes_used
 
-<p class="subtitle">code-intel: fs inodes in use by instance</p>**Descriptions:**
+<p class="subtitle">cloud: fs inodes in use by instance</p>**Descriptions:**
 
 - _syntect-server: 3e+06+ fs inodes in use by instance_
 
@@ -3538,7 +3538,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">code-intel: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
 - _syntect-server: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
@@ -3559,7 +3559,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">code-intel: container memory usage (1d maximum) by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
 - _syntect-server: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
 
@@ -3580,7 +3580,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">code-intel: container cpu usage total (5m maximum) across all cores by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container cpu usage total (5m maximum) across all cores by instance</p>**Descriptions:**
 
 - _syntect-server: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s_
 
@@ -3599,7 +3599,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">code-intel: container memory usage (5m maximum) by instance</p>**Descriptions:**
+<p class="subtitle">cloud: container memory usage (5m maximum) by instance</p>**Descriptions:**
 
 - _syntect-server: 90%+ container memory usage (5m maximum) by instance_
 
@@ -3618,7 +3618,7 @@ with your code hosts connections or networking issues affecting communication wi
 <br />
 ## syntect-server: pods_available_percentage
 
-<p class="subtitle">code-intel: percentage pods available</p>**Descriptions:**
+<p class="subtitle">cloud: percentage pods available</p>**Descriptions:**
 
 - _syntect-server: less than 90% percentage pods available for 10m0s_
 

--- a/monitoring/syntect_server.go
+++ b/monitoring/syntect_server.go
@@ -19,7 +19,7 @@ func SyntectServer() *Container {
 							DataMayNotExist:   true,
 							Warning:           Alert().GreaterOrEqual(5).For(5 * time.Minute),
 							PanelOptions:      PanelOptions().LegendFormat("error").Unit(Percentage),
-							Owner:             ObservableOwnerCodeIntel,
+							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "none",
 						},
 						{
@@ -29,7 +29,7 @@ func SyntectServer() *Container {
 							DataMayNotExist:   true,
 							Warning:           Alert().GreaterOrEqual(5).For(5 * time.Minute),
 							PanelOptions:      PanelOptions().LegendFormat("timeout").Unit(Percentage),
-							Owner:             ObservableOwnerCodeIntel,
+							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "none",
 						},
 					},
@@ -41,7 +41,7 @@ func SyntectServer() *Container {
 							DataMayNotExist:   true,
 							Warning:           Alert().GreaterOrEqual(5),
 							PanelOptions:      PanelOptions().LegendFormat("panic"),
-							Owner:             ObservableOwnerCodeIntel,
+							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "none",
 						},
 						{
@@ -51,7 +51,7 @@ func SyntectServer() *Container {
 							DataMayNotExist:   true,
 							Warning:           Alert().GreaterOrEqual(1),
 							PanelOptions:      PanelOptions().LegendFormat("worker death"),
-							Owner:             ObservableOwnerCodeIntel,
+							Owner:             ObservableOwnerCloud,
 							PossibleSolutions: "none",
 						},
 					},
@@ -62,12 +62,12 @@ func SyntectServer() *Container {
 				Hidden: true,
 				Rows: []Row{
 					{
-						sharedContainerCPUUsage("syntect-server", ObservableOwnerCodeIntel),
-						sharedContainerMemoryUsage("syntect-server", ObservableOwnerCodeIntel),
+						sharedContainerCPUUsage("syntect-server", ObservableOwnerCloud),
+						sharedContainerMemoryUsage("syntect-server", ObservableOwnerCloud),
 					},
 					{
-						sharedContainerRestarts("syntect-server", ObservableOwnerCodeIntel),
-						sharedContainerFsInodes("syntect-server", ObservableOwnerCodeIntel),
+						sharedContainerRestarts("syntect-server", ObservableOwnerCloud),
+						sharedContainerFsInodes("syntect-server", ObservableOwnerCloud),
 					},
 				},
 			},
@@ -76,12 +76,12 @@ func SyntectServer() *Container {
 				Hidden: true,
 				Rows: []Row{
 					{
-						sharedProvisioningCPUUsageLongTerm("syntect-server", ObservableOwnerCodeIntel),
-						sharedProvisioningMemoryUsageLongTerm("syntect-server", ObservableOwnerCodeIntel),
+						sharedProvisioningCPUUsageLongTerm("syntect-server", ObservableOwnerCloud),
+						sharedProvisioningMemoryUsageLongTerm("syntect-server", ObservableOwnerCloud),
 					},
 					{
-						sharedProvisioningCPUUsageShortTerm("syntect-server", ObservableOwnerCodeIntel),
-						sharedProvisioningMemoryUsageShortTerm("syntect-server", ObservableOwnerCodeIntel),
+						sharedProvisioningCPUUsageShortTerm("syntect-server", ObservableOwnerCloud),
+						sharedProvisioningMemoryUsageShortTerm("syntect-server", ObservableOwnerCloud),
 					},
 				},
 			},
@@ -90,7 +90,7 @@ func SyntectServer() *Container {
 				Hidden: true,
 				Rows: []Row{
 					{
-						sharedKubernetesPodsAvailable("syntect-server", ObservableOwnerCodeIntel),
+						sharedKubernetesPodsAvailable("syntect-server", ObservableOwnerCloud),
 					},
 				},
 			},


### PR DESCRIPTION
The code intel team never really owned this service. @slimsag built this
and mostly maintains it, but we have only team ownership of services, so
it makes sense to put this under Cloud / Backend Infra / Backend
Platform, because it's a shared service, like gitserver.

Time to learn some Rust I guess. :D



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
