### PR TITLE
codeintel: Reduce memory when calculating commit graph

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/commit_graph_view.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commit_graph_view.go
@@ -1,0 +1,59 @@
+package dbstore
+
+// CommitGraphView is a space-efficient view of a commit graph decorated with the
+// set of uploads visible at every commit.
+type CommitGraphView struct {
+	// Meta is a map from commit to metadata on each visible upload from that
+	// commit's location in the commit graph.
+	Meta map[string][]UploadMeta
+
+	// Tokens is a map from upload identifiers to a hash of their root an indexer
+	// field. Equality of this token for two uploads means that they are able to
+	// "shadow" one another.
+	Tokens map[int]string
+}
+
+func NewCommitGraphView() *CommitGraphView {
+	return &CommitGraphView{
+		Meta:   map[string][]UploadMeta{},
+		Tokens: map[int]string{},
+	}
+}
+
+func (v *CommitGraphView) Add(meta UploadMeta, commit, token string) {
+	v.Meta[commit] = append(v.Meta[commit], meta)
+	v.Tokens[meta.UploadID] = token
+}
+
+// UploadMeta represents the visibility of an LSIF upload from a particular location
+// on a repository's commit graph. The Flags field describes the visibility of the
+// upload from the current viewer's perspective.
+type UploadMeta struct {
+	UploadID int
+
+	// Flags encodes the flags FlagAncestorVisible and FlagOverwritten and leaves
+	// the remaining lower 30-bits to encode an unsigned distance between commits.
+	Flags uint32
+}
+
+const (
+	// FlagAncestorVisible indicates whether or not this upload was visible to the commit
+	// by looking for older uploads defined in an ancestor commit. False indicates that
+	// the upload is only visible via another upload defined in a descendant commit.
+	FlagAncestorVisible uint32 = (1 << 30)
+
+	// FlagOverwritten indicates that this upload defined on an ancestor commit that is
+	// farther away than an upload defined on a descendant commit that has the same root
+	// and indexer.
+	//
+	// If overwritten, this upload is not considered in nearest commit operations, but
+	// is kept in the database so that we can reconstruct the set of all ancestor-visible
+	// uploads of a commit, which is useful when determining the closest uploads with only
+	// a partial commit graph.
+	FlagOverwritten uint32 = (1 << 29)
+
+	// MaxDistance is the maximum encodeable distance between two commits.
+	//
+	// This value can be used to quickly remove flags from the encoded distance value.
+	MaxDistance = ^(FlagAncestorVisible | FlagOverwritten)
+)

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -62,8 +62,8 @@ func TestHasCommit(t *testing.T) {
 		{51, makeCommit(1), false},
 	}
 
-	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{makeCommit(1): {{UploadID: 42, Distance: 1}}})
-	insertNearestUploads(t, dbconn.Global, 51, map[string][]UploadMeta{makeCommit(2): {{UploadID: 43, Distance: 2}}})
+	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{makeCommit(1): {{UploadID: 42, Flags: 1}}})
+	insertNearestUploads(t, dbconn.Global, 51, map[string][]UploadMeta{makeCommit(2): {{UploadID: 43, Flags: 2}}})
 
 	for _, testCase := range testCases {
 		name := fmt.Sprintf("repositoryID=%d commit=%s", testCase.repositoryID, testCase.commit)
@@ -145,14 +145,14 @@ func TestCalculateVisibleUploads(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}},
-		makeCommit(3): {{UploadID: 2, Distance: 0}},
-		makeCommit(4): {{UploadID: 2, Distance: 1}},
-		makeCommit(5): {{UploadID: 1, Distance: 2}},
-		makeCommit(6): {{UploadID: 3, Distance: 1}},
-		makeCommit(7): {{UploadID: 3, Distance: 0}},
-		makeCommit(8): {{UploadID: 1, Distance: 4}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}},
+		makeCommit(3): {{UploadID: 2, Flags: 0}},
+		makeCommit(4): {{UploadID: 2, Flags: 1}},
+		makeCommit(5): {{UploadID: 1, Flags: 2}},
+		makeCommit(6): {{UploadID: 3, Flags: 1}},
+		makeCommit(7): {{UploadID: 3, Flags: 0}},
+		makeCommit(8): {{UploadID: 1, Flags: 4}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -199,9 +199,9 @@ func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 1}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 1}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -239,8 +239,8 @@ func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -305,12 +305,12 @@ func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 0}, {UploadID: 5, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}},
-		makeCommit(4): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 7, Distance: 0}},
-		makeCommit(5): {{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 3}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0}},
-		makeCommit(6): {{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 4}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1}, {UploadID: 9, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 0}, {UploadID: 5, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}},
+		makeCommit(4): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 7, Flags: 0}},
+		makeCommit(5): {{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 3}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0}},
+		makeCommit(6): {{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 4}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1}, {UploadID: 9, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -358,24 +358,24 @@ func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
 
 	expectedVisibleUploads := map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 3},
-			{UploadID: 5, Distance: 0}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 3},
+			{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 3},
+			{UploadID: 5, Flags: 0}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 3},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 2},
-			{UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 2},
+			{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 2},
+			{UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 2},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 2}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 0}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 2}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 0}, {UploadID: 8, Flags: 1},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 0},
-			{UploadID: 5, Distance: 3}, {UploadID: 6, Distance: 2}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0},
+			{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 0},
+			{UploadID: 5, Flags: 3}, {UploadID: 6, Flags: 2}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0},
 		},
 		makeCommit(5): {
-			{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 3}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 4}, {UploadID: 6, Distance: 3}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 3}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 4}, {UploadID: 6, Flags: 3}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1},
 		},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {

--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -182,9 +182,9 @@ func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 		commits = append(commits, sqlf.Sprintf("%s", commit))
 	}
 
-	uploadMeta, err := scanUploadMeta(s.Store.Query(ctx, sqlf.Sprintf(
+	commitGraphView, err := scanCommitGraphView(s.Store.Query(ctx, sqlf.Sprintf(
 		`
-			SELECT nu.upload_id, encode(nu.commit_bytea, 'hex'), u.root, u.indexer, nu.distance, nu.ancestor_visible, nu.overwritten
+			SELECT nu.upload_id, encode(nu.commit_bytea, 'hex'), md5(u.root || ':' || u.indexer) as token, nu.distance, nu.ancestor_visible, nu.overwritten
 			FROM lsif_nearest_uploads nu
 			JOIN lsif_uploads u ON u.id = nu.upload_id
 			WHERE nu.repository_id = %s AND encode(nu.commit_bytea, 'hex') IN (%s) AND nu.ancestor_visible
@@ -196,14 +196,14 @@ func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 		return nil, err
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, uploadMeta)
+	visibleUploads, err := calculateVisibleUploads(graph, commitGraphView)
 	if err != nil {
 		return nil, err
 	}
 
 	var ids []*sqlf.Query
 	for _, uploadMeta := range visibleUploads[commit] {
-		if !uploadMeta.Overwritten {
+		if (uploadMeta.Flags & FlagOverwritten) == 0 {
 			ids = append(ids, sqlf.Sprintf("%d", uploadMeta.UploadID))
 		}
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
@@ -102,21 +102,21 @@ func TestFindClosestDumps(t *testing.T) {
 		makeCommit(8): {makeCommit(6)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}},
-		makeCommit(3): {{UploadID: 2, Distance: 0}},
-		makeCommit(4): {{UploadID: 2, Distance: 1}},
-		makeCommit(5): {{UploadID: 1, Distance: 2}},
-		makeCommit(6): {{UploadID: 3, Distance: 1}},
-		makeCommit(7): {{UploadID: 3, Distance: 0}},
-		makeCommit(8): {{UploadID: 1, Distance: 4}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}},
+		makeCommit(3): {{UploadID: 2, Flags: 0}},
+		makeCommit(4): {{UploadID: 2, Flags: 1}},
+		makeCommit(5): {{UploadID: 1, Flags: 2}},
+		makeCommit(6): {{UploadID: 3, Flags: 1}},
+		makeCommit(7): {{UploadID: 3, Flags: 0}},
+		makeCommit(8): {{UploadID: 1, Flags: 4}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -165,16 +165,16 @@ func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 		makeCommit(8): {makeCommit(7)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 1}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 1}},
 		makeCommit(4): nil,
 		makeCommit(5): nil,
 		makeCommit(6): nil,
@@ -220,15 +220,15 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 		makeCommit(2): {makeCommit(1)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -292,19 +292,19 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 		makeCommit(6): {makeCommit(5)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 0}, {UploadID: 5, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}},
-		makeCommit(4): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 7, Distance: 0}},
-		makeCommit(5): {{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 3}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0}},
-		makeCommit(6): {{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 4}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1}, {UploadID: 9, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 0}, {UploadID: 5, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}},
+		makeCommit(4): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 7, Flags: 0}},
+		makeCommit(5): {{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 3}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0}},
+		makeCommit(6): {{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 4}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1}, {UploadID: 9, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -350,7 +350,7 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 		makeCommit(5): {makeCommit(4)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
@@ -358,24 +358,24 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 
 	expectedVisibleUploads := map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 3},
-			{UploadID: 5, Distance: 0}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 3},
+			{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 3},
+			{UploadID: 5, Flags: 0}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 3},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 2},
-			{UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 2},
+			{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 2},
+			{UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 2},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 2}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 0}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 2}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 0}, {UploadID: 8, Flags: 1},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 0},
-			{UploadID: 5, Distance: 3}, {UploadID: 6, Distance: 2}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0},
+			{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 0},
+			{UploadID: 5, Flags: 3}, {UploadID: 6, Flags: 2}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0},
 		},
 		makeCommit(5): {
-			{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 3}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 4}, {UploadID: 6, Distance: 3}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 3}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 4}, {UploadID: 6, Flags: 3}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1},
 		},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
@@ -414,14 +414,14 @@ func TestFindClosestDumpsIntersectingPath(t *testing.T) {
 		makeCommit(1): {},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
+		makeCommit(1): {{UploadID: 1}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -463,18 +463,18 @@ func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
 		makeCommit(6): {makeCommit(5)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(currentGraph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(currentGraph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}},
-		makeCommit(3): {{UploadID: 1, Distance: 2}},
-		makeCommit(5): {{UploadID: 2, Distance: 0}},
-		makeCommit(6): {{UploadID: 2, Distance: 1}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}},
+		makeCommit(3): {{UploadID: 1, Flags: 2}},
+		makeCommit(5): {{UploadID: 2, Flags: 0}},
+		makeCommit(6): {{UploadID: 2, Flags: 1}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)

--- a/enterprise/internal/codeintel/stores/dbstore/references_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/references_test.go
@@ -28,32 +28,32 @@ func TestSameRepoPager(t *testing.T) {
 
 	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Root: "sub1/", Distance: 1},
-			{UploadID: 2, Root: "sub2/", Distance: 2},
-			{UploadID: 3, Root: "sub3/", Distance: 3},
-			{UploadID: 4, Root: "sub4/", Distance: 2},
-			{UploadID: 5, Root: "sub5/", Distance: 1},
+			{UploadID: 1, Flags: 1},
+			{UploadID: 2, Flags: 2},
+			{UploadID: 3, Flags: 3},
+			{UploadID: 4, Flags: 2},
+			{UploadID: 5, Flags: 1},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Root: "sub1/", Distance: 0},
-			{UploadID: 2, Root: "sub2/", Distance: 1},
-			{UploadID: 3, Root: "sub3/", Distance: 2},
-			{UploadID: 4, Root: "sub4/", Distance: 1},
-			{UploadID: 5, Root: "sub5/", Distance: 0},
+			{UploadID: 1, Flags: 0},
+			{UploadID: 2, Flags: 1},
+			{UploadID: 3, Flags: 2},
+			{UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 0},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Root: "sub1/", Distance: 1},
-			{UploadID: 2, Root: "sub2/", Distance: 0},
-			{UploadID: 3, Root: "sub3/", Distance: 1},
-			{UploadID: 4, Root: "sub4/", Distance: 0},
-			{UploadID: 5, Root: "sub5/", Distance: 1},
+			{UploadID: 1, Flags: 1},
+			{UploadID: 2, Flags: 0},
+			{UploadID: 3, Flags: 1},
+			{UploadID: 4, Flags: 0},
+			{UploadID: 5, Flags: 1},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Root: "sub1/", Distance: 2},
-			{UploadID: 2, Root: "sub2/", Distance: 1},
-			{UploadID: 3, Root: "sub3/", Distance: 0},
-			{UploadID: 4, Root: "sub4/", Distance: 1},
-			{UploadID: 5, Root: "sub5/", Distance: 2},
+			{UploadID: 1, Flags: 2},
+			{UploadID: 2, Flags: 1},
+			{UploadID: 3, Flags: 0},
+			{UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 2},
 		},
 	})
 
@@ -122,15 +122,15 @@ func TestSameRepoPagerMultiplePages(t *testing.T) {
 
 	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Root: "sub1/", Distance: 0},
-			{UploadID: 2, Root: "sub2/", Distance: 0},
-			{UploadID: 3, Root: "sub3/", Distance: 0},
-			{UploadID: 4, Root: "sub4/", Distance: 0},
-			{UploadID: 5, Root: "sub5/", Distance: 0},
-			{UploadID: 6, Root: "sub6/", Distance: 0},
-			{UploadID: 7, Root: "sub7/", Distance: 0},
-			{UploadID: 8, Root: "sub8/", Distance: 0},
-			{UploadID: 9, Root: "sub9/", Distance: 0},
+			{UploadID: 1},
+			{UploadID: 2},
+			{UploadID: 3},
+			{UploadID: 4},
+			{UploadID: 5},
+			{UploadID: 6},
+			{UploadID: 7},
+			{UploadID: 8},
+			{UploadID: 9},
 		},
 	})
 
@@ -187,16 +187,12 @@ func TestSameRepoPagerVisibility(t *testing.T) {
 	)
 
 	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Root: "sub1/", Distance: 0}},
-		makeCommit(2): {{UploadID: 2, Root: "sub2/", Distance: 0}},
-		makeCommit(3): {{UploadID: 3, Root: "sub1/", Distance: 0}},
-		makeCommit(4): {{UploadID: 4, Root: "sub2/", Distance: 0}},
-		makeCommit(5): {{UploadID: 5, Root: "sub5/", Distance: 0}},
-		makeCommit(6): {
-			{UploadID: 3, Root: "sub1/", Distance: 3},
-			{UploadID: 4, Root: "sub2/", Distance: 2},
-			{UploadID: 5, Root: "sub5/", Distance: 1},
-		},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 2, Flags: 0}},
+		makeCommit(3): {{UploadID: 3, Flags: 0}},
+		makeCommit(4): {{UploadID: 4, Flags: 0}},
+		makeCommit(5): {{UploadID: 5, Flags: 0}},
+		makeCommit(6): {{UploadID: 3, Flags: 3}, {UploadID: 4, Flags: 2}, {UploadID: 5, Flags: 1}},
 	})
 
 	expected := []lsifstore.PackageReference{


### PR DESCRIPTION
This is an effort to reduce memory pressure as described in https://github.com/sourcegraph/sourcegraph/issues/16030.

## What changed?

We join lsif_nearest_uploads with lsif_uploads to bring back the root and indexer values of each upload to determine which uploads can "shadow" another's visibility on the git commit graph. We bring these fields back with full information, although we only need to determine if they are the same or not.

We instead bring back an md5 hash of those two fields. If the root and indexer fields are the same, the hash will also be the same. And, with acceptable likelihood, two different hashes have a different root or indexer.

This saves us many duplicate copies of the same strings in memory, which was causing a lot of pressure.

## Results

**TL;DR:** This change will make the graph update procedure 2.5x slower, but will take only 1/4 of the memory.

**Before:**
```
$ go test -run='^BenchmarkCalculateVisibleUploads$' -bench=. -benchmem -v
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore
BenchmarkCalculateVisibleUploads
BenchmarkCalculateVisibleUploads-16    	       1	3466152664 ns/op	415819920 B/op	   63756 allocs/op
PASS
ok  	github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore	3.726s

```

**After:**
```
$ go test -run='^BenchmarkCalculateVisibleUploads$' -bench=. -benchmem -v
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore
BenchmarkCalculateVisibleUploads
BenchmarkCalculateVisibleUploads-16    	       1	8871662674 ns/op	107866832 B/op	   63830 allocs/op
PASS
ok  	github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore	9.182s
```

<details>
<summary>Benchmark test (run on main@HEAD)</summary>

```go
func BenchmarkCalculateVisibleUploads(b *testing.B) {
	var (
		numCommits = 5000
		numUploads = 2000
		numRoots   = 500
	)

	var commits []string
	for i := 0; i < numCommits; i++ {
		commits = append(commits, fmt.Sprintf("%40d", i))
	}

	graph := map[string][]string{}
	for i, commit := range commits {
		if i == 0 {
			graph[commit] = nil
		} else {
			graph[commit] = commits[i-1 : i]
		}
	}

	var roots []string
	for i := 0; i < numRoots; i++ {
		roots = append(roots, fmt.Sprintf("sub%d/", i))
	}

	uploads := map[string][]UploadMeta{}
	for i := 0; i < numUploads; i++ {
		x := fmt.Sprintf("%40d", int((float64(i*numUploads) / float64(numCommits))))
		uploads[x] = append(uploads[x], UploadMeta{
			UploadID: i,
			Root:     roots[i%numRoots],
			Indexer:  "lsif-go",
		})
	}

	b.ResetTimer()
	b.ReportAllocs()

	for i := 0; i < b.N; i++ {
		_, _ = calculateVisibleUploads(graph, uploads)
	}
}
```
</details>