### PR TITLE
Send LSIF data to the dogfood instance

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -10,8 +10,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: Generate LSIF data
         run: lsif-go
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-web:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -31,6 +35,10 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-shared:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -50,6 +58,10 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-branded:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -69,6 +81,10 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/branded/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-browser:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -88,6 +104,10 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-web:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -109,6 +129,10 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-shared:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -130,6 +154,10 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-browser:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -151,3 +179,7 @@ jobs:
       - name: Upload LSIF data
         working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload LSIF data to dogfood
+        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -32,10 +32,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/web/
         run: lsif-tsc -p .
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
@@ -55,10 +56,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/shared/
         run: lsif-tsc -p .
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
@@ -78,10 +80,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/branded/
         run: lsif-tsc -p .
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/branded/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/branded/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
@@ -101,10 +104,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/browser/
         run: lsif-tsc -p .
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
@@ -126,10 +130,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/web/
         run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
@@ -151,10 +156,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/shared/
         run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
@@ -176,10 +182,11 @@ jobs:
       - name: Generate LSIF data
         working-directory: client/browser/
         run: yarn eslint -f lsif -o dump.lsif
-      - name: Upload LSIF data
+      - name: Upload LSIF data to .com
         working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload LSIF data to dogfood
+        working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/15510

As part of https://github.com/orgs/sourcegraph/projects/107 we want to make sure LSIF content is uploaded to our dogfood instance. This enables parallel uploads to .com and dogfood.