### PR TITLE
e2e: ensure artifacts are uploaded

### DIFF
--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -4,6 +4,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -euxo pipefail
 
 box="$1"
+exit_code=0
+
 pushd "dev/ci/test"
 
 cleanup() {
@@ -18,8 +20,12 @@ for i in "${plugins[@]}"; do
 done
 
 trap cleanup EXIT
-vagrant up "$box" --provider=google
+vagrant up "$box" --provider=google || exit_code=$?
 
 vagrant scp "${box}:/sourcegraph/puppeteer/*.png" ../../../
 vagrant scp "${box}:/sourcegraph/*.mp4" ../../../
 vagrant scp "${box}:/sourcegraph/*.log" ../../../
+
+if [ "$exit_code" != 0 ]; then
+  exit $exit_code
+fi

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -22,7 +22,7 @@ describe('e2e test suite', () => {
         // Cloning the repositories takes ~1 minute, so give initialization 2
         // minutes instead of 1 (which would be inherited from
         // `jest.setTimeout(1 * 60 * 1000)` above).
-        this.timeout(2 * 60 * 1000)
+        this.timeout(5 * 60 * 1000)
 
         // Reset date mocking
         MockDate.reset()

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -12,6 +12,7 @@ import { getConfig } from '../../../shared/src/testing/config'
 import assert from 'assert'
 import expect from 'expect'
 import { Settings } from '../schema/settings.schema'
+import delay from 'delay'
 
 const { gitHubToken, sourcegraphBaseUrl } = getConfig('gitHubToken', 'sourcegraphBaseUrl')
 
@@ -321,6 +322,7 @@ describe('e2e test suite', () => {
                 }),
                 ensureRepos: ['bbs/SOURCEGRAPH/jsonrpc2'],
             })
+            await delay(10000)
             await driver.page.goto(sourcegraphBaseUrl + '/bbs/SOURCEGRAPH/jsonrpc2/-/blob/.travis.yml')
             const blob = (await (
                 await driver.page.waitFor(() => document.querySelector<HTMLElement>('.test-repo-blob')?.textContent)

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -12,7 +12,6 @@ import { getConfig } from '../../../shared/src/testing/config'
 import assert from 'assert'
 import expect from 'expect'
 import { Settings } from '../schema/settings.schema'
-import delay from 'delay'
 
 const { gitHubToken, sourcegraphBaseUrl } = getConfig('gitHubToken', 'sourcegraphBaseUrl')
 
@@ -322,7 +321,6 @@ describe('e2e test suite', () => {
                 }),
                 ensureRepos: ['bbs/SOURCEGRAPH/jsonrpc2'],
             })
-            await delay(10000)
             await driver.page.goto(sourcegraphBaseUrl + '/bbs/SOURCEGRAPH/jsonrpc2/-/blob/.travis.yml')
             const blob = (await (
                 await driver.page.waitFor(() => document.querySelector<HTMLElement>('.test-repo-blob')?.textContent)

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -164,5 +164,5 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || c.branch == "dt/e2e_timeout"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
 }

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -164,5 +164,5 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || c.branch == "dt/e2e_timeout"
 }


### PR DESCRIPTION
Increases overall timeout due to errors in CI and ensures artifacts are uploaded even if tests fail. 