### PR TITLE
Add explicit note on HTTPS to Gitlab<>Sourcegraph native integration

### DIFF
--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -61,7 +61,7 @@ If enabled, the default rate is set at 36,000 per hour (10 per second) which can
 
 ## Native integration
 
-To provide out-of-the-box code intelligence and navigation features to your users on GitLab, you will need to [configure your GitLab instance](https://docs.gitlab.com/ee/integration/sourcegraph.html).
+To provide out-of-the-box code intelligence and navigation features to your users on GitLab, you will need to [configure your GitLab instance](https://docs.gitlab.com/ee/integration/sourcegraph.html). If you are using an HTTPS connection to GitLab, you will need to [configure HTTPS](https://docs.sourcegraph.com/admin/http_https_configuration) for your Sourcegraph instance.
 
 The Sourcegraph instance's site admin must [update the `corsOrigin` site config property](../config/site_config.md) to allow the GitLab instance to communicate with the Sourcegraph instance. For example:
 


### PR DESCRIPTION
A few customers have hit this so we want to add this explicit note. A few weeks ago I made a [MR for this update](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/46291#note_453079159) on our docs on GitLab; now catching up on my backlog and making the update here as well. 