### PR TITLE
search frontend: render streaming search results

### DIFF
--- a/client/shared/src/util/searchTestHelpers.ts
+++ b/client/shared/src/util/searchTestHelpers.ts
@@ -1,18 +1,19 @@
 import { of } from 'rxjs'
 import sinon from 'sinon'
+import { FlatExtensionHostAPI } from '../api/contract'
+import { pretendRemote } from '../api/util'
 import { Controller } from '../extensions/controller'
 import {
-    ISearchResults,
     IFileMatch,
-    ILineMatch,
     IGitBlob,
     IGitCommit,
+    ILineMatch,
     IRepository,
+    ISearchResultMatch,
+    ISearchResults,
     ISymbol,
     SearchResult,
 } from '../graphql/schema'
-import { pretendRemote } from '../api/util'
-import { FlatExtensionHostAPI } from '../api/contract'
 
 export const RESULT = {
     __typename: 'FileMatch' as const,
@@ -33,6 +34,14 @@ export const RESULT = {
         } as ILineMatch,
     ],
 } as IFileMatch
+
+export const REPO_MATCH_RESULT = {
+    __typename: 'Repository',
+    name: 'github.com/golang/oauth2',
+    url: '/github.com/golang/oauth2',
+    matches: [] as ISearchResultMatch[],
+    label: { __typename: 'Markdown', text: '[github.com/golang/oauth2](github.com/golang/oauth2)' },
+} as IRepository
 
 export const MULTIPLE_MATCH_RESULT = {
     __typename: 'FileMatch',

--- a/client/web/src/search/results/SearchResultsList.story.tsx
+++ b/client/web/src/search/results/SearchResultsList.story.tsx
@@ -6,6 +6,7 @@ import { NOOP_TELEMETRY_SERVICE } from '../../../../shared/src/telemetry/telemet
 import {
     extensionsController,
     HIGHLIGHTED_FILE_LINES_REQUEST,
+    MULTIPLE_SEARCH_REQUEST,
     SEARCH_REQUEST,
 } from '../../../../shared/src/util/searchTestHelpers'
 import { SearchResultsList, SearchResultsListProps } from './SearchResultsList'
@@ -71,6 +72,10 @@ const { add } = storiesOf('web/search/results/SearchResultsList', module).addPar
 add('loading', () => <WebStory>{() => <SearchResultsList {...defaultProps} resultsOrError={undefined} />}</WebStory>)
 
 add('single result', () => <WebStory>{() => <SearchResultsList {...defaultProps} />}</WebStory>)
+
+add('multiple results', () => (
+    <WebStory>{() => <SearchResultsList {...defaultProps} resultsOrError={MULTIPLE_SEARCH_REQUEST()} />}</WebStory>
+))
 
 add('no results with quote tip in infobar', () => {
     const resultsOrError: ISearchResults = {

--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -4,17 +4,23 @@ import React from 'react'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 import { SearchPatternType } from '../../../../../shared/src/graphql-operations'
+import * as GQL from '../../../../../shared/src/graphql/schema'
 import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
-import { extensionsController, MULTIPLE_SEARCH_RESULT } from '../../../../../shared/src/util/searchTestHelpers'
 import { WebStory } from '../../../components/WebStory'
 import { AggregateStreamingSearchResults } from '../../stream'
 import { StreamingSearchResults, StreamingSearchResultsProps } from './StreamingSearchResults'
+import {
+    extensionsController,
+    HIGHLIGHTED_FILE_LINES_LONG,
+    MULTIPLE_SEARCH_RESULT,
+    REPO_MATCH_RESULT,
+} from '../../../../../shared/src/util/searchTestHelpers'
 
 const history = createBrowserHistory()
 history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })
 
 const streamingSearchResult: AggregateStreamingSearchResults = {
-    results: MULTIPLE_SEARCH_RESULT.results,
+    results: [...MULTIPLE_SEARCH_RESULT.results, REPO_MATCH_RESULT] as GQL.SearchResult[],
     filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
     progress: {
         done: true,
@@ -40,6 +46,7 @@ const defaultProps: StreamingSearchResultsProps = {
     history,
     location: history.location,
     authenticatedUser: null,
+    isLightTheme: true,
 
     navbarSearchQueryState: { query: '', cursorPosition: 0 },
 
@@ -50,6 +57,8 @@ const defaultProps: StreamingSearchResultsProps = {
     platformContext: { forceUpdateTooltip: sinon.spy(), settings: NEVER },
 
     streamSearch: () => of(streamingSearchResult),
+
+    fetchHighlightedFileLines: () => of(HIGHLIGHTED_FILE_LINES_LONG),
 }
 
 const { add } = storiesOf('web/search/results/streaming/StreamingSearchResults', module).addParameters({

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -1,14 +1,19 @@
 import * as H from 'history'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { FileMatch } from '../../../../../shared/src/components/FileMatch'
+import { VirtualList } from '../../../../../shared/src/components/VirtualList'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { SearchPatternType } from '../../../../../shared/src/graphql-operations'
+import * as GQL from '../../../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
 import { SettingsCascadeProps } from '../../../../../shared/src/settings/settings'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
+import { ThemeProps } from '../../../../../shared/src/theme'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
 import { AuthenticatedUser } from '../../../auth'
 import { PageTitle } from '../../../components/PageTitle'
+import { SearchResult } from '../../../components/SearchResult'
 import { VersionContext } from '../../../schema/site.schema'
 import { QueryState } from '../../helpers'
 import { LATEST_VERSION } from '../SearchResults'
@@ -24,6 +29,11 @@ import {
     SearchStreamingProps,
     resolveVersionContext,
 } from '../..'
+import { FetchFileParameters } from '../../../../../shared/src/components/CodeExcerpt'
+import { Observable } from 'rxjs'
+import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import FileIcon from 'mdi-react/FileIcon'
+import { isDefined } from '../../../../../shared/src/util/types'
 
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
@@ -33,7 +43,8 @@ export interface StreamingSearchResultsProps
         SettingsCascadeProps,
         ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
-        TelemetryProps {
+        TelemetryProps,
+        ThemeProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -42,7 +53,12 @@ export interface StreamingSearchResultsProps
     setVersionContext: (versionContext: string | undefined) => void
     availableVersionContexts: VersionContext[] | undefined
     previousVersionContext: string | null
+
+    fetchHighlightedFileLines: (parameters: FetchFileParameters, force?: boolean) => Observable<string[]>
 }
+
+const initialItemsToShow = 15
+const incrementalItemsToShow = 10
 
 export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResultsProps> = props => {
     const {
@@ -130,6 +146,38 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         setShowVersionContextWarning,
     ])
 
+    const [itemsToShow, setItemsToShow] = useState(initialItemsToShow)
+    const onBottomHit = useCallback(
+        () => setItemsToShow(items => Math.min(results?.results.length || 0, items + incrementalItemsToShow)),
+        [results?.results.length]
+    )
+    const logSearchResultClicked = useCallback(() => props.telemetryService.log('SearchResultClicked'), [
+        props.telemetryService,
+    ])
+    const renderResult = (result: GQL.GenericSearchResultInterface | GQL.IFileMatch): JSX.Element | undefined => {
+        switch (result.__typename) {
+            case 'FileMatch':
+                return (
+                    <FileMatch
+                        key={'file:' + result.file.url}
+                        location={location}
+                        icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
+                        result={result}
+                        onSelect={logSearchResultClicked}
+                        expanded={false}
+                        showAllMatches={false}
+                        isLightTheme={props.isLightTheme}
+                        allExpanded={allExpanded}
+                        fetchHighlightedFileLines={props.fetchHighlightedFileLines}
+                        settingsCascade={props.settingsCascade}
+                    />
+                )
+        }
+        return (
+            <SearchResult key={result.url} result={result} isLightTheme={props.isLightTheme} history={props.history} />
+        )
+    }
+
     return (
         <div className="test-search-results search-results d-flex flex-column w-100">
             <PageTitle key="page-title" title={query} />
@@ -162,6 +210,14 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                         onDismissWarning={onDismissVersionContextWarning}
                     />
                 )}
+
+                {/* Results */}
+                <VirtualList
+                    className="mt-2"
+                    itemsToShow={itemsToShow}
+                    onShowMoreItems={onBottomHit}
+                    items={results?.results.map(result => renderResult(result)).filter(isDefined) || []}
+                />
             </div>
         </div>
     )


### PR DESCRIPTION
Renders search results for streaming search!
This still uses the GraphQL data types. This will be later changed as @keegancsmith is going to update the API so conversion to GraphQL types is no longer required (primarily adding a string type to each result)

Note that lots of features are still missing here (eg. loading state, footer, etc). This is meant to be the initial work to render results.

There is a bug in storybook tests where not all code excerpts are being rendered: #16095 This doesn't happen in the real webapp.

![image](https://user-images.githubusercontent.com/206864/100026978-a5866e00-2da0-11eb-85e1-b5ff9d57f9fa.png)

