### PR TITLE
doc: fix two extension links that had bitrotted

### DIFF
--- a/doc/extensions/authoring/index.md
+++ b/doc/extensions/authoring/index.md
@@ -2,7 +2,7 @@
 
 A [Sourcegraph extension](../index.md) is a single JavaScript file that runs in users' web browsers in a Web Worker and has an exported `activate` function. The JavaScript file is usually produced by compiling and bundling one or more TypeScript source files.
 
-The [Sourcegraph extension API](https://unpkg.com/sourcegraph/dist/docs/index.html) (generated from [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/packages/sourcegraph-extension-api/src/sourcegraph.d.ts)) is available to extensions by [importing the `sourcegraph` module](importing_sourcegraph.md). Writing a Sourcegraph extension is very similar to writing an editor extension for [VS Code](https://code.visualstudio.com/docs/extensions/overview).
+The [Sourcegraph extension API](https://unpkg.com/sourcegraph/dist/docs/index.html) (generated from [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts)) is available to extensions by [importing the `sourcegraph` module](importing_sourcegraph.md). Writing a Sourcegraph extension is very similar to writing an editor extension for [VS Code](https://code.visualstudio.com/docs/extensions/overview).
 
 ## Explanations
 - [Activation and deactivation](activation.md)
@@ -25,7 +25,7 @@ The [Sourcegraph extension API](https://unpkg.com/sourcegraph/dist/docs/index.ht
 - [Building a language specific extension](tutorials/lang_specific_extension_tutorial.md)
 
 ## References
-- [Extension API documentation](https://unpkg.com/sourcegraph/dist/docs/index.html) (full API is in [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/packages/sourcegraph-extension-api/src/sourcegraph.d.ts))
+- [Extension API documentation](https://unpkg.com/sourcegraph/dist/docs/index.html) (full API is in [`sourcegraph.d.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts))
 - [Extension manifest (`package.json`)](manifest.md)
 - [Testing extensions](testing_extensions.md)
 - [Example extension: Token Highlights](https://github.com/sourcegraph/sourcegraph-extension-samples/tree/master/token-highlights)


### PR DESCRIPTION
This was caused by the refactor in #14480.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
