### PR TITLE
Always refetch gitlab merge request data after mutation

### DIFF
--- a/cmd/repo-updater/repos/gitlab_test.go
+++ b/cmd/repo-updater/repos/gitlab_test.go
@@ -278,6 +278,8 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 				SourceBranch: p.mr.SourceBranch,
 				TargetBranch: p.mr.TargetBranch,
 			}, nil, gitlab.ErrMergeRequestAlreadyExists)
+			p.mockGetMergeRequestNotes(p.mr.IID, nil, 20, nil)
+			p.mockGetMergeRequestPipelines(p.mr.IID, nil, 20, nil)
 			p.mockGetOpenMergeRequestByRefs(p.mr, nil)
 
 			exists, err := p.source.CreateChangeset(p.ctx, p.changeset)
@@ -299,6 +301,8 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 				SourceBranch: p.mr.SourceBranch,
 				TargetBranch: p.mr.TargetBranch,
 			}, p.mr, nil)
+			p.mockGetMergeRequestNotes(p.mr.IID, nil, 20, nil)
+			p.mockGetMergeRequestPipelines(p.mr.IID, nil, 20, nil)
 
 			exists, err := p.source.CreateChangeset(p.ctx, p.changeset)
 			if exists {
@@ -343,11 +347,13 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 
 		t.Run("success", func(t *testing.T) {
 			want := &gitlab.MergeRequest{}
-			mr := &gitlab.MergeRequest{}
+			mr := &gitlab.MergeRequest{IID: 2}
 
 			p := newGitLabChangesetSourceTestProvider(t)
 			p.changeset.Changeset.Metadata = mr
 			p.mockUpdateMergeRequest(mr, want, gitlab.UpdateMergeRequestStateEventClose, nil)
+			p.mockGetMergeRequestNotes(mr.IID, nil, 20, nil)
+			p.mockGetMergeRequestPipelines(mr.IID, nil, 20, nil)
 
 			if err := p.source.CloseChangeset(p.ctx, p.changeset); err != nil {
 				t.Errorf("unexpected error: %+v", err)
@@ -384,11 +390,13 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 
 		t.Run("success", func(t *testing.T) {
 			want := &gitlab.MergeRequest{}
-			mr := &gitlab.MergeRequest{}
+			mr := &gitlab.MergeRequest{IID: 2}
 
 			p := newGitLabChangesetSourceTestProvider(t)
 			p.changeset.Changeset.Metadata = mr
 			p.mockUpdateMergeRequest(mr, want, gitlab.UpdateMergeRequestStateEventReopen, nil)
+			p.mockGetMergeRequestNotes(mr.IID, nil, 20, nil)
+			p.mockGetMergeRequestPipelines(mr.IID, nil, 20, nil)
 
 			if err := p.source.ReopenChangeset(p.ctx, p.changeset); err != nil {
 				t.Errorf("unexpected error: %+v", err)
@@ -613,12 +621,14 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 		})
 
 		t.Run("success", func(t *testing.T) {
-			in := &gitlab.MergeRequest{}
+			in := &gitlab.MergeRequest{IID: 2}
 			out := &gitlab.MergeRequest{}
 
 			p := newGitLabChangesetSourceTestProvider(t)
 			p.changeset.Changeset.Metadata = in
 			p.mockUpdateMergeRequest(in, out, "", nil)
+			p.mockGetMergeRequestNotes(in.IID, nil, 20, nil)
+			p.mockGetMergeRequestPipelines(in.IID, nil, 20, nil)
 
 			if err := p.source.UpdateChangeset(p.ctx, p.changeset); err != nil {
 				t.Errorf("unexpected non-nil error: %+v", err)


### PR DESCRIPTION
Whenever we modify the merge request on the codehost, there will potentially be new pipelines, new notes or changes to the MR itself. Before this change, sometimes after a reconciler action the UI state was inconsistent at first, like CI status not reported correctly for example.
This synchronizes the behavior with what we do for GitHub.
Nuance: GitHub allows us through graphql to get all the fields we need from a single GraphQL query whereas for GitLab it'll be multiple. I believe that is fine though, because
- we don't have another way around it
- for GitHub we consume 3-4 rate limit tokens with one request, so GitLab with 3 requests as well won't be standing out really