### PR TITLE
Gitlab: Make SetWIP and UnsetWIP work for both Draft and WIP prefixes

### DIFF
--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -57,10 +57,10 @@ func SetWIP(title string) string {
 	if strings.HasPrefix(title, "Draft:") {
 		return title
 	}
-	if !strings.HasPrefix(title, "WIP:") {
-		return "WIP: " + title
+	if strings.HasPrefix(title, "WIP:") {
+		return title
 	}
-	return title
+	return "WIP: " + title
 }
 
 // UnsetWIP removes "WIP:" and "Draft:" prefixes from the given title.

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -52,18 +52,21 @@ type MergeRequest struct {
 	Pipelines []*Pipeline
 }
 
+// SetWIP ensures a "WIP:" prefix on the given title. If a "Draft:" prefix is found, that one is retained instead.
 func SetWIP(title string) string {
+	if strings.HasPrefix(title, "Draft:") {
+		return title
+	}
 	if !strings.HasPrefix(title, "WIP:") {
 		return "WIP: " + title
 	}
 	return title
 }
 
+// UnsetWIP removes "WIP:" and "Draft:" prefixes from the given title.
+// Depending on the GitLab version, either of them are used so we need to strip them both.
 func UnsetWIP(title string) string {
-	if strings.HasPrefix(title, "WIP: ") {
-		return strings.TrimPrefix(title, "WIP: ")
-	}
-	return title
+	return strings.TrimPrefix(strings.TrimPrefix(title, "WIP: "), "Draft: ")
 }
 
 type DiffRefs struct {

--- a/internal/extsvc/gitlab/merge_requests_test.go
+++ b/internal/extsvc/gitlab/merge_requests_test.go
@@ -13,6 +13,7 @@ func TestWIP(t *testing.T) {
 		tests := []struct{ title, want string }{
 			{title: "My perfect changeset", want: "WIP: My perfect changeset"},
 			{title: "WIP: My perfect changeset", want: "WIP: My perfect changeset"},
+			{title: "Draft: My perfect changeset", want: "Draft: My perfect changeset"},
 		}
 		for _, tc := range tests {
 			if have, want := SetWIP(tc.title), tc.want; have != want {
@@ -23,6 +24,7 @@ func TestWIP(t *testing.T) {
 	t.Run("UnsetWIP", func(t *testing.T) {
 		tests := []struct{ title, want string }{
 			{title: "WIP: My perfect changeset", want: "My perfect changeset"},
+			{title: "Draft: My perfect changeset", want: "My perfect changeset"},
 			{title: "My perfect changeset", want: "My perfect changeset"},
 		}
 		for _, tc := range tests {


### PR DESCRIPTION
Depending on the GitLab version, both of these can be used to mark something as "work in progress". To be more resilient about this. For example when doing "undraft" and someone changed the title on the codehost manually to be draft: .., we wouldn't actually have undrafted, so we should allow both in the logic.