### PR TITLE
search frontend: add hovers for regexp patterns

### DIFF
--- a/client/shared/src/search/parser/hover.test.ts
+++ b/client/shared/src/search/parser/hover.test.ts
@@ -1,49 +1,257 @@
 import { getHoverResult } from './hover'
 import { scanSearchQuery, ScanSuccess, Token, ScanResult } from './scanner'
+import { SearchPatternType } from '../../graphql-operations'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value, null, 2),
+    test: () => true,
+})
 
 const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
 
 describe('getHoverResult()', () => {
     test('returns hover contents for filters', () => {
         const scannedQuery = toSuccess(scanSearchQuery('repo:sourcegraph file:code_intelligence'))
-        expect(getHoverResult(scannedQuery, { column: 4 })).toStrictEqual({
-            contents: [
+        expect(getHoverResult(scannedQuery, { column: 4 })).toMatchInlineSnapshot(`
+            {
+              "contents": [
                 {
-                    value: 'Include only results from repositories matching the given search pattern.',
-                },
-            ],
-            range: {
-                endColumn: 17,
-                endLineNumber: 1,
-                startColumn: 1,
-                startLineNumber: 1,
-            },
-        })
-        expect(getHoverResult(scannedQuery, { column: 18 })).toStrictEqual({
-            contents: [
+                  "value": "Include only results from repositories matching the given search pattern."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 17
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 18 })).toMatchInlineSnapshot(`
+            {
+              "contents": [
                 {
-                    value: 'Include only results from files matching the given search pattern.',
-                },
-            ],
-            range: {
-                endColumn: 40,
-                endLineNumber: 1,
-                startColumn: 18,
-                startLineNumber: 1,
-            },
-        })
-        expect(getHoverResult(scannedQuery, { column: 30 })).toStrictEqual({
-            contents: [
+                  "value": "Include only results from files matching the given search pattern."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 18,
+                "endColumn": 40
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 30 })).toMatchInlineSnapshot(`
+            {
+              "contents": [
                 {
-                    value: 'Include only results from files matching the given search pattern.',
-                },
-            ],
-            range: {
-                endColumn: 40,
-                endLineNumber: 1,
-                startColumn: 18,
-                startLineNumber: 1,
-            },
-        })
+                  "value": "Include only results from files matching the given search pattern."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 18,
+                "endColumn": 40
+              }
+            }
+        `)
+    })
+
+    test('smartQuery flag returns hover contents for fields and regexp values', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('repo:^hey$'))
+        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Include only results from repositories matching the given search pattern."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 6
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 6 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in \`^prefix\`. Also often used with the end anchor \`$\` to match an exact string, as in \`^exact$\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 6,
+                "endColumn": 7
+              }
+            }
+        `)
+    })
+
+    test('smartQuery flag returns hover contents regexp patterns', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('\\b.*?', false, SearchPatternType.regexp))
+        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 3
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in \`\\\\bword\\\\b\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 3
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Dot**. Match any character except a line break."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 3,
+                "endColumn": 4
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 4 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Zero or more**. Match zero or more of the previous expression."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 4,
+                "endColumn": 5
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 5 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Lazy**. Match as few as characters as possible that match the previous expression."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 5,
+                "endColumn": 6
+              }
+            }
+        `)
+    })
+
+    test('smartQuery flag regexp group range encloses pattern', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('(abcd){1,3}', false, SearchPatternType.regexp))
+        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Group**. Groups together multiple expressions to match."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 7
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the character \`a\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 2,
+                "endColumn": 3
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 8 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Range**. Match between 1 and 3 of the previous expression."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 7,
+                "endColumn": 12
+              }
+            }
+        `)
+    })
+
+    test('smartQuery flag as literal search interprets parentheses as patterns', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('(abcd)', false, SearchPatternType.literal))
+        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the string \`(abcd)\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 7
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "Matches the string \`(abcd)\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 7
+              }
+            }
+        `)
     })
 })

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -1,15 +1,93 @@
 import * as Monaco from 'monaco-editor'
 import { Token, toMonacoRange } from './scanner'
 import { resolveFilter } from './filters'
+import { decorateTokens, DecoratedToken, RegexpMetaKind } from './tokens'
+
+const toHover = (token: DecoratedToken): string => {
+    switch (token.type) {
+        case 'pattern': {
+            const quantity = token.value.length > 1 ? 'string' : 'character'
+            return `Matches the ${quantity} \`${token.value}\`.`
+        }
+        case 'regexpMeta': {
+            switch (token.kind) {
+                case RegexpMetaKind.Alternative:
+                    return '**Or**. Match either the expression before or after the `|`.'
+                case RegexpMetaKind.Assertion:
+                    switch (token.value) {
+                        case '^':
+                            return '**Start anchor**. Match the beginning of a string. Typically used to match a string prefix, as in `^prefix`. Also often used with the end anchor `$` to match an exact string, as in `^exact$`.'
+                        case '$':
+                            return '**End anchor**. Match the end of a string. Typically used to match a string suffix, as in `suffix$`. Also often used with the start anchor to match an exact string, as in `^exact$`.'
+                        case '\\b':
+                            return '**Word boundary**. Match a position where a word character comes after a non-word character, or vice versa. Typically used to match whole words, as in `\\bword\\b`.'
+                        case '\\B':
+                            return '**Negated word boundary**. Match a position between two word characters, or a position between two non-word characters. This is the negation of `\\b`.'
+                    }
+                case RegexpMetaKind.CharacterClass:
+                    return '**Character set**. Match any character in the set.'
+                case RegexpMetaKind.CharacterSet:
+                    switch (token.value) {
+                        case '.':
+                            return '**Dot**. Match any character except a line break.'
+                        case '\\w':
+                            return '**Word**. Match any word character. '
+                        case '\\W':
+                            return '**Negated word**. Match any non-word character. Matches any character that is **not** an alphabetic character, digit, or underscore.'
+                        case '\\d':
+                            return '**Digit**. Match any digit character `0-9`.'
+                        case '\\D':
+                            return '**Negated digit**. Match any character that is **not** a digit `0-9`.'
+                        case '\\s':
+                            return '**Whitespace**. Match any whitespace character like a space, line break, or tab.'
+                        case '\\S':
+                            return '**Negated whitespace**. Match any character that is **not** a whitespace character like a space, line break, or tab.'
+                    }
+                case RegexpMetaKind.Delimited:
+                    return '**Group**. Groups together multiple expressions to match.'
+                case RegexpMetaKind.EscapedCharacter:
+                    return `**Escaped Character**. Match the character \`${token.value[1]}\`.`
+                case RegexpMetaKind.LazyQuantifier:
+                    return '**Lazy**. Match as few as characters as possible that match the previous expression.'
+                case RegexpMetaKind.RangeQuantifier:
+                    switch (token.value) {
+                        case '*':
+                            return '**Zero or more**. Match zero or more of the previous expression.'
+                        case '?':
+                            return '**Optional**. Match zero or one of the previous expression.'
+                        case '+':
+                            return '**One or more**. Match one or more of the previous expression.'
+                        default: {
+                            const range = token.value.slice(1, -1).split(',')
+                            let quantity = ''
+                            if (range.length === 1 || (range.length === 2 && range[0] === range[1])) {
+                                quantity = range[0]
+                            } else if (range[1] === '') {
+                                quantity = `${range[0]} or more`
+                            } else {
+                                quantity = `between ${range[0]} and ${range[1]}`
+                            }
+                            return `**Range**. Match ${quantity} of the previous expression.`
+                        }
+                    }
+            }
+        }
+    }
+    return ''
+}
+
+const inside = (column: number) => ({ range }: Pick<Token | DecoratedToken, 'range'>): boolean =>
+    range.start + 1 <= column && range.end >= column
 
 /**
  * Returns the hover result for a hovered search token in the Monaco query input.
  */
 export const getHoverResult = (
     tokens: Token[],
-    { column }: Pick<Monaco.Position, 'column'>
+    { column }: Pick<Monaco.Position, 'column'>,
+    smartQuery = false
 ): Monaco.languages.Hover | null => {
-    const tokensAtCursor = tokens.filter(({ range }) => range.start + 1 <= column && range.end >= column)
+    const tokensAtCursor = (smartQuery ? decorateTokens(tokens) : tokens).filter(inside(column))
     if (tokensAtCursor.length === 0) {
         return null
     }
@@ -18,6 +96,9 @@ export const getHoverResult = (
     tokensAtCursor.map(token => {
         switch (token.type) {
             case 'filter': {
+                // This 'filter' branch only exists to preserve previous behavior when smmartQuery is false.
+                // When smartQuery is true, 'filter' tokens are handled by the 'field' case and its values in
+                // the rest of this switch statement.
                 const resolvedFilter = resolveFilter(token.field.value)
                 if (resolvedFilter) {
                     values.push(
@@ -29,6 +110,27 @@ export const getHoverResult = (
                 }
                 break
             }
+            case 'field': {
+                const resolvedFilter = resolveFilter(token.value)
+                if (resolvedFilter) {
+                    values.push(
+                        'negated' in resolvedFilter
+                            ? resolvedFilter.definition.description(resolvedFilter.negated)
+                            : resolvedFilter.definition.description
+                    )
+                    // Add 1 to end of range to include the ':'.
+                    range = toMonacoRange({ start: token.range.start, end: token.range.end + 1 })
+                }
+                break
+            }
+            case 'pattern':
+                values.push(toHover(token))
+                range = toMonacoRange(token.range)
+                break
+            case 'regexpMeta':
+                values.push(toHover(token))
+                range = toMonacoRange(token.groupRange ? token.groupRange : token.range)
+                break
         }
     })
     return {

--- a/client/shared/src/search/parser/providers.ts
+++ b/client/shared/src/search/parser/providers.ts
@@ -43,7 +43,7 @@ export function getProviders(
 ): SearchFieldProviders {
     const scannedQueries = searchQueries.pipe(
         map(rawQuery => {
-            const scanned = scanSearchQuery(rawQuery, options.interpretComments ?? false)
+            const scanned = scanSearchQuery(rawQuery, options.interpretComments ?? false, options.patternType)
             return { rawQuery, scanned }
         }),
         publishReplay(1),
@@ -72,7 +72,9 @@ export function getProviders(
                     .pipe(
                         first(),
                         map(({ scanned }) =>
-                            scanned.type === 'error' ? null : getHoverResult(scanned.term, position)
+                            scanned.type === 'error'
+                                ? null
+                                : getHoverResult(scanned.term, position, options.enableSmartQuery)
                         ),
                         takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
                     )

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -29,6 +29,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         'editorHoverWidget.background': '#1c2736',
         'editorHoverWidget.foreground': '#F2F4F8',
         'editorHoverWidget.border': '#2b3750',
+        'editor.hoverHighlightBackground': '#495057',
     },
     rules: [
         { token: 'identifier', foreground: '#f2f4f8' },
@@ -68,6 +69,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         'editorHoverWidget.background': '#ffffff',
         'editorHoverWidget.foreground': '#2b3750',
         'editorHoverWidget.border': '#cad2e2',
+        'editor.hoverHighlightBackground': '#dee2e6',
     },
     rules: [
         { token: 'identifier', foreground: '#2b3750' },
@@ -137,6 +139,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         }
         this.props.editorWillMount(monaco)
         const editor = monaco.editor.create(element, {
+            hover: { delay: 0 },
             value: this.props.value,
             language: this.props.language,
             theme: this.props.isLightTheme ? SOURCEGRAPH_LIGHT : SOURCEGRAPH_DARK,


### PR DESCRIPTION
This PR introduces hovers for regexp metasyntax and some basic hovers for literals. In later PRs I will add hovers for our expression language (`and`, `or`) and structural search.

I wanted to break this up more but there's some cross-cutting concerns that make that difficult. Also half this PR is just test values, it's not that big.

Basically:

![hoversss](https://user-images.githubusercontent.com/888624/100048204-8d7b1280-2dd1-11eb-939c-b1ca6132dffd.gif)


---

There's a current limitation for activating highlighting/hovering in a subrange depending on the outer range and cursor position. More details to follow, it's not a blocking issue, just something aesthetic/UX I care about.
