### PR TITLE
Sync private repositories when service owner has TagAllowUserExternalServicePrivate tag

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -44,6 +45,11 @@ func TestIntegration(t *testing.T) {
 	)
 
 	userID := insertTestUser(t, db)
+
+	dbconn.Global = db
+	defer func() {
+		dbconn.Global = nil
+	}()
 
 	for _, tc := range []struct {
 		name string

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -254,12 +254,10 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 		if err != nil {
 			return errors.Wrap(err, "getting service owner")
 		}
-		if user != nil {
-			for _, t := range user.Tags {
-				if t == TagAllowUserExternalServicePrivate {
-					syncPublicOnly = false
-					break
-				}
+		for _, t := range user.Tags {
+			if t == TagAllowUserExternalServicePrivate {
+				syncPublicOnly = false
+				break
 			}
 		}
 

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -245,7 +245,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 		return errors.Wrap(err, "syncer.sync.sourced")
 	}
 
-	// Unless explicitly specified with the "all" setting or unless the owner of the service has the "AllowUserExternalServicePrivate" tag,
+	// Unless explicitly specified with the "all" setting or the owner of the service has the "AllowUserExternalServicePrivate" tag,
 	// user added external services should only sync public code.
 	if isUserOwned && conf.ExternalServiceUserMode() != conf.ExternalServiceModeAll {
 		syncPublicOnly := true

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -168,6 +169,12 @@ func (s *Syncer) TriggerEnqueueSyncJobs() {
 	s.enqueueSignal.Trigger()
 }
 
+const (
+	// If the owner of an external service has this tag, the syncer
+	// will sync private repositories.
+	TagAllowUserExternalServicePrivate = "AllowUserExternalServicePrivate"
+)
+
 // SyncExternalService syncs repos using the supplied external service.
 func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServiceID int64, minSyncInterval time.Duration) (err error) {
 	var diff Diff
@@ -238,9 +245,27 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 		return errors.Wrap(err, "syncer.sync.sourced")
 	}
 
-	// Unless explicitly specified with "all", user added external services should only sync public code
+	// Unless explicitly specified with the "all" setting or if the owner of the service has the "AllowUserExternalServicePrivate" tag,
+	// user added external services should only sync public code.
 	if isUserOwned && conf.ExternalServiceUserMode() != conf.ExternalServiceModeAll {
-		sourced = sourced.Filter(func(r *Repo) bool { return !r.Private })
+		syncPublicOnly := true
+
+		user, err := db.Users.GetByID(ctx, svc.NamespaceUserID)
+		if err != nil {
+			return errors.Wrap(err, "getting service owner")
+		}
+		if user != nil {
+			for _, t := range user.Tags {
+				if t == TagAllowUserExternalServicePrivate {
+					syncPublicOnly = false
+					break
+				}
+			}
+		}
+
+		if syncPublicOnly {
+			sourced = sourced.Filter(func(r *Repo) bool { return !r.Private })
+		}
 	}
 
 	var storedServiceRepos Repos

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -245,7 +245,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 		return errors.Wrap(err, "syncer.sync.sourced")
 	}
 
-	// Unless explicitly specified with the "all" setting or if the owner of the service has the "AllowUserExternalServicePrivate" tag,
+	// Unless explicitly specified with the "all" setting or unless the owner of the service has the "AllowUserExternalServicePrivate" tag,
 	// user added external services should only sync public code.
 	if isUserOwned && conf.ExternalServiceUserMode() != conf.ExternalServiceModeAll {
 		syncPublicOnly := true

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gitchander/permutation"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lib/pq"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -1695,7 +1696,7 @@ func testUserAddedRepos(db *sql.DB, userID int32) func(t *testing.T, store repos
 			conf.Mock(nil)
 
 			// If the user has the AllowUserExternalServicePrivate tag, user service can also sync private code
-			_, err := db.ExecContext(ctx, "UPDATE users SET tags = '{\"AllowUserExternalServicePrivate\"}' WHERE id = $1", userID)
+			_, err := db.ExecContext(ctx, "UPDATE users SET tags = $1 WHERE id = $2", pq.Array([]string{repos.TagAllowUserExternalServicePrivate}), userID)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/16023