### PR TITLE
hotfix: Reduce memory usage when calculating commit graph

### DIFF
--- a/enterprise/internal/codeintel/store/commit_graph_test.go
+++ b/enterprise/internal/codeintel/store/commit_graph_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -35,17 +36,16 @@ var testGraph = map[string][]string{
 }
 
 func TestInternalCalculateVisibleUploads(t *testing.T) {
-	uploads := map[string][]UploadMeta{
-		"e66e8f9b": {{UploadID: 50, Root: "sub1/", Indexer: "lsif-go"}},
-		"f635b8d1": {{UploadID: 52, Root: "sub3/", Indexer: "lsif-go"}},
-		"d6e54842": {{UploadID: 53, Root: "sub3/", Indexer: "lsif-go"}},
-		"5340d471": {{UploadID: 54, Root: "sub3/", Indexer: "lsif-go"}},
-		"95dd4b2b": {{UploadID: 55, Root: "sub3/", Indexer: "lsif-go"}},
-		"5971b083": {{UploadID: 51, Root: "sub2/", Indexer: "lsif-go"}},
-		"0ed556d3": {{UploadID: 56, Root: "sub3/", Indexer: "lsif-go"}},
-	}
+	commitGraphView := NewCommitGraphView()
+	commitGraphView.Add(UploadMeta{UploadID: 50}, "e66e8f9b", "sub1/:lsif-go")
+	commitGraphView.Add(UploadMeta{UploadID: 51}, "5971b083", "sub2/:lsif-go")
+	commitGraphView.Add(UploadMeta{UploadID: 52}, "f635b8d1", "sub3/:lsif-go")
+	commitGraphView.Add(UploadMeta{UploadID: 53}, "d6e54842", "sub3/:lsif-go")
+	commitGraphView.Add(UploadMeta{UploadID: 54}, "5340d471", "sub3/:lsif-go")
+	commitGraphView.Add(UploadMeta{UploadID: 55}, "95dd4b2b", "sub3/:lsif-go")
+	commitGraphView.Add(UploadMeta{UploadID: 56}, "0ed556d3", "sub3/:lsif-go")
 
-	visibleUploads, err := calculateVisibleUploads(testGraph, uploads)
+	visibleUploads, err := calculateVisibleUploads(testGraph, commitGraphView)
 	if err != nil {
 		t.Fatalf("unexpected error calculating visible uploads: %s", err)
 	}
@@ -57,64 +57,19 @@ func TestInternalCalculateVisibleUploads(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		"e66e8f9b": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 0},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 2},
-			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
-		},
-		"0c5a779c": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 1},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 1},
-		},
-		"f635b8d1": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 1},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 4},
-			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
-		},
-		"4d36f88b": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 2},
-			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
-		},
-		"026b8df9": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 2},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 3},
-			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
-		},
-		"6c301adb": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 3},
-			{UploadID: 52, Root: "sub3/", Indexer: "lsif-go", Distance: 2},
-		},
-		"d6e54842": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 3},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 2},
-			{UploadID: 53, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
-		},
-		"5340d471": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 4},
-			{UploadID: 54, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
-		},
-		"cbc5cf7c": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 5},
-			{UploadID: 54, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
-		},
-		"95dd4b2b": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 4},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 1},
-			{UploadID: 55, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
-		},
-		"5971b083": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 2},
-			{UploadID: 51, Root: "sub2/", Indexer: "lsif-go", Distance: 0},
-			{UploadID: 55, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
-		},
-		"7cb4a974": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 5},
-			{UploadID: 55, Root: "sub3/", Indexer: "lsif-go", Distance: 1},
-		},
-		"0ed556d3": {
-			{UploadID: 50, Root: "sub1/", Indexer: "lsif-go", Distance: 6},
-			{UploadID: 56, Root: "sub3/", Indexer: "lsif-go", Distance: 0},
-		},
+		"e66e8f9b": {{UploadID: 50, Flags: 0}, {UploadID: 51, Flags: 2}, {UploadID: 52, Flags: 1}},
+		"0c5a779c": {{UploadID: 50, Flags: 1}, {UploadID: 51, Flags: 1}},
+		"f635b8d1": {{UploadID: 50, Flags: 1}, {UploadID: 51, Flags: 4}, {UploadID: 52, Flags: 0}},
+		"4d36f88b": {{UploadID: 50, Flags: 2}, {UploadID: 52, Flags: 1}},
+		"026b8df9": {{UploadID: 50, Flags: 2}, {UploadID: 51, Flags: 3}, {UploadID: 52, Flags: 1}},
+		"6c301adb": {{UploadID: 50, Flags: 3}, {UploadID: 52, Flags: 2}},
+		"d6e54842": {{UploadID: 50, Flags: 3}, {UploadID: 51, Flags: 2}, {UploadID: 53, Flags: 0}},
+		"5340d471": {{UploadID: 50, Flags: 4}, {UploadID: 54, Flags: 0}},
+		"cbc5cf7c": {{UploadID: 50, Flags: 5}, {UploadID: 54, Flags: 1}},
+		"95dd4b2b": {{UploadID: 50, Flags: 4}, {UploadID: 51, Flags: 1}, {UploadID: 55, Flags: 0}},
+		"5971b083": {{UploadID: 50, Flags: 2}, {UploadID: 51, Flags: 0}, {UploadID: 55, Flags: 1}},
+		"7cb4a974": {{UploadID: 50, Flags: 5}, {UploadID: 55, Flags: 1}},
+		"0ed556d3": {{UploadID: 50, Flags: 6}, {UploadID: 56, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, visibleUploads, UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected graph (-want +got):\n%s", diff)
@@ -184,6 +139,56 @@ func TestTopologicalSortCycles(t *testing.T) {
 	if _, err := topologicalSort(cyclicTestGraph); err != ErrCyclicCommitGraph {
 		t.Fatalf("unexpected error sorting graph. want=%q have=%q", ErrCyclicCommitGraph, err)
 	}
+}
+
+func BenchmarkCalculateVisibleUploads(b *testing.B) {
+	graph, commitGraphView := makeBenchmarkGraph()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = calculateVisibleUploads(graph, commitGraphView)
+	}
+}
+
+func makeBenchmarkGraph() (map[string][]string, *CommitGraphView) {
+	var (
+		numCommits = 5000
+		numUploads = 2000
+		numRoots   = 500
+	)
+
+	var commits []string
+	for i := 0; i < numCommits; i++ {
+		commits = append(commits, fmt.Sprintf("%40d", i))
+	}
+
+	graph := map[string][]string{}
+	for i, commit := range commits {
+		if i == 0 {
+			graph[commit] = nil
+		} else {
+			graph[commit] = commits[i-1 : i]
+		}
+	}
+
+	var roots []string
+	for i := 0; i < numRoots; i++ {
+		roots = append(roots, fmt.Sprintf("sub%d/", i))
+	}
+
+	commitGraphView := NewCommitGraphView()
+
+	for i := 0; i < numUploads; i++ {
+		commitGraphView.Add(
+			UploadMeta{UploadID: i},
+			fmt.Sprintf("%40d", int((float64(i*numUploads)/float64(numCommits)))),
+			fmt.Sprintf("%s:lsif-go", roots[i%numRoots]),
+		)
+	}
+
+	return graph, commitGraphView
 }
 
 func indexOf(ordering []string, commit string) (int, bool) {

--- a/enterprise/internal/codeintel/store/commit_graph_view.go
+++ b/enterprise/internal/codeintel/store/commit_graph_view.go
@@ -1,0 +1,59 @@
+package store
+
+// CommitGraphView is a space-efficient view of a commit graph decorated with the
+// set of uploads visible at every commit.
+type CommitGraphView struct {
+	// Meta is a map from commit to metadata on each visible upload from that
+	// commit's location in the commit graph.
+	Meta map[string][]UploadMeta
+
+	// Tokens is a map from upload identifiers to a hash of their root an indexer
+	// field. Equality of this token for two uploads means that they are able to
+	// "shadow" one another.
+	Tokens map[int]string
+}
+
+func NewCommitGraphView() *CommitGraphView {
+	return &CommitGraphView{
+		Meta:   map[string][]UploadMeta{},
+		Tokens: map[int]string{},
+	}
+}
+
+func (v *CommitGraphView) Add(meta UploadMeta, commit, token string) {
+	v.Meta[commit] = append(v.Meta[commit], meta)
+	v.Tokens[meta.UploadID] = token
+}
+
+// UploadMeta represents the visibility of an LSIF upload from a particular location
+// on a repository's commit graph. The Flags field describes the visibility of the
+// upload from the current viewer's perspective.
+type UploadMeta struct {
+	UploadID int
+
+	// Flags encodes the flags FlagAncestorVisible and FlagOverwritten and leaves
+	// the remaining lower 30-bits to encode an unsigned distance between commits.
+	Flags uint32
+}
+
+const (
+	// FlagAncestorVisible indicates whether or not this upload was visible to the commit
+	// by looking for older uploads defined in an ancestor commit. False indicates that
+	// the upload is only visible via another upload defined in a descendant commit.
+	FlagAncestorVisible uint32 = (1 << 30)
+
+	// FlagOverwritten indicates that this upload defined on an ancestor commit that is
+	// farther away than an upload defined on a descendant commit that has the same root
+	// and indexer.
+	//
+	// If overwritten, this upload is not considered in nearest commit operations, but
+	// is kept in the database so that we can reconstruct the set of all ancestor-visible
+	// uploads of a commit, which is useful when determining the closest uploads with only
+	// a partial commit graph.
+	FlagOverwritten uint32 = (1 << 29)
+
+	// MaxDistance is the maximum encodeable distance between two commits.
+	//
+	// This value can be used to quickly remove flags from the encoded distance value.
+	MaxDistance = ^(FlagAncestorVisible | FlagOverwritten)
+)

--- a/enterprise/internal/codeintel/store/commits.go
+++ b/enterprise/internal/codeintel/store/commits.go
@@ -9,25 +9,35 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/batch"
 )
 
-// scanUploadMeta scans upload metadata grouped by commit from the return value of `*store.query`.
-func scanUploadMeta(rows *sql.Rows, queryErr error) (_ map[string][]UploadMeta, err error) {
+// scanCommitGraphView scans a commit graph view from the return value of `*Store.query`.
+func scanCommitGraphView(rows *sql.Rows, queryErr error) (_ *CommitGraphView, err error) {
 	if queryErr != nil {
 		return nil, queryErr
 	}
 	defer func() { err = basestore.CloseRows(rows, err) }()
 
-	uploadMeta := map[string][]UploadMeta{}
+	commitGraphView := NewCommitGraphView()
+
 	for rows.Next() {
-		var commit string
-		var upload UploadMeta
-		if err := rows.Scan(&upload.UploadID, &commit, &upload.Root, &upload.Indexer, &upload.Distance, &upload.AncestorVisible, &upload.Overwritten); err != nil {
+		var meta UploadMeta
+		var commit, token string
+		var ancestorVisible, overwritten bool
+
+		if err := rows.Scan(&meta.UploadID, &commit, &token, &meta.Flags, &ancestorVisible, &overwritten); err != nil {
 			return nil, err
 		}
 
-		uploadMeta[commit] = append(uploadMeta[commit], upload)
+		if ancestorVisible {
+			meta.Flags |= FlagAncestorVisible
+		}
+		if overwritten {
+			meta.Flags |= FlagOverwritten
+		}
+
+		commitGraphView.Add(meta, commit, token)
 	}
 
-	return uploadMeta, nil
+	return commitGraphView, nil
 }
 
 // HasRepository determines if there is LSIF data for the given repository.
@@ -108,8 +118,8 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 
 	// Pull all queryable upload metadata known to this repository so we can correlate
 	// it with the current  commit graph.
-	uploadMeta, err := scanUploadMeta(tx.Store.Query(ctx, sqlf.Sprintf(`
-		SELECT id, commit, root, indexer, 0 as distance, true as ancestor_visible, false as overwritten
+	commitGraphView, err := scanCommitGraphView(tx.Store.Query(ctx, sqlf.Sprintf(`
+		SELECT id, commit, md5(root || ':' || indexer) as token, 0 as distance, true as ancestor_visible, false as overwritten
 		FROM lsif_uploads
 		WHERE state = 'completed' AND repository_id = %s
 	`, repositoryID)))
@@ -118,7 +128,7 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 	}
 
 	// Determine which uploads are visible to which commits for this repository
-	visibleUploads, err := calculateVisibleUploads(graph, uploadMeta)
+	visibleUploads, err := calculateVisibleUploads(graph, commitGraphView)
 	if err != nil {
 		return err
 	}
@@ -151,9 +161,9 @@ func (s *store) CalculateVisibleUploads(ctx context.Context, repositoryID int, g
 				repositoryID,
 				commit,
 				uploadMeta.UploadID,
-				uploadMeta.Distance,
-				uploadMeta.AncestorVisible,
-				uploadMeta.Overwritten,
+				uploadMeta.Flags&MaxDistance,
+				(uploadMeta.Flags&FlagAncestorVisible) != 0,
+				(uploadMeta.Flags&FlagOverwritten) != 0,
 			); err != nil {
 				return err
 			}

--- a/enterprise/internal/codeintel/store/commits_test.go
+++ b/enterprise/internal/codeintel/store/commits_test.go
@@ -62,8 +62,8 @@ func TestHasCommit(t *testing.T) {
 		{51, makeCommit(1), false},
 	}
 
-	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{makeCommit(1): {{UploadID: 42, Distance: 1}}})
-	insertNearestUploads(t, dbconn.Global, 51, map[string][]UploadMeta{makeCommit(2): {{UploadID: 43, Distance: 2}}})
+	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{makeCommit(1): {{UploadID: 42, Flags: 1}}})
+	insertNearestUploads(t, dbconn.Global, 51, map[string][]UploadMeta{makeCommit(2): {{UploadID: 43, Flags: 2}}})
 
 	for _, testCase := range testCases {
 		name := fmt.Sprintf("repositoryID=%d commit=%s", testCase.repositoryID, testCase.commit)
@@ -145,14 +145,14 @@ func TestCalculateVisibleUploads(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}},
-		makeCommit(3): {{UploadID: 2, Distance: 0}},
-		makeCommit(4): {{UploadID: 2, Distance: 1}},
-		makeCommit(5): {{UploadID: 1, Distance: 2}},
-		makeCommit(6): {{UploadID: 3, Distance: 1}},
-		makeCommit(7): {{UploadID: 3, Distance: 0}},
-		makeCommit(8): {{UploadID: 1, Distance: 4}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}},
+		makeCommit(3): {{UploadID: 2, Flags: 0}},
+		makeCommit(4): {{UploadID: 2, Flags: 1}},
+		makeCommit(5): {{UploadID: 1, Flags: 2}},
+		makeCommit(6): {{UploadID: 3, Flags: 1}},
+		makeCommit(7): {{UploadID: 3, Flags: 0}},
+		makeCommit(8): {{UploadID: 1, Flags: 4}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -199,9 +199,9 @@ func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 1}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 1}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -239,8 +239,8 @@ func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -305,12 +305,12 @@ func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
 	}
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 0}, {UploadID: 5, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}},
-		makeCommit(4): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 7, Distance: 0}},
-		makeCommit(5): {{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 3}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0}},
-		makeCommit(6): {{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 4}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1}, {UploadID: 9, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 0}, {UploadID: 5, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}},
+		makeCommit(4): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 7, Flags: 0}},
+		makeCommit(5): {{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 3}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0}},
+		makeCommit(6): {{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 4}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1}, {UploadID: 9, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -358,24 +358,24 @@ func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
 
 	expectedVisibleUploads := map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 3},
-			{UploadID: 5, Distance: 0}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 3},
+			{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 3},
+			{UploadID: 5, Flags: 0}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 3},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 2},
-			{UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 2},
+			{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 2},
+			{UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 2},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 2}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 0}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 2}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 0}, {UploadID: 8, Flags: 1},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 0},
-			{UploadID: 5, Distance: 3}, {UploadID: 6, Distance: 2}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0},
+			{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 0},
+			{UploadID: 5, Flags: 3}, {UploadID: 6, Flags: 2}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0},
 		},
 		makeCommit(5): {
-			{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 3}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 4}, {UploadID: 6, Distance: 3}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 3}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 4}, {UploadID: 6, Flags: 3}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1},
 		},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, dbconn.Global, 50), UploadMetaComparer); diff != "" {

--- a/enterprise/internal/codeintel/store/dumps_test.go
+++ b/enterprise/internal/codeintel/store/dumps_test.go
@@ -102,21 +102,21 @@ func TestFindClosestDumps(t *testing.T) {
 		makeCommit(8): {makeCommit(6)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}},
-		makeCommit(3): {{UploadID: 2, Distance: 0}},
-		makeCommit(4): {{UploadID: 2, Distance: 1}},
-		makeCommit(5): {{UploadID: 1, Distance: 2}},
-		makeCommit(6): {{UploadID: 3, Distance: 1}},
-		makeCommit(7): {{UploadID: 3, Distance: 0}},
-		makeCommit(8): {{UploadID: 1, Distance: 4}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}},
+		makeCommit(3): {{UploadID: 2, Flags: 0}},
+		makeCommit(4): {{UploadID: 2, Flags: 1}},
+		makeCommit(5): {{UploadID: 1, Flags: 2}},
+		makeCommit(6): {{UploadID: 3, Flags: 1}},
+		makeCommit(7): {{UploadID: 3, Flags: 0}},
+		makeCommit(8): {{UploadID: 1, Flags: 4}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -165,16 +165,16 @@ func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 		makeCommit(8): {makeCommit(7)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 1}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 1}},
 		makeCommit(4): nil,
 		makeCommit(5): nil,
 		makeCommit(6): nil,
@@ -220,15 +220,15 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 		makeCommit(2): {makeCommit(1)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -292,19 +292,19 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 		makeCommit(6): {makeCommit(5)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 0}, {UploadID: 5, Distance: 0}},
-		makeCommit(3): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 4, Distance: 1}, {UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}},
-		makeCommit(4): {{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 1}, {UploadID: 7, Distance: 0}},
-		makeCommit(5): {{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 3}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0}},
-		makeCommit(6): {{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 4}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1}, {UploadID: 9, Distance: 0}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 0}, {UploadID: 5, Flags: 0}},
+		makeCommit(3): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 4, Flags: 1}, {UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}},
+		makeCommit(4): {{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 1}, {UploadID: 7, Flags: 0}},
+		makeCommit(5): {{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 3}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0}},
+		makeCommit(6): {{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 4}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1}, {UploadID: 9, Flags: 0}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -350,7 +350,7 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 		makeCommit(5): {makeCommit(4)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
@@ -358,24 +358,24 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 
 	expectedVisibleUploads := map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Distance: 0}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 3},
-			{UploadID: 5, Distance: 0}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 3},
+			{UploadID: 1, Flags: 0}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 3},
+			{UploadID: 5, Flags: 0}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 3},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 0}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 2},
-			{UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 2},
+			{UploadID: 1, Flags: 1}, {UploadID: 2, Flags: 0}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 2},
+			{UploadID: 5, Flags: 1}, {UploadID: 6, Flags: 0}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 2},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 2}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 0}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 2}, {UploadID: 2, Flags: 1}, {UploadID: 3, Flags: 0}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 2}, {UploadID: 6, Flags: 1}, {UploadID: 7, Flags: 0}, {UploadID: 8, Flags: 1},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 0},
-			{UploadID: 5, Distance: 3}, {UploadID: 6, Distance: 2}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0},
+			{UploadID: 1, Flags: 3}, {UploadID: 2, Flags: 2}, {UploadID: 3, Flags: 1}, {UploadID: 4, Flags: 0},
+			{UploadID: 5, Flags: 3}, {UploadID: 6, Flags: 2}, {UploadID: 7, Flags: 1}, {UploadID: 8, Flags: 0},
 		},
 		makeCommit(5): {
-			{UploadID: 1, Distance: 4}, {UploadID: 2, Distance: 3}, {UploadID: 3, Distance: 2}, {UploadID: 4, Distance: 1},
-			{UploadID: 5, Distance: 4}, {UploadID: 6, Distance: 3}, {UploadID: 7, Distance: 2}, {UploadID: 8, Distance: 1},
+			{UploadID: 1, Flags: 4}, {UploadID: 2, Flags: 3}, {UploadID: 3, Flags: 2}, {UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 4}, {UploadID: 6, Flags: 3}, {UploadID: 7, Flags: 2}, {UploadID: 8, Flags: 1},
 		},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
@@ -414,14 +414,14 @@ func TestFindClosestDumpsIntersectingPath(t *testing.T) {
 		makeCommit(1): {},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(graph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(graph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
+		makeCommit(1): {{UploadID: 1}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -463,18 +463,18 @@ func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
 		makeCommit(6): {makeCommit(5)},
 	}
 
-	visibleUploads, err := calculateVisibleUploads(currentGraph, toUploadMeta(uploads))
+	visibleUploads, err := calculateVisibleUploads(currentGraph, toCommitGraphView(uploads))
 	if err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 	insertNearestUploads(t, dbconn.Global, 50, visibleUploads)
 
 	expectedVisibleUploads := map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Distance: 0}},
-		makeCommit(2): {{UploadID: 1, Distance: 1}},
-		makeCommit(3): {{UploadID: 1, Distance: 2}},
-		makeCommit(5): {{UploadID: 2, Distance: 0}},
-		makeCommit(6): {{UploadID: 2, Distance: 1}},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 1, Flags: 1}},
+		makeCommit(3): {{UploadID: 1, Flags: 2}},
+		makeCommit(5): {{UploadID: 2, Flags: 0}},
+		makeCommit(6): {{UploadID: 2, Flags: 1}},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads), UploadMetaComparer); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)

--- a/enterprise/internal/codeintel/store/helpers_test.go
+++ b/enterprise/internal/codeintel/store/helpers_test.go
@@ -217,7 +217,15 @@ func insertNearestUploads(t *testing.T, db *sql.DB, repositoryID int, uploads ma
 	var rows []*sqlf.Query
 	for commit, metas := range uploads {
 		for _, meta := range metas {
-			rows = append(rows, sqlf.Sprintf("(%s, %s, %s, %s, %s, %s)", repositoryID, commit, meta.UploadID, meta.Distance, meta.AncestorVisible, meta.Overwritten))
+			rows = append(rows, sqlf.Sprintf(
+				"(%s, %s, %s, %s, %s, %s)",
+				repositoryID,
+				commit,
+				meta.UploadID,
+				meta.Flags&MaxDistance,
+				(meta.Flags&FlagAncestorVisible) != 0,
+				(meta.Flags&FlagOverwritten) != 0,
+			))
 		}
 	}
 
@@ -230,21 +238,17 @@ func insertNearestUploads(t *testing.T, db *sql.DB, repositoryID int, uploads ma
 	}
 }
 
-func toUploadMeta(uploads []Upload) map[string][]UploadMeta {
-	meta := map[string][]UploadMeta{}
+func toCommitGraphView(uploads []Upload) *CommitGraphView {
+	commitGraphView := NewCommitGraphView()
 	for _, upload := range uploads {
-		meta[upload.Commit] = append(meta[upload.Commit], UploadMeta{
-			UploadID: upload.ID,
-			Root:     upload.Root,
-			Indexer:  upload.Indexer,
-		})
+		commitGraphView.Add(UploadMeta{UploadID: upload.ID}, upload.Commit, fmt.Sprintf("%s:%s", upload.Root, upload.Indexer))
 	}
 
-	return meta
+	return commitGraphView
 }
 
 var UploadMetaComparer = cmp.Comparer(func(x, y UploadMeta) bool {
-	return x.UploadID == y.UploadID && x.Distance == y.Distance
+	return x.UploadID == y.UploadID && (x.Flags&MaxDistance) == (y.Flags&MaxDistance)
 })
 
 func scanVisibleUploads(rows *sql.Rows, queryErr error) (_ map[string][]UploadMeta, err error) {
@@ -257,14 +261,14 @@ func scanVisibleUploads(rows *sql.Rows, queryErr error) (_ map[string][]UploadMe
 	for rows.Next() {
 		var commit string
 		var uploadID int
-		var distance int
+		var distance uint32
 		if err := rows.Scan(&commit, &uploadID, &distance); err != nil {
 			return nil, err
 		}
 
 		uploadMeta[commit] = append(uploadMeta[commit], UploadMeta{
 			UploadID: uploadID,
-			Distance: distance,
+			Flags:    distance,
 		})
 	}
 
@@ -302,7 +306,7 @@ func normalizeVisibleUploads(uploadMetas map[string][]UploadMeta) map[string][]U
 	for commit, uploads := range uploadMetas {
 		var filtered []UploadMeta
 		for _, upload := range uploads {
-			if !upload.Overwritten {
+			if (upload.Flags & FlagOverwritten) == 0 {
 				filtered = append(filtered, upload)
 			}
 		}

--- a/enterprise/internal/codeintel/store/references_test.go
+++ b/enterprise/internal/codeintel/store/references_test.go
@@ -28,32 +28,32 @@ func TestSameRepoPager(t *testing.T) {
 
 	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Root: "sub1/", Distance: 1},
-			{UploadID: 2, Root: "sub2/", Distance: 2},
-			{UploadID: 3, Root: "sub3/", Distance: 3},
-			{UploadID: 4, Root: "sub4/", Distance: 2},
-			{UploadID: 5, Root: "sub5/", Distance: 1},
+			{UploadID: 1, Flags: 1},
+			{UploadID: 2, Flags: 2},
+			{UploadID: 3, Flags: 3},
+			{UploadID: 4, Flags: 2},
+			{UploadID: 5, Flags: 1},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Root: "sub1/", Distance: 0},
-			{UploadID: 2, Root: "sub2/", Distance: 1},
-			{UploadID: 3, Root: "sub3/", Distance: 2},
-			{UploadID: 4, Root: "sub4/", Distance: 1},
-			{UploadID: 5, Root: "sub5/", Distance: 0},
+			{UploadID: 1, Flags: 0},
+			{UploadID: 2, Flags: 1},
+			{UploadID: 3, Flags: 2},
+			{UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 0},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Root: "sub1/", Distance: 1},
-			{UploadID: 2, Root: "sub2/", Distance: 0},
-			{UploadID: 3, Root: "sub3/", Distance: 1},
-			{UploadID: 4, Root: "sub4/", Distance: 0},
-			{UploadID: 5, Root: "sub5/", Distance: 1},
+			{UploadID: 1, Flags: 1},
+			{UploadID: 2, Flags: 0},
+			{UploadID: 3, Flags: 1},
+			{UploadID: 4, Flags: 0},
+			{UploadID: 5, Flags: 1},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Root: "sub1/", Distance: 2},
-			{UploadID: 2, Root: "sub2/", Distance: 1},
-			{UploadID: 3, Root: "sub3/", Distance: 0},
-			{UploadID: 4, Root: "sub4/", Distance: 1},
-			{UploadID: 5, Root: "sub5/", Distance: 2},
+			{UploadID: 1, Flags: 2},
+			{UploadID: 2, Flags: 1},
+			{UploadID: 3, Flags: 0},
+			{UploadID: 4, Flags: 1},
+			{UploadID: 5, Flags: 2},
 		},
 	})
 
@@ -122,15 +122,15 @@ func TestSameRepoPagerMultiplePages(t *testing.T) {
 
 	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{
 		makeCommit(1): {
-			{UploadID: 1, Root: "sub1/", Distance: 0},
-			{UploadID: 2, Root: "sub2/", Distance: 0},
-			{UploadID: 3, Root: "sub3/", Distance: 0},
-			{UploadID: 4, Root: "sub4/", Distance: 0},
-			{UploadID: 5, Root: "sub5/", Distance: 0},
-			{UploadID: 6, Root: "sub6/", Distance: 0},
-			{UploadID: 7, Root: "sub7/", Distance: 0},
-			{UploadID: 8, Root: "sub8/", Distance: 0},
-			{UploadID: 9, Root: "sub9/", Distance: 0},
+			{UploadID: 1},
+			{UploadID: 2},
+			{UploadID: 3},
+			{UploadID: 4},
+			{UploadID: 5},
+			{UploadID: 6},
+			{UploadID: 7},
+			{UploadID: 8},
+			{UploadID: 9},
 		},
 	})
 
@@ -187,16 +187,12 @@ func TestSameRepoPagerVisibility(t *testing.T) {
 	)
 
 	insertNearestUploads(t, dbconn.Global, 50, map[string][]UploadMeta{
-		makeCommit(1): {{UploadID: 1, Root: "sub1/", Distance: 0}},
-		makeCommit(2): {{UploadID: 2, Root: "sub2/", Distance: 0}},
-		makeCommit(3): {{UploadID: 3, Root: "sub1/", Distance: 0}},
-		makeCommit(4): {{UploadID: 4, Root: "sub2/", Distance: 0}},
-		makeCommit(5): {{UploadID: 5, Root: "sub5/", Distance: 0}},
-		makeCommit(6): {
-			{UploadID: 3, Root: "sub1/", Distance: 3},
-			{UploadID: 4, Root: "sub2/", Distance: 2},
-			{UploadID: 5, Root: "sub5/", Distance: 1},
-		},
+		makeCommit(1): {{UploadID: 1, Flags: 0}},
+		makeCommit(2): {{UploadID: 2, Flags: 0}},
+		makeCommit(3): {{UploadID: 3, Flags: 0}},
+		makeCommit(4): {{UploadID: 4, Flags: 0}},
+		makeCommit(5): {{UploadID: 5, Flags: 0}},
+		makeCommit(6): {{UploadID: 3, Flags: 3}, {UploadID: 4, Flags: 2}, {UploadID: 5, Flags: 1}},
 	})
 
 	expected := []types.PackageReference{


### PR DESCRIPTION
This PR cherry-picks updates from https://github.com/sourcegraph/sourcegraph/pull/16086 (off of main) into the 3.21 branch so that we can build an image for a customer who is currently experiencing memory pressure.