### PR TITLE
cherrypick: Limit size of commit graph

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/background/commit_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commit_updater.go
@@ -70,16 +70,51 @@ func (u *CommitUpdater) tryUpdate(ctx context.Context, repositoryID, dirtyToken 
 		err = unlock(err)
 	}()
 
+	// Construct a view of the git graph that we will later decorate with upload information.
+	// We will only fetch commits that are newer than the oldest commit with LSIF data. This
+	// will pull back the smaller set of _relevant_ commits which we need denormalized data
+	// for in the query path.
+	//
+	// Decorating the graph (below) is an operation that scales _multiplicatively_ with the
+	// size of the git graph and the number of uploads. This is a necessary optimization for
+	// repositories with very large number of commits. The number of commits pulled back here
+	// should not grow (unless the repo is growing at an accelerating rate) as we routinely
+	// expire old information for active repositories in a janitor process.
+	dump, ok, err := u.dbStore.OldestDumpForRepository(ctx, repositoryID)
+	if err != nil {
+		return errors.Wrap(err, "store.OldestDumpForRepository")
+	}
+
+	var graph map[string][]string
+	if ok {
+		oldestCommitDateWithUpload, err := u.gitserverClient.CommitDate(ctx, repositoryID, dump.Commit)
+		if err != nil {
+			// TODO(efritz) - handle missing commit error condition. This is probably an extremely
+			// unlikely edge case, but it's possible that the oldest commit was force-pushed out of
+			// existence in the code host (then subsequently gitserver) before the janitor process
+			// removes the orphaned commits. This will cause tryUpdate to fail here and the repo
+			// will remain dirty until one of the conditions above changes.
+			//
+			// It's a bit nasty but self-correcting.
+			return errors.Wrap(err, "gitserver.CommitDate")
+		}
+
+		graph, err = u.gitserverClient.CommitGraph(ctx, repositoryID, gitserver.CommitGraphOptions{
+			Since: &oldestCommitDateWithUpload,
+		})
+		if err != nil {
+			return errors.Wrap(err, "gitserver.CommitGraph")
+		}
+	}
+
 	tipCommit, err := u.gitserverClient.Head(ctx, repositoryID)
 	if err != nil {
 		return errors.Wrap(err, "gitserver.Head")
 	}
 
-	graph, err := u.gitserverClient.CommitGraph(ctx, repositoryID, gitserver.CommitGraphOptions{})
-	if err != nil {
-		return errors.Wrap(err, "gitserver.CommitGraph")
-	}
-
+	// Decorate the commit graph with the set of processed uploads are visible from each commit,
+	// then bulk update the denormalized view in Postgres. We call this with an empty graph as well
+	// so that we end up clearing the stale data and bulk inserting nothing.
 	if err := u.dbStore.CalculateVisibleUploads(ctx, repositoryID, graph, tipCommit, dirtyToken); err != nil {
 		return errors.Wrap(err, "store.CalculateVisibleUploads")
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/background/commit_updater_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commit_updater_test.go
@@ -3,6 +3,9 @@ package background
 import (
 	"context"
 	"testing"
+	"time"
+
+	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
 func TestCommitUpdater(t *testing.T) {
@@ -13,10 +16,13 @@ func TestCommitUpdater(t *testing.T) {
 
 	mockDBStore := NewMockDBStore()
 	mockDBStore.DirtyRepositoriesFunc.SetDefaultReturn(map[int]int{42: 15}, nil)
-	mockDBStore.LockFunc.SetDefaultReturn(false, nil, nil)
+	mockDBStore.LockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
+	mockDBStore.OldestDumpForRepositoryFunc.SetDefaultReturn(store.Dump{Commit: "deadbeef"}, true, nil)
 
+	commitTime := time.Unix(1587396557, 0).UTC()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitserverClient.CommitGraphFunc.SetDefaultReturn(graph, nil)
+	mockGitserverClient.CommitDateFunc.SetDefaultReturn(commitTime, nil)
 	mockGitserverClient.HeadFunc.SetDefaultReturn("b", nil)
 
 	updater := &CommitUpdater{
@@ -38,6 +44,57 @@ func TestCommitUpdater(t *testing.T) {
 		if call.Arg2 {
 			t.Errorf("unexpected blocking argument. want=%v have=%v", false, call.Arg2)
 		}
+	}
+
+	// Should fetch commit graph
+	if len(mockGitserverClient.CommitGraphFunc.History()) != 1 {
+		t.Fatalf("unexpected commit graph call count. want=%d have=%d", 1, len(mockGitserverClient.CommitGraphFunc.History()))
+	}
+	// Should calculate visible uploads with fetched graph
+	if len(mockDBStore.CalculateVisibleUploadsFunc.History()) != 1 {
+		t.Fatalf("unexpected calculate visible uploads call count. want=%d have=%d", 1, len(mockDBStore.CalculateVisibleUploadsFunc.History()))
+	}
+}
+
+func TestCommitUpdaterNoOldDump(t *testing.T) {
+	mockDBStore := NewMockDBStore()
+	mockDBStore.DirtyRepositoriesFunc.SetDefaultReturn(map[int]int{42: 15}, nil)
+	mockDBStore.LockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
+	mockDBStore.OldestDumpForRepositoryFunc.SetDefaultReturn(store.Dump{}, false, nil)
+	mockGitserverClient := NewMockGitserverClient()
+
+	updater := &CommitUpdater{
+		dbStore:         mockDBStore,
+		gitserverClient: mockGitserverClient,
+	}
+
+	if err := updater.Handle(context.Background()); err != nil {
+		t.Fatalf("unexpected error updating commit graph: %s", err)
+	}
+
+	// Should not not fetch commit graph
+	if len(mockGitserverClient.CommitGraphFunc.History()) != 0 {
+		t.Fatalf("unexpected commit graph call count. want=%d have=%d", 0, len(mockGitserverClient.CommitGraphFunc.History()))
+	}
+	// Should calculate visible uploads with empty graph
+	if len(mockDBStore.CalculateVisibleUploadsFunc.History()) != 1 {
+		t.Fatalf("unexpected calculate visible uploads call count. want=%d have=%d", 1, len(mockDBStore.CalculateVisibleUploadsFunc.History()))
+	}
+}
+
+func TestCommitUpdaterLocked(t *testing.T) {
+	mockDBStore := NewMockDBStore()
+	mockDBStore.DirtyRepositoriesFunc.SetDefaultReturn(map[int]int{42: 15}, nil)
+	mockDBStore.LockFunc.SetDefaultReturn(false, nil, nil)
+	mockGitserverClient := NewMockGitserverClient()
+
+	updater := &CommitUpdater{
+		dbStore:         mockDBStore,
+		gitserverClient: mockGitserverClient,
+	}
+
+	if err := updater.Handle(context.Background()); err != nil {
+		t.Fatalf("unexpected error updating commit graph: %s", err)
 	}
 
 	if len(mockDBStore.CalculateVisibleUploadsFunc.History()) != 0 {

--- a/enterprise/cmd/frontend/internal/codeintel/background/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/iface.go
@@ -35,6 +35,7 @@ type DBStore interface {
 	GetRepositoriesWithIndexConfiguration(ctx context.Context) ([]int, error)
 	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (dbstore.IndexConfiguration, bool, error)
 	DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore time.Time) (_ int, err error)
+	OldestDumpForRepository(ctx context.Context, repositoryID int) (dbstore.Dump, bool, error)
 }
 
 type DBStoreShim struct {
@@ -60,4 +61,5 @@ type GitserverClient interface {
 	FileExists(ctx context.Context, repositoryID int, commit, file string) (bool, error)
 	RawContents(ctx context.Context, repositoryID int, commit, file string) ([]byte, error)
 	CommitGraph(ctx context.Context, repositoryID int, options gitserver.CommitGraphOptions) (map[string][]string, error)
+	CommitDate(ctx context.Context, repositoryID int, commit string) (time.Time, error)
 }

--- a/enterprise/cmd/frontend/internal/codeintel/background/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/mock_iface_test.go
@@ -67,6 +67,9 @@ type MockDBStore struct {
 	// LockFunc is an instance of a mock function object controlling the
 	// behavior of the method Lock.
 	LockFunc *DBStoreLockFunc
+	// OldestDumpForRepositoryFunc is an instance of a mock function object
+	// controlling the behavior of the method OldestDumpForRepository.
+	OldestDumpForRepositoryFunc *DBStoreOldestDumpForRepositoryFunc
 	// RepoNameFunc is an instance of a mock function object controlling the
 	// behavior of the method RepoName.
 	RepoNameFunc *DBStoreRepoNameFunc
@@ -168,6 +171,11 @@ func NewMockDBStore() *MockDBStore {
 				return false, nil, nil
 			},
 		},
+		OldestDumpForRepositoryFunc: &DBStoreOldestDumpForRepositoryFunc{
+			defaultHook: func(context.Context, int) (dbstore.Dump, bool, error) {
+				return dbstore.Dump{}, false, nil
+			},
+		},
 		RepoNameFunc: &DBStoreRepoNameFunc{
 			defaultHook: func(context.Context, int) (string, error) {
 				return "", nil
@@ -249,6 +257,9 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 		},
 		LockFunc: &DBStoreLockFunc{
 			defaultHook: i.Lock,
+		},
+		OldestDumpForRepositoryFunc: &DBStoreOldestDumpForRepositoryFunc{
+			defaultHook: i.OldestDumpForRepository,
 		},
 		RepoNameFunc: &DBStoreRepoNameFunc{
 			defaultHook: i.RepoName,
@@ -1930,6 +1941,120 @@ func (c DBStoreLockFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// DBStoreOldestDumpForRepositoryFunc describes the behavior when the
+// OldestDumpForRepository method of the parent MockDBStore instance is
+// invoked.
+type DBStoreOldestDumpForRepositoryFunc struct {
+	defaultHook func(context.Context, int) (dbstore.Dump, bool, error)
+	hooks       []func(context.Context, int) (dbstore.Dump, bool, error)
+	history     []DBStoreOldestDumpForRepositoryFuncCall
+	mutex       sync.Mutex
+}
+
+// OldestDumpForRepository delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockDBStore) OldestDumpForRepository(v0 context.Context, v1 int) (dbstore.Dump, bool, error) {
+	r0, r1, r2 := m.OldestDumpForRepositoryFunc.nextHook()(v0, v1)
+	m.OldestDumpForRepositoryFunc.appendCall(DBStoreOldestDumpForRepositoryFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// OldestDumpForRepository method of the parent MockDBStore instance is
+// invoked and the hook queue is empty.
+func (f *DBStoreOldestDumpForRepositoryFunc) SetDefaultHook(hook func(context.Context, int) (dbstore.Dump, bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// OldestDumpForRepository method of the parent MockDBStore instance inovkes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *DBStoreOldestDumpForRepositoryFunc) PushHook(hook func(context.Context, int) (dbstore.Dump, bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBStoreOldestDumpForRepositoryFunc) SetDefaultReturn(r0 dbstore.Dump, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, int) (dbstore.Dump, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBStoreOldestDumpForRepositoryFunc) PushReturn(r0 dbstore.Dump, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, int) (dbstore.Dump, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *DBStoreOldestDumpForRepositoryFunc) nextHook() func(context.Context, int) (dbstore.Dump, bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreOldestDumpForRepositoryFunc) appendCall(r0 DBStoreOldestDumpForRepositoryFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreOldestDumpForRepositoryFuncCall
+// objects describing the invocations of this function.
+func (f *DBStoreOldestDumpForRepositoryFunc) History() []DBStoreOldestDumpForRepositoryFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreOldestDumpForRepositoryFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreOldestDumpForRepositoryFuncCall is an object that describes an
+// invocation of method OldestDumpForRepository on an instance of
+// MockDBStore.
+type DBStoreOldestDumpForRepositoryFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 dbstore.Dump
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 bool
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreOldestDumpForRepositoryFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreOldestDumpForRepositoryFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
 // DBStoreRepoNameFunc describes the behavior when the RepoName method of
 // the parent MockDBStore instance is invoked.
 type DBStoreRepoNameFunc struct {
@@ -2587,6 +2712,9 @@ func (c DBStoreUpdateIndexableRepositoryFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/background)
 // used for unit testing.
 type MockGitserverClient struct {
+	// CommitDateFunc is an instance of a mock function object controlling
+	// the behavior of the method CommitDate.
+	CommitDateFunc *GitserverClientCommitDateFunc
 	// CommitGraphFunc is an instance of a mock function object controlling
 	// the behavior of the method CommitGraph.
 	CommitGraphFunc *GitserverClientCommitGraphFunc
@@ -2609,6 +2737,11 @@ type MockGitserverClient struct {
 // overwritten.
 func NewMockGitserverClient() *MockGitserverClient {
 	return &MockGitserverClient{
+		CommitDateFunc: &GitserverClientCommitDateFunc{
+			defaultHook: func(context.Context, int, string) (time.Time, error) {
+				return time.Time{}, nil
+			},
+		},
 		CommitGraphFunc: &GitserverClientCommitGraphFunc{
 			defaultHook: func(context.Context, int, gitserver.CommitGraphOptions) (map[string][]string, error) {
 				return nil, nil
@@ -2642,6 +2775,9 @@ func NewMockGitserverClient() *MockGitserverClient {
 // overwritten.
 func NewMockGitserverClientFrom(i GitserverClient) *MockGitserverClient {
 	return &MockGitserverClient{
+		CommitDateFunc: &GitserverClientCommitDateFunc{
+			defaultHook: i.CommitDate,
+		},
 		CommitGraphFunc: &GitserverClientCommitGraphFunc{
 			defaultHook: i.CommitGraph,
 		},
@@ -2658,6 +2794,118 @@ func NewMockGitserverClientFrom(i GitserverClient) *MockGitserverClient {
 			defaultHook: i.RawContents,
 		},
 	}
+}
+
+// GitserverClientCommitDateFunc describes the behavior when the CommitDate
+// method of the parent MockGitserverClient instance is invoked.
+type GitserverClientCommitDateFunc struct {
+	defaultHook func(context.Context, int, string) (time.Time, error)
+	hooks       []func(context.Context, int, string) (time.Time, error)
+	history     []GitserverClientCommitDateFuncCall
+	mutex       sync.Mutex
+}
+
+// CommitDate delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitserverClient) CommitDate(v0 context.Context, v1 int, v2 string) (time.Time, error) {
+	r0, r1 := m.CommitDateFunc.nextHook()(v0, v1, v2)
+	m.CommitDateFunc.appendCall(GitserverClientCommitDateFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CommitDate method of
+// the parent MockGitserverClient instance is invoked and the hook queue is
+// empty.
+func (f *GitserverClientCommitDateFunc) SetDefaultHook(hook func(context.Context, int, string) (time.Time, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CommitDate method of the parent MockGitserverClient instance inovkes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitserverClientCommitDateFunc) PushHook(hook func(context.Context, int, string) (time.Time, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *GitserverClientCommitDateFunc) SetDefaultReturn(r0 time.Time, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (time.Time, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *GitserverClientCommitDateFunc) PushReturn(r0 time.Time, r1 error) {
+	f.PushHook(func(context.Context, int, string) (time.Time, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientCommitDateFunc) nextHook() func(context.Context, int, string) (time.Time, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientCommitDateFunc) appendCall(r0 GitserverClientCommitDateFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientCommitDateFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientCommitDateFunc) History() []GitserverClientCommitDateFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientCommitDateFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientCommitDateFuncCall is an object that describes an
+// invocation of method CommitDate on an instance of MockGitserverClient.
+type GitserverClientCommitDateFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 time.Time
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientCommitDateFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientCommitDateFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // GitserverClientCommitGraphFunc describes the behavior when the

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -8,6 +8,7 @@ import (
 )
 
 type operations struct {
+	commitDate        *observation.Operation
 	commitGraph       *observation.Operation
 	directoryChildren *observation.Operation
 	fileExists        *observation.Operation
@@ -33,6 +34,7 @@ func makeOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
+		commitDate:        op("CommitDate"),
 		commitGraph:       op("CommitGraph"),
 		directoryChildren: op("DirectoryChildren"),
 		fileExists:        op("FileExists"),

--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -106,6 +106,34 @@ func (s *Store) GetDumpByID(ctx context.Context, id int) (_ Dump, _ bool, err er
 	`, id)))
 }
 
+// OldestDumpForRepository returns the oldest dump for the given repository and boolean flag indicating its existence.
+func (s *Store) OldestDumpForRepository(ctx context.Context, repositoryID int) (_ Dump, _ bool, err error) {
+	ctx, endObservation := s.operations.getDumpByID.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("repositoryID", repositoryID),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	return scanFirstDump(s.Store.Query(ctx, sqlf.Sprintf(`
+		SELECT
+			d.id,
+			d.commit,
+			d.root,
+			EXISTS (SELECT 1 FROM lsif_uploads_visible_at_tip where repository_id = d.repository_id and upload_id = d.id) AS visible_at_tip,
+			d.uploaded_at,
+			d.state,
+			d.failure_message,
+			d.started_at,
+			d.finished_at,
+			d.process_after,
+			d.num_resets,
+			d.num_failures,
+			d.repository_id,
+			d.repository_name,
+			d.indexer
+		FROM lsif_dumps_with_repository_name d WHERE repository_id = %s ORDER BY d.uploaded_at LIMIT 1
+	`, repositoryID)))
+}
+
 // FindClosestDumps returns the set of dumps that can most accurately answer queries for the given repository, commit, path, and
 // optional indexer. If rootMustEnclosePath is true, then only dumps with a root which is a prefix of path are returned. Otherwise,
 // any dump with a root intersecting the given path is returned.

--- a/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
@@ -71,6 +71,57 @@ func TestGetDumpByID(t *testing.T) {
 	}
 }
 
+func TestOldestDumpForRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	// No dumps exist initially
+	if _, exists, err := store.OldestDumpForRepository(context.Background(), 1); err != nil {
+		t.Fatalf("unexpected error getting dump: %s", err)
+	} else if exists {
+		t.Fatal("unexpected record")
+	}
+
+	n := 20
+	baseTime := time.Unix(1587396557, 0).UTC()
+
+	var uploads []Upload
+	for i := 0; i < n; i++ {
+		uploads = append(uploads, Upload{
+			ID:             i,
+			Commit:         makeCommit(i),
+			RepositoryID:   50,
+			UploadedAt:     baseTime.Add(time.Minute * -time.Duration(i)),
+			State:          "completed",
+			RepositoryName: "n-50",
+			Indexer:        "lsif-go",
+		})
+	}
+	insertUploads(t, dbconn.Global, uploads...)
+
+	if dump, exists, err := store.OldestDumpForRepository(context.Background(), 50); err != nil {
+		t.Fatalf("unexpected error getting dump: %s", err)
+	} else if !exists {
+		t.Fatal("expected record to exist")
+	} else {
+		expectedDump := Dump{
+			ID:             n - 1,
+			Commit:         makeCommit(n - 1),
+			RepositoryID:   50,
+			UploadedAt:     baseTime.Add(time.Minute * -time.Duration(n-1)),
+			State:          "completed",
+			RepositoryName: "n-50",
+			Indexer:        "lsif-go",
+		}
+		if diff := cmp.Diff(expectedDump, dump); diff != "" {
+			t.Errorf("unexpected dump (-want +got):\n%s", diff)
+		}
+	}
+}
+
 func TestFindClosestDumps(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
This tracks a cherry-pick of c39245e47dcb6178857e82d0028f90a96e1cec33 into the 3.22 branch.