### PR TITLE
Don't try to update merged changesets on reapply

### DIFF
--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -772,6 +772,10 @@ func determinePlan(previousSpec, currentSpec *campaigns.ChangesetSpec, ch *campa
 		}
 
 	case campaigns.ChangesetPublicationStatePublished:
+		// Don't take any actions for merged changesets.
+		if ch.ExternalState == campaigns.ChangesetExternalStateMerged {
+			return pl, nil
+		}
 		if reopenAfterDetach(ch) {
 			pl.SetOp(operationReopen)
 		}

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -838,7 +838,7 @@ func TestDeterminePlan(t *testing.T) {
 	}
 
 	campaignSpec := createCampaignSpec(t, ctx, store, "test-plan", admin.ID)
-	createCampaign(t, ctx, store, "test-plan", admin.ID, campaignSpec.ID)
+	campaign := createCampaign(t, ctx, store, "test-plan", admin.ID, campaignSpec.ID)
 
 	tcs := []struct {
 		name           string
@@ -963,6 +963,44 @@ func TestDeterminePlan(t *testing.T) {
 				repo:             githubRepo.ID,
 			},
 			wantOperations: operations{operationPush, operationSleep, operationSync},
+		},
+		{
+			name: "changeset merged and spec changed is noop",
+			previousSpec: testSpecOpts{
+				published:  true,
+				repo:       githubRepo.ID,
+				commitDiff: "testDiff",
+			},
+			currentSpec: testSpecOpts{
+				published:  true,
+				repo:       githubRepo.ID,
+				commitDiff: "newTestDiff",
+			},
+			changeset: testChangesetOpts{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				externalState:    campaigns.ChangesetExternalStateMerged,
+				repo:             githubRepo.ID,
+			},
+			wantOperations: operations{},
+		},
+		{
+			name: "changeset closed and detached will reopen",
+			previousSpec: testSpecOpts{
+				published: true,
+				repo:      githubRepo.ID,
+			},
+			currentSpec: testSpecOpts{
+				published: true,
+				repo:      githubRepo.ID,
+			},
+			changeset: testChangesetOpts{
+				publicationState: campaigns.ChangesetPublicationStatePublished,
+				externalState:    campaigns.ChangesetExternalStateClosed,
+				repo:             githubRepo.ID,
+				ownedByCampaign:  campaign.ID,
+				campaignIDs:      []int64{campaign.ID},
+			},
+			wantOperations: operations{operationReopen},
 		},
 	}
 
@@ -1115,6 +1153,7 @@ type testChangesetOpts struct {
 	campaign     int64
 	currentSpec  int64
 	previousSpec int64
+	campaignIDs  []int64
 
 	externalServiceType string
 	externalID          string
@@ -1149,6 +1188,7 @@ func createChangeset(
 		RepoID:         opts.repo,
 		CurrentSpecID:  opts.currentSpec,
 		PreviousSpecID: opts.previousSpec,
+		CampaignIDs:    opts.campaignIDs,
 
 		ExternalServiceType: opts.externalServiceType,
 		ExternalID:          opts.externalID,

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -984,7 +984,7 @@ func TestDeterminePlan(t *testing.T) {
 			wantOperations: operations{},
 		},
 		{
-			name: "changeset closed and detached will reopen",
+			name: "changeset closed-and-detached will reopen",
 			previousSpec: testSpecOpts{
 				published: true,
 				repo:      githubRepo.ID,


### PR DESCRIPTION
Previously, this would have tried to modify merged changesets (push, sleep, sync). I think we should not allow that, since it will be a noop or fail and costs rate limit tokens.
This can happen when I merge a change against a repo and then the campaign yields a NEW diff for that repo. (Ie, just append to a file). After it's merged, my command would append, hence the diff changes and the reconcilerOperations are {push, sleep, sync}. That actually updates the branch on the remote even, but then silently doesn't do anything as close is a noop on a merged PR.

This is the first find from the more transparent reconciler operations we'll get with the delta API. :)