### PR TITLE
search frontend: refine hovers for escaped regexp

### DIFF
--- a/client/shared/src/search/parser/hover.test.ts
+++ b/client/shared/src/search/parser/hover.test.ts
@@ -221,6 +221,85 @@ describe('getHoverResult()', () => {
         `)
     })
 
+    test('smartQuery flag on regexp escape characters', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('\\q\\r\\n\\.\\\\', false, SearchPatternType.regexp))
+        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character. The character \`q\` is escaped."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 3
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character. Match a carriage return."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 3,
+                "endColumn": 5
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 5 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character. Match a new line."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 5,
+                "endColumn": 7
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 7 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character. Match the character \`.\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 7,
+                "endColumn": 9
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 9 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Escaped Character. Match the character \`\\\\\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 9,
+                "endColumn": 11
+              }
+            }
+        `)
+    })
+
     test('smartQuery flag as literal search interprets parentheses as patterns', () => {
         const scannedQuery = toSuccess(scanSearchQuery('(abcd)', false, SearchPatternType.literal))
         expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -45,8 +45,24 @@ const toHover = (token: DecoratedToken): string => {
                     }
                 case RegexpMetaKind.Delimited:
                     return '**Group**. Groups together multiple expressions to match.'
-                case RegexpMetaKind.EscapedCharacter:
-                    return `**Escaped Character**. Match the character \`${token.value[1]}\`.`
+                case RegexpMetaKind.EscapedCharacter: {
+                    const escapable = '~`!@#$%^&*()[]{}<>,.?/\\|=+-_'
+                    let description = escapable.includes(token.value[1])
+                        ? `Match the character \`${token.value[1]}\`.`
+                        : `The character \`${token.value[1]}\` is escaped.`
+                    switch (token.value[1]) {
+                        case 'n':
+                            description = 'Match a new line.'
+                            break
+                        case 't':
+                            description = 'Match a tab.'
+                            break
+                        case 'r':
+                            description = 'Match a carriage return.'
+                            break
+                    }
+                    return `**Escaped Character. ${description}`
+                }
                 case RegexpMetaKind.LazyQuantifier:
                     return '**Lazy**. Match as few as characters as possible that match the previous expression.'
                 case RegexpMetaKind.RangeQuantifier:


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/16141. 

Before this PR, we by default said an escaped sequence matches the escaped character. This isn't always true (and it depends on the regexp dialect). This PR refines how we handle escape characters. In general, we can say that escaped punctuation matches the punctuation character, and we should also describe escape sequences that are interpreted (e.g., `\n`, `\t`). For any other escape sequence, we simply say 'it is escaped', though it may not necessarily be valid for our backend (we use RE2 in the backend and will validate accordingly). 

