### PR TITLE
campaigns: notify the user upon fresher specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Extensions can now easily query the Sourcegraph GraphQL API through a dedicated API method. [#15566](https://github.com/sourcegraph/sourcegraph/pull/15566)
 - Individual changesets can now be downloaded as a diff. [#16098](https://github.com/sourcegraph/sourcegraph/issues/16098)
 - The campaigns preview page is much more detailed now, especially when updating existing campaigns. [#16240](https://github.com/sourcegraph/sourcegraph/pull/16240)
+- When a newer version of a campaign spec is uploaded, a message is now displayed when viewing the campaign or an outdated campaign spec. [#14532](https://github.com/sourcegraph/sourcegraph/issues/14532)
 
 ### Changed
 

--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.story.tsx
@@ -50,6 +50,12 @@ const campaignSpec = (): CampaignSpecFields => ({
         namespaceName: 'alice',
         url: '/users/alice',
     },
+    supersedingCampaignSpec: boolean('supersedingCampaignSpec', false)
+        ? {
+              createdAt: subDays(new Date(), 1).toISOString(),
+              applyURL: '/users/alice/campaigns/apply/newspecid',
+          }
+        : null,
     viewerCanAdminister: boolean('viewerCanAdminister', true),
     viewerCampaignsCodeHosts: {
         totalCount: 0,

--- a/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
+++ b/client/web/src/enterprise/campaigns/apply/CampaignApplyPage.tsx
@@ -56,7 +56,7 @@ export const CampaignApplyPage: React.FunctionComponent<CampaignApplyPageProps> 
             () =>
                 fetchCampaignSpecById(specID).pipe(
                     repeatWhen(notifier => notifier.pipe(delay(5000))),
-                    distinctUntilChanged((a, b) => isEqual(a, b))
+                    distinctUntilChanged(isEqual)
                 ),
             [specID, fetchCampaignSpecById]
         )

--- a/client/web/src/enterprise/campaigns/apply/backend.ts
+++ b/client/web/src/enterprise/campaigns/apply/backend.ts
@@ -29,6 +29,13 @@ export const viewerCampaignsCodeHostsFragment = gql`
     }
 `
 
+const supersedingCampaignSpecFragment = gql`
+    fragment SupersedingCampaignSpecFields on CampaignSpec {
+        createdAt
+        applyURL
+    }
+`
+
 export const campaignSpecFragment = gql`
     fragment CampaignSpecFields on CampaignSpec {
         id
@@ -55,6 +62,9 @@ export const campaignSpecFragment = gql`
         diffStat {
             ...DiffStatFields
         }
+        supersedingCampaignSpec {
+            ...SupersedingCampaignSpecFields
+        }
         viewerCampaignsCodeHosts(onlyWithoutCredential: true) {
             ...ViewerCampaignsCodeHostsFields
         }
@@ -63,6 +73,8 @@ export const campaignSpecFragment = gql`
     ${viewerCampaignsCodeHostsFragment}
 
     ${diffStatFields}
+
+    ${supersedingCampaignSpecFragment}
 `
 
 export const fetchCampaignSpecById = (campaignSpec: Scalars['ID']): Observable<CampaignSpecFields | null> =>

--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -64,6 +64,7 @@ const campaignDefaults: CampaignFields = {
     },
     currentSpec: {
         originalInput: 'name: awesome-campaign\ndescription: somestring',
+        supersedingCampaignSpec: null,
     },
 }
 

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -65,6 +65,7 @@ const campaignDefaults: CampaignFields = {
     },
     currentSpec: {
         originalInput: 'name: awesome-campaign\ndescription: somestring',
+        supersedingCampaignSpec: null,
     },
 }
 
@@ -268,15 +269,25 @@ const stories: Record<string, string> = {
 
 for (const [name, url] of Object.entries(stories)) {
     add(name, () => {
+        const supersedingCampaignSpec = boolean('supersedingCampaignSpec', false)
         const viewerCanAdminister = boolean('viewerCanAdminister', true)
         const isClosed = boolean('isClosed', false)
         const campaign: CampaignFields = useMemo(
             () => ({
                 ...campaignDefaults,
+                currentSpec: {
+                    originalInput: campaignDefaults.currentSpec.originalInput,
+                    supersedingCampaignSpec: supersedingCampaignSpec
+                        ? {
+                              createdAt: subDays(new Date(), 1).toISOString(),
+                              applyURL: '/users/alice/campaigns/apply/newspecid',
+                          }
+                        : null,
+                },
                 viewerCanAdminister,
                 closedAt: isClosed ? subDays(now, 1).toISOString() : null,
             }),
-            [viewerCanAdminister, isClosed]
+            [supersedingCampaignSpec, viewerCanAdminister, isClosed]
         )
 
         const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -261,15 +261,16 @@ const queryChangesetCountsOverTime: typeof _queryChangesetCountsOverTime = () =>
 
 const deleteCampaign = () => Promise.resolve(undefined)
 
-const stories: Record<string, string> = {
-    Overview: '/users/alice/campaigns/awesome-campaign',
-    'Burndown chart': '/users/alice/campaigns/awesome-campaign?tab=chart',
-    'Spec file': '/users/alice/campaigns/awesome-campaign?tab=spec',
+const stories: Record<string, { url: string; supersededCampaignSpec?: boolean }> = {
+    Overview: { url: '/users/alice/campaigns/awesome-campaign' },
+    'Burndown chart': { url: '/users/alice/campaigns/awesome-campaign?tab=chart' },
+    'Spec file': { url: '/users/alice/campaigns/awesome-campaign?tab=spec' },
+    'Superseded campaign': { url: '/users/alice/campaigns/awesome-campaign', supersededCampaignSpec: true },
 }
 
-for (const [name, url] of Object.entries(stories)) {
+for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
     add(name, () => {
-        const supersedingCampaignSpec = boolean('supersedingCampaignSpec', false)
+        const supersedingCampaignSpec = boolean('supersedingCampaignSpec', !!supersededCampaignSpec)
         const viewerCanAdminister = boolean('viewerCanAdminister', true)
         const isClosed = boolean('isClosed', false)
         const campaign: CampaignFields = useMemo(

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -26,6 +26,7 @@ import { CampaignTabs } from './CampaignTabs'
 import { CampaignDetailsActionSection } from './CampaignDetailsActionSection'
 import { CampaignInfoByline } from './CampaignInfoByline'
 import { UnpublishedNotice } from './UnpublishedNotice'
+import { SupersedingCampaignSpecAlert } from './SupersedingCampaignSpecAlert'
 
 export interface CampaignDetailsPageProps
     extends ThemeProps,
@@ -125,6 +126,7 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 lastApplier={campaign.lastApplier}
                 className="mb-3"
             />
+            <SupersedingCampaignSpecAlert spec={campaign.currentSpec.supersedingCampaignSpec} />
             <UnpublishedNotice
                 unpublished={campaign.changesetsStats.unpublished}
                 total={campaign.changesetsStats.total}

--- a/client/web/src/enterprise/campaigns/detail/SupersedingCampaignSpecAlert.tsx
+++ b/client/web/src/enterprise/campaigns/detail/SupersedingCampaignSpecAlert.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Timestamp } from '../../../components/time/Timestamp'
+import CreationIcon from 'mdi-react/CreationIcon'
+import { Link } from '../../../../../shared/src/components/Link'
+import { SupersedingCampaignSpecFields } from '../../../graphql-operations'
+
+export interface SupersedingCampaignSpecAlertProps {
+    spec: SupersedingCampaignSpecFields | null | undefined
+}
+
+export const SupersedingCampaignSpecAlert: React.FunctionComponent<SupersedingCampaignSpecAlertProps> = ({ spec }) => {
+    if (!spec) {
+        return <></>
+    }
+
+    const { applyURL, createdAt } = spec
+    return (
+        <div className="alert alert-info d-flex align-items-center">
+            <div className="d-none d-md-block">
+                <CreationIcon className="mr-2" size={40} />
+            </div>
+            <div className="flex-grow-1">
+                A <Link to={applyURL}>newer version of this campaign spec</Link> was uploaded{' '}
+                <Timestamp date={createdAt} />, and has not yet been applied.
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/campaigns/detail/SupersedingCampaignSpecAlert.tsx
+++ b/client/web/src/enterprise/campaigns/detail/SupersedingCampaignSpecAlert.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../../../../shared/src/components/Link'
 import { SupersedingCampaignSpecFields } from '../../../graphql-operations'
 
 export interface SupersedingCampaignSpecAlertProps {
-    spec: SupersedingCampaignSpecFields | null | undefined
+    spec: SupersedingCampaignSpecFields | null
 }
 
 export const SupersedingCampaignSpecAlert: React.FunctionComponent<SupersedingCampaignSpecAlertProps> = ({ spec }) => {
@@ -17,11 +17,11 @@ export const SupersedingCampaignSpecAlert: React.FunctionComponent<SupersedingCa
     return (
         <div className="alert alert-info d-flex align-items-center">
             <div className="d-none d-md-block">
-                <CreationIcon className="mr-2" size={40} />
+                <CreationIcon className="icon icon-inline mr-2" />
             </div>
             <div className="flex-grow-1">
-                A <Link to={applyURL}>newer version of this campaign spec</Link> was uploaded{' '}
-                <Timestamp date={createdAt} />, and has not yet been applied.
+                A <Link to={applyURL}>newer campaign spec</Link> was uploaded <Timestamp date={createdAt} />, and has
+                not yet been applied.
             </div>
         </div>
     )

--- a/client/web/src/enterprise/campaigns/detail/SupersedingCampaignSpecAlert.tsx
+++ b/client/web/src/enterprise/campaigns/detail/SupersedingCampaignSpecAlert.tsx
@@ -20,8 +20,7 @@ export const SupersedingCampaignSpecAlert: React.FunctionComponent<SupersedingCa
                 <CreationIcon className="icon icon-inline mr-2" />
             </div>
             <div className="flex-grow-1">
-                A <Link to={applyURL}>newer campaign spec</Link> was uploaded <Timestamp date={createdAt} />, and has
-                not yet been applied.
+                A <Link to={applyURL}>newer campaign spec</Link> was uploaded <Timestamp date={createdAt} />.
             </div>
         </div>
     )

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -70,6 +70,10 @@ const campaignFragment = gql`
 
         currentSpec {
             originalInput
+            supersedingCampaignSpec {
+                createdAt
+                applyURL
+            }
         }
     }
 

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -277,6 +277,7 @@ function mockCommonGraphQLResponses(
                 },
                 currentSpec: {
                     originalInput: 'name: awesome-campaign\ndescription: somesttring',
+                    supersedingCampaignSpec: null,
                 },
                 ...campaignOverrides,
             },
@@ -537,6 +538,7 @@ describe('Campaigns', () => {
                                           namespaceName: 'test-org',
                                           url: '/organizations/test-org',
                                       },
+                            supersedingCampaignSpec: null,
                             viewerCanAdminister: true,
                             viewerCampaignsCodeHosts: {
                                 totalCount: 0,

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -145,6 +145,8 @@ type CampaignSpecResolver interface {
 
 	AppliesToCampaign(ctx context.Context) (CampaignResolver, error)
 
+	SupersedingCampaignSpec(context.Context) (CampaignSpecResolver, error)
+
 	ViewerCampaignsCodeHosts(ctx context.Context, args *ListViewerCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 }
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1369,6 +1369,12 @@ type CampaignSpec implements Node {
     appliesToCampaign: Campaign
 
     """
+    The newest version of this campaign spec, as identified by its namespace
+    and name. If this is the newest version, this field will be null.
+    """
+    supersedingCampaignSpec: CampaignSpec
+
+    """
     The code host connections required for applying this spec. Includes the credentials of the current user.
     """
     viewerCampaignsCodeHosts(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1362,6 +1362,12 @@ type CampaignSpec implements Node {
     appliesToCampaign: Campaign
 
     """
+    The newest version of this campaign spec, as identified by its namespace
+    and name. If this is the newest version, this field will be null.
+    """
+    supersedingCampaignSpec: CampaignSpec
+
+    """
     The code host connections required for applying this spec. Includes the credentials of the current user.
     """
     viewerCampaignsCodeHosts(

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -211,6 +211,8 @@ type CampaignSpec struct {
 
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
+
+	SupersedingCampaignSpec *CampaignSpec
 }
 
 // ChangesetSpecDelta is the delta between two ChangesetSpecs describing the same Changeset.

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -215,6 +215,12 @@ func (r *campaignSpecResolver) SupersedingCampaignSpec(ctx context.Context) (gra
 		return nil, nil
 	}
 
+	// If this spec and the new spec have different creators, we shouldn't
+	// return this as a superseding spec.
+	if newest.UserID != r.campaignSpec.UserID {
+		return nil, nil
+	}
+
 	// Create our new resolver, reusing as many fields as we can from this one.
 	resolver := &campaignSpecResolver{
 		store:        r.store,

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -200,7 +200,7 @@ func (s *Service) GetCampaignMatchingCampaignSpec(ctx context.Context, spec *cam
 }
 
 // GetNewestCampaignSpec returns the newest campaign spec that matches the given
-// spec's namespace and name and is owned by the given user.
+// spec's namespace and name and is owned by the given user, or nil if none is found.
 func (s *Service) GetNewestCampaignSpec(ctx context.Context, tx *Store, spec *campaigns.CampaignSpec, userID int32) (*campaigns.CampaignSpec, error) {
 	opts := GetNewestCampaignSpecOpts{
 		UserID:          userID,

--- a/enterprise/internal/campaigns/service.go
+++ b/enterprise/internal/campaigns/service.go
@@ -199,6 +199,27 @@ func (s *Service) GetCampaignMatchingCampaignSpec(ctx context.Context, spec *cam
 	return campaign, err
 }
 
+// GetNewestCampaignSpec returns the newest campaign spec that matches the given
+// spec's namespace and name and is owned by the given user.
+func (s *Service) GetNewestCampaignSpec(ctx context.Context, tx *Store, spec *campaigns.CampaignSpec, userID int32) (*campaigns.CampaignSpec, error) {
+	opts := GetNewestCampaignSpecOpts{
+		UserID:          userID,
+		NamespaceUserID: spec.NamespaceUserID,
+		NamespaceOrgID:  spec.NamespaceOrgID,
+		Name:            spec.Spec.Name,
+	}
+
+	newest, err := tx.GetNewestCampaignSpec(ctx, opts)
+	if err != nil {
+		if err != ErrNoResults {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	return newest, nil
+}
+
 type MoveCampaignOpts struct {
 	CampaignID int64
 

--- a/enterprise/internal/campaigns/service_test.go
+++ b/enterprise/internal/campaigns/service_test.go
@@ -721,6 +721,38 @@ func TestService(t *testing.T) {
 		}
 	})
 
+	t.Run("GetNewestCampaignSpec", func(t *testing.T) {
+		older := createCampaignSpec(t, ctx, store, "superseding", user.ID)
+		newer := createCampaignSpec(t, ctx, store, "superseding", user.ID)
+
+		for name, in := range map[string]*campaigns.CampaignSpec{
+			"older": older,
+			"newer": newer,
+		} {
+			t.Run(name, func(t *testing.T) {
+				have, err := svc.GetNewestCampaignSpec(ctx, store, in, user.ID)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				if diff := cmp.Diff(newer, have); diff != "" {
+					t.Errorf("unexpected newer campaign spec (-want +have):\n%s", diff)
+				}
+			})
+		}
+
+		t.Run("different user", func(t *testing.T) {
+			have, err := svc.GetNewestCampaignSpec(ctx, store, older, admin.ID)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if have != nil {
+				t.Errorf("unexpected non-nil campaign spec: %+v", have)
+			}
+		})
+	})
+
 	t.Run("FetchUsernameForBitbucketServerToken", func(t *testing.T) {
 		fakeSource := &ct.FakeChangesetSource{Username: "my-bbs-username"}
 		sourcer := repos.NewFakeSourcer(nil, fakeSource)

--- a/enterprise/internal/campaigns/store_campaign_specs_test.go
+++ b/enterprise/internal/campaigns/store_campaign_specs_test.go
@@ -213,6 +213,57 @@ func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos
 		})
 	})
 
+	t.Run("GetNewest", func(t *testing.T) {
+		t.Run("NotFound", func(t *testing.T) {
+			opts := GetNewestCampaignSpecOpts{
+				NamespaceUserID: 1235,
+				Name:            "Foobar",
+				UserID:          1234567,
+			}
+
+			_, err := s.GetNewestCampaignSpec(ctx, opts)
+			if err != ErrNoResults {
+				t.Errorf("unexpected error: have=%v want=%v", err, ErrNoResults)
+			}
+		})
+
+		t.Run("NamespaceUser", func(t *testing.T) {
+			opts := GetNewestCampaignSpecOpts{
+				NamespaceUserID: 1235,
+				Name:            "Foobar",
+				UserID:          1235 + 1234,
+			}
+
+			have, err := s.GetNewestCampaignSpec(ctx, opts)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			want := campaignSpecs[1]
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Errorf("unexpected campaign spec:\n%s", diff)
+			}
+		})
+
+		t.Run("NamespaceOrg", func(t *testing.T) {
+			opts := GetNewestCampaignSpecOpts{
+				NamespaceOrgID: 23,
+				Name:           "Foobar",
+				UserID:         1234 + 1234,
+			}
+
+			have, err := s.GetNewestCampaignSpec(ctx, opts)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			want := campaignSpecs[0]
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Errorf("unexpected campaign spec:\n%s", diff)
+			}
+		})
+	})
+
 	t.Run("Delete", func(t *testing.T) {
 		for i := range campaignSpecs {
 			err := s.DeleteCampaignSpec(ctx, campaignSpecs[i].ID)

--- a/enterprise/internal/campaigns/store_campaign_specs_test.go
+++ b/enterprise/internal/campaigns/store_campaign_specs_test.go
@@ -213,7 +213,7 @@ func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos
 		})
 	})
 
-	t.Run("GetNewest", func(t *testing.T) {
+	t.Run("GetNewestCampaignSpec", func(t *testing.T) {
 		t.Run("NotFound", func(t *testing.T) {
 			opts := GetNewestCampaignSpecOpts{
 				NamespaceUserID: 1235,


### PR DESCRIPTION
This adds a banner to the preview and campaign pages that shows up if the user has uploaded a newer campaign spec with the same name and namespace.

The backend work for this is complete, as is the GraphQL and component plumbing underpinning the UI (except for the remaining type warnings, which I'm going to knock off this evening), but this definitely still needs some design love from @rrhyne in terms of what this _actually_ should look like. However, as discussed in the sprint 6 planning meeting, let's get this merged and we can work on the design issues later in the sprint.

[The storybook has been updated (make sure you enable the `supersedingCampaignSpec` knob!)](https://5f0f381c0e50750022dc6bf7-kaiocawarb.chromatic.com/?path=/story/web-campaigns-apply-campaignapplypage--create), but here are a couple of screenshots:

![image](https://user-images.githubusercontent.com/229984/100164016-d67fa500-2e6b-11eb-94e5-2824550372cc.png)

![image](https://user-images.githubusercontent.com/229984/100164104-062ead00-2e6c-11eb-8f4a-055b593de149.png)

(Side note: that link colour on an info alert in dark mode isn't ideal.)

Closes #14532.