### PR TITLE
search frontend: correct hover for negated character class

### DIFF
--- a/client/shared/src/search/parser/hover.test.ts
+++ b/client/shared/src/search/parser/hover.test.ts
@@ -300,6 +300,41 @@ describe('getHoverResult()', () => {
         `)
     })
 
+    test('smartQuery flag on ordinary and negated character class', () => {
+        const scannedQuery = toSuccess(scanSearchQuery('[^a-z][0-9]', false, SearchPatternType.regexp))
+        expect(getHoverResult(scannedQuery, { column: 2 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Negated character class**. Match any character _not_ inside the square brackets."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 7
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 7 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Character class**. Match any character inside the square brackets."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 7,
+                "endColumn": 12
+              }
+            }
+        `)
+    })
+
     test('smartQuery flag as literal search interprets parentheses as patterns', () => {
         const scannedQuery = toSuccess(scanSearchQuery('(abcd)', false, SearchPatternType.literal))
         expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`

--- a/client/shared/src/search/parser/hover.ts
+++ b/client/shared/src/search/parser/hover.ts
@@ -25,7 +25,9 @@ const toHover = (token: DecoratedToken): string => {
                             return '**Negated word boundary**. Match a position between two word characters, or a position between two non-word characters. This is the negation of `\\b`.'
                     }
                 case RegexpMetaKind.CharacterClass:
-                    return '**Character set**. Match any character in the set.'
+                    return token.value.startsWith('[^')
+                        ? '**Negated character class**. Match any character _not_ inside the square brackets.'
+                        : '**Character class**. Match any character inside the square brackets.'
                 case RegexpMetaKind.CharacterSet:
                     switch (token.value) {
                         case '.':

--- a/client/shared/src/search/parser/tokens.ts
+++ b/client/shared/src/search/parser/tokens.ts
@@ -124,12 +124,13 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                 })
             },
             onCharacterClassEnter(node: CharacterClass) {
+                const negatedOffset = node.negate ? 1 : 0
                 // Push the leading '['
                 tokens.push({
                     type: 'regexpMeta',
-                    range: { start: offset + node.start, end: offset + node.start + 1 },
+                    range: { start: offset + node.start, end: offset + node.start + 1 + negatedOffset },
                     groupRange: { start: offset + node.start, end: offset + node.end },
-                    value: '[',
+                    value: node.negate ? '[^' : '[',
                     kind: RegexpMetaKind.CharacterClass,
                 })
                 // Push the trailing ']'


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/16143, part of #16141. 

This surfaces a correct hover about negated character classes like `[^xyz]`.