### PR TITLE
Don't close already closed, detached changesets

### DIFF
--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -818,19 +818,10 @@ func reopenAfterDetach(ch *campaigns.Changeset) bool {
 		return false
 	}
 
-	// Check if it's (re-)attached to the campaign that created it.
-	attachedToOwner := false
-	for _, campaignID := range ch.CampaignIDs {
-		if campaignID == ch.OwnedByCampaignID {
-			attachedToOwner = true
-		}
-	}
-
-	// At this point the changeset is closed and not marked as to-be-closed and
-	// attached to the owning campaign.
-	return attachedToOwner
+	// At this point the changeset is closed and not marked as to-be-closed.
 
 	// TODO: What if somebody closed the changeset on purpose on the codehost?
+	return ch.AttachedTo(ch.OwnedByCampaignID)
 }
 
 func loadRepo(ctx context.Context, tx RepoStore, id api.RepoID) (*repos.Repo, error) {

--- a/enterprise/internal/campaigns/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer.go
@@ -110,6 +110,11 @@ func (r *changesetRewirer) Rewire(ctx context.Context) (changesets []*campaigns.
 				continue
 			}
 
+			// If the changeset is currently not attached to this campaign, we don't want to modify it.
+			if !changeset.AttachedTo(r.campaign.ID) {
+				continue
+			}
+
 			if err := r.closeChangeset(ctx, changeset); err != nil {
 				return nil, err
 			}

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -539,6 +539,16 @@ func (c *Changeset) BaseRef() (string, error) {
 	}
 }
 
+// AttachedTo returns true if the changeset is currently attached to the campaign with the given campaignID.
+func (c *Changeset) AttachedTo(campaignID int64) bool {
+	for _, cid := range c.CampaignIDs {
+		if cid == campaignID {
+			return true
+		}
+	}
+	return false
+}
+
 // SupportsLabels returns whether the code host on which the changeset is
 // hosted supports labels and whether it's safe to call the
 // (*Changeset).Labels() method.


### PR DESCRIPTION
When a changeset is not attached to the campaign, we don't want to close it _again_. For a campaign that I had which a couple of time rolled over the branch name (so close all changesets and create new ones), this caused quite a few close operation calls to be made, and I think this is unnecessary, given it's been detached before already.
We could've also added this to the store method, but then in the resolvers I wouldn't be able to get the matching changeset anymore, which I would like to get for visualizing close events in the future.

Closes https://github.com/sourcegraph/sourcegraph/issues/16148