### PR TITLE
Tour: remove onboardingTour query param on completion or cancellation

### DIFF
--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -85,6 +85,7 @@ describe('Search onboarding', () => {
         await driver.page.evaluate(() => {
             localStorage.setItem('has-seen-onboarding-tour', 'false')
             localStorage.setItem('has-cancelled-onboarding-tour', 'false')
+            localStorage.setItem('has-completed-onboarding-tour', 'false')
             location.reload()
         })
     }
@@ -94,7 +95,7 @@ describe('Search onboarding', () => {
     }
 
     describe('Onboarding', () => {
-        it('only diplay tour afteer input is focused', async () => {
+        it('only diplay tour after input is focused', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             let tourCard = await driver.page.evaluate(() => document.querySelector('.tour-card'))
             expect(tourCard).toBeNull()
@@ -247,6 +248,72 @@ describe('Search onboarding', () => {
             tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
             tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
             expect(tourStep3).toBeTruthy()
+        })
+
+        it('Removes onboardingTour query parameter when the query reference step is advanced', async () => {
+            await driver.page.goto(
+                driver.sourcegraphBaseUrl + '/search?q=lang:go+test&patternType=literal&onboardingTour=true'
+            )
+            await resetOnboardingTour()
+            await waitAndFocusInput()
+            await driver.page.waitForSelector('.tour-card')
+            await driver.page.waitForSelector('.test-tour-step-5')
+            await driver.page.waitForSelector('.search-help-dropdown-button')
+            await driver.page.click('.search-help-dropdown-button')
+            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-tour-step-5').length)).toBe(0)
+            await driver.assertWindowLocation('/search?q=lang%3Ago+test&patternType=literal')
+        })
+
+        it('Removes onboardingTour query parameter when the query reference step is cancelled', async () => {
+            await driver.page.goto(
+                driver.sourcegraphBaseUrl + '/search?q=lang:go+test&patternType=literal&onboardingTour=true'
+            )
+            await resetOnboardingTour()
+            await waitAndFocusInput()
+            await driver.page.waitForSelector('.tour-card')
+            await driver.page.waitForSelector('.test-tour-step-5')
+            await driver.page.waitForSelector('.test-tour-close-button')
+            await driver.page.click('.test-tour-close-button')
+            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-tour-step-5').length)).toBe(0)
+            await driver.assertWindowLocation('/search?q=lang%3Ago+test&patternType=literal')
+        })
+
+        it('Does not display tour step when re-visiting a page with onboardingTour query after already completing ', async () => {
+            await driver.page.goto(
+                driver.sourcegraphBaseUrl + '/search?q=lang:go+test&patternType=literal&onboardingTour=true'
+            )
+            await resetOnboardingTour()
+            await waitAndFocusInput()
+            await driver.page.waitForSelector('.tour-card')
+            await driver.page.waitForSelector('.test-tour-step-5')
+            await driver.page.waitForSelector('.search-help-dropdown-button')
+            await driver.page.click('.search-help-dropdown-button')
+            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-tour-step-5').length)).toBe(0)
+            await driver.assertWindowLocation('/search?q=lang%3Ago+test&patternType=literal')
+            await driver.page.goto(
+                driver.sourcegraphBaseUrl + '/search?q=lang:go+test&patternType=literal&onboardingTour=true'
+            )
+            await driver.page.waitForSelector('.search-help-dropdown-button')
+            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-tour-step-5').length)).toBe(0)
+        })
+
+        it('Does not display tour step when re-visiting a page with onboardingTour query after already closing tour ', async () => {
+            await driver.page.goto(
+                driver.sourcegraphBaseUrl + '/search?q=lang:go+test&patternType=literal&onboardingTour=true'
+            )
+            await resetOnboardingTour()
+            await waitAndFocusInput()
+            await driver.page.waitForSelector('.tour-card')
+            await driver.page.waitForSelector('.test-tour-step-5')
+            await driver.page.waitForSelector('.test-tour-close-button')
+            await driver.page.click('.test-tour-close-button')
+            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-tour-step-5').length)).toBe(0)
+            await driver.assertWindowLocation('/search?q=lang%3Ago+test&patternType=literal')
+            await driver.page.goto(
+                driver.sourcegraphBaseUrl + '/search?q=lang:go+test&patternType=literal&onboardingTour=true'
+            )
+            await driver.page.waitForSelector('.search-help-dropdown-button')
+            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-tour-step-5').length)).toBe(0)
         })
     })
 })

--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -70,7 +70,7 @@ export function generateStepTooltip(options: {
  */
 export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number, totalStepCount: number): HTMLElement {
     const closeTourButton = document.createElement('button')
-    closeTourButton.className = 'btn btn-link p-0'
+    closeTourButton.className = 'btn btn-link p-0 test-tour-close-button'
     closeTourButton.textContent = 'Close tour'
     closeTourButton.addEventListener('click', () => {
         tour.cancel()

--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -74,7 +74,6 @@ export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number, total
     closeTourButton.textContent = 'Close tour'
     closeTourButton.addEventListener('click', () => {
         tour.cancel()
-        localStorage.setItem(HAS_CANCELLED_TOUR_KEY, 'true')
         eventLogger.log('CloseOnboardingTourClicked', { stage: stepNumber })
     })
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/16142. 

When the user completes the tour by clicking the search reference, or clicks close to cancel the tour, we will now remove the `onboardingTour` query param. Furthermore, on the search results page, we check to ensure that the localStorage values checking whether the user has cancelled or completed the tour are not `true` before rendering the step. This means if the user were to refresh the page, and they've already dismissed the tour, they won't see it again.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
