### PR TITLE
Remove container_*_usage_7d_low alerts

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -805,14 +805,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">cloud: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _frontend: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _frontend: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the frontend service.
-	- **Docker Compose:** Consider increasing `cpus:` of the frontend container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the frontend service.
+- **Docker Compose:** Consider increasing `cpus:` of the frontend container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -826,14 +824,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">cloud: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _frontend: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _frontend: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the frontend service.
-	- **Docker Compose:** Consider increasing `memory:` of the frontend container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the frontend service.
+- **Docker Compose:** Consider increasing `memory:` of the frontend container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1161,14 +1157,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">cloud: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _gitserver: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _gitserver: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the gitserver service.
-	- **Docker Compose:** Consider increasing `cpus:` of the gitserver container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the gitserver service.
+- **Docker Compose:** Consider increasing `cpus:` of the gitserver container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1389,14 +1383,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">cloud: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _github-proxy: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _github-proxy: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the github-proxy service.
-	- **Docker Compose:** Consider increasing `cpus:` of the github-proxy container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the github-proxy service.
+- **Docker Compose:** Consider increasing `cpus:` of the github-proxy container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1410,14 +1402,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">cloud: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _github-proxy: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _github-proxy: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the github-proxy service.
-	- **Docker Compose:** Consider increasing `memory:` of the github-proxy container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the github-proxy service.
+- **Docker Compose:** Consider increasing `memory:` of the github-proxy container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1811,14 +1801,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">code-intel: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _precise-code-intel-worker: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _precise-code-intel-worker: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the precise-code-intel-worker service.
-	- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the precise-code-intel-worker service.
+- **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1832,14 +1820,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">code-intel: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _precise-code-intel-worker: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _precise-code-intel-worker: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the precise-code-intel-worker service.
-	- **Docker Compose:** Consider increasing `memory:` of the precise-code-intel-worker container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the precise-code-intel-worker service.
+- **Docker Compose:** Consider increasing `memory:` of the precise-code-intel-worker container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2046,14 +2032,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">search: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _query-runner: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _query-runner: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the query-runner service.
-	- **Docker Compose:** Consider increasing `cpus:` of the query-runner container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the query-runner service.
+- **Docker Compose:** Consider increasing `cpus:` of the query-runner container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2067,14 +2051,12 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <p class="subtitle">search: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _query-runner: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _query-runner: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the query-runner service.
-	- **Docker Compose:** Consider increasing `memory:` of the query-runner container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the query-runner service.
+- **Docker Compose:** Consider increasing `memory:` of the query-runner container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2723,14 +2705,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">cloud: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _repo-updater: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _repo-updater: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the repo-updater service.
-	- **Docker Compose:** Consider increasing `cpus:` of the repo-updater container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the repo-updater service.
+- **Docker Compose:** Consider increasing `cpus:` of the repo-updater container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2744,14 +2724,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">cloud: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _repo-updater: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _repo-updater: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the repo-updater service.
-	- **Docker Compose:** Consider increasing `memory:` of the repo-updater container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the repo-updater service.
+- **Docker Compose:** Consider increasing `memory:` of the repo-updater container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2992,14 +2970,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">search: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _searcher: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _searcher: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the searcher service.
-	- **Docker Compose:** Consider increasing `cpus:` of the searcher container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the searcher service.
+- **Docker Compose:** Consider increasing `cpus:` of the searcher container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3013,14 +2989,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">search: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _searcher: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _searcher: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the searcher service.
-	- **Docker Compose:** Consider increasing `memory:` of the searcher container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the searcher service.
+- **Docker Compose:** Consider increasing `memory:` of the searcher container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3261,14 +3235,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">code-intel: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _symbols: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _symbols: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the symbols service.
-	- **Docker Compose:** Consider increasing `cpus:` of the symbols container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the symbols service.
+- **Docker Compose:** Consider increasing `cpus:` of the symbols container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3282,14 +3254,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">code-intel: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _symbols: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _symbols: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the symbols service.
-	- **Docker Compose:** Consider increasing `memory:` of the symbols container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the symbols service.
+- **Docker Compose:** Consider increasing `memory:` of the symbols container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3540,14 +3510,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">cloud: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _syntect-server: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _syntect-server: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the syntect-server service.
-	- **Docker Compose:** Consider increasing `cpus:` of the syntect-server container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the syntect-server service.
+- **Docker Compose:** Consider increasing `cpus:` of the syntect-server container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3561,14 +3529,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">cloud: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _syntect-server: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _syntect-server: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the syntect-server service.
-	- **Docker Compose:** Consider increasing `memory:` of the syntect-server container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the syntect-server service.
+- **Docker Compose:** Consider increasing `memory:` of the syntect-server container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3753,14 +3719,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">search: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _zoekt-indexserver: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _zoekt-indexserver: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the zoekt-indexserver service.
-	- **Docker Compose:** Consider increasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the zoekt-indexserver service.
+- **Docker Compose:** Consider increasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3774,14 +3738,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">search: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _zoekt-indexserver: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _zoekt-indexserver: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the zoekt-indexserver service.
-	- **Docker Compose:** Consider increasing `memory:` of the zoekt-indexserver container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the zoekt-indexserver service.
+- **Docker Compose:** Consider increasing `memory:` of the zoekt-indexserver container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3964,14 +3926,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">search: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _zoekt-webserver: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _zoekt-webserver: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the zoekt-webserver service.
-	- **Docker Compose:** Consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the zoekt-webserver service.
+- **Docker Compose:** Consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3985,14 +3945,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">search: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _zoekt-webserver: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _zoekt-webserver: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the zoekt-webserver service.
-	- **Docker Compose:** Consider increasing `memory:` of the zoekt-webserver container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the zoekt-webserver service.
+- **Docker Compose:** Consider increasing `memory:` of the zoekt-webserver container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -4159,14 +4117,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">distribution: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _prometheus: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _prometheus: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the prometheus service.
-	- **Docker Compose:** Consider increasing `cpus:` of the prometheus container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the prometheus service.
+- **Docker Compose:** Consider increasing `cpus:` of the prometheus container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -4180,14 +4136,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">distribution: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _prometheus: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _prometheus: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the prometheus service.
-	- **Docker Compose:** Consider increasing `memory:` of the prometheus container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the prometheus service.
+- **Docker Compose:** Consider increasing `memory:` of the prometheus container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -4411,14 +4365,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">code-intel: container cpu usage total (90th percentile over 1d) across all cores by instance</p>**Descriptions:**
 
-- _executor-queue: 80%+ or less than 10% container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
+- _executor-queue: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the executor-queue service.
-	- **Docker Compose:** Consider increasing `cpus:` of the executor-queue container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the executor-queue service.
+- **Docker Compose:** Consider increasing `cpus:` of the executor-queue container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -4432,14 +4384,12 @@ with your code hosts connections or networking issues affecting communication wi
 
 <p class="subtitle">code-intel: container memory usage (1d maximum) by instance</p>**Descriptions:**
 
-- _executor-queue: 80%+ or less than 10% container memory usage (1d maximum) by instance for 336h0m0s_
+- _executor-queue: 80%+ container memory usage (1d maximum) by instance for 336h0m0s_
 
 **Possible solutions:**
 
-- If usage is high:
-	- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the executor-queue service.
-	- **Docker Compose:** Consider increasing `memory:` of the executor-queue container in `docker-compose.yml`.
-- If usage is low, consider decreasing the above values.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the executor-queue service.
+- **Docker Compose:** Consider increasing `memory:` of the executor-queue container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/monitoring/shared.go
+++ b/monitoring/shared.go
@@ -173,14 +173,12 @@ var sharedProvisioningCPUUsageLongTerm sharedObservable = func(containerName str
 		Description:     "container cpu usage total (90th percentile over 1d) across all cores by instance",
 		Query:           fmt.Sprintf(`quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
-		Warning:         Alert().LessOrEqual(10).GreaterOrEqual(80).For(14 * 24 * time.Hour),
+		Warning:         Alert().GreaterOrEqual(80).For(14 * 24 * time.Hour),
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Max(100).Min(0),
 		Owner:           owner,
 		PossibleSolutions: strings.Replace(`
-			- If usage is high:
-				- **Kubernetes:** Consider increasing CPU limits in the 'Deployment.yaml' for the {{CONTAINER_NAME}} service.
-				- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-			- If usage is low, consider decreasing the above values.
+			- **Kubernetes:** Consider increasing CPU limits in the 'Deployment.yaml' for the {{CONTAINER_NAME}} service.
+			- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
 		`, "{{CONTAINER_NAME}}", containerName, -1),
 	}
 }
@@ -191,14 +189,12 @@ var sharedProvisioningMemoryUsageLongTerm sharedObservable = func(containerName 
 		Description:     "container memory usage (1d maximum) by instance",
 		Query:           fmt.Sprintf(`max_over_time(cadvisor_container_memory_usage_percentage_total{%s}[1d])`, promCadvisorContainerMatchers(containerName)),
 		DataMayNotExist: true,
-		Warning:         Alert().LessOrEqual(10).GreaterOrEqual(80).For(14 * 24 * time.Hour),
+		Warning:         Alert().GreaterOrEqual(80).For(14 * 24 * time.Hour),
 		PanelOptions:    PanelOptions().LegendFormat("{{name}}").Unit(Percentage).Max(100).Min(0),
 		Owner:           owner,
 		PossibleSolutions: strings.Replace(`
-			- If usage is high:
-				- **Kubernetes:** Consider increasing memory limits in the 'Deployment.yaml' for the {{CONTAINER_NAME}} service.
-				- **Docker Compose:** Consider increasing 'memory:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-			- If usage is low, consider decreasing the above values.
+			- **Kubernetes:** Consider increasing memory limits in the 'Deployment.yaml' for the {{CONTAINER_NAME}} service.
+			- **Docker Compose:** Consider increasing 'memory:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
 		`, "{{CONTAINER_NAME}}", containerName, -1),
 	}
 }


### PR DESCRIPTION
The alerts generate a lot of red messages in our Grafana dashboards and many cases are not to be action immediately or represent an unhealthy state of the deployment, creating a "ignore red" situation.

![image](https://user-images.githubusercontent.com/9908105/100217863-3f225c80-2f14-11eb-89ec-dc4fa89b352d.png)

The alerts are not incorrect, and in many cases of the linked issues, we can reduce the provisioning on those containers, but the constantly red message until that is action is likely undesirable for this case.

We can still leverage the dashboards to do resource optimization and analyze provisioning or add these to the Cloud deployment if we want them for our Cloud, but I dont think they are as useful to customers given most follow our recommended values for provisioning.

Related: #12453, #12447

/cc @slimsag @bobheadxi as we discussed this before.