### PR TITLE
Change cAdvisor rules to use resources.reservation instead of limit

### DIFF
--- a/docker-images/prometheus/config/cadvisor_rules.yml
+++ b/docker-images/prometheus/config/cadvisor_rules.yml
@@ -5,7 +5,7 @@ groups:
     rules:
       # The number of CPUs allocated to the container according to the configured Docker / Kubernetes limits.
       - record: cadvisor_container_cpu_limit
-        expr: avg by (name)(container_spec_cpu_quota) / avg by (name)(container_spec_cpu_period)
+        expr: avg by (name)(container_spec_cpu_shares) / avg by (name)(container_spec_cpu_period)
 
       # Percentage of CPU cores the container consumed on average over a 1m period.
       # For example, if a container has a 4 CPU limit and this metric reports 50%,
@@ -15,4 +15,4 @@ groups:
 
       # Percentage of memory usage the container is consuming.
       - record: cadvisor_container_memory_usage_percentage_total
-        expr: max by (name)(container_memory_working_set_bytes / container_spec_memory_limit_bytes) * 100.0
+        expr: max by (name)(container_memory_working_set_bytes / container_spec_memory_reservation_limit_bytes) * 100.0


### PR DESCRIPTION
We currently use `resources.limits` to measure CPU and Memory to measure resource saturation, which is a good indicator for hitting the absolute limit (burst), but not of the actually reserved and expected utilization.

This changes the recording rules to use `resources.reservations` instead.

### TODO

- [ ] Test this works with docker-compose