### PR TITLE
Remove useless search e2e tests

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -1119,138 +1119,6 @@ describe('e2e test suite', () => {
     })
 
     describe('Search component', () => {
-        test('can execute search with search operators', async () => {
-            await driver.page.goto(sourcegraphBaseUrl + '/github.com/sourcegraph/go-diff')
-
-            const operators: { [key: string]: string } = {
-                repo: '^github.com/sourcegraph/go-diff$',
-                count: '1000',
-                type: 'file',
-                file: '.go',
-                '-file': '.md',
-            }
-
-            const operatorsQuery = Object.keys(operators)
-                .map(operator => `${operator}:${operators[operator]}`)
-                .join('+')
-
-            await driver.page.goto(`${sourcegraphBaseUrl}/search?q=diff+${operatorsQuery}&patternType=regexp`)
-            await driver.page.waitForSelector('.test-search-results-stats', { visible: true })
-            await retry(async () => {
-                const label = await driver.page.evaluate(
-                    () => document.querySelector('.test-search-results-stats')!.textContent || ''
-                )
-                expect(label.includes('results')).toEqual(true)
-            })
-            await driver.page.waitForSelector('.test-file-match-children-item', { visible: true })
-        })
-
-        test('renders results for sourcegraph/go-diff (no search group)', async () => {
-            await driver.page.goto(sourcegraphBaseUrl + '/github.com/sourcegraph/go-diff')
-            await driver.page.goto(
-                sourcegraphBaseUrl +
-                    '/search?q=diff+repo:sourcegraph/go-diff%403f415a150aec0685cb81b73cc201e762e075006d+type:file&patternType=regexp'
-            )
-            await driver.page.waitForSelector('.test-search-results-stats', { visible: true })
-            await retry(async () => {
-                const label = await driver.page.evaluate(
-                    () => document.querySelector('.test-search-results-stats')!.textContent || ''
-                )
-                expect(label.includes('results')).toEqual(true)
-            })
-
-            const firstFileMatchHref = await driver.page.$eval(
-                '.test-file-match-children-item',
-                a => (a as HTMLAnchorElement).href
-            )
-
-            // navigate to result on click
-            await driver.page.click('.test-file-match-children-item')
-
-            await retry(async () => {
-                expect(await driver.page.evaluate(() => window.location.href)).toEqual(firstFileMatchHref)
-            })
-        })
-
-        describe('multiple revisions per repository', () => {
-            let previousExperimentalFeatures: any
-            before(async () => {
-                await driver.setConfig(['experimentalFeatures'], previous => {
-                    previousExperimentalFeatures = previous?.value
-                    return { searchMultipleRevisionsPerRepository: true }
-                })
-                // Wait for configuration to be applied.
-                await new Promise(resolve => setTimeout(resolve, 6000))
-            })
-            after(async () => {
-                await driver.setConfig(['experimentalFeatures'], () => previousExperimentalFeatures)
-            })
-
-            test('searches', async () => {
-                await driver.page.goto(
-                    sourcegraphBaseUrl +
-                        '/search?q=repo:sourcegraph/go-diff%24%40master:print-options:*refs/heads/+func+NewHunksReader&patternType=regexp'
-                )
-                await driver.page.waitForSelector('.test-search-results-stats', { visible: true })
-                await retry(async () => {
-                    const label = await driver.page.evaluate(
-                        () => document.querySelector('.test-search-results-stats')!.textContent || ''
-                    )
-                    expect(label.includes('results')).toEqual(true)
-                })
-
-                const fileMatchHrefs = (
-                    await driver.page.$$eval('.test-file-match-children-item', as =>
-                        as.map(a => (a as HTMLAnchorElement).pathname)
-                    )
-                ).sort()
-
-                // Only check for specific branches, so that the test doesn't break when new
-                // branches are added (it's an active repository).
-                const checkBranches = [
-                    'master',
-                    'print-options',
-
-                    // These next 2 branches are included because of the *refs/heads/ in the query.
-                    // If they are ever deleted from the actual live repository, replace them with
-                    // any other branches that still exist.
-                    'test-already-exist-pr',
-                    'bug-fix-wip',
-                ].sort()
-                expect(
-                    fileMatchHrefs.filter(href => checkBranches.some(branch => href.includes(`@${branch}/`)))
-                ).toEqual(checkBranches.map(branch => `/github.com/sourcegraph/go-diff@${branch}/-/blob/diff/parse.go`))
-            })
-        })
-
-        test('accepts query for sourcegraph/jsonrpc2', async () => {
-            await driver.page.goto(sourcegraphBaseUrl + '/search')
-
-            // Update the input value
-            await driver.page.waitForSelector('#monaco-query-input', { visible: true })
-            await driver.page.keyboard.type('test repo:sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d')
-
-            // TODO: test search scopes
-
-            // Submit the search
-            await driver.page.click('.search-button')
-
-            await driver.page.waitForSelector('.test-search-results-stats', { visible: true })
-            await retry(async () => {
-                const label = await driver.page.evaluate(
-                    () => document.querySelector('.test-search-results-stats')!.textContent || ''
-                )
-                const match = /(\d+) results?/.exec(label)
-                if (!match) {
-                    throw new Error(
-                        `.test-search-results-stats textContent did not match regex '(\\d+) results': '${label}'`
-                    )
-                }
-                const numberOfResults = parseInt(match[1], 10)
-                expect(numberOfResults).toBeGreaterThan(0)
-            })
-        })
-
         test('redirects to a URL with &patternType=regexp if no patternType in URL', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/search?q=test')
             await driver.assertWindowLocation('/search?q=test&patternType=regexp')
@@ -1268,32 +1136,6 @@ describe('e2e test suite', () => {
             await driver.page.waitForSelector('.test-regexp-toggle')
             await driver.page.click('.test-regexp-toggle')
             await driver.page.goto(sourcegraphBaseUrl + '/search?q=test&patternType=literal')
-        })
-    })
-
-    describe.skip('Search pattern type setting', () => {
-        test('Search pattern type setting correctly sets default pattern type', async () => {
-            await driver.page.goto(sourcegraphBaseUrl + '/users/test/settings')
-            await driver.replaceText({
-                selector: '.test-settings-file .monaco-editor',
-                newText: JSON.stringify({
-                    'search.defaultPatternType': 'regexp',
-                }),
-                selectMethod: 'keyboard',
-            })
-            await driver.page.click('.test-settings-file .test-save-toolbar-save')
-
-            await driver.page.goto(sourcegraphBaseUrl + '/search')
-            await driver.page.waitForSelector('#monaco-query-input', { visible: true })
-            await driver.page.waitForSelector('.test-regexp-toggle', { visible: true })
-
-            const activeToggle = await driver.page.evaluate(
-                () => document.querySelectorAll('.test-regexp-toggle--active').length
-            )
-            expect(activeToggle).toEqual(1)
-            await driver.page.keyboard.type('test')
-            await driver.page.click('.search-button')
-            await driver.assertWindowLocation('/search?q=test&patternType=regexp')
         })
     })
 
@@ -1320,16 +1162,6 @@ describe('e2e test suite', () => {
                 () => document.querySelector('.test-search-result-tab--active')!.textContent || ''
             )
             expect(label).toEqual('Code')
-        })
-
-        test.skip('Clicking search results tabs updates query and URL', async () => {
-            for (const searchType of ['diff', 'commit', 'symbol', 'repo']) {
-                await driver.page.waitForSelector(`.test-search-result-tab-${searchType}`)
-                await driver.page.click(`.test-search-result-tab-${searchType}`)
-                await driver.assertWindowLocation(
-                    `/search?q=repo:%5Egithub.com/gorilla/mux%24+type:${searchType}&patternType=regexp`
-                )
-            }
         })
     })
 


### PR DESCRIPTION
Fixes #16136

I'm not sure why `accepts query for sourcegraph/jsonrpc2` fails, but I feel extremely confident that it is not a bug in Sourcegraph but rather a bug in the test itself -- the behaviour it tests is already well-covered by our frontend and backend integration tests.

This PR also removes other tests that are well covered by the backend integration tests, as well as tests that have been skipped forever.

I want to do a follow-up where I port all search tests to an appropriate integration test suite, replace them with the single, simple success case from our regression test suite, and remove the search regression test suite altogether.
