### PR TITLE
search: run queries for code monitors

### DIFF
--- a/enterprise/internal/codemonitors/background/background.go
+++ b/enterprise/internal/codemonitors/background/background.go
@@ -15,6 +15,7 @@ func StartBackgroundJobs(ctx context.Context, db *sql.DB) {
 
 	routines := []goroutine.BackgroundRoutine{
 		newTriggerQueryEnqueuer(ctx, codeMonitorsStore),
+		newTriggerJobsLogDeleter(ctx, codeMonitorsStore),
 		newTriggerQueryRunner(ctx, codeMonitorsStore, metrics),
 		newTriggerQueryResetter(ctx, codeMonitorsStore, metrics),
 	}

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -1,0 +1,199 @@
+package background
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"runtime"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/pkg/errors"
+)
+
+type graphQLQuery struct {
+	Query     string      `json:"query"`
+	Variables interface{} `json:"variables"`
+}
+
+const gqlSearchQuery = `query Search(
+	$query: String!,
+) {
+	search(query: $query) {
+		results {
+			approximateResultCount
+			limitHit
+			cloning { name }
+			timedout { name }
+			results {
+				__typename
+				... on FileMatch {
+					resource
+					limitHit
+					lineMatches {
+						preview
+						lineNumber
+						offsetAndLengths
+					}
+				}
+				... on CommitSearchResult {
+					refs {
+						name
+						displayName
+						prefix
+						repository {
+							name
+						}
+					}
+					sourceRefs {
+						name
+						displayName
+						prefix
+						repository {
+							name
+						}
+					}
+					messagePreview {
+						value
+						highlights {
+							line
+							character
+							length
+						}
+					}
+					diffPreview {
+						value
+						highlights {
+							line
+							character
+							length
+						}
+					}
+					commit {
+						repository {
+							name
+						}
+						oid
+						abbreviatedOID
+						author {
+							person {
+								displayName
+								avatarURL
+							}
+							date
+						}
+						message
+					}
+				}
+			}
+			alert {
+				title
+				description
+				proposedQueries {
+					description
+					query
+				}
+			}
+		}
+	}
+}`
+
+type gqlSearchVars struct {
+	Query string `json:"query"`
+}
+
+type gqlSearchResponse struct {
+	Data struct {
+		Search struct {
+			Results struct {
+				ApproximateResultCount string
+				Cloning                []*api.Repo
+				Timedout               []*api.Repo
+				Results                []interface{}
+			}
+		}
+	}
+	Errors []interface{}
+}
+
+func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(graphQLQuery{
+		Query:     gqlSearchQuery,
+		Variables: gqlSearchVars{Query: query},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Encode")
+	}
+
+	url, err := gqlURL("Search")
+	if err != nil {
+		return nil, errors.Wrap(err, "constructing frontend URL")
+	}
+
+	resp, err := ctxhttp.Post(ctx, nil, url, "application/json", &buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "Post")
+	}
+	defer resp.Body.Close()
+
+	var res *gqlSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, errors.Wrap(err, "Decode")
+	}
+	if len(res.Errors) > 0 {
+		return res, fmt.Errorf("graphql: errors: %v", res.Errors)
+	}
+	return res, nil
+}
+
+func gqlURL(queryName string) (string, error) {
+	u, err := url.Parse(api.InternalClient.URL)
+	if err != nil {
+		return "", err
+	}
+	u.Path = "/.internal/graphql"
+	u.RawQuery = queryName
+	return u.String(), nil
+}
+
+// extractTime extracts the time from the given search result.
+func extractTime(result interface{}) (t *time.Time, err error) {
+	// Use recover because we assume the data structure here a lot, for less
+	// error checking.
+	defer func() {
+		if r := recover(); r != nil {
+			// Same as net/http
+			const size = 64 << 10
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			log.Printf("failed to extract time from search result: %v\n%s", r, buf)
+		}
+		err = fmt.Errorf("failed to extract time from search result")
+	}()
+
+	m := result.(map[string]interface{})
+	typeName := m["__typename"].(string)
+	switch typeName {
+	case "CommitSearchResult":
+		commit := m["commit"].(map[string]interface{})
+		author := commit["author"].(map[string]interface{})
+		date := author["date"].(string)
+
+		// For now, our graphql API commit authorship date is in Go default time format.
+		goTimeFormat := "2006-01-02 15:04:05.999999999 -0700 MST"
+		t, err := time.Parse(date, goTimeFormat)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	default:
+		return nil, fmt.Errorf("unexpected result __typename %q", typeName)
+	}
+}

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -174,8 +174,8 @@ func extractTime(result interface{}) (t *time.Time, err error) {
 			buf := make([]byte, size)
 			buf = buf[:runtime.Stack(buf, false)]
 			log.Printf("failed to extract time from search result: %v\n%s", r, buf)
+			err = fmt.Errorf("failed to extract time from search result")
 		}
-		err = fmt.Errorf("failed to extract time from search result")
 	}()
 
 	m := result.(map[string]interface{})
@@ -186,9 +186,9 @@ func extractTime(result interface{}) (t *time.Time, err error) {
 		author := commit["author"].(map[string]interface{})
 		date := author["date"].(string)
 
-		// For now, our graphql API commit authorship date is in Go default time format.
-		goTimeFormat := "2006-01-02 15:04:05.999999999 -0700 MST"
-		t, err := time.Parse(date, goTimeFormat)
+		// This relies on the date format that our API returns. It was previously broken
+		// and should be checked first in case date extraction stops working.
+		t, err := time.Parse(time.RFC3339, date)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -2,6 +2,8 @@ package background
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -46,6 +48,15 @@ func newTriggerQueryResetter(ctx context.Context, s *cm.Store, metrics codeMonit
 	return dbworker.NewResetter(workerStore, options)
 }
 
+func newTriggerJobsLogDeleter(ctx context.Context, store *cm.Store) goroutine.BackgroundRoutine {
+	deleteObsoleteLogs := goroutine.NewHandlerWithErrorMessage(
+		"code_monitors_trigger_jobs_log_deleter",
+		func(ctx context.Context) error {
+			return store.DeleteObsoleteJobLogs(ctx)
+		})
+	return goroutine.NewPeriodicGoroutine(ctx, 60*time.Minute, deleteObsoleteLogs)
+}
+
 func createDBWorkerStore(s *cm.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
 		TableName:         "cm_trigger_jobs",
@@ -62,19 +73,70 @@ type queryRunner struct {
 	*cm.Store
 }
 
-func (r *queryRunner) Handle(ctx context.Context, workerStore dbworkerstore.Store, record workerutil.Record) error {
+func (r *queryRunner) Handle(ctx context.Context, workerStore dbworkerstore.Store, record workerutil.Record) (err error) {
 	s := r.Store.With(workerStore)
-	q, err := s.GetQueryByRecordID(ctx, record.RecordID())
+
+	var q *cm.MonitorQuery
+	q, err = s.GetQueryByRecordID(ctx, record.RecordID())
 	if err != nil {
 		return err
 	}
+	newQuery := newQueryWithAfterFilter(q)
 
-	// TODO (stefan): run the query
-
-	// Update next_run.
-	err = s.SetTriggerQueryNextRun(ctx, q.Id, s.Clock()().Add(5*time.Minute))
+	// Search.
+	var results *gqlSearchResponse
+	results, err = search(ctx, newQuery)
+	if err != nil {
+		return err
+	}
+	var numResults int
+	if results != nil {
+		numResults = len(results.Data.Search.Results.Results)
+	}
+	// Log next_run and latest_result to table cm_queries.
+	newLatestResult := latestResultTime(q.LatestResult, results, err)
+	err = s.SetTriggerQueryNextRun(ctx, q.Id, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
+	if err != nil {
+		return err
+	}
+	// Log the actual query we ran and whether we got any new results.
+	err = s.LogSearch(ctx, newQuery, numResults > 0, record.RecordID())
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func newQueryWithAfterFilter(q *cm.MonitorQuery) string {
+	// Construct a new query which finds search results introduced after the last
+	// time we queried.
+	var latestResult time.Time
+	if q.LatestResult != nil {
+		latestResult = *q.LatestResult
+	} else {
+		// We've never executed this search query before, so use the current
+		// time. We'll most certainly find nothing, which is okay.
+		latestResult = time.Now()
+	}
+	afterTime := latestResult.UTC().Format(time.RFC3339)
+	return strings.Join([]string{q.QueryString, fmt.Sprintf(`after:"%s"`, afterTime)}, " ")
+}
+
+func latestResultTime(previousLastResult *time.Time, v *gqlSearchResponse, searchErr error) time.Time {
+	if searchErr != nil || len(v.Data.Search.Results.Results) == 0 {
+		// Error performing the search, or there were no results. Assume the
+		// previous info's result time.
+		if previousLastResult != nil {
+			return *previousLastResult
+		}
+		return time.Now()
+	}
+
+	// Results are ordered chronologically, so first result is the latest.
+	t, err := extractTime(v.Data.Search.Results.Results[0])
+	if err != nil {
+		// Error already logged by extractTime.
+		return time.Now()
+	}
+	return *t
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	cm "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -719,7 +719,7 @@ RETURNING %s;
 
 func (r *Resolver) triggerQueryByMonitorQuery(ctx context.Context, monitorID int64) (*sqlf.Query, error) {
 	const triggerQueryByMonitorQuery = `
-SELECT id, monitor, query, next_run, created_by, created_at, changed_by, changed_at
+SELECT id, monitor, query, next_run, latest_result, created_by, created_at, changed_by, changed_at
 FROM cm_queries
 WHERE monitor = %s;
 `

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -358,6 +358,8 @@ Foreign-key constraints:
  num_resets      | integer                  | not null default 0
  num_failures    | integer                  | not null default 0
  log_contents    | text                     | 
+ query_string    | text                     | 
+ results         | boolean                  | 
 Indexes:
     "cm_trigger_jobs_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:

--- a/migrations/frontend/1528395755_cm_trigger_jobs_add_colums.down.sql
+++ b/migrations/frontend/1528395755_cm_trigger_jobs_add_colums.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE cm_trigger_jobs
+    DROP COLUMN IF EXISTS query_string,
+    DROP COLUMN IF EXISTS results;
+COMMIT;

--- a/migrations/frontend/1528395755_cm_trigger_jobs_add_colums.up.sql
+++ b/migrations/frontend/1528395755_cm_trigger_jobs_add_colums.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE cm_trigger_jobs
+    ADD COLUMN IF NOT EXISTS query_string text,
+    ADD COLUMN IF NOT EXISTS results boolean;
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -142,6 +142,8 @@
 // 1528395753_add_enqueue_table_for_trigger_queries.up.sql (559B)
 // 1528395754_add_cols_next_run_latest_result_to_cm_queries.down.sql (115B)
 // 1528395754_add_cols_next_run_latest_result_to_cm_queries.up.sql (159B)
+// 1528395755_cm_trigger_jobs_add_colums.down.sql (118B)
+// 1528395755_cm_trigger_jobs_add_colums.up.sql (137B)
 
 package migrations
 
@@ -3050,6 +3052,46 @@ func _1528395754_add_cols_next_run_latest_result_to_cm_queriesUpSql() (*asset, e
 	return a, nil
 }
 
+var __1528395755_cm_trigger_jobs_add_columsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x8d\x2f\x29\xca\x4c\x4f\x4f\x2d\x8a\xcf\xca\x4f\x2a\xe6\x52\x50\x50\x50\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x2c\x4d\x2d\xaa\x8c\x2f\x2e\x29\xca\xcc\x4b\xd7\xc1\xa3\xae\x28\xb5\xb8\x34\xa7\xa4\xd8\x9a\xcb\xd9\xdf\xd7\xd7\x33\xc4\x9a\x0b\x10\x00\x00\xff\xff\xdc\xd1\xaf\x8b\x76\x00\x00\x00")
+
+func _1528395755_cm_trigger_jobs_add_columsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395755_cm_trigger_jobs_add_columsDownSql,
+		"1528395755_cm_trigger_jobs_add_colums.down.sql",
+	)
+}
+
+func _1528395755_cm_trigger_jobs_add_columsDownSql() (*asset, error) {
+	bytes, err := _1528395755_cm_trigger_jobs_add_columsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395755_cm_trigger_jobs_add_colums.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7c, 0x5c, 0xb0, 0x95, 0xca, 0x34, 0xb9, 0x5b, 0xde, 0xc4, 0xa3, 0xbc, 0xf6, 0xea, 0xea, 0xd7, 0x54, 0x17, 0x33, 0xdf, 0x1e, 0xdb, 0xac, 0xea, 0x20, 0x97, 0xe5, 0xbe, 0xc, 0x46, 0xfa, 0x6a}}
+	return a, nil
+}
+
+var __1528395755_cm_trigger_jobs_add_columsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x7c\xca\x4d\xaa\xc2\x30\x10\x07\xf0\x7d\x4e\xf1\x3f\xc0\xbb\x41\x56\x69\x9b\x27\x81\x7c\x80\x8d\xe0\x2e\x58\x19\x42\xa5\x36\x38\x99\x82\xde\xde\x1b\xb8\xff\x0d\xf6\xe4\xa2\x56\xc6\x67\x7b\x46\x36\x83\xb7\xb8\x3f\x8b\xf0\x5a\x2b\x71\x79\xb4\xa5\x2b\x00\x30\xd3\x84\x31\xf9\x4b\x88\x70\xff\x88\x29\xc3\x5e\xdd\x9c\x67\xbc\x0e\xe2\x4f\xe9\xc2\xeb\x5e\x21\xf4\x96\xbf\xdf\x9e\xa9\x1f\x9b\x74\x2c\xad\x6d\x74\xdb\xb5\x1a\x53\x08\x2e\x6b\xf5\x0d\x00\x00\xff\xff\x21\x09\x59\x3e\x89\x00\x00\x00")
+
+func _1528395755_cm_trigger_jobs_add_columsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395755_cm_trigger_jobs_add_columsUpSql,
+		"1528395755_cm_trigger_jobs_add_colums.up.sql",
+	)
+}
+
+func _1528395755_cm_trigger_jobs_add_columsUpSql() (*asset, error) {
+	bytes, err := _1528395755_cm_trigger_jobs_add_columsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395755_cm_trigger_jobs_add_colums.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x54, 0xa4, 0x29, 0x2b, 0xf3, 0x5e, 0x82, 0x2b, 0x44, 0xb6, 0x1a, 0xbc, 0x80, 0x1e, 0x6, 0x26, 0xd1, 0x5d, 0x99, 0xdd, 0xac, 0xf2, 0x8c, 0xd3, 0xb7, 0x76, 0xe5, 0xce, 0xff, 0xfe, 0x38, 0x22}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -3283,6 +3325,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395753_add_enqueue_table_for_trigger_queries.up.sql":                                _1528395753_add_enqueue_table_for_trigger_queriesUpSql,
 	"1528395754_add_cols_next_run_latest_result_to_cm_queries.down.sql":                      _1528395754_add_cols_next_run_latest_result_to_cm_queriesDownSql,
 	"1528395754_add_cols_next_run_latest_result_to_cm_queries.up.sql":                        _1528395754_add_cols_next_run_latest_result_to_cm_queriesUpSql,
+	"1528395755_cm_trigger_jobs_add_colums.down.sql":                                         _1528395755_cm_trigger_jobs_add_columsDownSql,
+	"1528395755_cm_trigger_jobs_add_colums.up.sql":                                           _1528395755_cm_trigger_jobs_add_columsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -3471,6 +3515,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395753_add_enqueue_table_for_trigger_queries.up.sql":                                {_1528395753_add_enqueue_table_for_trigger_queriesUpSql, map[string]*bintree{}},
 	"1528395754_add_cols_next_run_latest_result_to_cm_queries.down.sql":                      {_1528395754_add_cols_next_run_latest_result_to_cm_queriesDownSql, map[string]*bintree{}},
 	"1528395754_add_cols_next_run_latest_result_to_cm_queries.up.sql":                        {_1528395754_add_cols_next_run_latest_result_to_cm_queriesUpSql, map[string]*bintree{}},
+	"1528395755_cm_trigger_jobs_add_colums.down.sql":                                         {_1528395755_cm_trigger_jobs_add_columsDownSql, map[string]*bintree{}},
+	"1528395755_cm_trigger_jobs_add_colums.up.sql":                                           {_1528395755_cm_trigger_jobs_add_columsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
Stacked on top of #16114 

With this PR we start executing the queries (IE triggers).  I copied `graphql.go`, which contains a GraphQL client for search,  without any changes from searchers's `query-runner`. Since we plan to sunset saved-searches in the long run, I decided for copy&paste instead of import.

Additionally, I added a periodic background job to delete old job logs. We only care about logs if they relate to new search results. Logs of searches that led to no results are useless.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
