### PR TITLE
repo-updater: Fix syncRepo logic

### DIFF
--- a/cmd/repo-updater/repos/integration_test.go
+++ b/cmd/repo-updater/repos/integration_test.go
@@ -82,6 +82,7 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/Syncer/NameConflictDiscardNew", testNameOnConflictDiscardNew(db)},
 		{"DBStore/Syncer/NameConflictOnRename", testNameOnConflictOnRename(db)},
 		{"DBStore/Syncer/ConflictingSyncers", testConflictingSyncers(db)},
+		{"DBStore/Syncer/SyncRepoMaintainsOtherSources", testSyncRepoMaintainsOtherSources(db)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Cleanup(func() {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -498,7 +498,7 @@ func (s *Syncer) syncRepo(ctx context.Context, store Store, insertOnly bool, pub
 		return Diff{}, nil
 	}
 
-	// sourcedRepo only knows about one source so we need to add in the OTHER stored
+	// sourcedRepo only knows about one source so we need to add in the remaining stored
 	// sources
 	if len(storedSubset) == 1 {
 		for k, v := range storedSubset[0].Sources {

--- a/cmd/repo-updater/repos/syncer.go
+++ b/cmd/repo-updater/repos/syncer.go
@@ -478,6 +478,7 @@ func (s *Syncer) insertIfNew(ctx context.Context, store Store, publicOnly bool, 
 	return err
 }
 
+// syncRepo syncs a single repo that has been sourced from a single external service.
 func (s *Syncer) syncRepo(ctx context.Context, store Store, insertOnly bool, publicOnly bool, sourcedRepo *Repo) (diff Diff, err error) {
 	if publicOnly && sourcedRepo.Private {
 		return Diff{}, nil
@@ -495,6 +496,18 @@ func (s *Syncer) syncRepo(ctx context.Context, store Store, insertOnly bool, pub
 
 	if insertOnly && len(storedSubset) > 0 {
 		return Diff{}, nil
+	}
+
+	// sourcedRepo only knows about one source so we need to add in the OTHER stored
+	// sources
+	if len(storedSubset) == 1 {
+		for k, v := range storedSubset[0].Sources {
+			// Don't update the source from sourcedRepo
+			if _, ok := sourcedRepo.Sources[k]; ok {
+				continue
+			}
+			sourcedRepo.Sources[k] = v
+		}
 	}
 
 	// NewDiff modifies the stored slice so we clone it before passing it

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -1567,6 +1567,92 @@ func testConflictingSyncers(db *sql.DB) func(t *testing.T, store repos.Store) fu
 	}
 }
 
+// Test that sync repo does not clear out any other repo relationships
+func testSyncRepoMaintainsOtherSources(db *sql.DB) func(t *testing.T, store repos.Store) func(t *testing.T) {
+	return func(t *testing.T, store repos.Store) func(t *testing.T) {
+		return func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			now := time.Now()
+
+			svc1 := &types.ExternalService{
+				Kind:        extsvc.KindGitHub,
+				DisplayName: "Github - Test1",
+				Config:      `{"url": "https://github.com"}`,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}
+			svc2 := &types.ExternalService{
+				Kind:        extsvc.KindGitHub,
+				DisplayName: "Github - Test2",
+				Config:      `{"url": "https://github.com"}`,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}
+
+			// setup services
+			if err := store.UpsertExternalServices(ctx, svc1, svc2); err != nil {
+				t.Fatal(err)
+			}
+
+			githubRepo := &repos.Repo{
+				Name:     "github.com/org/foo",
+				Metadata: &github.Repository{},
+				ExternalRepo: api.ExternalRepoSpec{
+					ID:          "foo-external-12345",
+					ServiceID:   "https://github.com/",
+					ServiceType: extsvc.TypeGitHub,
+				},
+			}
+
+			// Add two services, both pointing at the same repo
+
+			// Sync first service
+			syncer := &repos.Syncer{
+				Sourcer: func(services ...*types.ExternalService) (repos.Sources, error) {
+					s := repos.NewFakeSource(svc1, nil, githubRepo)
+					return repos.Sources{s}, nil
+				},
+				Now: time.Now,
+			}
+			if err := syncer.SyncExternalService(ctx, store, svc1.ID, 10*time.Second); err != nil {
+				t.Fatal(err)
+			}
+
+			// Sync second service
+			syncer = &repos.Syncer{
+				Sourcer: func(services ...*types.ExternalService) (repos.Sources, error) {
+					s := repos.NewFakeSource(svc2, nil, githubRepo)
+					return repos.Sources{s}, nil
+				},
+				Now: time.Now,
+			}
+			if err := syncer.SyncExternalService(ctx, store, svc2.ID, 10*time.Second); err != nil {
+				t.Fatal(err)
+			}
+
+			// Confirm that there are two relationships
+			assertSourceCount(ctx, t, db, 2)
+
+			// Run syncRepo with only one source
+			urn := extsvc.URN(extsvc.KindGitHub, svc1.ID)
+			githubRepo.Sources = map[string]*repos.SourceInfo{
+				urn: &repos.SourceInfo{
+					ID:       urn,
+					CloneURL: "cloneURL",
+				},
+			}
+			if err := syncer.SyncRepo(ctx, store, githubRepo); err != nil {
+				t.Fatal(err)
+			}
+
+			// We should still have two sources
+			assertSourceCount(ctx, t, db, 2)
+		}
+	}
+}
+
 func testUserAddedRepos(db *sql.DB, userID int32) func(t *testing.T, store repos.Store) func(t *testing.T) {
 	return func(t *testing.T, store repos.Store) func(t *testing.T) {
 		return func(t *testing.T) {

--- a/cmd/repo-updater/repos/syncer_test.go
+++ b/cmd/repo-updater/repos/syncer_test.go
@@ -1638,7 +1638,7 @@ func testSyncRepoMaintainsOtherSources(db *sql.DB) func(t *testing.T, store repo
 			// Run syncRepo with only one source
 			urn := extsvc.URN(extsvc.KindGitHub, svc1.ID)
 			githubRepo.Sources = map[string]*repos.SourceInfo{
-				urn: &repos.SourceInfo{
+				urn: {
 					ID:       urn,
 					CloneURL: "cloneURL",
 				},


### PR DESCRIPTION
syncRepo syncs a single repo that has been sourced from a single code
host. It is usually triggered by lazy syncing. Since it is only sourced
from a single code host its Sources map only contained mapping for that
one source. Our diff algorithm thus triggered the removal of the repo
from all other sources in the external_service_repos table.

Instead, we now assume that the current stored mapping is correct for
all OTHER sources.

Closes: https://github.com/sourcegraph/sourcegraph/issues/15820