### PR TITLE
Refactor changeset spec resolver to not require a context passed in for interface type resolution

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -335,13 +335,7 @@ func (r *changesetResolver) CurrentSpec(ctx context.Context) (graphqlbackend.Vis
 		return nil, err
 	}
 
-	return &changesetSpecResolver{
-		store:                r.store,
-		httpFactory:          r.httpFactory,
-		changesetSpec:        spec,
-		preloadedRepo:        r.repo,
-		attemptedPreloadRepo: true,
-	}, nil
+	return NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, r.repo, spec), nil
 }
 
 func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.ChangesetLabelResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -82,6 +82,7 @@ func (r *changesetSpecResolver) Type() campaigns.ChangesetSpecDescriptionType {
 func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend.ChangesetDescription, error) {
 	descriptionResolver := &changesetDescriptionResolver{
 		desc:         r.changesetSpec.Spec,
+		// Note: r.repo can never be nil, because Description is a VisibleChangesetSpecResolver-only field.
 		repoResolver: graphqlbackend.NewRepositoryResolver(r.repo),
 		diffStat:     r.changesetSpec.DiffStat(),
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -37,6 +37,12 @@ type changesetSpecResolver struct {
 }
 
 func NewChangesetSpecResolver(ctx context.Context, store *ee.Store, cf *httpcli.Factory, changesetSpec *campaigns.ChangesetSpec) (*changesetSpecResolver, error) {
+	resolver := &changesetSpecResolver{
+		store:         store,
+		httpFactory:   cf,
+		changesetSpec: changesetSpec,
+	}
+
 	// 🚨 SECURITY: db.Repos.GetByIDs uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
 	// In case we don't find a repository, it might be because it's deleted
@@ -45,18 +51,13 @@ func NewChangesetSpecResolver(ctx context.Context, store *ee.Store, cf *httpcli.
 	if err != nil {
 		return nil, err
 	}
-	var repo *types.Repo
+
 	// Not found is ok, the resolver will disguise as a HiddenChangesetResolver.
 	if len(rs) == 1 {
-		repo = rs[0]
+		resolver.repo = rs[0]
 	}
 
-	return &changesetSpecResolver{
-		store:         store,
-		httpFactory:   cf,
-		repo:          repo,
-		changesetSpec: changesetSpec,
-	}, nil
+	return resolver, nil
 }
 
 func NewChangesetSpecResolverWithRepo(store *ee.Store, cf *httpcli.Factory, repo *types.Repo, changesetSpec *campaigns.ChangesetSpec) *changesetSpecResolver {

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -81,7 +81,7 @@ func (r *changesetSpecResolver) Type() campaigns.ChangesetSpecDescriptionType {
 
 func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend.ChangesetDescription, error) {
 	descriptionResolver := &changesetDescriptionResolver{
-		desc:         r.changesetSpec.Spec,
+		desc: r.changesetSpec.Spec,
 		// Note: r.repo can never be nil, because Description is a VisibleChangesetSpecResolver-only field.
 		repoResolver: graphqlbackend.NewRepositoryResolver(r.repo),
 		diffStat:     r.changesetSpec.DiffStat(),

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -2,8 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
-	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -12,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -35,18 +33,39 @@ type changesetSpecResolver struct {
 
 	changesetSpec *campaigns.ChangesetSpec
 
-	preloadedRepo        *types.Repo
-	attemptedPreloadRepo bool
+	repo *types.Repo
+}
 
-	// Cache repo because it's accessed more than once
-	repoOnce sync.Once
-	repo     *graphqlbackend.RepositoryResolver
-	repoErr  error
-	// The context with which we try to load the repository if it's not
-	// preloaded. We need an extra field for that, because the
-	// ToVisibleChangesetSpec/ToHiddenChangesetSpec methods cannot take a
-	// context.Context without graphql-go panic'ing.
-	repoCtx context.Context
+func NewChangesetSpecResolver(ctx context.Context, store *ee.Store, cf *httpcli.Factory, changesetSpec *campaigns.ChangesetSpec) (*changesetSpecResolver, error) {
+	// 🚨 SECURITY: db.Repos.GetByIDs uses the authzFilter under the hood and
+	// filters out repositories that the user doesn't have access to.
+	// In case we don't find a repository, it might be because it's deleted
+	// or because the user doesn't have access.
+	rs, err := db.Repos.GetByIDs(ctx, changesetSpec.RepoID)
+	if err != nil {
+		return nil, err
+	}
+	var repo *types.Repo
+	// Not found is ok, the resolver will disguise as a HiddenChangesetResolver.
+	if len(rs) == 1 {
+		repo = rs[0]
+	}
+
+	return &changesetSpecResolver{
+		store:         store,
+		httpFactory:   cf,
+		repo:          repo,
+		changesetSpec: changesetSpec,
+	}, nil
+}
+
+func NewChangesetSpecResolverWithRepo(store *ee.Store, cf *httpcli.Factory, repo *types.Repo, changesetSpec *campaigns.ChangesetSpec) *changesetSpecResolver {
+	return &changesetSpecResolver{
+		store:         store,
+		httpFactory:   cf,
+		repo:          repo,
+		changesetSpec: changesetSpec,
+	}
 }
 
 func (r *changesetSpecResolver) ID() graphql.ID {
@@ -59,42 +78,10 @@ func (r *changesetSpecResolver) Type() campaigns.ChangesetSpecDescriptionType {
 	return r.changesetSpec.Spec.Type()
 }
 
-func (r *changesetSpecResolver) computeRepo() (*graphqlbackend.RepositoryResolver, error) {
-	r.repoOnce.Do(func() {
-		if r.attemptedPreloadRepo {
-			if r.preloadedRepo != nil {
-				r.repo = graphqlbackend.NewRepositoryResolver(r.preloadedRepo)
-			}
-		} else {
-			if r.repoCtx == nil {
-				r.repoErr = fmt.Errorf("no context available to query repository")
-				return
-			}
-
-			// 🚨 SECURITY: db.Repos.GetByIDs uses the authzFilter under the hood and
-			// filters out repositories that the user doesn't have access to.
-			// In case we don't find a repository, it might be because it's deleted
-			// or because the user doesn't have access.
-			repo, err := graphqlbackend.RepositoryByIDInt32(r.repoCtx, r.changesetSpec.RepoID)
-			if err != nil && !errcode.IsNotFound(err) {
-				r.repoErr = err
-				return
-			}
-			r.repo = repo
-		}
-	})
-	return r.repo, r.repoErr
-}
-
 func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend.ChangesetDescription, error) {
-	repo, err := r.computeRepo()
-	if err != nil {
-		return nil, err
-	}
-
 	descriptionResolver := &changesetDescriptionResolver{
 		desc:         r.changesetSpec.Spec,
-		repoResolver: repo,
+		repoResolver: graphqlbackend.NewRepositoryResolver(r.repo),
 		diffStat:     r.changesetSpec.DiffStat(),
 	}
 
@@ -128,25 +115,13 @@ func (r *changesetSpecResolver) Changeset() (graphqlbackend.ChangesetResolver, e
 	return nil, nil
 }
 
-func (r *changesetSpecResolver) repoAccessible() (bool, error) {
-	repo, err := r.computeRepo()
-	if err != nil {
-		// In case we couldn't load the repository because of an error, we
-		// return the error
-		return false, err
-	}
-
+func (r *changesetSpecResolver) repoAccessible() bool {
 	// If the repository is not nil, it's accessible
-	return repo != nil, nil
+	return r.repo != nil
 }
 
 func (r *changesetSpecResolver) ToHiddenChangesetSpec() (graphqlbackend.HiddenChangesetSpecResolver, bool) {
-	accessible, err := r.repoAccessible()
-	if err != nil {
-		return r, true
-	}
-
-	if accessible {
+	if r.repoAccessible() {
 		return nil, false
 	}
 
@@ -154,12 +129,7 @@ func (r *changesetSpecResolver) ToHiddenChangesetSpec() (graphqlbackend.HiddenCh
 }
 
 func (r *changesetSpecResolver) ToVisibleChangesetSpec() (graphqlbackend.VisibleChangesetSpecResolver, bool) {
-	accessible, err := r.repoAccessible()
-	if err != nil {
-		return r, true
-	}
-
-	if !accessible {
+	if !r.repoAccessible() {
 		return nil, false
 	}
 

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -70,15 +70,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		// In that case we'll set it anyway to nil and changesetSpecResolver
 		// will treat it as "hidden".
 
-		resolvers = append(resolvers, &changesetSpecResolver{
-			store:         r.store,
-			httpFactory:   r.httpFactory,
-			changesetSpec: c,
-
-			preloadedRepo:        repo,
-			attemptedPreloadRepo: true,
-			repoCtx:              ctx,
-		})
+		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -196,12 +196,7 @@ func (r *Resolver) ChangesetSpecByID(ctx context.Context, id graphql.ID) (graphq
 		return nil, err
 	}
 
-	return &changesetSpecResolver{
-		store:         r.store,
-		httpFactory:   r.httpFactory,
-		changesetSpec: changesetSpec,
-		repoCtx:       ctx,
-	}, nil
+	return NewChangesetSpecResolver(ctx, r.store, r.httpFactory, changesetSpec)
 }
 
 func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignsCredentialResolver, error) {
@@ -418,13 +413,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 		return nil, err
 	}
 
-	resolver := &changesetSpecResolver{
-		store:         r.store,
-		httpFactory:   r.httpFactory,
-		changesetSpec: spec,
-		repoCtx:       ctx,
-	}
-	return resolver, nil
+	return NewChangesetSpecResolver(ctx, r.store, r.httpFactory, spec)
 }
 
 func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCampaignArgs) (graphqlbackend.CampaignResolver, error) {


### PR DESCRIPTION
This was really a pain to deal with and not forget to pass in somewhere. So new approach: load it in the factory function already. Also one place less to swallow an error I guess :) 