### PR TITLE
search frontend: add global filter detection for query transformation

### DIFF
--- a/client/shared/src/search/parser/validate.test.ts
+++ b/client/shared/src/search/parser/validate.test.ts
@@ -1,0 +1,47 @@
+import { findGlobalFilter } from './validate'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value, null, 2),
+    test: () => true,
+})
+
+describe('finds a global filter', () => {
+    test('valid global filter', () => {
+        expect(findGlobalFilter('repo:sg/sg case:yes SauceGraph', 'case')).toMatchInlineSnapshot(`
+            {
+              "type": "filter",
+              "range": {
+                "start": 11,
+                "end": 19
+              },
+              "field": {
+                "type": "literal",
+                "value": "case",
+                "range": {
+                  "start": 11,
+                  "end": 15
+                }
+              },
+              "value": {
+                "type": "literal",
+                "value": "yes",
+                "range": {
+                  "start": 16,
+                  "end": 19
+                }
+              },
+              "negated": false
+            }
+        `)
+    })
+
+    test('invalid, more than one filter', () => {
+        expect(
+            findGlobalFilter('patterntype:literal SauceGraph or PatternType:regexp wafflecat', 'patterntype')
+        ).toBeUndefined()
+    })
+
+    test('invalid, grouped filter', () => {
+        expect(findGlobalFilter('repo:sg/sg (case:yes SauceGraph)', 'case')).toBeUndefined()
+    })
+})

--- a/client/shared/src/search/parser/validate.ts
+++ b/client/shared/src/search/parser/validate.ts
@@ -15,16 +15,14 @@ export const findGlobalFilter = (query: string, field: string): Filter | undefin
     const result = scanSearchQuery(query)
     let filter: Filter | undefined
     if (result.type === 'success') {
-        let balanced = 0
         let depth = 0
         let seenField = false
         for (const token of result.term) {
             if (token.type === 'openingParen') {
-                balanced = balanced + 1
                 depth = depth + 1
             }
             if (token.type === 'closingParen') {
-                balanced = balanced - 1
+                depth = depth - 1
             }
             if (token.type === 'filter' && token.field.value.toLowerCase() === field) {
                 if (seenField) {

--- a/client/shared/src/search/parser/validate.ts
+++ b/client/shared/src/search/parser/validate.ts
@@ -1,0 +1,45 @@
+import { Filter, scanSearchQuery } from './scanner'
+
+/**
+ * Returns a global filter for a field in a query, if any. A filter is
+ * global iff (1) it is specified once and (2) it is at the top-level of a query.
+ * For example, `case:yes` is not global in the following queries:
+ *
+ * `(case:yes some subexpression) case:no multiple cases`
+ * `(case:yes not at top level; inside a parentheses of a grouped expression)`
+ *
+ * @param query the query string
+ * @param field the field of the filter to find
+ */
+export const findGlobalFilter = (query: string, field: string): Filter | undefined => {
+    const result = scanSearchQuery(query)
+    let filter: Filter | undefined
+    if (result.type === 'success') {
+        let balanced = 0
+        let depth = 0
+        let seenField = false
+        for (const token of result.term) {
+            if (token.type === 'openingParen') {
+                balanced = balanced + 1
+                depth = depth + 1
+            }
+            if (token.type === 'closingParen') {
+                balanced = balanced - 1
+            }
+            if (token.type === 'filter' && token.field.value.toLowerCase() === field) {
+                if (seenField) {
+                    // More than one of this field.
+                    return undefined
+                }
+                if (depth > 0) {
+                    // Inside a grouped expression.
+                    return undefined
+                }
+                filter = token
+                seenField = true
+                continue
+            }
+        }
+    }
+    return filter
+}


### PR DESCRIPTION
This PR is about the logic that looks at a search query string and then sets URL parameters.

Before, we would set URL parameters for `case` and `patterntype` in the URL depending on query string contents. We would then erase the `field:value` members of the query string so they don't clutter the search bar. We want to preserve this, BUT we don't want to do this unconditionally any more, since subexpressions can contain `case` and `patterntype`, and the previous code didn't detect any of those possibilities. This leads to buggy. behavior in https://github.com/sourcegraph/sourcegraph/issues/13958.

This PR detects whether we can erase filters like `case` or `patterntype`. We can only do so if they are "global", see the first commit's `findGlobalFilter ` comments that checks this.

In the second commit, I use `findGlobalFilter` and simplify our current logic. See inline comments for more. @attfarhan would you throw a careful eye at the changes in this second commit?