### PR TITLE
Implement delta API resolvers on changeset spec

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -166,9 +166,9 @@ type ChangesetSpecResolver interface {
 
 	ExpiresAt() *DateTime
 
-	Operations() ([]campaigns.ReconcilerOperation, error)
-	Delta() (ChangesetSpecDeltaResolver, error)
-	Changeset() (ChangesetResolver, error)
+	Operations(ctx context.Context) ([]campaigns.ReconcilerOperation, error)
+	Delta(ctx context.Context) (ChangesetSpecDeltaResolver, error)
+	Changeset(ctx context.Context) (ChangesetResolver, error)
 
 	ToHiddenChangesetSpec() (HiddenChangesetSpecResolver, bool)
 	ToVisibleChangesetSpec() (VisibleChangesetSpecResolver, bool)

--- a/enterprise/internal/campaigns/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler_test.go
@@ -820,7 +820,7 @@ func TestReconcilerProcess(t *testing.T) {
 	}
 }
 
-func TestReconcilerDeterminePlan(t *testing.T) {
+func TestDetermineReconcilerPlan(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
 

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -213,9 +213,26 @@ type CampaignSpec struct {
 	ExpiresAt *graphqlbackend.DateTime
 }
 
+type ChangesetSpecDelta struct {
+	TitleChanged         bool
+	BodyChanged          bool
+	Undraft              bool
+	BaseRefChanged       bool
+	DiffChanged          bool
+	CommitMessageChanged bool
+	AuthorNameChanged    bool
+	AuthorEmailChanged   bool
+}
+
 type ChangesetSpec struct {
 	Typename string `json:"__typename"`
 	ID       string
+
+	Operations []campaigns.ReconcilerOperation
+	Delta      ChangesetSpecDelta
+	Changeset  struct {
+		ID string
+	}
 
 	Description ChangesetSpecDescription
 

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -213,6 +213,7 @@ type CampaignSpec struct {
 	ExpiresAt *graphqlbackend.DateTime
 }
 
+// ChangesetSpecDelta is the delta between two ChangesetSpecs describing the same Changeset.
 type ChangesetSpecDelta struct {
 	TitleChanged         bool
 	BodyChanged          bool

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -56,7 +56,7 @@ func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 }
 
 func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
-	opts := ee.ListChangesetSpecsOpts{CampaignSpecID: r.campaignSpec.ID}
+	opts := ee.ListChangesetSpecsOpts{}
 	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
@@ -70,9 +70,10 @@ func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphql
 	}
 
 	return &changesetSpecConnectionResolver{
-		store:       r.store,
-		httpFactory: r.httpFactory,
-		opts:        opts,
+		store:          r.store,
+		httpFactory:    r.httpFactory,
+		opts:           opts,
+		campaignSpecID: r.campaignSpec.ID,
 	}, nil
 }
 
@@ -154,11 +155,9 @@ func (r *campaignDescriptionResolver) Description() string {
 
 func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffStat, error) {
 	specsConnection := &changesetSpecConnectionResolver{
-		store:       r.store,
-		httpFactory: r.httpFactory,
-		opts: ee.ListChangesetSpecsOpts{
-			CampaignSpecID: r.campaignSpec.ID,
-		},
+		store:          r.store,
+		httpFactory:    r.httpFactory,
+		campaignSpecID: r.campaignSpec.ID,
 	}
 
 	specs, err := specsConnection.Nodes(ctx)

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -343,6 +343,9 @@ func (c *changesetSpecPreviewer) PlanForChangesetSpec(ctx context.Context, chang
 	var previousSpec, currentSpec *campaigns.ChangesetSpec
 	if changeset.PreviousSpecID != 0 {
 		previousSpec, err = c.store.GetChangesetSpecByID(ctx, changeset.PreviousSpecID)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if changeset.CurrentSpecID != 0 {
 		currentSpec = changesetSpec

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -117,6 +117,10 @@ func (r *changesetSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
 }
 
 func (r *changesetSpecResolver) Operations(ctx context.Context) ([]campaigns.ReconcilerOperation, error) {
+	if !r.repoAccessible() {
+		// If the repo is inaccessible, no operations would be taken, since the changeset is not created/updated.
+		return []campaigns.ReconcilerOperation{}, nil
+	}
 	plan, err := r.computePlan(ctx)
 	if err != nil {
 		return nil, err
@@ -126,6 +130,10 @@ func (r *changesetSpecResolver) Operations(ctx context.Context) ([]campaigns.Rec
 }
 
 func (r *changesetSpecResolver) Delta(ctx context.Context) (graphqlbackend.ChangesetSpecDeltaResolver, error) {
+	if !r.repoAccessible() {
+		// If the repo is inaccessible, no comparison is made, since the changeset is not created/updated.
+		return &changesetSpecDeltaResolver{}, nil
+	}
 	plan, err := r.computePlan(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -2,13 +2,16 @@ package resolvers
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -296,4 +299,119 @@ func (c *changesetSpecDeltaResolver) AuthorNameChanged() bool {
 }
 func (c *changesetSpecDeltaResolver) AuthorEmailChanged() bool {
 	return c.delta.AuthorEmailChanged
+}
+
+type changesetSpecPreviewer struct {
+	store          *ee.Store
+	campaignSpecID int64
+
+	mappingOnce sync.Once
+	mappingByID map[int64]*ee.RewirerMapping
+	mappingErr  error
+
+	campaignOnce sync.Once
+	campaign     *campaigns.Campaign
+	campaignErr  error
+}
+
+func (c *changesetSpecPreviewer) PlanForChangesetSpec(ctx context.Context, changesetSpec *campaigns.ChangesetSpec) (*ee.ReconcilerPlan, error) {
+	mapping, err := c.mappingForChangesetSpec(ctx, changesetSpec.ID)
+	if err != nil {
+		return nil, err
+	}
+	campaign, err := c.computeCampaign(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rewirer := ee.NewChangesetRewirer(ee.RewirerMappings{mapping}, campaign, repos.NewDBStore(c.store.DB(), sql.TxOptions{}))
+	changesets, err := rewirer.Rewire(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var changeset *campaigns.Changeset
+	if len(changesets) != 1 {
+		return nil, errors.New("rewirer did not return changeset")
+	} else {
+		changeset = changesets[0]
+	}
+
+	// Detached changesets would still appear here, but since they'll never match one of the new specs, they don't actually appear here.
+	// Once we have a way to have changeset specs for detached changesets, this would be the place to do a "will be detached" check.
+	// TBD: How we represent that in the API.
+
+	var previousSpec, currentSpec *campaigns.ChangesetSpec
+	if changeset.PreviousSpecID != 0 {
+		previousSpec, err = c.store.GetChangesetSpecByID(ctx, changeset.PreviousSpecID)
+	}
+	if changeset.CurrentSpecID != 0 {
+		currentSpec = changesetSpec
+	}
+	return ee.DetermineReconcilerPlan(previousSpec, currentSpec, changeset)
+}
+
+// ChangesetForChangesetSpec can return nil
+func (c *changesetSpecPreviewer) ChangesetForChangesetSpec(ctx context.Context, changesetSpecID int64) (*campaigns.Changeset, error) {
+	mapping, err := c.mappingForChangesetSpec(ctx, changesetSpecID)
+	if err != nil {
+		return nil, err
+	}
+	return mapping.Changeset, nil
+}
+
+func (c *changesetSpecPreviewer) mappingForChangesetSpec(ctx context.Context, id int64) (*ee.RewirerMapping, error) {
+	mappingByID, err := c.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	mapping, ok := mappingByID[id]
+	if !ok {
+		return nil, errors.New("couldn't find mapping for changeset")
+	}
+
+	return mapping, nil
+}
+
+func (c *changesetSpecPreviewer) computeCampaign(ctx context.Context) (*campaigns.Campaign, error) {
+	c.campaignOnce.Do(func() {
+		svc := ee.NewService(c.store, nil)
+		campaignSpec, err := c.store.GetCampaignSpec(ctx, ee.GetCampaignSpecOpts{ID: c.campaignSpecID})
+		if err != nil {
+			c.campaignErr = err
+			return
+		}
+		c.campaign, _, c.campaignErr = svc.ReconcileCampaign(ctx, campaignSpec)
+	})
+	return c.campaign, c.campaignErr
+}
+
+func (c *changesetSpecPreviewer) compute(ctx context.Context) (map[int64]*ee.RewirerMapping, error) {
+	c.mappingOnce.Do(func() {
+		campaign, err := c.computeCampaign(ctx)
+		if err != nil {
+			c.mappingErr = err
+			return
+		}
+		mappings, err := c.store.GetRewirerMappings(ctx, ee.GetRewirerMappingsOpts{
+			CampaignSpecID: c.campaignSpecID,
+			CampaignID:     campaign.ID,
+		})
+		if err != nil {
+			c.mappingErr = err
+			return
+		}
+		if err := mappings.Hydrate(ctx, c.store); err != nil {
+			c.mappingErr = err
+			return
+		}
+
+		c.mappingByID = make(map[int64]*ee.RewirerMapping)
+		for _, m := range mappings {
+			if m.ChangesetSpecID == 0 {
+				continue
+			}
+			c.mappingByID[m.ChangesetSpecID] = m
+		}
+	})
+	return c.mappingByID, c.mappingErr
 }

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -2,11 +2,14 @@ package resolvers
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -21,7 +24,8 @@ type changesetSpecConnectionResolver struct {
 	store       *ee.Store
 	httpFactory *httpcli.Factory
 
-	opts ee.ListChangesetSpecsOpts
+	opts           ee.ListChangesetSpecsOpts
+	campaignSpecID int64
 
 	// Cache results because they are used by multiple fields
 	once           sync.Once
@@ -33,7 +37,7 @@ type changesetSpecConnectionResolver struct {
 
 func (r *changesetSpecConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	count, err := r.store.CountChangesetSpecs(ctx, ee.CountChangesetSpecsOpts{
-		CampaignSpecID: r.opts.CampaignSpecID,
+		CampaignSpecID: r.campaignSpecID,
 	})
 	if err != nil {
 		return 0, err
@@ -62,6 +66,11 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		return nil, err
 	}
 
+	fetcher := &changesetSpecPreviewer{
+		store:          r.store,
+		campaignSpecID: r.campaignSpecID,
+	}
+
 	resolvers := make([]graphqlbackend.ChangesetSpecResolver, 0, len(changesetSpecs))
 	for _, c := range changesetSpecs {
 		repo := reposByID[c.RepoID]
@@ -70,7 +79,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		// In that case we'll set it anyway to nil and changesetSpecResolver
 		// will treat it as "hidden".
 
-		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c))
+		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c).WithRewirerMappingFetcher(fetcher))
 	}
 
 	return resolvers, nil
@@ -78,7 +87,9 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 
 func (r *changesetSpecConnectionResolver) compute(ctx context.Context) (campaigns.ChangesetSpecs, map[api.RepoID]*types.Repo, int64, error) {
 	r.once.Do(func() {
-		r.changesetSpecs, r.next, r.err = r.store.ListChangesetSpecs(ctx, r.opts)
+		opts := r.opts
+		opts.CampaignSpecID = r.campaignSpecID
+		r.changesetSpecs, r.next, r.err = r.store.ListChangesetSpecs(ctx, opts)
 		if r.err != nil {
 			return
 		}
@@ -89,4 +100,119 @@ func (r *changesetSpecConnectionResolver) compute(ctx context.Context) (campaign
 	})
 
 	return r.changesetSpecs, r.reposByID, r.next, r.err
+}
+
+type changesetSpecPreviewer struct {
+	store          *ee.Store
+	campaignSpecID int64
+
+	mappingOnce sync.Once
+	mappingByID map[int64]*ee.RewirerMapping
+	mappingErr  error
+
+	campaignOnce sync.Once
+	campaign     *campaigns.Campaign
+	campaignErr  error
+}
+
+func (c *changesetSpecPreviewer) PlanForChangesetSpec(ctx context.Context, changesetSpec *campaigns.ChangesetSpec) (*ee.ReconcilerPlan, error) {
+	mapping, err := c.mappingForChangesetSpec(ctx, changesetSpec.ID)
+	if err != nil {
+		return nil, err
+	}
+	campaign, err := c.computeCampaign(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rewirer := ee.NewChangesetRewirer(ee.RewirerMappings{mapping}, campaign, repos.NewDBStore(c.store.DB(), sql.TxOptions{}))
+	changesets, err := rewirer.Rewire(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var changeset *campaigns.Changeset
+	if len(changesets) != 1 {
+		return nil, errors.New("rewirer did not return changeset")
+	} else {
+		changeset = changesets[0]
+	}
+
+	// Detached changesets would still appear here, but since they'll never match one of the new specs, they don't actually appear here.
+	// Once we have a way to have changeset specs for detached changesets, this would be the place to do a "will be detached" check.
+	// TBD: How we represent that in the API.
+
+	var previousSpec, currentSpec *campaigns.ChangesetSpec
+	if changeset.PreviousSpecID != 0 {
+		previousSpec, err = c.store.GetChangesetSpecByID(ctx, changeset.PreviousSpecID)
+	}
+	if changeset.CurrentSpecID != 0 {
+		currentSpec = changesetSpec
+	}
+	return ee.DetermineReconcilerPlan(previousSpec, currentSpec, changeset)
+}
+
+// ChangesetForChangesetSpec can return nil
+func (c *changesetSpecPreviewer) ChangesetForChangesetSpec(ctx context.Context, changesetSpecID int64) (*campaigns.Changeset, error) {
+	mapping, err := c.mappingForChangesetSpec(ctx, changesetSpecID)
+	if err != nil {
+		return nil, err
+	}
+	return mapping.Changeset, nil
+}
+
+func (c *changesetSpecPreviewer) mappingForChangesetSpec(ctx context.Context, id int64) (*ee.RewirerMapping, error) {
+	mappingByID, err := c.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	mapping, ok := mappingByID[id]
+	if !ok {
+		return nil, errors.New("couldn't find mapping for changeset")
+	}
+
+	return mapping, nil
+}
+
+func (c *changesetSpecPreviewer) computeCampaign(ctx context.Context) (*campaigns.Campaign, error) {
+	c.campaignOnce.Do(func() {
+		svc := ee.NewService(c.store, nil)
+		campaignSpec, err := c.store.GetCampaignSpec(ctx, ee.GetCampaignSpecOpts{ID: c.campaignSpecID})
+		if err != nil {
+			c.campaignErr = err
+			return
+		}
+		c.campaign, _, c.campaignErr = svc.ReconcileCampaign(ctx, campaignSpec)
+	})
+	return c.campaign, c.campaignErr
+}
+
+func (c *changesetSpecPreviewer) compute(ctx context.Context) (map[int64]*ee.RewirerMapping, error) {
+	c.mappingOnce.Do(func() {
+		campaign, err := c.computeCampaign(ctx)
+		if err != nil {
+			c.mappingErr = err
+			return
+		}
+		mappings, err := c.store.GetRewirerMappings(ctx, ee.GetRewirerMappingsOpts{
+			CampaignSpecID: c.campaignSpecID,
+			CampaignID:     campaign.ID,
+		})
+		if err != nil {
+			c.mappingErr = err
+			return
+		}
+		if err := mappings.Hydrate(ctx, c.store); err != nil {
+			c.mappingErr = err
+			return
+		}
+
+		c.mappingByID = make(map[int64]*ee.RewirerMapping)
+		for _, m := range mappings {
+			if m.ChangesetSpecID == 0 {
+				continue
+			}
+			c.mappingByID[m.ChangesetSpecID] = m
+		}
+	})
+	return c.mappingByID, c.mappingErr
 }

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -63,6 +63,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		return nil, err
 	}
 
+	// Create a shared previewer so the expensive operations can be cached across changeset spec resolvers.
 	previewer := &changesetSpecPreviewer{
 		store:          r.store,
 		campaignSpecID: r.campaignSpecID,

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -63,7 +63,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		return nil, err
 	}
 
-	fetcher := &changesetSpecPreviewer{
+	previewer := &changesetSpecPreviewer{
 		store:          r.store,
 		campaignSpecID: r.campaignSpecID,
 	}
@@ -76,7 +76,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		// In that case we'll set it anyway to nil and changesetSpecResolver
 		// will treat it as "hidden".
 
-		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c).WithPreviewer(fetcher))
+		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c).WithPreviewer(previewer))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -76,7 +76,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		// In that case we'll set it anyway to nil and changesetSpecResolver
 		// will treat it as "hidden".
 
-		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c).WithRewirerMappingFetcher(fetcher))
+		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c).WithPreviewer(fetcher))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -54,6 +54,15 @@ func TestChangesetSpecResolver(t *testing.T) {
 	testRev := api.CommitID("b69072d5f687b31b9f6ae3ceafdc24c259c4b9ec")
 	mockBackendCommits(t, testRev)
 
+	campaignSpec, err := campaigns.NewCampaignSpecFromRaw(`name: awesome-test`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	campaignSpec.NamespaceUserID = userID
+	if err := store.CreateCampaignSpec(ctx, campaignSpec); err != nil {
+		t.Fatal(err)
+	}
+
 	s, err := graphqlbackend.NewSchema(&Resolver{store: store}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -69,8 +78,9 @@ func TestChangesetSpecResolver(t *testing.T) {
 			rawSpec: ct.NewRawChangesetSpecGitBranch(repoID, string(testRev)),
 			want: func(spec *campaigns.ChangesetSpec) apitest.ChangesetSpec {
 				return apitest.ChangesetSpec{
-					Typename: "VisibleChangesetSpec",
-					ID:       string(marshalChangesetSpecRandID(spec.RandID)),
+					Typename:   "VisibleChangesetSpec",
+					ID:         string(marshalChangesetSpecRandID(spec.RandID)),
+					Operations: []campaigns.ReconcilerOperation{},
 					Description: apitest.ChangesetSpecDescription{
 						Typename: "GitBranchChangesetDescription",
 						BaseRepository: apitest.Repository{
@@ -124,8 +134,9 @@ func TestChangesetSpecResolver(t *testing.T) {
 			rawSpec: ct.NewPublishedRawChangesetSpecGitBranch(repoID, string(testRev), campaigns.PublishedValue{Val: "draft"}),
 			want: func(spec *campaigns.ChangesetSpec) apitest.ChangesetSpec {
 				return apitest.ChangesetSpec{
-					Typename: "VisibleChangesetSpec",
-					ID:       string(marshalChangesetSpecRandID(spec.RandID)),
+					Typename:   "VisibleChangesetSpec",
+					ID:         string(marshalChangesetSpecRandID(spec.RandID)),
+					Operations: []campaigns.ReconcilerOperation{campaigns.ReconcilerOperationPush, campaigns.ReconcilerOperationPublishDraft},
 					Description: apitest.ChangesetSpecDescription{
 						Typename: "GitBranchChangesetDescription",
 						BaseRepository: apitest.Repository{
@@ -179,8 +190,9 @@ func TestChangesetSpecResolver(t *testing.T) {
 			rawSpec: ct.NewRawChangesetSpecExisting(repoID, "9999"),
 			want: func(spec *campaigns.ChangesetSpec) apitest.ChangesetSpec {
 				return apitest.ChangesetSpec{
-					Typename: "VisibleChangesetSpec",
-					ID:       string(marshalChangesetSpecRandID(spec.RandID)),
+					Typename:   "VisibleChangesetSpec",
+					ID:         string(marshalChangesetSpecRandID(spec.RandID)),
+					Operations: []campaigns.ReconcilerOperation{campaigns.ReconcilerOperationImport},
 					Description: apitest.ChangesetSpecDescription{
 						Typename: "ExistingChangesetReference",
 						BaseRepository: apitest.Repository{
@@ -202,6 +214,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 			}
 			spec.UserID = userID
 			spec.RepoID = repo.ID
+			spec.CampaignSpecID = campaignSpec.ID
 
 			if err := store.CreateChangesetSpec(ctx, spec); err != nil {
 				t.Fatal(err)
@@ -226,6 +239,19 @@ query($id: ID!) {
 
     ... on VisibleChangesetSpec {
       id
+
+      operations
+      changeset { id }
+      delta {
+          titleChanged
+          bodyChanged
+          undraft
+          baseRefChanged
+          diffChanged
+          commitMessageChanged
+          authorNameChanged
+          authorEmailChanged
+      }
 
       description {
         __typename

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -1187,7 +1187,18 @@ query($campaignSpec: ID!) {
         nodes {
           __typename
           type
-
+          operations
+          changeset { id }
+          delta {
+              titleChanged
+              bodyChanged
+              undraft
+              baseRefChanged
+              diffChanged
+              commitMessageChanged
+              authorNameChanged
+              authorEmailChanged
+          }
           ... on HiddenChangesetSpec {
             id
           }

--- a/enterprise/internal/campaigns/service_apply_campaign.go
+++ b/enterprise/internal/campaigns/service_apply_campaign.go
@@ -122,9 +122,12 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	if err != nil {
 		return nil, err
 	}
+	if err := mappings.Hydrate(ctx, tx); err != nil {
+		return nil, err
+	}
 
 	// And execute the mapping.
-	rewirer := NewChangesetRewirer(mappings, campaign, tx, rstore)
+	rewirer := NewChangesetRewirer(mappings, campaign, rstore)
 	changesets, err := rewirer.Rewire(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implements the GraphQL resolvers for the delta API fields added before.

Closes https://github.com/sourcegraph/sourcegraph/issues/16055
Closes https://github.com/sourcegraph/sourcegraph/issues/16057