### PR TITLE
search: refactor code monitor resolver to rely on store

### DIFF
--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -36,9 +36,9 @@ func TestCreateCodeMonitor(t *testing.T) {
 	want := &monitor{
 		id:              1,
 		createdBy:       userID,
-		createdAt:       r.clock(),
+		createdAt:       r.Now(),
 		changedBy:       userID,
-		changedAt:       r.clock(),
+		changedAt:       r.Now(),
 		description:     "test monitor",
 		enabled:         true,
 		namespaceUserID: &userID,
@@ -243,7 +243,7 @@ func TestQueryMonitor(t *testing.T) {
 					Enabled:     true,
 					Owner:       apitest.UserOrg{Name: userName},
 					CreatedBy:   apitest.UserOrg{Name: userName},
-					CreatedAt:   marshalDateTime(t, r.clock()),
+					CreatedAt:   marshalDateTime(t, r.Now()),
 					Trigger: apitest.Trigger{
 						Id:    string(relay.MarshalID(monitorTriggerQueryKind, 1)),
 						Query: "repo:foo",
@@ -391,7 +391,7 @@ func TestEditCodeMonitor(t *testing.T) {
 			CreatedBy: apitest.UserOrg{
 				Name: user1Name,
 			},
-			CreatedAt: marshalDateTime(t, r.clock()),
+			CreatedAt: marshalDateTime(t, r.store.Now()),
 			Trigger: apitest.Trigger{
 				Id:    string(relay.MarshalID(monitorTriggerQueryKind, 1)),
 				Query: "repo:bar",

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -1,6 +1,7 @@
 package codemonitors
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -38,4 +39,19 @@ func (s *Store) With(other basestore.ShareableStore) *Store {
 // Clock returns the clock of the underlying store.
 func (s *Store) Clock() func() time.Time {
 	return s.now
+}
+
+func (s *Store) Now() time.Time {
+	return s.now()
+}
+
+// Transact creates a new transaction.
+// It's required to implement this method and wrap the Transact method of the
+// underlying basestore.Store.
+func (s *Store) Transact(ctx context.Context) (*Store, error) {
+	txBase, err := s.Store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{Store: txBase, now: s.now}, nil
 }


### PR DESCRIPTION
Stacked on top of #16174

This is a pure refactor. The changes are almost all mechanical.

Previously, the resolver accessed the db directly. However, since we want
to share some of the code between the resolvers and the background
workers, it makes sense to add a db layer that both can access.

Additionally, I removed a piece of duplicate code. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
