### PR TITLE
search: connect trigger event resolvers to db

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -43,7 +43,7 @@ type MonitorTrigger interface {
 type MonitorQueryResolver interface {
 	ID() graphql.ID
 	Query() string
-	Events(ctx context.Context, args *ListEventsArgs) MonitorTriggerEventConnectionResolver
+	Events(ctx context.Context, args *ListEventsArgs) (MonitorTriggerEventConnectionResolver, error)
 }
 
 type MonitorTriggerEventConnectionResolver interface {
@@ -54,9 +54,9 @@ type MonitorTriggerEventConnectionResolver interface {
 
 type MonitorTriggerEventResolver interface {
 	ID() graphql.ID
-	Status() string
+	Status() (string, error)
 	Message() *string
-	Timestamp() DateTime
+	Timestamp() (DateTime, error)
 	Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error)
 }
 

--- a/enterprise/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/internal/codemonitors/resolvers/apitest/types.go
@@ -64,6 +64,20 @@ type RecipientsConnection struct {
 }
 
 type Trigger struct {
-	Id    string
-	Query string
+	Id     string
+	Query  string
+	Events TriggerEventConnection
+}
+
+type TriggerEventConnection struct {
+	Nodes      []TriggerEvent
+	TotalCount int
+	PageInfo   PageInfo
+}
+
+type TriggerEvent struct {
+	Id        string
+	Status    string
+	Timestamp string
+	Message   *string
 }

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -548,7 +548,7 @@ AND id > %s
 ORDER BY id ASC
 LIMIT %s
 `
-	after, err := unmarshallAfter(args.After)
+	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +794,7 @@ AND id > %s
 LIMIT %s;
 ;
 `
-	after, err := unmarshallAfter(args.After)
+	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err
 	}
@@ -867,7 +867,7 @@ AND id > %s
 ORDER BY id ASC
 LIMIT %s;
 `
-	after, err := unmarshallAfter(args.After)
+	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err
 	}
@@ -1427,7 +1427,7 @@ func (m *monitorActionEvent) Timestamp() graphqlbackend.DateTime {
 	return m.timestamp
 }
 
-func unmarshallAfter(after *string) (int64, error) {
+func unmarshalAfter(after *string) (int64, error) {
 	var a int64
 	if after == nil {
 		a = 0

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -67,7 +67,7 @@ LIMIT %s;
 `
 
 func (s *Store) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
-	after, err := unmarshallAfter(args.After)
+	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ var TriggerJobsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_trigger_jobs.log_contents"),
 }
 
-func unmarshallAfter(after *string) (int64, error) {
+func unmarshalAfter(after *string) (int64, error) {
 	var a int64
 	if after == nil {
 		a = 0


### PR DESCRIPTION
Stacked on top of #16189 

With this PR, the resolvers for events of triggers return data from the
database instead of mock data.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
