### PR TITLE
add support for multiple filters on FilteredConnection

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -167,9 +167,9 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
               className="hierarchical-locations-view__item-name-text"
             >
                
-              <strong>
+              <span>
                 file1.txt
-              </strong>
+              </span>
             </span>
           </span>
           <span
@@ -190,9 +190,9 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
               className="hierarchical-locations-view__item-name-text"
             >
                
-              <strong>
+              <span>
                 file2.txt
-              </strong>
+              </span>
             </span>
           </span>
           <span

--- a/client/shared/src/components/RepoLink.tsx
+++ b/client/shared/src/components/RepoLink.tsx
@@ -12,16 +12,24 @@ interface Props {
 
     className?: string
 
+    repoClassName?: string
+
     onClick?: React.MouseEventHandler<HTMLElement>
 }
 
-export const RepoLink: React.FunctionComponent<Props> = ({ repoName: fullRepoName, to, className, onClick }) => {
+export const RepoLink: React.FunctionComponent<Props> = ({
+    repoName: fullRepoName,
+    to,
+    className,
+    onClick,
+    repoClassName,
+}) => {
     const [repoBase, repoName] = splitPath(displayRepoName(fullRepoName))
     const children = (
         <>
             {' '}
             {repoBase ? `${repoBase}/` : null}
-            <strong>{repoName}</strong>
+            <span className={repoClassName}>{repoName}</span>
         </>
     )
     if (to === null) {

--- a/client/shared/src/components/__snapshots__/RepoLink.test.tsx.snap
+++ b/client/shared/src/components/__snapshots__/RepoLink.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`RepoLink renders a fragment when "to" is null 1`] = `
 Array [
   " ",
   "my/",
-  <strong>
+  <span>
     repo
-  </strong>,
+  </span>,
 ]
 `;
 
@@ -17,8 +17,8 @@ exports[`RepoLink renders a link when "to" is set 1`] = `
 >
    
   my/
-  <strong>
+  <span>
     repo
-  </strong>
+  </span>
 </a>
 `;

--- a/client/web/src/components/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection.scss
@@ -63,4 +63,8 @@
     &__show-more {
         flex: 0 0 auto;
     }
+
+    &__filter {
+        max-width: 30% !important;
+    }
 }

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -543,18 +543,18 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             activeValuesChanges
                 .pipe(
                     tap(values => {
-                        if (this.props.filters === undefined) {
+                        if (this.props.filters === undefined || this.props.onValueSelect === undefined) {
                             return
                         }
-                        this.props.filters.map((filter, index) => {
+                        for (const filter of this.props.filters) {
                             if (this.props.onValueSelect) {
                                 const value = values.get(filter.id)
                                 if (value === undefined) {
-                                    return
+                                    continue
                                 }
                                 this.props.onValueSelect(filter, value)
                             }
-                        })
+                        }
                     })
                 )
                 .subscribe()
@@ -776,20 +776,20 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             searchParameters.set('first', String(first))
         }
         if (values && this.props.filters) {
-            this.props.filters.map(filter => {
+            for (const filter of this.props.filters) {
                 if (values === undefined) {
-                    return
+                    continue
                 }
                 const value = values.get(filter.id)
                 if (value === undefined) {
-                    return
+                    continue
                 }
                 if (value !== filter.values[0]) {
                     searchParameters.set(filter.id, value.value)
                 } else {
                     searchParameters.delete(filter.id)
                 }
-            })
+            }
         }
         if (visible !== 0 && visible !== first) {
             searchParameters.set('visible', String(visible))
@@ -841,7 +841,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         )}
                         {!this.props.hideSearch && (
                             <input
-                                className="form-control filtered-connection__filter w-30"
+                                className="form-control filtered-connection__filter"
                                 type="search"
                                 placeholder={`Search ${this.props.pluralNoun}...`}
                                 name="query"
@@ -970,17 +970,17 @@ function getFilterFromURL(
     if (filters === undefined || filters.length === 0) {
         return values
     }
-    filters.map(filter => {
+    for (const filter of filters) {
         const urlValue = searchParameters.get(filter.id)
         if (urlValue !== null) {
             const value = filter.values.find(value => value.value === urlValue)
             if (value !== undefined) {
                 values.set(filter.id, value)
-                return
+                continue
             }
         }
         // couldn't find a value, add default
         values.set(filter.id, filter.values[0])
-    })
+    }
     return values
 }

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -826,7 +826,10 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                 }`}
             >
                 {(!this.props.hideSearch || this.props.filters) && (
-                    <Form className="w-100 d-inline-flex justify-content-between flex-row filtered-connection__form" onSubmit={this.onSubmit}>
+                    <Form
+                        className="w-100 d-inline-flex justify-content-between flex-row filtered-connection__form"
+                        onSubmit={this.onSubmit}
+                    >
                         {this.props.filters && (
                             <FilteredConnectionFilterControl
                                 filters={this.props.filters}

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -46,7 +46,7 @@ class FilteredConnectionFilterControl extends React.PureComponent<FilterProps, F
         return (
             <div className="filtered-connection-filter-control">
                 {this.props.filters.map(filter => (
-                    <div className="d-inline-flex flex-row" key={filter.id}>
+                    <div className="d-inline-flex flex-row radio-buttons" key={filter.id}>
                         {filter.type === 'radio' &&
                             filter.values.map(value => (
                                 <label key={value.value} className="radio-buttons__item" title={value.tooltip}>

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -46,7 +46,7 @@ class FilteredConnectionFilterControl extends React.PureComponent<FilterProps, F
         return (
             <div className="filtered-connection-filter-control">
                 {this.props.filters.map(filter => (
-                    <div className="d-flex " key={filter.id}>
+                    <div className="d-inline-flex flex-row" key={filter.id}>
                         {filter.type === 'radio' &&
                             filter.values.map(value => (
                                 <label key={value.value} className="radio-buttons__item" title={value.tooltip}>
@@ -69,7 +69,7 @@ class FilteredConnectionFilterControl extends React.PureComponent<FilterProps, F
                                 </label>
                             ))}
                         {filter.type === 'select' && (
-                            <div className="d-flex mr-3 align-items-baseline">
+                            <div className="d-inline-flex flex-row mr-3 align-items-baseline">
                                 <p className="text-xl-center text-nowrap mr-2">{filter.label}:</p>
                                 <select
                                     className="form-control"
@@ -826,7 +826,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                 }`}
             >
                 {(!this.props.hideSearch || this.props.filters) && (
-                    <Form className="filtered-connection__form" onSubmit={this.onSubmit}>
+                    <Form className="w-100 d-inline-flex justify-content-between flex-row filtered-connection__form" onSubmit={this.onSubmit}>
                         {this.props.filters && (
                             <FilteredConnectionFilterControl
                                 filters={this.props.filters}
@@ -838,7 +838,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         )}
                         {!this.props.hideSearch && (
                             <input
-                                className="form-control filtered-connection__filter"
+                                className="form-control filtered-connection__filter w-30"
                                 type="search"
                                 placeholder={`Search ${this.props.pluralNoun}...`}
                                 name="query"

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -22,7 +22,6 @@ import * as GQL from '../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { pluralize } from '../../../shared/src/util/strings'
 import { Form } from '../../../branded/src/components/Form'
-import { RadioButtons } from './RadioButtons'
 import { ErrorMessage } from './alerts'
 import { hasProperty } from '../../../shared/src/util/types'
 
@@ -35,10 +34,9 @@ interface FilterProps {
     filters: FilteredConnectionFilter[]
 
     /** Called when a filter is selected. */
-    onDidSelectFilter: (filter: FilteredConnectionFilter) => void
+    onDidSelectValue: (filter: FilteredConnectionFilter, value: FilterValue) => void
 
-    /** The ID of the active filter. */
-    value: string
+    values: Map<string, FilterValue>
 }
 
 interface FilterState {}
@@ -47,16 +45,58 @@ class FilteredConnectionFilterControl extends React.PureComponent<FilterProps, F
     public render(): React.ReactFragment {
         return (
             <div className="filtered-connection-filter-control">
-                <RadioButtons nodes={this.props.filters} selected={this.props.value} onChange={this.onChange} />
+                {this.props.filters.map(filter => (
+                    <div className="d-flex " key={filter.id}>
+                        {filter.type === 'radio' &&
+                            filter.values.map(value => (
+                                <label key={value.value} className="radio-buttons__item" title={value.tooltip}>
+                                    <input
+                                        className="radio-buttons__input"
+                                        name={value.value}
+                                        type="radio"
+                                        onChange={event => {
+                                            this.onChange(filter, event.currentTarget.value)
+                                        }}
+                                        value={value.value}
+                                        checked={
+                                            this.props.values.get(filter.id) &&
+                                            this.props.values.get(filter.id)!.value === value.value
+                                        }
+                                    />{' '}
+                                    <small>
+                                        <div className="radio-buttons__label">{value.label}</div>
+                                    </small>
+                                </label>
+                            ))}
+                        {filter.type === 'select' && (
+                            <div className="d-flex mr-3 align-items-baseline">
+                                <p className="text-xl-center text-nowrap mr-2">{filter.label}:</p>
+                                <select
+                                    className="form-control"
+                                    name={filter.id}
+                                    onChange={event => {
+                                        this.onChange(filter, event.currentTarget.value)
+                                    }}
+                                >
+                                    {filter.values.map(value => (
+                                        <option key={value.value} value={value.value} label={value.label} />
+                                    ))}
+                                </select>
+                            </div>
+                        )}
+                    </div>
+                ))}
                 {this.props.children}
             </div>
         )
     }
 
-    private onChange: React.ChangeEventHandler<HTMLInputElement> = event => {
-        const id = event.currentTarget.value
-        const filter = this.props.filters.find(filter => filter.id === id)!
-        this.props.onDidSelectFilter(filter)
+    private onChange(filter: FilteredConnectionFilter, id: string): void {
+        const value = filter.values.find(value => value.value === id)
+        if (value === undefined) {
+            return
+        }
+        this.props.onDidSelectValue(filter, value)
     }
 }
 
@@ -328,7 +368,7 @@ interface FilteredConnectionDisplayProps extends ConnectionDisplayProps {
     defaultFilter?: string
 
     /** Called when a filter is selected and on initial render. */
-    onFilterSelect?: (filterID: string | undefined) => void
+    onValueSelect?: (filter: FilteredConnectionFilter, value: FilterValue) => void
 }
 
 /**
@@ -364,6 +404,8 @@ export interface FilteredConnectionFilter {
     /** The UI label for the filter. */
     label: string
 
+    type: string
+
     /**
      * The URL string for this filter (conventionally the label, lowercased and without spaces and punctuation).
      */
@@ -372,13 +414,18 @@ export interface FilteredConnectionFilter {
     /** An optional tooltip to display for this filter. */
     tooltip?: string
 
-    /** Additional query args to pass to the queryConnection function when this filter is enabled. */
+    values: FilterValue[]
+}
+
+export interface FilterValue {
+    value: string
+    label: string
+    tooltip?: string
     args: { [name: string]: string | number | boolean }
 }
 
 interface FilteredConnectionState<C extends Connection<N>, N> extends ConnectionStateCommon {
-    /** The active filter's ID (FilteredConnectionFilter.id), if any. */
-    activeFilter: FilteredConnectionFilter | undefined
+    activeValues: Map<string, FilterValue>
 
     /** The fetched connection data or an error (if an error occurred). */
     connectionOrError?: C | ErrorLike
@@ -441,7 +488,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
     }
 
     private queryInputChanges = new Subject<string>()
-    private activeFilterChanges = new Subject<FilteredConnectionFilter>()
+    private activeValuesChanges = new Subject<Map<string, FilterValue>>()
     private showMoreClicks = new Subject<void>()
     private componentUpdates = new Subject<FilteredConnectionProps<C, N, NP>>()
     private subscriptions = new Subscription()
@@ -468,20 +515,17 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         this.state = {
             loading: true,
             query: (!this.props.hideSearch && this.props.useURLQuery && searchParameters.get(QUERY_KEY)) || '',
-            activeFilter:
-                (this.props.useURLQuery &&
-                    getFilterFromURL(searchParameters, this.props.filters, this.props.defaultFilter)) ||
-                undefined,
+            activeValues:
+                (this.props.useURLQuery && getFilterFromURL(searchParameters, this.props.filters)) ||
+                new Map<string, FilterValue>(),
             first: (this.props.useURLQuery && parseQueryInt(searchParameters, 'first')) || this.props.defaultFirst!,
             visible: (this.props.useURLQuery && parseQueryInt(searchParameters, 'visible')) || 0,
         }
     }
 
     public componentDidMount(): void {
-        const activeFilterChanges = this.activeFilterChanges.pipe(
-            startWith(this.state.activeFilter),
-            distinctUntilChanged()
-        )
+        const activeValuesChanges = this.activeValuesChanges.pipe(startWith(this.state.activeValues))
+
         const queryChanges = this.queryInputChanges.pipe(
             distinctUntilChanged(),
             tap(query => !this.props.hideSearch && this.setState({ query })),
@@ -496,12 +540,21 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         const refreshRequests = new Subject<{ forceRefresh: boolean }>()
 
         this.subscriptions.add(
-            activeFilterChanges
+            activeValuesChanges
                 .pipe(
-                    tap(filter => {
-                        if (this.props.onFilterSelect) {
-                            this.props.onFilterSelect(filter ? filter.id : undefined)
+                    tap(values => {
+                        if (this.props.filters === undefined) {
+                            return
                         }
+                        this.props.filters.map((filter, index) => {
+                            if (this.props.onValueSelect) {
+                                const value = values.get(filter.id)
+                                if (value === undefined) {
+                                    return
+                                }
+                                this.props.onValueSelect(filter, value)
+                            }
+                        })
                     })
                 )
                 .subscribe()
@@ -510,13 +563,15 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         this.subscriptions.add(
             // Use this.activeFilterChanges not activeFilterChanges so that it doesn't trigger on the initial mount
             // (it doesn't need to).
-            this.activeFilterChanges.subscribe(filter => this.setState({ activeFilter: filter }))
+            this.activeValuesChanges.subscribe(values => {
+                this.setState({ activeValues: new Map(values) })
+            })
         )
 
         this.subscriptions.add(
             combineLatest([
                 queryChanges,
-                activeFilterChanges,
+                activeValuesChanges,
                 refreshRequests.pipe(
                     startWith<{ forceRefresh: boolean }>({ forceRefresh: false })
                 ),
@@ -524,28 +579,28 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                 .pipe(
                     // Track whether the query or the active filter changed
                     scan<
-                        [string, FilteredConnectionFilter | undefined, { forceRefresh: boolean }],
+                        [string, Map<string, FilterValue> | undefined, { forceRefresh: boolean }],
                         {
                             query: string
-                            filter: FilteredConnectionFilter | undefined
+                            values: Map<string, FilterValue> | undefined
                             shouldRefresh: boolean
                             queryCount: number
                         }
                     >(
-                        ({ query, filter, queryCount }, [currentQuery, currentFilter, { forceRefresh }]) => ({
+                        ({ query, values, queryCount }, [currentQuery, currentValues, { forceRefresh }]) => ({
                             query: currentQuery,
-                            filter: currentFilter,
-                            shouldRefresh: forceRefresh || query !== currentQuery || filter !== currentFilter,
+                            values: currentValues,
+                            shouldRefresh: forceRefresh || query !== currentQuery || values !== currentValues,
                             queryCount: queryCount + 1,
                         }),
                         {
                             query: this.state.query,
-                            filter: undefined,
+                            values: this.state.activeValues,
                             shouldRefresh: false,
                             queryCount: 0,
                         }
                     ),
-                    switchMap(({ query, filter, shouldRefresh, queryCount }) => {
+                    switchMap(({ query, values, shouldRefresh, queryCount }) => {
                         const result = this.props
                             .queryConnection({
                                 // If this is our first query and we were supplied a value for `visible`,
@@ -554,7 +609,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 first: (queryCount === 1 && this.state.visible) || this.state.first,
                                 after: shouldRefresh ? undefined : this.state.after,
                                 query,
-                                ...(filter ? filter.args : {}),
+                                ...(values ? this.buildArgs(values) : {}),
                             })
                             .pipe(
                                 catchError(error => [asError(error)]),
@@ -695,12 +750,12 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
     private urlQuery({
         first,
         query,
-        filter,
+        values,
         visible,
     }: {
         first?: number
         query?: string
-        filter?: FilteredConnectionFilter
+        values?: Map<string, FilterValue>
         visible?: number
     }): string {
         if (!first) {
@@ -709,8 +764,8 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         if (!query) {
             query = this.state.query
         }
-        if (!filter) {
-            filter = this.state.activeFilter
+        if (!values) {
+            values = this.state.activeValues
         }
         const searchParameters = new URLSearchParams(this.props.location.search)
         if (query) {
@@ -720,12 +775,21 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         if (first !== this.props.defaultFirst) {
             searchParameters.set('first', String(first))
         }
-        if (filter && this.props.filters) {
-            if (filter !== this.props.filters[0]) {
-                searchParameters.set('filter', filter.id)
-            } else {
-                searchParameters.delete('filter')
-            }
+        if (values && this.props.filters) {
+            this.props.filters.map(filter => {
+                if (values === undefined) {
+                    return
+                }
+                const value = values.get(filter.id)
+                if (value === undefined) {
+                    return
+                }
+                if (value !== filter.values[0]) {
+                    searchParameters.set(filter.id, value.value)
+                } else {
+                    searchParameters.delete(filter.id)
+                }
+            })
         }
         if (visible !== 0 && visible !== first) {
             searchParameters.set('visible', String(visible))
@@ -763,6 +827,15 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
             >
                 {(!this.props.hideSearch || this.props.filters) && (
                     <Form className="filtered-connection__form" onSubmit={this.onSubmit}>
+                        {this.props.filters && (
+                            <FilteredConnectionFilterControl
+                                filters={this.props.filters}
+                                onDidSelectValue={this.onDidSelectValue}
+                                values={this.state.activeValues}
+                            >
+                                {this.props.additionalFilterElement}
+                            </FilteredConnectionFilterControl>
+                        )}
                         {!this.props.hideSearch && (
                             <input
                                 className="form-control filtered-connection__filter"
@@ -778,17 +851,6 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                                 ref={this.setFilterRef}
                                 spellCheck={false}
                             />
-                        )}
-                        {this.props.filters && this.state.activeFilter ? (
-                            <FilteredConnectionFilterControl
-                                filters={this.props.filters}
-                                onDidSelectFilter={this.onDidSelectFilter}
-                                value={this.state.activeFilter.id}
-                            >
-                                {this.props.additionalFilterElement}
-                            </FilteredConnectionFilterControl>
-                        ) : (
-                            this.props.additionalFilterElement
                         )}
                     </Form>
                 )}
@@ -858,10 +920,29 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         this.queryInputChanges.next(event.currentTarget.value)
     }
 
-    private onDidSelectFilter = (filter: FilteredConnectionFilter): void => this.activeFilterChanges.next(filter)
+    private onDidSelectValue = (filter: FilteredConnectionFilter, value: FilterValue): void => {
+        if (this.props.filters === undefined) {
+            return
+        }
+        const values = this.state.activeValues
+        values.set(filter.id, value)
+        this.activeValuesChanges.next(values)
+    }
 
     private onClickShowMore = (): void => {
         this.showMoreClicks.next()
+    }
+
+    private buildArgs = (values: Map<string, FilterValue>): { [name: string]: string | number | boolean } => {
+        let args: { [name: string]: string | number | boolean } = {}
+        for (const key of values.keys()) {
+            const value = values.get(key)
+            if (value === undefined) {
+                continue
+            }
+            args = { ...args, ...value.args }
+        }
+        return args
     }
 }
 
@@ -879,18 +960,24 @@ function parseQueryInt(searchParameters: URLSearchParams, name: string): number 
 
 function getFilterFromURL(
     searchParameters: URLSearchParams,
-    filters: FilteredConnectionFilter[] | undefined,
-    defaultFilterId: string | undefined
-): FilteredConnectionFilter | undefined {
+    filters: FilteredConnectionFilter[] | undefined
+): Map<string, FilterValue> {
+    const values: Map<string, FilterValue> = new Map<string, FilterValue>()
+
     if (filters === undefined || filters.length === 0) {
-        return undefined
+        return values
     }
-    const id = searchParameters.get('filter') || defaultFilterId
-    if (id !== null) {
-        const filter = filters.find(filter => filter.id === id)
-        if (filter) {
-            return filter
+    filters.map(filter => {
+        const urlValue = searchParameters.get(filter.id)
+        if (urlValue !== null) {
+            const value = filter.values.find(value => value.value === urlValue)
+            if (value !== undefined) {
+                values.set(filter.id, value)
+                return
+            }
         }
-    }
-    return filters[0] // default
+        // couldn't find a value, add default
+        values.set(filter.id, filter.values[0])
+    })
+    return values
 }

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
@@ -32,23 +32,30 @@ export interface CampaignListPageProps extends TelemetryProps, Pick<RouteCompone
 
 const FILTERS: FilteredConnectionFilter[] = [
     {
-        label: 'Open',
-        id: 'open',
-        tooltip: 'Show only campaigns that are open',
-        args: { state: CampaignState.OPEN },
-    },
-    {
-        label: 'Closed',
-        id: 'closed',
-        tooltip: 'Show only campaigns that are closed',
-        args: { state: CampaignState.CLOSED },
-    },
-    {
-        label: 'All',
-        id: 'all',
-        tooltip: 'Show all campaigns',
-        args: {},
-    },
+        id: 'status',
+        label: 'Status',
+        type: 'radio',
+        values: [
+            {
+                label: 'Open',
+                value: 'open',
+                tooltip: 'Show only campaigns that are open',
+                args: { state: CampaignState.OPEN },
+            },
+            {
+                label: 'Closed',
+                value: 'closed',
+                tooltip: 'Show only campaigns that are closed',
+                args: { state: CampaignState.CLOSED },
+            },
+            {
+                label: 'All',
+                value: 'all',
+                tooltip: 'Show all campaigns',
+                args: {},
+            },
+        ]
+    }
 ]
 
 type SelectedTab = 'campaigns' | 'gettingStarted'

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
@@ -54,8 +54,8 @@ const FILTERS: FilteredConnectionFilter[] = [
                 tooltip: 'Show all campaigns',
                 args: {},
             },
-        ]
-    }
+        ],
+    },
 ]
 
 type SelectedTab = 'campaigns' | 'gettingStarted'

--- a/client/web/src/enterprise/campaigns/list/__snapshots__/CampaignListPage.test.tsx.snap
+++ b/client/web/src/enterprise/campaigns/list/__snapshots__/CampaignListPage.test.tsx.snap
@@ -34,26 +34,33 @@ exports[`CampaignListPage renders for non-siteadmin and totalCount: 0 1`] = `
     filters={
       Array [
         Object {
-          "args": Object {
-            "state": "OPEN",
-          },
-          "id": "open",
-          "label": "Open",
-          "tooltip": "Show only campaigns that are open",
-        },
-        Object {
-          "args": Object {
-            "state": "CLOSED",
-          },
-          "id": "closed",
-          "label": "Closed",
-          "tooltip": "Show only campaigns that are closed",
-        },
-        Object {
-          "args": Object {},
-          "id": "all",
-          "label": "All",
-          "tooltip": "Show all campaigns",
+          "id": "status",
+          "label": "Status",
+          "type": "radio",
+          "values": Array [
+            Object {
+              "args": Object {
+                "state": "OPEN",
+              },
+              "label": "Open",
+              "tooltip": "Show only campaigns that are open",
+              "value": "open",
+            },
+            Object {
+              "args": Object {
+                "state": "CLOSED",
+              },
+              "label": "Closed",
+              "tooltip": "Show only campaigns that are closed",
+              "value": "closed",
+            },
+            Object {
+              "args": Object {},
+              "label": "All",
+              "tooltip": "Show all campaigns",
+              "value": "all",
+            },
+          ],
         },
       ]
     }
@@ -118,26 +125,33 @@ exports[`CampaignListPage renders for non-siteadmin and totalCount: 1 1`] = `
     filters={
       Array [
         Object {
-          "args": Object {
-            "state": "OPEN",
-          },
-          "id": "open",
-          "label": "Open",
-          "tooltip": "Show only campaigns that are open",
-        },
-        Object {
-          "args": Object {
-            "state": "CLOSED",
-          },
-          "id": "closed",
-          "label": "Closed",
-          "tooltip": "Show only campaigns that are closed",
-        },
-        Object {
-          "args": Object {},
-          "id": "all",
-          "label": "All",
-          "tooltip": "Show all campaigns",
+          "id": "status",
+          "label": "Status",
+          "type": "radio",
+          "values": Array [
+            Object {
+              "args": Object {
+                "state": "OPEN",
+              },
+              "label": "Open",
+              "tooltip": "Show only campaigns that are open",
+              "value": "open",
+            },
+            Object {
+              "args": Object {
+                "state": "CLOSED",
+              },
+              "label": "Closed",
+              "tooltip": "Show only campaigns that are closed",
+              "value": "closed",
+            },
+            Object {
+              "args": Object {},
+              "label": "All",
+              "tooltip": "Show all campaigns",
+              "value": "all",
+            },
+          ],
         },
       ]
     }
@@ -202,26 +216,33 @@ exports[`CampaignListPage renders for siteadmin and totalCount: 0 1`] = `
     filters={
       Array [
         Object {
-          "args": Object {
-            "state": "OPEN",
-          },
-          "id": "open",
-          "label": "Open",
-          "tooltip": "Show only campaigns that are open",
-        },
-        Object {
-          "args": Object {
-            "state": "CLOSED",
-          },
-          "id": "closed",
-          "label": "Closed",
-          "tooltip": "Show only campaigns that are closed",
-        },
-        Object {
-          "args": Object {},
-          "id": "all",
-          "label": "All",
-          "tooltip": "Show all campaigns",
+          "id": "status",
+          "label": "Status",
+          "type": "radio",
+          "values": Array [
+            Object {
+              "args": Object {
+                "state": "OPEN",
+              },
+              "label": "Open",
+              "tooltip": "Show only campaigns that are open",
+              "value": "open",
+            },
+            Object {
+              "args": Object {
+                "state": "CLOSED",
+              },
+              "label": "Closed",
+              "tooltip": "Show only campaigns that are closed",
+              "value": "closed",
+            },
+            Object {
+              "args": Object {},
+              "label": "All",
+              "tooltip": "Show all campaigns",
+              "value": "all",
+            },
+          ],
         },
       ]
     }
@@ -286,26 +307,33 @@ exports[`CampaignListPage renders for siteadmin and totalCount: 1 1`] = `
     filters={
       Array [
         Object {
-          "args": Object {
-            "state": "OPEN",
-          },
-          "id": "open",
-          "label": "Open",
-          "tooltip": "Show only campaigns that are open",
-        },
-        Object {
-          "args": Object {
-            "state": "CLOSED",
-          },
-          "id": "closed",
-          "label": "Closed",
-          "tooltip": "Show only campaigns that are closed",
-        },
-        Object {
-          "args": Object {},
-          "id": "all",
-          "label": "All",
-          "tooltip": "Show all campaigns",
+          "id": "status",
+          "label": "Status",
+          "type": "radio",
+          "values": Array [
+            Object {
+              "args": Object {
+                "state": "OPEN",
+              },
+              "label": "Open",
+              "tooltip": "Show only campaigns that are open",
+              "value": "open",
+            },
+            Object {
+              "args": Object {
+                "state": "CLOSED",
+              },
+              "label": "Closed",
+              "tooltip": "Show only campaigns that are closed",
+              "value": "closed",
+            },
+            Object {
+              "args": Object {},
+              "label": "All",
+              "tooltip": "Show all campaigns",
+              "value": "all",
+            },
+          ],
         },
       ]
     }

--- a/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.tsx
@@ -20,29 +20,36 @@ export interface CodeIntelIndexesPageProps extends RouteComponentProps<{}>, Tele
 
 const filters: FilteredConnectionFilter[] = [
     {
-        label: 'All',
-        id: 'all',
-        tooltip: 'Show all indexes',
-        args: {},
-    },
-    {
-        label: 'Completed',
-        id: 'completed',
-        tooltip: 'Show completed indexes only',
-        args: { state: LSIFIndexState.COMPLETED },
-    },
-    {
-        label: 'Errored',
-        id: 'errored',
-        tooltip: 'Show errored indexes only',
-        args: { state: LSIFIndexState.ERRORED },
-    },
-    {
-        label: 'Queued',
-        id: 'queued',
-        tooltip: 'Show queued indexes only',
-        args: { state: LSIFIndexState.QUEUED },
-    },
+        id: 'filters',
+        label: 'Filters',
+        type: 'radio',
+        values: [
+            {
+                label: 'All',
+                value: 'all',
+                tooltip: 'Show all indexes',
+                args: {},
+            },
+            {
+                label: 'Completed',
+                value: 'completed',
+                tooltip: 'Show completed indexes only',
+                args: {state: LSIFIndexState.COMPLETED},
+            },
+            {
+                label: 'Errored',
+                value: 'errored',
+                tooltip: 'Show errored indexes only',
+                args: {state: LSIFIndexState.ERRORED},
+            },
+            {
+                label: 'Queued',
+                value: 'queued',
+                tooltip: 'Show queued indexes only',
+                args: {state: LSIFIndexState.QUEUED},
+            },
+        ]
+    }
 ]
 
 export const CodeIntelIndexesPage: FunctionComponent<CodeIntelIndexesPageProps> = ({

--- a/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.tsx
@@ -34,22 +34,22 @@ const filters: FilteredConnectionFilter[] = [
                 label: 'Completed',
                 value: 'completed',
                 tooltip: 'Show completed indexes only',
-                args: {state: LSIFIndexState.COMPLETED},
+                args: { state: LSIFIndexState.COMPLETED },
             },
             {
                 label: 'Errored',
                 value: 'errored',
                 tooltip: 'Show errored indexes only',
-                args: {state: LSIFIndexState.ERRORED},
+                args: { state: LSIFIndexState.ERRORED },
             },
             {
                 label: 'Queued',
                 value: 'queued',
                 tooltip: 'Show queued indexes only',
-                args: {state: LSIFIndexState.QUEUED},
+                args: { state: LSIFIndexState.QUEUED },
             },
-        ]
-    }
+        ],
+    },
 ]
 
 export const CodeIntelIndexesPage: FunctionComponent<CodeIntelIndexesPageProps> = ({

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
@@ -20,35 +20,42 @@ export interface CodeIntelUploadsPageProps extends RouteComponentProps<{}>, Tele
 
 const filters: FilteredConnectionFilter[] = [
     {
-        label: 'All',
-        id: 'all',
-        tooltip: 'Show all uploads',
-        args: {},
-    },
-    {
-        label: 'Current',
-        id: 'current',
-        tooltip: 'Show current uploads only',
-        args: { isLatestForRepo: true },
-    },
-    {
-        label: 'Completed',
-        id: 'completed',
-        tooltip: 'Show completed uploads only',
-        args: { state: LSIFUploadState.COMPLETED },
-    },
-    {
-        label: 'Errored',
-        id: 'errored',
-        tooltip: 'Show errored uploads only',
-        args: { state: LSIFUploadState.ERRORED },
-    },
-    {
-        label: 'Queued',
-        id: 'queued',
-        tooltip: 'Show queued uploads only',
-        args: { state: LSIFUploadState.QUEUED },
-    },
+        id: 'filter',
+        type: 'radio',
+        label: 'Filter',
+        values: [
+        {
+            label: 'All',
+            value: 'all',
+            tooltip: 'Show all uploads',
+            args: {},
+        },
+        {
+            label: 'Current',
+            value: 'current',
+            tooltip: 'Show current uploads only',
+            args: { isLatestForRepo: true },
+        },
+        {
+            label: 'Completed',
+            value: 'completed',
+            tooltip: 'Show completed uploads only',
+            args: { state: LSIFUploadState.COMPLETED },
+        },
+        {
+            label: 'Errored',
+            value: 'errored',
+            tooltip: 'Show errored uploads only',
+            args: { state: LSIFUploadState.ERRORED },
+        },
+        {
+            label: 'Queued',
+            value: 'queued',
+            tooltip: 'Show queued uploads only',
+            args: { state: LSIFUploadState.QUEUED },
+        },
+        ]
+    }
 ]
 
 export const CodeIntelUploadsPage: FunctionComponent<CodeIntelUploadsPageProps> = ({

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
@@ -24,38 +24,38 @@ const filters: FilteredConnectionFilter[] = [
         type: 'radio',
         label: 'Filter',
         values: [
-        {
-            label: 'All',
-            value: 'all',
-            tooltip: 'Show all uploads',
-            args: {},
-        },
-        {
-            label: 'Current',
-            value: 'current',
-            tooltip: 'Show current uploads only',
-            args: { isLatestForRepo: true },
-        },
-        {
-            label: 'Completed',
-            value: 'completed',
-            tooltip: 'Show completed uploads only',
-            args: { state: LSIFUploadState.COMPLETED },
-        },
-        {
-            label: 'Errored',
-            value: 'errored',
-            tooltip: 'Show errored uploads only',
-            args: { state: LSIFUploadState.ERRORED },
-        },
-        {
-            label: 'Queued',
-            value: 'queued',
-            tooltip: 'Show queued uploads only',
-            args: { state: LSIFUploadState.QUEUED },
-        },
-        ]
-    }
+            {
+                label: 'All',
+                value: 'all',
+                tooltip: 'Show all uploads',
+                args: {},
+            },
+            {
+                label: 'Current',
+                value: 'current',
+                tooltip: 'Show current uploads only',
+                args: { isLatestForRepo: true },
+            },
+            {
+                label: 'Completed',
+                value: 'completed',
+                tooltip: 'Show completed uploads only',
+                args: { state: LSIFUploadState.COMPLETED },
+            },
+            {
+                label: 'Errored',
+                value: 'errored',
+                tooltip: 'Show errored uploads only',
+                args: { state: LSIFUploadState.ERRORED },
+            },
+            {
+                label: 'Queued',
+                value: 'queued',
+                tooltip: 'Show queued uploads only',
+                args: { state: LSIFUploadState.QUEUED },
+            },
+        ],
+    },
 ]
 
 export const CodeIntelUploadsPage: FunctionComponent<CodeIntelUploadsPageProps> = ({

--- a/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -160,8 +160,8 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
                     tooltip: 'Show only extensions from the local registry',
                     args: { remote: false, local: true },
                 },
-            ]
-        }
+            ],
+        },
     ]
 
     private updates = new Subject<void>()

--- a/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -138,23 +138,30 @@ interface Props extends RouteComponentProps<{}> {}
 export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> {
     public static FILTERS: FilteredConnectionFilter[] = [
         {
-            label: 'All',
-            id: 'all',
-            tooltip: 'Show all extensions',
-            args: { remote: true, local: true },
-        },
-        {
-            label: 'Remote',
-            id: 'remote',
-            tooltip: 'Show only extensions from the remote registry',
-            args: { remote: true, local: false },
-        },
-        {
-            label: 'Local',
-            id: 'local',
-            tooltip: 'Show only extensions from the local registry',
-            args: { remote: false, local: true },
-        },
+            id: 'filter',
+            label: 'Filter',
+            type: 'radio',
+            values: [
+                {
+                    label: 'All',
+                    value: 'all',
+                    tooltip: 'Show all extensions',
+                    args: { remote: true, local: true },
+                },
+                {
+                    label: 'Remote',
+                    value: 'remote',
+                    tooltip: 'Show only extensions from the remote registry',
+                    args: { remote: true, local: false },
+                },
+                {
+                    label: 'Local',
+                    value: 'local',
+                    tooltip: 'Show only extensions from the local registry',
+                    args: { remote: false, local: true },
+                },
+            ]
+        }
     ]
 
     private updates = new Subject<void>()

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -83,22 +83,22 @@ const FILTERS: FilteredConnectionFilter[] = [
                 label: 'Cloned',
                 value: 'cloned',
                 tooltip: 'Show cloned repositories only',
-                args: {cloned: true, notCloned: false},
+                args: { cloned: true, notCloned: false },
             },
             {
                 label: 'Not cloned',
                 value: 'not-cloned',
                 tooltip: 'Show only repositories that have not been cloned yet',
-                args: {cloned: false, notCloned: true},
+                args: { cloned: false, notCloned: true },
             },
             {
                 label: 'Needs index',
                 value: 'needs-index',
                 tooltip: 'Show only repositories that need to be indexed',
-                args: {indexed: false},
+                args: { indexed: false },
             },
-        ]
-    }
+        ],
+    },
 ]
 
 /**

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -69,29 +69,36 @@ interface Props extends RouteComponentProps<{}>, TelemetryProps {}
 
 const FILTERS: FilteredConnectionFilter[] = [
     {
-        label: 'All',
-        id: 'all',
-        tooltip: 'Show all repositories',
-        args: {},
-    },
-    {
-        label: 'Cloned',
-        id: 'cloned',
-        tooltip: 'Show cloned repositories only',
-        args: { cloned: true, notCloned: false },
-    },
-    {
-        label: 'Not cloned',
-        id: 'not-cloned',
-        tooltip: 'Show only repositories that have not been cloned yet',
-        args: { cloned: false, notCloned: true },
-    },
-    {
-        label: 'Needs index',
-        id: 'needs-index',
-        tooltip: 'Show only repositories that need to be indexed',
-        args: { indexed: false },
-    },
+        id: 'status',
+        label: 'Status',
+        type: 'radio',
+        values: [
+            {
+                label: 'All',
+                value: 'all',
+                tooltip: 'Show all repositories',
+                args: {},
+            },
+            {
+                label: 'Cloned',
+                value: 'cloned',
+                tooltip: 'Show cloned repositories only',
+                args: {cloned: true, notCloned: false},
+            },
+            {
+                label: 'Not cloned',
+                value: 'not-cloned',
+                tooltip: 'Show only repositories that have not been cloned yet',
+                args: {cloned: false, notCloned: true},
+            },
+            {
+                label: 'Needs index',
+                value: 'needs-index',
+                tooltip: 'Show only repositories that need to be indexed',
+                args: {indexed: false},
+            },
+        ]
+    }
 ]
 
 /**

--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -158,30 +158,37 @@ class UserUsageStatisticsNode extends React.PureComponent<UserUsageStatisticsNod
 class FilteredUserConnection extends FilteredConnection<GQL.IUser, {}> {}
 export const USER_ACTIVITY_FILTERS: FilteredConnectionFilter[] = [
     {
-        label: 'All users',
-        id: 'all',
-        tooltip: 'Show all users',
-        args: { activePeriod: UserActivePeriod.ALL_TIME },
-    },
-    {
-        label: 'Active today',
-        id: 'today',
-        tooltip: 'Show users active since this morning at 00:00 UTC',
-        args: { activePeriod: UserActivePeriod.TODAY },
-    },
-    {
-        label: 'Active this week',
-        id: 'week',
-        tooltip: 'Show users active since Monday at 00:00 UTC',
-        args: { activePeriod: UserActivePeriod.THIS_WEEK },
-    },
-    {
-        label: 'Active this month',
-        id: 'month',
-        tooltip: 'Show users active since the first day of the month at 00:00 UTC',
-        args: { activePeriod: UserActivePeriod.THIS_MONTH },
-    },
-]
+        label: '',
+        type:'radio',
+        id: 'user-activity-filters',
+        values: [
+            {
+                label: 'All users',
+                value: 'all',
+                tooltip: 'Show all users',
+                args: {activePeriod: UserActivePeriod.ALL_TIME},
+            },
+            {
+                label: 'Active today',
+                value: 'today',
+                tooltip: 'Show users active since this morning at 00:00 UTC',
+                args: {activePeriod: UserActivePeriod.TODAY},
+            },
+            {
+                label: 'Active this week',
+                value: 'week',
+                tooltip: 'Show users active since Monday at 00:00 UTC',
+                args: {activePeriod: UserActivePeriod.THIS_WEEK},
+            },
+            {
+                label: 'Active this month',
+                value: 'month',
+                tooltip: 'Show users active since the first day of the month at 00:00 UTC',
+                args: {activePeriod: UserActivePeriod.THIS_MONTH},
+            }
+        ]
+    }
+    ]
 
 interface SiteAdminUsageStatisticsPageProps extends RouteComponentProps<{}> {
     isLightTheme: boolean

--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -159,36 +159,36 @@ class FilteredUserConnection extends FilteredConnection<GQL.IUser, {}> {}
 export const USER_ACTIVITY_FILTERS: FilteredConnectionFilter[] = [
     {
         label: '',
-        type:'radio',
+        type: 'radio',
         id: 'user-activity-filters',
         values: [
             {
                 label: 'All users',
                 value: 'all',
                 tooltip: 'Show all users',
-                args: {activePeriod: UserActivePeriod.ALL_TIME},
+                args: { activePeriod: UserActivePeriod.ALL_TIME },
             },
             {
                 label: 'Active today',
                 value: 'today',
                 tooltip: 'Show users active since this morning at 00:00 UTC',
-                args: {activePeriod: UserActivePeriod.TODAY},
+                args: { activePeriod: UserActivePeriod.TODAY },
             },
             {
                 label: 'Active this week',
                 value: 'week',
                 tooltip: 'Show users active since Monday at 00:00 UTC',
-                args: {activePeriod: UserActivePeriod.THIS_WEEK},
+                args: { activePeriod: UserActivePeriod.THIS_WEEK },
             },
             {
                 label: 'Active this month',
                 value: 'month',
                 tooltip: 'Show users active since the first day of the month at 00:00 UTC',
-                args: {activePeriod: UserActivePeriod.THIS_MONTH},
-            }
-        ]
-    }
-    ]
+                args: { activePeriod: UserActivePeriod.THIS_MONTH },
+            },
+        ],
+    },
+]
 
 interface SiteAdminUsageStatisticsPageProps extends RouteComponentProps<{}> {
     isLightTheme: boolean


### PR DESCRIPTION
This adds support for multiple filters on a FilteredConnection, with each filter concatenating the arguments to the graphql query. This was needed to support the design here: https://www.figma.com/file/zXvqCASHDzmvKbrAl1EVsd/Public-%26-Private-Repos-for-Users-on-Cloud?node-id=699%3A2302

and i'll be raising a separate PR for adding the user repositories settings page.

here's what the select filters look like: 
<img width="1677" alt="Screenshot 2020-11-25 at 16 16 39" src="https://user-images.githubusercontent.com/5236823/100354691-6d716c00-2fe8-11eb-86eb-d06d81cea773.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
