### PR TITLE
Remove external code host link e2e test

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -1092,30 +1092,6 @@ describe('e2e test suite', () => {
                 await driver.assertAllHighlightedTokens('Router')
             })
         })
-
-        describe('external code host links', () => {
-            test('on repo navbar ("View on GitHub")', async () => {
-                await driver.page.goto(
-                    sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go#L19',
-                    { waitUntil: 'domcontentloaded' }
-                )
-                await driver.page.waitForSelector('.nav-link[href*="https://github"]', {
-                    visible: true,
-                    timeout: 300000,
-                })
-                await retry(async () =>
-                    expect(
-                        await driver.page.evaluate(
-                            () =>
-                                (document.querySelector('.nav-link[href*="https://github"]') as HTMLAnchorElement).href
-                        )
-                    ).toEqual(
-                        'https://github.com/sourcegraph/go-diff/blob/3f415a150aec0685cb81b73cc201e762e075006d/diff/parse.go#L19'
-                    )
-                )
-            })
-        })
     })
 
     describe('Search component', () => {


### PR DESCRIPTION
Closes #16135

This e2e test is broken, and the same functionality is covered in a [frontend integration test](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/integration/repository.test.ts#L484-489).

We can merge this once we have a corresponding backend integration test.