### PR TITLE
campaigns: add changeset text search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Individual changesets can now be downloaded as a diff. [#16098](https://github.com/sourcegraph/sourcegraph/issues/16098)
 - The campaigns preview page is much more detailed now, especially when updating existing campaigns. [#16240](https://github.com/sourcegraph/sourcegraph/pull/16240)
 - When a newer version of a campaign spec is uploaded, a message is now displayed when viewing the campaign or an outdated campaign spec. [#14532](https://github.com/sourcegraph/sourcegraph/issues/14532)
+- Changesets in a campaign can now be searched by title and repository name. [#15781](https://github.com/sourcegraph/sourcegraph/issues/15781)
 
 ### Changed
 

--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -17,7 +17,6 @@
 @import './enterprise/campaigns/close/HiddenExternalChangesetCloseNode';
 @import './enterprise/campaigns/close/ExternalChangesetCloseNode';
 @import './enterprise/campaigns/detail/changesets/CampaignChangesets';
-@import './enterprise/campaigns/detail/changesets/ChangesetFilterRow';
 @import './enterprise/campaigns/detail/changesets/ChangesetLabel';
 @import './enterprise/campaigns/detail/changesets/ChangesetNode';
 @import './enterprise/campaigns/detail/changesets/EmptyChangesetListElement';

--- a/client/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
@@ -78,6 +78,7 @@ export const CampaignCloseChangesetsList: React.FunctionComponent<Props> = ({
                 after: args.after ?? null,
                 campaign: campaignID,
                 onlyPublishedByThisCampaign: true,
+                search: null,
             }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000)))),
         [campaignID, queryChangesets]
     )

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -190,6 +190,7 @@ export const queryChangesets = ({
     publicationState,
     reconcilerState,
     onlyPublishedByThisCampaign,
+    search,
 }: CampaignChangesetsVariables): Observable<
     (CampaignChangesetsResult['node'] & { __typename: 'Campaign' })['changesets']
 > =>
@@ -205,6 +206,7 @@ export const queryChangesets = ({
                 $publicationState: ChangesetPublicationState
                 $reconcilerState: [ChangesetReconcilerState!]
                 $onlyPublishedByThisCampaign: Boolean
+                $search: String
             ) {
                 node(id: $campaign) {
                     __typename
@@ -218,6 +220,7 @@ export const queryChangesets = ({
                             reviewState: $reviewState
                             checkState: $checkState
                             onlyPublishedByThisCampaign: $onlyPublishedByThisCampaign
+                            search: $search
                         ) {
                             totalCount
                             pageInfo {
@@ -244,6 +247,7 @@ export const queryChangesets = ({
             publicationState,
             reconcilerState,
             onlyPublishedByThisCampaign,
+            search,
         }
     ).pipe(
         map(dataOrThrowErrors),

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -66,6 +66,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
         reviewState: null,
         publicationState: null,
         reconcilerState: null,
+        search: null,
     })
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArguments) =>
@@ -79,6 +80,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                 after: args.after ?? null,
                 campaign: campaignID,
                 onlyPublishedByThisCampaign: null,
+                search: changesetFilters.search,
             }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000)))),
         [
             campaignID,
@@ -87,6 +89,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
             changesetFilters.checkState,
             changesetFilters.reconcilerState,
             changesetFilters.publicationState,
+            changesetFilters.search,
             queryChangesets,
         ]
     )
@@ -148,7 +151,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
     return (
         <>
             {!hideFilters && (
-                <div className="d-flex justify-content-end">
+                <div className="d-sm-flex justify-content-end">
                     <ChangesetFilterRow history={history} location={location} onFiltersChange={setChangesetFilters} />
                 </div>
             )}
@@ -206,6 +209,7 @@ function filtersSelected(filters: ChangesetFilters): boolean {
         filters.externalState !== null ||
         filters.publicationState !== null ||
         filters.reconcilerState !== null ||
-        filters.reviewState !== null
+        filters.reviewState !== null ||
+        !!filters.search
     )
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -152,9 +152,7 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
     return (
         <>
             {!hideFilters && (
-                <div className="d-sm-flex justify-content-end">
-                    <ChangesetFilterRow history={history} location={location} onFiltersChange={setChangesetFilters} />
-                </div>
+                <ChangesetFilterRow history={history} location={location} onFiltersChange={setChangesetFilters} />
             )}
             <div className="list-group position-relative" ref={nextContainerElement}>
                 <FilteredConnection<ChangesetFields, Omit<ChangesetNodeProps, 'node'>>

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -26,6 +26,7 @@ import { getLSPTextDocumentPositionParameters } from '../../utils'
 import { CampaignChangesetsHeader } from './CampaignChangesetsHeader'
 import { ChangesetFilters, ChangesetFilterRow } from './ChangesetFilterRow'
 import { EmptyChangesetListElement } from './EmptyChangesetListElement'
+import { EmptyChangesetSearchElement } from './EmptyChangesetSearchElement'
 
 interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
     campaignID: Scalars['ID']
@@ -180,7 +181,13 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                     listClassName="campaign-changesets__grid mb-3"
                     headComponent={CampaignChangesetsHeader}
                     // Only show the empty element, if no filters are selected.
-                    emptyElement={filtersSelected(changesetFilters) ? undefined : <EmptyChangesetListElement />}
+                    emptyElement={
+                        filtersSelected(changesetFilters) ? (
+                            <EmptyChangesetSearchElement />
+                        ) : (
+                            <EmptyChangesetListElement />
+                        )
+                    }
                     noSummaryIfAllNodesVisible={true}
                 />
                 {hoverState?.hoverOverlayProps && (

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.scss
@@ -5,4 +5,9 @@
             margin-bottom: 0.5rem;
         }
     }
+
+    &__search {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.scss
@@ -1,8 +1,0 @@
-.changeset-filter {
-    &__dropdown {
-        @include media-breakpoint-down(xs) {
-            margin-right: 0 !important;
-            margin-bottom: 0.5rem;
-        }
-    }
-}

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.scss
@@ -5,9 +5,4 @@
             margin-bottom: 0.5rem;
         }
     }
-
-    &__search {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-    }
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
@@ -107,52 +107,51 @@ export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps
 
     return (
         <>
-            <div className="row">
+            <div className="row no-gutters">
                 <div className="m-0 col">
                     <Form className="form-inline d-flex my-2" onSubmit={onSubmit}>
                         <input
                             className="form-control flex-grow-1 changeset-filter__search"
-                            type="text"
+                            type="search"
                             ref={searchElement}
                             defaultValue={search}
-                            placeholder="Search"
+                            placeholder="Search title and repository name"
                         />
                     </Form>
                 </div>
-                <div className="m-0 my-2 col-auto">
-                    <div className="form-inline row">
-                        <ChangesetFilter<ChangesetUIState>
-                            values={Object.values(ChangesetUIState)}
-                            label="Changeset state"
-                            selected={uiState}
-                            onChange={setUIState}
-                            className="col ml-2"
-                        />
-                        <ChangesetFilter<ChangesetCheckState>
-                            values={Object.values(ChangesetCheckState)}
-                            label="Check state"
-                            selected={checkState}
-                            onChange={setCheckState}
-                            className="col ml-2"
-                        />
-                        <ChangesetFilter<ChangesetReviewState>
-                            values={Object.values(ChangesetReviewState)}
-                            label="Review state"
-                            selected={reviewState}
-                            onChange={setReviewState}
-                            className="col ml-2"
-                        />
+                <div className="w-100 d-block d-md-none" />
+                <div className="m-0 col col-md-auto">
+                    <div className="row no-gutters">
+                        <div className="col my-2 ml-0 ml-md-2">
+                            <ChangesetFilter<ChangesetUIState>
+                                values={Object.values(ChangesetUIState)}
+                                label="Status"
+                                selected={uiState}
+                                onChange={setUIState}
+                                className="w-100"
+                            />
+                        </div>
+                        <div className="col my-2 ml-2">
+                            <ChangesetFilter<ChangesetCheckState>
+                                values={Object.values(ChangesetCheckState)}
+                                label="Check state"
+                                selected={checkState}
+                                onChange={setCheckState}
+                                className="w-100"
+                            />
+                        </div>
+                        <div className="w-100 d-block d-sm-none" />
+                        <div className="col my-2 ml-0 ml-sm-2">
+                            <ChangesetFilter<ChangesetReviewState>
+                                values={Object.values(ChangesetReviewState)}
+                                label="Review state"
+                                selected={reviewState}
+                                onChange={setReviewState}
+                                className="w-100"
+                            />
+                        </div>
+                        <div className="col d-block d-sm-none ml-2" />
                     </div>
-                </div>
-            </div>
-            <div className="row">
-                <div className="m-0 col d-flex">
-                    <div className="flex-grow-1">this is a thing</div>
-                </div>
-                <div className="m-0 my-2 col-auto">
-                    <select>
-                        <option>this is a non-expanding thing</option>
-                    </select>
                 </div>
             </div>
         </>

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
@@ -16,7 +16,6 @@ import {
 import classNames from 'classnames'
 import { upperFirst, lowerCase } from 'lodash'
 import { Form } from 'reactstrap'
-import { SearchButton } from '../../../../search/input/SearchButton'
 
 export interface ChangesetFilters {
     externalState: ChangesetExternalState | null
@@ -108,39 +107,53 @@ export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps
 
     return (
         <>
-            <div className="form-inline flex-grow-1 m-0 my-2">
-                <Form className="w-100 d-flex" onSubmit={onSubmit}>
-                    <input
-                        className="form-control w-100 changeset-filter__search"
-                        type="text"
-                        ref={searchElement}
-                        defaultValue={search}
-                        placeholder="Search"
-                    />
-                    <SearchButton noHelp={true} />
-                </Form>
+            <div className="row">
+                <div className="m-0 col">
+                    <Form className="form-inline d-flex my-2" onSubmit={onSubmit}>
+                        <input
+                            className="form-control flex-grow-1 changeset-filter__search"
+                            type="text"
+                            ref={searchElement}
+                            defaultValue={search}
+                            placeholder="Search"
+                        />
+                    </Form>
+                </div>
+                <div className="m-0 my-2 col-auto">
+                    <div className="form-inline row">
+                        <ChangesetFilter<ChangesetUIState>
+                            values={Object.values(ChangesetUIState)}
+                            label="Changeset state"
+                            selected={uiState}
+                            onChange={setUIState}
+                            className="col ml-2"
+                        />
+                        <ChangesetFilter<ChangesetCheckState>
+                            values={Object.values(ChangesetCheckState)}
+                            label="Check state"
+                            selected={checkState}
+                            onChange={setCheckState}
+                            className="col ml-2"
+                        />
+                        <ChangesetFilter<ChangesetReviewState>
+                            values={Object.values(ChangesetReviewState)}
+                            label="Review state"
+                            selected={reviewState}
+                            onChange={setReviewState}
+                            className="col ml-2"
+                        />
+                    </div>
+                </div>
             </div>
-            <div className="flex-grow-1" />
-            <div className="form-inline m-0 my-2">
-                <ChangesetUIStateFilter
-                    values={Object.values(ChangesetUIState)}
-                    selected={uiState}
-                    onChange={setUIState}
-                    className="mr-2"
-                />
-                <ChangesetFilter<ChangesetCheckState>
-                    values={Object.values(ChangesetCheckState)}
-                    label="Check state"
-                    selected={checkState}
-                    onChange={setCheckState}
-                    className="mr-2"
-                />
-                <ChangesetFilter<ChangesetReviewState>
-                    values={Object.values(ChangesetReviewState)}
-                    label="Review state"
-                    selected={reviewState}
-                    onChange={setReviewState}
-                />
+            <div className="row">
+                <div className="m-0 col d-flex">
+                    <div className="flex-grow-1">this is a thing</div>
+                </div>
+                <div className="m-0 my-2 col-auto">
+                    <select>
+                        <option>this is a non-expanding thing</option>
+                    </select>
+                </div>
             </div>
         </>
     )
@@ -175,28 +188,6 @@ export const ChangesetFilter = <T extends string>({
             ))}
         </select>
     </>
-)
-
-export interface ChangesetUIStateFilterProps {
-    values: ChangesetUIState[]
-    selected: ChangesetUIState | undefined
-    onChange: (value: ChangesetUIState | undefined) => void
-    className?: string
-}
-
-export const ChangesetUIStateFilter: React.FunctionComponent<ChangesetUIStateFilterProps> = ({
-    values,
-    selected,
-    onChange,
-    className,
-}) => (
-    <ChangesetFilter
-        className="d-block mr-2"
-        label="Changeset state"
-        values={values}
-        selected={selected}
-        onChange={onChange}
-    />
 )
 
 function changesetUIStateToChangesetFilters(

--- a/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ChangesetFilterRow.tsx
@@ -51,10 +51,7 @@ export const ChangesetFilterRow: React.FunctionComponent<ChangesetFilterRowProps
         const value = searchParameters.get('check_state')
         return value && isValidChangesetCheckState(value) ? value : undefined
     })
-    const [search, setSearch] = useState<string | undefined>(() => {
-        const value = searchParameters.get('search')
-        return value && isValidChangesetCheckState(value) ? value : undefined
-    })
+    const [search, setSearch] = useState<string | undefined>(() => searchParameters.get('search') ?? undefined)
     useEffect(() => {
         const searchParameters = new URLSearchParams(location.search)
         if (uiState) {

--- a/client/web/src/enterprise/campaigns/detail/changesets/EmptyChangesetListElement.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/EmptyChangesetListElement.tsx
@@ -7,7 +7,7 @@ export const EmptyChangesetListElement: React.FunctionComponent<{}> = () => (
             <p>This can occur for several reasons:</p>
             <p>
                 <strong>
-                    The query specified in <span className="text-monospace">repositorieMatchingQuery:</span> may not
+                    The query specified in <span className="text-monospace">repositoriesMatchingQuery:</span> may not
                     have matched any repositories.
                 </strong>
             </p>

--- a/client/web/src/enterprise/campaigns/detail/changesets/EmptyChangesetSearchElement.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/EmptyChangesetSearchElement.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import MagnifyIcon from 'mdi-react/MagnifyIcon'
+
+export const EmptyChangesetSearchElement: React.FunctionComponent<{}> = () => (
+    <div className="text-muted mt-4 pt-4 mb-4 row">
+        <div className="col-12 text-center">
+            <MagnifyIcon className="icon" />
+            <div className="pt-2">No changesets matched this search.</div>
+        </div>
+    </div>
+)

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -267,6 +267,7 @@ type ListChangesetsArgs struct {
 	ReviewState                 *campaigns.ChangesetReviewState
 	CheckState                  *campaigns.ChangesetCheckState
 	OnlyPublishedByThisCampaign *bool
+	Search                      *string
 }
 
 type CampaignResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1524,9 +1524,7 @@ type Campaign implements Node {
         """
         onlyPublishedByThisCampaign: Boolean
         """
-        Search for changesets matching this query.
-
-        TODO: add notes about what syntax is supported
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
         """
         search: String
     ): ChangesetConnection!

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1523,6 +1523,12 @@ type Campaign implements Node {
         Only return changesets that have been published by this campaign. Imported changesets will be omitted.
         """
         onlyPublishedByThisCampaign: Boolean
+        """
+        Search for changesets matching this query.
+
+        TODO: add notes about what syntax is supported
+        """
+        search: String
     ): ChangesetConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1517,9 +1517,7 @@ type Campaign implements Node {
         """
         onlyPublishedByThisCampaign: Boolean
         """
-        Search for changesets matching this query.
-
-        TODO: add notes about what syntax is supported
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
         """
         search: String
     ): ChangesetConnection!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1516,6 +1516,12 @@ type Campaign implements Node {
         Only return changesets that have been published by this campaign. Imported changesets will be omitted.
         """
         onlyPublishedByThisCampaign: Boolean
+        """
+        Search for changesets matching this query.
+
+        TODO: add notes about what syntax is supported
+        """
+        search: String
     ): ChangesetConnection!
 
     """

--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -23,6 +23,7 @@ func TestIntegration(t *testing.T) {
 		t.Run("Changesets", storeTest(dbconn.Global, testStoreChangesets))
 		t.Run("ChangesetEvents", storeTest(dbconn.Global, testStoreChangesetEvents))
 		t.Run("ListChangesetSyncData", storeTest(dbconn.Global, testStoreListChangesetSyncData))
+		t.Run("ListChangesetsTextSearch", storeTest(dbconn.Global, testStoreListChangesetsTextSearch))
 		t.Run("CampaignSpecs", storeTest(dbconn.Global, testStoreCampaignSpecs))
 		t.Run("ChangesetSpecs", storeTest(dbconn.Global, testStoreChangesetSpecs))
 		t.Run("CodeHosts", storeTest(dbconn.Global, testStoreCodeHost))

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -648,6 +648,10 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 			return opts, false, errors.Wrap(err, "parsing search")
 		}
 		opts.TextSearch = ts.TextSearch
+		// Since we search for the repository name in text searches, the
+		// presence or absence of results may leak information about hidden
+		// repositories.
+		safe = false
 	}
 
 	return opts, safe, nil

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -6,15 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	ee "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/search"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -23,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
@@ -645,46 +643,11 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 		opts.PublicationState = &published
 	}
 	if args.Search != nil {
-		// TODO: move to a separate function for testing; shit, possibly move to
-		// a separate package, because this evil needs to be far, far away from
-		// the resolver
-		tree, err := syntax.Parse(*args.Search)
+		ts, err := search.ParseChangesetSearch(*args.Search)
 		if err != nil {
 			return opts, false, errors.Wrap(err, "parsing search")
 		}
-
-		opts.TextSearch = make([]ee.ListChangesetsTextSearchExpr, 0)
-		var errs *multierror.Error
-		for _, expr := range tree {
-			if expr.Field != "" {
-				// Eventually, we'll support some field types and these will
-				// override other options above. For now, though, this is an
-				// error.
-				errs = multierror.Append(errs, errors.Errorf("unsupported field of type %q at position %d", expr.Field, expr.Pos))
-				continue
-			}
-
-			switch expr.ValueType {
-			case syntax.TokenLiteral:
-				opts.TextSearch = append(opts.TextSearch, ee.ListChangesetsTextSearchExpr{
-					Term: expr.Value,
-					Not:  expr.Not,
-				})
-			case syntax.TokenQuoted:
-				opts.TextSearch = append(opts.TextSearch, ee.ListChangesetsTextSearchExpr{
-					Term: strings.Trim(expr.Value, `"`),
-					Not:  expr.Not,
-				})
-			// If we ever want to support regex patterns, this would be where
-			// we'd hook it in (by matching TokenPattern).
-			default:
-				errs = multierror.Append(errs, errors.Errorf("unsupported value type %q at position %d", expr.ValueType.String(), expr.Pos))
-			}
-		}
-
-		if err := errs.ErrorOrNil(); err != nil {
-			return opts, false, errors.Wrap(err, "parsing search")
-		}
+		opts.TextSearch = ts.TextSearch
 	}
 
 	return opts, safe, nil

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -728,7 +728,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			args: &graphqlbackend.ListChangesetsArgs{
 				Search: stringPtr("foo"),
 			},
-			wantSafe: true,
+			wantSafe: false,
 			wantParsed: ee.ListChangesetsOpts{
 				TextSearch: wantSearches[0:1],
 			},
@@ -738,7 +738,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			args: &graphqlbackend.ListChangesetsArgs{
 				Search: stringPtr("-bar"),
 			},
-			wantSafe: true,
+			wantSafe: false,
 			wantParsed: ee.ListChangesetsOpts{
 				TextSearch: wantSearches[1:],
 			},

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -610,6 +610,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 	wantReviewStates := []campaigns.ChangesetReviewState{"APPROVED", "INVALID"}
 	wantCheckStates := []campaigns.ChangesetCheckState{"PENDING", "INVALID"}
 	wantOnlyPublishedByThisCampaign := []bool{true}
+	wantSearches := []ee.ListChangesetsTextSearchExpr{{Term: "foo"}, {Term: "bar", Not: true}}
 	var campaignID int64 = 1
 
 	tcs := []struct {
@@ -720,6 +721,26 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			wantParsed: ee.ListChangesetsOpts{
 				PublicationState:  &wantPublicationStates[0],
 				OwnedByCampaignID: campaignID,
+			},
+		},
+		// Setting a positive search.
+		{
+			args: &graphqlbackend.ListChangesetsArgs{
+				Search: stringPtr("foo"),
+			},
+			wantSafe: true,
+			wantParsed: ee.ListChangesetsOpts{
+				TextSearch: wantSearches[0:1],
+			},
+		},
+		// Setting a negative search.
+		{
+			args: &graphqlbackend.ListChangesetsArgs{
+				Search: stringPtr("-bar"),
+			},
+			wantSafe: true,
+			wantParsed: ee.ListChangesetsOpts{
+				TextSearch: wantSearches[1:],
 			},
 		},
 	}
@@ -857,3 +878,5 @@ mutation($campaignsCredential: ID!) {
   deleteCampaignsCredential(campaignsCredential: $campaignsCredential) { alwaysNil }
 }
 `
+
+func stringPtr(s string) *string { return &s }

--- a/enterprise/internal/campaigns/search/changeset.go
+++ b/enterprise/internal/campaigns/search/changeset.go
@@ -1,0 +1,60 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
+)
+
+// ParseChangesetSearch parses the given search string into a set of options
+// that can be given to ListChangesets().
+//
+// At present, the only field that will be set in the options is TextSearch.
+// This will change in the future as we start to support field operators.
+func ParseChangesetSearch(search string) (*campaigns.ListChangesetsOpts, error) {
+	tree, err := syntax.Parse(search)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing search string")
+	}
+
+	opts := campaigns.ListChangesetsOpts{
+		TextSearch: make([]campaigns.ListChangesetsTextSearchExpr, 0),
+	}
+	var errs *multierror.Error
+	for _, expr := range tree {
+		if expr.Field != "" {
+			// Eventually, we'll support some field types and these will
+			// override other options above. For now, though, this is an error.
+			errs = multierror.Append(errs, ErrUnsupportedField{
+				ErrExprError: createErrExprError(search, expr),
+				Field:        expr.Field,
+			})
+			continue
+		}
+
+		switch expr.ValueType {
+		case syntax.TokenLiteral:
+			opts.TextSearch = append(opts.TextSearch, campaigns.ListChangesetsTextSearchExpr{
+				Term: expr.Value,
+				Not:  expr.Not,
+			})
+		case syntax.TokenQuoted:
+			opts.TextSearch = append(opts.TextSearch, campaigns.ListChangesetsTextSearchExpr{
+				Term: strings.Trim(expr.Value, `"`),
+				Not:  expr.Not,
+			})
+		// If we ever want to support regex patterns, this would be where we'd
+		// hook it in (by matching TokenPattern).
+		default:
+			errs = multierror.Append(errs, ErrUnsupportedValueType{
+				ErrExprError: createErrExprError(search, expr),
+				ValueType:    expr.ValueType,
+			})
+		}
+	}
+
+	return &opts, errs.ErrorOrNil()
+}

--- a/enterprise/internal/campaigns/search/changeset.go
+++ b/enterprise/internal/campaigns/search/changeset.go
@@ -26,11 +26,11 @@ func ParseChangesetSearch(search string) (*campaigns.ListChangesetsOpts, error) 
 	var errs *multierror.Error
 	for _, expr := range tree {
 		if expr.Field != "" {
-			// Eventually, we'll support some field types and these will
-			// override other options above. For now, though, this is an error.
+			// Eventually, we'll support some field types and these will set
+			// other options in the result. For now, though, this is an error.
 			errs = multierror.Append(errs, ErrUnsupportedField{
-				ErrExprError: createErrExprError(search, expr),
-				Field:        expr.Field,
+				ErrExpr: createErrExpr(search, expr),
+				Field:   expr.Field,
 			})
 			continue
 		}
@@ -50,8 +50,8 @@ func ParseChangesetSearch(search string) (*campaigns.ListChangesetsOpts, error) 
 		// hook it in (by matching TokenPattern).
 		default:
 			errs = multierror.Append(errs, ErrUnsupportedValueType{
-				ErrExprError: createErrExprError(search, expr),
-				ValueType:    expr.ValueType,
+				ErrExpr:   createErrExpr(search, expr),
+				ValueType: expr.ValueType,
 			})
 		}
 	}

--- a/enterprise/internal/campaigns/search/changeset_test.go
+++ b/enterprise/internal/campaigns/search/changeset_test.go
@@ -1,0 +1,135 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
+)
+
+func TestChangesetSearch(t *testing.T) {
+	t.Run("parse error", func(t *testing.T) {
+		if _, err := ParseChangesetSearch(`:`); err == nil {
+			t.Errorf("unexpected nil error")
+		}
+	})
+
+	t.Run("invalid field", func(t *testing.T) {
+		if _, err := ParseChangesetSearch(`x:`); err == nil {
+			t.Errorf("unexpected nil error")
+		} else if errs, ok := err.(*multierror.Error); !ok {
+			t.Errorf("unexpected error of type %T: %+v", err, err)
+		} else if diff := cmp.Diff([]error{
+			ErrUnsupportedField{
+				ErrExpr: ErrExpr{Pos: 0, Input: `x:`},
+				Field:   "x",
+			},
+		}, errs.Errors); diff != "" {
+			t.Errorf("unexpected error (-want +have):\n%s", diff)
+		}
+	})
+
+	t.Run("invalid value type", func(t *testing.T) {
+		if _, err := ParseChangesetSearch(`/foo/`); err == nil {
+			t.Errorf("unexpected nil error")
+		} else if errs, ok := err.(*multierror.Error); !ok {
+			t.Errorf("unexpected error of type %T: %+v", err, err)
+		} else if diff := cmp.Diff([]error{
+			ErrUnsupportedValueType{
+				ErrExpr:   ErrExpr{Pos: 1, Input: `/foo/`},
+				ValueType: syntax.TokenPattern,
+			},
+		}, errs.Errors); diff != "" {
+			t.Errorf("unexpected error (-want +have):\n%s", diff)
+		}
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		if _, err := ParseChangesetSearch(`x: /foo/`); err == nil {
+			t.Errorf("unexpected nil error")
+		} else if errs, ok := err.(*multierror.Error); !ok {
+			t.Errorf("unexpected error of type %T: %+v", err, err)
+		} else if diff := cmp.Diff([]error{
+			ErrUnsupportedField{
+				ErrExpr: ErrExpr{Pos: 0, Input: `x: /foo/`},
+				Field:   "x",
+			},
+			ErrUnsupportedValueType{
+				ErrExpr:   ErrExpr{Pos: 4, Input: `x: /foo/`},
+				ValueType: syntax.TokenPattern,
+			},
+		}, errs.Errors); diff != "" {
+			t.Errorf("unexpected error (-want +have):\n%s", diff)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			input string
+			want  campaigns.ListChangesetsOpts
+		}{
+			"empty string": {
+				input: ``,
+				want: campaigns.ListChangesetsOpts{
+					TextSearch: []campaigns.ListChangesetsTextSearchExpr{},
+				},
+			},
+			"single word": {
+				input: `foo`,
+				want: campaigns.ListChangesetsOpts{
+					TextSearch: []campaigns.ListChangesetsTextSearchExpr{
+						{Term: "foo"},
+					},
+				},
+			},
+			"negated single word": {
+				input: `-foo`,
+				want: campaigns.ListChangesetsOpts{
+					TextSearch: []campaigns.ListChangesetsTextSearchExpr{
+						{Term: "foo", Not: true},
+					},
+				},
+			},
+			"quoted phrase": {
+				input: `"foo bar"`,
+				want: campaigns.ListChangesetsOpts{
+					TextSearch: []campaigns.ListChangesetsTextSearchExpr{
+						{Term: "foo bar"},
+					},
+				},
+			},
+			"negated quoted phrase": {
+				input: `-"foo bar"`,
+				want: campaigns.ListChangesetsOpts{
+					TextSearch: []campaigns.ListChangesetsTextSearchExpr{
+						{Term: "foo bar", Not: true},
+					},
+				},
+			},
+			"multiple exprs": {
+				input: `foo "foo bar" -quux -"baz"`,
+				want: campaigns.ListChangesetsOpts{
+					TextSearch: []campaigns.ListChangesetsTextSearchExpr{
+						{Term: "foo"},
+						{Term: "foo bar"},
+						{Term: "quux", Not: true},
+						{Term: "baz", Not: true},
+					},
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				opts, err := ParseChangesetSearch(tc.input)
+				if err != nil {
+					t.Errorf("unexpected error: %+v", err)
+				}
+
+				if diff := cmp.Diff(&tc.want, opts); diff != "" {
+					t.Errorf("unexpected options (-want +have):\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/enterprise/internal/campaigns/search/errors.go
+++ b/enterprise/internal/campaigns/search/errors.go
@@ -6,21 +6,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 )
 
-// ErrExprError is a base type for errors that occur in a specific expression
+// ErrExpr is a base type for errors that occur in a specific expression
 // within a parse tree, and is intended to be embedded within other error types.
-type ErrExprError struct {
+type ErrExpr struct {
 	Pos   int
 	Input string
 }
 
-func createErrExprError(input string, expr *syntax.Expr) ErrExprError {
-	return ErrExprError{
+func createErrExpr(input string, expr *syntax.Expr) ErrExpr {
+	return ErrExpr{
 		Pos:   expr.Pos,
 		Input: input,
 	}
 }
 
-func (e ErrExprError) Error() string {
+func (e ErrExpr) Error() string {
 	preceding := ""
 	if e.Pos > 0 {
 		preceding = e.Input[0:e.Pos]
@@ -38,24 +38,24 @@ func (e ErrExprError) Error() string {
 }
 
 type ErrUnsupportedField struct {
-	ErrExprError
+	ErrExpr
 	Field string
 }
 
 func (e ErrUnsupportedField) Error() string {
-	return fmt.Sprintf("Fields of type `%s` are unsupported. %s", e.Field, e.ErrExprError.Error())
+	return fmt.Sprintf("Fields of type `%s` are unsupported. %s", e.Field, e.ErrExpr.Error())
 }
 
 type ErrUnsupportedValueType struct {
-	ErrExprError
+	ErrExpr
 	ValueType syntax.TokenType
 }
 
 func (e ErrUnsupportedValueType) Error() string {
 	switch e.ValueType {
 	case syntax.TokenPattern:
-		return fmt.Sprintf("Regular expressions are unsupported. %s", e.ErrExprError.Error())
+		return fmt.Sprintf("Regular expressions are unsupported. %s", e.ErrExpr.Error())
 	default:
-		return fmt.Sprintf("Values of type `%s` are unsupported. %s", e.ValueType.String(), e.ErrExprError.Error())
+		return fmt.Sprintf("Values of type `%s` are unsupported. %s", e.ValueType.String(), e.ErrExpr.Error())
 	}
 }

--- a/enterprise/internal/campaigns/search/errors.go
+++ b/enterprise/internal/campaigns/search/errors.go
@@ -1,0 +1,61 @@
+package search
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
+)
+
+// ErrExprError is a base type for errors that occur in a specific expression
+// within a parse tree, and is intended to be embedded within other error types.
+type ErrExprError struct {
+	Pos   int
+	Input string
+}
+
+func createErrExprError(input string, expr *syntax.Expr) ErrExprError {
+	return ErrExprError{
+		Pos:   expr.Pos,
+		Input: input,
+	}
+}
+
+func (e ErrExprError) Error() string {
+	preceding := ""
+	if e.Pos > 0 {
+		preceding = e.Input[0:e.Pos]
+		if len(preceding) > 10 {
+			preceding = "..." + preceding[len(preceding)-10:]
+		}
+	}
+
+	succeeding := ""
+	if e.Pos < len(e.Input)-1 {
+		succeeding = e.Input[e.Pos+1:]
+	}
+
+	return fmt.Sprintf("The error started at character %d: <code>%s<strong>%c</strong>%s</code>", e.Pos+1, preceding, e.Input[e.Pos], succeeding)
+}
+
+type ErrUnsupportedField struct {
+	ErrExprError
+	Field string
+}
+
+func (e ErrUnsupportedField) Error() string {
+	return fmt.Sprintf("Fields of type `%s` are unsupported. %s", e.Field, e.ErrExprError.Error())
+}
+
+type ErrUnsupportedValueType struct {
+	ErrExprError
+	ValueType syntax.TokenType
+}
+
+func (e ErrUnsupportedValueType) Error() string {
+	switch e.ValueType {
+	case syntax.TokenPattern:
+		return fmt.Sprintf("Regular expressions are unsupported. %s", e.ErrExprError.Error())
+	default:
+		return fmt.Sprintf("Values of type `%s` are unsupported. %s", e.ValueType.String(), e.ErrExprError.Error())
+	}
+}

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -417,7 +417,7 @@ type ListChangesetsTextSearchExpr struct {
 }
 
 func (expr ListChangesetsTextSearchExpr) query() *sqlf.Query {
-	// The general query format is for a positive query is:
+	// The general SQL query format for a positive query is:
 	//
 	// (field1 ~* value OR field2 ~* value)
 	//

--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -419,7 +419,7 @@ type ListChangesetsTextSearchExpr struct {
 func (expr ListChangesetsTextSearchExpr) query() *sqlf.Query {
 	// The general query format is for a positive query is:
 	//
-	// (field ~* value OR field ~* value)
+	// (field1 ~* value OR field2 ~* value)
 	//
 	// For negative queries, we negate both the regex and boolean
 	//

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -71,6 +71,15 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 	t.Run("Create", func(t *testing.T) {
 		var i int
 		for i = 0; i < cap(changesets); i++ {
+			spec := &cmpgn.ChangesetSpec{
+				Spec: &cmpgn.ChangesetSpecDescription{
+					Title: fmt.Sprintf("%s title-%d", githubPR.Title, i),
+				},
+			}
+			if err := s.CreateChangesetSpec(ctx, spec); err != nil {
+				t.Fatalf("creating changeset spec: %v", err)
+			}
+
 			failureMessage := fmt.Sprintf("failure-%d", i)
 			th := &cmpgn.Changeset{
 				RepoID:              repo.ID,
@@ -86,7 +95,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 				ExternalReviewState: cmpgn.ChangesetReviewStateApproved,
 				ExternalCheckState:  cmpgn.ChangesetCheckStatePassed,
 
-				CurrentSpecID:     int64(i) + 1,
+				CurrentSpecID:     spec.ID,
 				PreviousSpecID:    int64(i) + 1,
 				OwnedByCampaignID: int64(i) + 1,
 				PublicationState:  cmpgn.ChangesetPublicationStatePublished,
@@ -626,6 +635,104 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 					OnlySynced: true,
 				},
 				wantCount: 1,
+			},
+			{
+				// Find a single changeset based on the changing part of the
+				// title.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "title-1", Not: false},
+					},
+				},
+				wantCount: 1,
+			},
+			{
+				// Find all changesets based on an invariant part of the title.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "bunch of bugs", Not: false},
+					},
+				},
+				wantCount: len(changesets),
+			},
+			{
+				// Find all the changesets based on the repo name.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: repo.URI, Not: false},
+					},
+				},
+				wantCount: len(changesets),
+			},
+			{
+				// Find a single changeset based on the changing part of the
+				// title and the repo name.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "title-1", Not: false},
+						{Term: repo.URI, Not: false},
+					},
+				},
+				wantCount: 1,
+			},
+			{
+				// Find no changesets based on conflicting requirements.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "title-1", Not: false},
+						{Term: "title-2", Not: false},
+					},
+				},
+				wantCount: 0,
+			},
+			{
+				// Find no changesets based on text that doesn't exist anywhere
+				// in our search scope.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "she dreamt she was a bulldozer", Not: false},
+					},
+				},
+				wantCount: 0,
+			},
+			{
+				// Find no changesets by searching for subsets of words only.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "bug", Not: false},
+					},
+				},
+				wantCount: 0,
+			},
+			{
+				// Find all but one changeset when using a negative search for
+				// the title.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "title-1", Not: true},
+					},
+				},
+				wantCount: len(changesets) - 1,
+			},
+			{
+				// Find no changesets by negating the repo name.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: repo.URI, Not: true},
+					},
+				},
+				wantCount: 0,
+			},
+			{
+				// Find no changesets by negating the repo name, even though the
+				// title would match.
+				opts: ListChangesetsOpts{
+					TextSearch: []ListChangesetsTextSearchExpr{
+						{Term: "title-1", Not: true},
+						{Term: repo.URI, Not: true},
+					},
+				},
+				wantCount: 0,
 			},
 		}
 


### PR DESCRIPTION
This adds text search for changesets in campaigns. Currently, it supports titles (useful for imported changesets, no so much for created ones) and repo names.

![out](https://user-images.githubusercontent.com/229984/101111093-49390080-358f-11eb-8ecc-2979624c534d.gif)

The text search is using our internal parser package to parse the search. This means that we already have support for quoted substrings and negation essentially for free, and it means that there's a _very_ obvious entry point to add filtering fields and wire up the filter dropdowns when we decide it's time for that.

Design: https://www.figma.com/file/FV2gup39FRFztYJgTkFqDU/Campaigns-text-search-%2315889?node-id=0%3A1&viewport=-2057%2C-1114%2C0.8369423747062683

Closes #15781.