### PR TITLE
release: update version on about.sourcegraph.com

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -346,8 +346,12 @@ If you have changes that should go into this patch release, <${patchRequestTempl
 
             // default PR content
             const defaultPRMessage = `release: sourcegraph@${release.version}`
-            const prBodyAndDraftState = (actionItems: string[]): { draft: boolean; body: string } => {
+            const prBodyAndDraftState = (
+                actionItems: string[],
+                customMessage?: string
+            ): { draft: boolean; body: string } => {
                 const defaultBody = `This pull request is part of the Sourcegraph ${release.version} release.
+${customMessage || ''}
 
 * [Release campaign](${campaignURL})
 * ${trackingIssue ? `[Tracking issue](${trackingIssue.url})` : 'No tracking issue exists for this release'}`
@@ -416,6 +420,18 @@ cc @${config.captainGitHubUsername}
                                 return items
                             })()
                         ),
+                    },
+                    {
+                        owner: 'sourcegraph',
+                        repo: 'about',
+                        base: 'main',
+                        head: `publish-${release.version}`,
+                        commitMessage: defaultPRMessage,
+                        title: defaultPRMessage,
+                        edits: [
+                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/components/GetStarted.tsx'`,
+                        ],
+                        ...prBodyAndDraftState([], 'Note that this PR does *not* include the release blog post.'),
                     },
                     {
                         owner: 'sourcegraph',


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/14111 by automating diffs like https://github.com/sourcegraph/about/pull/2053

Manual run:

```
gsed -i -E 's/sourcegraph\/server:[0-9]+\.[0-9]+\.[0-9]+/sourcegraph\/server:3.99.0/g' 'website/src/components/GetStarted.tsx'
```

![image](https://user-images.githubusercontent.com/23356519/100422669-b2b79b80-30c5-11eb-831c-e5c7b964da6f.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
