### PR TITLE
db: remove bitbucket.org from allowed user code hosts

### DIFF
--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -155,7 +155,7 @@ type ValidateExternalServiceConfigOptions struct {
 func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) error {
 	// For user-added external services, we need to prevent them from using disallowed fields.
 	if opt.HasNamespace {
-		// We do not allow users to add external service other than GitHub.com, GitLab.com and Bitbucket.org
+		// We do not allow users to add external service other than GitHub.com and GitLab.com
 		result := gjson.Get(opt.Config, "url")
 		baseURL, err := url.Parse(result.String())
 		if err != nil {
@@ -163,9 +163,8 @@ func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateE
 		}
 		normalizedURL := extsvc.NormalizeBaseURL(baseURL).String()
 		if normalizedURL != "https://github.com/" &&
-			normalizedURL != "https://gitlab.com/" &&
-			normalizedURL != "https://bitbucket.org/" {
-			return errors.New("users are only allowed to add external service for https://github.com/, https://gitlab.com/ and https://bitbucket.org/")
+			normalizedURL != "https://gitlab.com/" {
+			return errors.New("users are only allowed to add external service for https://github.com/ and https://gitlab.com/")
 		}
 
 		disallowedFields := []string{"repositoryPathPattern", "nameTransformations", "rateLimit"}

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -163,7 +163,7 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			kind:         extsvc.KindGitHub,
 			config:       `{"url": "https://github.example.com", "repositoryQuery": ["none"], "token": "abc"}`,
 			hasNamespace: true,
-			wantErr:      `users are only allowed to add external service for https://github.com/, https://gitlab.com/ and https://bitbucket.org/`,
+			wantErr:      `users are only allowed to add external service for https://github.com/ and https://gitlab.com/`,
 		},
 		{
 			name:         "gjson handles comments",


### PR DESCRIPTION
Per our new Cloud milestone.