### PR TITLE
add Repositories connection to User

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -6324,22 +6324,57 @@ type User implements Node & SettingsSubject & Namespace {
         """
         after: String
     ): MonitorConnection!
+
+    repositories(
+        """
+        Returns the first n repositories from the list.
+        """
+        first: Int
+        """
+        Return repositories whose names match the query.
+        """
+        query: String
+        """
+        An opaque cursor that is used for pagination.
+        """
+        after: String
+        """
+        Include cloned repositories.
+        """
+        cloned: Boolean = true
+        """
+        Include repositories that are not yet cloned and for which cloning is not in progress.
+        """
+        notCloned: Boolean = true
+        """
+        Include repositories that have a text search index.
+        """
+        indexed: Boolean = true
+        """
+        Include repositories that do not have a text search index.
+        """
+        notIndexed: Boolean = true
+        """
+        Only include repositories from this external service URL.
+        """
+        externalServiceID: ID
+): RepositoryConnection!
 }
 
 """
 An access token that grants to the holder the privileges of the user who created it.
 """
 type AccessToken implements Node {
-    """
-    The unique ID for the access token.
-    """
-    id: ID!
-    """
-    The user whose privileges the access token grants.
-    """
-    subject: User!
-    """
-    The scopes that define the allowed set of operations that can be performed using this access token.
+"""
+The unique ID for the access token.
+"""
+id: ID!
+"""
+The user whose privileges the access token grants.
+"""
+subject: User!
+"""
+The scopes that define the allowed set of operations that can be performed using this access token.
     """
     scopes: [String!]!
     """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -6325,6 +6325,9 @@ type User implements Node & SettingsSubject & Namespace {
         after: String
     ): MonitorConnection!
 
+    """
+    Repositories from external services owned by this user.
+    """
     repositories(
         """
         Returns the first n repositories from the list.
@@ -6355,26 +6358,26 @@ type User implements Node & SettingsSubject & Namespace {
         """
         notIndexed: Boolean = true
         """
-        Only include repositories from this external service URL.
+        Only include repositories from this external service.
         """
         externalServiceID: ID
-): RepositoryConnection!
+    ): RepositoryConnection!
 }
 
 """
 An access token that grants to the holder the privileges of the user who created it.
 """
 type AccessToken implements Node {
-"""
-The unique ID for the access token.
-"""
-id: ID!
-"""
-The user whose privileges the access token grants.
-"""
-subject: User!
-"""
-The scopes that define the allowed set of operations that can be performed using this access token.
+    """
+    The unique ID for the access token.
+    """
+    id: ID!
+    """
+    The user whose privileges the access token grants.
+    """
+    subject: User!
+    """
+    The scopes that define the allowed set of operations that can be performed using this access token.
     """
     scopes: [String!]!
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6351,7 +6351,7 @@ type User implements Node & SettingsSubject & Namespace {
         Only include repositories from this external service URL.
         """
         externalServiceID: ID
-): RepositoryConnection!
+    ): RepositoryConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6317,6 +6317,41 @@ type User implements Node & SettingsSubject & Namespace {
         """
         after: String
     ): MonitorConnection!
+
+    repositories(
+        """
+        Returns the first n repositories from the list.
+        """
+        first: Int
+        """
+        Return repositories whose names match the query.
+        """
+        query: String
+        """
+        An opaque cursor that is used for pagination.
+        """
+        after: String
+        """
+        Include cloned repositories.
+        """
+        cloned: Boolean = true
+        """
+        Include repositories that are not yet cloned and for which cloning is not in progress.
+        """
+        notCloned: Boolean = true
+        """
+        Include repositories that have a text search index.
+        """
+        indexed: Boolean = true
+        """
+        Include repositories that do not have a text search index.
+        """
+        notIndexed: Boolean = true
+        """
+        Only include repositories from this external service URL.
+        """
+        externalServiceID: ID
+): RepositoryConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6318,6 +6318,9 @@ type User implements Node & SettingsSubject & Namespace {
         after: String
     ): MonitorConnection!
 
+    """
+    Repositories from external services owned by this user.
+    """
     repositories(
         """
         Returns the first n repositories from the list.
@@ -6348,7 +6351,7 @@ type User implements Node & SettingsSubject & Namespace {
         """
         notIndexed: Boolean = true
         """
-        Only include repositories from this external service URL.
+        Only include repositories from this external service.
         """
         externalServiceID: ID
     ): RepositoryConnection!

--- a/cmd/repo-updater/internal/store_test.go
+++ b/cmd/repo-updater/internal/store_test.go
@@ -882,7 +882,7 @@ func testStoreListRepos(t *testing.T, store *internal.Store) func(*testing.T) {
 			stored: repositories,
 			args: func(types.Repos) internaldb.ReposListOptions {
 				return internaldb.ReposListOptions{
-					ExternalServiceID: servicesPerKind[extsvc.KindGitHub].ID,
+					ExternalServiceIDs: []int64{servicesPerKind[extsvc.KindGitHub].ID},
 				}
 			},
 			repos: types.Assert.ReposEqual(github),

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -197,12 +197,21 @@ func (s *RepoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 		return 0, err
 	}
 
+	joins := []*sqlf.Query{}
+	if len(opt.ExternalServiceIDs) != 0 {
+		serviceIDQuery := []*sqlf.Query{}
+		for _, id := range opt.ExternalServiceIDs {
+			serviceIDQuery = append(serviceIDQuery, sqlf.Sprintf("%s", id))
+		}
+		joins = append(joins, sqlf.Sprintf("JOIN external_service_repos e ON (repo.id = e.repo_id AND e.external_service_id IN (%s))", sqlf.Join(serviceIDQuery, ",")))
+	}
+
 	predQ := sqlf.Sprintf("TRUE")
 	if len(conds) > 0 {
 		predQ = sqlf.Sprintf("(%s)", sqlf.Join(conds, "AND"))
 	}
 
-	q := sqlf.Sprintf("SELECT COUNT(*) FROM repo WHERE deleted_at IS NULL AND %s", predQ)
+	q := sqlf.Sprintf("SELECT COUNT(*) FROM repo %s WHERE deleted_at IS NULL AND %s", sqlf.Join(joins, " "), predQ)
 	tr.LazyPrintf("SQL: %v", q.Query(sqlf.PostgresBindVar))
 
 	var count int
@@ -439,9 +448,9 @@ type ReposListOptions struct {
 	// ServiceTypes of repos to list. When zero-valued, this is omitted from the predicate set.
 	ServiceTypes []string
 
-	// ExternalServiceID, if non zero, will only return repos added by the given external service.
+	// ExternalServiceIDs, if non empty, will only return repos added by the given external services.
 	// The id is that of the external_services table NOT the external_service_id in the repo table
-	ExternalServiceID int64
+	ExternalServiceIDs []int64
 
 	// PatternQuery is an expression tree of patterns to query. The atoms of
 	// the query are strings which are regular expression patterns.
@@ -556,8 +565,12 @@ func (s *RepoStore) List(ctx context.Context, opt ReposListOptions) (results []*
 	}
 
 	fromClause := sqlf.Sprintf("repo")
-	if opt.ExternalServiceID != 0 {
-		fromClause = sqlf.Sprintf("repo JOIN external_service_repos e ON (repo.id = e.repo_id AND e.external_service_id = %s)", opt.ExternalServiceID)
+	if len(opt.ExternalServiceIDs) != 0 {
+		serviceIDQuery := []*sqlf.Query{}
+		for _, id := range opt.ExternalServiceIDs {
+			serviceIDQuery = append(serviceIDQuery, sqlf.Sprintf("%s", id))
+		}
+		fromClause = sqlf.Sprintf("repo JOIN external_service_repos e ON (repo.id = e.repo_id AND e.external_service_id IN (%s))", sqlf.Join(serviceIDQuery, ","))
 	}
 
 	queryConds := sqlf.Sprintf("TRUE")

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -1073,9 +1073,9 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 		opt  ReposListOptions
 		want []*types.Repo
 	}{
-		{"Some", ReposListOptions{ExternalServiceID: service1.ID}, mine},
+		{"Some", ReposListOptions{ExternalServiceIDs: []int64{service1.ID}}, mine},
 		{"Default", ReposListOptions{}, append(mine, yours...)},
-		{"NonExistant", ReposListOptions{ExternalServiceID: 1000}, nil},
+		{"NonExistant", ReposListOptions{ExternalServiceIDs: []int64{1000}}, nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pr adds a connection for repositories on the User graphql object, selecting all repositories from external services owned by this user.

This is for the user settings repositories view (https://github.com/sourcegraph/sourcegraph/issues/15401), which will be added in a separate PR.

thanks to @eseliger for the walkthrough on adding this 🙏 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
