### PR TITLE
Improve file decoration style

### DIFF
--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -23,19 +23,28 @@ meter {
     }
 
     // Optimum value styles
-    &:-moz-meter-optimum::-moz-meter-bar,
+    &:-moz-meter-optimum::-moz-meter-bar {
+        background-color: var(--success);
+    }
+
     &::-webkit-meter-optimum-value {
         background-color: var(--success);
     }
 
     // Suboptimum value styles
-    &:-moz-meter-sub-optimum::-moz-meter-bar,
+    &:-moz-meter-sub-optimum::-moz-meter-bar {
+        background-color: var(--warning);
+    }
+
     &::-webkit-meter-sub-optimum-value {
         background-color: var(--warning);
     }
 
     // Horrible value styles
-    &:-moz-meter-sub-sub-optimum::-moz-meter-bar,
+    &:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+        background-color: var(--danger);
+    }
+
     &::-webkit-meter-even-less-good-value {
         background-color: var(--danger);
     }

--- a/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -934,8 +934,8 @@ declare module 'sourcegraph' {
         /** The CSS color property value for the text contet */
         color?: string
 
-        /** Overwrite style for when the file is selected */
-        selectedColor?: string
+        /** Overwrite style for when the file is active */
+        activeColor?: string
     }
 
     /** A decoration attachment adds content after a {@link FileDecoration}. */

--- a/client/shared/src/api/client/services/decoration.test.ts
+++ b/client/shared/src/api/client/services/decoration.test.ts
@@ -234,7 +234,7 @@ describe('fileDecorationColorForTheme', () => {
                 {
                     contentText: '',
                     color: 'red',
-                    selectedColor: 'orange',
+                    activeColor: 'orange',
                 },
                 false,
                 true
@@ -248,9 +248,9 @@ describe('fileDecorationColorForTheme', () => {
                 {
                     contentText: '',
                     color: 'red',
-                    selectedColor: 'orange',
+                    activeColor: 'orange',
                     dark: {
-                        selectedColor: 'teal',
+                        activeColor: 'teal',
                     },
                 },
                 false,

--- a/client/shared/src/api/client/services/decoration.ts
+++ b/client/shared/src/api/client/services/decoration.ts
@@ -62,15 +62,15 @@ export function decorationStyleForTheme(
 export function fileDecorationColorForTheme(
     after: NonNullable<FileDecoration['after']>,
     isLightTheme: boolean,
-    isSelected?: boolean
+    isActive?: boolean
 ): string | undefined {
     const overrides = isLightTheme ? after.light : after.dark
     // Discard non-ThemableFileDecorationStyle properties so they aren't included in result.
     const { light, dark, contentText, hoverMessage, ...base } = after
     const merged = { ...base, ...overrides }
 
-    // fall back to default color if selected color isn't specified
-    return isSelected ? merged.selectedColor ?? merged.color : merged.color
+    // fall back to default color if active color isn't specified
+    return isActive ? merged.activeColor ?? merged.color : merged.color
 }
 
 /**

--- a/client/web/src/repo/tree/TreeEntriesSection.test.tsx
+++ b/client/web/src/repo/tree/TreeEntriesSection.test.tsx
@@ -35,8 +35,15 @@ describe('TreeEntriesSection', () => {
                         },
                     ]}
                     fileDecorationsByPath={{
-                        src: [{ uri: 'git://test/src', after: { contentText: 'src decoration' } }],
-                        testdata: [{ uri: 'git://test/testdata', after: { contentText: 'testdata decoration' } }],
+                        src: [
+                            { uri: 'git://github.com/test/test?branch#src', after: { contentText: 'src decoration' } },
+                        ],
+                        testdata: [
+                            {
+                                uri: 'git://github.com/test/test?branch#testdata',
+                                after: { contentText: 'testdata decoration' },
+                            },
+                        ],
                     }}
                     isLightTheme={true}
                 />
@@ -76,14 +83,20 @@ describe('TreeEntriesSection', () => {
                     ]}
                     fileDecorationsByPath={{
                         'src/testutils': [
-                            { uri: 'git://test/src/testutils', after: { contentText: 'testutils decoration' } },
+                            {
+                                uri: 'git://github.com/test/test?branch#src/testutils',
+                                after: { contentText: 'testutils decoration' },
+                            },
                         ],
                         'src/typings': [
-                            { uri: 'git://test/src/typings', after: { contentText: 'typings decoration' } },
+                            {
+                                uri: 'git://github.com/test/test?branch#src/typings',
+                                after: { contentText: 'typings decoration' },
+                            },
                         ],
                         'src/errors.ts': [
                             {
-                                uri: 'git://test/src/errors.ts',
+                                uri: 'git://github.com/test/test?branch#src/errors.ts',
                                 where: 'sidebar',
                                 after: { contentText: 'errors decoration' },
                             }, // This shouldn't be rendered
@@ -132,8 +145,18 @@ describe('TreeEntriesSection', () => {
                         },
                     ]}
                     fileDecorationsByPath={{
-                        'x/ref': [{ uri: 'git://test/x/ref', after: { contentText: 'ref decoration' } }],
-                        'x/ref/cmd': [{ uri: 'git://test/x/ref/cmd', after: { contentText: 'cmd decoration' } }],
+                        'x/ref': [
+                            {
+                                uri: 'git://github.com/test/test?branch#x/ref',
+                                after: { contentText: 'ref decoration' },
+                            },
+                        ],
+                        'x/ref/cmd': [
+                            {
+                                uri: 'git://github.com/test/test?branch#x/ref/cmd',
+                                after: { contentText: 'cmd decoration' },
+                            },
+                        ],
                     }}
                     isLightTheme={true}
                 />

--- a/client/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
+++ b/client/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
           class="file-decoration d-flex align-items-center"
         >
           <small
-            class="file-decoration__after text-monospace text-muted font-weight-normal test-file-decoration-text"
+            class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
             data-placement="bottom"
           >
             src decoration
@@ -47,7 +47,7 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
           class="file-decoration d-flex align-items-center"
         >
           <small
-            class="file-decoration__after text-monospace text-muted font-weight-normal test-file-decoration-text"
+            class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
             data-placement="bottom"
           >
             testdata decoration
@@ -105,7 +105,7 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
           class="file-decoration d-flex align-items-center"
         >
           <small
-            class="file-decoration__after text-monospace text-muted font-weight-normal test-file-decoration-text"
+            class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
             data-placement="bottom"
           >
             testutils decoration
@@ -132,7 +132,7 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
           class="file-decoration d-flex align-items-center"
         >
           <small
-            class="file-decoration__after text-monospace text-muted font-weight-normal test-file-decoration-text"
+            class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
             data-placement="bottom"
           >
             typings decoration
@@ -190,7 +190,7 @@ exports[`TreeEntriesSection should render only direct children 1`] = `
           class="file-decoration d-flex align-items-center"
         >
           <small
-            class="file-decoration__after text-monospace text-muted font-weight-normal test-file-decoration-text"
+            class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
             data-placement="bottom"
           >
             ref decoration

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -18,7 +18,7 @@ interface TreeChildProps extends TreeLayerProps {
 
     fileDecorations?: FileDecoration[]
 
-    isSelected: boolean
+    isActive: boolean
 }
 
 /**
@@ -67,6 +67,7 @@ export const Directory: React.FunctionComponent<TreeChildProps> = (props: TreeCh
                         fileDecorations={props.fileDecorations?.filter(decoration => decoration?.where !== 'page')}
                         className="mr-3"
                         isLightTheme={props.isLightTheme}
+                        isActive={props.isActive}
                     />
                 </div>
                 {props.loading && (

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -11,7 +11,7 @@ interface FileProps extends TreeLayerProps {
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
     linkRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
-    isSelected: boolean
+    isActive: boolean
 }
 
 export const File: React.FunctionComponent<FileProps> = props => {
@@ -20,7 +20,7 @@ export const File: React.FunctionComponent<FileProps> = props => {
             // If component is not specified, or it is 'sidebar', render it.
             fileDecorations={props.fileDecorations?.filter(decoration => decoration?.where !== 'page')}
             isLightTheme={props.isLightTheme}
-            isSelected={props.isSelected}
+            isActive={props.isActive}
         />
     )
 

--- a/client/web/src/tree/FileDecorator.scss
+++ b/client/web/src/tree/FileDecorator.scss
@@ -1,6 +1,11 @@
 .file-decoration {
     &__after {
         margin-bottom: -0.125rem;
+        color: var(--text-muted);
+
+        &--active {
+            color: $white;
+        }
     }
 
     &__meter {

--- a/client/web/src/tree/FileDecorator.test.tsx
+++ b/client/web/src/tree/FileDecorator.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render } from 'enzyme'
+import { FileDecorator } from './FileDecorator'
+
+describe('FileDecorator', () => {
+    it('renders after text content', () => {
+        expect(
+            render(
+                <FileDecorator
+                    fileDecorations={[
+                        { uri: 'git://github.com/test/test?branch#src', after: { contentText: 'src decoration' } },
+                    ]}
+                    isLightTheme={true}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    it('renders meter', () => {
+        expect(
+            render(
+                <FileDecorator
+                    fileDecorations={[
+                        {
+                            uri: 'git://github.com/test/test?branch#src',
+                            meter: { value: 40, min: 0, max: 100, optimum: 70, high: 60, low: 50 },
+                        },
+                    ]}
+                    isLightTheme={true}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    it('renders both after text content and meter', () => {
+        expect(
+            render(
+                <FileDecorator
+                    fileDecorations={[
+                        {
+                            uri: 'git://github.com/test/test?branch#src',
+                            after: { contentText: 'src decoration' },
+                            meter: { value: 40, min: 0, max: 100, optimum: 70, high: 60, low: 50 },
+                        },
+                    ]}
+                    isLightTheme={true}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    it('respects active state', () => {
+        expect(
+            render(
+                <FileDecorator
+                    fileDecorations={[
+                        { uri: 'git://github.com/test/test?branch#src', after: { contentText: 'src decoration' } },
+                    ]}
+                    isLightTheme={true}
+                    isActive={true}
+                />
+            )
+        ).toMatchSnapshot()
+    })
+
+    // Theming logic is already tested (fileDecorationColorForTheme())
+})

--- a/client/web/src/tree/FileDecorator.tsx
+++ b/client/web/src/tree/FileDecorator.tsx
@@ -12,9 +12,9 @@ interface FileDecoratorProps {
 
     /**
      * File decorations may be styled differently depending on whether or not
-     * the decorated file is selected
+     * the decorated file is active
      */
-    isSelected?: boolean
+    isActive?: boolean
 
     className?: string
 }
@@ -26,7 +26,7 @@ export const FileDecorator: React.FunctionComponent<FileDecoratorProps> = ({
     fileDecorations,
     isLightTheme,
     className,
-    isSelected,
+    isActive,
 }) => {
     // Only need to check for number of decorations, other validation (like whether the decoration specifies at
     // least one of `text` or `percentage`) is done in the extension host
@@ -55,12 +55,15 @@ export const FileDecorator: React.FunctionComponent<FileDecoratorProps> = ({
                                         color: fileDecorationColorForTheme(
                                             fileDecoration.after,
                                             isLightTheme,
-                                            isSelected
+                                            isActive
                                         ),
                                     }}
                                     data-tooltip={fileDecoration.after.hoverMessage}
                                     data-placement="bottom"
-                                    className="file-decoration__after text-monospace text-muted font-weight-normal test-file-decoration-text"
+                                    className={classNames(
+                                        'file-decoration__after text-monospace font-weight-normal test-file-decoration-text',
+                                        isActive && 'file-decoration__after--active'
+                                    )}
                                 >
                                     {fileDecoration.after.contentText}
                                 </small>

--- a/client/web/src/tree/SingleChildTreeLayer.tsx
+++ b/client/web/src/tree/SingleChildTreeLayer.tsx
@@ -113,12 +113,12 @@ export class SingleChildTreeLayer extends React.Component<SingleChildTreeLayerPr
     }
 
     public render(): JSX.Element | null {
-        const isSelectedNode = this.node === this.props.selectedNode
+        const isActive = this.node === this.props.activeNode
         const className = classNames(
             'tree__row',
             this.props.isExpanded && 'tree__row--expanded',
             this.node === this.props.activeNode && 'tree__row--active',
-            isSelectedNode && 'tree__row--selected'
+            this.node === this.props.selectedNode && 'tree__row--selected'
         )
 
         return (
@@ -137,7 +137,7 @@ export class SingleChildTreeLayer extends React.Component<SingleChildTreeLayerPr
                             noopRowClick={this.noopRowClick}
                             linkRowClick={this.linkRowClick}
                             fileDecorations={this.props.fileDecorations}
-                            isSelected={isSelectedNode}
+                            isActive={isActive}
                         />
                         {this.props.isExpanded && (
                             <tr>

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -263,12 +263,12 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
 
     public render(): JSX.Element | null {
         const entryInfo = this.props.entryInfo
-        const isSelectedNode = this.node === this.props.selectedNode
+        const isActive = this.node === this.props.activeNode
         const className = classNames(
             'tree__row',
             this.props.isExpanded && 'tree__row--expanded',
-            this.node === this.props.activeNode && 'tree__row--active',
-            isSelectedNode && 'tree__row--selected'
+            isActive && 'tree__row--active',
+            this.node === this.props.selectedNode && 'tree__row--selected'
         )
         const { treeOrError } = this.state
 
@@ -300,7 +300,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                     handleTreeClick={this.handleTreeClick}
                                     noopRowClick={this.noopRowClick}
                                     linkRowClick={this.linkRowClick}
-                                    isSelected={isSelectedNode}
+                                    isActive={isActive}
                                 />
                                 {this.props.isExpanded && treeOrError !== LOADING && (
                                     <tr>
@@ -340,7 +340,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 handleTreeClick={this.handleTreeClick}
                                 noopRowClick={this.noopRowClick}
                                 linkRowClick={this.linkRowClick}
-                                isSelected={isSelectedNode}
+                                isActive={isActive}
                             />
                         )}
                     </tbody>

--- a/client/web/src/tree/__snapshots__/FileDecorator.test.tsx.snap
+++ b/client/web/src/tree/__snapshots__/FileDecorator.test.tsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileDecorator renders after text content 1`] = `
+<div
+  class="d-flex align-items-center text-nowrap pl-1 test-file-decoration-container"
+>
+  <div
+    class="file-decoration d-flex align-items-center"
+  >
+    <small
+      class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
+      data-placement="bottom"
+    >
+      src decoration
+    </small>
+  </div>
+</div>
+`;
+
+exports[`FileDecorator renders both after text content and meter 1`] = `
+<div
+  class="d-flex align-items-center text-nowrap pl-1 test-file-decoration-container"
+>
+  <div
+    class="file-decoration d-flex align-items-center"
+  >
+    <small
+      class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text"
+      data-placement="bottom"
+    >
+      src decoration
+    </small>
+    <meter
+      class="file-decoration__meter test-file-decoration-meter ml-2"
+      data-placement="bottom"
+      high="60"
+      low="50"
+      max="100"
+      min="0"
+      optimum="70"
+      value="40"
+    />
+  </div>
+</div>
+`;
+
+exports[`FileDecorator renders meter 1`] = `
+<div
+  class="d-flex align-items-center text-nowrap pl-1 test-file-decoration-container"
+>
+  <div
+    class="file-decoration d-flex align-items-center"
+  >
+    <meter
+      class="file-decoration__meter test-file-decoration-meter"
+      data-placement="bottom"
+      high="60"
+      low="50"
+      max="100"
+      min="0"
+      optimum="70"
+      value="40"
+    />
+  </div>
+</div>
+`;
+
+exports[`FileDecorator respects active state 1`] = `
+<div
+  class="d-flex align-items-center text-nowrap pl-1 test-file-decoration-container"
+>
+  <div
+    class="file-decoration d-flex align-items-center"
+  >
+    <small
+      class="file-decoration__after text-monospace font-weight-normal test-file-decoration-text file-decoration__after--active"
+      data-placement="bottom"
+    >
+      src decoration
+    </small>
+  </div>
+</div>
+`;


### PR DESCRIPTION
- Re-duplicate meter selectors to work for WebKit
- Change override color state from selected to active (active applies deeper blue)
- Make decoration text white by default when file node is active
- Snapshot test file decorations