### PR TITLE
search frontend: localize query transformation for case

### DIFF
--- a/client/web/src/search/index.test.tsx
+++ b/client/web/src/search/index.test.tsx
@@ -6,7 +6,7 @@ describe('search/index', () => {
         expect(
             parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=literal&case=yes')
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph  case:yes',
             patternType: SearchPatternType.literal,
             caseSensitive: true,
             versionContext: undefined,
@@ -24,14 +24,14 @@ describe('search/index', () => {
         expect(
             parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+patternType:regexp&patternType=literal&case=yes')
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph  case:yes',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
             versionContext: undefined,
         })
 
         expect(parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=literal')).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph  case:yes',
             patternType: SearchPatternType.literal,
             caseSensitive: true,
             versionContext: undefined,

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -103,6 +103,8 @@ export function parseSearchURL(
             caseSensitive = false
         }
     }
+    // Invariant: If case:value was in the query, it is erased at this point. Add case:yes if needed.
+    finalQuery = caseSensitive ? `${finalQuery} case:yes` : finalQuery
 
     return {
         query: finalQuery,

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -170,7 +170,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                             // Do async search request
                             this.props
                                 .searchRequest(
-                                    caseSensitive ? `${query} case:yes` : query,
+                                    query,
                                     LATEST_VERSION,
                                     patternType,
                                     resolveVersionContext(versionContext, this.props.availableVersionContexts),

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -100,12 +100,12 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         useMemo(
             () =>
                 streamSearch(
-                    caseSensitive ? `${query} case:yes` : query,
+                    query,
                     LATEST_VERSION,
                     patternType ?? SearchPatternType.literal,
                     resolveVersionContext(versionContext, availableVersionContexts)
                 ),
-            [streamSearch, caseSensitive, query, patternType, versionContext, availableVersionContexts]
+            [streamSearch, query, patternType, versionContext, availableVersionContexts]
         )
     )
 


### PR DESCRIPTION
Spreading out and doing query transformation far away from the state that determines those transformations is asking for trouble. This PR moves the `case:yes` addition closer to the place where this is actually determined. This is part of setup for adding logic where `case:yes` should _not_ be added (i.e., for complex expressions, as in https://github.com/sourcegraph/sourcegraph/issues/13958). 

I think we're a bit unhygienic about the query state here in general and could get it cleaned up a bit later.