### PR TITLE
Implement workbench view system and status bar

### DIFF
--- a/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1059,6 +1059,38 @@ declare module 'sourcegraph' {
     }
 
     /**
+     * @template TState TODO(tj): thorough explanation
+     */
+    export interface WorkbenchView<TState extends object> {
+        state: TState
+
+        update: (nextState: Partial<TState>) => void
+    }
+
+    // TODO(tj): better types
+    export type WorkbenchViewType = 'statusBarItem'
+
+    export interface StatusBarItemState {
+        /**
+         * Whether to show the status bar item.
+         *
+         * @default true
+         */
+        visible: boolean
+
+        /** Text to display in the status bar. This will be prepended by the status bar item's `id`. */
+        contentText: string
+
+        /** Tooltip text to display when hovering over the status bar item. */
+        hoverMessage?: string
+
+        /** If set, the status bar item becomes a link with this destination URL. */
+        linkURL?: string
+    }
+
+    export interface StatusBarItem extends Unsubscribable, WorkbenchView<StatusBarItemState> {}
+
+    /**
      * The client application that is running the extension.
      */
     export namespace app {
@@ -1091,6 +1123,15 @@ declare module 'sourcegraph' {
          * @returns The panel view.
          */
         export function createPanelView(id: string): PanelView
+
+        /**
+         * Create a status bar item with the given {@link id}.
+         *
+         * @param id The ID of the status bar item. This may be shown to the user (e.g., in the URL fragment when the panel is
+         * active).
+         * @param options TODO(tj): Consider whether alignment and/or priority options are necessary
+         */
+        export function createStatusBarItem(id: string): StatusBarItem
 
         /**
          * Creates a decorationType that can be used to add decorations to code views.

--- a/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1078,7 +1078,7 @@ declare module 'sourcegraph' {
          */
         visible: boolean
 
-        /** Text to display in the status bar. This will be prepended by the status bar item's `id`. */
+        /** Text to display in the status bar. */
         contentText: string
 
         /** Title text that is prepended to `contentText` */

--- a/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
+++ b/client/packages/sourcegraph-extension-api/src/sourcegraph.d.ts
@@ -1081,6 +1081,9 @@ declare module 'sourcegraph' {
         /** Text to display in the status bar. This will be prepended by the status bar item's `id`. */
         contentText: string
 
+        /** Title text that is prepended to `contentText` */
+        title?: string
+
         /** Tooltip text to display when hovering over the status bar item. */
         hoverMessage?: string
 

--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -2,7 +2,7 @@ import { SettingsCascade } from '../settings/settings'
 import { SettingsEdit } from './client/services/settings'
 import * as clientType from '@sourcegraph/extension-api-types'
 import { Remote, ProxyMarked } from 'comlink'
-import { Unsubscribable, DocumentHighlight, FileDecorationContext } from 'sourcegraph'
+import { Unsubscribable, DocumentHighlight, FileDecorationContext, StatusBarItemState } from 'sourcegraph'
 import { ProxySubscribable } from './extension/api/common'
 import { TextDocumentPositionParameters } from './protocol'
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
@@ -37,6 +37,9 @@ export interface FlatExtensionHostAPI {
 
     // Tree
     getFileDecorations: (parameters: FileDecorationContext) => ProxySubscribable<FileDecorationsByPath>
+
+    // Workbench views
+    getStatusBarItems: () => ProxySubscribable<Map<string, StatusBarItemState>>
 }
 
 /**

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -150,6 +150,7 @@ function createExtensionAPI(
         languages: { registerHoverProvider, registerDocumentHighlightProvider, registerDefinitionProvider },
         registerFileDecorationProvider,
         graphQL,
+        app: { createStatusBarItem },
     } = initNewExtensionAPI(proxy, initData.initialSettings, documents)
 
     // Expose the extension host API to the client (main thread)
@@ -193,6 +194,7 @@ function createExtensionAPI(
                 return windows.getAll()
             },
             createPanelView: (id: string) => views.createPanelView(id),
+            createStatusBarItem,
             createDecorationType,
             registerViewProvider: (id, provider) => views.registerViewProvider(id, provider),
             registerFileDecorationProvider,
@@ -270,5 +272,26 @@ function createExtensionAPI(
             clientApplication: initData.clientApplication,
         },
     }
+
+    /**
+     * TEST STATUS BAR ITEM API
+     * Calling APIs directly for easy collaboration (no need to sideload extension)
+     * Move this to extensionHost so I can subscribe to text document changes
+     *
+     * TODO(tj): Remove this
+     */
+    setTimeout(() => {
+        const bar = createStatusBarItem('fun-item')
+        bar.update({ contentText: 'an update in the same tick!' })
+
+        // setTimeout(() => {
+        //     bar.unsubscribe()
+        // }, 1000)
+    }, 3000)
+
+    setTimeout(() => {
+        createStatusBarItem('test-item-2')
+    }, 3000)
+
     return { extensionHostAPI, extensionAPI, subscription }
 }

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -282,7 +282,7 @@ function createExtensionAPI(
      */
     setTimeout(() => {
         const bar = createStatusBarItem('fun-item')
-        bar.update({ contentText: 'an update in the same tick!' })
+        bar.update({ contentText: 'an update in the same *frame!' })
 
         // setTimeout(() => {
         //     bar.unsubscribe()
@@ -290,7 +290,10 @@ function createExtensionAPI(
     }, 3000)
 
     setTimeout(() => {
-        createStatusBarItem('test-item-2')
+        for (let index = 1; index < 10; index++) {
+            const item = createStatusBarItem(`test-item-${index}`)
+            item.update({ contentText: `content for item ${index}` })
+        }
     }, 3000)
 
     return { extensionHostAPI, extensionAPI, subscription }

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -276,26 +276,36 @@ function createExtensionAPI(
     /**
      * TEST STATUS BAR ITEM API
      * Calling APIs directly for easy collaboration (no need to sideload extension)
-     * Move this to extensionHost so I can subscribe to text document changes
      *
      * Note that these individual timeouts only result in one render :D
      *
      * TODO(tj): Remove this
      */
+    setTimeout(() => {
+        const item = createStatusBarItem('char-count')
+        item.update({ contentText: '12356', title: 'Characters' })
+
+        // eslint-disable-next-line rxjs/no-ignored-subscription
+        windows.activeWindow.activeViewComponentChanges.subscribe(viewComponent => {
+            if (viewComponent?.type === 'CodeEditor') {
+                item.update({ contentText: String(viewComponent.document.text?.length ?? 0) })
+            }
+        })
+    }, 500)
 
     setTimeout(() => {
         const item = createStatusBarItem('codecov')
-        item.update({ contentText: '89%', title: 'Codecov coverage' })
-    }, 500)
+
+        item.update({
+            contentText: '89%',
+            title: 'Codecov coverage',
+            hoverMessage: 'The code coverage of this file is',
+        })
+    }, 501)
 
     setTimeout(() => {
         const item = createStatusBarItem('git-extras')
         item.update({ contentText: 'Felix Becker, Rob Rhyne', title: '2 authors' })
-    }, 501)
-
-    setTimeout(() => {
-        const item = createStatusBarItem('char-count')
-        item.update({ contentText: '12356', title: 'Characters' })
     }, 502)
 
     return { extensionHostAPI, extensionAPI, subscription }

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -278,23 +278,25 @@ function createExtensionAPI(
      * Calling APIs directly for easy collaboration (no need to sideload extension)
      * Move this to extensionHost so I can subscribe to text document changes
      *
+     * Note that these individual timeouts only result in one render :D
+     *
      * TODO(tj): Remove this
      */
-    setTimeout(() => {
-        const bar = createStatusBarItem('fun-item')
-        bar.update({ contentText: 'an update in the same *frame!' })
-
-        // setTimeout(() => {
-        //     bar.unsubscribe()
-        // }, 1000)
-    }, 3000)
 
     setTimeout(() => {
-        for (let index = 1; index < 10; index++) {
-            const item = createStatusBarItem(`test-item-${index}`)
-            item.update({ contentText: `content for item ${index}` })
-        }
-    }, 3000)
+        const item = createStatusBarItem('codecov')
+        item.update({ contentText: '89%', title: 'Codecov coverage' })
+    }, 500)
+
+    setTimeout(() => {
+        const item = createStatusBarItem('git-extras')
+        item.update({ contentText: 'Felix Becker, Rob Rhyne', title: '2 authors' })
+    }, 501)
+
+    setTimeout(() => {
+        const item = createStatusBarItem('char-count')
+        item.update({ contentText: '12356', title: 'Characters' })
+    }, 502)
 
     return { extensionHostAPI, extensionAPI, subscription }
 }

--- a/client/shared/src/api/extension/flatExtensionApi.ts
+++ b/client/shared/src/api/extension/flatExtensionApi.ts
@@ -19,7 +19,6 @@ import { fromHoverMerged } from '../client/types/hover'
 import { isNot, isExactly, isDefined } from '../../util/types'
 import { validateFileDecoration } from './api/decorations'
 import { createWorkbenchViewScheduler, ExtensionStatusBarItem } from './workbench'
-import iterate from 'iterare'
 
 /**
  * Holds the entire state exposed to the extension host

--- a/client/shared/src/api/extension/flatExtensionApi.ts
+++ b/client/shared/src/api/extension/flatExtensionApi.ts
@@ -222,13 +222,8 @@ export const initNewExtensionAPI = (
             ),
 
         // Workbench views
-        getStatusBarItems: () => {
-            console.log('getting status bar items')
-            // Memoize in client?
-
-            getWorkbenchViewsState(state.statusBarItemInstances)
-
-            return proxySubscribable(
+        getStatusBarItems: () =>
+            proxySubscribable(
                 concat(
                     of(getWorkbenchViewsState(state.statusBarItemInstances)),
                     workbenchViewChanges.pipe(
@@ -236,8 +231,7 @@ export const initNewExtensionAPI = (
                         map(() => getWorkbenchViewsState(state.statusBarItemInstances))
                     )
                 )
-            )
-        },
+            ),
     }
 
     // Configuration
@@ -448,6 +442,8 @@ export function mergeProviderResults<TProviderResultElement>(
  *
  * @param workbenchViewInstances
  */
-function getWorkbenchViewsState<T>(workbenchViewInstances: Map<string, sourcegraph.WorkbenchView<T>>): Map<string, T> {
+function getWorkbenchViewsState<TState extends object>(
+    workbenchViewInstances: Map<string, sourcegraph.WorkbenchView<TState>>
+): Map<string, TState> {
     return new Map([...workbenchViewInstances].map(([id, instance]) => [id, instance.state]))
 }

--- a/client/shared/src/api/extension/workbench/index.ts
+++ b/client/shared/src/api/extension/workbench/index.ts
@@ -1,0 +1,4 @@
+import { createWorkbenchViewScheduler } from './scheduler'
+import { ExtensionStatusBarItem } from './views'
+
+export { createWorkbenchViewScheduler, ExtensionStatusBarItem }

--- a/client/shared/src/api/extension/workbench/scheduler.test.ts
+++ b/client/shared/src/api/extension/workbench/scheduler.test.ts
@@ -1,0 +1,37 @@
+import { noop } from 'lodash'
+import { createWorkbenchViewScheduler } from './scheduler'
+import sinon from 'sinon'
+
+describe('workbenchViewScheduler', () => {
+    let requestID = 1
+    let flush: FrameRequestCallback | undefined
+    const requestAnimationFrame = sinon.spy<(callback: FrameRequestCallback) => number>(callback => {
+        flush = callback
+        return requestID++
+    })
+    const scheduler = createWorkbenchViewScheduler(noop, requestAnimationFrame)
+
+    afterAll(() => {
+        scheduler.unsubscribe()
+    })
+
+    test('createWorkbenchViewScheduler() is idempotent', () => {
+        expect(createWorkbenchViewScheduler(noop, requestAnimationFrame)).toBe(scheduler)
+    })
+
+    test('only calls requestAnimationFrame() once per frame', () => {
+        scheduler.schedule({ type: 'creation', viewType: 'statusBarItem' })
+        scheduler.schedule({ type: 'update', viewType: 'statusBarItem' })
+        scheduler.schedule({ type: 'update', viewType: 'statusBarItem' })
+
+        sinon.assert.calledOnce(requestAnimationFrame)
+
+        flush?.(1) // browser about to repaint
+
+        scheduler.schedule({ type: 'deletion', viewType: 'statusBarItem' })
+        scheduler.schedule({ type: 'creation', viewType: 'statusBarItem' })
+        scheduler.schedule({ type: 'update', viewType: 'statusBarItem' })
+
+        sinon.assert.calledTwice(requestAnimationFrame)
+    })
+})

--- a/client/shared/src/api/extension/workbench/scheduler.ts
+++ b/client/shared/src/api/extension/workbench/scheduler.ts
@@ -2,6 +2,7 @@ import { WorkbenchViewType } from 'sourcegraph'
 
 export interface WorkbenchViewScheduler {
     schedule: (update: ViewUpdate) => void
+    unsubscribe: () => void
 }
 
 let schedulerInstance: WorkbenchViewScheduler | undefined
@@ -12,17 +13,26 @@ interface ViewUpdate {
     viewType: WorkbenchViewType
 }
 
+/**
+ * Idempotent.
+ *
+ * @param onFlush Callback called when scheduler deems that it is appropriate to
+ * notify the UI of view updates
+ */
 export function createWorkbenchViewScheduler(
-    // TODO(tj): document
-    onFlush: (updatedViewTypes: Set<WorkbenchViewType>) => void
+    onFlush: (updatedViewTypes: Set<WorkbenchViewType>) => void,
+    requestAnimationFrame: (callback: FrameRequestCallback) => number | undefined = globalThis.requestAnimationFrame
 ): WorkbenchViewScheduler {
     if (schedulerInstance) {
         return schedulerInstance
     }
 
-    // TODO: if we don't need anymore info from the update, just make it a Set of updated types
+    // TODO(tj): For now, we clone all views on each update, so we don't need anymore info from the update.
+    // If we need to send deltas only (cloning views becomes too expensive), we will store whole updates
+    // to pass to the `onFlush` handler
     let updatedViewTypes = new Set<WorkbenchViewType>()
     let updateScheduled = false
+    let requestID: number | undefined
 
     function flush(): void {
         onFlush(updatedViewTypes)
@@ -35,9 +45,15 @@ export function createWorkbenchViewScheduler(
             updatedViewTypes.add(update.viewType)
 
             if (!updateScheduled) {
-                requestAnimationFrame(flush)
+                requestID = requestAnimationFrame(flush)
                 updateScheduled = true
             }
+        },
+        unsubscribe: () => {
+            if (requestID) {
+                cancelAnimationFrame(requestID)
+            }
+            schedulerInstance = undefined
         },
     }
 

--- a/client/shared/src/api/extension/workbench/scheduler.ts
+++ b/client/shared/src/api/extension/workbench/scheduler.ts
@@ -25,17 +25,20 @@ export function createWorkbenchViewScheduler(
     let updateScheduled = false
 
     function flush(): void {
+        console.log('flush called')
         onFlush(updatedViewTypes)
-        updatedViewTypes = new Set()
+        updatedViewTypes = new Set<WorkbenchViewType>()
         updateScheduled = false
     }
 
     schedulerInstance = {
-        schedule: (update: ViewUpdate) => {
+        schedule: (update: ViewUpdate): void => {
             updatedViewTypes.add(update.viewType)
+            console.log('schedule called')
 
             if (!updateScheduled) {
                 requestAnimationFrame(flush)
+                console.log('requested frame')
                 updateScheduled = true
             }
         },

--- a/client/shared/src/api/extension/workbench/scheduler.ts
+++ b/client/shared/src/api/extension/workbench/scheduler.ts
@@ -1,0 +1,45 @@
+import { WorkbenchViewType } from 'sourcegraph'
+
+export interface WorkbenchViewScheduler {
+    schedule: (update: ViewUpdate) => void
+}
+
+let schedulerInstance: WorkbenchViewScheduler | undefined
+
+// TODO(tj): Clarify language (update vs change)
+interface ViewUpdate {
+    type: 'creation' | 'update' | 'deletion'
+    viewType: WorkbenchViewType
+}
+
+export function createWorkbenchViewScheduler(
+    // TODO(tj): document
+    onFlush: (updatedViewTypes: Set<WorkbenchViewType>) => void
+): WorkbenchViewScheduler {
+    if (schedulerInstance) {
+        return schedulerInstance
+    }
+
+    // TODO: if we don't need anymore info from the update, just make it a Set of updated types
+    let updatedViewTypes = new Set<WorkbenchViewType>()
+    let updateScheduled = false
+
+    function flush(): void {
+        onFlush(updatedViewTypes)
+        updatedViewTypes = new Set()
+        updateScheduled = false
+    }
+
+    schedulerInstance = {
+        schedule: (update: ViewUpdate) => {
+            updatedViewTypes.add(update.viewType)
+
+            if (!updateScheduled) {
+                requestAnimationFrame(flush)
+                updateScheduled = true
+            }
+        },
+    }
+
+    return schedulerInstance
+}

--- a/client/shared/src/api/extension/workbench/scheduler.ts
+++ b/client/shared/src/api/extension/workbench/scheduler.ts
@@ -25,7 +25,6 @@ export function createWorkbenchViewScheduler(
     let updateScheduled = false
 
     function flush(): void {
-        console.log('flush called')
         onFlush(updatedViewTypes)
         updatedViewTypes = new Set<WorkbenchViewType>()
         updateScheduled = false
@@ -34,11 +33,9 @@ export function createWorkbenchViewScheduler(
     schedulerInstance = {
         schedule: (update: ViewUpdate): void => {
             updatedViewTypes.add(update.viewType)
-            console.log('schedule called')
 
             if (!updateScheduled) {
                 requestAnimationFrame(flush)
-                console.log('requested frame')
                 updateScheduled = true
             }
         },

--- a/client/shared/src/api/extension/workbench/views.test.ts
+++ b/client/shared/src/api/extension/workbench/views.test.ts
@@ -1,0 +1,47 @@
+import { noop } from 'lodash'
+import { WorkbenchViewType } from 'sourcegraph'
+import { createWorkbenchViewScheduler, WorkbenchViewScheduler } from './scheduler'
+import { WorkbenchView } from './views'
+
+// Create a minimal workbench view that extends the base class in order to test
+// shared behavior of workbench views and to avoid duplicating tests.
+// Any functionality specific to a workbench view type can be tested separately
+// or in an integration test.
+
+interface MockWorkbenchViewState {
+    contentText: string
+    visible: boolean
+}
+
+class MockWorkbenchView extends WorkbenchView<MockWorkbenchViewState> {
+    public state: MockWorkbenchViewState = {
+        contentText: '',
+        visible: true,
+    }
+
+    constructor(scheduler: WorkbenchViewScheduler, public unsubscribe: () => void) {
+        super(scheduler, 'mockWorkbenchViewType' as WorkbenchViewType)
+    }
+}
+
+describe('Workbench View', () => {
+    const scheduler = createWorkbenchViewScheduler(noop, () => undefined)
+
+    afterAll(() => {
+        scheduler.unsubscribe()
+    })
+
+    test('updating state', () => {
+        const viewInstance = new MockWorkbenchView(scheduler, noop)
+
+        expect(viewInstance.state).toStrictEqual({ contentText: '', visible: true })
+
+        // partial update
+        viewInstance.update({ contentText: 'partial' })
+        expect(viewInstance.state).toStrictEqual({ contentText: 'partial', visible: true })
+
+        // full update
+        viewInstance.update({ contentText: 'hidden', visible: false })
+        expect(viewInstance.state).toStrictEqual({ contentText: 'hidden', visible: false })
+    })
+})

--- a/client/shared/src/api/extension/workbench/views.ts
+++ b/client/shared/src/api/extension/workbench/views.ts
@@ -12,16 +12,6 @@ abstract class WorkbenchView<TState extends object> {
     }
 }
 
-// FOR NOW finish naive impl (cloning all view state)
-// TODO(tj): Where should we keep migrated services?
-
-// VIEWS
-
-// Why am I using classes? Saves memory (prototype methods)
-
-// Implement merging state setter so extensions can batch-update
-// interface StatusBarItemState extends Pick<sourcegraph.StatusBarItem, 'contentText' | 'hoverMessage' | 'linkURL'> {}
-
 export class ExtensionStatusBarItem
     extends WorkbenchView<sourcegraph.StatusBarItemState>
     implements sourcegraph.StatusBarItem {
@@ -35,39 +25,4 @@ export class ExtensionStatusBarItem
     constructor(scheduler: WorkbenchViewScheduler, public unsubscribe: () => void) {
         super(scheduler, 'statusBarItem')
     }
-
-    // TODO(tj): don't need these getters and setters
-    // Will increase development speed for views with complex state
-
-    // public get visible(): boolean {
-    //     return this.state.visible
-    // }
-
-    // public set visible(visible: boolean) {
-    //     this.update({ visible })
-    // }
-
-    // public get contentText(): string {
-    //     return this.state.contentText
-    // }
-
-    // public set contentText(contentText: string) {
-    //     this.update({ contentText })
-    // }
-
-    // public get hoverMessage(): string | undefined {
-    //     return this.state.hoverMessage
-    // }
-
-    // public set hoverMessage(hoverMessage: string | undefined) {
-    //     this.update({ hoverMessage })
-    // }
-
-    // public get linkURL(): string | undefined {
-    //     return this.state.linkURL
-    // }
-
-    // public set linkURL(linkURL: string | undefined) {
-    //     this.update({ linkURL })
-    // }
 }

--- a/client/shared/src/api/extension/workbench/views.ts
+++ b/client/shared/src/api/extension/workbench/views.ts
@@ -1,7 +1,7 @@
 import * as sourcegraph from 'sourcegraph'
 import { WorkbenchViewScheduler } from './scheduler'
 
-abstract class WorkbenchView<TState extends object> {
+export abstract class WorkbenchView<TState extends object> {
     abstract state: TState
 
     constructor(private scheduler: WorkbenchViewScheduler, private viewType: sourcegraph.WorkbenchViewType) {}

--- a/client/shared/src/api/extension/workbench/views.ts
+++ b/client/shared/src/api/extension/workbench/views.ts
@@ -1,0 +1,73 @@
+import * as sourcegraph from 'sourcegraph'
+import { WorkbenchViewScheduler } from './scheduler'
+
+abstract class WorkbenchView<TState extends object> {
+    abstract state: TState
+
+    constructor(private scheduler: WorkbenchViewScheduler, private viewType: sourcegraph.WorkbenchViewType) {}
+
+    public update(nextState: Partial<TState>): void {
+        this.state = { ...this.state, ...nextState }
+        this.scheduler.schedule({ viewType: this.viewType, type: 'update' })
+    }
+}
+
+// FOR NOW finish naive impl (cloning all view state)
+// TODO(tj): Where should we keep migrated services?
+
+// VIEWS
+
+// Why am I using classes? Saves memory (prototype methods)
+
+// Implement merging state setter so extensions can batch-update
+// interface StatusBarItemState extends Pick<sourcegraph.StatusBarItem, 'contentText' | 'hoverMessage' | 'linkURL'> {}
+
+export class ExtensionStatusBarItem
+    extends WorkbenchView<sourcegraph.StatusBarItemState>
+    implements sourcegraph.StatusBarItem {
+    public state: sourcegraph.StatusBarItemState = {
+        visible: true,
+        contentText: '',
+        hoverMessage: '',
+        linkURL: '',
+    }
+
+    constructor(scheduler: WorkbenchViewScheduler, public unsubscribe: () => void) {
+        super(scheduler, 'statusBarItem')
+    }
+
+    // TODO(tj): don't need these getters and setters
+    // Will increase development speed for views with complex state
+
+    // public get visible(): boolean {
+    //     return this.state.visible
+    // }
+
+    // public set visible(visible: boolean) {
+    //     this.update({ visible })
+    // }
+
+    // public get contentText(): string {
+    //     return this.state.contentText
+    // }
+
+    // public set contentText(contentText: string) {
+    //     this.update({ contentText })
+    // }
+
+    // public get hoverMessage(): string | undefined {
+    //     return this.state.hoverMessage
+    // }
+
+    // public set hoverMessage(hoverMessage: string | undefined) {
+    //     this.update({ hoverMessage })
+    // }
+
+    // public get linkURL(): string | undefined {
+    //     return this.state.linkURL
+    // }
+
+    // public set linkURL(linkURL: string | undefined) {
+    //     this.update({ linkURL })
+    // }
+}

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -151,7 +151,4 @@ body,
     // Skip Reach UI styles. See https://reacttraining.com/reach-ui/styling/.
     --reach-menu-button: 1;
     --reach-accordion: 1;
-
-    // TODO(tj): Explain
-    --repo-content-padding-bottom: 0;
 }

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -137,6 +137,7 @@ body,
 @import './components/SearchResultMatch';
 @import './components/diff/FileDiffNode';
 @import './components/externalServices/AddExternalServicesPage';
+@import './components/StatusBar.scss';
 @import '../../branded/src/components/Tabs';
 @import '../../branded/src/components/panel/Panel';
 @import '../../branded/src/components/panel/views/FileLocations';

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -151,4 +151,7 @@ body,
     // Skip Reach UI styles. See https://reacttraining.com/reach-ui/styling/.
     --reach-menu-button: 1;
     --reach-accordion: 1;
+
+    // TODO(tj): Explain
+    --repo-content-padding-bottom: 0;
 }

--- a/client/web/src/backend/features.ts
+++ b/client/web/src/backend/features.ts
@@ -12,7 +12,7 @@ import {
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { switchMap } from 'rxjs/operators'
 import { wrapRemoteObservable } from '../../../shared/src/api/client/api/common'
-import { DocumentHighlight } from 'sourcegraph'
+import { DocumentHighlight, StatusBarItemState } from 'sourcegraph'
 import { memoizeObservable } from '../../../shared/src/util/memoizeObservable'
 import { Remote } from 'comlink'
 import { FlatExtensionHostAPI } from '../../../shared/src/api/contract'
@@ -119,3 +119,10 @@ const getFileDecorationsFromHost = memoizeObservable(
         ),
     ({ parentNodeUri, files }) => `parentNodeUri:${parentNodeUri} files:${files.length}`
 )
+
+export const getStatusBarItems = ({
+    extensionsController,
+}: ExtensionsControllerProps): Observable<Map<string, StatusBarItemState>> =>
+    from(extensionsController.extHostAPI).pipe(
+        switchMap(extensionHost => wrapRemoteObservable(extensionHost.getStatusBarItems()))
+    )

--- a/client/web/src/components/StatusBar.scss
+++ b/client/web/src/components/StatusBar.scss
@@ -1,0 +1,18 @@
+.status-bar {
+    height: 1.5rem;
+    background-color: var(--color-bg-2);
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.0625rem; // 1px
+
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+
+    // TODO(tj): truncation
+
+    &__item {
+        &:not(:last-child) {
+            margin-right: 1rem;
+        }
+    }
+}

--- a/client/web/src/components/StatusBar.tsx
+++ b/client/web/src/components/StatusBar.tsx
@@ -1,0 +1,32 @@
+import React, { useMemo } from 'react'
+import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
+import { useObservable } from '../../../shared/src/util/useObservable'
+import { getStatusBarItems } from '../backend/features'
+import classNames from 'classnames'
+import iterate from 'iterare'
+
+interface Props extends ExtensionsControllerProps {
+    className?: string
+}
+
+/**
+ * Component that fetches and renders status bar items from extensions
+ */
+export const StatusBar: React.FunctionComponent<Props> = ({ extensionsController, className }) => {
+    const statusBarItems = useObservable(
+        useMemo(() => getStatusBarItems({ extensionsController }), [extensionsController])
+    )
+
+    if (!statusBarItems) {
+        return null
+    }
+
+    return (
+        <div className={classNames(className)}>
+            {iterate(statusBarItems)
+                .filter(([, item]) => item.visible && !!item.contentText)
+                .map(([id, item]) => <p key={id}>{item.contentText}</p>)
+                .toArray()}
+        </div>
+    )
+}

--- a/client/web/src/components/StatusBar.tsx
+++ b/client/web/src/components/StatusBar.tsx
@@ -1,43 +1,52 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { useObservable } from '../../../shared/src/util/useObservable'
 import { getStatusBarItems } from '../backend/features'
 import classNames from 'classnames'
 import iterate from 'iterare'
+import { isString } from 'lodash'
 
 interface Props extends ExtensionsControllerProps {
     className?: string
 }
 
 /**
- * Component that fetches and renders status bar items from extensions
+ * Component that fetches and renders status bar items from extensions.
+ *
+ * Memoized since its props are not likely to change.
  */
-export const StatusBar: React.FunctionComponent<Props> = ({ extensionsController, className }) => {
+export const StatusBar = React.memo<Props>(({ extensionsController, className }) => {
     const statusBarItems = useObservable(
         useMemo(() => getStatusBarItems({ extensionsController }), [extensionsController])
     )
 
-    if (!statusBarItems) {
-        return null
-    }
+    const renderedItems =
+        statusBarItems &&
+        iterate(statusBarItems)
+            .filter(([, item]) => item.visible && isString(item.contentText) && (!item.title || isString(item.title)))
+            .map(([id, item]) => (
+                <small key={id} className="status-bar__item" data-tooltip={item.hoverMessage}>
+                    {item.title && <small className="text-muted">{item.title}: </small>}
+                    {item.contentText}
+                </small>
+            ))
+            .toArray()
 
-    const renderedItems = iterate(statusBarItems)
-        .filter(
-            ([, item]) =>
-                item.visible &&
-                !!item.contentText &&
-                typeof item.contentText === 'string' &&
-                (typeof item.title !== 'object' || item.title === null)
+    const shouldDisplayStatusBar = renderedItems && renderedItems.length > 0
+
+    useEffect(() => {
+        // Increase repo revision container content margin-bottom when status bar is visible.
+        document.documentElement.style.setProperty(
+            '--repo-content-padding-bottom',
+            shouldDisplayStatusBar ? '1.5rem' : '0'
         )
-        .map(([id, item]) => (
-            <small key={id} className="status-bar__item">
-                {item.title && <small className="text-muted">{item.title}: </small>}
-                {item.contentText}
-            </small>
-        ))
-        .toArray()
 
-    return renderedItems.length > 0 ? (
+        return () => {
+            document.documentElement.style.setProperty('--repo-content-padding-bottom', '0')
+        }
+    }, [shouldDisplayStatusBar])
+
+    return shouldDisplayStatusBar ? (
         <div className={classNames(className, 'status-bar d-flex align-items-center px-2')}>{renderedItems}</div>
     ) : null
-}
+})

--- a/client/web/src/components/StatusBar.tsx
+++ b/client/web/src/components/StatusBar.tsx
@@ -21,12 +21,23 @@ export const StatusBar: React.FunctionComponent<Props> = ({ extensionsController
         return null
     }
 
-    return (
-        <div className={classNames(className)}>
-            {iterate(statusBarItems)
-                .filter(([, item]) => item.visible && !!item.contentText)
-                .map(([id, item]) => <p key={id}>{item.contentText}</p>)
-                .toArray()}
-        </div>
-    )
+    const renderedItems = iterate(statusBarItems)
+        .filter(
+            ([, item]) =>
+                item.visible &&
+                !!item.contentText &&
+                typeof item.contentText === 'string' &&
+                (typeof item.title !== 'object' || item.title === null)
+        )
+        .map(([id, item]) => (
+            <small key={id} className="status-bar__item">
+                {item.title && <small className="text-muted">{item.title}: </small>}
+                {item.contentText}
+            </small>
+        ))
+        .toArray()
+
+    return renderedItems.length > 0 ? (
+        <div className={classNames(className, 'status-bar d-flex align-items-center px-2')}>{renderedItems}</div>
+    ) : null
 }

--- a/client/web/src/global/GlobalDebug.tsx
+++ b/client/web/src/global/GlobalDebug.tsx
@@ -6,7 +6,7 @@ import { PlatformContextProps } from '../../../shared/src/platform/context'
 
 interface Props extends ExtensionsControllerProps, PlatformContextProps {}
 
-const SHOW_DEBUG = localStorage.getItem('debug') !== null
+const SHOW_DEBUG = localStorage.getItem('debug') === 'true'
 
 const ExtensionLink: React.FunctionComponent<{ id: string }> = props => (
     <Link to={`/extensions/${props.id}`}>{props.id}</Link>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -375,13 +375,6 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         setHasDismissedExtensionAlert(true)
     }, [onExtensionAlertDismissed, setHasDismissedExtensionAlert])
 
-    /**
-     * TODO(tj):
-     * - Maintain action items bar open/close state here. useLocalStorage.
-     * - nvm, always render <ActionItemsBar> on search + repo pages. it maintains
-     * its own state. Replace `ActionsNavItems` in the web app
-     */
-
     if (!repoOrError) {
         // Render nothing while loading
         return null

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -377,14 +377,10 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
 
     /**
      * TODO(tj):
-     * - Maintain action items bar open/close state here. useLocalStorage
-     * - get action items OUT of RepoHeader, and into action items bar (icon/toggling) + status bar (static info)
+     * - Maintain action items bar open/close state here. useLocalStorage.
+     * - nvm, always render <ActionItemsBar> on search + repo pages. it maintains
+     * its own state. Replace `ActionsNavItems` in the web app
      */
-    useEffect(() => {
-        getStatusBarItems({ extensionsController: props.extensionsController }).subscribe(statusBarItems => {
-            console.log({ statusBarItems })
-        })
-    }, [props.extensionsController])
 
     if (!repoOrError) {
         // Render nothing while loading

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -61,6 +61,7 @@ import { InstallBrowserExtensionAlert } from './actions/InstallBrowserExtensionA
 import { IS_CHROME } from '../marketing/util'
 import { useLocalStorage } from '../util/useLocalStorage'
 import { Settings } from '../schema/settings.schema'
+import { getStatusBarItems } from '../backend/features'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -373,6 +374,17 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         onExtensionAlertDismissed()
         setHasDismissedExtensionAlert(true)
     }, [onExtensionAlertDismissed, setHasDismissedExtensionAlert])
+
+    /**
+     * TODO(tj):
+     * - Maintain action items bar open/close state here. useLocalStorage
+     * - get action items OUT of RepoHeader, and into action items bar (icon/toggling) + status bar (static info)
+     */
+    useEffect(() => {
+        getStatusBarItems({ extensionsController: props.extensionsController }).subscribe(statusBarItems => {
+            console.log({ statusBarItems })
+        })
+    }, [props.extensionsController])
 
     if (!repoOrError) {
         // Render nothing while loading

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -47,7 +47,5 @@
         min-width: 0;
 
         background-color: var(--body-bg);
-
-        padding-bottom: var(--repo-content-padding-bottom);
     }
 }

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -47,9 +47,7 @@
         min-width: 0;
 
         background-color: var(--body-bg);
-    }
 
-    &__status-bar {
-        // TODO(tj)
+        padding-bottom: var(--repo-content-padding-bottom);
     }
 }

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -48,4 +48,8 @@
 
         background-color: var(--body-bg);
     }
+
+    &__status-bar {
+        // TODO(tj)
+    }
 }

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -37,6 +37,7 @@ import { RepoSettingsSideBarGroup } from './settings/RepoSettingsSidebar'
 import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { AuthenticatedUser } from '../auth'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
+import { StatusBarProps, StatusBarContainerProps, useStatusBar } from '../components/StatusBar'
 
 /** Props passed to sub-routes of {@link RepoRevisionContainer}. */
 export interface RepoRevisionContainerContext
@@ -57,7 +58,9 @@ export interface RepoRevisionContainerContext
         CopyQueryButtonProps,
         VersionContextProps,
         RevisionSpec,
-        BreadcrumbSetters {
+        BreadcrumbSetters,
+        StatusBarProps,
+        StatusBarContainerProps {
     repo: GQL.IRepository
     resolvedRev: ResolvedRevision
 
@@ -168,6 +171,8 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
         ])
     )
 
+    const statusBarProps = useStatusBar()
+
     if (!props.resolvedRevisionOrError) {
         // Render nothing while loading
         return null
@@ -216,6 +221,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     const context: RepoRevisionContainerContext = {
         ...props,
         ...breadcrumbSetters,
+        ...statusBarProps,
         resolvedRev: props.resolvedRevisionOrError,
     }
 

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -6,6 +6,7 @@ import { lazyComponent } from '../util/lazyComponent'
 import { formatHash } from '../util/url'
 import { RepoContainerRoute } from './RepoContainer'
 import { RepoRevisionContainerContext, RepoRevisionContainerRoute } from './RepoRevisionContainer'
+import classNames from 'classnames'
 
 const BlobPage = lazyComponent(() => import('./blob/BlobPage'), 'BlobPage')
 const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCommitsPage'), 'RepositoryCommitsPage')
@@ -144,8 +145,6 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                 versionContext,
                 globbing,
             }
-            // TODO(tj): Might have to extract a RepoRevisionContent component to elegantly change content padding based on
-            // whether the status bar is rendered. Currently using CSS custom property that `StatusBar` sets on visibility changes
 
             return (
                 <>
@@ -157,7 +156,12 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                         defaultBranch={defaultBranch || 'HEAD'}
                     />
                     {!hideRepoRevisionContent && (
-                        <div className="repo-revision-container__content">
+                        <div
+                            className={classNames(
+                                'repo-revision-container__content',
+                                context.statusBarContainerClassName
+                            )}
+                        >
                             {objectType === 'blob' ? (
                                 <BlobPage
                                     {...context}
@@ -170,7 +174,10 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                             ) : (
                                 <TreePage {...context} {...repoRevisionProps} />
                             )}
-                            <StatusBar extensionsController={context.extensionsController} />
+                            <StatusBar
+                                extensionsController={context.extensionsController}
+                                onStatusBarVisiblityChange={context.onStatusBarVisiblityChange}
+                            />
                         </div>
                     )}
                 </>

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { getModeFromPath } from '../../../shared/src/languages'
 import { isLegacyFragment, parseHash, toRepoURL } from '../../../shared/src/util/url'
+import { StatusBar } from '../components/StatusBar'
 import { lazyComponent } from '../util/lazyComponent'
 import { formatHash } from '../util/url'
 import { RepoContainerRoute } from './RepoContainer'
@@ -169,6 +170,7 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                             )}
                         </div>
                     )}
+                    <StatusBar extensionsController={context.extensionsController} />
                 </>
             )
         },

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -168,9 +168,9 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                             ) : (
                                 <TreePage {...context} {...repoRevisionProps} />
                             )}
+                            <StatusBar extensionsController={context.extensionsController} />
                         </div>
                     )}
-                    <StatusBar extensionsController={context.extensionsController} />
                 </>
             )
         },

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { getModeFromPath } from '../../../shared/src/languages'
 import { isLegacyFragment, parseHash, toRepoURL } from '../../../shared/src/util/url'
-import { StatusBar } from '../components/StatusBar'
 import { lazyComponent } from '../util/lazyComponent'
 import { formatHash } from '../util/url'
 import { RepoContainerRoute } from './RepoContainer'
@@ -12,6 +11,7 @@ const BlobPage = lazyComponent(() => import('./blob/BlobPage'), 'BlobPage')
 const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCommitsPage'), 'RepositoryCommitsPage')
 const RepoRevisionSidebar = lazyComponent(() => import('./RepoRevisionSidebar'), 'RepoRevisionSidebar')
 const TreePage = lazyComponent(() => import('./tree/TreePage'), 'TreePage')
+const StatusBar = lazyComponent(() => import('../components/StatusBar'), 'StatusBar')
 
 const RepositoryGitDataContainer = lazyComponent(
     () => import('./RepositoryGitDataContainer'),
@@ -144,6 +144,8 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                 versionContext,
                 globbing,
             }
+            // TODO(tj): Might have to extract a RepoRevisionContent component to elegantly change content padding based on
+            // whether the status bar is rendered. Currently using CSS custom property that `StatusBar` sets on visibility changes
 
             return (
                 <>


### PR DESCRIPTION
Description WIP

Implement workbench view system and status bar, the first workbench view. 

---

### Workbench views

#### What is a workbench view?

TODO

| Workbench view | Insights view |
| --- | --- |
| Extension pushes updates to UI | UI pulls from provider |
| Persists between pages | Scoped to a single page |
| Presents lower-level information | Presents higher-level information |
| "Contextual" views | Primary focus TODO | 

#### Implementation details

![workbenchViews](https://user-images.githubusercontent.com/37420160/100558903-5b106000-327e-11eb-8643-4e39315e4120.png)

For now, we send the state of all views on each "flush". The main performance pitfall I envisioned was the main thread rendering too often (see: "Motivation"), so optimizing communication between the threads was not a priority. 

Once we have more complex views with ["deep and broad" state objects](https://surma.dev/things/is-postmessage-slow/), we can consider sending diffs to the main thread instead. The increased complexity of maintaining view state on the main thread as well outweighs the potential performance boosts for our existing (simple) workbench views

#### Motivation

TODO

---


### Status bar

The status bar is our first workbench view. 

<details open>
<summary>Dynamic status bar item (mock character count extension)</summary>
<img src="https://user-images.githubusercontent.com/37420160/100558963-a32f8280-327e-11eb-93b1-a44623d57de8.gif" />
</details>

We plan to add an "action items bar" workbench view as part of RFC 250 (action items bar). We can also convert our panel view and add a sidebar workbench view as we complete our RFC 155 (extension API architecture) refactoring work.