### PR TITLE
search: code monitoring, move emails to store

### DIFF
--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -1,0 +1,66 @@
+package codemonitors
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+type MonitorEmail struct {
+	Id        int64
+	Monitor   int64
+	Enabled   bool
+	Priority  string
+	Header    string
+	CreatedBy int32
+	CreatedAt time.Time
+	ChangedBy int32
+	ChangedAt time.Time
+}
+
+const getAllEmailActionsForTriggerQueryIDInt64FmtStr = `
+SELECT e.id, e.monitor, e.enabled, e.priority, e.header, e.created_by, e.created_at, e.changed_by, e.changed_at
+FROM cm_emails e INNER JOIN cm_queries q ON e.monitor = q.monitor
+WHERE q.id = %s
+`
+
+var EmailsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_emails.id"),
+	sqlf.Sprintf("cm_emails.monitor"),
+	sqlf.Sprintf("cm_emails.enabled"),
+	sqlf.Sprintf("cm_emails.priority"),
+	sqlf.Sprintf("cm_emails.header"),
+	sqlf.Sprintf("cm_emails.created_by"),
+	sqlf.Sprintf("cm_emails.created_at"),
+	sqlf.Sprintf("cm_emails.changed_by"),
+	sqlf.Sprintf("cm_emails.changed_at"),
+}
+
+func ScanEmails(rows *sql.Rows) (ms []*MonitorEmail, err error) {
+	for rows.Next() {
+		m := &MonitorEmail{}
+		if err = rows.Scan(
+			&m.Id,
+			&m.Monitor,
+			&m.Enabled,
+			&m.Priority,
+			&m.Header,
+			&m.CreatedBy,
+			&m.CreatedAt,
+			&m.ChangedBy,
+			&m.ChangedAt,
+		); err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	err = rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ms, nil
+}

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	campaignApitest "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers/apitest"

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -83,7 +84,7 @@ func (s *Store) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, arg
 }
 
 type TriggerJobs struct {
-	Id    int32
+	Id    int
 	Query int64
 
 	// The query we ran including after: filter.
@@ -104,7 +105,7 @@ type TriggerJobs struct {
 }
 
 func (r *TriggerJobs) RecordID() int {
-	return int(r.Id)
+	return r.Id
 }
 
 func ScanTriggerJobs(rows *sql.Rows, err error) (workerutil.Record, bool, error) {


### PR DESCRIPTION
This is a refactor, moving db interactions with table `cm_emails` from the
resolver to store.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
