### PR TITLE
search: add email recipients to code monitor store

### DIFF
--- a/enterprise/internal/codemonitors/actions.go
+++ b/enterprise/internal/codemonitors/actions.go
@@ -1,0 +1,21 @@
+package codemonitors
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+func (s *Store) CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) (err error) {
+	for _, a := range args {
+		e, err := s.CreateActionEmail(ctx, monitorID, a)
+		if err != nil {
+			return err
+		}
+		err = s.CreateRecipients(ctx, a.Email.Recipients, e.Id)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -1,0 +1,172 @@
+package codemonitors
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+type Recipient struct {
+	ID              int64
+	Email           int64
+	NamespaceUserID *int32
+	NamespaceOrgID  *int32
+}
+
+var recipientsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_recipients.id"),
+	sqlf.Sprintf("cm_recipients.email"),
+	sqlf.Sprintf("cm_recipients.namespace_user_id"),
+	sqlf.Sprintf("cm_recipients.namespace_org_id"),
+}
+
+func (s *Store) CreateRecipients(ctx context.Context, recipients []graphql.ID, monitorID int64) (err error) {
+	var q *sqlf.Query
+	q, err = createRecipientsQuery(ctx, recipients, monitorID)
+	if err != nil {
+		return err
+	}
+	err = s.Exec(ctx, q)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) DeleteRecipients(ctx context.Context, emailID int64) (err error) {
+	var q *sqlf.Query
+	q, err = deleteRecipientsQuery(ctx, emailID)
+	if err != nil {
+		return err
+	}
+	err = s.Exec(ctx, q)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) RecipientsForEmailIDInt64(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
+	q, err := s.ReadRecipientQuery(ctx, emailID, args)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ms, err := ScanRecipients(rows)
+	if err != nil {
+		return nil, err
+	}
+	return ms, nil
+}
+
+const totalCountRecipientsFmtStr = `
+SELECT COUNT(*)
+FROM cm_recipients
+WHERE email = %s
+`
+
+func (s *Store) TotalCountRecipients(ctx context.Context, emailID int64) (count int32, err error) {
+	err = s.QueryRow(ctx, sqlf.Sprintf(totalCountRecipientsFmtStr, emailID)).Scan(&count)
+	return count, err
+}
+
+func ScanRecipients(rows *sql.Rows) (ms []*Recipient, err error) {
+	for rows.Next() {
+		m := &Recipient{}
+		if err := rows.Scan(
+			&m.ID,
+			&m.Email,
+			&m.NamespaceUserID,
+			&m.NamespaceOrgID,
+		); err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	err = rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ms, nil
+}
+
+// CreateRecipientsQuery returns a query that inserts several recipients at once.
+func createRecipientsQuery(ctx context.Context, namespaces []graphql.ID, emailID int64) (*sqlf.Query, error) {
+	const header = `
+INSERT INTO cm_recipients (email, namespace_user_id, namespace_org_id)
+VALUES`
+	const values = `
+(%s,%s,%s),`
+	var (
+		userID        int32
+		orgID         int32
+		combinedQuery string
+		args          []interface{}
+	)
+	combinedQuery = header
+	for range namespaces {
+		combinedQuery += values
+	}
+	combinedQuery = strings.TrimSuffix(combinedQuery, ",") + ";"
+	for _, ns := range namespaces {
+		err := graphqlbackend.UnmarshalNamespaceID(ns, &userID, &orgID)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, emailID, nilOrInt32(userID), nilOrInt32(orgID))
+	}
+	return sqlf.Sprintf(
+		combinedQuery,
+		args...,
+	), nil
+}
+
+const deleteRecipientFmtStr = `DELETE FROM cm_recipients WHERE email = %s`
+
+func deleteRecipientsQuery(ctx context.Context, emailId int64) (*sqlf.Query, error) {
+	return sqlf.Sprintf(
+		deleteRecipientFmtStr,
+		emailId,
+	), nil
+}
+
+const readRecipientQueryFmtStr = `
+SELECT id, email, namespace_user_id, namespace_org_id
+FROM cm_recipients
+WHERE email = %s
+AND id > %s
+ORDER BY id ASC
+LIMIT %s;
+`
+
+func (s *Store) ReadRecipientQuery(ctx context.Context, emailId int64, args *graphqlbackend.ListRecipientsArgs) (*sqlf.Query, error) {
+	after, err := unmarshalAfter(args.After)
+	if err != nil {
+		return nil, err
+	}
+	return sqlf.Sprintf(
+		readRecipientQueryFmtStr,
+		emailId,
+		after,
+		args.First,
+	), nil
+}
+
+func nilOrInt32(n int32) *int32 {
+	if n == 0 {
+		return nil
+	}
+	return &n
+}

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
@@ -97,7 +96,7 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 	}
 
 	// create actions
-	err = tx.createActions(ctx, args.Actions, m.(*monitor).id)
+	err = tx.store.CreateActions(ctx, args.Actions, m.(*monitor).id)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +168,7 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 	if err != nil {
 		return nil, err
 	}
-	err = tx.createActions(ctx, toCreate, monitorID)
+	err = tx.store.CreateActions(ctx, toCreate, monitorID)
 	if err != nil {
 		return nil, err
 	}
@@ -316,20 +315,6 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		}
 	}
 	return m, nil
-}
-
-func (r *Resolver) createActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) (err error) {
-	for _, a := range args {
-		e, err := r.store.CreateActionEmail(ctx, monitorID, a)
-		if err != nil {
-			return err
-		}
-		err = r.store.CreateRecipients(ctx, a.Email.Recipients, e.Id)
-		if err != nil {
-			return err
-		}
-	}
-	return err
 }
 
 func (r *Resolver) transact(ctx context.Context) (*Resolver, error) {
@@ -589,73 +574,6 @@ WHERE monitor = %s;
 	return sqlf.Sprintf(
 		triggerQueryByMonitorQuery,
 		monitorID,
-	), nil
-}
-
-var recipientsColumns = []*sqlf.Query{
-	sqlf.Sprintf("cm_recipients.id"),
-	sqlf.Sprintf("cm_recipients.email"),
-	sqlf.Sprintf("cm_recipients.namespace_user_id"),
-	sqlf.Sprintf("cm_recipients.namespace_org_id"),
-}
-
-// createRecipientsQuery returns a query that inserts several recipients at once.
-func createRecipientsQuery(ctx context.Context, namespaces []graphql.ID, emailID int64) (*sqlf.Query, error) {
-	const header = `
-INSERT INTO cm_recipients (email, namespace_user_id, namespace_org_id)
-VALUES`
-	const values = `
-(%s,%s,%s),`
-	var (
-		userID        int32
-		orgID         int32
-		combinedQuery string
-		args          []interface{}
-	)
-	combinedQuery = header
-	for range namespaces {
-		combinedQuery += values
-	}
-	combinedQuery = strings.TrimSuffix(combinedQuery, ",") + ";"
-	for _, ns := range namespaces {
-		err := graphqlbackend.UnmarshalNamespaceID(ns, &userID, &orgID)
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, emailID, nilOrInt32(userID), nilOrInt32(orgID))
-	}
-	return sqlf.Sprintf(
-		combinedQuery,
-		args...,
-	), nil
-}
-
-func (r *Resolver) deleteRecipientsQuery(ctx context.Context, emailId int64) (*sqlf.Query, error) {
-	const deleteRecipientQuery = `DELETE FROM cm_recipients WHERE email = %s`
-	return sqlf.Sprintf(
-		deleteRecipientQuery,
-		emailId,
-	), nil
-}
-
-func (r *Resolver) readRecipientQuery(ctx context.Context, emailId int64, args *graphqlbackend.ListRecipientsArgs) (*sqlf.Query, error) {
-	const readRecipientQuery = `
-SELECT id, email, namespace_user_id, namespace_org_id
-FROM cm_recipients
-WHERE email = %s
-AND id > %s
-ORDER BY id ASC
-LIMIT %s;
-`
-	after, err := unmarshalAfter(args.After)
-	if err != nil {
-		return nil, err
-	}
-	return sqlf.Sprintf(
-		readRecipientQuery,
-		emailId,
-		after,
-		args.First,
 	), nil
 }
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -1000,6 +1000,9 @@ func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.List
 		} else {
 			n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, *r.NamespaceOrgID)
 		}
+		if err != nil {
+			return nil, err
+		}
 		ns = append(ns, n)
 	}
 


### PR DESCRIPTION
This PR prepares code monitoring to send emails for trigger events.
It is mostly a refactor which moves db-CRUD operations for
recipients from `resolvers.go` down to the store. The goal is to
provide access to recipients for the background workers as well as
for the GraphQL resolvers.

I also added another test to make sure we get paging right.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
