### PR TITLE
buildkite: pass on log groups from vagrant

### DIFF
--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -12,6 +12,19 @@ cleanup() {
   vagrant destroy -f "$box"
 }
 
+# remove log prefix that vagrant inserts so buildkite can interpret control
+# characters from output. For example
+#
+#     sourcegraph-e2e: --- yarn run test-e2e
+#
+# becomes
+#
+# --- yarn run test-e2e
+remove_log_prefix() {
+  # We don't use ^ due to control characters.
+  sed -E "s/    ${box}: (---|\+\+\+|\^\^\^) /\1 /g"
+}
+
 plugins=(vagrant-google vagrant-env vagrant-scp)
 for i in "${plugins[@]}"; do
   if ! vagrant plugin list --no-tty | grep "$i"; then
@@ -20,7 +33,8 @@ for i in "${plugins[@]}"; do
 done
 
 trap cleanup EXIT
-vagrant up "$box" --provider=google || exit_code=$?
+
+(vagrant up "$box" --provider=google | remove_log_prefix) || exit_code=$?
 
 vagrant scp "${box}:/sourcegraph/puppeteer/*.png" ../../../
 vagrant scp "${box}:/sourcegraph/*.mp4" ../../../


### PR DESCRIPTION
vagrant prefixes all output with the box name. I couldn't find a way to
prevent this behaviour, so instead we strip it out for lines we care
about. In particular the buildkite log grouping lines [1] we care about.
This should help improve the output of the e2e steps.

[1]: https://buildkite.com/docs/pipelines/managing-log-output