### PR TITLE
web: cleanup CodeExcerpt / CodeExcerpt2 code split

### DIFF
--- a/client/shared/src/components/CodeExcerpt.tsx
+++ b/client/shared/src/components/CodeExcerpt.tsx
@@ -48,6 +48,9 @@ interface State {
     blobLinesOrError?: string[] | ErrorLike
 }
 
+/**
+ * A code excerpt that displays syntax highlighting and match range highlighting.
+ */
 export class CodeExcerpt extends React.PureComponent<Props, State> {
     public state: State = {}
     private tableContainerElement: HTMLElement | null = null

--- a/client/shared/src/components/CodeExcerptUnhighlighted.tsx
+++ b/client/shared/src/components/CodeExcerptUnhighlighted.tsx
@@ -16,7 +16,10 @@ interface Props {
     onSelect: () => void
 }
 
-export class CodeExcerpt2 extends React.PureComponent<Props> {
+/**
+ * A code excerpt that displays match range highlighting, but no syntax highlighting.
+ */
+export class CodeExcerptUnhighlighted extends React.PureComponent<Props> {
     public render(): JSX.Element | null {
         const maxDigits = this.props.items.reduce((digitsTotal, { line }) => {
             const digits = (line + 1).toString().length

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -7,7 +7,7 @@ import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
 import { SymbolIcon } from '../symbols/SymbolIcon'
 import { toPositionOrRangeHash, appendSubtreeQueryParameter } from '../util/url'
 import { CodeExcerpt, FetchFileParameters } from './CodeExcerpt'
-import { CodeExcerpt2 } from './CodeExcerpt2'
+import { CodeExcerptUnhighlighted } from './CodeExcerptUnhighlighted'
 import { IFileMatch, IMatchItem } from './FileMatch'
 import { mergeContext } from './FileMatchContext'
 import { Link } from './Link'
@@ -87,7 +87,13 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
     )
 
     if (NO_SEARCH_HIGHLIGHTING) {
-        return <CodeExcerpt2 urlWithoutPosition={props.result.file.url} items={showItems} onSelect={props.onSelect} />
+        return (
+            <CodeExcerptUnhighlighted
+                urlWithoutPosition={props.result.file.url}
+                items={showItems}
+                onSelect={props.onSelect}
+            />
+        )
     }
 
     const groupsOfItems = mergeContext(


### PR DESCRIPTION
`CodeExcerpt2` feels like a particularly bad name for something that is only
enabled by developers in the case of:

```ts
// Dev flag for disabling syntax highlighting on search results pages.
const NO_SEARCH_HIGHLIGHTING = localStorage.getItem('noSearchHighlighting') !== null
```

This change renames it to `CodeExcerptUnhighlighted` and adds documentation to
both which describes the difference between the two.

Helps #6992

Signed-off-by: Stephen Gutekanst <stephen.gutekanst@gmail.com>