### PR TITLE
Manage code monitor page: base routing

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
@@ -1,5 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import React, { useState, useCallback } from 'react'
+import * as H from 'history'
 import { Observable, concat, of } from 'rxjs'
 import { switchMap, catchError, startWith, takeUntil, tap, delay } from 'rxjs/operators'
 import { Toggle } from '../../../../branded/src/components/Toggle'
@@ -9,13 +10,17 @@ import { useEventObservable } from '../../../../shared/src/util/useObservable'
 import { CodeMonitorFields, ToggleCodeMonitorEnabledResult } from '../../graphql-operations'
 import { toggleCodeMonitorEnabled } from './backend'
 
-interface CodeMonitorNodeProps {
+export interface CodeMonitorNodeProps {
     node: CodeMonitorFields
+    location: H.Location
 }
 
 const LOADING = 'LOADING' as const
 
-export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({ node }: CodeMonitorNodeProps) => {
+export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
+    location,
+    node,
+}: CodeMonitorNodeProps) => {
     const [enabled, setEnabled] = useState<boolean>(node.enabled)
 
     const [toggleMonitor, toggleMonitorOrError] = useEventObservable(
@@ -65,7 +70,7 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                             <Toggle value={enabled} className="mr-3" disabled={toggleMonitorOrError === LOADING} />
                         </div>
                         {/** TODO: link to edit pages. */}
-                        <Link to="/">Edit</Link>
+                        <Link to={`${location.pathname}/${node.id}`}>Edit</Link>
                     </div>
                 </div>
             </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -8,8 +8,8 @@ import { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-o
 import sinon from 'sinon'
 import { mockCodeMonitorNodes } from './testing/util'
 
-const history = H.createBrowserHistory()
-
+const history = H.createBrowserHistory({})
+history.replace({ pathname: '/code-monitoring' })
 const additionalProps = {
     history,
     location: history.location,

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -7,11 +7,11 @@ import { PageHeader } from '../../components/PageHeader'
 import { PageTitle } from '../../components/PageTitle'
 import { AuthenticatedUser } from '../../auth'
 import { FilteredConnection } from '../../components/FilteredConnection'
-import { CodeMonitorFields, ListUserCodeMonitorsVariables } from '../../graphql-operations'
+import { CodeMonitorFields, ListUserCodeMonitorsResult, ListUserCodeMonitorsVariables } from '../../graphql-operations'
 import { Link } from '../../../../shared/src/components/Link'
 import { CodeMonitoringProps } from '.'
 import PlusIcon from 'mdi-react/PlusIcon'
-import { CodeMonitorNode } from './CodeMonitoringNode'
+import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
 
 export interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters, CodeMonitoringProps {
     authenticatedUser: AuthenticatedUser
@@ -99,13 +99,18 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                         <h3 className="mb-2">
                             {`${monitorListFilter === 'all' ? 'All code monitors' : 'Your code monitors'}`}
                         </h3>
-                        <FilteredConnection<CodeMonitorFields>
+                        <FilteredConnection<
+                            CodeMonitorFields,
+                            Omit<CodeMonitorNodeProps, 'node'>,
+                            (ListUserCodeMonitorsResult['node'] & { __typename: 'User' })['monitors']
+                        >
                             location={props.location}
                             history={props.history}
                             defaultFirst={10}
                             queryConnection={queryConnection}
                             hideSearch={true}
                             nodeComponent={CodeMonitorNode}
+                            nodeComponentProps={{ location: props.location }}
                             noun="code monitor"
                             pluralNoun="code monitors"
                             noSummaryIfAllNodesVisible={true}

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -1,0 +1,3 @@
+import * as React from 'react'
+
+export const ManageCodeMonitorPage: React.FunctionComponent<{}> = () => <div>Hello world!</div>

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
   }
   fetchUserCodeMonitors={[Function]}
   history="[History]"
-  location="[Location path=/]"
+  location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
   useBreadcrumb={[Function]}
 >
@@ -166,9 +166,14 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
             defaultFirst={10}
             hideSearch={true}
             history="[History]"
-            location="[Location path=/]"
+            location="[Location path=/code-monitoring]"
             noSummaryIfAllNodesVisible={true}
             nodeComponent={[Function]}
+            nodeComponentProps={
+              Object {
+                "location": "[Location path=/code-monitoring]",
+              }
+            }
             noun="code monitor"
             pluralNoun="code monitors"
             queryConnection={[Function]}
@@ -382,9 +387,14 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                 connectionQuery=""
                 first={10}
                 loading={false}
-                location="[Location path=/]"
+                location="[Location path=/code-monitoring]"
                 noSummaryIfAllNodesVisible={true}
                 nodeComponent={[Function]}
+                nodeComponentProps={
+                  Object {
+                    "location": "[Location path=/code-monitoring]",
+                  }
+                }
                 noun="code monitor"
                 onShowMore={[Function]}
                 pluralNoun="code monitors"
@@ -395,6 +405,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                 >
                   <CodeMonitorNode
                     key="foo0"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -473,10 +484,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo0"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo0"
                               >
                                 Edit
                               </a>
@@ -488,6 +499,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo1"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -566,10 +578,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo1"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo1"
                               >
                                 Edit
                               </a>
@@ -581,6 +593,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo2"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -659,10 +672,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo2"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo2"
                               >
                                 Edit
                               </a>
@@ -674,6 +687,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo3"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -752,10 +766,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo3"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo3"
                               >
                                 Edit
                               </a>
@@ -767,6 +781,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo4"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -845,10 +860,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo4"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo4"
                               >
                                 Edit
                               </a>
@@ -860,6 +875,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo5"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -938,10 +954,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo5"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo5"
                               >
                                 Edit
                               </a>
@@ -953,6 +969,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo6"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1031,10 +1048,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo6"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo6"
                               >
                                 Edit
                               </a>
@@ -1046,6 +1063,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo7"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1124,10 +1142,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo7"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo7"
                               >
                                 Edit
                               </a>
@@ -1139,6 +1157,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo9"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1217,10 +1236,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo9"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo9"
                               >
                                 Edit
                               </a>
@@ -1232,6 +1251,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo10"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1310,10 +1330,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo10"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo10"
                               >
                                 Edit
                               </a>
@@ -1363,7 +1383,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
   }
   fetchUserCodeMonitors={[Function]}
   history="[History]"
-  location="[Location path=/]"
+  location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
   useBreadcrumb={[Function]}
 >
@@ -1510,9 +1530,14 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
             defaultFirst={10}
             hideSearch={true}
             history="[History]"
-            location="[Location path=/]"
+            location="[Location path=/code-monitoring]"
             noSummaryIfAllNodesVisible={true}
             nodeComponent={[Function]}
+            nodeComponentProps={
+              Object {
+                "location": "[Location path=/code-monitoring]",
+              }
+            }
             noun="code monitor"
             pluralNoun="code monitors"
             queryConnection={[Function]}
@@ -1593,9 +1618,14 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                 connectionQuery=""
                 first={10}
                 loading={false}
-                location="[Location path=/]"
+                location="[Location path=/code-monitoring]"
                 noSummaryIfAllNodesVisible={true}
                 nodeComponent={[Function]}
+                nodeComponentProps={
+                  Object {
+                    "location": "[Location path=/code-monitoring]",
+                  }
+                }
                 noun="code monitor"
                 onShowMore={[Function]}
                 pluralNoun="code monitors"
@@ -1606,6 +1636,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                 >
                   <CodeMonitorNode
                     key="foo0"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1684,10 +1715,10 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo0"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo0"
                               >
                                 Edit
                               </a>
@@ -1699,6 +1730,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo1"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1777,10 +1809,10 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo1"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo1"
                               >
                                 Edit
                               </a>
@@ -1792,6 +1824,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo2"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -1870,10 +1903,10 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo2"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo2"
                               >
                                 Edit
                               </a>
@@ -1923,7 +1956,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
   }
   fetchUserCodeMonitors={[Function]}
   history="[History]"
-  location="[Location path=/]"
+  location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
   useBreadcrumb={[Function]}
 >
@@ -2070,9 +2103,14 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
             defaultFirst={10}
             hideSearch={true}
             history="[History]"
-            location="[Location path=/]"
+            location="[Location path=/code-monitoring]"
             noSummaryIfAllNodesVisible={true}
             nodeComponent={[Function]}
+            nodeComponentProps={
+              Object {
+                "location": "[Location path=/code-monitoring]",
+              }
+            }
             noun="code monitor"
             pluralNoun="code monitors"
             queryConnection={[Function]}
@@ -2324,9 +2362,14 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 connectionQuery=""
                 first={10}
                 loading={false}
-                location="[Location path=/]"
+                location="[Location path=/code-monitoring]"
                 noSummaryIfAllNodesVisible={true}
                 nodeComponent={[Function]}
+                nodeComponentProps={
+                  Object {
+                    "location": "[Location path=/code-monitoring]",
+                  }
+                }
                 noun="code monitor"
                 onShowMore={[Function]}
                 pluralNoun="code monitors"
@@ -2337,6 +2380,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 >
                   <CodeMonitorNode
                     key="foo0"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2415,10 +2459,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo0"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo0"
                               >
                                 Edit
                               </a>
@@ -2430,6 +2474,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo1"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2508,10 +2553,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo1"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo1"
                               >
                                 Edit
                               </a>
@@ -2523,6 +2568,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo2"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2601,10 +2647,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo2"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo2"
                               >
                                 Edit
                               </a>
@@ -2616,6 +2662,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo3"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2694,10 +2741,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo3"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo3"
                               >
                                 Edit
                               </a>
@@ -2709,6 +2756,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo4"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2787,10 +2835,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo4"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo4"
                               >
                                 Edit
                               </a>
@@ -2802,6 +2850,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo5"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2880,10 +2929,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo5"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo5"
                               >
                                 Edit
                               </a>
@@ -2895,6 +2944,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo6"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -2973,10 +3023,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo6"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo6"
                               >
                                 Edit
                               </a>
@@ -2988,6 +3038,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo7"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -3066,10 +3117,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo7"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo7"
                               >
                                 Edit
                               </a>
@@ -3081,6 +3132,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo9"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -3159,10 +3211,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo9"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo9"
                               >
                                 Edit
                               </a>
@@ -3174,6 +3226,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo10"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -3252,10 +3305,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo10"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo10"
                               >
                                 Edit
                               </a>
@@ -3267,6 +3320,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo11"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -3345,10 +3399,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo11"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo11"
                               >
                                 Edit
                               </a>
@@ -3360,6 +3414,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </CodeMonitorNode>
                   <CodeMonitorNode
                     key="foo12"
+                    location="[Location path=/code-monitoring]"
                     node={
                       Object {
                         "actions": Object {
@@ -3438,10 +3493,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                               </Toggle>
                             </div>
                             <AnchorLink
-                              to="/"
+                              to="/code-monitoring/foo12"
                             >
                               <a
-                                href="/"
+                                href="/code-monitoring/foo12"
                               >
                                 Edit
                               </a>

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -34,6 +34,11 @@ const CreateCodeMonitorPage = lazyComponent<CreateCodeMonitorPageProps, 'CreateC
     'CreateCodeMonitorPage'
 )
 
+const ManageCodeMonitorPage = lazyComponent<{}, 'ManageCodeMonitorPage'>(
+    () => import('../ManageCodeMonitorPage'),
+    'ManageCodeMonitorPage'
+)
+
 /**
  * The global code monitoring area.
  */
@@ -70,6 +75,11 @@ export const AuthenticatedCodeMonitoringArea = withAuthenticatedUser<Authenticat
                     <Route
                         path={`${match.url}/new`}
                         render={props => <CreateCodeMonitorPage {...outerProps} {...props} {...breadcrumbSetters} />}
+                        exact={true}
+                    />
+                    <Route
+                        path={`${match.path}/:id`}
+                        render={props => <ManageCodeMonitorPage {...outerProps} {...props} {...breadcrumbSetters} />}
                         exact={true}
                     />
                 </Switch>


### PR DESCRIPTION
Adds routing for the code monitor edit/manage pages. Clicking the edit button for a code monitor on the listing page will take you to the manage page. The URL for code monitors is `/code-monitors/${MONITOR_ID}` (@stefanhengl).

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
