### PR TITLE
search: streaming final progress event

### DIFF
--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -73,6 +73,11 @@ type RepositoryMatch = { type: 'repo' } & Pick<FileMatch, 'repository' | 'branch
  */
 export interface Progress {
     /**
+     * True if this is the final progress update for this stream
+     */
+    done: boolean
+
+    /**
      * The number of repositories matching the repo: filter. Is set once they
      * are resolved.
      */
@@ -280,6 +285,7 @@ const emptyAggregateResults: AggregateStreamingSearchResults = {
     results: [],
     filters: [],
     progress: {
+        done: false,
         durationMs: 0,
         matchCount: 0,
         skipped: [],

--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -73,11 +73,6 @@ type RepositoryMatch = { type: 'repo' } & Pick<FileMatch, 'repository' | 'branch
  */
 export interface Progress {
     /**
-     * True if this is the final progress update for this stream
-     */
-    done: boolean
-
-    /**
      * The number of repositories matching the repo: filter. Is set once they
      * are resolved.
      */
@@ -285,7 +280,6 @@ const emptyAggregateResults: AggregateStreamingSearchResults = {
     results: [],
     filters: [],
     progress: {
-        done: false,
         durationMs: 0,
         matchCount: 0,
         skipped: [],

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -201,7 +201,7 @@ func (sr *SearchResultsResolver) ApproximateResultCount() string {
 func (sr *SearchResultsResolver) Alert() *searchAlert { return sr.alert }
 
 func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
-	return int32(time.Since(sr.start).Nanoseconds() / int64(time.Millisecond))
+	return int32(time.Since(sr.start).Milliseconds())
 }
 
 // commonFileFilters are common filters used. It is used by DynamicFilters to

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -127,7 +127,7 @@ var skippedHandlers = []func(*graphqlbackend.SearchResultsResolver) (eventSkippe
 	repositoryMissingHandler,
 	repositoryCloningHandler,
 	// documentMatchLimitHandler,
-	// shardMatchLimitHandler,
+	shardMatchLimitHandler,
 	// repositoryLimitHandler,
 	shardTimeoutHandler,
 	// excludedForkHandler,

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -1,0 +1,153 @@
+package search
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+type eventProgress struct {
+	RepositoriesCount *int           `json:"repositoriesCount"`
+	MatchCount        int            `json:"matchCount"`
+	DurationMs        int            `json:"durationMs"`
+	Skipped           []eventSkipped `json:"skipped"`
+}
+
+type eventSkipped struct {
+	Reason    skippedReason   `json:"reason"`
+	Title     string          `json:"title"`
+	Message   string          `json:"message"`
+	Severity  severityType    `json:"severity"`
+	Suggested *eventSuggested `json:"suggested,omitempty"`
+}
+
+type eventSuggested struct {
+	Title           string `json:"title"`
+	QueryExpression string `json:"queryExpression"`
+}
+
+type skippedReason string
+
+const (
+	documentMatchLimit skippedReason = "document-match-limit"
+	shardMatchLimit                  = "shard-match-limit"
+	repositoryLimit                  = "repository-limit"
+	shardTimeout                     = "shard-timeout"
+	repositoryCloning                = "repository-cloning"
+	repositoryMissing                = "repository-missing"
+	excludedFork                     = "repository-fork"
+	excludedArchive                  = "excluded-archive"
+)
+
+type severityType string
+
+const (
+	severityInfo severityType = "info"
+	severityWarn              = "warn"
+)
+
+func number(i int) string {
+	if i < 1000 {
+		return strconv.Itoa(i)
+	}
+	if i < 10000 {
+		return fmt.Sprintf("%d,%d", i/1000, i%1000)
+	}
+	return fmt.Sprintf("%dk", i/1000)
+}
+
+func repositoryCloningHandler(resultsResolver *graphqlbackend.SearchResultsResolver) (eventSkipped, bool) {
+	repos := resultsResolver.Cloning()
+	if len(repos) == 0 {
+		return eventSkipped{}, false
+	}
+
+	amount := number(len(repos))
+	return eventSkipped{
+		Reason: repositoryCloning,
+		Title:  fmt.Sprintf("%s cloning", amount),
+		// TODO sample of repos in message
+		Message:  fmt.Sprintf("%s repositories could not be searched since they are still cloning. Try searching again or reducing the scope of your query with repo: repogroup: or other filters.", amount),
+		Severity: severityWarn,
+	}, true
+}
+
+func repositoryMissingHandler(resultsResolver *graphqlbackend.SearchResultsResolver) (eventSkipped, bool) {
+	repos := resultsResolver.Missing()
+	if len(repos) == 0 {
+		return eventSkipped{}, false
+	}
+
+	amount := number(len(repos))
+	return eventSkipped{
+		Reason: repositoryMissing,
+		Title:  fmt.Sprintf("%s missing", amount),
+		// TODO sample of repos in message
+		Message:  fmt.Sprintf("%s repositories could not be searched. Try reducing the scope of your query with repo: repogroup: or other filters.", amount),
+		Severity: severityWarn,
+	}, true
+}
+
+func shardTimeoutHandler(resultsResolver *graphqlbackend.SearchResultsResolver) (eventSkipped, bool) {
+	// This is not the same, but once we expose this more granular details
+	// from our backend it will be shard specific.
+	repos := resultsResolver.Timedout()
+	if len(repos) == 0 {
+		return eventSkipped{}, false
+	}
+
+	amount := number(len(repos))
+	return eventSkipped{
+		Reason: shardTimeout,
+		Title:  fmt.Sprintf("%s timedout", amount),
+		// TODO sample of repos in message
+		Message:  fmt.Sprintf("%s repositories could not be searched in time. Try reducing the scope of your query with repo: repogroup: or other filters.", amount),
+		Severity: severityWarn,
+	}, true
+}
+
+func shardMatchLimitHandler(resultsResolver *graphqlbackend.SearchResultsResolver) (eventSkipped, bool) {
+	// We don't have the details of repo vs shard vs document limits yet. So
+	// we just pretend all our shard limits.
+	if !resultsResolver.LimitHit() {
+		return eventSkipped{}, false
+	}
+
+	return eventSkipped{
+		Reason:   shardMatchLimit,
+		Title:    "result limit hit",
+		Message:  "Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.",
+		Severity: severityWarn,
+	}, true
+}
+
+// TODO implement all skipped reasons
+var skippedHandlers = []func(*graphqlbackend.SearchResultsResolver) (eventSkipped, bool){
+	repositoryMissingHandler,
+	repositoryCloningHandler,
+	// documentMatchLimitHandler,
+	// shardMatchLimitHandler,
+	// repositoryLimitHandler,
+	shardTimeoutHandler,
+	// excludedForkHandler,
+	// excludedArchiveHandler,
+}
+
+// progressFromResolver builds a progress event from a final results resolver.
+func progressFromResolver(resultsResolver *graphqlbackend.SearchResultsResolver) eventProgress {
+	skipped := []eventSkipped{}
+
+	for _, handler := range skippedHandlers {
+		if sk, ok := handler(resultsResolver); ok {
+			skipped = append(skipped, sk)
+		}
+	}
+
+	return eventProgress{
+		RepositoriesCount: intPtr(int(resultsResolver.RepositoriesCount())),
+		MatchCount:        int(resultsResolver.MatchCount()),
+		DurationMs:        int(resultsResolver.ElapsedMilliseconds()),
+		Skipped:           skipped,
+	}
+}

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -8,6 +8,7 @@ import (
 )
 
 type eventProgress struct {
+	Done              bool           `json:"done"`
 	RepositoriesCount *int           `json:"repositoriesCount"`
 	MatchCount        int            `json:"matchCount"`
 	DurationMs        int            `json:"durationMs"`
@@ -145,6 +146,7 @@ func progressFromResolver(resultsResolver *graphqlbackend.SearchResultsResolver)
 	}
 
 	return eventProgress{
+		Done:              true,
 		RepositoriesCount: intPtr(int(resultsResolver.RepositoriesCount())),
 		MatchCount:        int(resultsResolver.MatchCount()),
 		DurationMs:        int(resultsResolver.ElapsedMilliseconds()),

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -167,7 +167,9 @@ func ServeStream(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// TODO stats
+	_ = eventWriter.Event("progress", progressFromResolver(resultsResolver))
+
+	// TODO done event includes progress
 	_ = eventWriter.Event("done", map[string]interface{}{})
 }
 
@@ -199,6 +201,10 @@ func parseURLQuery(q url.Values) (*args, error) {
 	}
 
 	return &a, nil
+}
+
+func intPtr(i int) *int {
+	return &i
 }
 
 func strPtr(s string) *string {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -51,7 +51,7 @@ func ServeStream(w http.ResponseWriter, r *http.Request) {
 		VersionContext: strPtr(args.VersionContext),
 	})
 	if err != nil {
-		eventWriter.Event("error", err.Error())
+		_ = eventWriter.Event("error", err.Error())
 		return
 	}
 
@@ -126,7 +126,7 @@ func ServeStream(w http.ResponseWriter, r *http.Request) {
 	final := <-resultsStreamDone
 	resultsResolver, err := final.resultsResolver, final.err
 	if err != nil {
-		eventWriter.Event("error", err.Error())
+		_ = eventWriter.Event("error", err.Error())
 		return
 	}
 


### PR DESCRIPTION
This is our initial support for progress events. Currently it is
partially implementing all the reasons we could skip. More invasive
changes are required to our graphqlbackend to report more. Additionally
it is only sending the progress event once at the end of the
stream. This will also require more changes to graphqlbackend.

Follow up commits will add progress events during search as well as a
implement all skipped reasons.