### PR TITLE
search: add query monitorByID

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 )
 
 type CodeMonitorsResolver interface {
 	// Query
 	Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error)
+	MonitorByID(ctx context.Context, id graphql.ID) (MonitorResolver, error)
 
 	// Mutations
 	CreateCodeMonitor(ctx context.Context, args *CreateCodeMonitorArgs) (MonitorResolver, error)
@@ -188,6 +190,10 @@ var DefaultCodeMonitorsResolver = &defaultCodeMonitorsResolver{}
 var codeMonitorsOnlyInEnterprise = errors.New("code monitors are only available in enterprise")
 
 type defaultCodeMonitorsResolver struct {
+}
+
+func (d defaultCodeMonitorsResolver) MonitorByID(ctx context.Context, id graphql.ID) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
 }
 
 func (d defaultCodeMonitorsResolver) Monitors(ctx context.Context, userID int32, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -624,6 +624,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return r.LSIFUploadByID(ctx, id)
 	case "LSIFIndex":
 		return r.LSIFIndexByID(ctx, id)
+	case "CodeMonitor":
+		return r.MonitorByID(ctx, id)
 	default:
 		return nil, errors.New("invalid id")
 	}

--- a/enterprise/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/internal/codemonitors/resolvers/apitest/types.go
@@ -13,6 +13,10 @@ type User struct {
 	Monitors MonitorConnection
 }
 
+type Node struct {
+	Node Monitor
+}
+
 type MonitorConnection struct {
 	Nodes      []Monitor
 	TotalCount int

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -76,6 +76,9 @@ func (r *Resolver) MonitorByID(ctx context.Context, ID graphql.ID) (m graphqlbac
 	}
 	q := sqlf.Sprintf(monitorByIDFmtStr, monitorID)
 	m, err = r.runMonitorQuery(ctx, q)
+	if err != nil {
+		return nil, err
+	}
 	// Hydrate monitor with resolver.
 	m.(*monitor).Resolver = r
 	return m, nil

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -58,6 +58,29 @@ func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlback
 	return &monitorConnection{r, ms}, nil
 }
 
+const monitorByIDFmtStr = `
+SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
+FROM cm_monitors
+WHERE id = %s
+`
+
+func (r *Resolver) MonitorByID(ctx context.Context, ID graphql.ID) (m graphqlbackend.MonitorResolver, err error) {
+	err = r.isAllowedToEdit(ctx, ID)
+	if err != nil {
+		return nil, err
+	}
+	var monitorID int64
+	err = relay.UnmarshalSpec(ID, &monitorID)
+	if err != nil {
+		return nil, err
+	}
+	q := sqlf.Sprintf(monitorByIDFmtStr, monitorID)
+	m, err = r.runMonitorQuery(ctx, q)
+	// Hydrate monitor with resolver.
+	m.(*monitor).Resolver = r
+	return m, nil
+}
+
 func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (m graphqlbackend.MonitorResolver, err error) {
 	err = r.isAllowedToCreate(ctx, args.Monitor.Namespace)
 	if err != nil {


### PR DESCRIPTION
This PR adds `monitorByID` which allows us to query the monitor independently of the user. 

```
query ($id: ID!) {
  node(id: $id) {
    ... on Monitor {
      id
      description
      enabled
  }
 }
}
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
