### PR TITLE
Removes bitbucket cloud from user code hosts

### DIFF
--- a/client/web/src/user/settings/UserAddExternalServicesPage.tsx
+++ b/client/web/src/user/settings/UserAddExternalServicesPage.tsx
@@ -14,7 +14,6 @@ export const UserAddExternalServicesPage: React.FunctionComponent<UserAddExterna
         codeHostExternalServices={{
             github: codeHostExternalServices.github,
             gitlabcom: codeHostExternalServices.gitlabcom,
-            bitbucket: codeHostExternalServices.bitbucket,
         }}
         nonCodeHostExternalServices={{}}
     />


### PR DESCRIPTION
### Description

Removes Bitbucket Cloud option from _user-level_ code hosts. Fixes #16315 

#### User settings
<img width="1263" alt="As user" src="https://user-images.githubusercontent.com/1319181/100795687-7057cc80-33ed-11eb-8e53-b62fb1f7f848.png">

#### Admin settings - Bitbucket cloud still there
<img width="1242" alt="as admin" src="https://user-images.githubusercontent.com/1319181/100795691-7188f980-33ed-11eb-9957-186068e0b1b6.png">
