### PR TITLE
search: combine matches and progress

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -337,7 +337,7 @@ describe('Search', () => {
 
         test('Streaming search with single repo result', async () => {
             const searchStreamEvents: SearchEvent[] = [
-                { type: 'matches', data: [{ type: 'repo', repository: 'github.com/sourcegraph/sourcegraph' }] },
+                { type: 'results', data: [progres: {}, matches: { type: 'repo', repository: 'github.com/sourcegraph/sourcegraph' })] },
                 { type: 'done', data: {} },
             ]
 

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -347,18 +347,13 @@ const switchAggregateSearchResults: OperatorFunction<SearchEvent, AggregateStrea
             switch (newEvent.kind) {
                 case 'N': {
                     switch (newEvent.value?.type) {
-                        case 'matches':
+                        case 'results':
                             return {
                                 ...results,
                                 // Matches are additive
-                                results: results.results.concat(newEvent.value.data.map(toGQLSearchResult)),
-                            }
-
-                        case 'progress':
-                            return {
-                                ...results,
+                                results: results.results.concat(newEvent.value.data.matches.map(toGQLSearchResult)),
                                 // Progress updates replace
-                                progress: newEvent.value.data,
+                                progress: newEvent.value.data.progress,
                             }
 
                         case 'filters':
@@ -463,8 +458,7 @@ const messageHandlers: {
             }
             eventSource.close()
         }),
-    matches: observeMessages,
-    progress: observeMessages,
+    results: observeMessages,
     filters: observeMessages,
     alert: observeMessages,
 }

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -11,12 +11,28 @@ import { SearchPatternType } from '../graphql-operations'
 // until it is no longer a proof of concept and instead works well.
 
 export type SearchEvent =
-    | { type: 'matches'; data: Match[] }
-    | { type: 'progress'; data: Progress }
+    | { type: 'results'; data: Results }
     | { type: 'filters'; data: Filter[] }
     | { type: 'alert'; data: Alert }
     | { type: 'error'; data: Error }
     | { type: 'done'; data: {} }
+
+/**
+ * Results is the main event data for streaming search.
+ *
+ * It contains both new matches found and the current value of progress.
+ * We send both at the same time so the frontend has a consistent view over progress and results to show.
+ */
+interface Results {
+    /**
+     * matches is a list of zero or more matches to add to the result set.
+     */
+    matches: Match[]
+    /**
+     * progress is the current value of progress
+     */
+    progress: Progress
+}
 
 type Match = FileMatch | RepositoryMatch | CommitMatch | FileSymbolMatch
 


### PR DESCRIPTION
In the current protocol progress and matches events can come in at different times. This can lead to updating the list of results shown without updating progress. Or vice versa. To avoid that we group both matches and progress together.