### PR TITLE
search frontend: allow multiple toggle state rules

### DIFF
--- a/client/web/src/search/input/__snapshots__/LazyMonacoQueryInput.test.tsx.snap
+++ b/client/web/src/search/input/__snapshots__/LazyMonacoQueryInput.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`PlainQueryInput empty 1`] = `
       </div>
       <div
         aria-checked={true}
+        aria-disabled={false}
         aria-label="Regular expression toggle"
         className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-regexp-toggle toggle-container__toggle--active test-regexp-toggle--active"
         data-tooltip="Disable regular expression"
@@ -62,6 +63,7 @@ exports[`PlainQueryInput empty 1`] = `
       </div>
       <div
         aria-checked={false}
+        aria-disabled={false}
         aria-label="Structural search toggle"
         className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-structural-search-toggle test-structural-search-toggle--active"
         data-tooltip="Enable structural search"
@@ -127,6 +129,7 @@ exports[`PlainQueryInput with query 1`] = `
       </div>
       <div
         aria-checked={true}
+        aria-disabled={false}
         aria-label="Regular expression toggle"
         className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-regexp-toggle toggle-container__toggle--active test-regexp-toggle--active"
         data-tooltip="Disable regular expression"
@@ -148,6 +151,7 @@ exports[`PlainQueryInput with query 1`] = `
       </div>
       <div
         aria-checked={false}
+        aria-disabled={false}
         aria-label="Structural search toggle"
         className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-structural-search-toggle test-structural-search-toggle--active"
         data-tooltip="Enable structural search"

--- a/client/web/src/search/input/toggles/QueryInputToggle.tsx
+++ b/client/web/src/search/input/toggles/QueryInputToggle.tsx
@@ -19,10 +19,11 @@ export interface ToggleProps extends PatternTypeProps, CaseSensitivityProps {
     isActive: boolean
     /** Callback on toggle.  */
     onToggle: () => void
-    /** Condition to disable the toggle, if any.  */
-    disabledCondition?: boolean
-    /** Message to display in tooltip when disabled. */
-    disabledMessage?: string
+    /**
+     * A list of conditions to disable the toggle, displaying an associated tooltip when the condition is true.
+     * For multiple true conditions, use the first rule that evalutes to true.
+     */
+    disableOn?: { condition: boolean; reason: string }[]
     /** Filters in the query in interactive mode. */
     filtersInQuery?: FiltersToTypeAndValue
     hasGlobalQueryBehavior?: boolean
@@ -60,23 +61,34 @@ export class QueryInputToggle extends React.Component<ToggleProps> {
 
     public render(): JSX.Element | null {
         const Icon = this.props.icon
-        const tooltipValue = this.props.disabledCondition
-            ? this.props.disabledMessage ?? null
-            : `${this.props.isActive ? 'Disable' : 'Enable'} ${this.props.title.toLowerCase()}`
+
+        let tooltipValue = `${this.props.isActive ? 'Disable' : 'Enable'} ${this.props.title.toLowerCase()}`
+        let disabled = false
+        let onToggle = this.props.onToggle
+        if (this.props.disableOn) {
+            for (const rule of this.props.disableOn) {
+                if (rule.condition) {
+                    disabled = true
+                    tooltipValue = rule.reason
+                    onToggle = (): void => undefined // Make the button untoggleable.
+                    break
+                }
+            }
+        }
 
         return (
             <div
                 ref={this.toggleCheckbox}
-                onClick={this.props.onToggle}
+                onClick={onToggle}
                 className={classNames(
                     'btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle',
                     this.props.className,
-                    { disabled: this.props.disabledCondition },
+                    { disabled },
                     { 'toggle-container__toggle--active': this.props.isActive },
                     this.props.activeClassName
                 )}
                 role="checkbox"
-                aria-disabled={this.props.disabledCondition}
+                aria-disabled={disabled}
                 aria-checked={this.props.isActive}
                 aria-label={`${this.props.title} toggle`}
                 tabIndex={0}

--- a/client/web/src/search/input/toggles/Toggles.tsx
+++ b/client/web/src/search/input/toggles/Toggles.tsx
@@ -78,13 +78,10 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
     )
 
     const toggleCaseSensitivity = useCallback((): void => {
-        if (patternType === SearchPatternType.structural) {
-            return
-        }
         const newCaseSensitivity = !caseSensitive
         setCaseSensitivity(newCaseSensitivity)
         submitOnToggle({ newCaseSensitivity })
-    }, [caseSensitive, patternType, setCaseSensitivity, submitOnToggle])
+    }, [caseSensitive, setCaseSensitivity, submitOnToggle])
 
     const toggleRegexp = useCallback((): void => {
         const newPatternType =
@@ -134,8 +131,12 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
                 icon={FormatLetterCaseIcon}
                 className="test-case-sensitivity-toggle"
                 activeClassName="test-case-sensitivity-toggle--active"
-                disabledCondition={patternType === SearchPatternType.structural}
-                disabledMessage="Structural search is always case sensitive"
+                disableOn={[
+                    {
+                        condition: patternType === SearchPatternType.structural,
+                        reason: 'Structural search is always case sensitive',
+                    },
+                ]}
             />
             <QueryInputToggle
                 {...props}


### PR DESCRIPTION
Helps with https://github.com/sourcegraph/sourcegraph/issues/13958#issuecomment-695087318. This refactor allows specifying multiple rules to disable toggles. See inline comments for more.