### PR TITLE
search frontend: refactor findFilter validate function

### DIFF
--- a/client/shared/src/search/parser/validate.test.ts
+++ b/client/shared/src/search/parser/validate.test.ts
@@ -1,47 +1,40 @@
-import { findGlobalFilter } from './validate'
+import { findFilter, FilterKind } from './validate'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value, null, 2),
     test: () => true,
 })
 
-describe('finds a global filter', () => {
+describe('finds a filter', () => {
     test('valid global filter', () => {
-        expect(findGlobalFilter('repo:sg/sg case:yes SauceGraph', 'case')).toMatchInlineSnapshot(`
-            {
-              "type": "filter",
-              "range": {
-                "start": 11,
-                "end": 19
-              },
-              "field": {
-                "type": "literal",
-                "value": "case",
-                "range": {
-                  "start": 11,
-                  "end": 15
-                }
-              },
-              "value": {
-                "type": "literal",
-                "value": "yes",
-                "range": {
-                  "start": 16,
-                  "end": 19
-                }
-              },
-              "negated": false
-            }
-        `)
+        expect(findFilter('repo:sg/sg case:yes SauceGraph', 'case', FilterKind.Global)).toBeTruthy()
     })
 
-    test('invalid, more than one filter', () => {
+    test('invalid global filter for more than one filter', () => {
         expect(
-            findGlobalFilter('patterntype:literal SauceGraph or PatternType:regexp wafflecat', 'patterntype')
+            findFilter(
+                'patterntype:literal SauceGraph or PatternType:regexp wafflecat',
+                'patterntype',
+                FilterKind.Global
+            )
         ).toBeUndefined()
     })
 
-    test('invalid, grouped filter', () => {
-        expect(findGlobalFilter('repo:sg/sg (case:yes SauceGraph)', 'case')).toBeUndefined()
+    test('invalid global filter for subexpression filter', () => {
+        expect(findFilter('repo:sg/sg (case:yes SauceGraph)', 'case', FilterKind.Global)).toBeUndefined()
+    })
+
+    test('valid single subexpression filter', () => {
+        expect(findFilter('repo:sg/sg (case:yes SauceGraph)', 'case', FilterKind.Subexpression)).toBeTruthy()
+    })
+
+    test('valid multiple subexpression filters', () => {
+        expect(
+            findFilter('repo:sg/sg (case:yes SauceGraph) or (case:no derp)', 'case', FilterKind.Subexpression)
+        ).toBeTruthy()
+    })
+
+    test('invalid subexpression filter when global', () => {
+        expect(findFilter('repo:sg/sg case:yes', 'case', FilterKind.Subexpression)).toBeUndefined()
     })
 })

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -6,7 +6,7 @@ import { replaceRange } from './strings'
 import { discreteValueAliases } from '../search/parser/filters'
 import { tryCatch } from './errors'
 import { SearchPatternType } from '../graphql-operations'
-import { findGlobalFilter } from '../search/parser/validate'
+import { findFilter, FilterKind } from '../search/parser/validate'
 
 export interface RepoSpec {
     /**
@@ -603,14 +603,14 @@ export function buildSearchURLQuery(
             .join(' ')
     }
 
-    const globalPatternType = findGlobalFilter(queryParameter, 'patterntype')
+    const globalPatternType = findFilter(queryParameter, 'patterntype', FilterKind.Global)
     if (globalPatternType?.value && globalPatternType.value.type === 'literal') {
         const { start, end } = globalPatternType.range
         patternTypeParameter = query.slice(globalPatternType.value.range.start, end)
         queryParameter = replaceRange(queryParameter, { start: Math.max(0, start - 1), end }).trim()
     }
 
-    const globalCase = findGlobalFilter(queryParameter, 'case')
+    const globalCase = findFilter(queryParameter, 'case', FilterKind.Global)
     if (globalCase?.value && globalCase.value.type === 'literal') {
         // When case:value is explicit in the query, override any previous value of caseParameter.
         caseParameter = discreteValueAliases.yes.includes(globalCase.value.value) ? 'yes' : 'no'

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs'
 import { ISavedSearch } from '../../../shared/src/graphql/schema'
 import { EventLogResult } from './backend'
 import { AggregateStreamingSearchResults } from './stream'
-import { findGlobalFilter } from '../../../shared/src/search/parser/validate'
+import { findFilter, FilterKind } from '../../../shared/src/search/parser/validate'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
@@ -54,7 +54,7 @@ export function parseSearchURLVersionContext(query: string): string | undefined 
 }
 
 export function searchURLIsCaseSensitive(query: string): boolean {
-    const globalCase = findGlobalFilter(parseSearchURLQuery(query) || '', 'case')
+    const globalCase = findFilter(parseSearchURLQuery(query) || '', 'case', FilterKind.Global)
     if (globalCase?.value && globalCase.value.type === 'literal') {
         // if `case:` filter exists in the query, override the existing case: query param
         return discreteValueAliases.yes.includes(globalCase.value.value)
@@ -85,14 +85,14 @@ export function parseSearchURL(
     let patternType = parseSearchURLPatternType(urlSearchQuery)
     let caseSensitive = searchURLIsCaseSensitive(urlSearchQuery)
 
-    const globalPatternType = findGlobalFilter(finalQuery, 'patterntype')
+    const globalPatternType = findFilter(finalQuery, 'patterntype', FilterKind.Global)
     if (globalPatternType?.value && globalPatternType.value.type === 'literal') {
         // Any `patterntype:` filter in the query should override the patternType= URL query parameter if it exists.
         finalQuery = replaceRange(finalQuery, globalPatternType.range)
         patternType = globalPatternType.value.value as SearchPatternType
     }
 
-    const globalCase = findGlobalFilter(finalQuery, 'case')
+    const globalCase = findFilter(finalQuery, 'case', FilterKind.Global)
     if (globalCase?.value && globalCase.value.type === 'literal') {
         // Any `case:` filter in the query should override the case= URL query parameter if it exists.
         finalQuery = replaceRange(finalQuery, globalCase.range)


### PR DESCRIPTION
Stacked on #16343. A refactor for the `findGlobalFilter` function. Previously, this function returned either a global filter like `case:`, or `undefined` if _either_ a filter in a subexpression exists, or if _no_ filter exists. I need a function that can tell me whether a subexpression exists for the toggle buttons. So I refactor this function to just find a filter, with a parameter to return the kind of filter if it is global, or part of a subexpression. 