### PR TITLE
graphqlbackend: add new scalar BigInt to fix int overflow

### DIFF
--- a/client/shared/src/util/strings.ts
+++ b/client/shared/src/util/strings.ts
@@ -21,7 +21,7 @@ export function numberWithCommas(number: string | number): string {
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 }
 
-export function pluralize(string: string, count: number, plural = string + 's'): string {
+export function pluralize(string: string, count: number | bigint, plural = string + 's'): string {
     return count === 1 ? string : plural
 }
 

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -85,8 +85,8 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
     SiteAdminActivationStatus: () => ({
         externalServices: { totalCount: 3 },
         repositoryStats: {
-            gitDirBytes: 1825299556,
-            indexedLinesCount: 2616264,
+            gitDirBytes: '1825299556',
+            indexedLinesCount: '2616264',
         },
         repositories: { totalCount: 9 },
         viewerSettings: {

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.test.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.test.tsx
@@ -53,8 +53,8 @@ describe('SiteAdminOverviewPage', () => {
                     of({
                         repositories: 0,
                         repositoryStats: {
-                            gitDirBytes: 1825299556,
-                            indexedLinesCount: 2616264,
+                            gitDirBytes: '1825299556',
+                            indexedLinesCount: '2616264',
                         },
                         users: 1,
                         orgs: 1,
@@ -89,8 +89,8 @@ describe('SiteAdminOverviewPage', () => {
                     of({
                         repositories: 100,
                         repositoryStats: {
-                            gitDirBytes: 1825299556,
-                            indexedLinesCount: 2616264,
+                            gitDirBytes: '1825299556',
+                            indexedLinesCount: '2616264',
                         },
                         users: 1,
                         orgs: 1,
@@ -132,8 +132,8 @@ describe('SiteAdminOverviewPage', () => {
                     of({
                         repositories: 100,
                         repositoryStats: {
-                            gitDirBytes: 1825299556,
-                            indexedLinesCount: 2616264,
+                            gitDirBytes: '1825299556',
+                            indexedLinesCount: '2616264',
                         },
                         users: 10,
                         orgs: 5,

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
@@ -28,8 +28,8 @@ interface Props extends ActivationProps, ThemeProps {
     _fetchOverview?: () => Observable<{
         repositories: number | null
         repositoryStats: {
-            gitDirBytes: number
-            indexedLinesCount: number
+            gitDirBytes: string
+            indexedLinesCount: string
         }
         users: number
         orgs: number
@@ -45,8 +45,8 @@ interface Props extends ActivationProps, ThemeProps {
 const fetchOverview = (): Observable<{
     repositories: number | null
     repositoryStats: {
-        gitDirBytes: number
-        indexedLinesCount: number
+        gitDirBytes: string
+        indexedLinesCount: string
     }
     users: number
     orgs: number
@@ -194,8 +194,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                 to="/site-admin/repositories"
                                 className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
                             >
-                                {numberWithCommas(info.repositoryStats.gitDirBytes)}{' '}
-                                {pluralize('byte stored', info.repositoryStats.gitDirBytes, 'bytes stored')}
+                                {BigInt(info.repositoryStats.gitDirBytes).toLocaleString()} bytes stored
                             </Link>
                         )}
                         {info.repositoryStats !== null && (
@@ -203,12 +202,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                 to="/site-admin/repositories"
                                 className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
                             >
-                                {numberWithCommas(info.repositoryStats.indexedLinesCount)}{' '}
-                                {pluralize(
-                                    'line of code indexed',
-                                    info.repositoryStats.indexedLinesCount,
-                                    'lines of code indexed'
-                                )}
+                                {BigInt(info.repositoryStats.indexedLinesCount).toLocaleString()} lines of code indexed
                             </Link>
                         )}
                         {info.users > 1 && (

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
@@ -19,6 +19,7 @@ import { useObservable } from '../../../../shared/src/util/useObservable'
 import { ErrorLike, asError, isErrorLike } from '../../../../shared/src/util/errors'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { Link } from '../../../../shared/src/components/Link'
+import { Scalars } from '../../graphql-operations'
 
 interface Props extends ActivationProps, ThemeProps {
     history: H.History
@@ -28,8 +29,8 @@ interface Props extends ActivationProps, ThemeProps {
     _fetchOverview?: () => Observable<{
         repositories: number | null
         repositoryStats: {
-            gitDirBytes: string
-            indexedLinesCount: string
+            gitDirBytes: Scalars['BigInt']
+            indexedLinesCount: Scalars['BigInt']
         }
         users: number
         orgs: number
@@ -45,8 +46,8 @@ interface Props extends ActivationProps, ThemeProps {
 const fetchOverview = (): Observable<{
     repositories: number | null
     repositoryStats: {
-        gitDirBytes: string
-        indexedLinesCount: string
+        gitDirBytes: Scalars['BigInt']
+        indexedLinesCount: Scalars['BigInt']
     }
     users: number
     orgs: number
@@ -194,7 +195,8 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                 to="/site-admin/repositories"
                                 className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
                             >
-                                {BigInt(info.repositoryStats.gitDirBytes).toLocaleString()} bytes stored
+                                {BigInt(info.repositoryStats.gitDirBytes).toLocaleString()}{' '}
+                                {pluralize('byte stored', BigInt(info.repositoryStats.gitDirBytes), 'bytes stored')}
                             </Link>
                         )}
                         {info.repositoryStats !== null && (
@@ -202,7 +204,12 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                 to="/site-admin/repositories"
                                 className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
                             >
-                                {BigInt(info.repositoryStats.indexedLinesCount).toLocaleString()} lines of code indexed
+                                {BigInt(info.repositoryStats.indexedLinesCount).toLocaleString()}{' '}
+                                {pluralize(
+                                    'line of code indexed',
+                                    BigInt(info.repositoryStats.indexedLinesCount),
+                                    'lines of code indexed'
+                                )}
                             </Link>
                         )}
                         {info.users > 1 && (

--- a/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
+++ b/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
@@ -23,14 +23,16 @@ exports[`SiteAdminOverviewPage < 2 users 1`] = `
       href="/site-admin/repositories"
     >
       1,825,299,556
-       bytes stored
+       
+      bytes stored
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
       href="/site-admin/repositories"
     >
       2,616,264
-       lines of code indexed
+       
+      lines of code indexed
     </a>
   </div>
 </div>
@@ -59,14 +61,16 @@ exports[`SiteAdminOverviewPage >= 2 users 1`] = `
       href="/site-admin/repositories"
     >
       1,825,299,556
-       bytes stored
+       
+      bytes stored
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
       href="/site-admin/repositories"
     >
       2,616,264
-       lines of code indexed
+       
+      lines of code indexed
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
@@ -334,14 +338,16 @@ exports[`SiteAdminOverviewPage activation in progress 1`] = `
       href="/site-admin/repositories"
     >
       1,825,299,556
-       bytes stored
+       
+      bytes stored
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
       href="/site-admin/repositories"
     >
       2,616,264
-       lines of code indexed
+       
+      lines of code indexed
     </a>
   </div>
 </div>

--- a/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
+++ b/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
@@ -23,16 +23,14 @@ exports[`SiteAdminOverviewPage < 2 users 1`] = `
       href="/site-admin/repositories"
     >
       1,825,299,556
-       
-      bytes stored
+       bytes stored
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
       href="/site-admin/repositories"
     >
       2,616,264
-       
-      lines of code indexed
+       lines of code indexed
     </a>
   </div>
 </div>
@@ -61,16 +59,14 @@ exports[`SiteAdminOverviewPage >= 2 users 1`] = `
       href="/site-admin/repositories"
     >
       1,825,299,556
-       
-      bytes stored
+       bytes stored
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
       href="/site-admin/repositories"
     >
       2,616,264
-       
-      lines of code indexed
+       lines of code indexed
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
@@ -338,16 +334,14 @@ exports[`SiteAdminOverviewPage activation in progress 1`] = `
       href="/site-admin/repositories"
     >
       1,825,299,556
-       
-      bytes stored
+       bytes stored
     </a>
     <a
       className="list-group-item list-group-item-action h5 mb-0 font-weight-normal py-2 px-3"
       href="/site-admin/repositories"
     >
       2,616,264
-       
-      lines of code indexed
+       lines of code indexed
     </a>
   </div>
 </div>

--- a/cmd/frontend/graphqlbackend/bigint.go
+++ b/cmd/frontend/graphqlbackend/bigint.go
@@ -1,0 +1,40 @@
+package graphqlbackend
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// BigInt implements the BigInt GraphQL scalar type.
+type BigInt struct{ Int uint64 }
+
+// BigIntOrNil is a helper function that returns nil for int == nil and otherwise wraps int in
+// BigInt.
+func BigIntOrNil(int *uint64) *BigInt {
+	if int == nil {
+		return nil
+	}
+	return &BigInt{Int: *int}
+}
+
+func (BigInt) ImplementsGraphQLType(name string) bool {
+	return name == "BigInt"
+}
+
+func (v BigInt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatUint(v.Int, 10))
+}
+
+func (v *BigInt) UnmarshalGraphQL(input interface{}) error {
+	s, ok := input.(string)
+	if !ok {
+		return fmt.Errorf("invalid GraphQL BigInt scalar value input (got %T, expected string)", input)
+	}
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*v = BigInt{Int: n}
+	return nil
+}

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -12,12 +12,12 @@ type repositoryStatsResolver struct {
 	indexedLinesCount uint64
 }
 
-func (r *repositoryStatsResolver) GitDirBytes() int32 {
-	return int32(r.gitDirBytes)
+func (r *repositoryStatsResolver) GitDirBytes() BigInt {
+	return BigInt{Int: r.gitDirBytes}
 }
 
-func (r *repositoryStatsResolver) IndexedLinesCount() int32 {
-	return int32(r.indexedLinesCount)
+func (r *repositoryStatsResolver) IndexedLinesCount() BigInt {
+	return BigInt{Int: r.indexedLinesCount}
 }
 
 func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsResolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -8789,7 +8789,7 @@ FOR INTERNAL USE ONLY: A status message
 union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 """
-A string-format big integer that could not be held with a number.
+An arbitrarily large integer encoded as a decimal string.
 """
 scalar BigInt
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -8789,17 +8789,22 @@ FOR INTERNAL USE ONLY: A status message
 union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 """
+A string-format big integer that could not be held with a number.
+"""
+scalar BigInt
+
+"""
 FOR INTERNAL USE ONLY: A repository statistic
 """
 type RepositoryStats {
     """
     The amount of bytes stored in .git directories
     """
-    gitDirBytes: Int!
+    gitDirBytes: BigInt!
     """
     The number of lines indexed
     """
-    indexedLinesCount: Int!
+    indexedLinesCount: BigInt!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8782,17 +8782,22 @@ FOR INTERNAL USE ONLY: A status message
 union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 """
+A string-format big integer that could not be held with a number.
+"""
+scalar BigInt
+
+"""
 FOR INTERNAL USE ONLY: A repository statistic
 """
 type RepositoryStats {
     """
     The amount of bytes stored in .git directories
     """
-    gitDirBytes: Int!
+    gitDirBytes: BigInt!
     """
     The number of lines indexed
     """
-    indexedLinesCount: Int!
+    indexedLinesCount: BigInt!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8782,7 +8782,7 @@ FOR INTERNAL USE ONLY: A status message
 union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 """
-A string-format big integer that could not be held with a number.
+An arbitrarily large integer encoded as a decimal string.
 """
 scalar BigInt
 


### PR DESCRIPTION
Converting uint64 to int32 caused int overflow, so create a new BigInt scalar to store very large integers.