### PR TITLE
search frontend: disable toggles for search expressions

### DIFF
--- a/client/web/src/search/input/toggles/Toggles.test.tsx
+++ b/client/web/src/search/input/toggles/Toggles.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import * as H from 'history'
+import { Toggles } from './Toggles'
+import { mount } from 'enzyme'
+import { SearchPatternType } from '../../../graphql-operations'
+
+describe('Query input toggle state', () => {
+    test('case toggle for case subexpressions', () => {
+        expect(
+            mount(
+                <Toggles
+                    navbarSearchQuery="(case:yes foo) or (case:no bar)"
+                    history={H.createBrowserHistory()}
+                    location={H.createBrowserHistory().location}
+                    patternType={SearchPatternType.literal}
+                    setPatternType={() => undefined}
+                    caseSensitive={false}
+                    setCaseSensitivity={() => undefined}
+                    settingsCascade={{ subjects: null, final: {} }}
+                    copyQueryButton={false}
+                    versionContext={undefined}
+                />
+            ).find('.test-case-sensitivity-toggle')
+        ).toMatchSnapshot()
+    })
+
+    test('case toggle for patterntype subexpressions', () => {
+        expect(
+            mount(
+                <Toggles
+                    navbarSearchQuery="(foo patterntype:literal) or (bar patterntype:structural)"
+                    history={H.createBrowserHistory()}
+                    location={H.createBrowserHistory().location}
+                    patternType={SearchPatternType.literal}
+                    setPatternType={() => undefined}
+                    caseSensitive={false}
+                    setCaseSensitivity={() => undefined}
+                    settingsCascade={{ subjects: null, final: {} }}
+                    copyQueryButton={false}
+                    versionContext={undefined}
+                />
+            ).find('.test-case-sensitivity-toggle')
+        ).toMatchSnapshot()
+    })
+
+    test('regexp toggle for patterntype subexpressions', () => {
+        expect(
+            mount(
+                <Toggles
+                    navbarSearchQuery="(foo patterntype:literal) or (bar patterntype:structural)"
+                    history={H.createBrowserHistory()}
+                    location={H.createBrowserHistory().location}
+                    patternType={SearchPatternType.literal}
+                    setPatternType={() => undefined}
+                    caseSensitive={false}
+                    setCaseSensitivity={() => undefined}
+                    settingsCascade={{ subjects: null, final: {} }}
+                    copyQueryButton={false}
+                    versionContext={undefined}
+                />
+            ).find('.test-regexp-toggle')
+        ).toMatchSnapshot()
+    })
+})

--- a/client/web/src/search/input/toggles/Toggles.tsx
+++ b/client/web/src/search/input/toggles/Toggles.tsx
@@ -14,6 +14,7 @@ import { generateFiltersQuery } from '../../../../../shared/src/util/url'
 import { CopyQueryButton } from './CopyQueryButton'
 import { VersionContextProps } from '../../../../../shared/src/search/util'
 import { SearchPatternType } from '../../../graphql-operations'
+import { findFilter, FilterKind } from '../../../../../shared/src/search/parser/validate'
 
 export interface TogglesProps
     extends PatternTypeProps,
@@ -133,6 +134,15 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
                 activeClassName="test-case-sensitivity-toggle--active"
                 disableOn={[
                     {
+                        condition: findFilter(navbarSearchQuery, 'case', FilterKind.Subexpression) !== undefined,
+                        reason: 'Query already contains one or more case subexpressions',
+                    },
+                    {
+                        condition: findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
+                        reason:
+                            'Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity',
+                    },
+                    {
                         condition: patternType === SearchPatternType.structural,
                         reason: 'Structural search is always case sensitive',
                     },
@@ -146,6 +156,12 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
                 icon={RegexIcon}
                 className="test-regexp-toggle"
                 activeClassName="test-regexp-toggle--active"
+                disableOn={[
+                    {
+                        condition: findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
+                        reason: 'Query already contains one or more patterntype subexpressions',
+                    },
+                ]}
             />
             {!structuralSearchDisabled && (
                 <QueryInputToggle
@@ -156,6 +172,13 @@ export const Toggles: React.FunctionComponent<TogglesProps> = (props: TogglesPro
                     isActive={patternType === SearchPatternType.structural}
                     onToggle={toggleStructuralSearch}
                     icon={CodeBracketsIcon}
+                    disableOn={[
+                        {
+                            condition:
+                                findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
+                            reason: 'Query already contains one or more patterntype subexpressions',
+                        },
+                    ]}
                 />
             )}
         </div>

--- a/client/web/src/search/input/toggles/__snapshots__/Toggles.test.tsx.snap
+++ b/client/web/src/search/input/toggles/__snapshots__/Toggles.test.tsx.snap
@@ -1,0 +1,239 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Query input toggle state case toggle for case subexpressions 1`] = `
+Array [
+  <QueryInputToggle
+    activeClassName="test-case-sensitivity-toggle--active"
+    caseSensitive={false}
+    className="test-case-sensitivity-toggle"
+    copyQueryButton={false}
+    disableOn={
+      Array [
+        Object {
+          "condition": true,
+          "reason": "Query already contains one or more case subexpressions",
+        },
+        Object {
+          "condition": false,
+          "reason": "Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity",
+        },
+        Object {
+          "condition": false,
+          "reason": "Structural search is always case sensitive",
+        },
+      ]
+    }
+    history="[History]"
+    icon={
+      Object {
+        "$$typeof": Symbol(react.memo),
+        "compare": null,
+        "type": [Function],
+      }
+    }
+    isActive={false}
+    location="[Location path=/]"
+    navbarSearchQuery="(case:yes foo) or (case:no bar)"
+    onToggle={[Function]}
+    patternType="literal"
+    setCaseSensitivity={[Function]}
+    setPatternType={[Function]}
+    settingsCascade={
+      Object {
+        "final": Object {},
+        "subjects": null,
+      }
+    }
+    title="Case sensitivity"
+  >
+    <div
+      aria-checked={false}
+      aria-disabled={true}
+      aria-label="Case sensitivity toggle"
+      className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
+      data-tooltip="Query already contains one or more case subexpressions"
+      onClick={[Function]}
+      role="checkbox"
+      tabIndex={0}
+    >
+      <Memo(FormatLetterCaseIcon) />
+    </div>
+  </QueryInputToggle>,
+  <div
+    aria-checked={false}
+    aria-disabled={true}
+    aria-label="Case sensitivity toggle"
+    className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
+    data-tooltip="Query already contains one or more case subexpressions"
+    onClick={[Function]}
+    role="checkbox"
+    tabIndex={0}
+  >
+    <Memo(FormatLetterCaseIcon) />
+  </div>,
+]
+`;
+
+exports[`Query input toggle state case toggle for patterntype subexpressions 1`] = `
+Array [
+  <QueryInputToggle
+    activeClassName="test-case-sensitivity-toggle--active"
+    caseSensitive={false}
+    className="test-case-sensitivity-toggle"
+    copyQueryButton={false}
+    disableOn={
+      Array [
+        Object {
+          "condition": false,
+          "reason": "Query already contains one or more case subexpressions",
+        },
+        Object {
+          "condition": true,
+          "reason": "Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity",
+        },
+        Object {
+          "condition": false,
+          "reason": "Structural search is always case sensitive",
+        },
+      ]
+    }
+    history="[History]"
+    icon={
+      Object {
+        "$$typeof": Symbol(react.memo),
+        "compare": null,
+        "type": [Function],
+      }
+    }
+    isActive={false}
+    location="[Location path=/]"
+    navbarSearchQuery="(foo patterntype:literal) or (bar patterntype:structural)"
+    onToggle={[Function]}
+    patternType="literal"
+    setCaseSensitivity={[Function]}
+    setPatternType={[Function]}
+    settingsCascade={
+      Object {
+        "final": Object {},
+        "subjects": null,
+      }
+    }
+    title="Case sensitivity"
+  >
+    <div
+      aria-checked={false}
+      aria-disabled={true}
+      aria-label="Case sensitivity toggle"
+      className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
+      data-tooltip="Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity"
+      onClick={[Function]}
+      role="checkbox"
+      tabIndex={0}
+    >
+      <Memo(FormatLetterCaseIcon) />
+    </div>
+  </QueryInputToggle>,
+  <div
+    aria-checked={false}
+    aria-disabled={true}
+    aria-label="Case sensitivity toggle"
+    className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
+    data-tooltip="Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity"
+    onClick={[Function]}
+    role="checkbox"
+    tabIndex={0}
+  >
+    <Memo(FormatLetterCaseIcon) />
+  </div>,
+]
+`;
+
+exports[`Query input toggle state regexp toggle for patterntype subexpressions 1`] = `
+Array [
+  <div
+    aria-checked={false}
+    aria-disabled={true}
+    aria-label="Case sensitivity toggle"
+    className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
+    data-tooltip="Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity"
+    onClick={[Function]}
+    role="checkbox"
+    tabIndex={0}
+  >
+    <Memo(FormatLetterCaseIcon) />
+  </div>,
+  <QueryInputToggle
+    activeClassName="test-regexp-toggle--active"
+    caseSensitive={false}
+    className="test-regexp-toggle"
+    copyQueryButton={false}
+    disableOn={
+      Array [
+        Object {
+          "condition": true,
+          "reason": "Query already contains one or more patterntype subexpressions",
+        },
+      ]
+    }
+    history="[History]"
+    icon={
+      Object {
+        "$$typeof": Symbol(react.memo),
+        "compare": null,
+        "type": [Function],
+      }
+    }
+    isActive={false}
+    location="[Location path=/]"
+    navbarSearchQuery="(foo patterntype:literal) or (bar patterntype:structural)"
+    onToggle={[Function]}
+    patternType="literal"
+    setCaseSensitivity={[Function]}
+    setPatternType={[Function]}
+    settingsCascade={
+      Object {
+        "final": Object {},
+        "subjects": null,
+      }
+    }
+    title="Regular expression"
+  >
+    <div
+      aria-checked={false}
+      aria-disabled={true}
+      aria-label="Regular expression toggle"
+      className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-regexp-toggle disabled test-regexp-toggle--active"
+      data-tooltip="Query already contains one or more patterntype subexpressions"
+      onClick={[Function]}
+      role="checkbox"
+      tabIndex={0}
+    >
+      <Memo(RegexIcon) />
+    </div>
+  </QueryInputToggle>,
+  <div
+    aria-checked={false}
+    aria-disabled={true}
+    aria-label="Regular expression toggle"
+    className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-regexp-toggle disabled test-regexp-toggle--active"
+    data-tooltip="Query already contains one or more patterntype subexpressions"
+    onClick={[Function]}
+    role="checkbox"
+    tabIndex={0}
+  >
+    <Memo(RegexIcon) />
+  </div>,
+  <div
+    aria-checked={false}
+    aria-disabled={true}
+    aria-label="Structural search toggle"
+    className="btn btn-icon icon-inline toggle-container__toggle test-regexp-toggle test-structural-search-toggle disabled test-structural-search-toggle--active"
+    data-tooltip="Query already contains one or more patterntype subexpressions"
+    onClick={[Function]}
+    role="checkbox"
+    tabIndex={0}
+  >
+    <Memo(CodeBracketsIcon) />
+  </div>,
+]
+`;


### PR DESCRIPTION
Stacked on #16344. Fixes #13958. The previous two PRs make it easy to implement the toggle disable logic. Example:

![togglessss](https://user-images.githubusercontent.com/888624/100840781-9e5fff80-3433-11eb-8a97-892c13b43cb8.gif)

TODO: add tests. Question for @attfarhan: what's the best way to test the ^ above? I came across [e2e tests](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@57e0d67/-/blob/client/web/src/end-to-end/end-to-end.test.ts#L1107:49), but those are more for checking redirection. Any tips?

The current code does a lot of rescanning/checking of the query string. I will optimize that in a follow-up.
