### PR TITLE
search: generate progress events in graphqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/search_progress.go
+++ b/cmd/frontend/graphqlbackend/search_progress.go
@@ -17,6 +17,13 @@ func number(i int) string {
 	return fmt.Sprintf("%dk", i/1000)
 }
 
+func plural(one, many string, n int) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
 func repositoryCloningHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
 	repos := resultsResolver.Cloning()
 	if len(repos) == 0 {
@@ -28,7 +35,7 @@ func repositoryCloningHandler(resultsResolver *SearchResultsResolver) (search.Sk
 		Reason: search.RepositoryCloning,
 		Title:  fmt.Sprintf("%s cloning", amount),
 		// TODO sample of repos in message
-		Message:  fmt.Sprintf("%s repositories could not be searched since they are still cloning. Try searching again or reducing the scope of your query with repo: repogroup: or other filters.", amount),
+		Message:  fmt.Sprintf("%s %s could not be searched since they are still cloning. Try searching again or reducing the scope of your query with repo: repogroup: or other filters.", amount, plural("repository", "repositories", len(repos))),
 		Severity: search.SeverityWarn,
 	}, true
 }
@@ -44,7 +51,7 @@ func repositoryMissingHandler(resultsResolver *SearchResultsResolver) (search.Sk
 		Reason: search.RepositoryMissing,
 		Title:  fmt.Sprintf("%s missing", amount),
 		// TODO sample of repos in message
-		Message:  fmt.Sprintf("%s repositories could not be searched. Try reducing the scope of your query with repo: repogroup: or other filters.", amount),
+		Message:  fmt.Sprintf("%s %s could not be searched. Try reducing the scope of your query with repo: repogroup: or other filters.", amount, plural("repository", "repositories", len(repos))),
 		Severity: search.SeverityWarn,
 	}, true
 }
@@ -62,7 +69,7 @@ func shardTimeoutHandler(resultsResolver *SearchResultsResolver) (search.Skipped
 		Reason: search.ShardTimeout,
 		Title:  fmt.Sprintf("%s timedout", amount),
 		// TODO sample of repos in message
-		Message:  fmt.Sprintf("%s repositories could not be searched in time. Try reducing the scope of your query with repo: repogroup: or other filters.", amount),
+		Message:  fmt.Sprintf("%s %s could not be searched in time. Try reducing the scope of your query with repo: repogroup: or other filters.", amount, plural("repository", "repositories", len(repos))),
 		Severity: search.SeverityWarn,
 	}, true
 }

--- a/cmd/frontend/graphqlbackend/search_progress_test.go
+++ b/cmd/frontend/graphqlbackend/search_progress_test.go
@@ -1,0 +1,39 @@
+package graphqlbackend
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+var updateGolden = flag.Bool("update", false, "Update testdata goldens")
+
+func TestSearchProgress(t *testing.T) {
+	cases := map[string]*SearchResultsResolver{
+		"empty": {},
+		"all": {
+			SearchResults: []SearchResultResolver{mkFileMatch(&types.Repo{Name: "found-1"}, "dir/file", 123)},
+			searchResultsCommon: searchResultsCommon{
+				limitHit: true,
+				repos:    mkRepos("found-1", "missing-1", "missing-2", "cloning-1", "timedout-1"),
+				missing:  mkRepos("missing-1", "missing-2"),
+				cloning:  mkRepos("cloning-1"),
+				timedout: mkRepos("timedout-1"),
+				excluded: excludedRepos{
+					forks:    5,
+					archived: 1,
+				},
+			},
+		},
+	}
+
+	for name, sr := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := sr.Progress()
+			got.DurationMs = 0 // clear out non-deterministic field
+			testutil.AssertGolden(t, "testdata/golden/"+t.Name()+".json", *updateGolden, got)
+		})
+	}
+}

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
@@ -1,0 +1,32 @@
+{
+  "done": false,
+  "repositoriesCount": 5,
+  "matchCount": 1,
+  "durationMs": 0,
+  "skipped": [
+   {
+    "reason": "repository-missing",
+    "title": "1 missing",
+    "message": "1 repositories could not be searched. Try reducing the scope of your query with repo: repogroup: or other filters.",
+    "severity": "warn"
+   },
+   {
+    "reason": "repository-cloning",
+    "title": "1 cloning",
+    "message": "1 repositories could not be searched since they are still cloning. Try searching again or reducing the scope of your query with repo: repogroup: or other filters.",
+    "severity": "warn"
+   },
+   {
+    "reason": "shard-match-limit",
+    "title": "result limit hit",
+    "message": "Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.",
+    "severity": "warn"
+   },
+   {
+    "reason": "shard-timeout",
+    "title": "1 timedout",
+    "message": "1 repositories could not be searched in time. Try reducing the scope of your query with repo: repogroup: or other filters.",
+    "severity": "warn"
+   }
+  ]
+ }

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
@@ -7,13 +7,13 @@
    {
     "reason": "repository-missing",
     "title": "1 missing",
-    "message": "1 repositories could not be searched. Try reducing the scope of your query with repo: repogroup: or other filters.",
+    "message": "1 repository could not be searched. Try reducing the scope of your query with repo: repogroup: or other filters.",
     "severity": "warn"
    },
    {
     "reason": "repository-cloning",
     "title": "1 cloning",
-    "message": "1 repositories could not be searched since they are still cloning. Try searching again or reducing the scope of your query with repo: repogroup: or other filters.",
+    "message": "1 repository could not be searched since they are still cloning. Try searching again or reducing the scope of your query with repo: repogroup: or other filters.",
     "severity": "warn"
    },
    {
@@ -25,7 +25,7 @@
    {
     "reason": "shard-timeout",
     "title": "1 timedout",
-    "message": "1 repositories could not be searched in time. Try reducing the scope of your query with repo: repogroup: or other filters.",
+    "message": "1 repository could not be searched in time. Try reducing the scope of your query with repo: repogroup: or other filters.",
     "severity": "warn"
    }
   ]

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/empty.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/empty.json
@@ -1,0 +1,7 @@
+{
+  "done": false,
+  "repositoriesCount": 0,
+  "matchCount": 0,
+  "durationMs": 0,
+  "skipped": []
+ }

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -226,15 +226,15 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 	return r
 }
 
-func TestLimitSearcherRepos(t *testing.T) {
-	repos := func(names ...string) []*types.Repo {
-		var repos []*types.Repo
-		for _, name := range names {
-			repos = append(repos, &types.Repo{Name: api.RepoName(name)})
-		}
-		return repos
+func mkRepos(names ...string) []*types.Repo {
+	var repos []*types.Repo
+	for _, name := range names {
+		repos = append(repos, &types.Repo{Name: api.RepoName(name)})
 	}
+	return repos
+}
 
+func TestLimitSearcherRepos(t *testing.T) {
 	repoRevs := func(repoRevs ...string) []*search.RepositoryRevisions {
 		var result []*search.RepositoryRevisions
 		for _, repoRev := range repoRevs {
@@ -279,21 +279,21 @@ func TestLimitSearcherRepos(t *testing.T) {
 			limit:       5,
 			input:       repoRevs("a@1", "b@1", "c@1", "d@1", "e@1", "f@1", "g@1"),
 			want:        repoRevs("a@1", "b@1", "c@1", "d@1", "e@1"),
-			wantLimited: repos("f", "g"),
+			wantLimited: mkRepos("f", "g"),
 		},
 		{
 			name:        "rev_limited",
 			limit:       6,
 			input:       repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1", "f@1", "g@1"),
 			want:        repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1"),
-			wantLimited: repos("f", "g"),
+			wantLimited: mkRepos("f", "g"),
 		},
 		{
 			name:        "rev_limited_duplication",
 			limit:       6,
 			input:       repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1", "f@1", "f@2", "g@1"),
 			want:        repoRevs("a@1", "a@2", "b@1", "c@1", "d@1", "e@1"),
-			wantLimited: repos("f", "g"),
+			wantLimited: mkRepos("f", "g"),
 		},
 	}
 	for _, tst := range tests {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -167,7 +167,9 @@ func ServeStream(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	_ = eventWriter.Event("progress", progressFromResolver(resultsResolver))
+	pr := resultsResolver.Progress()
+	pr.Done = true
+	_ = eventWriter.Event("progress", pr)
 
 	// TODO done event includes progress
 	_ = eventWriter.Event("done", map[string]interface{}{})
@@ -201,10 +203,6 @@ func parseURLQuery(q url.Values) (*args, error) {
 	}
 
 	return &a, nil
-}
-
-func intPtr(i int) *int {
-	return &i
 }
 
 func strPtr(s string) *string {

--- a/internal/search/progress.go
+++ b/internal/search/progress.go
@@ -1,0 +1,85 @@
+package search
+
+// Progress is an aggregate type representing a progress update.
+type Progress struct {
+	// Done is true if this is a final progress event.
+	Done bool `json:"done"`
+
+	// RepositoriesCount is the number of repositories being searched. It is
+	// non-nil once the set of repositories has been resolved.
+	RepositoriesCount *int `json:"repositoriesCount"`
+
+	// MatchCount is number of non-overlapping matches. If skipped is
+	// non-empty, then this is a lower bound.
+	MatchCount int `json:"matchCount"`
+
+	// DurationMs is the wall clock time in milliseconds for this search.
+	DurationMs int `json:"durationMs"`
+
+	// Skipped is a description of shards or documents that were skipped. This
+	// has a deterministic ordering. More important reasons will be listed
+	// first. If a search is repeated, the final skipped list will be the
+	// same.  However, within a search stream when a new skipped reason is
+	// found, it may appear anywhere in the list.
+	Skipped []Skipped `json:"skipped"`
+}
+
+// Skipped is a description of shards or documents that were skipped.
+type Skipped struct {
+	// Reason is why a document/shard/repository was skipped. We group counts
+	// by reason. eg ShardTimeout
+	Reason SkippedReason `json:"reason"`
+	// Title is a short message. eg "1,200 timed out".
+	Title string `json:"title"`
+	// Message is a message to show the user. Usually includes information
+	// explaining the reason, count as well as a sample of the missing items.
+	Message  string          `json:"message"`
+	Severity SkippedSeverity `json:"severity"`
+	// Suggested is a query expression to remedy the skip. eg "archived:yes".
+	Suggested *SkippedSuggested `json:"suggested,omitempty"`
+}
+
+// SkippedSuggested is a query to suggest to the user to resolve the reason
+// for skipping.
+type SkippedSuggested struct {
+	Title           string `json:"title"`
+	QueryExpression string `json:"queryExpression"`
+}
+
+// SkippedReason is an enum for Skipped.Reason.
+type SkippedReason string
+
+const (
+	// DocumentMatchLimit is when we found too many matches in a document, so
+	// we stopped searching it.
+	DocumentMatchLimit SkippedReason = "document-match-limit"
+	// ShardMatchLimit is when we found too many matches in a
+	// shard/repository, so we stopped searching it.
+	ShardMatchLimit = "shard-match-limit"
+	// RepositoryLimit is when we did not search a repository because the set
+	// of repositories to search was too large.
+	RepositoryLimit = "repository-limit"
+	// ShardTimeout is when we ran out of time before searching a
+	// shard/repository.
+	ShardTimeout = "shard-timeout"
+	// RepositoryCloning is when we could not search a repository because it
+	// is not cloned.
+	RepositoryCloning = "repository-cloning"
+	// RepositoryMissing is when we could not search a repository because it
+	// is not cloned and we failed to find it on the remote code host.
+	RepositoryMissing = "repository-missing"
+	// ExcludedFork is when we did not search a repository because it is a
+	// fork.
+	ExcludedFork = "repository-fork"
+	// ExcludedArchive is when we did not search a repository because it is
+	// archived.
+	ExcludedArchive = "excluded-archive"
+)
+
+// SkippedSeverity is an enum for Skipped.Severity.
+type SkippedSeverity string
+
+const (
+	SeverityInfo SkippedSeverity = "info"
+	SeverityWarn                 = "warn"
+)

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,6 +16,9 @@ func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
 	data := marshal(t, want)
 
 	if update {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatalf("failed to update golden file %q: %s", path, err)
+		}
 		if err := ioutil.WriteFile(path, data, 0640); err != nil {
 			t.Fatalf("failed to update golden file %q: %s", path, err)
 		}


### PR DESCRIPTION
As we improve on progress, we will need more access to "search
internals" which currently live in the graphqlbackend. I wanted to avoid
this, but for practicality purposes this is best.

To accomplish this we factor out the search progress types into a shared
package. The types have been exported as well as documented.

We have also added some golden tests.