### PR TITLE
tsconfig: bump to es2020 to use bigint

### DIFF
--- a/client/shared/src/util/strings.ts
+++ b/client/shared/src/util/strings.ts
@@ -22,7 +22,7 @@ export function numberWithCommas(number: string | number): string {
 }
 
 export function pluralize(string: string, count: number | bigint, plural = string + 's'): string {
-    return count === 1 ? string : plural
+    return count === 1 || count === 1n ? string : plural
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@sourcegraph/tsconfig",
   "references": [],
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
     "allowJs": false,
     "moduleResolution": "node",


### PR DESCRIPTION
Followup of https://github.com/sourcegraph/sourcegraph/pull/16345#discussion_r534055393