### PR TITLE
search: make streaming search handler testable

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -50,6 +50,9 @@ type SearchArgs struct {
 	After          *string
 	First          *int32
 	VersionContext *string
+
+	// For tests
+	Settings *schema.Settings
 }
 
 type SearchImplementer interface {
@@ -66,9 +69,14 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplem
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	settings, err := decodedViewerFinalSettings(ctx)
-	if err != nil {
-		return nil, err
+
+	settings := args.Settings
+	if settings == nil {
+		var err error
+		settings, err = decodedViewerFinalSettings(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	useNewParser := getBoolPtr(settings.SearchMigrateParser, true)
@@ -217,7 +225,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 		case "V2":
 			searchType = query.SearchTypeLiteral
 		default:
-			return -1, fmt.Errorf("unrecognized version: %v", version)
+			return -1, fmt.Errorf("unrecognized version want \"V1\" or \"V2\": %v", version)
 		}
 	}
 	return searchType, nil

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -256,7 +256,7 @@ func initRouter() {
 	}, nil)))
 
 	// streaming search
-	router.Get(routeSearchStream).HandlerFunc(search.ServeStream)
+	router.Get(routeSearchStream).Handler(search.StreamHandler)
 
 	// search badge
 	router.Get(routeSearchBadge).Handler(searchBadgeHandler)

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -76,7 +76,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Re
 
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
 
-	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(http.HandlerFunc(frontendsearch.ServeStream)))
+	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(frontendsearch.StreamHandler))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCliVersion).Handler(trace.TraceRoute(handler(srcCliVersionServe)))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -14,8 +14,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-// ServeStream is an http handler which streams back search results.
-func ServeStream(w http.ResponseWriter, r *http.Request) {
+// StreamHandler is an http handler which streams back search results.
+var StreamHandler http.Handler = &streamHandler{
+	newSearchResolver: defaultNewSearchResolver,
+}
+
+type streamHandler struct {
+	newSearchResolver func(context.Context, *graphqlbackend.SearchArgs) (searchResolver, error)
+}
+
+func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
@@ -44,7 +52,7 @@ func ServeStream(w http.ResponseWriter, r *http.Request) {
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
-	search, err := graphqlbackend.NewSearchImplementer(ctx, &graphqlbackend.SearchArgs{
+	search, err := h.newSearchResolver(ctx, &graphqlbackend.SearchArgs{
 		Query:          args.Query,
 		Version:        args.Version,
 		PatternType:    strPtr(args.PatternType),
@@ -175,6 +183,23 @@ func ServeStream(w http.ResponseWriter, r *http.Request) {
 	_ = eventWriter.Event("done", map[string]interface{}{})
 }
 
+type searchResolver interface {
+	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
+	SetResultChannel(c chan<- []graphqlbackend.SearchResultResolver)
+}
+
+func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {
+	searchImpl, err := graphqlbackend.NewSearchImplementer(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	search, ok := searchImpl.(searchResolver)
+	if !ok {
+		return nil, errors.New("SearchImplementer does not support streaming")
+	}
+	return search, nil
+}
+
 type args struct {
 	Query          string
 	Version        string
@@ -231,21 +256,14 @@ type finalResult struct {
 //
 //   - results is written to 0 or more times before closing.
 //   - final is written to once.
-func newResultsStream(ctx context.Context, search graphqlbackend.SearchImplementer) (results <-chan []graphqlbackend.SearchResultResolver, final <-chan finalResult) {
+func newResultsStream(ctx context.Context, search searchResolver) (results <-chan []graphqlbackend.SearchResultResolver, final <-chan finalResult) {
 	resultsC := make(chan []graphqlbackend.SearchResultResolver)
 	finalC := make(chan finalResult, 1)
 	go func() {
 		defer close(finalC)
 		defer close(resultsC)
 
-		if setter, ok := search.(interface {
-			SetResultChannel(c chan<- []graphqlbackend.SearchResultResolver)
-		}); !ok {
-			finalC <- finalResult{err: errors.New("SearchImplementer does not support streaming")}
-			return
-		} else {
-			setter.SetResultChannel(resultsC)
-		}
+		search.SetResultChannel(resultsC)
 
 		r, err := search.Results(ctx)
 		finalC <- finalResult{resultsResolver: r, err: err}

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -1,0 +1,20 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Ensures graphqlbackend matches the interface we expect
+func TestDefaultNewSearchResolver(t *testing.T) {
+	_, err := defaultNewSearchResolver(context.Background(), &graphqlbackend.SearchArgs{
+		Version:  "V2",
+		Settings: &schema.Settings{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This doesn't fully test it yet, but adds in the necessary points of
injection to mock out the graphqlbackend.