### PR TITLE
vcs/git: Remove commandRetryer

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -123,7 +123,7 @@ func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) (
 	if err != nil {
 		return nil, err
 	}
-	commitID, err := git.ResolveRevision(ctx, *gitRepo, nil, "HEAD", git.ResolveRevisionOptions{})
+	commitID, err := git.ResolveRevision(ctx, *gitRepo, "HEAD", git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -223,14 +223,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 	if err != nil && !isIgnorableRepoUpdaterError(err) {
 		return "", err
 	}
-	remoteURLFunc := func() (string, error) {
-		grepo, err := GitRepo(ctx, repo)
-		if err != nil {
-			return "", err
-		}
-		return grepo.URL, nil
-	}
-	return git.ResolveRevision(ctx, *gitserverRepo, remoteURLFunc, rev, git.ResolveRevisionOptions{})
+	return git.ResolveRevision(ctx, *gitserverRepo, rev, git.ResolveRevisionOptions{})
 }
 
 func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *git.Commit, err error) {
@@ -256,14 +249,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 	if err != nil && !isIgnorableRepoUpdaterError(err) {
 		return nil, err
 	}
-	remoteURLFunc := func() (string, error) {
-		grepo, err := GitRepo(ctx, repo)
-		if err != nil {
-			return "", err
-		}
-		return grepo.URL, nil
-	}
-	return git.GetCommit(ctx, *gitserverRepo, remoteURLFunc, commitID, git.ResolveRevisionOptions{})
+	return git.GetCommit(ctx, *gitserverRepo, commitID, git.ResolveRevisionOptions{})
 }
 
 func isIgnorableRepoUpdaterError(err error) bool {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -68,7 +68,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*git.Commit, err
 		}
 
 		opts := git.ResolveRevisionOptions{}
-		r.commit, r.commitErr = git.GetCommit(ctx, r.gitRepo, nil, api.CommitID(r.oid), opts)
+		r.commit, r.commitErr = git.GetCommit(ctx, r.gitRepo, api.CommitID(r.oid), opts)
 	})
 	return r.commit, r.commitErr
 }

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -21,7 +21,7 @@ func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
 	if err != nil {
 		return nil, err
 	}
-	oid, err := git.ResolveRevision(ctx, *cachedRepo, nil, r.expr, git.ResolveRevisionOptions{})
+	oid, err := git.ResolveRevision(ctx, *cachedRepo, r.expr, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -183,7 +183,7 @@ func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver
 
 		if err == nil && exitCode == 0 {
 			// Check that our repo is not empty
-			_, err = git.ResolveRevision(ctx, *cachedRepo, nil, "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
+			_, err = git.ResolveRevision(ctx, *cachedRepo, "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
 		}
 
 		// If we fail to get the default branch due to cloning or being empty, we return nothing.
@@ -391,7 +391,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 		if err != nil {
 			return nil, err
 		}
-		_, err = git.ResolveRevision(ctx, *cachedRepo, nil, targetRef, git.ResolveRevisionOptions{
+		_, err = git.ResolveRevision(ctx, *cachedRepo, targetRef, git.ResolveRevisionOptions{
 			NoEnsureRevision: true,
 		})
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -82,7 +82,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 
 		// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't
 		// exist).
-		commitID, err := git.ResolveRevision(ctx, repo, nil, revspec, opt)
+		commitID, err := git.ResolveRevision(ctx, repo, revspec, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -164,7 +164,7 @@ func hydrateBranchCommits(ctx context.Context, repo gitserver.Repo, interactive 
 	}
 
 	for _, branch := range branches {
-		branch.Commit, err = git.GetCommit(ctx, repo, nil, branch.Head, git.ResolveRevisionOptions{})
+		branch.Commit, err = git.GetCommit(ctx, repo, branch.Head, git.ResolveRevisionOptions{})
 		if err != nil {
 			if parentCtx.Err() == nil && ctx.Err() != nil {
 				// reached interactive timeout

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1014,7 +1014,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 			// taking a long time because they all ask gitserver to try to fetch from the remote
 			// repo.
 			trimmedRefSpec := strings.TrimPrefix(rev.RevSpec, "^") // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
-			if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), nil, trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); err != nil {
+			if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					return resolvedRepositories{}, context.DeadlineExceeded
 				}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -238,7 +238,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commitID, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), nil, inputRev, git.ResolveRevisionOptions{})
+	commitID, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -181,7 +181,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commit, err := git.ResolveRevision(ctx, gitserverRepo, nil, rev, git.ResolveRevisionOptions{NoEnsureRevision: true})
+	commit, err := git.ResolveRevision(ctx, gitserverRepo, rev, git.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return nil, false, err
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -173,7 +173,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 
 		getVersion := func(branch string) (string, error) {
 			// Do not to trigger a repo-updater lookup since this is a batch job.
-			commitID, err := git.ResolveRevision(ctx, gitserver.Repo{Name: repo.Name}, nil, branch, git.ResolveRevisionOptions{})
+			commitID, err := git.ResolveRevision(ctx, gitserver.Repo{Name: repo.Name}, branch, git.ResolveRevisionOptions{})
 			if err != nil && errcode.HTTP(err) == http.StatusNotFound {
 				// GetIndexOptions wants an empty rev for a missing rev or empty
 				// repo.
@@ -483,7 +483,7 @@ func serveGitResolveRevision(w http.ResponseWriter, r *http.Request) error {
 	spec := vars["Spec"]
 
 	// Do not to trigger a repo-updater lookup since this is a batch job.
-	commitID, err := git.ResolveRevision(r.Context(), gitserver.Repo{Name: name}, nil, spec, git.ResolveRevisionOptions{})
+	commitID, err := git.ResolveRevision(r.Context(), gitserver.Repo{Name: name}, spec, git.ResolveRevisionOptions{})
 	if err != nil {
 		return err
 	}
@@ -501,7 +501,7 @@ func serveGitTar(w http.ResponseWriter, r *http.Request) error {
 
 	// Ensure commit exists. Do not want to trigger a repo-updater lookup since this is a batch job.
 	repo := gitserver.Repo{Name: name}
-	commit, err := git.ResolveRevision(r.Context(), repo, nil, spec, git.ResolveRevisionOptions{})
+	commit, err := git.ResolveRevision(r.Context(), repo, spec, git.ResolveRevisionOptions{})
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -220,7 +220,7 @@ func (r *CachedLocationResolver) resolveCommit(ctx context.Context, repositoryRe
 		return nil, err
 	}
 
-	commitID, err := git.ResolveRevision(ctx, *gitserverRepo, nil, commit, git.ResolveRevisionOptions{NoEnsureRevision: true})
+	commitID, err := git.ResolveRevision(ctx, *gitserverRepo, commit, git.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		if gitserver.IsRevisionNotFound(err) {
 			return nil, nil

--- a/enterprise/internal/campaigns/state.go
+++ b/enterprise/internal/campaigns/state.go
@@ -605,7 +605,7 @@ func computeRev(ctx context.Context, repo gitserver.Repo, getOid, getRef func() 
 
 	// Resolve the revision to make sure it's on gitserver and, in case we did
 	// the fallback to ref, to get the specific revision.
-	gitRev, err := git.ResolveRevision(ctx, repo, nil, rev, git.ResolveRevisionOptions{})
+	gitRev, err := git.ResolveRevision(ctx, repo, rev, git.ResolveRevisionOptions{})
 	return string(gitRev), err
 }
 

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -259,7 +259,7 @@ func (c *Client) FileExists(ctx context.Context, repositoryID int, commit, file 
 		return false, err
 	}
 
-	if _, err := git.ResolveRevision(ctx, repo, nil, commit, git.ResolveRevisionOptions{}); err != nil {
+	if _, err := git.ResolveRevision(ctx, repo, commit, git.ResolveRevisionOptions{}); err != nil {
 		return false, errors.Wrap(err, "git.ResolveRevision")
 	}
 

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -49,7 +49,7 @@ func TestRepository_BlameFile(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		newestCommitID, err := ResolveRevision(ctx, test.repo, nil, string(test.opt.NewestCommit), ResolveRevisionOptions{})
+		newestCommitID, err := ResolveRevision(ctx, test.repo, string(test.opt.NewestCommit), ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on base: %s", label, test.opt.NewestCommit, err)
 			continue

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -61,7 +61,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		resolveRevisionOptions := ResolveRevisionOptions{
 			NoEnsureRevision: test.noEnsureRevision,
 		}
-		commit, err := GetCommit(ctx, test.repo, nil, test.id, resolveRevisionOptions)
+		commit, err := GetCommit(ctx, test.repo, test.id, resolveRevisionOptions)
 		if err != nil {
 			t.Errorf("%s: GetCommit: %s", label, err)
 			continue
@@ -72,7 +72,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-		if _, err := GetCommit(ctx, test.repo, nil, NonExistentCommitID, resolveRevisionOptions); !gitserver.IsRevisionNotFound(err) {
+		if _, err := GetCommit(ctx, test.repo, NonExistentCommitID, resolveRevisionOptions); !gitserver.IsRevisionNotFound(err) {
 			t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 		}
 

--- a/internal/vcs/git/merge_base_test.go
+++ b/internal/vcs/git/merge_base_test.go
@@ -42,19 +42,19 @@ func TestMerger_MergeBase(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		a, err := ResolveRevision(ctx, test.repo, nil, test.a, ResolveRevisionOptions{})
+		a, err := ResolveRevision(ctx, test.repo, test.a, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on a: %s", label, test.a, err)
 			continue
 		}
 
-		b, err := ResolveRevision(ctx, test.repo, nil, test.b, ResolveRevisionOptions{})
+		b, err := ResolveRevision(ctx, test.repo, test.b, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on b: %s", label, test.b, err)
 			continue
 		}
 
-		want, err := ResolveRevision(ctx, test.repo, nil, test.wantMergeBase, ResolveRevisionOptions{})
+		want, err := ResolveRevision(ctx, test.repo, test.wantMergeBase, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on wantMergeBase: %s", label, test.wantMergeBase, err)
 			continue

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -180,7 +180,7 @@ func ListBranches(ctx context.Context, repo gitserver.Repo, opt BranchesOptions)
 
 		branch := &Branch{Name: name, Head: ref.CommitID}
 		if opt.IncludeCommit {
-			branch.Commit, err = getCommit(ctx, repo, nil, ref.CommitID, ResolveRevisionOptions{})
+			branch.Commit, err = getCommit(ctx, repo, ref.CommitID, ResolveRevisionOptions{})
 			if err != nil {
 				return nil, err
 			}

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -54,12 +54,7 @@ type ResolveRevisionOptions struct {
 // * Commit does not exist: RevisionNotFoundError
 // * Empty repository: RevisionNotFoundError
 // * Other unexpected errors.
-//
-// The remoteURLFunc is called to get the Git remote URL if it's not set in r and if it is
-// needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
-// the repository or if the revision must be fetched from the remote. This only happens when calling
-// ResolveRevision.
-func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc func() (string, error), spec string, opt ResolveRevisionOptions) (api.CommitID, error) {
+func ResolveRevision(ctx context.Context, repo gitserver.Repo, spec string, opt ResolveRevisionOptions) (api.CommitID, error) {
 	if Mocks.ResolveRevision != nil {
 		return Mocks.ResolveRevision(spec, opt)
 	}
@@ -83,29 +78,18 @@ func ResolveRevision(ctx context.Context, repo gitserver.Repo, remoteURLFunc fun
 		spec = spec + "^0"
 	}
 
-	var (
-		commit api.CommitID
-		err    error
-	)
 	cmd := gitserver.DefaultClient.Command("git", "rev-parse", spec)
 	cmd.Repo = repo
 	cmd.EnsureRevision = spec
-	retryer := &commandRetryer{
-		cmd:           cmd,
-		remoteURLFunc: remoteURLFunc,
-		exec: func() error {
-			commit, err = runRevParse(ctx, cmd, spec)
-			return err
-		},
-	}
-	if opt.NoEnsureRevision {
-		// Make the commandRetryer no-op so that gitserver does not try to
-		// update the repository.
+
+	// We don't ever need to ensure that HEAD is in git-server.
+	// HEAD is always there once a repo is cloned
+	// (except empty repos, but we don't need to ensure revision on those).
+	if opt.NoEnsureRevision || spec == "HEAD" {
 		cmd.EnsureRevision = ""
-		retryer.remoteURLFunc = nil
 	}
-	err = retryer.run()
-	return commit, err
+
+	return runRevParse(ctx, cmd, spec)
 }
 
 type BadCommitError struct {

--- a/internal/vcs/git/revisions_test.go
+++ b/internal/vcs/git/revisions_test.go
@@ -42,7 +42,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.branch, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -73,7 +73,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.branch, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -105,7 +105,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.tag, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -136,7 +136,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, nil, test.tag, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -331,7 +331,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, "master", ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(ctx, test.repo, "master", ResolveRevisionOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -390,7 +390,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(ctx, test.repo, nil, "master", ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(ctx, test.repo, "master", ResolveRevisionOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This changeset removes the jurassic `commandRetryer` struct and logic, that was used by `git.ResolveRevision` and `git.GetCommit`. With gitserver now always knowing the clone URL for a given repo name it receives, there's no need for the client side to have the logic to acquire the remote URL if needed.

![](https://media2.giphy.com/media/jV6W6F4xXCcfc77TpD/giphy-downsized-medium.gif)