### PR TITLE
Convert Range class to plain Range when merging hovers

### DIFF
--- a/client/shared/src/api/client/types/hover.ts
+++ b/client/shared/src/api/client/types/hover.ts
@@ -1,19 +1,19 @@
-import { MarkupKind } from '@sourcegraph/extension-api-classes'
-import { Hover as PlainHover, Range } from '@sourcegraph/extension-api-types'
+import { MarkupKind, Range } from '@sourcegraph/extension-api-classes'
+import { Hover as PlainHover, Range as PlainRange } from '@sourcegraph/extension-api-types'
 import { Badged, Hover, MarkupContent, HoverAlert } from 'sourcegraph'
 
 /** A hover that is merged from multiple Hover results and normalized. */
 export interface HoverMerged {
     contents: Badged<MarkupContent>[]
     alerts?: Badged<HoverAlert>[]
-    range?: Range
+    range?: PlainRange
 }
 
 /** Create a merged hover from the given individual hovers. */
 export function fromHoverMerged(values: (Badged<Hover | PlainHover> | null | undefined)[]): HoverMerged | null {
     const contents: HoverMerged['contents'] = []
     const alerts: HoverMerged['alerts'] = []
-    let range: Range | undefined
+    let range: PlainRange | undefined
     for (const result of values) {
         if (result) {
             if (result.contents?.value) {
@@ -27,7 +27,12 @@ export function fromHoverMerged(values: (Badged<Hover | PlainHover> | null | und
                 alerts.push(...result.alerts)
             }
             if (result.range && !range) {
-                range = result.range
+                // TODO(tj): Merge ranges so we highlight all provided ranges, not just the first range
+                if (result.range instanceof Range) {
+                    range = result.range.toPlain()
+                } else {
+                    range = result.range
+                }
             }
         }
     }


### PR DESCRIPTION
Now that we use `Range` in codeintellify, we need to make sure that we're passing it the expected type in the web app. 

`Range` lost its [`start` and `end` getters as it was cloned](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#Things_that_dont_work_with_structured_clone) to the main thread. This PR adds a check for the prototype of the range to be merged. If it's an instance of the `Range` class, convert it to a plain object.