### PR TITLE
repo-updater: Use unnest instead of json_to_recordset

### DIFF
--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -780,79 +780,69 @@ func (s *DBStore) UpsertSources(ctx context.Context, inserts, updates, deletes m
 		return nil
 	}
 
-	marshalSourceList := func(sources map[api.RepoID][]SourceInfo) ([]byte, error) {
-		srcs := make([]externalServiceRepo, 0, len(sources))
+	type sourceSlices struct {
+		exteralServiceIDs []int64
+		repoIDs           []int64
+		cloneURLs         []string
+	}
+
+	makeSourceSlices := func(sources map[api.RepoID][]SourceInfo) sourceSlices {
+		srcs := sourceSlices{
+			exteralServiceIDs: make([]int64, 0, len(sources)),
+			repoIDs:           make([]int64, 0, len(sources)),
+			cloneURLs:         make([]string, 0, len(sources)),
+		}
 		for rid, infoList := range sources {
 			for _, info := range infoList {
-				srcs = append(srcs, externalServiceRepo{
-					ExternalServiceID: info.ExternalServiceID(),
-					RepoID:            int64(rid),
-					CloneURL:          info.CloneURL,
-				})
+				srcs.exteralServiceIDs = append(srcs.exteralServiceIDs, info.ExternalServiceID())
+				srcs.repoIDs = append(srcs.repoIDs, int64(rid))
+				srcs.cloneURLs = append(srcs.cloneURLs, info.CloneURL)
 			}
 		}
-		return json.Marshal(srcs)
+		return srcs
 	}
 
-	insertedSources, err := marshalSourceList(inserts)
-	if err != nil {
-		return err
-	}
+	insertedSources := makeSourceSlices(inserts)
+	updatedSources := makeSourceSlices(updates)
+	deletedSources := makeSourceSlices(deletes)
 
-	updatedSources, err := marshalSourceList(updates)
-	if err != nil {
-		return err
-	}
-
-	deletedSources, err := marshalSourceList(deletes)
-	if err != nil {
-		return err
-	}
+	// TODO: Most of the time deletes don't happen so we should lazily add that statement because
+	// even if it runs and affects zero rows, it still causes the slow orphaned repo
+	// trigger to run.
 
 	q := sqlf.Sprintf(upsertSourcesQueryFmtstr,
-		string(deletedSources),
-		string(updatedSources),
-		string(insertedSources),
+		// Updated
+		pq.Int64Array(updatedSources.exteralServiceIDs),
+		pq.Int64Array(updatedSources.repoIDs),
+		pq.StringArray(updatedSources.cloneURLs),
+		// Inserted
+		pq.Int64Array(insertedSources.exteralServiceIDs),
+		pq.Int64Array(insertedSources.repoIDs),
+		pq.StringArray(insertedSources.cloneURLs),
+		// Deleted
+		pq.Int64Array(deletedSources.exteralServiceIDs),
+		pq.Int64Array(deletedSources.repoIDs),
 	)
 
-	err = s.Exec(ctx, q)
-	return err
+	return s.Exec(ctx, q)
 }
 
 const upsertSourcesQueryFmtstr = `
 -- source: cmd/repo-updater/repos/store.go:DBStore.UpsertSources
-WITH deleted_sources_list AS (
-  SELECT * FROM ROWS FROM (
-	json_to_recordset(%s)
-	AS (
-		external_service_id bigint,
-		repo_id             integer,
-		clone_url           text
-	)
-  )
-  WITH ORDINALITY
-),
-updated_sources_list AS (
-  SELECT * FROM ROWS FROM (
-    json_to_recordset(%s)
-    AS (
-      external_service_id bigint,
-      repo_id             integer,
-      clone_url           text
-    )
-  )
-  WITH ORDINALITY
+WITH updated_sources_list AS (
+  SELECT * FROM
+  unnest(%s::bigint[], %s::integer[], %s::text[]) AS
+  x ( external_service_id, repo_id, clone_url )
 ),
 inserted_sources_list AS (
-  SELECT * FROM ROWS FROM (
-    json_to_recordset(%s)
-    AS (
-        external_service_id bigint,
-        repo_id             integer,
-        clone_url           text
-    )
-  )
-  WITH ORDINALITY
+  SELECT * FROM
+  unnest(%s::bigint[], %s::integer[], %s::text[]) AS
+  x ( external_service_id, repo_id, clone_url )
+),
+deleted_sources_list AS (
+  SELECT * FROM
+  unnest(%s::bigint[], %s::integer[]) AS
+  x ( external_service_id, repo_id )
 ),
 delete_sources AS (
   DELETE FROM external_service_repos AS e

--- a/cmd/repo-updater/repos/store.go
+++ b/cmd/repo-updater/repos/store.go
@@ -781,20 +781,20 @@ func (s *DBStore) UpsertSources(ctx context.Context, inserts, updates, deletes m
 	}
 
 	type sourceSlices struct {
-		exteralServiceIDs []int64
-		repoIDs           []int64
-		cloneURLs         []string
+		externalServiceIDs []int64
+		repoIDs            []int64
+		cloneURLs          []string
 	}
 
 	makeSourceSlices := func(sources map[api.RepoID][]SourceInfo) sourceSlices {
 		srcs := sourceSlices{
-			exteralServiceIDs: make([]int64, 0, len(sources)),
-			repoIDs:           make([]int64, 0, len(sources)),
-			cloneURLs:         make([]string, 0, len(sources)),
+			externalServiceIDs: make([]int64, 0, len(sources)),
+			repoIDs:            make([]int64, 0, len(sources)),
+			cloneURLs:          make([]string, 0, len(sources)),
 		}
 		for rid, infoList := range sources {
 			for _, info := range infoList {
-				srcs.exteralServiceIDs = append(srcs.exteralServiceIDs, info.ExternalServiceID())
+				srcs.externalServiceIDs = append(srcs.externalServiceIDs, info.ExternalServiceID())
 				srcs.repoIDs = append(srcs.repoIDs, int64(rid))
 				srcs.cloneURLs = append(srcs.cloneURLs, info.CloneURL)
 			}
@@ -812,15 +812,15 @@ func (s *DBStore) UpsertSources(ctx context.Context, inserts, updates, deletes m
 
 	q := sqlf.Sprintf(upsertSourcesQueryFmtstr,
 		// Updated
-		pq.Int64Array(updatedSources.exteralServiceIDs),
+		pq.Int64Array(updatedSources.externalServiceIDs),
 		pq.Int64Array(updatedSources.repoIDs),
 		pq.StringArray(updatedSources.cloneURLs),
 		// Inserted
-		pq.Int64Array(insertedSources.exteralServiceIDs),
+		pq.Int64Array(insertedSources.externalServiceIDs),
 		pq.Int64Array(insertedSources.repoIDs),
 		pq.StringArray(insertedSources.cloneURLs),
 		// Deleted
-		pq.Int64Array(deletedSources.exteralServiceIDs),
+		pq.Int64Array(deletedSources.externalServiceIDs),
 		pq.Int64Array(deletedSources.repoIDs),
 	)
 


### PR DESCRIPTION
We found previously that using json_to_recordset can lead to temporary
file limit errors.

In this case, even though we're mostly sending small amounts of data to
our statements we have a trigger that runs after any rows in
external_service_repos are deleted. The trigger reads most rows in our
repo and external_service_repos table and this in combination with
json_to_recordset appears to lead to temporary file limit errors.

Closes: https://github.com/sourcegraph/sourcegraph/issues/16318
