### PR TITLE
search: code monitoring, move monitors to store

### DIFF
--- a/enterprise/internal/codemonitors/code_monitors.go
+++ b/enterprise/internal/codemonitors/code_monitors.go
@@ -1,0 +1,36 @@
+package codemonitors
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+func (s *Store) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (m *Monitor, err error) {
+	// Start transaction.
+	var txStore *Store
+	txStore, err = s.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = txStore.Done(err) }()
+
+	// Create monitor.
+	m, err = txStore.CreateMonitor(ctx, args.Monitor)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create trigger.
+	err = txStore.CreateTriggerQuery(ctx, m.ID, args.Trigger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create actions.
+	err = txStore.CreateActions(ctx, args.Actions, m.ID)
+	if err != nil {
+		return nil, err
+	}
+	return m, err
+}

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -1,0 +1,277 @@
+package codemonitors
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+)
+
+type Monitor struct {
+	ID              int64
+	CreatedBy       int32
+	CreatedAt       time.Time
+	ChangedBy       int32
+	ChangedAt       time.Time
+	Description     string
+	Enabled         bool
+	NamespaceUserID *int32
+	NamespaceOrgID  *int32
+}
+
+var monitorColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_monitors.id"),
+	sqlf.Sprintf("cm_monitors.created_by"),
+	sqlf.Sprintf("cm_monitors.created_at"),
+	sqlf.Sprintf("cm_monitors.changed_by"),
+	sqlf.Sprintf("cm_monitors.changed_at"),
+	sqlf.Sprintf("cm_monitors.description"),
+	sqlf.Sprintf("cm_monitors.enabled"),
+	sqlf.Sprintf("cm_monitors.namespace_user_id"),
+	sqlf.Sprintf("cm_monitors.namespace_org_id"),
+}
+
+func (s *Store) CreateMonitor(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (m *Monitor, err error) {
+	var q *sqlf.Query
+	q, err = s.createCodeMonitorQuery(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return s.runMonitorQuery(ctx, q)
+}
+
+func (s *Store) UpdateMonitor(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (m *Monitor, err error) {
+	var q *sqlf.Query
+	q, err = s.updateCodeMonitorQuery(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return s.runMonitorQuery(ctx, q)
+}
+
+func (s *Store) ToggleMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (m *Monitor, err error) {
+	var q *sqlf.Query
+	q, err = s.toggleCodeMonitorQuery(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return s.runMonitorQuery(ctx, q)
+}
+
+func (s *Store) DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) (err error) {
+	var q *sqlf.Query
+	q, err = s.deleteMonitorQuery(ctx, args)
+	if err != nil {
+		return err
+	}
+	return s.Exec(ctx, q)
+}
+
+func (s *Store) Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
+	q, err := monitorsQuery(userID, args)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanMonitors(rows)
+}
+
+const monitorByIDFmtStr = `
+SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
+FROM cm_monitors
+WHERE id = %s
+`
+
+func (s *Store) MonitorByIDInt64(ctx context.Context, monitorID int64) (m *Monitor, err error) {
+	return s.runMonitorQuery(ctx, sqlf.Sprintf(monitorByIDFmtStr, monitorID))
+}
+
+const monitorsFmtStr = `
+SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
+FROM cm_monitors
+WHERE namespace_user_id = %s
+AND id > %s
+ORDER BY id ASC
+LIMIT %s
+`
+
+func monitorsQuery(userID int32, args *graphqlbackend.ListMonitorsArgs) (*sqlf.Query, error) {
+	after, err := unmarshalAfter(args.After)
+	if err != nil {
+		return nil, err
+	}
+	query := sqlf.Sprintf(
+		monitorsFmtStr,
+		userID,
+		after,
+		args.First,
+	)
+	return query, nil
+}
+
+const toggleCodeMonitorFmtStr = `
+UPDATE cm_monitors
+SET enabled = %s,
+	changed_by = %s,
+	changed_at = %s
+WHERE id = %s
+RETURNING %s
+`
+
+func (s *Store) toggleCodeMonitorQuery(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*sqlf.Query, error) {
+	var monitorID int64
+	err := relay.UnmarshalSpec(args.Id, &monitorID)
+	if err != nil {
+		return nil, err
+	}
+	actorUID := actor.FromContext(ctx).UID
+	query := sqlf.Sprintf(
+		toggleCodeMonitorFmtStr,
+		args.Enabled,
+		actorUID,
+		s.Now(),
+		monitorID,
+		sqlf.Join(monitorColumns, ", "),
+	)
+	return query, nil
+}
+
+const insertCodeMonitorFmtStr = `
+INSERT INTO cm_monitors
+(created_at, created_by, changed_at, changed_by, description, enabled, namespace_user_id, namespace_org_id)
+VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+RETURNING %s;
+`
+
+func (s *Store) createCodeMonitorQuery(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (*sqlf.Query, error) {
+	var userID int32
+	var orgID int32
+	err := graphqlbackend.UnmarshalNamespaceID(args.Namespace, &userID, &orgID)
+	if err != nil {
+		return nil, err
+	}
+	now := s.Now()
+	a := actor.FromContext(ctx)
+	return sqlf.Sprintf(
+		insertCodeMonitorFmtStr,
+		now,
+		a.UID,
+		now,
+		a.UID,
+		args.Description,
+		args.Enabled,
+		nilOrInt32(userID),
+		nilOrInt32(orgID),
+		sqlf.Join(monitorColumns, ", "),
+	), nil
+}
+
+const updateCodeMonitorFmtStr = `
+UPDATE cm_monitors
+SET description = %s,
+	enabled	= %s,
+	namespace_user_id = %s,
+	namespace_org_id = %s,
+	changed_by = %s,
+	changed_at = %s
+WHERE id = %s
+RETURNING %s;
+`
+
+func (s *Store) updateCodeMonitorQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (*sqlf.Query, error) {
+	var userID int32
+	var orgID int32
+	err := graphqlbackend.UnmarshalNamespaceID(args.Monitor.Update.Namespace, &userID, &orgID)
+	if err != nil {
+		return nil, err
+	}
+	now := s.Now()
+	a := actor.FromContext(ctx)
+	var monitorID int64
+	err = relay.UnmarshalSpec(args.Monitor.Id, &monitorID)
+	if err != nil {
+		return nil, err
+	}
+	return sqlf.Sprintf(
+		updateCodeMonitorFmtStr,
+		args.Monitor.Update.Description,
+		args.Monitor.Update.Enabled,
+		nilOrInt32(userID),
+		nilOrInt32(orgID),
+		a.UID,
+		now,
+		monitorID,
+		sqlf.Join(monitorColumns, ", "),
+	), nil
+}
+
+const deleteMonitorFmtStr = `DELETE FROM cm_monitors WHERE id = %s`
+
+func (s *Store) deleteMonitorQuery(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) (*sqlf.Query, error) {
+	var monitorID int64
+	err := relay.UnmarshalSpec(args.Id, &monitorID)
+	if err != nil {
+		return nil, err
+	}
+	query := sqlf.Sprintf(
+		deleteMonitorFmtStr,
+		monitorID,
+	)
+	return query, nil
+}
+
+func scanMonitors(rows *sql.Rows) ([]*Monitor, error) {
+	var ms []*Monitor
+	for rows.Next() {
+		m := &Monitor{}
+		if err := rows.Scan(
+			&m.ID,
+			&m.CreatedBy,
+			&m.CreatedAt,
+			&m.ChangedBy,
+			&m.ChangedAt,
+			&m.Description,
+			&m.Enabled,
+			&m.NamespaceUserID,
+			&m.NamespaceOrgID,
+		); err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	err := rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	// Rows.Err will report the last error encountered by Rows.Scan.
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ms, nil
+}
+
+func (s *Store) runMonitorQuery(ctx context.Context, q *sqlf.Query) (*Monitor, error) {
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ms, err := scanMonitors(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(ms) == 0 {
+		return nil, fmt.Errorf("operation failed. Query should have returned 1 row")
+	}
+	return ms[0], nil
+}

--- a/enterprise/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/internal/codemonitors/resolvers/main_test.go
@@ -142,13 +142,6 @@ func newTestResolver(t *testing.T) *Resolver {
 	return newResolverWithClock(dbconn.Global, clock).(*Resolver)
 }
 
-func (r *Resolver) monitorForIDInt32(ctx context.Context, t *testing.T, monitorID int64) (graphqlbackend.MonitorResolver, error) {
-	t.Helper()
-
-	q := sqlf.Sprintf("SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id FROM cm_monitors WHERE id = %s", monitorID)
-	return r.runMonitorQuery(ctx, q)
-}
-
 func marshalDateTime(t testing.TB, ts time.Time) string {
 	t.Helper()
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	cm "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
@@ -37,32 +36,19 @@ func (r *Resolver) Now() time.Time {
 }
 
 func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) (graphqlbackend.MonitorConnectionResolver, error) {
-	q, err := monitorsQuery(userID, args)
+	ms, err := r.store.Monitors(ctx, userID, args)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.store.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	ms, err := scanMonitors(rows)
-	if err != nil {
-		return nil, err
-	}
-	// Hydrate the monitors with the resolver.
+	mrs := make([]graphqlbackend.MonitorResolver, 0, len(ms))
 	for _, m := range ms {
-		m.(*monitor).Resolver = r
+		mrs = append(mrs, &monitor{
+			Resolver: r,
+			Monitor:  m,
+		})
 	}
-	return &monitorConnection{r, ms}, nil
+	return &monitorConnection{r, mrs}, nil
 }
-
-const monitorByIDFmtStr = `
-SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
-FROM cm_monitors
-WHERE id = %s
-`
 
 func (r *Resolver) MonitorByID(ctx context.Context, ID graphql.ID) (m graphqlbackend.MonitorResolver, err error) {
 	err = r.isAllowedToEdit(ctx, ID)
@@ -74,14 +60,15 @@ func (r *Resolver) MonitorByID(ctx context.Context, ID graphql.ID) (m graphqlbac
 	if err != nil {
 		return nil, err
 	}
-	q := sqlf.Sprintf(monitorByIDFmtStr, monitorID)
-	m, err = r.runMonitorQuery(ctx, q)
+	var mo *cm.Monitor
+	mo, err = r.store.MonitorByIDInt64(ctx, monitorID)
 	if err != nil {
 		return nil, err
 	}
-	// Hydrate monitor with resolver.
-	m.(*monitor).Resolver = r
-	return m, nil
+	return &monitor{
+		Resolver: r,
+		Monitor:  mo,
+	}, nil
 }
 
 func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (m graphqlbackend.MonitorResolver, err error) {
@@ -89,55 +76,28 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 	if err != nil {
 		return nil, err
 	}
-	// start transaction
-	var txStore *cm.Store
-	txStore, err = r.store.Transact(ctx)
+	var mo *cm.Monitor
+	mo, err = r.store.CreateCodeMonitor(ctx, args)
 	if err != nil {
 		return nil, err
 	}
-	tx := Resolver{
-		store: txStore,
-	}
-	defer func() { err = tx.store.Done(err) }()
-
-	// create code monitor
-	var q *sqlf.Query
-	q, err = tx.createCodeMonitorQuery(ctx, args.Monitor)
-	if err != nil {
-		return nil, err
-	}
-	m, err = tx.runMonitorQuery(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create trigger.
-	err = tx.store.CreateTriggerQuery(ctx, m.(*monitor).id, args.Trigger)
-	if err != nil {
-		return nil, err
-	}
-
-	// create actions
-	err = tx.store.CreateActions(ctx, args.Actions, m.(*monitor).id)
-	if err != nil {
-		return nil, err
-	}
-
-	// Hydrate monitor with Resolver.
-	m.(*monitor).Resolver = r
-	return m, nil
+	return &monitor{
+		Resolver: r,
+		Monitor:  mo,
+	}, nil
 }
 
-func (r *Resolver) ToggleCodeMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (graphqlbackend.MonitorResolver, error) {
-	err := r.isAllowedToEdit(ctx, args.Id)
+func (r *Resolver) ToggleCodeMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (mr graphqlbackend.MonitorResolver, err error) {
+	err = r.isAllowedToEdit(ctx, args.Id)
 	if err != nil {
 		return nil, fmt.Errorf("ToggleCodeMonitor: %w", err)
 	}
-	q, err := r.toggleCodeMonitorQuery(ctx, args)
+	var mo *cm.Monitor
+	mo, err = r.store.ToggleMonitor(ctx, args)
 	if err != nil {
 		return nil, err
 	}
-	return r.runMonitorQuery(ctx, q)
+	return &monitor{r, mo}, nil
 }
 
 func (r *Resolver) DeleteCodeMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) (*graphqlbackend.EmptyResponse, error) {
@@ -145,13 +105,7 @@ func (r *Resolver) DeleteCodeMonitor(ctx context.Context, args *graphqlbackend.D
 	if err != nil {
 		return nil, fmt.Errorf("DeleteCodeMonitor: %w", err)
 	}
-	q, err := r.deleteCodeMonitorQuery(ctx, args)
-	if err != nil {
-		return nil, err
-	}
-	if err := r.store.Exec(ctx, q); err != nil {
-		return nil, err
-	}
+	err = r.store.DeleteMonitor(ctx, args)
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
@@ -290,13 +244,9 @@ func splitActionIDs(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorA
 }
 
 func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (m graphqlbackend.MonitorResolver, err error) {
-	var q *sqlf.Query
 	// Update monitor.
-	q, err = r.updateCodeMonitorQuery(ctx, args)
-	if err != nil {
-		return nil, err
-	}
-	m, err = r.runMonitorQuery(ctx, q)
+	var mo *cm.Monitor
+	mo, err = r.store.UpdateMonitor(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +257,10 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 	}
 	// Update actions.
 	if len(args.Actions) == 0 {
-		return m, nil
+		return &monitor{
+			Resolver: r,
+			Monitor:  mo,
+		}, nil
 	}
 	var emailID int64
 	var e *cm.MonitorEmail
@@ -323,7 +276,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		if err != nil {
 			return nil, err
 		}
-		e, err = r.store.UpdateActionEmail(ctx, m.(*monitor).id, action)
+		e, err = r.store.UpdateActionEmail(ctx, mo.ID, action)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +285,10 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 			return nil, err
 		}
 	}
-	return m, nil
+	return &monitor{
+		Resolver: r,
+		Monitor:  mo,
+	}, nil
 }
 
 func (r *Resolver) transact(ctx context.Context) (*Resolver, error) {
@@ -343,200 +299,6 @@ func (r *Resolver) transact(ctx context.Context) (*Resolver, error) {
 	return &Resolver{
 		store: txStore,
 	}, nil
-}
-
-func (r *Resolver) runMonitorQuery(ctx context.Context, q *sqlf.Query) (graphqlbackend.MonitorResolver, error) {
-	rows, err := r.store.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	ms, err := scanMonitors(rows)
-	if err != nil {
-		return nil, err
-	}
-	if len(ms) == 0 {
-		return nil, fmt.Errorf("operation failed. Query should have returned 1 row")
-	}
-	return ms[0], nil
-}
-
-func scanMonitors(rows *sql.Rows) ([]graphqlbackend.MonitorResolver, error) {
-	var ms []graphqlbackend.MonitorResolver
-	for rows.Next() {
-		m := &monitor{}
-		if err := rows.Scan(
-			&m.id,
-			&m.createdBy,
-			&m.createdAt,
-			&m.changedBy,
-			&m.changedAt,
-			&m.description,
-			&m.enabled,
-			&m.namespaceUserID,
-			&m.namespaceOrgID,
-		); err != nil {
-			return nil, err
-		}
-		ms = append(ms, m)
-	}
-	err := rows.Close()
-	if err != nil {
-		return nil, err
-	}
-	// Rows.Err will report the last error encountered by Rows.Scan.
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return ms, nil
-}
-
-func nilOrInt32(n int32) *int32 {
-	if n == 0 {
-		return nil
-	}
-	return &n
-}
-
-var monitorColumns = []*sqlf.Query{
-	sqlf.Sprintf("cm_monitors.id"),
-	sqlf.Sprintf("cm_monitors.created_by"),
-	sqlf.Sprintf("cm_monitors.created_at"),
-	sqlf.Sprintf("cm_monitors.changed_by"),
-	sqlf.Sprintf("cm_monitors.changed_at"),
-	sqlf.Sprintf("cm_monitors.description"),
-	sqlf.Sprintf("cm_monitors.enabled"),
-	sqlf.Sprintf("cm_monitors.namespace_user_id"),
-	sqlf.Sprintf("cm_monitors.namespace_org_id"),
-}
-
-func monitorsQuery(userID int32, args *graphqlbackend.ListMonitorsArgs) (*sqlf.Query, error) {
-	const SelectMonitorsByOwner = `
-SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
-FROM cm_monitors
-WHERE namespace_user_id = %s
-AND id > %s
-ORDER BY id ASC
-LIMIT %s
-`
-	after, err := unmarshalAfter(args.After)
-	if err != nil {
-		return nil, err
-	}
-	query := sqlf.Sprintf(
-		SelectMonitorsByOwner,
-		userID,
-		after,
-		args.First,
-	)
-	return query, nil
-}
-
-func (r *Resolver) createCodeMonitorQuery(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (*sqlf.Query, error) {
-	const InsertCodeMonitorQuery = `
-INSERT INTO cm_monitors
-(created_at, created_by, changed_at, changed_by, description, enabled, namespace_user_id, namespace_org_id)
-VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
-RETURNING %s;
-`
-	var userID int32
-	var orgID int32
-	err := graphqlbackend.UnmarshalNamespaceID(args.Namespace, &userID, &orgID)
-	if err != nil {
-		return nil, err
-	}
-	now := r.Now()
-	a := actor.FromContext(ctx)
-	return sqlf.Sprintf(
-		InsertCodeMonitorQuery,
-		now,
-		a.UID,
-		now,
-		a.UID,
-		args.Description,
-		args.Enabled,
-		nilOrInt32(userID),
-		nilOrInt32(orgID),
-		sqlf.Join(monitorColumns, ", "),
-	), nil
-}
-
-func (r *Resolver) updateCodeMonitorQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (*sqlf.Query, error) {
-	const updateCodeMonitorQuery = `
-UPDATE cm_monitors
-SET description = %s,
-	enabled	= %s,
-	namespace_user_id = %s,
-	namespace_org_id = %s,
-	changed_by = %s,
-	changed_at = %s
-WHERE id = %s
-RETURNING %s;
-`
-	var userID int32
-	var orgID int32
-	err := graphqlbackend.UnmarshalNamespaceID(args.Monitor.Update.Namespace, &userID, &orgID)
-	if err != nil {
-		return nil, err
-	}
-	now := r.Now()
-	a := actor.FromContext(ctx)
-	var monitorID int64
-	err = relay.UnmarshalSpec(args.Monitor.Id, &monitorID)
-	if err != nil {
-		return nil, err
-	}
-	return sqlf.Sprintf(
-		updateCodeMonitorQuery,
-		args.Monitor.Update.Description,
-		args.Monitor.Update.Enabled,
-		nilOrInt32(userID),
-		nilOrInt32(orgID),
-		a.UID,
-		now,
-		monitorID,
-		sqlf.Join(monitorColumns, ", "),
-	), nil
-}
-
-func (r *Resolver) toggleCodeMonitorQuery(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*sqlf.Query, error) {
-	toggleCodeMonitorQuery := `
-UPDATE cm_monitors
-SET enabled = %s,
-	changed_by = %s,
-	changed_at = %s
-WHERE id = %s
-RETURNING %s
-`
-	var monitorID int64
-	err := relay.UnmarshalSpec(args.Id, &monitorID)
-	if err != nil {
-		return nil, err
-	}
-	actorUID := actor.FromContext(ctx).UID
-	query := sqlf.Sprintf(
-		toggleCodeMonitorQuery,
-		args.Enabled,
-		actorUID,
-		r.Now(),
-		monitorID,
-		sqlf.Join(monitorColumns, ", "),
-	)
-	return query, nil
-}
-
-func (r *Resolver) deleteCodeMonitorQuery(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) (*sqlf.Query, error) {
-	deleteCodeMonitorQuery := `DELETE FROM cm_monitors WHERE id = %s`
-	var monitorID int64
-	err := relay.UnmarshalSpec(args.Id, &monitorID)
-	if err != nil {
-		return nil, err
-	}
-	query := sqlf.Sprintf(
-		deleteCodeMonitorQuery,
-		monitorID,
-	)
-	return query, nil
 }
 
 // isAllowedToEdit checks whether an actor is allowed to edit a given monitor.
@@ -654,15 +416,7 @@ func (m *monitorConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo
 //
 type monitor struct {
 	*Resolver
-	id              int64
-	createdBy       int32
-	createdAt       time.Time
-	changedBy       int32
-	changedAt       time.Time
-	description     string
-	enabled         bool
-	namespaceUserID *int32
-	namespaceOrgID  *int32
+	*cm.Monitor
 }
 
 const (
@@ -674,36 +428,36 @@ const (
 )
 
 func (m *monitor) ID() graphql.ID {
-	return relay.MarshalID(monitorKind, m.id)
+	return relay.MarshalID(monitorKind, m.Monitor.ID)
 }
 
 func (m *monitor) CreatedBy(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return graphqlbackend.UserByIDInt32(ctx, m.createdBy)
+	return graphqlbackend.UserByIDInt32(ctx, m.Monitor.CreatedBy)
 }
 
 func (m *monitor) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: m.createdAt}
+	return graphqlbackend.DateTime{Time: m.Monitor.CreatedAt}
 }
 
 func (m *monitor) Description() string {
-	return m.description
+	return m.Monitor.Description
 }
 
 func (m *monitor) Enabled() bool {
-	return m.enabled
+	return m.Monitor.Enabled
 }
 
 func (m *monitor) Owner(ctx context.Context) (n graphqlbackend.NamespaceResolver, err error) {
-	if m.namespaceOrgID == nil {
-		n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, *m.namespaceUserID)
+	if m.NamespaceOrgID == nil {
+		n.Namespace, err = graphqlbackend.UserByIDInt32(ctx, *m.NamespaceUserID)
 	} else {
-		n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, *m.namespaceOrgID)
+		n.Namespace, err = graphqlbackend.OrgByIDInt32(ctx, *m.NamespaceOrgID)
 	}
 	return n, err
 }
 
 func (m *monitor) Trigger(ctx context.Context) (graphqlbackend.MonitorTrigger, error) {
-	t, err := m.store.TriggerQueryByMonitorIDInt64(ctx, m.id)
+	t, err := m.store.TriggerQueryByMonitorIDInt64(ctx, m.Monitor.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +465,7 @@ func (m *monitor) Trigger(ctx context.Context) (graphqlbackend.MonitorTrigger, e
 }
 
 func (m *monitor) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
-	return m.actionConnectionResolverWithTriggerID(ctx, nil, m.id, args)
+	return m.actionConnectionResolverWithTriggerID(ctx, nil, m.Monitor.ID, args)
 }
 
 func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int, monitorID int64, args *graphqlbackend.ListActionArgs) (c graphqlbackend.MonitorActionConnectionResolver, err error) {
@@ -1028,17 +782,4 @@ func (m *monitorActionEvent) Message() *string {
 
 func (m *monitorActionEvent) Timestamp() graphqlbackend.DateTime {
 	return m.timestamp
-}
-
-func unmarshalAfter(after *string) (int64, error) {
-	var a int64
-	if after == nil {
-		a = 0
-	} else {
-		err := relay.UnmarshalSpec(graphql.ID(*after), &a)
-		if err != nil {
-			return -1, err
-		}
-	}
-	return a, nil
 }


### PR DESCRIPTION
This should be the last of the "move to the store" refactorings.

With the exception of `UpdateCodeMonitors`, this PR moves all
db-interactions with `cm_monitors` from `resolvers.go` to the store.

UpdateCodeMonitors needs a little bit of refactoring itself before it can
move down. I will postpone this, for now, to keep the momentum for the
delivery of the POC.

With this PR it will be much easier to create meaningful tests for the
store.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
