### PR TITLE
Set read and write timeouts on gitserver http server

### DIFF
--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -158,7 +158,13 @@ func main() {
 	}
 	addr := net.JoinHostPort(host, port)
 	log15.Info("github-proxy: listening", "addr", addr)
-	log.Fatal(http.ListenAndServe(addr, nil))
+	s := http.Server{
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Addr:         addr,
+		Handler:      http.DefaultServeMux,
+	}
+	log.Fatal(s.ListenAndServe())
 }
 
 func instrumentHandler(r prometheus.Registerer, h http.Handler) http.Handler {

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -109,7 +109,12 @@ func main() {
 		host = "127.0.0.1"
 	}
 	addr := net.JoinHostPort(host, port)
-	srv := &http.Server{Addr: addr, Handler: handler}
+	srv := &http.Server{
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute, // set a high write timeout as we may serve large archives
+		Addr:         addr,
+		Handler:      handler,
+	}
 	log15.Info("git-server: listening", "addr", srv.Addr)
 
 	go func() {

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -69,7 +69,13 @@ func main() {
 	}
 	addr := net.JoinHostPort(host, port)
 	log15.Info("query-runner: listening", "addr", addr)
-	log.Fatalf("Fatal error serving: %s", http.ListenAndServe(addr, nil))
+	s := http.Server{
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Addr:         addr,
+		Handler:      http.DefaultServeMux,
+	}
+	log.Fatalf("Fatal error serving: %s", s.ListenAndServe())
 }
 
 func writeError(w http.ResponseWriter, err error) {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -330,7 +330,11 @@ func Main(enterpriseInit EnterpriseInit) {
 	},
 	)
 
-	httpSrv := httpserver.NewFromAddr(addr, &http.Server{Handler: ot.Middleware(handler)})
+	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Handler:      ot.Middleware(handler),
+	})
 	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }
 

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -72,7 +72,9 @@ func main() {
 	}
 	addr := net.JoinHostPort(host, port)
 	server := &http.Server{
-		Addr: addr,
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Addr:         addr,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// For cluster liveness and readiness probes
 			if r.URL.Path == "/healthz" {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -75,7 +75,12 @@ func main() {
 		host = "127.0.0.1"
 	}
 	addr := net.JoinHostPort(host, port)
-	server := &http.Server{Addr: addr, Handler: handler}
+	server := &http.Server{
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Addr:         addr,
+		Handler:      handler,
+	}
 	go shutdownOnSIGINT(server)
 
 	log15.Info("symbols: listening", "addr", addr)

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
@@ -42,7 +43,11 @@ func main() {
 		apiworker.NewWorker(config.APIWorkerOptions(nil)),
 	}
 	if !config.DisableHealthServer {
-		routines = append(routines, httpserver.NewFromAddr(addr, &http.Server{Handler: httpserver.NewHandler(nil)}))
+		routines = append(routines, httpserver.NewFromAddr(addr, &http.Server{
+			ReadTimeout:  75 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+			Handler:      httpserver.NewHandler(nil),
+		}))
 	}
 
 	goroutine.MonitorBackgroundRoutines(context.Background(), routines...)

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -93,7 +93,11 @@ func main() {
 	)
 
 	// Initialize health server
-	server := httpserver.NewFromAddr(addr, &http.Server{Handler: httpserver.NewHandler(nil)})
+	server := httpserver.NewFromAddr(addr, &http.Server{
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Handler:      httpserver.NewHandler(nil),
+	})
 
 	// Go!
 	goroutine.MonitorBackgroundRoutines(context.Background(), worker, server)


### PR DESCRIPTION
Whilst debugging the gitserver echo command alerts & CPU throttling, we noticed a goroutine leak that mostly looks like connections hanging waiting on reading. We don't set any timeouts on the http server, so i've set the same ones that we do on the frontend.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
