### PR TITLE
Instrument when gitserver janitor is running

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -4,7 +4,6 @@ package main // import "github.com/sourcegraph/sourcegraph/cmd/gitserver"
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"log"
 	"net"
 	"net/http"
@@ -93,7 +92,16 @@ func main() {
 
 	go debugserver.Start()
 
-	runJanitor(&gitserver)
+	janitorInterval2, err := time.ParseDuration(janitorInterval)
+	if err != nil {
+		log.Fatalf("parsing $SRC_REPOS_JANITOR_INTERVAL: %v", err)
+	}
+	go func() {
+		for {
+			gitserver.Janitor()
+			time.Sleep(janitorInterval2)
+		}
+	}()
 
 	port := "3178"
 	host := ""
@@ -174,31 +182,4 @@ func getRepoStore() (*db.RepoStore, error) {
 	}
 
 	return db.NewRepoStoreWithDB(h), nil
-}
-
-func runJanitor(gitserver *server.Server) {
-	janitorDuration := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "src_gitserver_janitor_duration_seconds",
-		Help: "Duration of executing the background janitor job.",
-	})
-	janitorRunning := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "src_gitserver_janitor_running",
-		Help: "Is the gitserver janitor background task running.",
-	})
-	prometheus.MustRegister(janitorDuration)
-	prometheus.MustRegister(janitorRunning)
-	janitorInterval2, err := time.ParseDuration(janitorInterval)
-	if err != nil {
-		log.Fatalf("parsing $SRC_REPOS_JANITOR_INTERVAL: %v", err)
-	}
-	go func() {
-		for {
-			start := time.Now()
-			janitorRunning.Set(1)
-			gitserver.Janitor()
-			janitorRunning.Set(0)
-			janitorDuration.Set(time.Since(start).Seconds())
-			time.Sleep(janitorInterval2)
-		}
-	}()
 }

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -50,10 +50,6 @@ var (
 		Name: "src_gitserver_repos_removed_disk_pressure",
 		Help: "number of repos removed due to not enough disk space",
 	})
-	janitorDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "src_gitserver_janitor_duration_seconds",
-		Help: "duration of the gitserver janitor background job",
-	})
 	janitorRunning = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "src_gitserver_janitor_running",
 		Help: "set to 1 when the gitserver janitor background job is running",
@@ -74,9 +70,7 @@ const reposStatsName = "repos-stats.json"
 // 4. Reclone repos after a while. (simulate git gc)
 func (s *Server) cleanupRepos() {
 	janitorRunning.Set(1)
-	start := time.Now()
 	defer func() {
-		janitorDuration.Observe(time.Since(start).Seconds())
 		janitorRunning.Set(0)
 	}()
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -70,9 +70,9 @@ const reposStatsName = "repos-stats.json"
 // 4. Reclone repos after a while. (simulate git gc)
 func (s *Server) cleanupRepos() {
 	janitorRunning.Set(1)
-	janitorTimer := prometheus.NewTimer(janitorDuration)
+	start := time.Now()
 	defer func() {
-		janitorTimer.ObserveDuration()
+		janitorDuration.Observe(time.Since(start).Seconds())
 		janitorRunning.Set(0)
 	}()
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -50,6 +50,14 @@ var (
 		Name: "src_gitserver_repos_removed_disk_pressure",
 		Help: "number of repos removed due to not enough disk space",
 	})
+	janitorDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "src_gitserver_janitor_duration",
+		Help: "duration of the gitserver janitor background job",
+	})
+	janitorRunning = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "src_gitserver_janitor_running",
+		Help: "set to 1 when the gitserver janitor background job is running",
+	})
 )
 
 const reposStatsName = "repos-stats.json"
@@ -61,6 +69,13 @@ const reposStatsName = "repos-stats.json"
 // 3. Remove inactive repos on sourcegraph.com
 // 4. Reclone repos after a while. (simulate git gc)
 func (s *Server) cleanupRepos() {
+	janitorRunning.Set(1)
+	janitorTimer := prometheus.NewTimer(janitorDuration)
+	defer func() {
+		janitorTimer.ObserveDuration()
+		janitorRunning.Set(0)
+	}()
+
 	bCtx, bCancel := s.serverContext()
 	defer bCancel()
 
@@ -212,10 +227,20 @@ func (s *Server) cleanupRepos() {
 		gitDir := GitDir(dir)
 
 		for _, cfn := range cleanups {
+			start := time.Now()
+			jobTimer := promauto.NewHistogram(prometheus.HistogramOpts{
+				Name: "src_gitserver_janitor_job_duration",
+				Help: "Duration of the individual jobs within the gitserver janitor background job",
+				ConstLabels: prometheus.Labels{
+					"job_name": cfn.Name,
+					"dir":      dir,
+				},
+			})
 			done, err := cfn.Do(gitDir)
 			if err != nil {
 				log15.Error("error running cleanup command", "name", cfn.Name, "repo", gitDir, "error", err)
 			}
+			jobTimer.Observe(time.Since(start).Seconds())
 			if done {
 				break
 			}

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -51,7 +51,7 @@ var (
 		Help: "number of repos removed due to not enough disk space",
 	})
 	janitorDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "src_gitserver_janitor_duration",
+		Name: "src_gitserver_janitor_duration_seconds",
 		Help: "duration of the gitserver janitor background job",
 	})
 	janitorRunning = promauto.NewGauge(prometheus.GaugeOpts{
@@ -59,7 +59,7 @@ var (
 		Help: "set to 1 when the gitserver janitor background job is running",
 	})
 	jobTimer = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "src_gitserver_janitor_job_duration",
+		Name: "src_gitserver_janitor_job_duration_seconds",
 		Help: "Duration of the individual jobs within the gitserver janitor background job",
 	}, []string{"job_name", "dir"})
 )


### PR DESCRIPTION
Further to the gitserver echo duration investigation, it would be useful to know when the janitor is running to see if that aligns with CPU throttling.

https://sourcegraph.slack.com/archives/CMBA8F926/p1606995926230800?thread_ts=1606990551.206000&cid=CMBA8F926


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
