### PR TITLE
Manage campaigns credentials for viewed user, not the current user

### DIFF
--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.story.tsx
@@ -19,6 +19,7 @@ add('GitHub', () => (
         {props => (
             <AddCredentialModal
                 {...props}
+                userID="user-id-1"
                 externalServiceKind={ExternalServiceKind.GITHUB}
                 externalServiceURL="https://github.com/"
                 afterCreate={noop}
@@ -33,6 +34,7 @@ add('GitLab', () => (
         {props => (
             <AddCredentialModal
                 {...props}
+                userID="user-id-1"
                 externalServiceKind={ExternalServiceKind.GITLAB}
                 externalServiceURL="https://gitlab.com/"
                 afterCreate={noop}
@@ -47,6 +49,7 @@ add('Bitbucket Server', () => (
         {props => (
             <AddCredentialModal
                 {...props}
+                userID="user-id-1"
                 externalServiceKind={ExternalServiceKind.BITBUCKETSERVER}
                 externalServiceURL="https://bitbucket.sgdev.org/"
                 afterCreate={noop}

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
@@ -12,7 +12,7 @@ export interface AddCredentialModalProps {
     onCancel: () => void
     afterCreate: () => void
     history: H.History
-    userID: string
+    userID: Scalars['ID']
     externalServiceKind: ExternalServiceKind
     externalServiceURL: string
 }

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
@@ -12,6 +12,7 @@ export interface AddCredentialModalProps {
     onCancel: () => void
     afterCreate: () => void
     history: H.History
+    userID: string
     externalServiceKind: ExternalServiceKind
     externalServiceURL: string
 }
@@ -79,6 +80,7 @@ export const AddCredentialModal: React.FunctionComponent<AddCredentialModalProps
     onCancel,
     afterCreate,
     history,
+    userID,
     externalServiceKind,
     externalServiceURL,
 }) => {
@@ -95,13 +97,13 @@ export const AddCredentialModal: React.FunctionComponent<AddCredentialModalProps
             event.preventDefault()
             setIsLoading(true)
             try {
-                await createCampaignsCredential({ credential, externalServiceKind, externalServiceURL })
+                await createCampaignsCredential({ user: userID, credential, externalServiceKind, externalServiceURL })
                 afterCreate()
             } catch (error) {
                 setIsLoading(asError(error))
             }
         },
-        [afterCreate, credential, externalServiceKind, externalServiceURL]
+        [afterCreate, userID, credential, externalServiceKind, externalServiceURL]
     )
 
     return (

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
@@ -6,7 +6,7 @@ import { Form } from '../../../../../branded/src/components/Form'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
 import { createCampaignsCredential } from './backend'
-import { ExternalServiceKind } from '../../../graphql-operations'
+import { ExternalServiceKind, Scalars } from '../../../graphql-operations'
 
 export interface AddCredentialModalProps {
     onCancel: () => void

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
@@ -14,6 +14,7 @@ add('Overview', () => (
         {props => (
             <CampaignsSettingsArea
                 {...props}
+                user={{ username: 'my-username' }}
                 queryUserCampaignsCodeHosts={() =>
                     of({
                         totalCount: 3,
@@ -50,6 +51,7 @@ add('Config added', () => (
         {props => (
             <CampaignsSettingsArea
                 {...props}
+                user={{ username: 'my-username' }}
                 queryUserCampaignsCodeHosts={() =>
                     of({
                         totalCount: 3,

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
@@ -14,7 +14,7 @@ add('Overview', () => (
         {props => (
             <CampaignsSettingsArea
                 {...props}
-                user={{ id: 'user-id-1', username: 'my-username' }}
+                user={{ id: 'user-id-1' }}
                 queryUserCampaignsCodeHosts={() =>
                     of({
                         totalCount: 3,
@@ -51,7 +51,7 @@ add('Config added', () => (
         {props => (
             <CampaignsSettingsArea
                 {...props}
-                user={{ id: 'user-id-2', username: 'my-username' }}
+                user={{ id: 'user-id-2' }}
                 queryUserCampaignsCodeHosts={() =>
                     of({
                         totalCount: 3,

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
@@ -14,7 +14,7 @@ add('Overview', () => (
         {props => (
             <CampaignsSettingsArea
                 {...props}
-                user={{ username: 'my-username' }}
+                user={{ id: 'user-id-1', username: 'my-username' }}
                 queryUserCampaignsCodeHosts={() =>
                     of({
                         totalCount: 3,
@@ -51,7 +51,7 @@ add('Config added', () => (
         {props => (
             <CampaignsSettingsArea
                 {...props}
-                user={{ username: 'my-username' }}
+                user={{ id: 'user-id-2', username: 'my-username' }}
                 queryUserCampaignsCodeHosts={() =>
                     of({
                         totalCount: 3,

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
@@ -6,7 +6,7 @@ import { queryUserCampaignsCodeHosts } from './backend'
 import { CodeHostConnections } from './CodeHostConnections'
 
 export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'history' | 'location'> {
-    user: Pick<UserAreaUserFields, 'username'>
+    user: Pick<UserAreaUserFields, 'id' | 'username'>
     queryUserCampaignsCodeHosts?: typeof queryUserCampaignsCodeHosts
 }
 
@@ -14,6 +14,11 @@ export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'h
 export const CampaignsSettingsArea: React.FunctionComponent<CampaignsSettingsAreaProps> = props => (
     <div className="web-content test-campaigns-settings-page">
         <PageTitle title="Campaigns settings" />
-        <CodeHostConnections username={props.user.username} history={props.history} location={props.location} />
+        <CodeHostConnections
+            username={props.user.username}
+            userID={props.user.id}
+            history={props.history}
+            location={props.location}
+        />
     </div>
 )

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
@@ -6,7 +6,7 @@ import { queryUserCampaignsCodeHosts } from './backend'
 import { CodeHostConnections } from './CodeHostConnections'
 
 export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'history' | 'location'> {
-    user: Pick<UserAreaUserFields, 'id' | 'username'>
+    user: Pick<UserAreaUserFields, 'id'>
     queryUserCampaignsCodeHosts?: typeof queryUserCampaignsCodeHosts
 }
 
@@ -14,6 +14,6 @@ export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'h
 export const CampaignsSettingsArea: React.FunctionComponent<CampaignsSettingsAreaProps> = props => (
     <div className="web-content test-campaigns-settings-page">
         <PageTitle title="Campaigns settings" />
-        <CodeHostConnections user={props.user} history={props.history} location={props.location} />
+        <CodeHostConnections userID={props.user.id} {...props} />
     </div>
 )

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { PageTitle } from '../../../components/PageTitle'
+import { UserAreaUserFields } from '../../../graphql-operations'
 import { queryUserCampaignsCodeHosts } from './backend'
 import { CodeHostConnections } from './CodeHostConnections'
 
 export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'history' | 'location'> {
+    user: Pick<UserAreaUserFields, 'username'>
     queryUserCampaignsCodeHosts?: typeof queryUserCampaignsCodeHosts
 }
 
@@ -12,6 +14,6 @@ export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'h
 export const CampaignsSettingsArea: React.FunctionComponent<CampaignsSettingsAreaProps> = props => (
     <div className="web-content test-campaigns-settings-page">
         <PageTitle title="Campaigns settings" />
-        <CodeHostConnections {...props} />
+        <CodeHostConnections username={props.user.username} history={props.history} location={props.location} />
     </div>
 )

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.tsx
@@ -14,11 +14,6 @@ export interface CampaignsSettingsAreaProps extends Pick<RouteComponentProps, 'h
 export const CampaignsSettingsArea: React.FunctionComponent<CampaignsSettingsAreaProps> = props => (
     <div className="web-content test-campaigns-settings-page">
         <PageTitle title="Campaigns settings" />
-        <CodeHostConnections
-            username={props.user.username}
-            userID={props.user.id}
-            history={props.history}
-            location={props.location}
-        />
+        <CodeHostConnections user={props.user} history={props.history} location={props.location} />
     </div>
 )

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
@@ -3,14 +3,14 @@ import * as H from 'history'
 import CheckboxBlankCircleOutlineIcon from 'mdi-react/CheckboxBlankCircleOutlineIcon'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import { defaultExternalServices } from '../../../components/externalServices/externalServices'
-import { CampaignsCodeHostFields } from '../../../graphql-operations'
+import { CampaignsCodeHostFields, Scalars } from '../../../graphql-operations'
 import { AddCredentialModal } from './AddCredentialModal'
 import { RemoveCredentialModal } from './RemoveCredentialModal'
 import { Subject } from 'rxjs'
 
 export interface CodeHostConnectionNodeProps {
     node: CampaignsCodeHostFields
-    userID: string
+    userID: Scalars['ID']
     history: H.History
     updateList: Subject<void>
 }

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
@@ -10,6 +10,7 @@ import { Subject } from 'rxjs'
 
 export interface CodeHostConnectionNodeProps {
     node: CampaignsCodeHostFields
+    userID: string
     history: H.History
     updateList: Subject<void>
 }
@@ -18,6 +19,7 @@ type OpenModal = 'add' | 'delete'
 
 export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionNodeProps> = ({
     node,
+    userID,
     history,
     updateList,
 }) => {
@@ -95,6 +97,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                     onCancel={onCancel}
                     afterCreate={afterAction}
                     history={history}
+                    userID={userID}
                     externalServiceKind={node.externalServiceKind}
                     externalServiceURL={node.externalServiceURL}
                 />

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
@@ -1,24 +1,40 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { RouteComponentProps } from 'react-router'
-import { Subject } from 'rxjs'
+import { Observable, Subject } from 'rxjs'
 import { FilteredConnection } from '../../../components/FilteredConnection'
 import { PageHeader } from '../../../components/PageHeader'
-import { CampaignsCodeHostFields } from '../../../graphql-operations'
+import {
+    CampaignsCodeHostFields,
+    CampaignsCodeHostsFields,
+    Scalars,
+    UserCampaignsCodeHostsVariables,
+} from '../../../graphql-operations'
 import { CampaignsIconFlushLeft } from '../icons'
 import { queryUserCampaignsCodeHosts as _queryUserCampaignsCodeHosts } from './backend'
 import { CodeHostConnectionNode, CodeHostConnectionNodeProps } from './CodeHostConnectionNode'
 
 export interface CodeHostConnectionsProps extends Pick<RouteComponentProps, 'history' | 'location'> {
+    username: Scalars['String']
     queryUserCampaignsCodeHosts?: typeof _queryUserCampaignsCodeHosts
 }
 
 export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsProps> = ({
+    username,
     history,
     location,
     queryUserCampaignsCodeHosts = _queryUserCampaignsCodeHosts,
 }) => {
     // Subject to fire a reload of the list.
     const updateList = useMemo(() => new Subject<void>(), [])
+    const query = useCallback<(args: Partial<UserCampaignsCodeHostsVariables>) => Observable<CampaignsCodeHostsFields>>(
+        args =>
+            queryUserCampaignsCodeHosts({
+                username: username ?? null,
+                first: args.first ?? null,
+                after: args.after ?? null,
+            }),
+        [queryUserCampaignsCodeHosts, username]
+    )
     return (
         <>
             <PageHeader icon={CampaignsIconFlushLeft} title="Campaigns" className="justify-content-end" />
@@ -30,7 +46,7 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
                 useURLQuery={false}
                 nodeComponent={CodeHostConnectionNode}
                 nodeComponentProps={{ history, updateList }}
-                queryConnection={queryUserCampaignsCodeHosts}
+                queryConnection={query}
                 hideSearch={true}
                 defaultFirst={15}
                 noun="code host"

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
@@ -15,11 +15,13 @@ import { CodeHostConnectionNode, CodeHostConnectionNodeProps } from './CodeHostC
 
 export interface CodeHostConnectionsProps extends Pick<RouteComponentProps, 'history' | 'location'> {
     username: Scalars['String']
+    userID: Scalars['ID']
     queryUserCampaignsCodeHosts?: typeof _queryUserCampaignsCodeHosts
 }
 
 export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsProps> = ({
     username,
+    userID,
     history,
     location,
     queryUserCampaignsCodeHosts = _queryUserCampaignsCodeHosts,
@@ -45,7 +47,7 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
                 location={location}
                 useURLQuery={false}
                 nodeComponent={CodeHostConnectionNode}
-                nodeComponentProps={{ history, updateList }}
+                nodeComponentProps={{ userID, history, updateList }}
                 queryConnection={query}
                 hideSearch={true}
                 defaultFirst={15}

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
@@ -6,7 +6,6 @@ import { PageHeader } from '../../../components/PageHeader'
 import {
     CampaignsCodeHostFields,
     CampaignsCodeHostsFields,
-    Scalars,
     UserCampaignsCodeHostsVariables,
 } from '../../../graphql-operations'
 import { CampaignsIconFlushLeft } from '../icons'
@@ -14,14 +13,12 @@ import { queryUserCampaignsCodeHosts as _queryUserCampaignsCodeHosts } from './b
 import { CodeHostConnectionNode, CodeHostConnectionNodeProps } from './CodeHostConnectionNode'
 
 export interface CodeHostConnectionsProps extends Pick<RouteComponentProps, 'history' | 'location'> {
-    username: Scalars['String']
-    userID: Scalars['ID']
+    user: { id: string; username: string }
     queryUserCampaignsCodeHosts?: typeof _queryUserCampaignsCodeHosts
 }
 
 export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsProps> = ({
-    username,
-    userID,
+    user,
     history,
     location,
     queryUserCampaignsCodeHosts = _queryUserCampaignsCodeHosts,
@@ -31,11 +28,11 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
     const query = useCallback<(args: Partial<UserCampaignsCodeHostsVariables>) => Observable<CampaignsCodeHostsFields>>(
         args =>
             queryUserCampaignsCodeHosts({
-                username: username ?? null,
+                username: user.username ?? null,
                 first: args.first ?? null,
                 after: args.after ?? null,
             }),
-        [queryUserCampaignsCodeHosts, username]
+        [queryUserCampaignsCodeHosts, user.username]
     )
     return (
         <>
@@ -47,7 +44,7 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
                 location={location}
                 useURLQuery={false}
                 nodeComponent={CodeHostConnectionNode}
-                nodeComponentProps={{ userID, history, updateList }}
+                nodeComponentProps={{ userID: user.id, history, updateList }}
                 queryConnection={query}
                 hideSearch={true}
                 defaultFirst={15}

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnections.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from '../../../components/PageHeader'
 import {
     CampaignsCodeHostFields,
     CampaignsCodeHostsFields,
+    Scalars,
     UserCampaignsCodeHostsVariables,
 } from '../../../graphql-operations'
 import { CampaignsIconFlushLeft } from '../icons'
@@ -13,12 +14,12 @@ import { queryUserCampaignsCodeHosts as _queryUserCampaignsCodeHosts } from './b
 import { CodeHostConnectionNode, CodeHostConnectionNodeProps } from './CodeHostConnectionNode'
 
 export interface CodeHostConnectionsProps extends Pick<RouteComponentProps, 'history' | 'location'> {
-    user: { id: string; username: string }
+    userID: Scalars['ID']
     queryUserCampaignsCodeHosts?: typeof _queryUserCampaignsCodeHosts
 }
 
 export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsProps> = ({
-    user,
+    userID,
     history,
     location,
     queryUserCampaignsCodeHosts = _queryUserCampaignsCodeHosts,
@@ -28,11 +29,11 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
     const query = useCallback<(args: Partial<UserCampaignsCodeHostsVariables>) => Observable<CampaignsCodeHostsFields>>(
         args =>
             queryUserCampaignsCodeHosts({
-                username: user.username ?? null,
+                user: userID,
                 first: args.first ?? null,
                 after: args.after ?? null,
             }),
-        [queryUserCampaignsCodeHosts, user.username]
+        [queryUserCampaignsCodeHosts, userID]
     )
     return (
         <>
@@ -44,7 +45,7 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
                 location={location}
                 useURLQuery={false}
                 nodeComponent={CodeHostConnectionNode}
-                nodeComponentProps={{ userID: user.id, history, updateList }}
+                nodeComponentProps={{ userID, history, updateList }}
                 queryConnection={query}
                 hideSearch={true}
                 defaultFirst={15}

--- a/client/web/src/enterprise/campaigns/settings/backend.ts
+++ b/client/web/src/enterprise/campaigns/settings/backend.ts
@@ -61,13 +61,14 @@ export function deleteCampaignsCredential(id: Scalars['ID']): Promise<void> {
 }
 
 export const queryUserCampaignsCodeHosts = ({
+    username,
     first,
     after,
 }: Partial<UserCampaignsCodeHostsVariables>): Observable<CampaignsCodeHostsFields> =>
     requestGraphQL<UserCampaignsCodeHostsResult, UserCampaignsCodeHostsVariables>(
         gql`
-            query UserCampaignsCodeHosts($first: Int, $after: String) {
-                currentUser {
+            query UserCampaignsCodeHosts($username: String!, $first: Int, $after: String) {
+                user(username: $username) {
                     campaignsCodeHosts(first: $first, after: $after) {
                         ...CampaignsCodeHostsFields
                     }
@@ -96,15 +97,16 @@ export const queryUserCampaignsCodeHosts = ({
             ${campaignsCredentialFieldsFragment}
         `,
         {
+            username: username ?? '', // TODO: why is this required?
             first: first ?? null,
             after: after ?? null,
         }
     ).pipe(
         map(dataOrThrowErrors),
         map(data => {
-            if (data.currentUser === null) {
-                throw new Error('Current user not found')
+            if (data.user === null) {
+                throw new Error('User not found')
             }
-            return data.currentUser.campaignsCodeHosts
+            return data.user.campaignsCodeHosts
         })
     )

--- a/client/web/src/enterprise/campaigns/settings/backend.ts
+++ b/client/web/src/enterprise/campaigns/settings/backend.ts
@@ -71,6 +71,7 @@ export const queryUserCampaignsCodeHosts = ({
         gql`
             query UserCampaignsCodeHosts($user: ID!, $first: Int, $after: String) {
                 node(id: $user) {
+                    __typename
                     ... on User {
                         campaignsCodeHosts(first: $first, after: $after) {
                             ...CampaignsCodeHostsFields
@@ -110,6 +111,9 @@ export const queryUserCampaignsCodeHosts = ({
         map(data => {
             if (data.node === null) {
                 throw new Error('User not found')
+            }
+            if (data.node.__typename !== 'User') {
+                throw new Error(`Node is a ${data.node.__typename}, not a User`)
             }
             return data.node.campaignsCodeHosts
         })

--- a/client/web/src/enterprise/campaigns/settings/backend.ts
+++ b/client/web/src/enterprise/campaigns/settings/backend.ts
@@ -24,11 +24,13 @@ export function createCampaignsCredential(args: CreateCampaignsCredentialVariabl
     return requestGraphQL<CreateCampaignsCredentialResult, CreateCampaignsCredentialVariables>(
         gql`
             mutation CreateCampaignsCredential(
+                $user: ID!
                 $credential: String!
                 $externalServiceKind: ExternalServiceKind!
                 $externalServiceURL: String!
             ) {
                 createCampaignsCredential(
+                    user: $user
                     credential: $credential
                     externalServiceKind: $externalServiceKind
                     externalServiceURL: $externalServiceURL

--- a/client/web/src/enterprise/campaigns/settings/backend.ts
+++ b/client/web/src/enterprise/campaigns/settings/backend.ts
@@ -63,16 +63,18 @@ export function deleteCampaignsCredential(id: Scalars['ID']): Promise<void> {
 }
 
 export const queryUserCampaignsCodeHosts = ({
-    username,
+    user,
     first,
     after,
-}: Partial<UserCampaignsCodeHostsVariables>): Observable<CampaignsCodeHostsFields> =>
+}: UserCampaignsCodeHostsVariables): Observable<CampaignsCodeHostsFields> =>
     requestGraphQL<UserCampaignsCodeHostsResult, UserCampaignsCodeHostsVariables>(
         gql`
-            query UserCampaignsCodeHosts($username: String!, $first: Int, $after: String) {
-                user(username: $username) {
-                    campaignsCodeHosts(first: $first, after: $after) {
-                        ...CampaignsCodeHostsFields
+            query UserCampaignsCodeHosts($user: ID!, $first: Int, $after: String) {
+                node(id: $user) {
+                    ... on User {
+                        campaignsCodeHosts(first: $first, after: $after) {
+                            ...CampaignsCodeHostsFields
+                        }
                     }
                 }
             }
@@ -99,16 +101,16 @@ export const queryUserCampaignsCodeHosts = ({
             ${campaignsCredentialFieldsFragment}
         `,
         {
-            username: username ?? '', // TODO: why is this required?
-            first: first ?? null,
-            after: after ?? null,
+            user,
+            first,
+            after,
         }
     ).pipe(
         map(dataOrThrowErrors),
         map(data => {
-            if (data.user === null) {
+            if (data.node === null) {
                 throw new Error('User not found')
             }
-            return data.user.campaignsCodeHosts
+            return data.node.campaignsCodeHosts
         })
     )

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -694,7 +694,7 @@ describe('Campaigns', () => {
                 ...commonWebGraphQlResults,
                 ...mockCommonGraphQLResponses('user'),
                 UserCampaignsCodeHosts: () => ({
-                    currentUser: {
+                    user: {
                         campaignsCodeHosts: {
                             totalCount: 1,
                             pageInfo: {

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -694,7 +694,7 @@ describe('Campaigns', () => {
                 ...commonWebGraphQlResults,
                 ...mockCommonGraphQLResponses('user'),
                 UserCampaignsCodeHosts: () => ({
-                    user: {
+                    node: {
                         campaignsCodeHosts: {
                             totalCount: 1,
                             pageInfo: {

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -695,6 +695,7 @@ describe('Campaigns', () => {
                 ...mockCommonGraphQLResponses('user'),
                 UserCampaignsCodeHosts: () => ({
                     node: {
+                        __typename: 'User',
                         campaignsCodeHosts: {
                             totalCount: 1,
                             pageInfo: {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -713,7 +713,7 @@ type Mutation {
     """
     createCampaignsCredential(
         """
-        The user for which to create the credentials.
+        The user for which to create the credential.
         """
         user: ID!
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -707,11 +707,16 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 
     """
-    Create a new credential for the requesting user for the given code host.
+    Create a new credential for the given user for the given code host.
     If another token for that code host already exists, an error with the error code
     ErrDuplicateCredential is returned.
     """
     createCampaignsCredential(
+        """
+        The user for which to create the credentials.
+        """
+        user: ID!
+
         """
         The kind of external service being configured.
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -706,7 +706,7 @@ type Mutation {
     """
     createCampaignsCredential(
         """
-        The user for which to create the credentials.
+        The user for which to create the credential.
         """
         user: ID!
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -700,11 +700,16 @@ type Mutation {
     syncChangeset(changeset: ID!): EmptyResponse!
 
     """
-    Create a new credential for the requesting user for the given code host.
+    Create a new credential for the given user for the given code host.
     If another token for that code host already exists, an error with the error code
     ErrDuplicateCredential is returned.
     """
     createCampaignsCredential(
+        """
+        The user for which to create the credentials.
+        """
+        user: ID!
+
         """
         The kind of external service being configured.
         """

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -713,10 +713,18 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		return nil, err
 	}
 
-	// Check user is authenticated.
-	user := actor.FromContext(ctx)
-	if !user.IsAuthenticated() {
-		return nil, backend.ErrNotAuthenticated
+	userID, err := graphqlbackend.UnmarshalUserID(args.User)
+	if err != nil {
+		return nil, err
+	}
+
+	if userID == 0 {
+		return nil, ErrIDIsZero{}
+	}
+
+	// 🚨 SECURITY: Check that the requesting user can create the credential.
+	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
+		return nil, err
 	}
 
 	// Need to validate externalServiceKind, otherwise this'll panic.
@@ -735,7 +743,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		Domain:              db.UserCredentialDomainCampaigns,
 		ExternalServiceID:   args.ExternalServiceURL,
 		ExternalServiceType: extsvc.KindToType(kind),
-		UserID:              user.UID,
+		UserID:              userID,
 	}
 
 	// Throw error documented in schema.graphql.

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -768,6 +768,7 @@ func TestCreateCampaignsCredential(t *testing.T) {
 	}
 
 	input := map[string]interface{}{
+		"user":                graphqlbackend.MarshalUserID(userID),
 		"externalServiceKind": string(extsvc.KindGitHub),
 		"externalServiceURL":  "https://github.com/",
 		"credential":          "SOSECRET",
@@ -795,8 +796,8 @@ func TestCreateCampaignsCredential(t *testing.T) {
 }
 
 const mutationCreateCredential = `
-mutation($externalServiceKind: ExternalServiceKind!, $externalServiceURL: String!, $credential: String!) {
-  createCampaignsCredential(externalServiceKind: $externalServiceKind, externalServiceURL: $externalServiceURL, credential: $credential) { id }
+mutation($user: ID!, $externalServiceKind: ExternalServiceKind!, $externalServiceURL: String!, $credential: String!) {
+  createCampaignsCredential(user: $user, externalServiceKind: $externalServiceKind, externalServiceURL: $externalServiceURL, credential: $credential) { id }
 }
 `
 


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/16217 by making sure that

1. when viewing a user's campaigns credentials, that users credentials are displayed, not the current user's
1. when creating new campaigns credentials they are created for the user that's displayed, not the current user