### PR TITLE
Use generated GraphQL types for Repository

### DIFF
--- a/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useCallback, useEffect } from 'react'
 import { RouteComponentProps } from 'react-router'
-import * as GQL from '../../../../../shared/src/graphql/schema'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import {
     FilteredConnection,
@@ -8,12 +7,12 @@ import {
     FilteredConnectionQueryArguments,
 } from '../../../components/FilteredConnection'
 import { PageTitle } from '../../../components/PageTitle'
-import { LsifIndexFields, LSIFIndexState } from '../../../graphql-operations'
+import { LsifIndexFields, LSIFIndexState, SettingsAreaRepositoryFields } from '../../../graphql-operations'
 import { fetchLsifIndexes as defaultFetchLsifIndexes } from './backend'
 import { CodeIntelIndexNode, CodeIntelIndexNodeProps } from './CodeIntelIndexNode'
 
 export interface CodeIntelIndexesPageProps extends RouteComponentProps<{}>, TelemetryProps {
-    repo?: GQL.IRepository
+    repo?: SettingsAreaRepositoryFields
     fetchLsifIndexes?: typeof defaultFetchLsifIndexes
     now?: () => Date
 }

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useCallback, useEffect } from 'react'
 import { RouteComponentProps } from 'react-router'
-import * as GQL from '../../../../../shared/src/graphql/schema'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import {
     FilteredConnection,
@@ -8,12 +7,12 @@ import {
     FilteredConnectionQueryArguments,
 } from '../../../components/FilteredConnection'
 import { PageTitle } from '../../../components/PageTitle'
-import { LsifUploadFields, LSIFUploadState } from '../../../graphql-operations'
+import { LsifUploadFields, LSIFUploadState, SettingsAreaRepositoryFields } from '../../../graphql-operations'
 import { fetchLsifUploads as defaultFetchLsifUploads } from './backend'
 import { CodeIntelUploadNode, CodeIntelUploadNodeProps } from './CodeIntelUploadNode'
 
 export interface CodeIntelUploadsPageProps extends RouteComponentProps<{}>, TelemetryProps {
-    repo?: GQL.IRepository
+    repo?: SettingsAreaRepositoryFields
     fetchLsifUploads?: typeof defaultFetchLsifUploads
     now?: () => Date
 }

--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect } from 'react'
-import * as GQL from '../../../../../shared/src/graphql/schema'
 import { PageTitle } from '../../../components/PageTitle'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { eventLogger } from '../../../tracking/eventLogger'
 import * as H from 'history'
 import { scheduleRepositoryPermissionsSync } from '../../../site-admin/backend'
 import { ActionContainer } from '../../../repo/settings/components/ActionContainer'
+import { SettingsAreaRepositoryFields } from '../../../graphql-operations'
 
 export interface RepoSettingsPermissionsPageProps {
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
     history: H.History
 }
 
@@ -69,7 +69,7 @@ export const RepoSettingsPermissionsPage: React.FunctionComponent<RepoSettingsPe
 }
 
 interface ScheduleRepositoryPermissionsSyncActionContainerProps {
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
     history: H.History
 }
 

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../../shared/src/backend/errors'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike, asError } from '../../../shared/src/util/errors'
@@ -55,7 +54,7 @@ import { RepositoriesPopover } from './RepositoriesPopover'
 import { displayRepoName } from '../../../shared/src/components/RepoFileLink'
 import { AuthenticatedUser } from '../auth'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
-import { ExternalLinkFields } from '../graphql-operations'
+import { ExternalLinkFields, RepositoryFields } from '../graphql-operations'
 import { browserExtensionInstalled } from '../tracking/analyticsUtils'
 import { InstallBrowserExtensionAlert } from './actions/InstallBrowserExtensionAlert'
 import { IS_CHROME } from '../marketing/util'
@@ -80,7 +79,7 @@ export interface RepoContainerContext
         CopyQueryButtonProps,
         VersionContextProps,
         BreadcrumbSetters {
-    repo: GQL.IRepository
+    repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
@@ -88,7 +87,7 @@ export interface RepoContainerContext
     /** The URL route match for {@link RepoContainer}. */
     routePrefix: string
 
-    onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    onDidUpdateRepository: (update: Partial<RepositoryFields>) => void
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 
     globbing: boolean
@@ -175,9 +174,9 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
     // Allow partial updates of the repository from components further down the tree.
     const [nextRepoOrErrorUpdate, repoOrError] = useEventObservable(
         useCallback(
-            (repoOrErrorUpdates: Observable<Partial<GQL.IRepository>>) =>
+            (repoOrErrorUpdates: Observable<Partial<RepositoryFields>>) =>
                 repoOrErrorUpdates.pipe(
-                    map((update): GQL.IRepository | ErrorLike | undefined =>
+                    map((update): RepositoryFields | ErrorLike | undefined =>
                         isErrorLike(initialRepoOrError) || initialRepoOrError === undefined
                             ? initialRepoOrError
                             : { ...initialRepoOrError, ...update }

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../../shared/src/backend/errors'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
-import * as GQL from '../../../shared/src/graphql/schema'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
 import { SettingsCascadeProps } from '../../../shared/src/settings/settings'
 import { ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
@@ -37,6 +36,7 @@ import { RepoSettingsSideBarGroup } from './settings/RepoSettingsSidebar'
 import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { AuthenticatedUser } from '../auth'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
+import { RepositoryFields } from '../graphql-operations'
 
 /** Props passed to sub-routes of {@link RepoRevisionContainer}. */
 export interface RepoRevisionContainerContext
@@ -48,17 +48,14 @@ export interface RepoRevisionContainerContext
         TelemetryProps,
         HoverThresholdProps,
         ActivationProps,
-        Pick<
-            RepoContainerContext,
-            Exclude<keyof RepoContainerContext, 'onDidUpdateRepository' | 'onDidUpdateExternalLinks'>
-        >,
+        Omit<RepoContainerContext, 'onDidUpdateRepository' | 'onDidUpdateExternalLinks'>,
         PatternTypeProps,
         CaseSensitivityProps,
         CopyQueryButtonProps,
         VersionContextProps,
         RevisionSpec,
         BreadcrumbSetters {
-    repo: GQL.IRepository
+    repo: RepositoryFields
     resolvedRev: ResolvedRevision
 
     /** The URL route match for {@link RepoRevisionContainer}. */
@@ -89,7 +86,7 @@ interface RepoRevisionContainerProps
     routes: readonly RepoRevisionContainerRoute[]
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
-    repo: GQL.IRepository
+    repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
     routePrefix: string
 

--- a/client/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -7,11 +7,10 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { merge, of } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 import { PhabricatorIcon } from '../../../../shared/src/components/icons' // TODO: Switch mdi icon
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
 import { fetchFileExternalLinks } from '../backend'
 import { RevisionSpec, FileSpec } from '../../../../shared/src/util/url'
-import { ExternalLinkFields } from '../../graphql-operations'
+import { ExternalLinkFields, RepositoryFields } from '../../graphql-operations'
 import { useObservable } from '../../../../shared/src/util/useObservable'
 import GitlabIcon from 'mdi-react/GitlabIcon'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -32,7 +31,7 @@ interface GoToCodeHostPopoverProps {
 }
 
 interface Props extends RevisionSpec, Partial<FileSpec>, GoToCodeHostPopoverProps {
-    repo?: Pick<GQL.IRepository, 'name' | 'defaultBranch' | 'externalURLs'> | null
+    repo?: Pick<RepositoryFields, 'name' | 'defaultBranch' | 'externalURLs'> | null
     filePath?: string
     commitRange?: string
     position?: Position

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.story.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.story.tsx
@@ -24,13 +24,7 @@ for (const serviceType of services) {
                         isChrome={true}
                         onAlertDismissed={onAlertDismissed}
                         codeHostIntegrationMessaging="browser-extension"
-                        externalURLs={[
-                            {
-                                __typename: 'ExternalLink',
-                                url: '',
-                                serviceType,
-                            },
-                        ]}
+                        externalURLs={[{ url: '', serviceType }]}
                     />
                 )}
             </WebStory>
@@ -51,13 +45,7 @@ for (const serviceType of services) {
                         isChrome={false}
                         onAlertDismissed={onAlertDismissed}
                         codeHostIntegrationMessaging="browser-extension"
-                        externalURLs={[
-                            {
-                                __typename: 'ExternalLink',
-                                url: '',
-                                serviceType,
-                            },
-                        ]}
+                        externalURLs={[{ url: '', serviceType }]}
                     />
                 )}
             </WebStory>
@@ -78,13 +66,7 @@ for (const serviceType of services) {
                         isChrome={false}
                         onAlertDismissed={onAlertDismissed}
                         codeHostIntegrationMessaging="native-integration"
-                        externalURLs={[
-                            {
-                                __typename: 'ExternalLink',
-                                url: '',
-                                serviceType,
-                            },
-                        ]}
+                        externalURLs={[{ url: '', serviceType }]}
                     />
                 )}
             </WebStory>

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.test.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.test.tsx
@@ -17,17 +17,7 @@ describe('InstallBrowserExtensionAlert', () => {
                             codeHostIntegrationMessaging={
                                 integrationType === 'native integration' ? 'native-integration' : 'browser-extension'
                             }
-                            externalURLs={
-                                serviceType
-                                    ? [
-                                          {
-                                              __typename: 'ExternalLink',
-                                              url: '',
-                                              serviceType,
-                                          },
-                                      ]
-                                    : []
-                            }
+                            externalURLs={serviceType ? [{ url: '', serviceType }] : []}
                         />
                     )
                 ).toMatchSnapshot()

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import CloseIcon from 'mdi-react/CloseIcon'
 import ExportIcon from 'mdi-react/ExportIcon'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { serviceTypeDisplayNameAndIcon } from './GoToCodeHostAction'
+import { ExternalLinkFields } from '../../graphql-operations'
 
 interface Props {
     onAlertDismissed: () => void
-    externalURLs: GQL.IExternalLink[]
+    externalURLs: ExternalLinkFields[]
     isChrome: boolean
     codeHostIntegrationMessaging: 'browser-extension' | 'native-integration'
 }

--- a/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
+++ b/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`InstallBrowserExtensionAlert bitbucketServer (Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "bitbucketServer",
         "url": "",
       },
@@ -74,7 +73,6 @@ exports[`InstallBrowserExtensionAlert bitbucketServer (native integration) 1`] =
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "bitbucketServer",
         "url": "",
       },
@@ -147,7 +145,6 @@ exports[`InstallBrowserExtensionAlert bitbucketServer (non-Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "bitbucketServer",
         "url": "",
       },
@@ -215,7 +212,6 @@ exports[`InstallBrowserExtensionAlert github (Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "github",
         "url": "",
       },
@@ -283,7 +279,6 @@ exports[`InstallBrowserExtensionAlert github (native integration) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "github",
         "url": "",
       },
@@ -356,7 +351,6 @@ exports[`InstallBrowserExtensionAlert github (non-Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "github",
         "url": "",
       },
@@ -424,7 +418,6 @@ exports[`InstallBrowserExtensionAlert gitlab (Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "gitlab",
         "url": "",
       },
@@ -492,7 +485,6 @@ exports[`InstallBrowserExtensionAlert gitlab (native integration) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "gitlab",
         "url": "",
       },
@@ -565,7 +557,6 @@ exports[`InstallBrowserExtensionAlert gitlab (non-Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "gitlab",
         "url": "",
       },
@@ -660,7 +651,6 @@ exports[`InstallBrowserExtensionAlert phabricator (Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "phabricator",
         "url": "",
       },
@@ -755,7 +745,6 @@ exports[`InstallBrowserExtensionAlert phabricator (native integration) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "phabricator",
         "url": "",
       },
@@ -857,7 +846,6 @@ exports[`InstallBrowserExtensionAlert phabricator (non-Chrome) 1`] = `
   externalURLs={
     Array [
       Object {
-        "__typename": "ExternalLink",
         "serviceType": "phabricator",
         "url": "",
       },

--- a/client/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -1,13 +1,13 @@
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useMemo } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { HeroPage } from '../../components/HeroPage'
 import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepositoryBranchesAllPage } from './RepositoryBranchesAllPage'
 import { RepositoryBranchesNavbar } from './RepositoryBranchesNavbar'
 import { RepositoryBranchesOverviewPage } from './RepositoryBranchesOverviewPage'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
+import { RepositoryFields } from '../../graphql-operations'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -18,7 +18,7 @@ const NotFoundPage: React.FunctionComponent = () => (
 )
 
 interface Props extends RouteComponentProps<{}>, BreadcrumbSetters {
-    repo: GQL.IRepository
+    repo: RepositoryFields
 }
 
 /**
@@ -28,14 +28,14 @@ export interface RepositoryBranchesAreaPageProps {
     /**
      * The active repository.
      */
-    repo: GQL.IRepository
+    repo: RepositoryFields
 }
 
 /**
  * Renders pages related to repository branches.
  */
 export const RepositoryBranchesArea: React.FunctionComponent<Props> = ({ useBreadcrumb, repo, match }) => {
-    const transferProps: { repo: GQL.IRepository } = {
+    const transferProps: { repo: RepositoryFields } = {
         repo,
     }
 

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -43,6 +43,7 @@ import {
     GitCommitFields,
     RepositoryCommitResult,
     RepositoryCommitVariables,
+    RepositoryFields,
     Scalars,
 } from '../../graphql-operations'
 
@@ -87,7 +88,7 @@ interface Props
         PlatformContextProps,
         ExtensionsControllerProps,
         ThemeProps {
-    repo: GQL.IRepository
+    repo: RepositoryFields
 
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 }

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -13,7 +13,7 @@ import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 import { GitCommitNode, GitCommitNodeProps } from './GitCommitNode'
 import { RevisionSpec, ResolvedRevisionSpec } from '../../../../shared/src/util/url'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { GitCommitFields } from '../../graphql-operations'
+import { GitCommitFields, RepositoryFields } from '../../graphql-operations'
 import { externalLinkFieldsFragment } from '../backend'
 
 export const gitCommitFragment = gql`
@@ -109,7 +109,7 @@ interface Props
         Partial<RevisionSpec>,
         ResolvedRevisionSpec,
         BreadcrumbSetters {
-    repo: GQL.IRepository
+    repo: RepositoryFields
 
     history: H.History
     location: H.Location

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -9,7 +9,6 @@ import { filter, map, withLatestFrom } from 'rxjs/operators'
 import { ActionItemAction } from '../../../../shared/src/actions/ActionItem'
 import { HoverMerged } from '../../../../shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { getHoverActions } from '../../../../shared/src/hover/actions'
 import { HoverContext } from '../../../../shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '../../../../shared/src/languages'
@@ -35,6 +34,7 @@ import { ErrorMessage } from '../../components/alerts'
 import * as H from 'history'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
+import { RepositoryFields, Scalars } from '../../graphql-operations'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -52,7 +52,7 @@ interface RepositoryCompareAreaProps
         ExtensionsControllerProps,
         ThemeProps,
         BreadcrumbSetters {
-    repo: GQL.IRepository
+    repo: RepositoryFields
     history: H.History
 }
 
@@ -65,13 +65,13 @@ interface State extends HoverState<HoverContext, HoverMerged, ActionItemAction> 
  */
 export interface RepositoryCompareAreaPageProps extends PlatformContextProps {
     /** The repository being compared. */
-    repo: GQL.IRepository
+    repo: RepositoryFields
 
     /** The base of the comparison. */
-    base: { repoName: string; repoID: GQL.ID; revision?: string | null }
+    base: { repoName: string; repoID: Scalars['ID']; revision?: string | null }
 
     /** The head of the comparison. */
-    head: { repoName: string; repoID: GQL.ID; revision?: string | null }
+    head: { repoName: string; repoID: Scalars['ID']; revision?: string | null }
 
     /** The URL route prefix for the comparison. */
     routePrefix: string

--- a/client/web/src/repo/releases/RepositoryReleasesArea.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesArea.tsx
@@ -1,13 +1,13 @@
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useMemo } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { HeroPage } from '../../components/HeroPage'
 import { RepoContainerContext } from '../RepoContainer'
 import { RepoHeaderBreadcrumbNavItem } from '../RepoHeaderBreadcrumbNavItem'
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
 import * as H from 'history'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
+import { RepositoryFields } from '../../graphql-operations'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -21,7 +21,7 @@ interface Props
     extends RouteComponentProps<{}>,
         Pick<RepoContainerContext, 'repo' | 'routePrefix' | 'repoHeaderContributionsLifecycleProps'>,
         BreadcrumbSetters {
-    repo: GQL.IRepository
+    repo: RepositoryFields
     history: H.History
 }
 
@@ -32,7 +32,7 @@ export interface RepositoryReleasesAreaPageProps {
     /**
      * The active repository.
      */
-    repo: GQL.IRepository
+    repo: RepositoryFields
 }
 
 /**
@@ -49,7 +49,7 @@ export const RepositoryReleasesArea: React.FunctionComponent<Props> = ({ useBrea
         )
     )
 
-    const transferProps: { repo: GQL.IRepository } = {
+    const transferProps: { repo: RepositoryFields } = {
         repo,
     }
 

--- a/client/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/client/web/src/repo/settings/RepoSettingsArea.tsx
@@ -5,9 +5,8 @@ import React, { useMemo } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
 import { of } from 'rxjs'
 import { catchError } from 'rxjs/operators'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { HeroPage } from '../../components/HeroPage'
-import { fetchRepository } from './backend'
+import { fetchSettingsAreaRepository } from './backend'
 import { RepoSettingsSidebar, RepoSettingsSideBarGroups } from './RepoSettingsSidebar'
 import { RouteDescriptor } from '../../util/contributions'
 import { ErrorMessage } from '../../components/alerts'
@@ -17,6 +16,7 @@ import { useObservable } from '../../../../shared/src/util/useObservable'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { AuthenticatedUser } from '../../auth'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
+import { RepositoryFields, SettingsAreaRepositoryFields } from '../../graphql-operations'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -27,8 +27,8 @@ const NotFoundPage: React.FunctionComponent = () => (
 )
 
 export interface RepoSettingsAreaRouteContext extends TelemetryProps {
-    repo: GQL.IRepository
-    onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    repo: SettingsAreaRepositoryFields
+    onDidUpdateRepository: (update: Partial<RepositoryFields>) => void
 }
 
 export interface RepoSettingsAreaRoute extends RouteDescriptor<RepoSettingsAreaRouteContext> {}
@@ -36,9 +36,9 @@ export interface RepoSettingsAreaRoute extends RouteDescriptor<RepoSettingsAreaR
 interface Props extends RouteComponentProps<{}>, BreadcrumbSetters, TelemetryProps {
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: RepoSettingsSideBarGroups
-    repo: GQL.IRepository
+    repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
-    onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    onDidUpdateRepository: (update: Partial<RepositoryFields>) => void
     history: H.History
 }
 
@@ -53,7 +53,9 @@ export const RepoSettingsArea: React.FunctionComponent<Props> = ({
 }) => {
     const repoName = props.repo.name
     const repoOrError = useObservable(
-        useMemo(() => fetchRepository(repoName).pipe(catchError(error => of<ErrorLike>(asError(error)))), [repoName])
+        useMemo(() => fetchSettingsAreaRepository(repoName).pipe(catchError(error => of<ErrorLike>(asError(error)))), [
+            repoName,
+        ])
     )
 
     useBreadcrumb(useMemo(() => ({ key: 'settings', element: 'Settings' }), []))

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -17,11 +17,12 @@ import { Timestamp } from '../../components/time/Timestamp'
 import { eventLogger } from '../../tracking/eventLogger'
 import { ErrorAlert } from '../../components/alerts'
 import * as H from 'history'
+import { Scalars, SettingsAreaRepositoryFields } from '../../graphql-operations'
 
 /**
  * Fetches a repository's text search index information.
  */
-function fetchRepositoryTextSearchIndex(id: GQL.ID): Observable<GQL.IRepositoryTextSearchIndex | null> {
+function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<GQL.IRepositoryTextSearchIndex | null> {
     return queryGraphQL(
         gql`
             query RepositoryTextSearchIndex($id: ID!) {
@@ -70,7 +71,7 @@ function fetchRepositoryTextSearchIndex(id: GQL.ID): Observable<GQL.IRepositoryT
 }
 
 const TextSearchIndexedReference: React.FunctionComponent<{
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
     indexedRef: GQL.IRepositoryTextSearchIndexedRef
 }> = ({ repo, indexedRef }) => {
     let Icon: React.ComponentType<{ className?: string }>
@@ -113,7 +114,7 @@ const TextSearchIndexedReference: React.FunctionComponent<{
 }
 
 interface Props extends RouteComponentProps<{}> {
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
     history: H.History
 }
 

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -13,14 +13,15 @@ import { Timestamp } from '../../components/time/Timestamp'
 import { checkMirrorRepositoryConnection, updateMirrorRepository } from '../../site-admin/backend'
 import { eventLogger } from '../../tracking/eventLogger'
 import { DirectImportRepoAlert } from '../DirectImportRepoAlert'
-import { fetchRepository } from './backend'
+import { fetchSettingsAreaRepository } from './backend'
 import { ActionContainer, BaseActionContainer } from './components/ActionContainer'
 import { ErrorAlert } from '../../components/alerts'
 import { asError } from '../../../../shared/src/util/errors'
 import * as H from 'history'
+import { RepositoryFields, SettingsAreaRepositoryFields } from '../../graphql-operations'
 
 interface UpdateMirrorRepositoryActionContainerProps {
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
     onDidUpdateRepository: () => void
     disabled: boolean
     disabledReason: string | undefined
@@ -126,7 +127,7 @@ class UpdateMirrorRepositoryActionContainer extends React.PureComponent<UpdateMi
 }
 
 interface CheckMirrorRepositoryConnectionActionContainerProps {
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
     onDidUpdateReachability: (reachable: boolean | undefined) => void
     history: H.History
 }
@@ -239,8 +240,8 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
 }
 
 interface Props extends RouteComponentProps<{}> {
-    repo: GQL.IRepository
-    onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    repo: SettingsAreaRepositoryFields
+    onDidUpdateRepository: (update: Partial<RepositoryFields>) => void
     history: H.History
 }
 
@@ -248,7 +249,7 @@ interface State {
     /**
      * The repository object, refreshed after we make changes that modify it.
      */
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
 
     /**
      * Whether the repository connection check reports that the repository is reachable.
@@ -279,7 +280,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<Props, State> {
         eventLogger.logViewEvent('RepoSettingsMirror')
 
         this.subscriptions.add(
-            this.repoUpdates.pipe(switchMap(() => fetchRepository(this.props.repo.name))).subscribe(
+            this.repoUpdates.pipe(switchMap(() => fetchSettingsAreaRepository(this.props.repo.name))).subscribe(
                 repo => this.setState({ repo }),
                 error => this.setState({ error: asError(error).message })
             )

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -3,20 +3,20 @@ import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { ExternalServiceCard } from '../../components/externalServices/ExternalServiceCard'
 import { Form } from '../../../../branded/src/components/Form'
 import { PageTitle } from '../../components/PageTitle'
 import { eventLogger } from '../../tracking/eventLogger'
-import { fetchRepository } from './backend'
+import { fetchSettingsAreaRepository } from './backend'
 import { ErrorAlert } from '../../components/alerts'
 import { defaultExternalServices } from '../../components/externalServices/externalServices'
 import { asError } from '../../../../shared/src/util/errors'
 import * as H from 'history'
+import { RepositoryFields, SettingsAreaRepositoryFields } from '../../graphql-operations'
 
 interface Props extends RouteComponentProps<{}> {
-    repo: GQL.IRepository
-    onDidUpdateRepository: (update: Partial<GQL.IRepository>) => void
+    repo: SettingsAreaRepositoryFields
+    onDidUpdateRepository: (update: Partial<RepositoryFields>) => void
     history: H.History
 }
 
@@ -24,7 +24,7 @@ interface State {
     /**
      * The repository object, refreshed after we make changes that modify it.
      */
-    repo: GQL.IRepository
+    repo: SettingsAreaRepositoryFields
 
     loading: boolean
     error?: string
@@ -50,7 +50,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
         eventLogger.logViewEvent('RepoSettings')
 
         this.subscriptions.add(
-            this.repoUpdates.pipe(switchMap(() => fetchRepository(this.props.repo.name))).subscribe(
+            this.repoUpdates.pipe(switchMap(() => fetchSettingsAreaRepository(this.props.repo.name))).subscribe(
                 repo => this.setState({ repo }),
                 error => this.setState({ error: asError(error).message })
             )

--- a/client/web/src/repo/settings/RepoSettingsSidebar.tsx
+++ b/client/web/src/repo/settings/RepoSettingsSidebar.tsx
@@ -1,7 +1,6 @@
 import ConsoleIcon from 'mdi-react/ConsoleIcon'
 import * as React from 'react'
 import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import {
     SIDEBAR_BUTTON_CLASS,
     SIDEBAR_LIST_GROUP_ITEM_ACTION_CLASS,
@@ -9,6 +8,7 @@ import {
     SidebarGroupHeader,
     SidebarGroup,
 } from '../../components/Sidebar'
+import { SettingsAreaRepositoryFields } from '../../graphql-operations'
 import { NavGroupDescriptor } from '../../util/contributions'
 
 export interface RepoSettingsSideBarGroup extends NavGroupDescriptor {}
@@ -18,7 +18,7 @@ export type RepoSettingsSideBarGroups = readonly RepoSettingsSideBarGroup[]
 interface Props extends RouteComponentProps<{}> {
     repoSettingsSidebarGroups: RepoSettingsSideBarGroups
     className?: string
-    repo?: GQL.IRepository
+    repo?: SettingsAreaRepositoryFields
 }
 
 /**

--- a/client/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -1,12 +1,12 @@
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useMemo } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router'
-import * as GQL from '../../../../shared/src/graphql/schema'
 import { HeroPage } from '../../components/HeroPage'
 import { RepositoryStatsContributorsPage } from './RepositoryStatsContributorsPage'
 import { RepositoryStatsNavbar } from './RepositoryStatsNavbar'
 import { PatternTypeProps } from '../../search'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
+import { RepositoryFields } from '../../graphql-operations'
 
 const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage
@@ -17,7 +17,7 @@ const NotFoundPage: React.FunctionComponent = () => (
 )
 
 interface Props extends RouteComponentProps<{}>, BreadcrumbSetters, Omit<PatternTypeProps, 'setPatternType'> {
-    repo: GQL.IRepository
+    repo: RepositoryFields
     globbing: boolean
 }
 
@@ -28,7 +28,7 @@ export interface RepositoryStatsAreaPageProps {
     /**
      * The active repository.
      */
-    repo: GQL.IRepository
+    repo: RepositoryFields
 }
 
 const showNavbar = false


### PR DESCRIPTION
This makes a big part of our app a lot more type-safe and easier to work with.

There are two separate types: The minimal one used by the RepoContainer, and one with more details used in the RepoSettingsArea.