### PR TITLE
Update documentation for Codenotify experiment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,10 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# We are experimenting with not using CODEOWNERS until the end of October.
-# More context: https://github.com/sourcegraph/sourcegraph/pull/13838
+# We prefer to use Codenotify (https://github.com/sourcegraph/codenotify) instead of CODEOWNERS.
+# More context is in this blog post: https://about.sourcegraph.com/blog/a-different-way-to-think-about-code-ownership/
+# If you are tempted to add an entry to CODEOWNERS, please try using Codenotify first for some amount of time.
+# If Codenotify does not satisfy your needs, then you can open a PR to propose adding a new entry to CODEOWNERS and Nick will review.
+# The PR description should describe why using Codenotify was insufficient. Thanks!
 CODEOWNERS @nicksnyder
 .github/CODEOWNERS @nicksnyder


### PR DESCRIPTION
Given the results from the survey (included below), and positive feedback I have received from teammates over the last two months, I am updating our documented policy.

1. Codenotify is no longer an experiment, but an expressed preference of our team.
2. I am leaving the door open to there being exceptions to this preference, and we can evaluate those exceptions on a case by case basis. If the exceptions turn into a pattern then we can further update this policy to clarify if/when it is appropriate to use CODEOWNERS.

Results from anonymous survey: https://docs.google.com/forms/d/12vPwWSZiH72k7dzItnMmynfHS-ruHjv9HsXY3LAAVo8/viewanalytics

![Screen Shot 2020-12-03 at 9 59 31 AM](https://user-images.githubusercontent.com/754768/101069427-d4de6d00-354e-11eb-86de-c80ddd76d1a4.png)
![Screen Shot 2020-12-03 at 9 59 42 AM](https://user-images.githubusercontent.com/754768/101069416-d27c1300-354e-11eb-8bba-a64a3c956180.png)

> I know the CODENOTIFY experiment is still in progress - just wanted to put a big thumbs up to CODENOTIFY files and workflow. I no longer feel like I'm "spamming" folks on PRs with them automatically getting added, and I am able to track the files and changes I care about (extra bonus = GitHub Slack integration). I found the docs easy to understand, and the examples helpful and relevant, so I was able to quickly make the addition I needed

> I think this is a roaring success

> I sometimes get notified by github slack integration that CODENOTIFY has commented on my PRs, and that feels noisy. But I'm happy to concede that and get notified when people modify code, so..

> Great idea, thanks for doing this. I like how it doesn't block on "the wrong" people.

> codenotify comments are quite large, maybe possible to hide large sections behind <spoiler> tags? notably better experience than codeowners, before opening a PR it is not clear who will be marked as reviewer and causes unnecessary blocking pressure, adopting codenotify is better for aligning with our async value

> I was added by others to a few files, but never added myself because I didn't see it in the handbook and didn't get around to finding out how to do it (although I'm sure it's extremely easy)

> I was wavering between the hybrid option and going back, and could be convinced either way. I think CODENOTIFY is useful, but I think it addresses a different problem to CODEOWNERS: CODENOTIFY is good for existing developers who want to know what's happening in parts of the codebase that affect them, but CODEOWNERS makes the life of the new developer (or driveby OSS contributor) easier by not requiring them to figure out who to tag for an appropriate review. That said, if we bring CODEOWNERS back, I think we should be very explicit that only teams can be owners and not individuals.

