### PR TITLE
qa: create code-intel pipeline

### DIFF
--- a/.buildkite/pipeline.codeintel.yml
+++ b/.buildkite/pipeline.codeintel.yml
@@ -1,0 +1,9 @@
+env:
+  VAGRANT_RUN_ENV: "CI"
+steps:
+- label: ':docker::brain: Code Intel'
+  command:
+    - .buildkite/vagrant-run.sh sourcegraph-code-intel-test
+  artifact_paths: ./*.log
+  agents:
+    queue: 'baremetal'

--- a/.buildkite/pipeline.qa.yml
+++ b/.buildkite/pipeline.qa.yml
@@ -15,13 +15,6 @@ steps:
   agents:
     queue: 'baremetal'
 
-- label: ':docker::brain: Code Intel'
-  command:
-    - .buildkite/vagrant-run.sh sourcegraph-code-intel-test
-  artifact_paths: ./*.log
-  agents:
-    queue: 'baremetal'
-
 - label: ":k8s: Sourcegraph Cluster (deploy-sourcegraph) QA"
   commands:
     - dev/ci/test/cluster/cluster-test.sh

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -165,7 +165,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || c.branch == "dt/codeintel-pipeline"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -165,7 +165,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || c.branch == "dt/codeintel-pipeline"
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -291,7 +291,7 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 			}),
 		)
 		pipeline.AddTrigger(":chromium: Trigger QA",
-			bk.Trigger("codeintel-qa"),
+			bk.Trigger("code-intel-qa"),
 			bk.Async(async),
 			bk.Build(bk.BuildOptions{
 				Message: os.Getenv("BUILDKITE_MESSAGE"),

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -290,6 +290,16 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 				Env:     env,
 			}),
 		)
+		pipeline.AddTrigger(":chromium: Trigger QA",
+			bk.Trigger("codeintel-qa"),
+			bk.Async(async),
+			bk.Build(bk.BuildOptions{
+				Message: os.Getenv("BUILDKITE_MESSAGE"),
+				Commit:  c.commit,
+				Branch:  c.branch,
+				Env:     env,
+			}),
+		)
 	}
 }
 

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -290,7 +290,7 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 				Env:     env,
 			}),
 		)
-		pipeline.AddTrigger(":chromium: Trigger QA",
+		pipeline.AddTrigger(":chromium: Trigger Code Intel QA",
 			bk.Trigger("code-intel-qa"),
 			bk.Async(async),
 			bk.Build(bk.BuildOptions{


### PR DESCRIPTION
Notifications are available on our qa pipeline now, I'm moving this because these tests, while QA aren't the same and I think it makes more sense to group QA tests together. In addition, if this is broken but regular QA is passing, this will break our QA pipeline and make it less obvious what isn't working. 

