### PR TITLE
Use EXPERIMENTAL_useSourceOfProjectReferenceRedirect

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ const config = {
     ecmaFeatures: {
       jsx: true,
     },
+    EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
     project: __dirname + '/tsconfig.json',
   },
   settings: {


### PR DESCRIPTION
This should mean a lot faster ESLinting, a lot less VS Code reloads needed, and a lot less types/file changes not being picked up by ESLint and false positives because of it.

https://github.com/typescript-eslint/typescript-eslint/pull/2669