### PR TITLE
search frontend: factor out loops in token decoration

### DIFF
--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -1,7 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { Token, toMonacoRange } from './scanner'
 import { resolveFilter } from './filters'
-import { decorateTokens, DecoratedToken, RegexpMetaKind } from './tokens'
+import { decorate, DecoratedToken, RegexpMetaKind } from './tokens'
 
 const toHover = (token: DecoratedToken): string => {
     switch (token.type) {
@@ -105,7 +105,7 @@ export const getHoverResult = (
     { column }: Pick<Monaco.Position, 'column'>,
     smartQuery = false
 ): Monaco.languages.Hover | null => {
-    const tokensAtCursor = (smartQuery ? decorateTokens(tokens) : tokens).filter(inside(column))
+    const tokensAtCursor = (smartQuery ? tokens.flatMap(decorate) : tokens).filter(inside(column))
     if (tokensAtCursor.length === 0) {
         return null
     }


### PR DESCRIPTION
Stacked on #16422.

The diff looks horrible but all I'm doing is converting signatures like:

`(tokens: DecoratedToken[]): Monaco.languages.IToken[]` to `(token: DecoratedToken): Monaco.languages.IToken`

 removing the fact that these converters act on lists, and make them just accept atoms. This makes the functions more standalone and easier to read (you remove a loop and don't declare the intermediate list) and callers use `map` or `flatMap` to reduce.  I did a quick search and `map` and `flatMap` are negligibly slower but it really is so negligible it doesn't matter.