### PR TITLE
search frontend: move token definitions out of scanner

### DIFF
--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -1,6 +1,7 @@
 import * as Monaco from 'monaco-editor'
 import { getCompletionItems, repositoryCompletionItemKind } from './completion'
-import { scanSearchQuery, ScanSuccess, ScanResult, Token } from './scanner'
+import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
+import { Token } from './tokens'
 import { NEVER, of } from 'rxjs'
 import { SearchSuggestion } from '../../graphql/schema'
 

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -1,8 +1,8 @@
 import * as Monaco from 'monaco-editor'
 import { escapeRegExp, startCase } from 'lodash'
 import { FILTERS, resolveFilter } from './filters'
-import { Token } from './scanner'
-import { toMonacoRange } from './tokens'
+import { Token, toMonacoRange } from './tokens'
+
 import { Omit } from 'utility-types'
 import { Observable } from 'rxjs'
 import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup } from '../../graphql/schema'

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -1,5 +1,6 @@
 import { getDiagnostics } from './diagnostics'
-import { scanSearchQuery, ScanSuccess, ScanResult, Token } from './scanner'
+import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
+import { Token } from './tokens'
 import { SearchPatternType } from '../../graphql-operations'
 
 const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -1,6 +1,6 @@
 import * as Monaco from 'monaco-editor'
-import { Token } from './scanner'
-import { toMonacoRange } from './tokens'
+import { Token, toMonacoRange } from './tokens'
+
 import { validateFilter } from './filters'
 import { SearchPatternType } from '../../graphql-operations'
 

--- a/client/shared/src/search/query/filters.test.ts
+++ b/client/shared/src/search/query/filters.test.ts
@@ -1,5 +1,5 @@
 import { validateFilter } from './filters'
-import { Literal, Quoted } from './scanner'
+import { Literal, Quoted } from './tokens'
 
 describe('validateFilter()', () => {
     interface TestCase {

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -1,4 +1,4 @@
-import { Filter } from './scanner'
+import { Filter } from './tokens'
 import { SearchSuggestion } from '../suggestions'
 import {
     FilterType,

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -1,5 +1,6 @@
 import { getHoverResult } from './hover'
-import { scanSearchQuery, ScanSuccess, Token, ScanResult } from './scanner'
+import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
+import { Token } from './tokens'
 import { SearchPatternType } from '../../graphql-operations'
 
 expect.addSnapshotSerializer({

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -1,6 +1,5 @@
 import * as Monaco from 'monaco-editor'
-import { Token } from './scanner'
-import { toMonacoRange, decorate, DecoratedToken, RegexpMetaKind } from './tokens'
+import { toMonacoRange, decorate, DecoratedToken, RegexpMetaKind, Token } from './tokens'
 import { resolveFilter } from './filters'
 
 const toHover = (token: DecoratedToken): string => {

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -1,4 +1,5 @@
-import { scanSearchQuery, PatternKind, Token, KeywordKind } from './scanner'
+import { scanSearchQuery } from './scanner'
+import { PatternKind, Token, KeywordKind } from './tokens'
 
 export interface Pattern {
     type: 'pattern'

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -1,4 +1,5 @@
-import { scanSearchQuery, scanBalancedLiteral, toPatternResult, PatternKind } from './scanner'
+import { scanSearchQuery, scanBalancedLiteral, toPatternResult } from './scanner'
+import { PatternKind } from './tokens'
 import { SearchPatternType } from '../../graphql-operations'
 
 expect.addSnapshotSerializer({

--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -1,124 +1,25 @@
 import { filterTypeKeysWithAliases } from '../interactive/util'
 import { SearchPatternType } from '../../graphql-operations'
-
-/**
- * Defines common properties for tokens.
- */
-export interface BaseToken {
-    type: Token['type']
-    range: CharacterRange
-}
-
-/**
- * All recognized tokens.
- */
-export type Token = Whitespace | OpeningParen | ClosingParen | Keyword | Comment | Literal | Pattern | Filter | Quoted
+import {
+    Token,
+    Whitespace,
+    OpeningParen,
+    ClosingParen,
+    Keyword,
+    Comment,
+    Literal,
+    Pattern,
+    Filter,
+    Quoted,
+    KeywordKind,
+    PatternKind,
+    CharacterRange,
+} from './tokens'
 
 /**
  * A scanner produces a term, which is either a token or a list of tokens.
  */
 export type Term = Token | Token[]
-
-/**
- * Represents a zero-indexed character range in a single-line search query.
- */
-export interface CharacterRange {
-    /** Zero-based character on the line */
-    start: number
-    /** Zero-based character on the line */
-    end: number
-}
-
-/**
- * A label associated with a pattern token. We don't use SearchPatternType because
- * that is used as a global quantifier for all patterns in a query. PatternKind
- * allows to qualify multiple pattern tokens differently within a single query.
- */
-export enum PatternKind {
-    Literal = 1,
-    Regexp,
-    Structural,
-}
-
-/**
- * A value interpreted as a pattern of kind {@link PatternKind}.
- */
-export interface Pattern extends BaseToken {
-    type: 'pattern'
-    kind: PatternKind
-    value: string
-}
-
-/**
- * Represents a literal in a search query.
- *
- * Example: `Conn`.
- */
-export interface Literal extends BaseToken {
-    type: 'literal'
-    value: string
-}
-
-/**
- * Represents a filter in a search query.
- *
- * Example: `repo:^github\.com\/sourcegraph\/sourcegraph$`.
- */
-export interface Filter extends BaseToken {
-    type: 'filter'
-    field: Literal
-    value: Quoted | Literal | undefined
-    negated: boolean
-}
-
-export enum KeywordKind {
-    Or = 'or',
-    And = 'and',
-    Not = 'not',
-}
-
-/**
- * Represents a keyword in a search query.
- *
- * Current keywords are: AND, and, OR, or, NOT, not.
- */
-export interface Keyword extends BaseToken {
-    type: 'keyword'
-    value: string
-    kind: KeywordKind
-}
-
-/**
- * Represents a quoted string in a search query.
- *
- * Example: "Conn".
- */
-export interface Quoted extends BaseToken {
-    type: 'quoted'
-    quotedValue: string
-}
-
-/**
- * Represents a C-style comment, terminated by a newline.
- *
- * Example: `// Oh hai`
- */
-export interface Comment extends BaseToken {
-    type: 'comment'
-    value: string
-}
-
-export interface Whitespace extends BaseToken {
-    type: 'whitespace'
-}
-
-export interface OpeningParen extends BaseToken {
-    type: 'openingParen'
-}
-
-export interface ClosingParen extends BaseToken {
-    type: 'closingParen'
-}
 
 /**
  * Represents the failed result of running a {@link Scanner} on a search query.

--- a/client/shared/src/search/query/tokens.test.ts
+++ b/client/shared/src/search/query/tokens.test.ts
@@ -1,5 +1,5 @@
-import { getMonacoTokens } from './tokens'
-import { scanSearchQuery, ScanSuccess, Token, ScanResult } from './scanner'
+import { getMonacoTokens, Token } from './tokens'
+import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
 import { SearchPatternType } from '../../graphql-operations'
 
 expect.addSnapshotSerializer({

--- a/client/shared/src/search/query/tokens.ts
+++ b/client/shared/src/search/query/tokens.ts
@@ -1,5 +1,4 @@
 import * as Monaco from 'monaco-editor'
-import { Token, Pattern, CharacterRange, PatternKind } from './scanner'
 import { RegExpParser, visitRegExpAST } from 'regexpp'
 import {
     Alternative,
@@ -12,6 +11,120 @@ import {
     Group,
     Quantifier,
 } from 'regexpp/ast'
+
+/**
+ * Represents a zero-indexed character range in a single-line search query.
+ */
+export interface CharacterRange {
+    /** Zero-based character on the line */
+    start: number
+    /** Zero-based character on the line */
+    end: number
+}
+
+/**
+ * Defines common properties for tokens.
+ */
+export interface BaseToken {
+    type: Token['type']
+    range: CharacterRange
+}
+
+/**
+ * All recognized tokens.
+ */
+export type Token = Whitespace | OpeningParen | ClosingParen | Keyword | Comment | Literal | Pattern | Filter | Quoted
+
+/**
+ * A label associated with a pattern token. We don't use SearchPatternType because
+ * that is used as a global quantifier for all patterns in a query. PatternKind
+ * allows to qualify multiple pattern tokens differently within a single query.
+ */
+export enum PatternKind {
+    Literal = 1,
+    Regexp,
+    Structural,
+}
+
+/**
+ * A value interpreted as a pattern of kind {@link PatternKind}.
+ */
+export interface Pattern extends BaseToken {
+    type: 'pattern'
+    kind: PatternKind
+    value: string
+}
+
+/**
+ * Represents a literal in a search query.
+ *
+ * Example: `Conn`.
+ */
+export interface Literal extends BaseToken {
+    type: 'literal'
+    value: string
+}
+
+/**
+ * Represents a filter in a search query.
+ *
+ * Example: `repo:^github\.com\/sourcegraph\/sourcegraph$`.
+ */
+export interface Filter extends BaseToken {
+    type: 'filter'
+    field: Literal
+    value: Quoted | Literal | undefined
+    negated: boolean
+}
+
+export enum KeywordKind {
+    Or = 'or',
+    And = 'and',
+    Not = 'not',
+}
+
+/**
+ * Represents a keyword in a search query.
+ *
+ * Current keywords are: AND, and, OR, or, NOT, not.
+ */
+export interface Keyword extends BaseToken {
+    type: 'keyword'
+    value: string
+    kind: KeywordKind
+}
+
+/**
+ * Represents a quoted string in a search query.
+ *
+ * Example: "Conn".
+ */
+export interface Quoted extends BaseToken {
+    type: 'quoted'
+    quotedValue: string
+}
+
+/**
+ * Represents a C-style comment, terminated by a newline.
+ *
+ * Example: `// Oh hai`
+ */
+export interface Comment extends BaseToken {
+    type: 'comment'
+    value: string
+}
+
+export interface Whitespace extends BaseToken {
+    type: 'whitespace'
+}
+
+export interface OpeningParen extends BaseToken {
+    type: 'openingParen'
+}
+
+export interface ClosingParen extends BaseToken {
+    type: 'closingParen'
+}
 
 export enum RegexpMetaKind {
     Assertion = 'Assertion', // like ^ or \b

--- a/client/shared/src/search/query/validate.ts
+++ b/client/shared/src/search/query/validate.ts
@@ -1,4 +1,5 @@
-import { Filter, scanSearchQuery } from './scanner'
+import { scanSearchQuery } from './scanner'
+import { Filter } from './tokens'
 
 export enum FilterKind {
     Global = 'Global',

--- a/client/shared/src/search/query/visitor.ts
+++ b/client/shared/src/search/query/visitor.ts
@@ -1,5 +1,5 @@
 import { Node, Operator, Parameter, Pattern, OperatorKind } from './parser'
-import { PatternKind } from './scanner'
+import { PatternKind } from './tokens'
 
 export class Visitor {
     /**

--- a/client/web/src/search/queryTelemetry.tsx
+++ b/client/web/src/search/queryTelemetry.tsx
@@ -1,5 +1,6 @@
 import { count } from '../../../shared/src/util/strings'
-import { scanSearchQuery, ScanResult, Token } from '../../../shared/src/search/query/scanner'
+import { scanSearchQuery, ScanResult } from '../../../shared/src/search/query/scanner'
+import { Token } from '../../../shared/src/search/query/tokens'
 import { resolveFilter } from '../../../shared/src/search/query/filters'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
Stacked on #16426.

Moves scanner token definitions to `tokens.ts`. This is an intermediate step before splitting `tokens.ts`. The idea is that the dependencies/definitions work like this:

```
parser <- scanner
      `------ ` ---token.ts
                     /
      decoratedToken.ts (search query highlighting/hovers, this should not depend on definitions in scanner, just the output)
```
