### PR TITLE
search: prepare store to send emails

### DIFF
--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -25,18 +25,6 @@ type MonitorEmail struct {
 	ChangedAt time.Time
 }
 
-var EmailsColumns = []*sqlf.Query{
-	sqlf.Sprintf("cm_emails.id"),
-	sqlf.Sprintf("cm_emails.monitor"),
-	sqlf.Sprintf("cm_emails.enabled"),
-	sqlf.Sprintf("cm_emails.priority"),
-	sqlf.Sprintf("cm_emails.header"),
-	sqlf.Sprintf("cm_emails.created_by"),
-	sqlf.Sprintf("cm_emails.created_at"),
-	sqlf.Sprintf("cm_emails.changed_by"),
-	sqlf.Sprintf("cm_emails.changed_at"),
-}
-
 func (s *Store) UpdateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error) {
 	var q *sqlf.Query
 	q, err = s.updateActionEmailQuery(ctx, monitorID, action.Email)
@@ -205,6 +193,18 @@ SELECT e.id, e.monitor, e.enabled, e.priority, e.header, e.created_by, e.created
 FROM cm_emails e INNER JOIN cm_queries q ON e.monitor = q.monitor
 WHERE q.id = %s
 `
+
+var EmailsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_emails.id"),
+	sqlf.Sprintf("cm_emails.monitor"),
+	sqlf.Sprintf("cm_emails.enabled"),
+	sqlf.Sprintf("cm_emails.priority"),
+	sqlf.Sprintf("cm_emails.header"),
+	sqlf.Sprintf("cm_emails.created_by"),
+	sqlf.Sprintf("cm_emails.created_at"),
+	sqlf.Sprintf("cm_emails.changed_by"),
+	sqlf.Sprintf("cm_emails.changed_at"),
+}
 
 func ScanEmails(rows *sql.Rows) (ms []*MonitorEmail, err error) {
 	for rows.Next() {

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -25,6 +25,18 @@ type MonitorEmail struct {
 	ChangedAt time.Time
 }
 
+var EmailsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_emails.id"),
+	sqlf.Sprintf("cm_emails.monitor"),
+	sqlf.Sprintf("cm_emails.enabled"),
+	sqlf.Sprintf("cm_emails.priority"),
+	sqlf.Sprintf("cm_emails.header"),
+	sqlf.Sprintf("cm_emails.created_by"),
+	sqlf.Sprintf("cm_emails.created_at"),
+	sqlf.Sprintf("cm_emails.changed_by"),
+	sqlf.Sprintf("cm_emails.changed_at"),
+}
+
 func (s *Store) UpdateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error) {
 	var q *sqlf.Query
 	q, err = s.updateActionEmailQuery(ctx, monitorID, action.Email)
@@ -65,6 +77,16 @@ func (s *Store) DeleteActionsInt64(ctx context.Context, actionIDs []int64, monit
 		return err
 	}
 	return nil
+}
+
+const actionEmailByIDFmtStr = `
+SELECT id, monitor, enabled, priority, header, created_by, created_at, changed_by, changed_at
+FROM cm_emails
+WHERE id = %s
+`
+
+func (s *Store) ActionEmailByIDInt64(ctx context.Context, emailID int64) (m *MonitorEmail, err error) {
+	return s.runEmailQuery(ctx, sqlf.Sprintf(actionEmailByIDFmtStr, emailID))
 }
 
 func (s *Store) runEmailQuery(ctx context.Context, q *sqlf.Query) (*MonitorEmail, error) {
@@ -183,18 +205,6 @@ SELECT e.id, e.monitor, e.enabled, e.priority, e.header, e.created_by, e.created
 FROM cm_emails e INNER JOIN cm_queries q ON e.monitor = q.monitor
 WHERE q.id = %s
 `
-
-var EmailsColumns = []*sqlf.Query{
-	sqlf.Sprintf("cm_emails.id"),
-	sqlf.Sprintf("cm_emails.monitor"),
-	sqlf.Sprintf("cm_emails.enabled"),
-	sqlf.Sprintf("cm_emails.priority"),
-	sqlf.Sprintf("cm_emails.header"),
-	sqlf.Sprintf("cm_emails.created_by"),
-	sqlf.Sprintf("cm_emails.created_at"),
-	sqlf.Sprintf("cm_emails.changed_by"),
-	sqlf.Sprintf("cm_emails.changed_at"),
-}
 
 func ScanEmails(rows *sql.Rows) (ms []*MonitorEmail, err error) {
 	for rows.Next() {

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -1,0 +1,161 @@
+package codemonitors
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+)
+
+type ActionJob struct {
+	Id           int32
+	Email        int64
+	TriggerEvent int
+
+	// Fields demanded by any dbworker.
+	State          string
+	FailureMessage *string
+	StartedAt      *time.Time
+	FinishedAt     *time.Time
+	ProcessAfter   *time.Time
+	NumResets      int32
+	NumFailures    int32
+	LogContents    *string
+}
+
+func (a *ActionJob) RecordID() int {
+	return int(a.Id)
+}
+
+type ActionJobMetadata struct {
+	Description string
+	MonitorID   int64
+	NumResults  *int
+
+	// The query with after: filter.
+	Query string
+}
+
+var ActionJobsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_action_jobs.id"),
+	sqlf.Sprintf("cm_action_jobs.email"),
+	sqlf.Sprintf("cm_action_jobs.trigger_event"),
+	sqlf.Sprintf("cm_action_jobs.state"),
+	sqlf.Sprintf("cm_action_jobs.failure_message"),
+	sqlf.Sprintf("cm_action_jobs.started_at"),
+	sqlf.Sprintf("cm_action_jobs.finished_at"),
+	sqlf.Sprintf("cm_action_jobs.process_after"),
+	sqlf.Sprintf("cm_action_jobs.num_resets"),
+	sqlf.Sprintf("cm_action_jobs.num_failures"),
+	sqlf.Sprintf("cm_action_jobs.log_contents"),
+}
+
+const enqueueActionEmailFmtStr = `
+WITH due AS (
+	SELECT e.id, e.monitor, e.enabled, e.priority, e.header, e.created_by, e.created_at, e.changed_by, e.changed_at
+	FROM cm_emails e INNER JOIN cm_queries q ON e.monitor = q.monitor
+	WHERE q.id = %s
+),
+busy AS (
+    SELECT DISTINCT email as id FROM cm_action_jobs
+    WHERE state = 'queued'
+    OR state = 'processing'
+)
+INSERT INTO cm_action_jobs (email, trigger_event)
+SELECT id, %s::integer from due EXCEPT SELECT id, %s::integer from busy ORDER BY id
+`
+
+func (s *Store) EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error) {
+	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueActionEmailFmtStr, queryID, triggerEventID, triggerEventID))
+}
+
+const getActionJobMetadataFmtStr = `
+select cm.description, ctj.query_string, cm.id as monitorID, ctj.num_results from
+cm_action_jobs caj
+inner join cm_trigger_jobs ctj on caj.trigger_event = ctj.id
+inner join cm_queries cq on cq.id = ctj.query
+inner join cm_monitors cm on cm.id = cq.monitor
+where caj.id = %s
+`
+
+func (s *Store) GetActionJobMetadata(ctx context.Context, recordID int) (m *ActionJobMetadata, err error) {
+	row := s.Store.QueryRow(ctx, sqlf.Sprintf(getActionJobMetadataFmtStr, recordID))
+	m = &ActionJobMetadata{}
+	err = row.Scan(&m.Description, &m.Query, &m.MonitorID, &m.NumResults)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+const actionJobForIDFmtStr = `
+SELECT id, email, trigger_event, state, failure_message, started_at, finished_at, process_after, num_resets, num_failures, log_contents
+FROM cm_action_jobs
+WHERE id = %s
+`
+
+func (s *Store) ActionJobForIDInt(ctx context.Context, recordID int) (*ActionJob, error) {
+	return s.runActionJobQuery(ctx, sqlf.Sprintf(actionJobForIDFmtStr, recordID))
+}
+
+func (s *Store) runActionJobQuery(ctx context.Context, q *sqlf.Query) (ajs *ActionJob, err error) {
+	var rows *sql.Rows
+	rows, err = s.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var es []*ActionJob
+	es, err = scanActionJobs(rows, err)
+	if err != nil {
+		return nil, err
+	}
+	if len(es) == 0 {
+		return nil, fmt.Errorf("operation failed. Query should have returned at least 1 row")
+	}
+	return es[0], nil
+}
+
+func ScanActionJobs(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
+	records, err := scanActionJobs(rows, err)
+	if err != nil {
+		return &TriggerJobs{}, false, err
+	}
+	return records[0], true, nil
+}
+
+func scanActionJobs(rows *sql.Rows, err error) ([]*ActionJob, error) {
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+	var ajs []*ActionJob
+	for rows.Next() {
+		aj := &ActionJob{}
+		if err := rows.Scan(
+			&aj.Id,
+			&aj.Email,
+			&aj.TriggerEvent,
+			&aj.State,
+			&aj.FailureMessage,
+			&aj.StartedAt,
+			&aj.FinishedAt,
+			&aj.ProcessAfter,
+			&aj.NumResets,
+			&aj.NumFailures,
+			&aj.LogContents,
+		); err != nil {
+			return nil, err
+		}
+		ajs = append(ajs, aj)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ajs, nil
+}

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -1,0 +1,137 @@
+package codemonitors
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t)
+	_, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got *ActionJob
+	got, err = s.ActionJobForIDInt(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ActionJob{
+		Id:             1,
+		Email:          1,
+		TriggerEvent:   1,
+		State:          "queued",
+		FailureMessage: nil,
+		StartedAt:      nil,
+		FinishedAt:     nil,
+		ProcessAfter:   nil,
+		NumResets:      0,
+		NumFailures:    0,
+		LogContents:    nil,
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("diff: %s", diff)
+	}
+}
+
+func TestGetActionJobMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t)
+	_, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		wantNumResults       = 42
+		wantQuery            = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
+		wantMonitorID  int64 = 1
+	)
+	err = s.LogSearch(ctx, wantQuery, wantNumResults, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetActionJobMetadata(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ActionJobMetadata{
+		Description: testDescription,
+		Query:       wantQuery,
+		NumResults:  &wantNumResults,
+		MonitorID:   wantMonitorID,
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("diff: %s", diff)
+	}
+}
+
+func TestScanActionJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	var (
+		testRecordID             = 1
+		testTriggerEventID       = 1
+		testQueryID        int64 = 1
+	)
+
+	ctx, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t)
+	_, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueActionEmailsForQueryIDInt64(ctx, testQueryID, testTriggerEventID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows *sql.Rows
+	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, testRecordID))
+	record, _, err := ScanActionJobs(rows, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if record.RecordID() != testRecordID {
+		t.Fatalf("got %d, want %d", record.RecordID(), testRecordID)
+	}
+}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -101,7 +101,7 @@ func (r *queryRunner) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 		return err
 	}
 	// Log the actual query we ran and whether we got any new results.
-	err = s.LogSearch(ctx, newQuery, numResults > 0, record.RecordID())
+	err = s.LogSearch(ctx, newQuery, numResults, record.RecordID())
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -1,0 +1,88 @@
+package codemonitors
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "codemonitorsstoredb"
+}
+
+const (
+	testQuery       = "repo:github\\.com/sourcegraph/sourcegraph func type:diff patternType:literal"
+	testDescription = "test description"
+)
+
+func (s *Store) insertTestMonitor(ctx context.Context, t *testing.T) (*Monitor, error) {
+	t.Helper()
+
+	owner := relay.MarshalID("User", actor.FromContext(ctx).UID)
+	args := &graphqlbackend.CreateCodeMonitorArgs{
+		Monitor: &graphqlbackend.CreateMonitorArgs{
+			Namespace:   owner,
+			Description: testDescription,
+			Enabled:     true,
+		},
+		Trigger: &graphqlbackend.CreateTriggerArgs{
+			Query: testQuery,
+		},
+		Actions: []*graphqlbackend.CreateActionArgs{
+			{
+				Email: &graphqlbackend.CreateActionEmailArgs{
+					Enabled:    true,
+					Priority:   "NORMAL",
+					Recipients: []graphql.ID{owner},
+					Header:     "test header 1"},
+			},
+			{
+				Email: &graphqlbackend.CreateActionEmailArgs{
+					Enabled:    true,
+					Priority:   "CRITICAL",
+					Recipients: []graphql.ID{owner},
+					Header:     "test header 2"},
+			},
+		},
+	}
+	return s.CreateCodeMonitor(ctx, args)
+}
+
+func newTestStore(t *testing.T) (context.Context, *Store) {
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+	now := time.Now()
+	return ctx, NewStoreWithClock(dbconn.Global, func() time.Time { return now })
+}
+
+func newTestUser(ctx context.Context, t *testing.T) (name string, id int32, namespace graphql.ID, userContext context.Context) {
+	t.Helper()
+
+	name = "cm-user1"
+	id = insertTestUser(t, dbconn.Global, name, true)
+	namespace = relay.MarshalID("User", id)
+	ctx = actor.WithActor(ctx, actor.FromUser(id))
+	return name, id, namespace, ctx
+}
+
+func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
+	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return userID
+}

--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -62,7 +62,7 @@ func (s *Store) insertTestMonitor(ctx context.Context, t *testing.T) (*Monitor, 
 func newTestStore(t *testing.T) (context.Context, *Store) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	dbtesting.SetupGlobalTestDB(t)
-	now := time.Now()
+	now := time.Now().Truncate(time.Microsecond)
 	return ctx, NewStoreWithClock(dbconn.Global, func() time.Time { return now })
 }
 

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -19,9 +19,9 @@ type MonitorQuery struct {
 	QueryString  string
 	NextRun      time.Time
 	LatestResult *time.Time
-	CreatedBy    int64
+	CreatedBy    int32
 	CreatedAt    time.Time
-	ChangedBy    int64
+	ChangedBy    int32
 	ChangedAt    time.Time
 }
 
@@ -66,8 +66,8 @@ func (s *Store) TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int6
 
 const createTriggerQueryFmtStr = `
 INSERT INTO cm_queries
-(monitor, query, created_by, created_at, changed_by, changed_at)
-VALUES (%s,%s,%s,%s,%s,%s)
+(monitor, query, created_by, created_at, changed_by, changed_at, next_run)
+VALUES (%s,%s,%s,%s,%s,%s,%s)
 RETURNING %s;
 `
 
@@ -81,6 +81,7 @@ func (s *Store) createTriggerQueryQuery(ctx context.Context, monitorID int64, ar
 		a.UID,
 		now,
 		a.UID,
+		now,
 		now,
 		sqlf.Join(queryColumns, ", "),
 	), nil

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -1,0 +1,87 @@
+package codemonitors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestQueryByRecordID(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t)
+	m, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetQueryByRecordID(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &MonitorQuery{
+		Id:           1,
+		Monitor:      m.ID,
+		QueryString:  testQuery,
+		NextRun:      s.Now(),
+		LatestResult: nil,
+		CreatedBy:    id,
+		CreatedAt:    s.Now(),
+		ChangedBy:    id,
+		ChangedAt:    s.Now(),
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("diff: %s", diff)
+	}
+}
+
+func TestTriggerQueryNextRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t)
+	m, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantLatestResult := s.Now().Add(time.Minute)
+	wantNextRun := s.Now().Add(time.Hour)
+
+	err = s.SetTriggerQueryNextRun(ctx, 1, wantNextRun, wantLatestResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetQueryByRecordID(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &MonitorQuery{
+		Id:           1,
+		Monitor:      m.ID,
+		QueryString:  testQuery,
+		NextRun:      wantNextRun,
+		LatestResult: &wantLatestResult,
+		CreatedBy:    id,
+		CreatedAt:    s.Now(),
+		ChangedBy:    id,
+		ChangedAt:    s.Now(),
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("diff: %s", diff)
+	}
+}

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -58,6 +58,29 @@ func (s *Store) RecipientsForEmailIDInt64(ctx context.Context, emailID int64, ar
 	return ms, nil
 }
 
+func scanRecipients(rows *sql.Rows) (ms []*Recipient, err error) {
+	for rows.Next() {
+		m := &Recipient{}
+		if err := rows.Scan(
+			&m.ID,
+			&m.Email,
+			&m.NamespaceUserID,
+			&m.NamespaceOrgID,
+		); err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	err = rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ms, nil
+}
+
 const allRecipientsForEmailIDInt64FmtStr = `
 SELECT id, email, namespace_user_id, namespace_org_id
 FROM cm_recipients
@@ -130,29 +153,6 @@ func readRecipientQuery(ctx context.Context, emailId int64, args *graphqlbackend
 		after,
 		args.First,
 	), nil
-}
-
-func scanRecipients(rows *sql.Rows) (ms []*Recipient, err error) {
-	for rows.Next() {
-		m := &Recipient{}
-		if err := rows.Scan(
-			&m.ID,
-			&m.Email,
-			&m.NamespaceUserID,
-			&m.NamespaceOrgID,
-		); err != nil {
-			return nil, err
-		}
-		ms = append(ms, m)
-	}
-	err = rows.Close()
-	if err != nil {
-		return nil, err
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-	return ms, nil
 }
 
 func nilOrInt32(n int32) *int32 {

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -1,0 +1,36 @@
+package codemonitors
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAllRecipientsForEmailIDInt64(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t)
+	_, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var (
+		wantEmailID     int64 = 1
+		wantRecipientID int64 = 1
+	)
+	rs, err := s.AllRecipientsForEmailIDInt64(ctx, wantEmailID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(rs, []*Recipient{{
+		ID:              wantRecipientID,
+		Email:           wantEmailID,
+		NamespaceUserID: &id,
+		NamespaceOrgID:  nil,
+	}}); diff != "" {
+		t.Fatalf("diff: %s", diff)
+	}
+}

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -14,46 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
-type TriggerJobs struct {
-	Id    int
-	Query int64
-
-	// The query we ran including after: filter.
-	QueryString *string
-
-	// Whether we got any results.
-	Results    *bool
-	NumResults *int
-
-	// Fields demanded for any dbworker.
-	State          string
-	FailureMessage *string
-	StartedAt      *time.Time
-	FinishedAt     *time.Time
-	ProcessAfter   *time.Time
-	NumResets      int32
-	NumFailures    int32
-	LogContents    *string
-}
-
 func (r *TriggerJobs) RecordID() int {
 	return r.Id
-}
-
-var TriggerJobsColumns = []*sqlf.Query{
-	sqlf.Sprintf("cm_trigger_jobs.id"),
-	sqlf.Sprintf("cm_trigger_jobs.query"),
-	sqlf.Sprintf("cm_trigger_jobs.query_string"),
-	sqlf.Sprintf("cm_trigger_jobs.results"),
-	sqlf.Sprintf("cm_trigger_jobs.num_results"),
-	sqlf.Sprintf("cm_trigger_jobs.state"),
-	sqlf.Sprintf("cm_trigger_jobs.failure_message"),
-	sqlf.Sprintf("cm_trigger_jobs.started_at"),
-	sqlf.Sprintf("cm_trigger_jobs.finished_at"),
-	sqlf.Sprintf("cm_trigger_jobs.process_after"),
-	sqlf.Sprintf("cm_trigger_jobs.num_resets"),
-	sqlf.Sprintf("cm_trigger_jobs.num_failures"),
-	sqlf.Sprintf("cm_trigger_jobs.log_contents"),
 }
 
 const enqueueTriggerQueryFmtStr = `
@@ -126,6 +88,28 @@ func (s *Store) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, arg
 	return scanTriggerJobs(rows, err)
 }
 
+type TriggerJobs struct {
+	Id    int
+	Query int64
+
+	// The query we ran including after: filter.
+	QueryString *string
+
+	// Whether we got any results.
+	Results    *bool
+	NumResults *int
+
+	// Fields demanded for any dbworker.
+	State          string
+	FailureMessage *string
+	StartedAt      *time.Time
+	FinishedAt     *time.Time
+	ProcessAfter   *time.Time
+	NumResets      int32
+	NumFailures    int32
+	LogContents    *string
+}
+
 func ScanTriggerJobs(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	records, err := scanTriggerJobs(rows, err)
 	if err != nil {
@@ -169,6 +153,22 @@ func scanTriggerJobs(rows *sql.Rows, err error) ([]*TriggerJobs, error) {
 		return nil, err
 	}
 	return ms, nil
+}
+
+var TriggerJobsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_trigger_jobs.id"),
+	sqlf.Sprintf("cm_trigger_jobs.query"),
+	sqlf.Sprintf("cm_trigger_jobs.query_string"),
+	sqlf.Sprintf("cm_trigger_jobs.results"),
+	sqlf.Sprintf("cm_trigger_jobs.num_results"),
+	sqlf.Sprintf("cm_trigger_jobs.state"),
+	sqlf.Sprintf("cm_trigger_jobs.failure_message"),
+	sqlf.Sprintf("cm_trigger_jobs.started_at"),
+	sqlf.Sprintf("cm_trigger_jobs.finished_at"),
+	sqlf.Sprintf("cm_trigger_jobs.process_after"),
+	sqlf.Sprintf("cm_trigger_jobs.num_resets"),
+	sqlf.Sprintf("cm_trigger_jobs.num_failures"),
+	sqlf.Sprintf("cm_trigger_jobs.log_contents"),
 }
 
 func unmarshalAfter(after *string) (int64, error) {

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -14,6 +14,48 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
+type TriggerJobs struct {
+	Id    int
+	Query int64
+
+	// The query we ran including after: filter.
+	QueryString *string
+
+	// Whether we got any results.
+	Results    *bool
+	NumResults *int
+
+	// Fields demanded for any dbworker.
+	State          string
+	FailureMessage *string
+	StartedAt      *time.Time
+	FinishedAt     *time.Time
+	ProcessAfter   *time.Time
+	NumResets      int32
+	NumFailures    int32
+	LogContents    *string
+}
+
+func (r *TriggerJobs) RecordID() int {
+	return r.Id
+}
+
+var TriggerJobsColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_trigger_jobs.id"),
+	sqlf.Sprintf("cm_trigger_jobs.query"),
+	sqlf.Sprintf("cm_trigger_jobs.query_string"),
+	sqlf.Sprintf("cm_trigger_jobs.results"),
+	sqlf.Sprintf("cm_trigger_jobs.num_results"),
+	sqlf.Sprintf("cm_trigger_jobs.state"),
+	sqlf.Sprintf("cm_trigger_jobs.failure_message"),
+	sqlf.Sprintf("cm_trigger_jobs.started_at"),
+	sqlf.Sprintf("cm_trigger_jobs.finished_at"),
+	sqlf.Sprintf("cm_trigger_jobs.process_after"),
+	sqlf.Sprintf("cm_trigger_jobs.num_resets"),
+	sqlf.Sprintf("cm_trigger_jobs.num_failures"),
+	sqlf.Sprintf("cm_trigger_jobs.log_contents"),
+}
+
 const enqueueTriggerQueryFmtStr = `
 WITH due AS (
     SELECT cm_queries.id as id
@@ -27,7 +69,7 @@ busy AS (
     OR state = 'processing'
 )
 INSERT INTO cm_trigger_jobs (query)
-SELECT id from due EXCEPT SELECT id from busy
+SELECT id from due EXCEPT SELECT id from busy ORDER BY id
 `
 
 func (s *Store) EnqueueTriggerQueries(ctx context.Context) (err error) {
@@ -37,12 +79,13 @@ func (s *Store) EnqueueTriggerQueries(ctx context.Context) (err error) {
 const logSearchFmtStr = `
 UPDATE cm_trigger_jobs
 SET query_string = %s,
-	results = %s
+	results = %s,
+	num_results = %s
 WHERE id = %s
 `
 
-func (s *Store) LogSearch(ctx context.Context, queryString string, results bool, recordID int) error {
-	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, results, recordID))
+func (s *Store) LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error {
+	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, numResults > 0, numResults, recordID))
 }
 
 const deleteObsoleteJobLogsFmtStr = `
@@ -58,7 +101,7 @@ func (s *Store) DeleteObsoleteJobLogs(ctx context.Context) error {
 }
 
 const getEventsForQueryIDInt64FmtStr = `
-SELECT id, query, query_string, results, state, failure_message, started_at, finished_at, process_after, num_resets, num_failures, log_contents
+SELECT id, query, query_string, results, num_results, state, failure_message, started_at, finished_at, process_after, num_resets, num_failures, log_contents
 FROM cm_trigger_jobs
 WHERE ((state = 'completed' AND results IS TRUE) OR (state != 'completed'))
 AND query = %s
@@ -83,31 +126,6 @@ func (s *Store) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, arg
 	return scanTriggerJobs(rows, err)
 }
 
-type TriggerJobs struct {
-	Id    int
-	Query int64
-
-	// The query we ran including after: filter.
-	QueryString *string
-
-	// Whether we got any results.
-	Results *bool
-
-	// Fields demanded for any dbworker.
-	State          string
-	FailureMessage *string
-	StartedAt      *time.Time
-	FinishedAt     *time.Time
-	ProcessAfter   *time.Time
-	NumResets      int32
-	NumFailures    int32
-	LogContents    *string
-}
-
-func (r *TriggerJobs) RecordID() int {
-	return r.Id
-}
-
 func ScanTriggerJobs(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	records, err := scanTriggerJobs(rows, err)
 	if err != nil {
@@ -129,6 +147,7 @@ func scanTriggerJobs(rows *sql.Rows, err error) ([]*TriggerJobs, error) {
 			&m.Query,
 			&m.QueryString,
 			&m.Results,
+			&m.NumResults,
 			&m.State,
 			&m.FailureMessage,
 			&m.StartedAt,
@@ -150,21 +169,6 @@ func scanTriggerJobs(rows *sql.Rows, err error) ([]*TriggerJobs, error) {
 		return nil, err
 	}
 	return ms, nil
-}
-
-var TriggerJobsColumns = []*sqlf.Query{
-	sqlf.Sprintf("cm_trigger_jobs.id"),
-	sqlf.Sprintf("cm_trigger_jobs.query"),
-	sqlf.Sprintf("cm_trigger_jobs.query_string"),
-	sqlf.Sprintf("cm_trigger_jobs.results"),
-	sqlf.Sprintf("cm_trigger_jobs.state"),
-	sqlf.Sprintf("cm_trigger_jobs.failure_message"),
-	sqlf.Sprintf("cm_trigger_jobs.started_at"),
-	sqlf.Sprintf("cm_trigger_jobs.finished_at"),
-	sqlf.Sprintf("cm_trigger_jobs.process_after"),
-	sqlf.Sprintf("cm_trigger_jobs.num_resets"),
-	sqlf.Sprintf("cm_trigger_jobs.num_failures"),
-	sqlf.Sprintf("cm_trigger_jobs.log_contents"),
 }
 
 func unmarshalAfter(after *string) (int64, error) {


### PR DESCRIPTION
To finally send emails, the store needs to provide a few more methods. 
The challenge is mostly to aggregate data from various tables which are all
linked by foreign keys.

I used the opportunity of previous refactorings to add several
tests to the store.

A follow-up PR will contain the changes to the background workers that
will call the methods introduced here.

Key additions are in `action_jobs.go`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
