### PR TITLE
search: add email package to code monitors

### DIFF
--- a/enterprise/internal/codemonitors/background/email/email.go
+++ b/enterprise/internal/codemonitors/background/email/email.go
@@ -33,19 +33,19 @@ func canSendEmail(ctx context.Context) error {
 }
 
 type TemplateDataNewSearchResults struct {
-	Priority        string
-	CodeMonitorURL  string
-	SearchURL       string
-	Description     string
-	NumberOfResults string
+	Priority                  string
+	CodeMonitorURL            string
+	SearchURL                 string
+	Description               string
+	NumberOfResultsWithDetail string
 }
 
-func NewTemplateDataForNewSearchResults(monitorDescription string, queryString string, email *codemonitors.MonitorEmail, results int) (d *TemplateDataNewSearchResults, err error) {
+func NewTemplateDataForNewSearchResults(monitorDescription string, queryString string, email *codemonitors.MonitorEmail, numResults int) (d *TemplateDataNewSearchResults, err error) {
 	var (
-		searchURL       string
-		codeMonitorURL  string
-		priority        string
-		numberOfResults string
+		searchURL                 string
+		codeMonitorURL            string
+		priority                  string
+		numberOfResultsWithDetail string
 	)
 	searchURL, err = getSearchURL(queryString, utmSourceEmail)
 	if err != nil {
@@ -63,18 +63,18 @@ func NewTemplateDataForNewSearchResults(monitorDescription string, queryString s
 		priority = "New"
 	}
 
-	if results == 1 {
-		numberOfResults = fmt.Sprintf("There was %d new search result for your query", results)
+	if numResults == 1 {
+		numberOfResultsWithDetail = fmt.Sprintf("There was %d new search result for your query", numResults)
 	} else {
-		numberOfResults = fmt.Sprintf("There were %d new search results for your query", results)
+		numberOfResultsWithDetail = fmt.Sprintf("There were %d new search results for your query", numResults)
 	}
 
 	return &TemplateDataNewSearchResults{
-		Priority:        priority,
-		CodeMonitorURL:  codeMonitorURL,
-		SearchURL:       searchURL,
-		Description:     monitorDescription,
-		NumberOfResults: numberOfResults,
+		Priority:                  priority,
+		CodeMonitorURL:            codeMonitorURL,
+		SearchURL:                 searchURL,
+		Description:               monitorDescription,
+		NumberOfResultsWithDetail: numberOfResultsWithDetail,
 	}, nil
 
 }

--- a/enterprise/internal/codemonitors/background/email/email.go
+++ b/enterprise/internal/codemonitors/background/email/email.go
@@ -1,0 +1,137 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
+)
+
+var externalURL *url.URL
+
+const utmSourceEmail = "code-monitoring-email"
+const priorityCritical = "CRITICAL"
+
+func SendEmailForNewSearchResult(ctx context.Context, userID int32, data *TemplateDataNewSearchResults) error {
+	return sendEmail(ctx, userID, newSearchResultsEmailTemplates, data)
+}
+
+func canSendEmail(ctx context.Context) error {
+	canSendEmail, err := api.InternalClient.CanSendEmail(ctx)
+	if err != nil {
+		return fmt.Errorf("InternalClient.CanSendEmail: %w", err)
+	}
+	if !canSendEmail {
+		return fmt.Errorf("SMTP server not set in site configuration")
+	}
+	return nil
+}
+
+type TemplateDataNewSearchResults struct {
+	Priority        string
+	CodeMonitorURL  string
+	SearchURL       string
+	Description     string
+	NumberOfResults string
+}
+
+func NewTemplateDataForNewSearchResults(monitorDescription string, queryString string, email *codemonitors.MonitorEmail, results int) (d *TemplateDataNewSearchResults, err error) {
+	var (
+		searchURL       string
+		codeMonitorURL  string
+		priority        string
+		numberOfResults string
+	)
+	searchURL, err = getSearchURL(queryString, utmSourceEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	codeMonitorURL, err = getCodeMonitorURL(email.Monitor, utmSourceEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	if email.Priority == priorityCritical {
+		priority = "Critical"
+	} else {
+		priority = "New"
+	}
+
+	if results == 1 {
+		numberOfResults = fmt.Sprintf("There was %d new search result for your query", results)
+	} else {
+		numberOfResults = fmt.Sprintf("There were %d new search results for your query", results)
+	}
+
+	return &TemplateDataNewSearchResults{
+		Priority:        priority,
+		CodeMonitorURL:  codeMonitorURL,
+		SearchURL:       searchURL,
+		Description:     monitorDescription,
+		NumberOfResults: numberOfResults,
+	}, nil
+
+}
+
+func sendEmail(ctx context.Context, userID int32, template txtypes.Templates, data interface{}) error {
+	err := canSendEmail(ctx)
+	if err != nil {
+		return err
+	}
+
+	email, err := api.InternalClient.UserEmailsGetEmail(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("InternalClient.UserEmailsGetEmail for userID=%d: %w", userID, err)
+	}
+	if email == nil {
+		return fmt.Errorf("unable to send email to user ID %d with unknown email address", userID)
+	}
+
+	if err := api.InternalClient.SendEmail(ctx, txtypes.Message{
+		To:       []string{*email},
+		Template: template,
+		Data:     data,
+	}); err != nil {
+		return fmt.Errorf("InternalClient.SendEmail to email=%q userID=%d: %w", *email, userID, err)
+	}
+	return nil
+}
+
+func getSearchURL(query, utmSource string) (string, error) {
+	return sourcegraphURL("search", query, utmSource)
+}
+
+func getCodeMonitorURL(monitorID int64, utmSource string) (string, error) {
+	return sourcegraphURL(fmt.Sprintf("code-monitoring/%s", relay.MarshalID("FIXME", monitorID)), "", utmSource)
+}
+
+func sourcegraphURL(path, query, utmSource string) (string, error) {
+	if externalURL == nil {
+		// Determine the external URL.
+		externalURLStr, err := api.InternalClient.ExternalURL(context.Background())
+		if err != nil {
+			return "", fmt.Errorf("failed to get ExternalURL: %w", err)
+		}
+		externalURL, err = url.Parse(externalURLStr)
+		if err != nil {
+
+			return "", fmt.Errorf("failed to get ExternalURL: %w", err)
+		}
+	}
+
+	// Construct URL to the search query.
+	u := externalURL.ResolveReference(&url.URL{Path: path})
+	q := u.Query()
+	if query != "" {
+		q.Set("q", query)
+	}
+	q.Set("utm_source", utmSource)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/enterprise/internal/codemonitors/background/email/templates.go
+++ b/enterprise/internal/codemonitors/background/email/templates.go
@@ -28,7 +28,7 @@ Sourcegraph limits what information is contained in this notification.
 <html>
   <body>
     <p style="font-size: 16px; line-height: 24px">
-      Code monitoring triggered a new event:a
+      Code monitoring triggered a new event:
     </p>
     <p style="font-size: 20px; line-height: 30px; font-weight: 700">
       {{.Description}}<br />

--- a/enterprise/internal/codemonitors/background/email/templates.go
+++ b/enterprise/internal/codemonitors/background/email/templates.go
@@ -1,0 +1,54 @@
+package email
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
+)
+
+var newSearchResultsEmailTemplates = txemail.MustValidate(txtypes.Templates{
+	Subject: `[{{.Priority}} event] {{.Description}}`,
+	Text: `
+Code monitoring triggered a new event:
+
+{{.Description}}
+{{.NumberOfResults}}
+
+View search on Sourcegraph {{.SearchURL}}
+	
+__
+You are receiving this notification because you are a recipient on a code monitor.
+
+View code monitor: {{.CodeMonitorURL}}
+
+Search results may contain confidential data. To protect your privacy and security,
+Sourcegraph limits what information is contained in this notification.
+`,
+	HTML: `
+<html>
+<body>
+<span style="font-size:16px;line-height:24px;font-weight:400">Code monitoring triggered a new event:</span>
+<br>
+<br>
+<span style="font-size:20px;line-height:30px;font-weight:700">{{.Description}}</span>
+<br>
+<span style="font-size:16px;line-height:24px;font-weight:400">{{.NumberOfResults}}</span>
+<br>
+<br>
+<span style="font-size:16px;line-height:24px;font-weight:400"><a href="{{.SearchURL}}">View search on Sourcegraph</a></span><br>
+<br>
+<br>
+__
+<br>
+<span style="font-size:14px;line-height:24px;font-weight:400">You are receiving this notification because you are a recipient on a code monitor.</span>
+<br>
+<br>
+<span style="font-size:14px;line-height:24px;font-weight:400"><a href="{{.CodeMonitorURL}}">View code monitor</a>
+<br>
+<br>
+<span style="font-size:12px;line-height:24px;font-weight:400">Search results may contain confidential data. To protect your privacy and security,
+<br>
+Sourcegraph limits what information is contained in this notification.<span>
+</body>
+</html>
+`,
+})

--- a/enterprise/internal/codemonitors/background/email/templates.go
+++ b/enterprise/internal/codemonitors/background/email/templates.go
@@ -11,7 +11,7 @@ var newSearchResultsEmailTemplates = txemail.MustValidate(txtypes.Templates{
 Code monitoring triggered a new event:
 
 {{.Description}}
-{{.NumberOfResults}}
+{{.NumberOfResultsWithDetail}}
 
 View search on Sourcegraph {{.SearchURL}}
 	
@@ -24,31 +24,37 @@ Search results may contain confidential data. To protect your privacy and securi
 Sourcegraph limits what information is contained in this notification.
 `,
 	HTML: `
+<!DOCTYPE html>
 <html>
-<body>
-<span style="font-size:16px;line-height:24px;font-weight:400">Code monitoring triggered a new event:</span>
-<br>
-<br>
-<span style="font-size:20px;line-height:30px;font-weight:700">{{.Description}}</span>
-<br>
-<span style="font-size:16px;line-height:24px;font-weight:400">{{.NumberOfResults}}</span>
-<br>
-<br>
-<span style="font-size:16px;line-height:24px;font-weight:400"><a href="{{.SearchURL}}">View search on Sourcegraph</a></span><br>
-<br>
-<br>
-__
-<br>
-<span style="font-size:14px;line-height:24px;font-weight:400">You are receiving this notification because you are a recipient on a code monitor.</span>
-<br>
-<br>
-<span style="font-size:14px;line-height:24px;font-weight:400"><a href="{{.CodeMonitorURL}}">View code monitor</a>
-<br>
-<br>
-<span style="font-size:12px;line-height:24px;font-weight:400">Search results may contain confidential data. To protect your privacy and security,
-<br>
-Sourcegraph limits what information is contained in this notification.<span>
-</body>
+  <body>
+    <p style="font-size: 16px; line-height: 24px">
+      Code monitoring triggered a new event:a
+    </p>
+    <p style="font-size: 20px; line-height: 30px; font-weight: 700">
+      {{.Description}}<br />
+      <span style="font-size: 16px; line-height: 24px"
+        >{{.NumberOfResultsWithDetail}}</span
+      >
+    </p>
+    <p style="font-size: 16px; line-height: 24px">
+      <a href="{{.SearchURL}}">View search on Sourcegraph</a>
+    </p>
+    <br />
+    <br />
+    __
+    <p style="font-size: 14px; line-height: 24px">
+      You are receiving this notification because you are a recipient on a code
+      monitor.
+    </p>
+    <p style="font-size: 14px; line-height: 24px">
+      <a href="{{.CodeMonitorURL}}">View code monitor</a>
+    </p>
+    <p style="font-size: 12px; line-height: 24px">
+      Search results may contain confidential data. To protect your privacy and
+      security, Sourcegraph limits what information is contained in this
+      notification.
+    </p>
+  </body>
 </html>
 `,
 })


### PR DESCRIPTION
stacked on top of #16433

I copied `email.go` from query-runner to code monitors,
with the following adjustments:
- delete unused code
- extract into separate package
- wrap `sendEmail` in `SendEmailForNewSearchResult` to make it harder to send broken emails
- update the email template

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
