### PR TITLE
Faster campaigns tests, part 1: the low-hanging fruit.

### DIFF
--- a/enterprise/internal/campaigns/fake_store_test.go
+++ b/enterprise/internal/campaigns/fake_store_test.go
@@ -1,0 +1,27 @@
+package campaigns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+type mockMissingErr struct {
+	mockName string
+}
+
+func (e mockMissingErr) Error() string {
+	return fmt.Sprintf("FakeStore is missing mock for %s", e.mockName)
+}
+
+type FakeStore struct {
+	GetCampaignMock func(context.Context, GetCampaignOpts) (*campaigns.Campaign, error)
+}
+
+func (fs *FakeStore) GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaigns.Campaign, error) {
+	if fs.GetCampaignMock != nil {
+		return fs.GetCampaignMock(ctx, opts)
+	}
+	return nil, mockMissingErr{"GetCampaign"}
+}

--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
@@ -20,23 +20,22 @@ func TestIntegration(t *testing.T) {
 	t.Parallel()
 
 	dbtesting.SetupGlobalTestDB(t)
-	db := dbtest.NewDB(t, *dsn)
 
-	userID := insertTestUser(t, db)
+	userID := insertTestUser(t, dbconn.Global)
 
 	t.Run("Store", func(t *testing.T) {
-		t.Run("Campaigns", storeTest(db, testStoreCampaigns))
-		t.Run("Changesets", storeTest(db, testStoreChangesets))
-		t.Run("ChangesetEvents", storeTest(db, testStoreChangesetEvents))
-		t.Run("ListChangesetSyncData", storeTest(db, testStoreListChangesetSyncData))
-		t.Run("CampaignSpecs", storeTest(db, testStoreCampaignSpecs))
-		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
-		t.Run("CodeHosts", storeTest(db, testStoreCodeHost))
+		t.Run("Campaigns", storeTest(dbconn.Global, testStoreCampaigns))
+		t.Run("Changesets", storeTest(dbconn.Global, testStoreChangesets))
+		t.Run("ChangesetEvents", storeTest(dbconn.Global, testStoreChangesetEvents))
+		t.Run("ListChangesetSyncData", storeTest(dbconn.Global, testStoreListChangesetSyncData))
+		t.Run("CampaignSpecs", storeTest(dbconn.Global, testStoreCampaignSpecs))
+		t.Run("ChangesetSpecs", storeTest(dbconn.Global, testStoreChangesetSpecs))
+		t.Run("CodeHosts", storeTest(dbconn.Global, testStoreCodeHost))
 	})
 
-	t.Run("GitHubWebhook", testGitHubWebhook(db, userID))
-	t.Run("BitbucketWebhook", testBitbucketWebhook(db, userID))
-	t.Run("GitLabWebhook", testGitLabWebhook(db, userID))
+	t.Run("GitHubWebhook", testGitHubWebhook(dbconn.Global, userID))
+	t.Run("BitbucketWebhook", testBitbucketWebhook(dbconn.Global, userID))
+	t.Run("GitLabWebhook", testGitLabWebhook(dbconn.Global, userID))
 }
 
 func truncateTables(t *testing.T, db *sql.DB, tables ...string) {

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -868,7 +868,11 @@ func loadExternalService(ctx context.Context, reposStore RepoStore, repo *repos.
 	return externalService, nil
 }
 
-func loadCampaign(ctx context.Context, tx *Store, id int64) (*campaigns.Campaign, error) {
+type getCampaigner interface {
+	GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaigns.Campaign, error)
+}
+
+func loadCampaign(ctx context.Context, tx getCampaigner, id int64) (*campaigns.Campaign, error) {
 	if id == 0 {
 		return nil, errors.New("changeset has no owning campaign")
 	}
@@ -912,7 +916,7 @@ func loadUserCredential(ctx context.Context, userID int32, repo *repos.Repo) (*d
 	})
 }
 
-func decorateChangesetBody(ctx context.Context, tx *Store, cs *repos.Changeset) error {
+func decorateChangesetBody(ctx context.Context, tx getCampaigner, cs *repos.Changeset) error {
 	campaign, err := loadCampaign(ctx, tx, cs.OwnedByCampaignID)
 	if err != nil {
 		return errors.Wrap(err, "failed to load campaign")

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -473,6 +473,7 @@ func TestUserDeleteCascades(t *testing.T) {
 		t.Skip()
 	}
 
+	// Why not the global one?
 	db := dbtest.NewDB(t, *dsn)
 	orgID := insertTestOrg(t, db)
 	userID := insertTestUser(t, db)

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
 func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock clock) {
@@ -473,12 +474,12 @@ func TestUserDeleteCascades(t *testing.T) {
 		t.Skip()
 	}
 
-	// Why not the global one?
-	db := dbtest.NewDB(t, *dsn)
-	orgID := insertTestOrg(t, db)
-	userID := insertTestUser(t, db)
+	dbtesting.SetupGlobalTestDB(t)
 
-	t.Run("user delete", storeTest(db, func(t *testing.T, ctx context.Context, store *Store, rs repos.Store, clock clock) {
+	orgID := insertTestOrg(t, dbconn.Global)
+	userID := insertTestUser(t, dbconn.Global)
+
+	t.Run("user delete", storeTest(dbconn.Global, func(t *testing.T, ctx context.Context, store *Store, rs repos.Store, clock clock) {
 		// Set up two campaigns and specs: one in the user's namespace (which
 		// should be deleted when the user is hard deleted), and one that is
 		// merely created by the user (which should remain).


### PR DESCRIPTION
This improves on the test times reported here https://github.com/sourcegraph/sourcegraph/issues/16320#issuecomment-738681917 by **3-4 seconds**.

Before:

```
go test ./enterprise/internal/campaigns -count=1
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        15.346s
```

After:

```
go test ./enterprise/internal/campaigns -count=1
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        12.438s
```

Speed bump is relatively stable.

---

What's in here:

* Rewriting one test to not use the database by introducing a tiny `FakeStore` that we could extend for other methods to inject a subset of the real `*Store`.
* **Big one**: instead of calling `dbtest.NewDB` (twice!) to create completely new test databases (as in: `CREATE DATABASE`-new) we only use `dbconn.Global`. That means we only need to create the "setup test database" cost (roughly ~3s) once when running tests.