### PR TITLE
Faster campaigns tests, part 2: determine plan without a database.

### DIFF
--- a/enterprise/internal/campaigns/fake_store_test.go
+++ b/enterprise/internal/campaigns/fake_store_test.go
@@ -1,0 +1,27 @@
+package campaigns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+type mockMissingErr struct {
+	mockName string
+}
+
+func (e mockMissingErr) Error() string {
+	return fmt.Sprintf("FakeStore is missing mock for %s", e.mockName)
+}
+
+type FakeStore struct {
+	GetCampaignMock func(context.Context, GetCampaignOpts) (*campaigns.Campaign, error)
+}
+
+func (fs *FakeStore) GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaigns.Campaign, error) {
+	if fs.GetCampaignMock != nil {
+		return fs.GetCampaignMock(ctx, opts)
+	}
+	return nil, mockMissingErr{"GetCampaign"}
+}

--- a/enterprise/internal/campaigns/integration_test.go
+++ b/enterprise/internal/campaigns/integration_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
@@ -20,23 +20,22 @@ func TestIntegration(t *testing.T) {
 	t.Parallel()
 
 	dbtesting.SetupGlobalTestDB(t)
-	db := dbtest.NewDB(t, *dsn)
 
-	userID := insertTestUser(t, db)
+	userID := insertTestUser(t, dbconn.Global)
 
 	t.Run("Store", func(t *testing.T) {
-		t.Run("Campaigns", storeTest(db, testStoreCampaigns))
-		t.Run("Changesets", storeTest(db, testStoreChangesets))
-		t.Run("ChangesetEvents", storeTest(db, testStoreChangesetEvents))
-		t.Run("ListChangesetSyncData", storeTest(db, testStoreListChangesetSyncData))
-		t.Run("CampaignSpecs", storeTest(db, testStoreCampaignSpecs))
-		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
-		t.Run("CodeHosts", storeTest(db, testStoreCodeHost))
+		t.Run("Campaigns", storeTest(dbconn.Global, testStoreCampaigns))
+		t.Run("Changesets", storeTest(dbconn.Global, testStoreChangesets))
+		t.Run("ChangesetEvents", storeTest(dbconn.Global, testStoreChangesetEvents))
+		t.Run("ListChangesetSyncData", storeTest(dbconn.Global, testStoreListChangesetSyncData))
+		t.Run("CampaignSpecs", storeTest(dbconn.Global, testStoreCampaignSpecs))
+		t.Run("ChangesetSpecs", storeTest(dbconn.Global, testStoreChangesetSpecs))
+		t.Run("CodeHosts", storeTest(dbconn.Global, testStoreCodeHost))
 	})
 
-	t.Run("GitHubWebhook", testGitHubWebhook(db, userID))
-	t.Run("BitbucketWebhook", testBitbucketWebhook(db, userID))
-	t.Run("GitLabWebhook", testGitLabWebhook(db, userID))
+	t.Run("GitHubWebhook", testGitHubWebhook(dbconn.Global, userID))
+	t.Run("BitbucketWebhook", testBitbucketWebhook(dbconn.Global, userID))
+	t.Run("GitLabWebhook", testGitLabWebhook(dbconn.Global, userID))
 }
 
 func truncateTables(t *testing.T, db *sql.DB, tables ...string) {

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -868,7 +868,11 @@ func loadExternalService(ctx context.Context, reposStore RepoStore, repo *repos.
 	return externalService, nil
 }
 
-func loadCampaign(ctx context.Context, tx *Store, id int64) (*campaigns.Campaign, error) {
+type getCampaigner interface {
+	GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaigns.Campaign, error)
+}
+
+func loadCampaign(ctx context.Context, tx getCampaigner, id int64) (*campaigns.Campaign, error) {
 	if id == 0 {
 		return nil, errors.New("changeset has no owning campaign")
 	}
@@ -912,7 +916,7 @@ func loadUserCredential(ctx context.Context, userID int32, repo *repos.Repo) (*d
 	})
 }
 
-func decorateChangesetBody(ctx context.Context, tx *Store, cs *repos.Changeset) error {
+func decorateChangesetBody(ctx context.Context, tx getCampaigner, cs *repos.Changeset) error {
 	campaign, err := loadCampaign(ctx, tx, cs.OwnedByCampaignID)
 	if err != nil {
 		return errors.Wrap(err, "failed to load campaign")

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -473,6 +473,7 @@ func TestUserDeleteCascades(t *testing.T) {
 		t.Skip()
 	}
 
+	// Why not the global one?
 	db := dbtest.NewDB(t, *dsn)
 	orgID := insertTestOrg(t, db)
 	userID := insertTestUser(t, db)

--- a/enterprise/internal/campaigns/store_campaigns_test.go
+++ b/enterprise/internal/campaigns/store_campaigns_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repos"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	cmpgn "github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 )
 
 func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock clock) {
@@ -473,12 +474,12 @@ func TestUserDeleteCascades(t *testing.T) {
 		t.Skip()
 	}
 
-	// Why not the global one?
-	db := dbtest.NewDB(t, *dsn)
-	orgID := insertTestOrg(t, db)
-	userID := insertTestUser(t, db)
+	dbtesting.SetupGlobalTestDB(t)
 
-	t.Run("user delete", storeTest(db, func(t *testing.T, ctx context.Context, store *Store, rs repos.Store, clock clock) {
+	orgID := insertTestOrg(t, dbconn.Global)
+	userID := insertTestUser(t, dbconn.Global)
+
+	t.Run("user delete", storeTest(dbconn.Global, func(t *testing.T, ctx context.Context, store *Store, rs repos.Store, clock clock) {
 		// Set up two campaigns and specs: one in the user's namespace (which
 		// should be deleted when the user is hard deleted), and one that is
 		// merely created by the user (which should remain).


### PR DESCRIPTION
Stacked on top of https://github.com/sourcegraph/sourcegraph/pull/16441/files.

We don't need the database since everything is passed in.

### on `main`

```
$ for i in $(seq 0 5); do time go test ./enterprise/internal/campaigns -count=1; done
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        15.346s
go test ./enterprise/internal/campaigns -count=1  5.63s user 2.71s system 46% cpu 17.913 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        15.995s
go test ./enterprise/internal/campaigns -count=1  5.64s user 2.54s system 44% cpu 18.545 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        16.017s
go test ./enterprise/internal/campaigns -count=1  5.47s user 2.68s system 43% cpu 18.555 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        15.430s
go test ./enterprise/internal/campaigns -count=1  5.47s user 2.61s system 44% cpu 18.008 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        15.261s
go test ./enterprise/internal/campaigns -count=1  5.65s user 2.57s system 46% cpu 17.814 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        15.367s
go test ./enterprise/internal/campaigns -count=1  5.58s user 2.50s system 45% cpu 17.834 total
```

### after the changes in part 1 and part 2
```
$ for i in $(seq 0 5); do time go test ./enterprise/internal/campaigns -count=1; done
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        11.493s
go test ./enterprise/internal/campaigns -count=1  5.44s user 2.52s system 56% cpu 14.052 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        11.253s
go test ./enterprise/internal/campaigns -count=1  5.58s user 2.55s system 59% cpu 13.735 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        10.968s
go test ./enterprise/internal/campaigns -count=1  5.49s user 2.61s system 60% cpu 13.479 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        10.464s
go test ./enterprise/internal/campaigns -count=1  5.55s user 2.57s system 62% cpu 13.041 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        9.160s
go test ./enterprise/internal/campaigns -count=1  5.48s user 2.63s system 68% cpu 11.818 total
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns        10.835s

```