### PR TITLE
remove timeouts from gitserver http server

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -110,10 +110,8 @@ func main() {
 	}
 	addr := net.JoinHostPort(host, port)
 	srv := &http.Server{
-		ReadTimeout:  75 * time.Second,
-		WriteTimeout: 10 * time.Minute, // set a high write timeout as we may serve large archives
-		Addr:         addr,
-		Handler:      handler,
+		Addr:    addr,
+		Handler: handler,
 	}
 	log15.Info("git-server: listening", "addr", srv.Addr)
 


### PR DESCRIPTION
ref https://github.com/sourcegraph/sourcegraph/pull/16396


from @keegancsmith:
>keegancsmith 20 hours ago Member
@arussellsaw these numbers are too low. For example with git protocol v2 there is bidirectional communication while cloning. We may need more than 75s. Additionally 10m is too low. For example we have a timeout of 1h for running git archive (see longGitCommandTimeout). This is done intentionally for monorepos. Can you adjust this to be much higher. Alternatively, do we have any evidence this will help, and instead we remove these and rely on per request use of ctx?

Considering the real upper bound on connection timeouts is so high and i don't have a strong idea of the ideal numbers here i figured i should remove this. The goroutine leaks are only a side effect of the CPU throttling problem, rather than the actual cause, so i'd rather not be breaking things for no reason.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
