### PR TITLE
repo-updater: Don't delete repos when rate limit exceeded

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -538,14 +538,16 @@ func (s *Server) remoteRepoSync(ctx context.Context, codehost *extsvc.CodeHost, 
 					ErrorNotFound: true,
 				}, nil
 			}
-			if isUnauthorized(err) {
-				return &protocol.RepoLookupResult{
-					ErrorUnauthorized: true,
-				}, nil
-			}
+			// This check needs to come before isUnauthorized since GitHub returns 403 when
+			// rate limit has been exceeded.
 			if isTemporarilyUnavailable(err) {
 				return &protocol.RepoLookupResult{
 					ErrorTemporarilyUnavailable: true,
+				}, nil
+			}
+			if isUnauthorized(err) {
+				return &protocol.RepoLookupResult{
+					ErrorUnauthorized: true,
 				}, nil
 			}
 			return nil, err

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -137,6 +137,9 @@ func IsNotFound(err error) bool {
 // IsRateLimitExceeded reports whether err is a GitHub API error reporting that the GitHub API rate
 // limit was exceeded.
 func IsRateLimitExceeded(err error) bool {
+	if err == errInternalRateLimitExceeded {
+		return true
+	}
 	if e, ok := errors.Cause(err).(*APIError); ok {
 		return strings.Contains(e.Message, "API rate limit exceeded") || strings.Contains(e.DocumentationURL, "#rate-limiting")
 	}
@@ -154,6 +157,8 @@ func IsRateLimitExceeded(err error) bool {
 	}
 	return false
 }
+
+var errInternalRateLimitExceeded = errors.New("internal rate limit exceeded")
 
 // ErrIncompleteResults is returned when the GitHub Search API returns an `incomplete_results: true` field in their response
 var ErrIncompleteResults = errors.New("github repository search returned incomplete results. This is an ephemeral error from GitHub, so does not indicate a problem with your configuration. See https://developer.github.com/changes/2014-04-07-understanding-search-results-and-potential-timeouts/ for more information")

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -134,7 +134,7 @@ func (c *V3Client) requestGet(ctx context.Context, requestURI string, result int
 
 	err = c.rateLimit.Wait(ctx)
 	if err != nil {
-		return errors.Wrap(err, "rate limit")
+		return errInternalRateLimitExceeded
 	}
 
 	return doRequest(ctx, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, result)


### PR DESCRIPTION
When we perform a repoLookup on sourcegraph.com and discover that we are
not able to access a public repo we delete that repo as we assume that
it is no longer public. Unfortunately, the GitHub rest API returns a 403
code when rate limit has been exhausted.

To fix this we first check for the special case of rate limit error
before falling back check if we have a 403 or 401 error.

This change also recognises when we internally rate limit requests.

Closes: https://github.com/sourcegraph/sourcegraph/issues/16393
