### PR TITLE
Code monitoring: Add manage page functionality

### DIFF
--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -1,3 +1,115 @@
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import * as H from 'history'
 import * as React from 'react'
+import { RouteComponentProps } from 'react-router'
+import { Observable } from 'rxjs'
+import { startWith, catchError, tap } from 'rxjs/operators'
+import { CodeMonitoringProps } from '.'
+import { Scalars } from '../../../../shared/src/graphql-operations'
+import { asError, isErrorLike } from '../../../../shared/src/util/errors'
+import { useObservable } from '../../../../shared/src/util/useObservable'
+import { AuthenticatedUser } from '../../auth'
+import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
+import { PageHeader } from '../../components/PageHeader'
+import { PageTitle } from '../../components/PageTitle'
+import { CodeMonitorFields, MonitorEmailPriority } from '../../graphql-operations'
+import { fetchCodeMonitor, updateCodeMonitor } from './backend'
+import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-export const ManageCodeMonitorPage: React.FunctionComponent<{}> = () => <div>Hello world!</div>
+export interface ManageCodeMonitorPageProps
+    extends RouteComponentProps<{ id: Scalars['ID'] }>,
+        BreadcrumbsProps,
+        BreadcrumbSetters,
+        CodeMonitoringProps {
+    authenticatedUser: AuthenticatedUser
+    location: H.Location
+    history: H.History
+}
+
+export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPageProps> = props => {
+    const LOADING = 'loading' as const
+
+    const [codeMonitorState, setCodeMonitorState] = React.useState<CodeMonitorFields>({
+        id: '',
+        description: '',
+        enabled: true,
+        trigger: { id: '', query: '' },
+        actions: { nodes: [{ id: '', enabled: true, recipients: { nodes: [{ id: props.authenticatedUser.id }] } }] },
+    })
+
+    const codeMonitorOrError = useObservable(
+        React.useMemo(
+            () =>
+                fetchCodeMonitor(props.match.params.id).pipe(
+                    tap(monitor => {
+                        if (monitor.node !== null) {
+                            setCodeMonitorState(monitor.node)
+                        }
+                    }),
+                    startWith(LOADING),
+                    catchError(error => [asError(error)])
+                ),
+            [props.match.params.id]
+        )
+    )
+
+    props.useBreadcrumb(
+        React.useMemo(
+            () => ({
+                key: 'Manage Code Monitor',
+                element: <>Manage code monitor</>,
+            }),
+            []
+        )
+    )
+
+    const updateMonitorRequest = React.useCallback(
+        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> =>
+            updateCodeMonitor(
+                {
+                    id: props.match.params.id,
+                    update: {
+                        namespace: props.authenticatedUser.id,
+                        description: codeMonitor.description,
+                        enabled: codeMonitor.enabled,
+                    },
+                },
+                { id: codeMonitor.trigger.id, update: { query: codeMonitor.trigger.query } },
+                codeMonitor.actions.nodes.map(action => ({
+                    email: {
+                        id: action.id,
+                        update: {
+                            enabled: action.enabled,
+                            priority: MonitorEmailPriority.NORMAL,
+                            recipients: [props.authenticatedUser.id],
+                            header: '',
+                        },
+                    },
+                }))
+            ),
+        [props.authenticatedUser.id, props.match.params.id]
+    )
+
+    return (
+        <div>
+            <PageTitle title="Manage code monitor" />
+            <PageHeader title="Manage code monitor" />
+            Code monitors watch your code for specific triggers and run actions in response.{' '}
+            <a href="" target="_blank" rel="noopener">
+                {/* TODO: populate link */}
+                Learn more
+            </a>
+            {codeMonitorOrError === 'loading' && <LoadingSpinner className="icon-inline" />}
+            {codeMonitorOrError && !isErrorLike(codeMonitorOrError) && codeMonitorOrError !== 'loading' && (
+                <>
+                    <CodeMonitorForm
+                        {...props}
+                        onSubmit={updateMonitorRequest}
+                        codeMonitor={codeMonitorState}
+                        submitButtonLabel="Save"
+                    />
+                </>
+            )}
+        </div>
+    )
+}

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -30,9 +30,10 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
         setShowQueryForm(show => !show)
     }, [])
 
-    const [queryState, nextQueryFieldChange, queryInputReference] = useInputValidation(
+    const [queryState, nextQueryFieldChange, queryInputReference, overrideState] = useInputValidation(
         useMemo(
             () => ({
+                initialValue: query,
                 synchronousValidators: [
                     (value: string) => {
                         const tokens = scanSearchQuery(value)
@@ -70,7 +71,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     },
                 ],
             }),
-            []
+            [query]
         )
     )
 
@@ -95,8 +96,9 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
         event => {
             event.preventDefault()
             setShowQueryForm(false)
+            overrideState({ value: query })
         },
-        [setShowQueryForm]
+        [setShowQueryForm, overrideState, query]
     )
 
     return (
@@ -162,7 +164,6 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                             <button
                                 className="btn btn-outline-secondary mr-1 test-submit-trigger"
                                 onClick={completeForm}
-                                onSubmit={completeForm}
                                 type="submit"
                                 disabled={queryState.kind !== 'VALID'}
                             >

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -11,6 +11,7 @@ import { BreadcrumbsProps, BreadcrumbSetters, Breadcrumbs } from '../../../compo
 import { lazyComponent } from '../../../util/lazyComponent'
 import { CodeMonitoringPageProps } from '../CodeMonitoringPage'
 import { CreateCodeMonitorPageProps } from '../CreateCodeMonitorPage'
+import { ManageCodeMonitorPageProps } from '../ManageCodeMonitorPage'
 
 interface Props
     extends RouteComponentProps<{}>,
@@ -34,7 +35,7 @@ const CreateCodeMonitorPage = lazyComponent<CreateCodeMonitorPageProps, 'CreateC
     'CreateCodeMonitorPage'
 )
 
-const ManageCodeMonitorPage = lazyComponent<{}, 'ManageCodeMonitorPage'>(
+const ManageCodeMonitorPage = lazyComponent<ManageCodeMonitorPageProps, 'ManageCodeMonitorPage'>(
     () => import('../ManageCodeMonitorPage'),
     'ManageCodeMonitorPage'
 )


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/16440. Adds functionality for the code monitor manage/edit page. Updates the CodeMonitorForm accept a code monitor via props to initialize the form. 

Still TODO in follow-up PRs:
- Update/factor out CSS
- Add different conditions for disabling the continue/cancel buttons on the manage page.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
