### PR TITLE
web: search: major code excerpt refactor (better testing, code structure, etc.)

### DIFF
--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -9,7 +9,7 @@ import * as React from 'react'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 import { FetchFileParameters } from '../../../../../shared/src/components/CodeExcerpt'
-import { FileMatch, IFileMatch, ILineMatch } from '../../../../../shared/src/components/FileMatch'
+import { FileLineMatch, FileMatch, LineMatch } from '../../../../../shared/src/components/FileMatch'
 import { VirtualList } from '../../../../../shared/src/components/VirtualList'
 import { SettingsCascadeProps } from '../../../../../shared/src/settings/settings'
 import { asError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/errors'
@@ -142,7 +142,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
                             key={index}
                             location={this.props.location}
                             expanded={true}
-                            result={referencesToFileMatch(uri, locationsByURI.get(uri)!)}
+                            result={referencesToFileLineMatch(uri, locationsByURI.get(uri)!)}
                             icon={this.props.icon}
                             onSelect={this.onSelect}
                             showAllMatches={true}
@@ -167,7 +167,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
     }
 }
 
-function referencesToFileMatch(uri: string, references: Badged<Location>[]): IFileMatch {
+function referencesToFileLineMatch(uri: string, references: Badged<Location>[]): FileLineMatch {
     const parsedUri = parseRepoURI(uri)
     return {
         file: {
@@ -190,7 +190,7 @@ function referencesToFileMatch(uri: string, references: Badged<Location>[]): IFi
         },
         limitHit: false,
         lineMatches: references.filter(property('range', isDefined)).map(
-            (reference): ILineMatch => ({
+            (reference): LineMatch => ({
                 preview: '',
                 limitHit: false,
                 lineNumber: reference.range.start.line,

--- a/client/shared/src/components/CodeExcerpt.test.tsx
+++ b/client/shared/src/components/CodeExcerpt.test.tsx
@@ -35,7 +35,7 @@ describe('CodeExcerpt', () => {
 
     const startLine = 0
     const endLine = 3
-    let defaultProps = {
+    const defaultProps = {
         repoName: 'github.com/golang/oauth2',
         commitID: 'e64efc72b421e893cbf63f17ba2221e7d6d0b0f3',
         filePath: '.travis.yml',
@@ -49,12 +49,12 @@ describe('CodeExcerpt', () => {
         isLightTheme: false,
         className: 'file-match__item-code-excerpt',
         fetchHighlightedFileRangeLines: () =>
-            of(HIGHLIGHTED_FILE_LINES_SIMPLE).pipe(map(x => x.slice(startLine, endLine))),
+            of(HIGHLIGHTED_FILE_LINES_SIMPLE).pipe(map(lines => lines.slice(startLine, endLine))),
     }
 
     it('renders correct number of rows', () => {
         const { container } = render(<CodeExcerpt {...defaultProps} />)
-        expect(container.querySelectorAll('.code-excerpt tr').length).toMatchInlineSnapshot(`3`)
+        expect(container.querySelectorAll('.code-excerpt tr').length).toMatchInlineSnapshot('3')
     })
 
     it('renders the line number container on each row', () => {
@@ -63,7 +63,7 @@ describe('CodeExcerpt', () => {
         // at least exist.
         const { container } = render(<CodeExcerpt {...defaultProps} />)
         const dataLines = container.querySelectorAll('[data-line]')
-        expect(dataLines.length).toMatchInlineSnapshot(`3`)
+        expect(dataLines.length).toMatchInlineSnapshot('3')
     })
 
     it('renders the code portion of each row', () => {
@@ -93,7 +93,7 @@ describe('CodeExcerpt', () => {
                 endLine={endLine}
                 highlightRanges={highlightRanges}
                 fetchHighlightedFileRangeLines={() =>
-                    of(HIGHLIGHTED_FILE_LINES).pipe(map(x => x.slice(startLine, endLine)))
+                    of(HIGHLIGHTED_FILE_LINES).pipe(map(highlights => highlights.slice(startLine, endLine)))
                 }
             />
         )
@@ -126,7 +126,7 @@ describe('CodeExcerpt', () => {
                 endLine={endLine}
                 highlightRanges={highlightRanges}
                 fetchHighlightedFileRangeLines={() =>
-                    of(HIGHLIGHTED_FILE_LINES_LONG).pipe(map(x => x.slice(startLine, endLine)))
+                    of(HIGHLIGHTED_FILE_LINES_LONG).pipe(map(highlights => highlights.slice(startLine, endLine)))
                 }
             />
         )
@@ -157,7 +157,7 @@ describe('CodeExcerpt', () => {
                 endLine={endLine}
                 highlightRanges={highlightRanges}
                 fetchHighlightedFileRangeLines={() =>
-                    of(HIGHLIGHTED_FILE_LINES_LONG).pipe(map(x => x.slice(startLine, endLine)))
+                    of(HIGHLIGHTED_FILE_LINES_LONG).pipe(map(highlights => highlights.slice(startLine, endLine)))
                 }
             />
         )

--- a/client/shared/src/components/CodeExcerpt.test.tsx
+++ b/client/shared/src/components/CodeExcerpt.test.tsx
@@ -54,7 +54,7 @@ describe('CodeExcerpt', () => {
 
     it('renders correct number of rows', () => {
         const { container } = render(<CodeExcerpt {...defaultProps} />)
-        expect(container.querySelectorAll('.code-excerpt tr').length).toMatchInlineSnapshot('3')
+        expect(container.querySelectorAll('.code-excerpt tr').length).toBe(3)
     })
 
     it('renders the line number container on each row', () => {

--- a/client/shared/src/components/CodeExcerpt.test.tsx
+++ b/client/shared/src/components/CodeExcerpt.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import _VisibilitySensor from 'react-visibility-sensor'
-import sinon from 'sinon'
 export class MockVisibilitySensor extends React.Component<{ onChange?: (isVisible: boolean) => void }> {
     constructor(props: { onChange?: (isVisible: boolean) => void }) {
         super(props)
@@ -20,21 +19,23 @@ jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children
     </>
 ))
 
-import { cleanup, getAllByText, getByText, render } from '@testing-library/react'
-import { of } from 'rxjs'
+import { cleanup, getByText, render } from '@testing-library/react'
 
 import { CodeExcerpt } from './CodeExcerpt'
 import {
     HIGHLIGHTED_FILE_LINES,
-    HIGHLIGHTED_FILE_LINES_REQUEST,
-    HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
     HIGHLIGHTED_FILE_LINES_LONG,
+    HIGHLIGHTED_FILE_LINES_SIMPLE,
 } from '../util/searchTestHelpers'
+import { of } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 describe('CodeExcerpt', () => {
     afterAll(cleanup)
 
-    const defaultProps = {
+    const startLine = 0
+    const endLine = 3
+    let defaultProps = {
         repoName: 'github.com/golang/oauth2',
         commitID: 'e64efc72b421e893cbf63f17ba2221e7d6d0b0f3',
         filePath: '.travis.yml',
@@ -43,27 +44,17 @@ describe('CodeExcerpt', () => {
             { line: 1, character: 7, highlightLength: 4 },
             { line: 2, character: 6, highlightLength: 4 },
         ],
-        lastSubsetMatchLineNumber: 2,
+        startLine,
+        endLine,
         isLightTheme: false,
         className: 'file-match__item-code-excerpt',
-        fetchHighlightedFileLines: HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
+        fetchHighlightedFileRangeLines: () =>
+            of(HIGHLIGHTED_FILE_LINES_SIMPLE).pipe(map(x => x.slice(startLine, endLine))),
     }
 
     it('renders correct number of rows', () => {
         const { container } = render(<CodeExcerpt {...defaultProps} />)
-        expect(container.querySelectorAll('.code-excerpt tr').length).toBe(4)
-    })
-
-    it('renders correct number of rows with context value as 5', () => {
-        const { container } = render(
-            <CodeExcerpt
-                {...defaultProps}
-                context={5}
-                highlightRanges={[{ line: 4, character: 1, highlightLength: 2 }]}
-                lastSubsetMatchLineNumber={4}
-            />
-        )
-        expect(container.querySelectorAll('.code-excerpt tr').length).toBe(10)
+        expect(container.querySelectorAll('.code-excerpt tr').length).toMatchInlineSnapshot(`3`)
     })
 
     it('renders the line number container on each row', () => {
@@ -72,7 +63,7 @@ describe('CodeExcerpt', () => {
         // at least exist.
         const { container } = render(<CodeExcerpt {...defaultProps} />)
         const dataLines = container.querySelectorAll('[data-line]')
-        expect(dataLines.length).toBe(4)
+        expect(dataLines.length).toMatchInlineSnapshot(`3`)
     })
 
     it('renders the code portion of each row', () => {
@@ -80,8 +71,6 @@ describe('CodeExcerpt', () => {
         expect(getByText(container, 'first of code')).toBeTruthy()
         expect(getByText(container, 'second of code')).toBeTruthy()
         expect(getByText(container, 'third of code')).toBeTruthy()
-        expect(getAllByText(container, 'line').length).toBe(3)
-        expect(getByText(container, 'fourth')).toBeTruthy()
     })
 
     it('highlights matches correctly', () => {
@@ -94,12 +83,18 @@ describe('CodeExcerpt', () => {
     })
 
     it('highlights matches correctly in syntax highlighted code blocks', () => {
-        const highlightRange = [{ line: 12, character: 7, highlightLength: 4 }]
+        const highlightRanges = [{ line: 12, character: 7, highlightLength: 4 }]
+        const startLine = 0
+        const endLine = 13
         const { container } = render(
             <CodeExcerpt
                 {...defaultProps}
-                highlightRanges={highlightRange}
-                fetchHighlightedFileLines={HIGHLIGHTED_FILE_LINES_REQUEST}
+                startLine={startLine}
+                endLine={endLine}
+                highlightRanges={highlightRanges}
+                fetchHighlightedFileRangeLines={() =>
+                    of(HIGHLIGHTED_FILE_LINES).pipe(map(x => x.slice(startLine, endLine)))
+                }
             />
         )
         const highlightedSpans = container.querySelectorAll('.selection-highlight')
@@ -109,28 +104,7 @@ describe('CodeExcerpt', () => {
         }
     })
 
-    it('does not disable the highlighting timeout', () => {
-        /*
-            Because disabling the timeout should only ever be done in response
-            to the user asking us to do so, something that we do not do for
-            code excerpts because falling back to plaintext rendering is most
-            ideal.
-        */
-        const fetchHighlightedFileLines = sinon.spy(context => of(HIGHLIGHTED_FILE_LINES))
-        const highlightRange = [{ line: 12, character: 7, highlightLength: 4 }]
-        render(
-            <CodeExcerpt
-                {...defaultProps}
-                highlightRanges={highlightRange}
-                fetchHighlightedFileLines={fetchHighlightedFileLines}
-            />
-        )
-        sinon.assert.calledOnce(fetchHighlightedFileLines)
-        sinon.assert.calledWithMatch(fetchHighlightedFileLines, { disableTimeout: false })
-    })
-
     it('displays the correct number of lines, with no highlight matches on the context lines', () => {
-        const fetchHighlightedFileLines = sinon.spy(context => of(HIGHLIGHTED_FILE_LINES_LONG))
         const highlightRanges = [
             { line: 0, character: 0, highlightLength: 1 },
             { line: 1, character: 0, highlightLength: 1 },
@@ -143,13 +117,17 @@ describe('CodeExcerpt', () => {
             { line: 17, character: 0, highlightLength: 1 },
             { line: 19, character: 0, highlightLength: 1 },
         ]
+        const startLine = 0
+        const endLine = 22
         const { container } = render(
             <CodeExcerpt
                 {...defaultProps}
-                context={2}
-                lastSubsetMatchLineNumber={20}
+                startLine={startLine}
+                endLine={endLine}
                 highlightRanges={highlightRanges}
-                fetchHighlightedFileLines={fetchHighlightedFileLines}
+                fetchHighlightedFileRangeLines={() =>
+                    of(HIGHLIGHTED_FILE_LINES_LONG).pipe(map(x => x.slice(startLine, endLine)))
+                }
             />
         )
         const rows = container.querySelectorAll('tr')
@@ -157,7 +135,6 @@ describe('CodeExcerpt', () => {
     })
 
     it('displays the correct number of lines, with matches on the context line', () => {
-        const fetchHighlightedFileLines = sinon.spy(context => of(HIGHLIGHTED_FILE_LINES_LONG))
         const highlightRanges = [
             { line: 0, character: 0, highlightLength: 1 },
             { line: 1, character: 0, highlightLength: 1 },
@@ -171,13 +148,17 @@ describe('CodeExcerpt', () => {
             { line: 19, character: 0, highlightLength: 1 },
             { line: 20, character: 0, highlightLength: 1 },
         ]
+        const startLine = 0
+        const endLine = 22
         const { container } = render(
             <CodeExcerpt
                 {...defaultProps}
-                context={2}
-                lastSubsetMatchLineNumber={19}
+                startLine={startLine}
+                endLine={endLine}
                 highlightRanges={highlightRanges}
-                fetchHighlightedFileLines={fetchHighlightedFileLines}
+                fetchHighlightedFileRangeLines={() =>
+                    of(HIGHLIGHTED_FILE_LINES_LONG).pipe(map(x => x.slice(startLine, endLine)))
+                }
             />
         )
         const rows = container.querySelectorAll('tr')

--- a/client/shared/src/components/CodeExcerpt.tsx
+++ b/client/shared/src/components/CodeExcerpt.tsx
@@ -26,8 +26,9 @@ interface Props extends Repo {
     endLine: number
     isLightTheme: boolean
     className?: string
-    /** A function to fetch the range of lines this code excerpt will display. */
-    fetchHighlightedFileRangeLines: () => Observable<string[]>
+    /** A function to fetch the range of lines this code excerpt will display. It will be provided
+     * the same start and end lines properties that were provided as component props */
+    fetchHighlightedFileRangeLines: (startLine: number, endLine: number) => Observable<string[]>
 }
 
 interface HighlightRange {
@@ -66,15 +67,17 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
             combineLatest([this.propsChanges, this.visibilityChanges])
                 .pipe(
                     filter(([, isVisible]) => isVisible),
-                    map(([{ repoName, filePath, commitID, isLightTheme }]) => ({
+                    map(([{ repoName, filePath, commitID, isLightTheme, startLine, endLine }]) => ({
                         repoName,
                         filePath,
                         commitID,
                         isLightTheme,
+                        startLine,
+                        endLine,
                     })),
                     distinctUntilChanged((a, b) => isEqual(a, b)),
-                    switchMap(({ repoName, filePath, commitID, isLightTheme }) =>
-                        props.fetchHighlightedFileRangeLines()
+                    switchMap(({ repoName, filePath, commitID, isLightTheme, startLine, endLine }) =>
+                        props.fetchHighlightedFileRangeLines(startLine, endLine)
                     ),
                     catchError(error => [asError(error)])
                 )

--- a/client/shared/src/components/CodeExcerpt.tsx
+++ b/client/shared/src/components/CodeExcerpt.tsx
@@ -20,13 +20,14 @@ interface Props extends Repo {
     commitID: string
     filePath: string
     highlightRanges: HighlightRange[]
-    /** The highest line number among the subset matches. */
-    lastSubsetMatchLineNumber: number
+    /** The 0-based (inclusive) line number that this code excerpt starts at */
+    startLine: number
+    /** The 0-based (exclusive) line number that this code excerpt ends at */
+    endLine: number
     isLightTheme: boolean
     className?: string
-    /** How many extra lines to show in the excerpt before/after the ref.  */
-    context?: number
-    fetchHighlightedFileLines: (parameters: FetchFileParameters, force?: boolean) => Observable<string[]>
+    /** A function to fetch the range of lines this code excerpt will display. */
+    fetchHighlightedFileRangeLines: () => Observable<string[]>
 }
 
 interface HighlightRange {
@@ -73,13 +74,7 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
                     })),
                     distinctUntilChanged((a, b) => isEqual(a, b)),
                     switchMap(({ repoName, filePath, commitID, isLightTheme }) =>
-                        props.fetchHighlightedFileLines({
-                            repoName,
-                            commitID,
-                            filePath,
-                            isLightTheme,
-                            disableTimeout: false,
-                        })
+                        props.fetchHighlightedFileRangeLines()
                     ),
                     catchError(error => [asError(error)])
                 )
@@ -100,10 +95,10 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
             const visibleRows = this.tableContainerElement.querySelectorAll('table tr')
             for (const highlight of this.props.highlightRanges) {
                 // Select the HTML row in the excerpt that corresponds to the line to be highlighted.
-                // `highlight.line` is the 1-indexed line number in the code file, and this.getFirstLine() returns the
-                // 1-indexed line number of the first visible line in the excerpt. So, subtract this.getFirstLine()
+                // highlight.line is the 0-indexed line number in the code file, and this.props.startLine is the 0-indexed
+                // line number of the first visible line in the excerpt. So, subtract this.props.startLine
                 // from highlight.line to get the correct 0-based index in visibleRows that holds the HTML row.
-                const tableRow = visibleRows[highlight.line - this.getFirstLine()]
+                const tableRow = visibleRows[highlight.line - this.props.startLine]
                 if (tableRow) {
                     // Take the lastChild of the row to select the code portion of the table row (each table row consists of the line number and code).
                     const code = tableRow.lastChild as HTMLTableDataCellElement
@@ -117,55 +112,11 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
         this.subscriptions.unsubscribe()
     }
 
-    private getFirstLine(): number {
-        const contextLines = this.props.context || this.props.context === 0 ? this.props.context : 1
-        // Of the matches in this excerpt, pick the one with the lowest line number.
-        // Take the maximum between the (lowest line number - the lines of context) and 0,
-        // so we don't try and display a negative line index.
-        return Math.max(0, Math.min(...this.props.highlightRanges.map(range => range.line)) - contextLines)
-    }
-
-    private getLastLine(blobLines: string[] | undefined): number {
-        const contextLines = this.props.context || this.props.context === 0 ? this.props.context : 1
-
-        const highlightRangeLines = this.props.highlightRanges.map(range => range.line)
-        // The highest line number of all highlights in this excerpt.
-        const lastHighlightLineNumber = Math.max(...highlightRangeLines)
-
-        // If the highest highlight line number is greater than the last line number of the subsetMatches,
-        // then we know that there's at least one highlight in the context lines.
-        const contextLineHasHighlight = lastHighlightLineNumber > this.props.lastSubsetMatchLineNumber
-
-        // The gap between the last highlight provided to this excerpt, and the line number of the last highlighted
-        // match that is not a context line. If this value is larger than contextLines, it means that we are
-        // displaying _all_ matches, and therefore, do not need to reduce the number of context lines shown.
-        const remainingContextLinesToShow = lastHighlightLineNumber - this.props.lastSubsetMatchLineNumber
-
-        const numberOfcontextLinesToShow = contextLineHasHighlight
-            ? contextLines - (remainingContextLinesToShow <= contextLines ? remainingContextLinesToShow : 0)
-            : contextLines
-
-        // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
-        // Don't add the context value to calculate the last line if the last highlight match is the highlight range + contextLines
-        const lastLine = contextLineHasHighlight
-            ? Math.max(...highlightRangeLines) + numberOfcontextLinesToShow
-            : Math.max(...highlightRangeLines) + contextLines
-        // If there are lines, take the minimum of lastLine and the number of lines in the file,
-        // so we don't try to display a line index beyond the maximum line number in the file.
-        return blobLines ? Math.min(lastLine, blobLines.length) : lastLine
-    }
-
     private onChangeVisibility = (isVisible: boolean): void => {
         this.visibilityChanges.next(isVisible)
     }
 
     public render(): JSX.Element | null {
-        // If the search.contextLines value is 0, we need to add 1 to the
-        // last line value so that `range(firstLine, lastLine)` is a non-empty array
-        // since range is exclusive of the lastLine value, and this.getFirstLine() and this.getLastLine()
-        // will return the same value.
-        const additionalLine = this.props.context === 0 ? 1 : 0
-
         return (
             <VisibilitySensor
                 onChange={this.onChangeVisibility}
@@ -192,10 +143,7 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
                     {!this.state.blobLinesOrError && (
                         <table>
                             <tbody>
-                                {range(
-                                    this.getFirstLine(),
-                                    this.getLastLine(this.state.blobLinesOrError) + additionalLine
-                                ).map(index => (
+                                {range(this.props.startLine, this.props.endLine).map(index => (
                                     <tr key={index}>
                                         <td className="line">{index + 1}</td>
                                         {/* create empty space to fill viewport (as if the blob content were already fetched, otherwise we'll overfetch) */}
@@ -215,6 +163,6 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
     }
 
     private makeTableHTML(blobLines: string[]): string {
-        return '<table>' + blobLines.slice(this.getFirstLine(), this.getLastLine(blobLines) + 1).join('') + '</table>'
+        return '<table>' + blobLines.join('') + '</table>'
     }
 }

--- a/client/shared/src/components/FileMatch.test.tsx
+++ b/client/shared/src/components/FileMatch.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, getAllByTestId, getByTestId, render } from '@testing-library/r
 import _VisibilitySensor from 'react-visibility-sensor'
 import sinon from 'sinon'
 import { MockVisibilitySensor } from './CodeExcerpt.test'
-import { FileMatch, IFileMatch } from './FileMatch'
+import { FileLineMatch, FileMatch } from './FileMatch'
 import { HIGHLIGHTED_FILE_LINES_REQUEST, NOOP_SETTINGS_CASCADE, RESULT } from '../util/searchTestHelpers'
 
 jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children, onChange }) => (
@@ -19,7 +19,7 @@ describe('FileMatch', () => {
     const history = createBrowserHistory()
     const defaultProps = {
         location: history.location,
-        result: RESULT as IFileMatch,
+        result: RESULT as FileLineMatch,
         icon: FileIcon,
         onSelect: sinon.spy(),
         expanded: true,

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -28,6 +28,9 @@ export interface IMatchItem {
         highlightLength: number
     }[]
     preview: string
+    /**
+     * The 0-based line number of this match.
+     */
     line: number
     badge?: BadgeAttachmentRenderOptions
 }

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -40,7 +40,7 @@ interface Props extends SettingsCascadeProps {
     /**
      * The file match search result.
      */
-    result: FileMatch
+    result: FileLineMatch
 
     /**
      * Formatted repository name to be displayed in repository link. If not

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -12,17 +12,17 @@ import { BadgeAttachmentRenderOptions } from 'sourcegraph'
 
 const SUBSET_COUNT_KEY = 'fileMatchSubsetCount'
 
-export type IFileMatch = Partial<Pick<GQL.IFileMatch, 'revSpec' | 'symbols' | 'limitHit'>> & {
+export type FileLineMatch = Partial<Pick<GQL.IFileMatch, 'revSpec' | 'symbols' | 'limitHit'>> & {
     file: Pick<GQL.IFile, 'path' | 'url'> & { commit: Pick<GQL.IGitCommit, 'oid'> }
     repository: Pick<GQL.IRepository, 'name' | 'url'>
-    lineMatches: ILineMatch[]
+    lineMatches: LineMatch[]
 }
 
-export type ILineMatch = Pick<GQL.ILineMatch, 'preview' | 'lineNumber' | 'offsetAndLengths' | 'limitHit'> & {
+export type LineMatch = Pick<GQL.ILineMatch, 'preview' | 'lineNumber' | 'offsetAndLengths' | 'limitHit'> & {
     badge?: BadgeAttachmentRenderOptions
 }
 
-export interface IMatchItem {
+export interface MatchItem {
     highlightRanges: {
         start: number
         highlightLength: number
@@ -40,7 +40,7 @@ interface Props extends SettingsCascadeProps {
     /**
      * The file match search result.
      */
-    result: IFileMatch
+    result: FileMatch
 
     /**
      * Formatted repository name to be displayed in repository link. If not
@@ -89,7 +89,7 @@ export class FileMatch extends React.PureComponent<Props> {
 
     public render(): React.ReactNode {
         const result = this.props.result
-        const items: IMatchItem[] = this.props.result.lineMatches.map(match => ({
+        const items: MatchItem[] = this.props.result.lineMatches.map(match => ({
             highlightRanges: match.offsetAndLengths.map(([start, highlightLength]) => ({ start, highlightLength })),
             preview: match.preview,
             line: match.lineNumber,

--- a/client/shared/src/components/FileMatchChildren.test.tsx
+++ b/client/shared/src/components/FileMatchChildren.test.tsx
@@ -13,7 +13,13 @@ jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => ({ children
 import sinon from 'sinon'
 
 import { FileMatchChildren } from './FileMatchChildren'
-import { RESULT, HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST, NOOP_SETTINGS_CASCADE } from '../util/searchTestHelpers'
+import {
+    RESULT,
+    HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
+    NOOP_SETTINGS_CASCADE,
+    HIGHLIGHTED_FILE_LINES,
+} from '../util/searchTestHelpers'
+import { of } from 'rxjs'
 
 const history = H.createBrowserHistory()
 history.replace({ pathname: '/search' })
@@ -72,5 +78,18 @@ describe('FileMatchChildren', () => {
         const { container } = render(<FileMatchChildren {...defaultProps} settingsCascade={settingsCascade} />)
         const tableRows = container.querySelectorAll('.code-excerpt tr')
         expect(tableRows.length).toBe(7)
+    })
+
+    it('does not disable the highlighting timeout', () => {
+        /*
+            Because disabling the timeout should only ever be done in response
+            to the user asking us to do so, something that we do not do for
+            file matches because falling back to plaintext rendering is most
+            ideal.
+        */
+        const fetchHighlightedFileLines = sinon.spy(context => of(HIGHLIGHTED_FILE_LINES))
+        render(<FileMatchChildren {...defaultProps} fetchHighlightedFileLines={fetchHighlightedFileLines} />)
+        sinon.assert.calledOnce(fetchHighlightedFileLines)
+        sinon.assert.calledWithMatch(fetchHighlightedFileLines, { disableTimeout: false })
     })
 })

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -14,6 +14,7 @@ import { BadgeAttachment } from './BadgeAttachment'
 import { isErrorLike } from '../util/errors'
 import { ISymbol } from '../graphql/schema'
 import { map } from 'rxjs/operators'
+import { useMemo } from 'react'
 
 interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
@@ -61,7 +62,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
     }
 
     const maxMatches = props.allMatches ? 0 : props.subsetMatches
-    const { matches, grouped } = calculateMatchGroups(props.items, maxMatches, context)
+    const { matches, grouped } = useMemo(() => calculateMatchGroups(props.items, maxMatches, context), [props.items, maxMatches, context])
 
     if (NO_SEARCH_HIGHLIGHTING) {
         return (

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -7,7 +7,7 @@ import { SymbolIcon } from '../symbols/SymbolIcon'
 import { toPositionOrRangeHash, appendSubtreeQueryParameter } from '../util/url'
 import { CodeExcerpt, FetchFileParameters } from './CodeExcerpt'
 import { CodeExcerptUnhighlighted } from './CodeExcerptUnhighlighted'
-import { IFileMatch, IMatchItem } from './FileMatch'
+import { FileMatch, MatchItem } from './FileMatch'
 import { calculateMatchGroups } from './FileMatchContext'
 import { Link } from './Link'
 import { BadgeAttachment } from './BadgeAttachment'
@@ -18,8 +18,8 @@ import { useMemo } from 'react'
 
 interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
-    items: IMatchItem[]
-    result: IFileMatch
+    items: MatchItem[]
+    result: FileMatch
     /**
      * Whether or not to show all matches for this file, or only a subset.
      */

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -1,5 +1,4 @@
 import * as H from 'history'
-import { flatMap } from 'lodash'
 import * as React from 'react'
 import { Observable } from 'rxjs'
 import { ThemeProps } from '../theme'
@@ -9,17 +8,24 @@ import { toPositionOrRangeHash, appendSubtreeQueryParameter } from '../util/url'
 import { CodeExcerpt, FetchFileParameters } from './CodeExcerpt'
 import { CodeExcerptUnhighlighted } from './CodeExcerptUnhighlighted'
 import { IFileMatch, IMatchItem } from './FileMatch'
-import { mergeContext } from './FileMatchContext'
+import { calculateMatchGroups } from './FileMatchContext'
 import { Link } from './Link'
 import { BadgeAttachment } from './BadgeAttachment'
 import { isErrorLike } from '../util/errors'
 import { ISymbol } from '../graphql/schema'
+import { map } from 'rxjs/operators'
 
 interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
     items: IMatchItem[]
     result: IFileMatch
+    /**
+     * Whether or not to show all matches for this file, or only a subset.
+     */
     allMatches: boolean
+    /**
+     * The number of matches to show when the results are collapsed (allMatches===false, user has not clicked "Show N more matches")
+     */
     subsetMatches: number
     fetchHighlightedFileLines: (parameters: FetchFileParameters, force?: boolean) => Observable<string[]>
     /**
@@ -54,59 +60,18 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         }
     }
 
-    const sortedItems = props.items.sort((a, b) => {
-        if (a.line < b.line) {
-            return -1
-        }
-        if (a.line === b.line) {
-            if (a.highlightRanges[0].start < b.highlightRanges[0].start) {
-                return -1
-            }
-            if (a.highlightRanges[0].start === b.highlightRanges[0].start) {
-                return 0
-            }
-            return 1
-        }
-        return 1
-    })
-
-    // This checks the highest line number amongst the number of matches
-    // that we want to show in a collapsed result preview.
-    const highestLineNumberWithinSubsetMatches =
-        sortedItems.length > 0
-            ? sortedItems.length > props.subsetMatches
-                ? sortedItems[props.subsetMatches - 1].line
-                : sortedItems[sortedItems.length - 1].line
-            : 0
-
-    const showItems = sortedItems.filter(
-        (item, index) =>
-            props.allMatches ||
-            index < props.subsetMatches ||
-            item.line <= highestLineNumberWithinSubsetMatches + context
-    )
+    const maxMatches = props.allMatches ? 0 : props.subsetMatches
+    const { matches, grouped } = calculateMatchGroups(props.items, maxMatches, context)
 
     if (NO_SEARCH_HIGHLIGHTING) {
         return (
             <CodeExcerptUnhighlighted
                 urlWithoutPosition={props.result.file.url}
-                items={showItems}
+                items={matches}
                 onSelect={props.onSelect}
             />
         )
     }
-
-    const groupsOfItems = mergeContext(
-        context,
-        flatMap(showItems, item =>
-            item.highlightRanges.map(range => ({
-                line: item.line,
-                character: range.start,
-                highlightLength: range.highlightLength,
-                badge: item.badge,
-            }))
-        )
-    )
 
     return (
         <div className="file-match-children">
@@ -124,47 +89,59 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                     </code>
                 </Link>
             ))}
-            {groupsOfItems.map(items => {
-                const item = items[0]
-                const position = { line: item.line + 1, character: item.character + 1 }
-                return (
-                    <div
-                        key={`linematch:${props.result.file.url}${position.line}:${position.character}`}
-                        className="file-match-children__item-code-wrapper test-file-match-children-item-wrapper"
+            {grouped.map(group => (
+                <div
+                    key={`linematch:${props.result.file.url}${group.position.line}:${group.position.character}`}
+                    className="file-match-children__item-code-wrapper test-file-match-children-item-wrapper"
+                >
+                    <Link
+                        to={appendSubtreeQueryParameter(
+                            `${props.result.file.url}${toPositionOrRangeHash({ position: group.position })}`
+                        )}
+                        className="file-match-children__item file-match-children__item-clickable test-file-match-children-item"
+                        onClick={props.onSelect}
                     >
-                        <Link
-                            to={appendSubtreeQueryParameter(
-                                `${props.result.file.url}${toPositionOrRangeHash({ position })}`
-                            )}
-                            className="file-match-children__item file-match-children__item-clickable test-file-match-children-item"
-                            onClick={props.onSelect}
-                        >
-                            <CodeExcerpt
-                                repoName={props.result.repository.name}
-                                commitID={props.result.file.commit.oid}
-                                filePath={props.result.file.path}
-                                lastSubsetMatchLineNumber={highestLineNumberWithinSubsetMatches}
-                                context={context}
-                                highlightRanges={items}
-                                className="file-match-children__item-code-excerpt"
-                                isLightTheme={props.isLightTheme}
-                                fetchHighlightedFileLines={props.fetchHighlightedFileLines}
-                            />
-                        </Link>
+                        <CodeExcerpt
+                            repoName={props.result.repository.name}
+                            commitID={props.result.file.commit.oid}
+                            filePath={props.result.file.path}
+                            startLine={group.startLine}
+                            endLine={group.endLine}
+                            highlightRanges={group.matches}
+                            className="file-match-children__item-code-excerpt"
+                            isLightTheme={props.isLightTheme}
+                            fetchHighlightedFileRangeLines={() =>
+                                props
+                                    .fetchHighlightedFileLines(
+                                        {
+                                            repoName: props.result.repository.name,
+                                            commitID: props.result.file.commit.oid,
+                                            filePath: props.result.file.path,
+                                            disableTimeout: false,
+                                            isLightTheme: props.isLightTheme,
+                                        },
+                                        false
+                                    )
+                                    .pipe(map(lines => lines.slice(group.startLine, group.endLine)))
+                            }
+                        />
+                    </Link>
 
-                        <div className="file-match-children__item-badge-row test-badge-row">
-                            {item.badge && showBadges && (
-                                // This div is necessary: it has block display, where the badge row
-                                // has flex display and would cause the hover tooltip to be offset
-                                // in a weird way (centered in the code context, not on the icon).
-                                <div>
-                                    <BadgeAttachment attachment={item.badge} isLightTheme={props.isLightTheme} />
-                                </div>
-                            )}
-                        </div>
+                    <div className="file-match-children__item-badge-row test-badge-row">
+                        {group.matches[0].badge && showBadges && (
+                            // This div is necessary: it has block display, where the badge row
+                            // has flex display and would cause the hover tooltip to be offset
+                            // in a weird way (centered in the code context, not on the icon).
+                            <div>
+                                <BadgeAttachment
+                                    attachment={group.matches[0].badge}
+                                    isLightTheme={props.isLightTheme}
+                                />
+                            </div>
+                        )}
                     </div>
-                )
-            })}
+                </div>
+            ))}
         </div>
     )
 }

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -61,27 +61,31 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
     }
 
     const maxMatches = props.allMatches ? 0 : props.subsetMatches
-    const [ matches, grouped ] = React.useMemo(() => calculateMatchGroups(props.items, maxMatches, context), [props.items, maxMatches, context])
+    const [matches, grouped] = React.useMemo(() => calculateMatchGroups(props.items, maxMatches, context), [
+        props.items,
+        maxMatches,
+        context,
+    ])
 
     const { result, isLightTheme, fetchHighlightedFileLines } = props
     const fetchHighlightedFileRangeLines = React.useCallback(
-        (startLine, endLine) => fetchHighlightedFileLines({
-            repoName: result.repository.name,
-            commitID: result.file.commit.oid,
-            filePath: result.file.path,
-            disableTimeout: false,
-            isLightTheme,
-        }, false).pipe(map(lines => lines.slice(startLine, endLine))),
-        [result, isLightTheme, fetchHighlightedFileLines],
+        (startLine, endLine) =>
+            fetchHighlightedFileLines(
+                {
+                    repoName: result.repository.name,
+                    commitID: result.file.commit.oid,
+                    filePath: result.file.path,
+                    disableTimeout: false,
+                    isLightTheme,
+                },
+                false
+            ).pipe(map(lines => lines.slice(startLine, endLine))),
+        [result, isLightTheme, fetchHighlightedFileLines]
     )
 
     if (NO_SEARCH_HIGHLIGHTING) {
         return (
-            <CodeExcerptUnhighlighted
-                urlWithoutPosition={result.file.url}
-                items={matches}
-                onSelect={props.onSelect}
-            />
+            <CodeExcerptUnhighlighted urlWithoutPosition={result.file.url} items={matches} onSelect={props.onSelect} />
         )
     }
 
@@ -132,10 +136,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                             // has flex display and would cause the hover tooltip to be offset
                             // in a weird way (centered in the code context, not on the icon).
                             <div>
-                                <BadgeAttachment
-                                    attachment={group.matches[0].badge}
-                                    isLightTheme={isLightTheme}
-                                />
+                                <BadgeAttachment attachment={group.matches[0].badge} isLightTheme={isLightTheme} />
                             </div>
                         )}
                     </div>

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -110,6 +110,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                             highlightRanges={group.matches}
                             className="file-match-children__item-code-excerpt"
                             isLightTheme={props.isLightTheme}
+                            /* eslint-disable react/jsx-no-bind */
                             fetchHighlightedFileRangeLines={() =>
                                 props
                                     .fetchHighlightedFileLines(

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -62,7 +62,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
     }
 
     const maxMatches = props.allMatches ? 0 : props.subsetMatches
-    const { matches, grouped } = useMemo(() => calculateMatchGroups(props.items, maxMatches, context), [props.items, maxMatches, context])
+    const [ matches, grouped ] = useMemo(() => calculateMatchGroups(props.items, maxMatches, context), [props.items, maxMatches, context])
 
     if (NO_SEARCH_HIGHLIGHTING) {
         return (

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -65,12 +65,12 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
 
     const { result, isLightTheme, fetchHighlightedFileLines } = props
     const fetchHighlightedFileRangeLines = React.useCallback(
-        (startLine, endLine) => props.fetchHighlightedFileLines({
+        (startLine, endLine) => fetchHighlightedFileLines({
             repoName: result.repository.name,
             commitID: result.file.commit.oid,
             filePath: result.file.path,
             disableTimeout: false,
-            isLightTheme: isLightTheme,
+            isLightTheme,
         }, false).pipe(map(lines => lines.slice(startLine, endLine))),
         [result, isLightTheme, fetchHighlightedFileLines],
     )

--- a/client/shared/src/components/FileMatchContext.test.tsx
+++ b/client/shared/src/components/FileMatchContext.test.tsx
@@ -223,10 +223,10 @@ describe('components/FileMatchContext', () => {
 })
 
 // "error" matched 5 times, once per line.
-const testData6ConsecutiveMatches: IMatchItem[] = range(0, 6).map(i => ({
+const testData6ConsecutiveMatches: IMatchItem[] = range(0, 6).map(index => ({
     highlightRanges: [{ start: 0, highlightLength: 5 }],
     preview: 'error',
-    line: i,
+    line: index,
 }))
 
 // Real match data from searching a file for `error`.

--- a/client/shared/src/components/FileMatchContext.test.tsx
+++ b/client/shared/src/components/FileMatchContext.test.tsx
@@ -30,9 +30,8 @@ describe('components/FileMatchContext', () => {
         test('simple', () => {
             const maxMatches = 3
             const context = 1
-            const [ , grouped ] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
-            expect(grouped)
-                .toMatchInlineSnapshot(`
+            const [, grouped] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
+            expect(grouped).toMatchInlineSnapshot(`
                 [
                   {
                     "matches": [
@@ -75,9 +74,8 @@ describe('components/FileMatchContext', () => {
         test('no context', () => {
             const maxMatches = 3
             const context = 0
-            const [ , grouped ] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
-            expect(grouped)
-                .toMatchInlineSnapshot(`
+            const [, grouped] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
+            expect(grouped).toMatchInlineSnapshot(`
                 [
                   {
                     "matches": [
@@ -114,7 +112,7 @@ describe('components/FileMatchContext', () => {
         test('complex grouping', () => {
             const maxMatches = 10
             const context = 2
-            const [ , grouped ] = calculateMatchGroups(testDataRealMatches, maxMatches, context)
+            const [, grouped] = calculateMatchGroups(testDataRealMatches, maxMatches, context)
             expect(grouped).toMatchInlineSnapshot(`
                 [
                   {

--- a/client/shared/src/components/FileMatchContext.test.tsx
+++ b/client/shared/src/components/FileMatchContext.test.tsx
@@ -1,4 +1,11 @@
-import { mergeContext } from './FileMatchContext'
+import { range } from 'lodash'
+import { IMatchItem } from './FileMatch'
+import { calculateMatchGroups, mergeContext } from './FileMatchContext'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value, null, 2),
+    test: () => true,
+})
 
 describe('components/FileMatchContext', () => {
     describe('mergeContext', () => {
@@ -18,4 +25,630 @@ describe('components/FileMatchContext', () => {
             expect(mergeContext(1, [{ line: 5 }, { line: 9 }])).toEqual([[{ line: 5 }], [{ line: 9 }]])
         })
     })
+
+    describe('calculateMatchGroups', () => {
+        test('simple', () => {
+            const maxMatches = 3
+            const context = 1
+            expect(calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context).grouped)
+                .toMatchInlineSnapshot(`
+                [
+                  {
+                    "matches": [
+                      {
+                        "line": 0,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 1,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 2,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 3,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": true
+                      }
+                    ],
+                    "position": {
+                      "line": 1,
+                      "character": 1
+                    },
+                    "startLine": 0,
+                    "endLine": 4
+                  }
+                ]
+            `)
+        })
+
+        test('no context', () => {
+            const maxMatches = 3
+            const context = 0
+            expect(calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context).grouped)
+                .toMatchInlineSnapshot(`
+                [
+                  {
+                    "matches": [
+                      {
+                        "line": 0,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 1,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 2,
+                        "character": 0,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      }
+                    ],
+                    "position": {
+                      "line": 1,
+                      "character": 1
+                    },
+                    "startLine": 0,
+                    "endLine": 3
+                  }
+                ]
+            `)
+        })
+
+        test('complex grouping', () => {
+            const maxMatches = 10
+            const context = 2
+            expect(calculateMatchGroups(testDataRealMatches, maxMatches, context).grouped).toMatchInlineSnapshot(`
+                [
+                  {
+                    "matches": [
+                      {
+                        "line": 0,
+                        "character": 51,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 2,
+                        "character": 48,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 3,
+                        "character": 15,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 3,
+                        "character": 39,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 8,
+                        "character": 2,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      }
+                    ],
+                    "position": {
+                      "line": 1,
+                      "character": 52
+                    },
+                    "startLine": 0,
+                    "endLine": 11
+                  },
+                  {
+                    "matches": [
+                      {
+                        "line": 14,
+                        "character": 19,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      }
+                    ],
+                    "position": {
+                      "line": 15,
+                      "character": 20
+                    },
+                    "startLine": 12,
+                    "endLine": 17
+                  },
+                  {
+                    "matches": [
+                      {
+                        "line": 20,
+                        "character": 11,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 24,
+                        "character": 8,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 24,
+                        "character": 19,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 27,
+                        "character": 53,
+                        "highlightLength": 5,
+                        "IsInContext": false
+                      },
+                      {
+                        "line": 28,
+                        "character": 3,
+                        "highlightLength": 5,
+                        "IsInContext": true
+                      },
+                      {
+                        "line": 29,
+                        "character": 13,
+                        "highlightLength": 5,
+                        "IsInContext": true
+                      }
+                    ],
+                    "position": {
+                      "line": 21,
+                      "character": 12
+                    },
+                    "startLine": 18,
+                    "endLine": 30
+                  }
+                ]
+            `)
+        })
+    })
 })
+
+// "error" matched 5 times, once per line.
+const testData6ConsecutiveMatches: IMatchItem[] = range(0, 6).map(i => ({
+    highlightRanges: [{ start: 0, highlightLength: 5 }],
+    preview: 'error',
+    line: i,
+}))
+
+// Real match data from searching a file for `error`.
+const testDataRealMatches: IMatchItem[] = [
+    {
+        highlightRanges: [{ start: 51, highlightLength: 5 }],
+        preview: '// Package errwrap implements methods to formalize error wrapping in Go.',
+        line: 0,
+    },
+    {
+        highlightRanges: [{ start: 48, highlightLength: 5 }],
+        preview: '// All of the top-level functions that take an `error` are built to be able',
+        line: 2,
+    },
+    {
+        highlightRanges: [{ start: 15, highlightLength: 5 }],
+        preview: '// to take any error, not just wrapped errors. This allows you to use errwrap',
+        line: 3,
+    },
+    {
+        highlightRanges: [{ start: 39, highlightLength: 5 }],
+        preview: '// to take any error, not just wrapped errors. This allows you to use errwrap',
+        line: 3,
+    },
+    {
+        highlightRanges: [{ start: 2, highlightLength: 5 }],
+        preview: '\t"errors"',
+        line: 8,
+    },
+    {
+        highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: 'type WalkFunc func(error)',
+        line: 14,
+    },
+    {
+        highlightRanges: [{ start: 11, highlightLength: 5 }],
+        preview: '// wrapped error in addition to the wrapper itself. Since all the top-level',
+        line: 20,
+    },
+    {
+        highlightRanges: [{ start: 8, highlightLength: 5 }],
+        preview: '\tWrappedErrors() []error',
+        line: 24,
+    },
+    {
+        highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: '\tWrappedErrors() []error',
+        line: 24,
+    },
+    {
+        highlightRanges: [{ start: 53, highlightLength: 5 }],
+        preview: '// Wrap defines that outer wraps inner, returning an error type that',
+        line: 27,
+    },
+    {
+        highlightRanges: [{ start: 3, highlightLength: 5 }],
+        preview: '// error be cleanly used with the other methods in this package, such as',
+        line: 28,
+    },
+    {
+        highlightRanges: [{ start: 13, highlightLength: 5 }],
+        preview: '// Contains, error, etc.',
+        line: 29,
+    },
+    {
+        highlightRanges: [{ start: 2, highlightLength: 5 }],
+        preview: '//error',
+        line: 30,
+    },
+    {
+        highlightRanges: [{ start: 8, highlightLength: 5 }],
+        preview: "// This error won't modify the error message at all (the outer message",
+        line: 31,
+    },
+    {
+        highlightRanges: [{ start: 31, highlightLength: 5 }],
+        preview: "// This error won't modify the error message at all (the outer message",
+        line: 31,
+    },
+    {
+        highlightRanges: [{ start: 11, highlightLength: 5 }],
+        preview: '// will be error).',
+        line: 32,
+    },
+    {
+        highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: 'func Wrap(outer, inner error) error {',
+        line: 33,
+    },
+    {
+        highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: 'func Wrap(outer, inner error) error {',
+        line: 33,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: '\treturn &wrappedError{',
+        line: 34,
+    },
+    {
+        highlightRanges: [{ start: 2, highlightLength: 5 }],
+        preview: '\t\terror: outer,',
+        line: 35,
+    },
+    {
+        highlightRanges: [{ start: 18, highlightLength: 5 }],
+        preview: '// Wrapf wraps an error with a formatting message. This is similar to using',
+        line: 40,
+    },
+    {
+        highlightRanges: [{ start: 8, highlightLength: 5 }],
+        preview: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
+        line: 41,
+    },
+    {
+        highlightRanges: [{ start: 27, highlightLength: 5 }],
+        preview: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
+        line: 41,
+    },
+    {
+        highlightRanges: [{ start: 55, highlightLength: 5 }],
+        preview: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
+        line: 41,
+    },
+    {
+        highlightRanges: [{ start: 3, highlightLength: 5 }],
+        preview: '// errors, you should replace it with this.',
+        line: 42,
+    },
+    {
+        highlightRanges: [{ start: 31, highlightLength: 5 }],
+        preview: "// format is the format of the error message. The string '{{err}}' will",
+        line: 44,
+    },
+    {
+        highlightRanges: [{ start: 33, highlightLength: 5 }],
+        preview: '// be replaced with the original error message.',
+        line: 45,
+    },
+    {
+        highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: '// Deprecated: Use fmt.Errorf()',
+        line: 47,
+    },
+    {
+        highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: 'func Wrapf(format string, err error) error {',
+        line: 48,
+    },
+    {
+        highlightRanges: [{ start: 37, highlightLength: 5 }],
+        preview: 'func Wrapf(format string, err error) error {',
+        line: 48,
+    },
+    {
+        highlightRanges: [{ start: 17, highlightLength: 5 }],
+        preview: '\t\touterMsg = err.Error()',
+        line: 51,
+    },
+    {
+        highlightRanges: [{ start: 10, highlightLength: 5 }],
+        preview: '\touter := errors.New(strings.Replace(',
+        line: 54,
+    },
+    {
+        highlightRanges: [{ start: 32, highlightLength: 5 }],
+        preview: '// Contains checks if the given error contains an error with the',
+        line: 60,
+    },
+    {
+        highlightRanges: [{ start: 50, highlightLength: 5 }],
+        preview: '// Contains checks if the given error contains an error with the',
+        line: 60,
+    },
+    {
+        highlightRanges: [{ start: 40, highlightLength: 5 }],
+        preview: '// message msg. If err is not a wrapped error, this will always return',
+        line: 61,
+    },
+    {
+        highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: '// false unless the error itself happens to match this msg.',
+        line: 62,
+    },
+    {
+        highlightRanges: [{ start: 18, highlightLength: 5 }],
+        preview: 'func Contains(err error, msg string) bool {',
+        line: 63,
+    },
+    {
+        highlightRanges: [{ start: 36, highlightLength: 5 }],
+        preview: '// ContainsType checks if the given error contains an error with',
+        line: 67,
+    },
+    {
+        highlightRanges: [{ start: 54, highlightLength: 5 }],
+        preview: '// ContainsType checks if the given error contains an error with',
+        line: 67,
+    },
+    {
+        highlightRanges: [{ start: 56, highlightLength: 5 }],
+        preview: '// the same concrete type as v. If err is not a wrapped error, this will',
+        line: 68,
+    },
+    {
+        highlightRanges: [{ start: 22, highlightLength: 5 }],
+        preview: 'func ContainsType(err error, v interface{}) bool {',
+        line: 70,
+    },
+    {
+        highlightRanges: [{ start: 62, highlightLength: 5 }],
+        preview: '// Get is the same as GetAll but returns the deepest matching error.',
+        line: 74,
+    },
+    {
+        highlightRanges: [{ start: 13, highlightLength: 5 }],
+        preview: 'func Get(err error, msg string) error {',
+        line: 75,
+    },
+    {
+        highlightRanges: [{ start: 32, highlightLength: 5 }],
+        preview: 'func Get(err error, msg string) error {',
+        line: 75,
+    },
+    {
+        highlightRanges: [{ start: 70, highlightLength: 5 }],
+        preview: '// GetType is the same as GetAllType but returns the deepest matching error.',
+        line: 84,
+    },
+    {
+        highlightRanges: [{ start: 17, highlightLength: 5 }],
+        preview: 'func GetType(err error, v interface{}) error {',
+        line: 85,
+    },
+    {
+        highlightRanges: [{ start: 39, highlightLength: 5 }],
+        preview: 'func GetType(err error, v interface{}) error {',
+        line: 85,
+    },
+    {
+        highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: '// GetAll gets all the errors that might be wrapped in err with the',
+        line: 94,
+    },
+    {
+        highlightRanges: [{ start: 35, highlightLength: 5 }],
+        preview: '// given message. The order of the errors is such that the outermost',
+        line: 95,
+    },
+    {
+        highlightRanges: [{ start: 12, highlightLength: 5 }],
+        preview: '// matching error (the most recent wrap) is index zero, and so on.',
+        line: 96,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func GetAll(err error, msg string) []error {',
+        line: 97,
+    },
+    {
+        highlightRanges: [{ start: 37, highlightLength: 5 }],
+        preview: 'func GetAll(err error, msg string) []error {',
+        line: 97,
+    },
+    {
+        highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: '\tvar result []error',
+        line: 98,
+    },
+    {
+        highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: '\tWalk(err, func(err error) {',
+        line: 100,
+    },
+    {
+        highlightRanges: [{ start: 9, highlightLength: 5 }],
+        preview: '\t\tif err.Error() == msg {',
+        line: 101,
+    },
+    {
+        highlightRanges: [{ start: 27, highlightLength: 5 }],
+        preview: '// GetAllType gets all the errors that are the same type as v.',
+        line: 109,
+    },
+    {
+        highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: 'func GetAllType(err error, v interface{}) []error {',
+        line: 112,
+    },
+    {
+        highlightRanges: [{ start: 44, highlightLength: 5 }],
+        preview: 'func GetAllType(err error, v interface{}) []error {',
+        line: 112,
+    },
+    {
+        highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: '\tvar result []error',
+        line: 113,
+    },
+    {
+        highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: '\tWalk(err, func(err error) {',
+        line: 119,
+    },
+    {
+        highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: '// Walk walks all the wrapped errors in err and calls the callback. If',
+        line: 133,
+    },
+    {
+        highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: "// err isn't a wrapped error, this will be called once for err. If err",
+        line: 134,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: '// is a wrapped error, the callback will be called for both the wrapper',
+        line: 135,
+    },
+    {
+        highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: '// that implements error as well as the wrapped error itself.',
+        line: 136,
+    },
+    {
+        highlightRanges: [{ start: 48, highlightLength: 5 }],
+        preview: '// that implements error as well as the wrapped error itself.',
+        line: 136,
+    },
+    {
+        highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: 'func Walk(err error, cb WalkFunc) {',
+        line: 137,
+    },
+    {
+        highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: '\tcase *wrappedError:',
+        line: 143,
+    },
+    {
+        highlightRanges: [{ start: 31, highlightLength: 5 }],
+        preview: '\t\tfor _, err := range e.WrappedErrors() {',
+        line: 149,
+    },
+    {
+        highlightRanges: [{ start: 26, highlightLength: 5 }],
+        preview: '\tcase interface{ Unwrap() error }:',
+        line: 152,
+    },
+    {
+        highlightRanges: [{ start: 10, highlightLength: 5 }],
+        preview: '// wrappedError is an implementation of error that has both the',
+        line: 160,
+    },
+    {
+        highlightRanges: [{ start: 40, highlightLength: 5 }],
+        preview: '// wrappedError is an implementation of error that has both the',
+        line: 160,
+    },
+    {
+        highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: '// outer and inner errors.',
+        line: 161,
+    },
+    {
+        highlightRanges: [{ start: 12, highlightLength: 5 }],
+        preview: 'type wrappedError struct {',
+        line: 162,
+    },
+    {
+        highlightRanges: [{ start: 7, highlightLength: 5 }],
+        preview: '\tOuter error',
+        line: 163,
+    },
+    {
+        highlightRanges: [{ start: 7, highlightLength: 5 }],
+        preview: '\tInner error',
+        line: 164,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Error() string {',
+        line: 167,
+    },
+    {
+        highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Error() string {',
+        line: 167,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: '\treturn w.Outer.Error()',
+        line: 168,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) WrappedErrors() []error {',
+        line: 171,
+    },
+    {
+        highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) WrappedErrors() []error {',
+        line: 171,
+    },
+    {
+        highlightRanges: [{ start: 41, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) WrappedErrors() []error {',
+        line: 171,
+    },
+    {
+        highlightRanges: [{ start: 10, highlightLength: 5 }],
+        preview: '\treturn []error{w.Outer, w.Inner}',
+        line: 172,
+    },
+    {
+        highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Unwrap() error {',
+        line: 175,
+    },
+    {
+        highlightRanges: [{ start: 32, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Unwrap() error {',
+        line: 175,
+    },
+]

--- a/client/shared/src/components/FileMatchContext.test.tsx
+++ b/client/shared/src/components/FileMatchContext.test.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash'
-import { IMatchItem } from './FileMatch'
+import { MatchItem } from './FileMatch'
 import { calculateMatchGroups, mergeContext } from './FileMatchContext'
 
 expect.addSnapshotSerializer({
@@ -223,14 +223,14 @@ describe('components/FileMatchContext', () => {
 })
 
 // "error" matched 5 times, once per line.
-const testData6ConsecutiveMatches: IMatchItem[] = range(0, 6).map(index => ({
+const testData6ConsecutiveMatches: MatchItem[] = range(0, 6).map(index => ({
     highlightRanges: [{ start: 0, highlightLength: 5 }],
     preview: 'error',
     line: index,
 }))
 
 // Real match data from searching a file for `error`.
-const testDataRealMatches: IMatchItem[] = [
+const testDataRealMatches: MatchItem[] = [
     {
         highlightRanges: [{ start: 51, highlightLength: 5 }],
         preview: '// Package errwrap implements methods to formalize error wrapping in Go.',

--- a/client/shared/src/components/FileMatchContext.test.tsx
+++ b/client/shared/src/components/FileMatchContext.test.tsx
@@ -30,7 +30,8 @@ describe('components/FileMatchContext', () => {
         test('simple', () => {
             const maxMatches = 3
             const context = 1
-            expect(calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context).grouped)
+            const [ , grouped ] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
+            expect(grouped)
                 .toMatchInlineSnapshot(`
                 [
                   {
@@ -74,7 +75,8 @@ describe('components/FileMatchContext', () => {
         test('no context', () => {
             const maxMatches = 3
             const context = 0
-            expect(calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context).grouped)
+            const [ , grouped ] = calculateMatchGroups(testData6ConsecutiveMatches, maxMatches, context)
+            expect(grouped)
                 .toMatchInlineSnapshot(`
                 [
                   {
@@ -112,7 +114,8 @@ describe('components/FileMatchContext', () => {
         test('complex grouping', () => {
             const maxMatches = 10
             const context = 2
-            expect(calculateMatchGroups(testDataRealMatches, maxMatches, context).grouped).toMatchInlineSnapshot(`
+            const [ , grouped ] = calculateMatchGroups(testDataRealMatches, maxMatches, context)
+            expect(grouped).toMatchInlineSnapshot(`
                 [
                   {
                     "matches": [

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -117,7 +117,7 @@ interface MatchGroup {
  * @param maxMatches The maximum number of matches to show, or 0 for all.
  * @param context The number of surrounding context lines to show for each match.
  * @returns The subset of matches that were sorted and chosen for display, as well as that same
- *          list of matches grouped together.
+ * list of matches grouped together.
  */
 export const calculateMatchGroups = (matches: MatchItem[], maxMatches: number, context: number): [MatchItem[], MatchGroup[]] => {
     const sortedMatches = matches.sort((a, b) => {

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -1,6 +1,6 @@
 import { BadgeAttachmentRenderOptions } from 'sourcegraph'
 import { flatMap } from 'lodash'
-import { IMatchItem } from './FileMatch'
+import { MatchItem } from './FileMatch'
 
 /**
  * Groups highlights that have overlapping or adjacent context. The input must be sorted.
@@ -37,7 +37,7 @@ const calculateGroupPositions = (
     }[],
     context: number,
     highestLineNumberWithinSubsetMatches: number
-): IMatchGroup => {
+): MatchGroup => {
     {
         let startLine = matches[0].line - context
         startLine = startLine < 0 ? 0 : startLine
@@ -82,7 +82,7 @@ const calculateGroupPositions = (
 /**
  * Describes a single group of matches.
  */
-interface IMatchGroup {
+interface MatchGroup {
     // The matches in this group to display.
     matches: {
         line: number
@@ -108,13 +108,13 @@ interface IMatchGroup {
 /**
  * Describes matches that have been grouped together.
  */
-interface IMatchGroups {
+interface MatchGroups {
     // The grouped matches.
-    grouped: IMatchGroup[]
+    grouped: MatchGroup[]
 
     // The subset of sorted matches that should be displayed. Useful if e.g. rendering matches as
     // plaintext.
-    matches: IMatchItem[]
+    matches: MatchItem[]
 }
 
 /**
@@ -129,7 +129,7 @@ interface IMatchGroups {
  * @param maxMatches The maximum number of matches to show, or 0 for all.
  * @param context The number of surrounding context lines to show for each match.
  */
-export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, context: number): IMatchGroups => {
+export const calculateMatchGroups = (matches: MatchItem[], maxMatches: number, context: number): MatchGroups => {
     const sortedMatches = matches.sort((a, b) => {
         if (a.line < b.line) {
             return -1

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -49,8 +49,8 @@ const calculateGroupPositions = (
         // The highest line number of all highlights in this excerpt.
         const lastHighlightLineNumber = Math.max(...highlightRangeLines)
 
-        // If the highest highlight line number is greater than the last line number of the subsetMatches,
-        // then we know that there's at least one highlight in the context lines.
+        // If the last highlight line is greater than the highest line number within the subset of matches
+        // we are displaying, then we know that there's at least one highlight in the context lines.
         const contextLineHasHighlight = lastHighlightLineNumber > highestLineNumberWithinSubsetMatches
 
         // The gap between the last highlight provided to this excerpt, and the line number of the last highlighted

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -119,7 +119,11 @@ interface MatchGroup {
  * @returns The subset of matches that were sorted and chosen for display, as well as that same
  * list of matches grouped together.
  */
-export const calculateMatchGroups = (matches: MatchItem[], maxMatches: number, context: number): [MatchItem[], MatchGroup[]] => {
+export const calculateMatchGroups = (
+    matches: MatchItem[],
+    maxMatches: number,
+    context: number
+): [MatchItem[], MatchGroup[]] => {
     const sortedMatches = matches.sort((a, b) => {
         if (a.line < b.line) {
             return -1

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -39,9 +39,7 @@ const calculateGroupPositions = (
     highestLineNumberWithinSubsetMatches: number
 ): IGroupedMatch => {
     {
-        const contextLines = context || context === 0 ? context : 1
-
-        let startLine = matches[0].line - contextLines
+        let startLine = matches[0].line - context
         startLine = startLine < 0 ? 0 : startLine
 
         const highlightRangeLines = matches.map(range => range.line)
@@ -54,19 +52,19 @@ const calculateGroupPositions = (
         const contextLineHasHighlight = lastHighlightLineNumber > highestLineNumberWithinSubsetMatches
 
         // The gap between the last highlight provided to this excerpt, and the line number of the last highlighted
-        // match that is not a context line. If this value is larger than contextLines, it means that we are
+        // match that is not a context line. If this value is larger than context lines, it means that we are
         // displaying _all_ matches, and therefore, do not need to reduce the number of context lines shown.
         const remainingContextLinesToShow = lastHighlightLineNumber - highestLineNumberWithinSubsetMatches
 
         const numberOfContextLinesToShow = contextLineHasHighlight
-            ? contextLines - (remainingContextLinesToShow <= contextLines ? remainingContextLinesToShow : 0)
-            : contextLines
+            ? context - (remainingContextLinesToShow <= context ? remainingContextLinesToShow : 0)
+            : context
 
         // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
-        // Don't add the context value to calculate the last line if the last highlight match is the highlight range + contextLines
+        // Don't add the context value to calculate the last line if the last highlight match is the highlight range + context
         const endLine = contextLineHasHighlight
             ? Math.max(...highlightRangeLines) + numberOfContextLinesToShow
-            : Math.max(...highlightRangeLines) + contextLines
+            : Math.max(...highlightRangeLines) + context
 
         return {
             matches,

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -143,7 +143,6 @@ export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, 
             if (a.highlightRanges[0].start === b.highlightRanges[0].start) {
                 return 0
             }
-            return 1
         }
         return 1
     })

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -37,7 +37,7 @@ const calculateGroupPositions = (
     }[],
     context: number,
     highestLineNumberWithinSubsetMatches: number
-) => {
+): IGroupedMatch => {
     {
         const contextLines = context || context === 0 ? context : 1
 
@@ -69,15 +69,42 @@ const calculateGroupPositions = (
             : Math.max(...highlightRangeLines) + contextLines
 
         return {
-            matches: matches,
+            matches,
+
             // 1-based position describing the starting place of the matches.
             position: { line: matches[0].line + 1, character: matches[0].character + 1 },
 
             // 0-based range describing the start and end lines (end line is exclusive.)
-            startLine: startLine,
+            startLine,
             endLine: endLine + 1,
         }
     }
+}
+
+/**
+ * Describes a single group of matches.
+ */
+interface IGroupedMatch {
+    // The matches in this group to display.
+    matches: {
+        line: number
+        character: number
+        highlightLength: number
+        badge: BadgeAttachmentRenderOptions | undefined
+        IsInContext: boolean
+    }[]
+
+    // The 1-based position of where the first match in the group.
+    position: {
+        line: number
+        character: number
+    }
+
+    // The 0-based start line of the group (inclusive.)
+    startLine: number
+
+    // The 0-based end line of the group (exclusive.)
+    endLine: number
 }
 
 /**
@@ -85,28 +112,7 @@ const calculateGroupPositions = (
  */
 interface IGroupedMatches {
     // The grouped matches.
-    grouped: {
-        // The matches in this group to display.
-        matches: {
-            line: number
-            character: number
-            highlightLength: number
-            badge: BadgeAttachmentRenderOptions | undefined
-            IsInContext: boolean
-        }[]
-
-        // The 1-based position of where the first match in the group.
-        position: {
-            line: number
-            character: number
-        }
-
-        // The 0-based start line of the group (inclusive.)
-        startLine: number
-
-        // The 0-based end line of the group (exclusive.)
-        endLine: number
-    }[]
+    grouped: IGroupedMatch[]
 
     // The subset of sorted matches that should be displayed. Useful if e.g. rendering matches as
     // plaintext.
@@ -147,7 +153,7 @@ export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, 
     const highestLineNumberWithinSubsetMatches =
         sortedMatches.length > 0
             ? sortedMatches.length > maxMatches
-                ? sortedMatches[maxMatches == 0 ? 0 : maxMatches - 1].line
+                ? sortedMatches[maxMatches === 0 ? 0 : maxMatches - 1].line
                 : sortedMatches[sortedMatches.length - 1].line
             : 0
 
@@ -172,7 +178,7 @@ export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, 
     ).map(group => calculateGroupPositions(group, context, highestLineNumberWithinSubsetMatches))
 
     return {
-        grouped: grouped,
+        grouped,
         matches: showMatches,
     }
 }

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -37,7 +37,7 @@ const calculateGroupPositions = (
     }[],
     context: number,
     highestLineNumberWithinSubsetMatches: number
-): IGroupedMatch => {
+): IMatchGroup => {
     {
         let startLine = matches[0].line - context
         startLine = startLine < 0 ? 0 : startLine
@@ -82,7 +82,7 @@ const calculateGroupPositions = (
 /**
  * Describes a single group of matches.
  */
-interface IGroupedMatch {
+interface IMatchGroup {
     // The matches in this group to display.
     matches: {
         line: number
@@ -108,9 +108,9 @@ interface IGroupedMatch {
 /**
  * Describes matches that have been grouped together.
  */
-interface IGroupedMatches {
+interface IMatchGroups {
     // The grouped matches.
-    grouped: IGroupedMatch[]
+    grouped: IMatchGroup[]
 
     // The subset of sorted matches that should be displayed. Useful if e.g. rendering matches as
     // plaintext.
@@ -129,7 +129,7 @@ interface IGroupedMatches {
  * @param maxMatches The maximum number of matches to show, or 0 for all.
  * @param context The number of surrounding context lines to show for each match.
  */
-export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, context: number): IGroupedMatches => {
+export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, context: number): IMatchGroups => {
     const sortedMatches = matches.sort((a, b) => {
         if (a.line < b.line) {
             return -1

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -1,3 +1,7 @@
+import { BadgeAttachmentRenderOptions } from 'sourcegraph'
+import { flatMap } from 'lodash'
+import { IMatchItem } from './FileMatch'
+
 /**
  * Groups highlights that have overlapping or adjacent context. The input must be sorted.
  */
@@ -21,4 +25,154 @@ export const mergeContext = <T extends { line: number }>(context: number, highli
     }
 
     return groupsOfHighlights
+}
+
+const calculateGroupPositions = (
+    matches: {
+        line: number
+        character: number
+        highlightLength: number
+        badge: BadgeAttachmentRenderOptions | undefined
+        IsInContext: boolean
+    }[],
+    context: number,
+    highestLineNumberWithinSubsetMatches: number
+) => {
+    {
+        const contextLines = context || context === 0 ? context : 1
+
+        let startLine = matches[0].line - contextLines
+        startLine = startLine < 0 ? 0 : startLine
+
+        const highlightRangeLines = matches.map(range => range.line)
+
+        // The highest line number of all highlights in this excerpt.
+        const lastHighlightLineNumber = Math.max(...highlightRangeLines)
+
+        // If the highest highlight line number is greater than the last line number of the subsetMatches,
+        // then we know that there's at least one highlight in the context lines.
+        const contextLineHasHighlight = lastHighlightLineNumber > highestLineNumberWithinSubsetMatches
+
+        // The gap between the last highlight provided to this excerpt, and the line number of the last highlighted
+        // match that is not a context line. If this value is larger than contextLines, it means that we are
+        // displaying _all_ matches, and therefore, do not need to reduce the number of context lines shown.
+        const remainingContextLinesToShow = lastHighlightLineNumber - highestLineNumberWithinSubsetMatches
+
+        const numberOfContextLinesToShow = contextLineHasHighlight
+            ? contextLines - (remainingContextLinesToShow <= contextLines ? remainingContextLinesToShow : 0)
+            : contextLines
+
+        // Of the matches in this excerpt, pick the one with the highest line number + lines of context.
+        // Don't add the context value to calculate the last line if the last highlight match is the highlight range + contextLines
+        const endLine = contextLineHasHighlight
+            ? Math.max(...highlightRangeLines) + numberOfContextLinesToShow
+            : Math.max(...highlightRangeLines) + contextLines
+
+        return {
+            matches: matches,
+            // 1-based position describing the starting place of the matches.
+            position: { line: matches[0].line + 1, character: matches[0].character + 1 },
+
+            // 0-based range describing the start and end lines (end line is exclusive.)
+            startLine: startLine,
+            endLine: endLine + 1,
+        }
+    }
+}
+
+/**
+ * Describes matches that have been grouped together.
+ */
+interface IGroupedMatches {
+    // The grouped matches.
+    grouped: {
+        // The matches in this group to display.
+        matches: {
+            line: number
+            character: number
+            highlightLength: number
+            badge: BadgeAttachmentRenderOptions | undefined
+            IsInContext: boolean
+        }[]
+
+        // The 1-based position of where the first match in the group.
+        position: {
+            line: number
+            character: number
+        }
+
+        // The 0-based start line of the group (inclusive.)
+        startLine: number
+
+        // The 0-based end line of the group (exclusive.)
+        endLine: number
+    }[]
+
+    // The subset of sorted matches that should be displayed. Useful if e.g. rendering matches as
+    // plaintext.
+    matches: IMatchItem[]
+}
+
+/**
+ * Calculates how to group together matches for display. Takes into account:
+ *
+ * - Whether or not displaying a subset or all matches is desired
+ * - A surrounding number of context lines to display
+ * - Whether or not context lines have (or do not have) matches within them
+ * - Grouping based on whether or not there is overlapping or adjacent context.
+ *
+ * @param matches The matches to split into groups.
+ * @param maxMatches The maximum number of matches to show, or 0 for all.
+ * @param context The number of surrounding context lines to show for each match.
+ */
+export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, context: number): IGroupedMatches => {
+    const sortedMatches = matches.sort((a, b) => {
+        if (a.line < b.line) {
+            return -1
+        }
+        if (a.line === b.line) {
+            if (a.highlightRanges[0].start < b.highlightRanges[0].start) {
+                return -1
+            }
+            if (a.highlightRanges[0].start === b.highlightRanges[0].start) {
+                return 0
+            }
+            return 1
+        }
+        return 1
+    })
+
+    // This checks the highest line number amongst the number of matches
+    // that we want to show in a collapsed result preview.
+    const highestLineNumberWithinSubsetMatches =
+        sortedMatches.length > 0
+            ? sortedMatches.length > maxMatches
+                ? sortedMatches[maxMatches == 0 ? 0 : maxMatches - 1].line
+                : sortedMatches[sortedMatches.length - 1].line
+            : 0
+
+    // Determine which line matches we will show. This includes matches that are in the context
+    // area (if any.)
+    const showMatches = sortedMatches.filter(
+        (match, index) =>
+            maxMatches === 0 || index < maxMatches || match.line <= highestLineNumberWithinSubsetMatches + context
+    )
+
+    const grouped = mergeContext(
+        context,
+        flatMap(showMatches, (match, index) =>
+            match.highlightRanges.map(range => ({
+                line: match.line,
+                character: range.start,
+                highlightLength: range.highlightLength,
+                badge: match.badge,
+                IsInContext: maxMatches === 0 ? false : match.line > highestLineNumberWithinSubsetMatches,
+            }))
+        )
+    ).map(group => calculateGroupPositions(group, context, highestLineNumberWithinSubsetMatches))
+
+    return {
+        grouped: grouped,
+        matches: showMatches,
+    }
 }

--- a/client/shared/src/components/FileMatchContext.ts
+++ b/client/shared/src/components/FileMatchContext.ts
@@ -106,18 +106,6 @@ interface MatchGroup {
 }
 
 /**
- * Describes matches that have been grouped together.
- */
-interface MatchGroups {
-    // The grouped matches.
-    grouped: MatchGroup[]
-
-    // The subset of sorted matches that should be displayed. Useful if e.g. rendering matches as
-    // plaintext.
-    matches: MatchItem[]
-}
-
-/**
  * Calculates how to group together matches for display. Takes into account:
  *
  * - Whether or not displaying a subset or all matches is desired
@@ -128,8 +116,10 @@ interface MatchGroups {
  * @param matches The matches to split into groups.
  * @param maxMatches The maximum number of matches to show, or 0 for all.
  * @param context The number of surrounding context lines to show for each match.
+ * @returns The subset of matches that were sorted and chosen for display, as well as that same
+ *          list of matches grouped together.
  */
-export const calculateMatchGroups = (matches: MatchItem[], maxMatches: number, context: number): MatchGroups => {
+export const calculateMatchGroups = (matches: MatchItem[], maxMatches: number, context: number): [MatchItem[], MatchGroup[]] => {
     const sortedMatches = matches.sort((a, b) => {
         if (a.line < b.line) {
             return -1
@@ -174,8 +164,5 @@ export const calculateMatchGroups = (matches: MatchItem[], maxMatches: number, c
         )
     ).map(group => calculateGroupPositions(group, context, highestLineNumberWithinSubsetMatches))
 
-    return {
-        grouped,
-        matches: showMatches,
-    }
+    return [showMatches, grouped]
 }


### PR DESCRIPTION
## Overview

This is a prerequisite requirement for implementing optimizations like #6992 and #16467 in a clean fashion.

It refactors how `CodeExcerpt`, `FileMatchChildren`, and `FileMatch` work together, giving us:

- Better, more isolated unit-testing of the functionality which breaks line matches up into groups.
- More tests (added in this PR.)
- A more clear separation of concerns.

## The problem

The code structure behind `CodeExcerpt` is a bit spaghetti today.

1. (ok) `FileMatch` takes the actual individual-line matches returned from the search GraphQL API and passes those to `FileMatchChildren`.
2. (ok) `FileMatch` tells `FileMatchChildren` exactly how many matches (`FileMatchProps.subsetMatches`) to show when the file is collapsed (user has not clicked "Show N more matches").
3. (ok) `FileMatchChildren` groups the individual line matches into groups based on:
    - The number of desired matches to show (`FileMatchProps.subsetMatches`)
    - Whether or not the matches are contiguous regions or not.
4. (ok) `FileMatchChildren` renders a `CodeExcerpt` for each group of matches it wants rendered.
5. (?) `FileMatchChildren` gives the `CodeExcerpt` a function to fetch the *entire* highlighted file instead of giving it the subset of matches and syntax highlighted lines it is responsible for.
6. (??) `CodeExcerpt` must calculate how many lines it should display which [is very complex](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@55d41b342736b318b76cb5ffe54db14ed5558ee6/-/blob/client/shared/src/components/CodeExcerpt.tsx#L120-156).
7. (???) `CodeExcerpt` must account for the user-configurable number of context lines, instead of rendering the section of code the parent told it.
8  (???!) `CodeExcerpt` must account for adjacent `CodeExcerpt`s

In short, the actual logic for how we go from "individual line matches -> groups of matches" is today split across multiple locations:

- `FileMatchChildren`
- `CodeExcerpt`
- `FileMatchContext`

A change in any of the three can break the behavior in totality, and it is quite brittle / hard to test.

## Solution

This change lifts the logic for "individual line matches -> groups of matches" out of the three components and into a single function:

```ts
/**
 * Calculates how to group together matches for display. Takes into account:
 *
 * - Whether or not displaying a subset or all matches is desired
 * - A surrounding number of context lines to display
 * - Whether or not context lines have (or do not have) matches within them
 * - Grouping based on whether or not there is overlapping or adjacent context.
 *
 * @param matches The matches to split into groups.
 * @param maxMatches The maximum number of matches to show, or 0 for all.
 * @param context The number of surrounding context lines to show for each match.
 */
export const calculateMatchGroups = (matches: IMatchItem[], maxMatches: number, context: number): IGroupedMatches
```

Thus making the behavior of the components here very straightforward:

- `FileMatch` renders a file match by creating `FileMatchChildren`.
- `FileMatchChildren` takes the search results and sends them to `calculateMatchGroups`, rendering a `CodeExcerpt` for each group.
- Each `CodeExcerpt` is now a simple, straightforward component only responsible for the excerpt of code _it is rendering_.
    - No longer responsible for splitting the excerpt of code it is rendering out of the entire file.
    - No longer responsible for caring about adjacent excerpts of code and performing complex end-of-excerpt calculations.
    - No longer is the parent partially responsible for splitting, and passing "fun" parameters like this to the `CodeExcerpt`:
        ```
            /** The highest line number among the subset matches. */
            lastSubsetMatchLineNumber: number
        ```

## Future improvements & confidence in this change

I think `calculateMatchGroups` can be made a lot more straightforward in how it operates. The logic is sound, but the way it is written is convoluted. I initially tried to tackle this, but due to the lack of tests and isolation I ended up wasting ~7d here attempting to rewrite this logic and discovering numerous edge cases that needed to be handled when doing side-by-side comparisons.

This change is mostly just moving the logic that previously existed into another location, so there are zero behavior changes here and I have done extensive automated, and manual, testing to ensure that is the case.

Now that this code is isolated and heavily tested, we should be able to do some more fearless refactoring of it to make it more legible.

Helps #6992 and #16467

Signed-off-by: Stephen Gutekanst <stephen.gutekanst@gmail.com>