### PR TITLE
search frontend: some streaming search progress QA items

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -96,6 +96,7 @@ $text-muted: var(--text-muted);
     --sourcegraph-logo-text-color: #242427;
     --search-filter-keyword-color: #1c7cd6;
     --search-keyword-color: #{$oc-grape-7};
+    --infobar-warning-color: #{$oc-red-8};
 }
 .theme-dark {
     // Affects default browser styles
@@ -120,4 +121,5 @@ $text-muted: var(--text-muted);
     --sourcegraph-logo-text-color: #ffffff;
     --search-filter-keyword-color: #329af0;
     --search-keyword-color: #{$oc-grape-4};
+    --infobar-warning-color: #{$oc-red-6};
 }

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -8,6 +8,11 @@
 }
 
 .streaming-progress {
+    &__count,
+    &__skipped {
+        padding: 0.25rem 0.5rem;
+    }
+
     &__count {
         color: var(--link-color);
 
@@ -25,6 +30,8 @@
 
     &__skipped {
         border: none;
+        margin-left: 0.25rem;
+
         &.btn.btn-secondary {
             color: var(--link-color);
             background-color: transparent;

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -29,13 +29,16 @@
     }
 
     &__skipped {
-        border: none;
-        margin-left: 0.25rem;
-
         &.btn.btn-secondary {
+            border: none;
+            margin-left: 0.25rem;
             color: var(--link-color);
             background-color: transparent;
             box-shadow: none;
+        }
+
+        &--warning.btn.btn-secondary {
+            color: var(--infobar-warning-color);
         }
 
         &-popover {

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
@@ -68,9 +68,85 @@ add('2 results from 2 repositories, complete, skipped with info', () => {
     return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
 })
 
+add('2 results from 2 repositories, loading, skipped with info', () => {
+    const progress: Progress = {
+        done: false,
+        durationMs: 1500,
+        matchCount: 2,
+        repositoriesCount: 2,
+        skipped: [
+            {
+                reason: 'excluded-fork',
+                message: '10k forked repositories excluded',
+                severity: 'info',
+                title: '10k forked repositories excluded',
+                suggested: {
+                    title: 'forked:yes',
+                    queryExpression: 'forked:yes',
+                },
+            },
+            {
+                reason: 'excluded-archive',
+                message: '60k archived repositories excluded',
+                severity: 'info',
+                title: '60k archived repositories excluded',
+                suggested: {
+                    title: 'archived:yes',
+                    queryExpression: 'archived:yes',
+                },
+            },
+        ],
+    }
+
+    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+})
+
 add('2 results from 2 repositories, complete, skipped with warning', () => {
     const progress: Progress = {
         done: true,
+        durationMs: 1500,
+        matchCount: 2,
+        repositoriesCount: 2,
+        skipped: [
+            {
+                reason: 'excluded-fork',
+                message: '10k forked repositories excluded',
+                severity: 'info',
+                title: '10k forked repositories excluded',
+                suggested: {
+                    title: 'forked:yes',
+                    queryExpression: 'forked:yes',
+                },
+            },
+            {
+                reason: 'excluded-archive',
+                message: '60k archived repositories excluded',
+                severity: 'info',
+                title: '60k archived repositories excluded',
+                suggested: {
+                    title: 'archived:yes',
+                    queryExpression: 'archived:yes',
+                },
+            },
+            {
+                reason: 'shard-timedout',
+                message: 'Search timed out',
+                severity: 'warn',
+                title: 'Search timed out',
+                suggested: {
+                    title: 'timeout:2m',
+                    queryExpression: 'timeout:2m',
+                },
+            },
+        ],
+    }
+
+    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+})
+
+add('2 results from 2 repositories, loading, skipped with warning', () => {
+    const progress: Progress = {
+        done: false,
         durationMs: 1500,
         matchCount: 2,
         repositoriesCount: 2,

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
@@ -16,7 +16,7 @@ export const defaultProgress: Progress = {
 }
 
 export const StreamingProgress: React.FunctionComponent<StreamingProgressProps> = props => (
-    <div className="d-flex streaming-progress">
+    <div className="d-flex align-items-center streaming-progress">
         <StreamingProgressCount {...props} />
         <StreamingProgressSkippedButton {...props} />
     </div>

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -8,11 +8,11 @@ export const StreamingProgressCount: React.FunctionComponent<StreamingProgressPr
     progress = defaultProgress,
 }) => (
     <div
-        className={classNames('streaming-progress__count p-2 d-flex align-items-center', {
+        className={classNames('streaming-progress__count d-flex align-items-center', {
             'streaming-progress__count--in-progress': !progress.done,
         })}
     >
-        <CalculatorIcon className="mr-2" />
+        <CalculatorIcon className="mr-2 icon-inline" />
         {progress.matchCount} {pluralize('result', progress.matchCount)} in {(progress.durationMs / 1000).toFixed(2)}s
         {progress.repositoriesCount && (
             <>

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
@@ -101,7 +101,7 @@ describe('StreamingProgressSkippedButton', () => {
 
         const element = mount(<StreamingProgressSkippedButton progress={progress} />, { attachTo: div })
         expect(element.find('.btn.streaming-progress__skipped')).toHaveLength(1)
-        expect(element.find('.btn.streaming-progress__skipped.alert.alert-danger')).toHaveLength(1)
+        expect(element.find('.btn.streaming-progress__skipped--warning')).toHaveLength(1)
     })
 
     it('should open and close popover when button is clicked', () => {

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -20,7 +20,7 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingPr
             {progress.skipped.length > 0 && (
                 <>
                     <Button
-                        className={classNames('streaming-progress__skipped p-2 mb-0 d-flex align-items-center', {
+                        className={classNames('streaming-progress__skipped mb-0 ml-2 d-flex align-items-center', {
                             'alert alert-danger': skippedWithWarning,
                         })}
                         color={skippedWithWarning ? 'danger' : 'secondary'}
@@ -28,9 +28,9 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingPr
                         id="streaming-progress__skipped"
                     >
                         {skippedWithWarning ? (
-                            <AlertCircleIcon className="mr-2" />
+                            <AlertCircleIcon className="mr-2 icon-inline" />
                         ) : (
-                            <InformationOutlineIcon className="mr-2" />
+                            <InformationOutlineIcon className="mr-2 icon-inline" />
                         )}
                         Some repositories excluded
                         <MenuDownIcon className="icon-inline" />

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -21,9 +21,9 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingPr
                 <>
                     <Button
                         className={classNames('streaming-progress__skipped mb-0 ml-2 d-flex align-items-center', {
-                            'alert alert-danger': skippedWithWarning,
+                            'streaming-progress__skipped--warning': skippedWithWarning,
                         })}
-                        color={skippedWithWarning ? 'danger' : 'secondary'}
+                        color="secondary"
                         onClick={toggleOpen}
                         id="streaming-progress__skipped"
                     >

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -35,7 +35,7 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<StreamingP
     return (
         <>
             {progress.skipped.map(skipped => (
-                <Alert key={skipped.reason} color={skipped.severity === 'warn' ? 'danger' : 'primary'}>
+                <Alert key={skipped.reason} color={skipped.severity === 'warn' ? 'danger' : 'info'}>
                     <h4 className="d-flex align-items-center mb-0">
                         {skipped.severity === 'warn' ? (
                             <AlertCircleIcon className="icon-inline mr-2" />

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -12,10 +12,10 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
   }
 >
   <div
-    className="streaming-progress__count p-2 d-flex align-items-center streaming-progress__count--in-progress"
+    className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
     <Memo(CalculatorIcon)
-      className="mr-2"
+      className="mr-2 icon-inline"
     />
     0
      
@@ -40,10 +40,10 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
   }
 >
   <div
-    className="streaming-progress__count p-2 d-flex align-items-center"
+    className="streaming-progress__count d-flex align-items-center"
   >
     <Memo(CalculatorIcon)
-      className="mr-2"
+      className="mr-2 icon-inline"
     />
     1
      
@@ -73,10 +73,10 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
   }
 >
   <div
-    className="streaming-progress__count p-2 d-flex align-items-center"
+    className="streaming-progress__count d-flex align-items-center"
   >
     <Memo(CalculatorIcon)
-      className="mr-2"
+      className="mr-2 icon-inline"
     />
     123
      

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
 >
   <Alert
     closeAriaLabel="Close"
-    color="primary"
+    color="info"
     fade={true}
     isOpen={true}
     key="excluded-fork"
@@ -75,7 +75,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       appear={true}
       baseClass="fade"
       baseClassActive="show"
-      className="alert alert-primary"
+      className="alert alert-info"
       enter={true}
       exit={true}
       in={true}
@@ -107,7 +107,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         unmountOnExit={true}
       >
         <div
-          className="alert alert-primary fade"
+          className="alert alert-info fade"
           role="alert"
         >
           <h4
@@ -131,7 +131,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   </Alert>
   <Alert
     closeAriaLabel="Close"
-    color="primary"
+    color="info"
     fade={true}
     isOpen={true}
     key="excluded-archive"
@@ -161,7 +161,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       appear={true}
       baseClass="fade"
       baseClassActive="show"
-      className="alert alert-primary"
+      className="alert alert-info"
       enter={true}
       exit={true}
       in={true}
@@ -193,7 +193,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         unmountOnExit={true}
       >
         <div
-          className="alert alert-primary fade"
+          className="alert alert-info fade"
           role="alert"
         >
           <h4


### PR DESCRIPTION
See storybook for before/after comparisons.

- Fix progress items icon size, item height, and padding
- Added margin between progress indicator and skipped button
- Skipped button on warning state now just has red text instead of the button itself being red
- In progress popover, `info` severity items are now styles as info instead of primary
- Added more storybook tests for missing scenarios