### PR TITLE
search frontend: infobar items are now always right-aligned

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -17,18 +17,10 @@
     &__row {
         display: flex;
         flex-wrap: wrap;
-        justify-content: space-between;
+        justify-content: flex-end;
         height: 100%;
-
-        &-left {
-            display: flex;
-            flex-wrap: wrap;
-        }
-
-        &-right {
-            flex: 1 0 auto;
-            text-align: right;
-        }
+        flex: 1 0 auto;
+        text-align: right;
     }
 
     &__notice {

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -70,12 +70,10 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => (
     <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
         <small className="search-results-info-bar__row">
-            <div className="search-results-info-bar__row-left">
-                {props.stats}
-                <QuotesInterpretedLiterallyNotice {...props} />
-            </div>
+            {props.stats}
+            <QuotesInterpretedLiterallyNotice {...props} />
 
-            <ul className="search-results-info-bar__row-right nav align-items-center justify-content-end">
+            <ul className="nav align-items-center justify-content-end">
                 <ActionsNavItems
                     {...props}
                     extraContext={{ searchQuery: props.query || null }}

--- a/client/web/src/search/results/SearchResultsList.scss
+++ b/client/web/src/search/results/SearchResultsList.scss
@@ -15,11 +15,6 @@
         border-bottom: 1px solid var(--border-color);
     }
 
-    &__tabs {
-        // Large value so that infobar doesn't grow when side by side with tabs but does grow when wrapped
-        flex-grow: 9999;
-    }
-
     // In narrow windows, make the results flush with the left/right sides,
     // but we still need padding for the header and alerts.
     @include media-breakpoint-down(lg) {


### PR DESCRIPTION
Infobar items are now always right-aligned, even when wrapped.
Also gets rid of the hacky `flex-grow: 9999` 🎉

Wrapped:
![image](https://user-images.githubusercontent.com/206864/101222316-5e209d00-363e-11eb-8033-849989c242c6.png)

Not wrapped:
![image](https://user-images.githubusercontent.com/206864/101222338-68429b80-363e-11eb-9653-46851517cd36.png)

