### PR TITLE
search frontend: coalesce literal patttern chars

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -151,23 +151,11 @@ describe('getMonacoTokens()', () => {
                 "scopes": "identifier"
               },
               {
-                "startIndex": 2,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 3,
                 "scopes": "metaRegexpEscapedCharacter"
               },
               {
                 "startIndex": 5,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 6,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 7,
                 "scopes": "identifier"
               },
               {
@@ -355,10 +343,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpCharacterClass"
               },
               {
-                "startIndex": 4,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 5,
                 "scopes": "metaRegexpCharacterClass"
               },
@@ -387,10 +371,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpCharacterClass"
               },
               {
-                "startIndex": 3,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 4,
                 "scopes": "metaRegexpCharacterClass"
               },
@@ -407,10 +387,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpCharacterClass"
               },
               {
-                "startIndex": 8,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 9,
                 "scopes": "metaRegexpCharacterClass"
               },
@@ -425,10 +401,6 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 12,
                 "scopes": "metaRegexpCharacterClass"
-              },
-              {
-                "startIndex": 13,
-                "scopes": "identifier"
               },
               {
                 "startIndex": 14,
@@ -456,14 +428,6 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 6,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 7,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 8,
                 "scopes": "identifier"
               },
               {
@@ -551,10 +515,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
-                "startIndex": 9,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 10,
                 "scopes": "metaRegexpDelimited"
               },
@@ -563,20 +523,12 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
-                "startIndex": 12,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 13,
                 "scopes": "metaRegexpDelimited"
               },
               {
                 "startIndex": 14,
                 "scopes": "metaRegexpAlternative"
-              },
-              {
-                "startIndex": 15,
-                "scopes": "identifier"
               }
             ]
         `)
@@ -604,10 +556,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
-                "startIndex": 8,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 9,
                 "scopes": "metaRegexpDelimited"
               },
@@ -628,10 +576,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
-                "startIndex": 14,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 15,
                 "scopes": "metaRegexpDelimited"
               },
@@ -650,10 +594,6 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 19,
                 "scopes": "metaRegexpAlternative"
-              },
-              {
-                "startIndex": 20,
-                "scopes": "identifier"
               },
               {
                 "startIndex": 21,
@@ -689,10 +629,6 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 6,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 7,
                 "scopes": "identifier"
               },
               {
@@ -744,14 +680,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "identifier"
               },
               {
-                "startIndex": 3,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 4,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 5,
                 "scopes": "whitespace"
               },
@@ -793,14 +721,6 @@ describe('getMonacoTokens()', () => {
                 "scopes": "identifier"
               },
               {
-                "startIndex": 3,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 4,
-                "scopes": "identifier"
-              },
-              {
                 "startIndex": 5,
                 "scopes": "whitespace"
               },
@@ -834,14 +754,6 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 2,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 3,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 4,
                 "scopes": "identifier"
               },
               {
@@ -889,14 +801,6 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 2,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 3,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 4,
                 "scopes": "identifier"
               },
               {

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -194,14 +194,14 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "Matches the character \`a\`."
+                  "value": "Matches the string \`abcd\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 2,
-                "endColumn": 3
+                "endColumn": 6
               }
             }
         `)


### PR DESCRIPTION
Before, a hover on a literal char would be like "matches the character `u`". 

<img width="554" alt="Screen Shot 2020-12-04 at 6 50 48 PM" src="https://user-images.githubusercontent.com/888624/101230430-7c988f80-3662-11eb-89ef-0e56d1970851.png">

This is sort of OK, but in general I think it's better to coalesce contiguous literal chars into a string. So now:

<img width="648" alt="Screen Shot 2020-12-04 at 6 50 33 PM" src="https://user-images.githubusercontent.com/888624/101230456-a2259900-3662-11eb-8cea-a43eb4aa9a66.png">

This is also a better default for things like:

`repo:^foo@abcd1234`

where it's silly to say 'matches the character `a`' for the revision, which is what currently happens. Yes I'm working on contextual hovers for revisions, see future PR :-)

