### PR TITLE
Code monitoring: add unit tests

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -69,7 +69,12 @@ import {
 } from './util/settings'
 import { SearchPatternType } from '../../shared/src/graphql-operations'
 import { HTTPStatusError } from '../../shared/src/backend/fetch'
-import { fetchCodeMonitor, listUserCodeMonitors, updateCodeMonitor } from './enterprise/code-monitoring/backend'
+import {
+    fetchCodeMonitor,
+    listUserCodeMonitors,
+    toggleCodeMonitorEnabled,
+    updateCodeMonitor,
+} from './enterprise/code-monitoring/backend'
 import { aggregateStreamingSearch } from './search/stream'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
@@ -463,6 +468,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     fetchUserCodeMonitors={listUserCodeMonitors}
                                     fetchCodeMonitor={fetchCodeMonitor}
                                     updateCodeMonitor={updateCodeMonitor}
+                                    toggleCodeMonitorEnabled={toggleCodeMonitorEnabled}
                                     streamSearch={aggregateStreamingSearch}
                                 />
                             )}

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -69,7 +69,7 @@ import {
 } from './util/settings'
 import { SearchPatternType } from '../../shared/src/graphql-operations'
 import { HTTPStatusError } from '../../shared/src/backend/fetch'
-import { listUserCodeMonitors } from './enterprise/code-monitoring/backend'
+import { fetchCodeMonitor, listUserCodeMonitors, updateCodeMonitor } from './enterprise/code-monitoring/backend'
 import { aggregateStreamingSearch } from './search/stream'
 
 export interface SourcegraphWebAppProps extends KeyboardShortcutsProps {
@@ -461,6 +461,8 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}
                                     fetchUserCodeMonitors={listUserCodeMonitors}
+                                    fetchCodeMonitor={fetchCodeMonitor}
+                                    updateCodeMonitor={updateCodeMonitor}
                                     streamSearch={aggregateStreamingSearch}
                                 />
                             )}

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -71,7 +71,7 @@ import { SearchPatternType } from '../../shared/src/graphql-operations'
 import { HTTPStatusError } from '../../shared/src/backend/fetch'
 import {
     fetchCodeMonitor,
-    listUserCodeMonitors,
+    fetchUserCodeMonitors,
     toggleCodeMonitorEnabled,
     updateCodeMonitor,
 } from './enterprise/code-monitoring/backend'
@@ -465,7 +465,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}
-                                    fetchUserCodeMonitors={listUserCodeMonitors}
+                                    fetchUserCodeMonitors={fetchUserCodeMonitors}
                                     fetchCodeMonitor={fetchCodeMonitor}
                                     updateCodeMonitor={updateCodeMonitor}
                                     toggleCodeMonitorEnabled={toggleCodeMonitorEnabled}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
@@ -8,9 +8,9 @@ import { Link } from '../../../../shared/src/components/Link'
 import { ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/errors'
 import { useEventObservable } from '../../../../shared/src/util/useObservable'
 import { CodeMonitorFields, ToggleCodeMonitorEnabledResult } from '../../graphql-operations'
-import { toggleCodeMonitorEnabled } from './backend'
+import { CodeMonitoringProps } from '.'
 
-export interface CodeMonitorNodeProps {
+export interface CodeMonitorNodeProps extends Pick<CodeMonitoringProps, 'toggleCodeMonitorEnabled'> {
     node: CodeMonitorFields
     location: H.Location
 }
@@ -18,6 +18,7 @@ export interface CodeMonitorNodeProps {
 const LOADING = 'LOADING' as const
 
 export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
+    toggleCodeMonitorEnabled,
     location,
     node,
 }: CodeMonitorNodeProps) => {
@@ -49,7 +50,7 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                         )
                     })
                 ),
-            [node, enabled, setEnabled]
+            [node, enabled, setEnabled, toggleCodeMonitorEnabled]
         )
     )
 
@@ -66,7 +67,7 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                 <div className="d-flex flex-column">
                     <div className="d-flex">
                         {toggleMonitorOrError === LOADING && <LoadingSpinner className="icon-inline mr-2" />}
-                        <div onClick={toggleMonitor}>
+                        <div onClick={toggleMonitor} className="test-toggle-monitor-enabled">
                             <Toggle value={enabled} className="mr-3" disabled={toggleMonitorOrError === LOADING} />
                         </div>
                         {/** TODO: link to edit pages. */}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -7,6 +7,7 @@ import { AuthenticatedUser } from '../../auth'
 import { ListUserCodeMonitorsVariables } from '../../graphql-operations'
 import { of } from 'rxjs'
 import { mockCodeMonitorNodes } from './testing/util'
+import sinon from 'sinon'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CodeMonitoringPage', module)
 
@@ -21,6 +22,7 @@ const additionalProps = {
             },
             totalCount: 12,
         }),
+    toggleCodeMonitorEnabled: sinon.fake(),
 }
 
 add(

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -26,6 +26,7 @@ const additionalProps = {
             },
             totalCount: 12,
         }),
+    toggleCodeMonitorEnabled: sinon.spy(),
 }
 
 const generateMockFetchMonitors = (count: number) => ({ id, first, after }: ListUserCodeMonitorsVariables) => {
@@ -55,5 +56,14 @@ describe('CodeMonitoringListPage', () => {
         expect(
             mount(<CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(12)} />)
         ).toMatchSnapshot()
+    })
+
+    test('Clicking enabled toggle calls toggleCodeMonitorEnabled', () => {
+        const component = mount(
+            <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
+        )
+        const toggle = component.find('.test-toggle-monitor-enabled')
+        toggle.simulate('click')
+        expect(additionalProps.toggleCodeMonitorEnabled.calledOnce)
     })
 })

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -26,7 +26,7 @@ const additionalProps = {
             },
             totalCount: 12,
         }),
-    toggleCodeMonitorEnabled: sinon.spy(),
+    toggleCodeMonitorEnabled: sinon.spy((id: string, enabled: boolean) => of({ id: 'test', enabled: true })),
 }
 
 const generateMockFetchMonitors = (count: number) => ({ id, first, after }: ListUserCodeMonitorsVariables) => {

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -13,7 +13,10 @@ import { CodeMonitoringProps } from '.'
 import PlusIcon from 'mdi-react/PlusIcon'
 import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
 
-export interface CodeMonitoringPageProps extends BreadcrumbsProps, BreadcrumbSetters, CodeMonitoringProps {
+export interface CodeMonitoringPageProps
+    extends BreadcrumbsProps,
+        BreadcrumbSetters,
+        Pick<CodeMonitoringProps, 'fetchUserCodeMonitors' | 'toggleCodeMonitorEnabled'> {
     authenticatedUser: AuthenticatedUser
     location: H.Location
     history: H.History
@@ -110,7 +113,10 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                             queryConnection={queryConnection}
                             hideSearch={true}
                             nodeComponent={CodeMonitorNode}
-                            nodeComponentProps={{ location: props.location }}
+                            nodeComponentProps={{
+                                location: props.location,
+                                toggleCodeMonitorEnabled: props.toggleCodeMonitorEnabled,
+                            }}
                             noun="code monitor"
                             pluralNoun="code monitors"
                             noSummaryIfAllNodesVisible={true}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -25,7 +25,7 @@ export interface CodeMonitoringPageProps
 type CodeMonitorFilter = 'all' | 'user'
 
 export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => {
-    const { authenticatedUser, fetchUserCodeMonitors } = props
+    const { authenticatedUser, fetchUserCodeMonitors, toggleCodeMonitorEnabled } = props
 
     const queryConnection = useCallback(
         (args: Partial<ListUserCodeMonitorsVariables>) =>
@@ -115,7 +115,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                             nodeComponent={CodeMonitorNode}
                             nodeComponentProps={{
                                 location: props.location,
-                                toggleCodeMonitorEnabled: props.toggleCodeMonitorEnabled,
+                                toggleCodeMonitorEnabled,
                             }}
                             noun="code monitor"
                             pluralNoun="code monitors"

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -20,6 +20,7 @@ describe('CreateCodeMonitorPage', () => {
         breadcrumbs: [{ depth: 0, breadcrumb: null }],
         setBreadcrumb: sinon.spy(),
         useBreadcrumb: sinon.spy(),
+        history,
     }
     test('Actions area button is disabled while trigger is incomplete', () => {
         const component = mount(<CreateCodeMonitorPage {...props} />)

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -12,6 +12,7 @@ import { CodeMonitorForm } from './components/CodeMonitorForm'
 
 export interface CreateCodeMonitorPageProps extends BreadcrumbsProps, BreadcrumbSetters {
     location: H.Location
+    history: H.History
     authenticatedUser: AuthenticatedUser
 }
 

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -32,6 +32,7 @@ describe('ManageCodeMonitorPage', () => {
             path: history.location.pathname,
             url: 'https://sourcegraph.com',
         },
+        toggleCodeMonitorEnabled: sinon.spy(),
     }
     test('Form is pre-loaded with code monitor data', () => {
         const component = mount(<ManageCodeMonitorPage {...props} />)

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+import * as H from 'history'
+import { AuthenticatedUser } from '../../auth'
+import sinon from 'sinon'
+import { mount } from 'enzyme'
+import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
+import { mockCodeMonitor, mockCodeMonitorNodes } from './testing/util'
+import { of } from 'rxjs'
+
+describe('ManageCodeMonitorPage', () => {
+    const mockUser = {
+        id: 'userID',
+        username: 'username',
+        email: 'user@me.com',
+        siteAdmin: true,
+    } as AuthenticatedUser
+
+    const history = H.createMemoryHistory()
+    const props = {
+        history,
+        location: history.location,
+        authenticatedUser: mockUser,
+        breadcrumbs: [{ depth: 0, breadcrumb: null }],
+        setBreadcrumb: sinon.spy(),
+        useBreadcrumb: sinon.spy(),
+        fetchUserCodeMonitors: sinon.spy(),
+        updateCodeMonitor: sinon.spy(),
+        fetchCodeMonitor: sinon.spy((id: string) => of(mockCodeMonitor)),
+        match: {
+            params: { id: 'test-id' },
+            isExact: true,
+            path: history.location.pathname,
+            url: 'https://sourcegraph.com',
+        },
+    }
+    test('Form is pre-loaded with data', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        const nameInput = component.find('.test-name-input')
+        expect(nameInput.length).toBe(1)
+        const nameValue = nameInput.getDOMNode().getAttribute('value')
+        expect(nameValue).toBe('Test code monitor')
+        const currentQueryValue = component.find('.test-existing-query')
+        const currentActionEmailValue = component.find('.test-existing-action-email')
+        expect(currentQueryValue.getDOMNode().innerHTML).toBe('test')
+        expect(currentActionEmailValue.getDOMNode().innerHTML).toBe('user@me.com')
+        component.unmount()
+    })
+
+    test('Updating the form calls the update request', () => {
+        const updateSpy = sinon.spy()
+        const component = mount(<ManageCodeMonitorPage {...props} updateCodeMonitor={updateSpy} />)
+        const nameInput = component.find('.test-name-input')
+        const nameValue = nameInput.getDOMNode().getAttribute('value')
+        expect(nameValue).toBe('Test code monitor')
+        nameInput.simulate('change', { target: { value: 'Test updated' } })
+        const submitButton = component.find('.test-submit-monitor')
+        submitButton.simulate('click')
+        expect(updateSpy.calledOnce)
+        component.unmount()
+    })
+})

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -58,6 +58,7 @@ describe('ManageCodeMonitorPage', () => {
         const submitButton = component.find('.test-submit-monitor')
         submitButton.simulate('click')
         expect(props.updateCodeMonitor.calledOnce)
+        expect(props.updateCodeMonitor.calledWith({ ...mockCodeMonitor, name: 'Test code monitor' }))
         component.unmount()
     })
 

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -32,7 +32,7 @@ describe('ManageCodeMonitorPage', () => {
             path: history.location.pathname,
             url: 'https://sourcegraph.com',
         },
-        toggleCodeMonitorEnabled: sinon.spy(),
+        toggleCodeMonitorEnabled: sinon.spy((id: string, enabled: boolean) => of({ id: 'test', enabled: true })),
     }
     test('Form is pre-loaded with code monitor data', () => {
         const component = mount(<ManageCodeMonitorPage {...props} />)

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -4,7 +4,7 @@ import { AuthenticatedUser } from '../../auth'
 import sinon from 'sinon'
 import { mount } from 'enzyme'
 import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
-import { mockCodeMonitor, mockCodeMonitorNodes } from './testing/util'
+import { mockCodeMonitor } from './testing/util'
 import { of } from 'rxjs'
 
 describe('ManageCodeMonitorPage', () => {
@@ -33,8 +33,10 @@ describe('ManageCodeMonitorPage', () => {
             url: 'https://sourcegraph.com',
         },
     }
-    test('Form is pre-loaded with data', () => {
+    test('Form is pre-loaded with code monitor data', () => {
         const component = mount(<ManageCodeMonitorPage {...props} />)
+        expect(props.fetchCodeMonitor.calledOnce)
+
         const nameInput = component.find('.test-name-input')
         expect(nameInput.length).toBe(1)
         const nameValue = nameInput.getDOMNode().getAttribute('value')
@@ -46,16 +48,35 @@ describe('ManageCodeMonitorPage', () => {
         component.unmount()
     })
 
-    test('Updating the form calls the update request', () => {
-        const updateSpy = sinon.spy()
-        const component = mount(<ManageCodeMonitorPage {...props} updateCodeMonitor={updateSpy} />)
+    test('Updating the form executes the update request', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
         const nameInput = component.find('.test-name-input')
         const nameValue = nameInput.getDOMNode().getAttribute('value')
         expect(nameValue).toBe('Test code monitor')
         nameInput.simulate('change', { target: { value: 'Test updated' } })
         const submitButton = component.find('.test-submit-monitor')
         submitButton.simulate('click')
-        expect(updateSpy.calledOnce)
+        expect(props.updateCodeMonitor.calledOnce)
         component.unmount()
+    })
+
+    test('Clicking Edit in the trigger area opens the query form', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        let triggerInput = component.find('.test-trigger-input')
+        expect(triggerInput.length).toBe(0)
+        const editTrigger = component.find('.test-edit-trigger')
+        editTrigger.simulate('click')
+        triggerInput = component.find('.test-trigger-input')
+        expect(triggerInput.length).toBe(1)
+    })
+
+    test('Clicking Edit in the action area opens the action form', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        let triggerInput = component.find('.test-action-form')
+        expect(triggerInput.length).toBe(0)
+        const editTrigger = component.find('.test-edit-action')
+        editTrigger.simulate('click')
+        triggerInput = component.find('.test-action-form')
+        expect(triggerInput.length).toBe(1)
     })
 })

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -81,4 +81,34 @@ describe('ManageCodeMonitorPage', () => {
         triggerInput = component.find('.test-action-form')
         expect(triggerInput.length).toBe(1)
     })
+
+    test('Save button is disabled when no changes have been made, enabled when changes have been made', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        let submitButton = component.find('.test-submit-monitor')
+        expect(submitButton.prop('disabled')).toBe(true)
+        const nameInput = component.find('.test-name-input')
+        nameInput.simulate('change', { target: { value: 'Test code monitor updated' } })
+        submitButton = component.find('.test-submit-monitor')
+        expect(submitButton.prop('disabled')).toBe(false)
+    })
+
+    test('Cancelling after changes have been made shows confirmation prompt', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        const confirmStub = sinon.stub(window, 'confirm')
+        const nameInput = component.find('.test-name-input')
+        nameInput.simulate('change', { target: { value: 'Test code monitor updated' } })
+        const cancelButton = component.find('.test-cancel-monitor')
+        cancelButton.simulate('click')
+        expect(confirmStub.calledOnce)
+        confirmStub.restore()
+    })
+
+    test('Cancelling without any changes made does not show confirmation prompt', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        const confirmStub = sinon.stub(window, 'confirm')
+        const cancelButton = component.find('.test-cancel-monitor')
+        cancelButton.simulate('click')
+        expect(confirmStub.notCalled)
+        confirmStub.restore()
+    })
 })

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import * as React from 'react'
+import React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { startWith, catchError, tap } from 'rxjs/operators'

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -19,7 +19,7 @@ export interface ManageCodeMonitorPageProps
     extends RouteComponentProps<{ id: Scalars['ID'] }>,
         BreadcrumbsProps,
         BreadcrumbSetters,
-        CodeMonitoringProps {
+        Pick<CodeMonitoringProps, 'updateCodeMonitor' | 'fetchCodeMonitor'> {
     authenticatedUser: AuthenticatedUser
     location: H.Location
     history: H.History

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
   history="[History]"
   location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
+  toggleCodeMonitorEnabled={[Function]}
   useBreadcrumb={[Function]}
 >
   <div
@@ -172,6 +173,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
             nodeComponentProps={
               Object {
                 "location": "[Location path=/code-monitoring]",
+                "toggleCodeMonitorEnabled": [Function],
               }
             }
             noun="code monitor"
@@ -463,6 +465,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                 nodeComponentProps={
                   Object {
                     "location": "[Location path=/code-monitoring]",
+                    "toggleCodeMonitorEnabled": [Function],
                   }
                 }
                 noun="code monitor"
@@ -504,6 +507,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -532,6 +536,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -605,6 +610,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -633,6 +639,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -706,6 +713,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -734,6 +742,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -807,6 +816,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -835,6 +845,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -908,6 +919,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -936,6 +948,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1009,6 +1022,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1037,6 +1051,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1110,6 +1125,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1138,6 +1154,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1211,6 +1228,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1239,6 +1257,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1312,6 +1331,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1340,6 +1360,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1413,6 +1434,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1441,6 +1463,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1525,6 +1548,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
   history="[History]"
   location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
+  toggleCodeMonitorEnabled={[Function]}
   useBreadcrumb={[Function]}
 >
   <div
@@ -1676,6 +1700,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
             nodeComponentProps={
               Object {
                 "location": "[Location path=/code-monitoring]",
+                "toggleCodeMonitorEnabled": [Function],
               }
             }
             noun="code monitor"
@@ -1785,6 +1810,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                 nodeComponentProps={
                   Object {
                     "location": "[Location path=/code-monitoring]",
+                    "toggleCodeMonitorEnabled": [Function],
                   }
                 }
                 noun="code monitor"
@@ -1826,6 +1852,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1854,6 +1881,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -1927,6 +1955,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -1955,6 +1984,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -2028,6 +2058,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -2056,6 +2087,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -2140,6 +2172,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
   history="[History]"
   location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
+  toggleCodeMonitorEnabled={[Function]}
   useBreadcrumb={[Function]}
 >
   <div
@@ -2291,6 +2324,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
             nodeComponentProps={
               Object {
                 "location": "[Location path=/code-monitoring]",
+                "toggleCodeMonitorEnabled": [Function],
               }
             }
             noun="code monitor"
@@ -2634,6 +2668,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 nodeComponentProps={
                   Object {
                     "location": "[Location path=/code-monitoring]",
+                    "toggleCodeMonitorEnabled": [Function],
                   }
                 }
                 noun="code monitor"
@@ -2675,6 +2710,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -2703,6 +2739,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -2776,6 +2813,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -2804,6 +2842,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -2877,6 +2916,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -2905,6 +2945,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -2978,6 +3019,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3006,6 +3048,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3079,6 +3122,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3107,6 +3151,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3180,6 +3225,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3208,6 +3254,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3281,6 +3328,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3309,6 +3357,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3382,6 +3431,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3410,6 +3460,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3483,6 +3534,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3511,6 +3563,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3584,6 +3637,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3612,6 +3666,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3685,6 +3740,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3713,6 +3769,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle
@@ -3786,6 +3843,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
                       className="card p-3 mb-2"
@@ -3814,6 +3872,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             className="d-flex"
                           >
                             <div
+                              className="test-toggle-monitor-enabled"
                               onClick={[Function]}
                             >
                               <Toggle

--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -91,7 +91,7 @@ export interface ListCodeMonitorsResult {
     monitors: ListCodeMonitors
 }
 
-export const listUserCodeMonitors = ({
+export const fetchUserCodeMonitors = ({
     id,
     first,
     after,

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -128,7 +128,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                     <div className="d-flex justify-content-between align-items-center">
                         <div>
                             <div className="font-weight-bold">Send email notifications</div>
-                            <span className="text-muted">{authenticatedUser.email}</span>
+                            <span className="text-muted test-existing-action-email">{authenticatedUser.email}</span>
                         </div>
                         <div className="d-flex">
                             <div className="flex my-4">

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -139,7 +139,11 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                                     className="mr-2"
                                 />
                             </div>
-                            <button type="button" onClick={editForm} className="btn btn-link p-0 text-left">
+                            <button
+                                type="button"
+                                onClick={editForm}
+                                className="btn btn-link p-0 text-left test-edit-action"
+                            >
                                 Edit
                             </button>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -179,7 +179,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     <div className="d-flex justify-content-between align-items-center">
                         <div>
                             <div className="font-weight-bold">When there are new search results</div>
-                            <code className="text-muted">{query}</code>
+                            <code className="text-muted test-existing-query">{query}</code>
                         </div>
                         <div>
                             <button type="button" onClick={editForm} className="btn btn-link p-0 text-left">

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -182,7 +182,11 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                             <code className="text-muted test-existing-query">{query}</code>
                         </div>
                         <div>
-                            <button type="button" onClick={editForm} className="btn btn-link p-0 text-left">
+                            <button
+                                type="button"
+                                onClick={editForm}
+                                className="btn btn-link p-0 text-left test-edit-trigger"
+                            >
                                 Edit
                             </button>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/index.ts
+++ b/client/web/src/enterprise/code-monitoring/index.ts
@@ -1,6 +1,20 @@
 import { Observable } from 'rxjs'
-import { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-operations'
+import {
+    FetchCodeMonitorResult,
+    ListCodeMonitors,
+    ListUserCodeMonitorsVariables,
+    MonitorEditActionInput,
+    MonitorEditInput,
+    MonitorEditTriggerInput,
+    UpdateCodeMonitorResult,
+} from '../../graphql-operations'
 
 export interface CodeMonitoringProps {
     fetchUserCodeMonitors: ({ id, first, after }: ListUserCodeMonitorsVariables) => Observable<ListCodeMonitors>
+    fetchCodeMonitor: (id: string) => Observable<FetchCodeMonitorResult>
+    updateCodeMonitor: (
+        monitorEditInput: MonitorEditInput,
+        triggerEditInput: MonitorEditTriggerInput,
+        actionEditInput: MonitorEditActionInput[]
+    ) => Observable<UpdateCodeMonitorResult['updateCodeMonitor']>
 }

--- a/client/web/src/enterprise/code-monitoring/index.ts
+++ b/client/web/src/enterprise/code-monitoring/index.ts
@@ -6,6 +6,7 @@ import {
     MonitorEditActionInput,
     MonitorEditInput,
     MonitorEditTriggerInput,
+    ToggleCodeMonitorEnabledResult,
     UpdateCodeMonitorResult,
 } from '../../graphql-operations'
 
@@ -17,4 +18,8 @@ export interface CodeMonitoringProps {
         triggerEditInput: MonitorEditTriggerInput,
         actionEditInput: MonitorEditActionInput[]
     ) => Observable<UpdateCodeMonitorResult['updateCodeMonitor']>
+    toggleCodeMonitorEnabled: (
+        id: string,
+        enabled: boolean
+    ) => Observable<ToggleCodeMonitorEnabledResult['toggleCodeMonitor']>
 }

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -1,3 +1,20 @@
+export const mockCodeMonitor = {
+    node: {
+        id: 'foo0',
+        description: 'Test code monitor',
+        enabled: true,
+        owner: { id: 'test-id', namespaceName: 'test-user' },
+        actions: {
+            id: 'test-0',
+            enabled: true,
+            nodes: [
+                { id: 'test-action-0 ', enabled: true, recipients: { nodes: [{ id: 'baz-0', url: '/user/test' }] } },
+            ],
+        },
+        trigger: { id: 'test-0', query: 'test' },
+    },
+}
+
 export const mockCodeMonitorNodes = [
     {
         id: 'foo0',


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/16460. Adds unit tests for code monitoring management and listing pages.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
