### PR TITLE
search: send emails for code monitors

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -13,7 +13,7 @@ import (
 )
 
 type ActionJob struct {
-	Id           int32
+	Id           int
 	Email        int64
 	TriggerEvent int
 

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keegancsmith/sqlf"
-
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 )
 
 func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {

--- a/enterprise/internal/codemonitors/background/background.go
+++ b/enterprise/internal/codemonitors/background/background.go
@@ -11,13 +11,16 @@ import (
 func StartBackgroundJobs(ctx context.Context, db *sql.DB) {
 	codeMonitorsStore := codemonitors.NewStore(db)
 
-	metrics := newMetricsForTriggerQueries()
+	triggerMetrics := newMetricsForTriggerQueries()
+	actionMetrics := newActionMetrics()
 
 	routines := []goroutine.BackgroundRoutine{
 		newTriggerQueryEnqueuer(ctx, codeMonitorsStore),
 		newTriggerJobsLogDeleter(ctx, codeMonitorsStore),
-		newTriggerQueryRunner(ctx, codeMonitorsStore, metrics),
-		newTriggerQueryResetter(ctx, codeMonitorsStore, metrics),
+		newTriggerQueryRunner(ctx, codeMonitorsStore, triggerMetrics),
+		newTriggerQueryResetter(ctx, codeMonitorsStore, triggerMetrics),
+		newActionRunner(ctx, codeMonitorsStore, actionMetrics),
+		newActionJobResetter(ctx, codeMonitorsStore, actionMetrics),
 	}
 	go goroutine.MonitorBackgroundRoutines(ctx, routines...)
 }

--- a/enterprise/internal/codemonitors/background/email/email.go
+++ b/enterprise/internal/codemonitors/background/email/email.go
@@ -98,10 +98,13 @@ func getSearchURL(ctx context.Context, query, utmSource string) (string, error) 
 }
 
 func getCodeMonitorURL(ctx context.Context, monitorID int64, utmSource string) (string, error) {
-	return sourcegraphURL(ctx, fmt.Sprintf("code-monitoring/%s", relay.MarshalID("FIXME", monitorID)), "", utmSource)
+	return sourcegraphURL(ctx, fmt.Sprintf("code-monitoring/%s", relay.MarshalID(resolvers.MonitorKind, monitorID)), "", utmSource)
 }
 
 func sourcegraphURL(ctx context.Context, path, query, utmSource string) (string, error) {
+	if MockExternalURL != nil {
+		externalURL = MockExternalURL()
+	}
 	if externalURL == nil {
 		// Determine the external URL.
 		externalURLStr, err := api.InternalClient.ExternalURL(ctx)

--- a/enterprise/internal/codemonitors/background/email/email.go
+++ b/enterprise/internal/codemonitors/background/email/email.go
@@ -8,6 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )
@@ -17,7 +18,13 @@ var externalURL *url.URL
 const utmSourceEmail = "code-monitoring-email"
 const priorityCritical = "CRITICAL"
 
+var MockSendEmailForNewSearchResult func(ctx context.Context, userID int32, data *TemplateDataNewSearchResults) error
+var MockExternalURL func() *url.URL
+
 func SendEmailForNewSearchResult(ctx context.Context, userID int32, data *TemplateDataNewSearchResults) error {
+	if MockSendEmailForNewSearchResult != nil {
+		return MockSendEmailForNewSearchResult(ctx, userID, data)
+	}
 	return sendEmail(ctx, userID, newSearchResultsEmailTemplates, data)
 }
 

--- a/enterprise/internal/codemonitors/background/metrics.go
+++ b/enterprise/internal/codemonitors/background/metrics.go
@@ -61,3 +61,49 @@ func newMetricsForTriggerQueries() codeMonitorsMetrics {
 		errors:          errors,
 	}
 }
+
+func newActionMetrics() codeMonitorsMetrics {
+	observationContext := &observation.Context{
+		Logger:     log15.Root(),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+
+	metrics := metrics.NewOperationMetrics(
+		observationContext.Registerer,
+		"code_monitors_actions",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of actions run"),
+	)
+
+	handleOperation := observationContext.Operation(observation.Op{
+		Name:         "Action.Run",
+		MetricLabels: []string{"process"},
+		Metrics:      metrics,
+	})
+
+	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_codemonitors_action_reset_failures_total",
+		Help: "The number of reset failures.",
+	})
+	observationContext.Registerer.MustRegister(resetFailures)
+
+	resets := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_codemonitors_action_resets_total",
+		Help: "The number of records reset.",
+	})
+	observationContext.Registerer.MustRegister(resets)
+
+	errors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_codemonitors_action_errors_total",
+		Help: "The number of errors that occur during job.",
+	})
+	observationContext.Registerer.MustRegister(errors)
+
+	return codeMonitorsMetrics{
+		handleOperation: handleOperation,
+		resets:          resets,
+		resetFailures:   resetFailures,
+		errors:          errors,
+	}
+}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -182,9 +182,10 @@ func (r *actionRunner) Handle(ctx context.Context, workerStore dbworkerstore.Sto
 		data *email.TemplateDataNewSearchResults
 	)
 
-	j, err = s.ActionJobForIDInt(ctx, record.RecordID())
-	if err != nil {
-		return fmt.Errorf("store.ActionJobForIDInt: %w", err)
+	var ok bool
+	j, ok = record.(*cm.ActionJob)
+	if !ok {
+		return fmt.Errorf("type assertion failed")
 	}
 
 	m, err = s.GetActionJobMetadata(ctx, record.RecordID())

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -203,9 +203,9 @@ func (r *actionRunner) Handle(ctx context.Context, workerStore dbworkerstore.Sto
 		return fmt.Errorf("store.AllRecipientsForEmailIDInt64: %w", err)
 	}
 
-	data, err = email.NewTemplateDataForNewSearchResults(m.Description, m.Query, e, zeroOrVal(m.NumResults))
+	data, err = email.NewTemplateDataForNewSearchResults(ctx, m.Description, m.Query, e, zeroOrVal(m.NumResults))
 	if err != nil {
-		return fmt.Errorf("email.NewTemplateDataForNewSearchResults")
+		return fmt.Errorf("email.NewTemplateDataForNewSearchResults: %w", err)
 	}
 	for _, rec := range recs {
 		if rec.NamespaceOrgID != nil {

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -1,0 +1,121 @@
+package background
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background/email"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/storetest"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "codemonitorsbackground"
+}
+
+func TestActionRunner(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	externalURL := "https://www.sourcegraph.com"
+	testQuery := "test patternType:literal"
+
+	// Mocks.
+	got := email.TemplateDataNewSearchResults{}
+	email.MockSendEmailForNewSearchResult = func(ctx context.Context, userID int32, data *email.TemplateDataNewSearchResults) error {
+		got = *data
+		return nil
+	}
+	email.MockExternalURL = func() *url.URL {
+		externalURL, _ := url.Parse("https://www.sourcegraph.com")
+		return externalURL
+	}
+
+	// Create a TestStore.
+	var err error
+	dbtesting.SetupGlobalTestDB(t)
+	now := time.Now()
+	clock := func() time.Time { return now }
+	s := codemonitors.NewStoreWithClock(dbconn.Global, clock)
+	ctx, ts := storetest.NewTestStoreWithStore(t, s)
+
+	tests := []struct {
+		name               string
+		numResults         int
+		wantNumResultsText string
+	}{
+		{
+			name:               "5 results",
+			numResults:         5,
+			wantNumResultsText: "There were 5 new search results for your query",
+		},
+		{
+			name:               "1 result",
+			numResults:         1,
+			wantNumResultsText: "There was 1 new search result for your query",
+		},
+	}
+
+	want := email.TemplateDataNewSearchResults{
+		Priority:       "New",
+		SearchURL:      externalURL + "/search?q=test+patternType%3Aliteral&utm_source=code-monitoring-email",
+		Description:    "test description",
+		CodeMonitorURL: externalURL + "/code-monitoring/" + string(relay.MarshalID(resolvers.MonitorKind, 1)) + "?utm_source=code-monitoring-email",
+	}
+
+	var (
+		queryID      int64 = 1
+		triggerEvent       = 1
+		record       *codemonitors.ActionJob
+	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//Empty db, preserve schema.
+			dbtesting.SetupGlobalTestDB(t)
+
+			_, _, _, userCtx := storetest.NewTestUser(ctx, t)
+
+			// Run a complete pipeline from creation of a code monitor to sending of an email.
+			_, err = ts.InsertTestMonitor(userCtx, t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = ts.EnqueueTriggerQueries(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = ts.LogSearch(ctx, testQuery, tt.numResults, triggerEvent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = ts.EnqueueActionEmailsForQueryIDInt64(ctx, queryID, triggerEvent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			record, err = ts.ActionJobForIDInt(ctx, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a := actionRunner{s}
+			err = a.Handle(ctx, createDBWorkerStoreForActionJobs(s), record)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want.NumberOfResultsWithDetail = tt.wantNumResultsText
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Fatalf("diff: %s", diff)
+			}
+		})
+	}
+}

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -420,7 +420,7 @@ type monitor struct {
 }
 
 const (
-	monitorKind                     = "CodeMonitor"
+	MonitorKind                     = "CodeMonitor"
 	monitorTriggerQueryKind         = "CodeMonitorTriggerQuery"
 	monitorTriggerEventKind         = "CodeMonitorTriggerEvent"
 	monitorActionEmailKind          = "CodeMonitorActionEmail"
@@ -428,7 +428,7 @@ const (
 )
 
 func (m *monitor) ID() graphql.ID {
-	return relay.MarshalID(monitorKind, m.Monitor.ID)
+	return relay.MarshalID(MonitorKind, m.Monitor.ID)
 }
 
 func (m *monitor) CreatedBy(ctx context.Context) (*graphqlbackend.UserResolver, error) {

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -62,7 +62,7 @@ func TestCreateCodeMonitor(t *testing.T) {
 
 	// Toggle field enabled from true to false.
 	got, err = r.ToggleCodeMonitor(ctx, &graphqlbackend.ToggleCodeMonitorArgs{
-		Id:      relay.MarshalID(monitorKind, got.(*monitor).Monitor.ID),
+		Id:      relay.MarshalID(MonitorKind, got.(*monitor).Monitor.ID),
 		Enabled: false,
 	})
 	if err != nil {
@@ -243,7 +243,7 @@ func TestQueryMonitor(t *testing.T) {
 			Monitors: apitest.MonitorConnection{
 				TotalCount: 1,
 				Nodes: []apitest.Monitor{{
-					Id:          string(relay.MarshalID(monitorKind, 1)),
+					Id:          string(relay.MarshalID(MonitorKind, 1)),
 					Description: "test monitor",
 					Enabled:     true,
 					Owner:       apitest.UserOrg{Name: userName},
@@ -404,7 +404,7 @@ func TestEditCodeMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 	updateInput := map[string]interface{}{
-		"monitorID": string(relay.MarshalID(monitorKind, 1)),
+		"monitorID": string(relay.MarshalID(MonitorKind, 1)),
 		"triggerID": string(relay.MarshalID(monitorTriggerQueryKind, 1)),
 		"actionID":  string(relay.MarshalID(monitorActionEmailKind, 1)),
 		"user1ID":   ns1,
@@ -415,7 +415,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	want := apitest.UpdateCodeMonitorResponse{
 		UpdateCodeMonitor: apitest.Monitor{
-			Id:          string(relay.MarshalID(monitorKind, 1)),
+			Id:          string(relay.MarshalID(MonitorKind, 1)),
 			Description: "updated test monitor",
 			Enabled:     false,
 			Owner: apitest.UserOrg{
@@ -668,7 +668,7 @@ func TestQueryMonitorByID(t *testing.T) {
 
 	want := apitest.Node{
 		Node: apitest.Monitor{
-			Id:          string(relay.MarshalID(monitorKind, 1)),
+			Id:          string(relay.MarshalID(MonitorKind, 1)),
 			Description: "test monitor",
 			Enabled:     true,
 			Owner:       apitest.UserOrg{Name: userName},

--- a/enterprise/internal/codemonitors/storetest/monitor_creator.go
+++ b/enterprise/internal/codemonitors/storetest/monitor_creator.go
@@ -1,0 +1,93 @@
+package storetest
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "codemonitorsstoredb"
+}
+
+const (
+	testQuery       = "repo:github\\.com/sourcegraph/sourcegraph func type:diff patternType:literal"
+	testDescription = "test description"
+)
+
+type TestStore struct {
+	*codemonitors.Store
+}
+
+func (s *TestStore) InsertTestMonitor(ctx context.Context, t *testing.T) (*codemonitors.Monitor, error) {
+	t.Helper()
+
+	owner := relay.MarshalID("User", actor.FromContext(ctx).UID)
+	args := &graphqlbackend.CreateCodeMonitorArgs{
+		Monitor: &graphqlbackend.CreateMonitorArgs{
+			Namespace:   owner,
+			Description: testDescription,
+			Enabled:     true,
+		},
+		Trigger: &graphqlbackend.CreateTriggerArgs{
+			Query: testQuery,
+		},
+		Actions: []*graphqlbackend.CreateActionArgs{
+			{
+				Email: &graphqlbackend.CreateActionEmailArgs{
+					Enabled:    true,
+					Priority:   "NORMAL",
+					Recipients: []graphql.ID{owner},
+					Header:     "test header 1"},
+			},
+			{
+				Email: &graphqlbackend.CreateActionEmailArgs{
+					Enabled:    true,
+					Priority:   "CRITICAL",
+					Recipients: []graphql.ID{owner},
+					Header:     "test header 2"},
+			},
+		},
+	}
+	return s.CreateCodeMonitor(ctx, args)
+}
+
+func NewTestStoreWithStore(t *testing.T, store *codemonitors.Store) (context.Context, *TestStore) {
+	ctx := backend.WithAuthzBypass(context.Background())
+	dbtesting.SetupGlobalTestDB(t)
+	now := time.Now().Truncate(time.Microsecond)
+	return ctx, &TestStore{codemonitors.NewStoreWithClock(dbconn.Global, func() time.Time { return now })}
+}
+
+func NewTestUser(ctx context.Context, t *testing.T) (name string, id int32, namespace graphql.ID, userContext context.Context) {
+	t.Helper()
+
+	name = "cm-user1"
+	id = insertTestUser(t, dbconn.Global, name, true)
+	namespace = relay.MarshalID("User", id)
+	ctx = actor.WithActor(ctx, actor.FromUser(id))
+	return name, id, namespace, ctx
+}
+
+func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+	t.Helper()
+
+	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
+	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return userID
+}


### PR DESCRIPTION
Stacked on top of #16438 

The commits can be reviewed separately.

We add 2 new background workers, one for sending emails and one for resetting stalled jobs. 

The second commit adds a test case for the new worker. I decided to create a package `storetest` that exposes useful functionality for testing around code monitors. At some point down the line, we can use `storetest` to remove similar code in the resolvers package.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
