### PR TITLE
Code monitoring: redirect to list page, properly enable/disable submit buttons, confirm before cancelling

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -20,6 +20,7 @@ describe('CreateCodeMonitorPage', () => {
         breadcrumbs: [{ depth: 0, breadcrumb: null }],
         setBreadcrumb: sinon.spy(),
         useBreadcrumb: sinon.spy(),
+        history,
     }
     test('Actions area button is disabled while trigger is incomplete', () => {
         const component = mount(<CreateCodeMonitorPage {...props} />)

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -12,6 +12,7 @@ import { CodeMonitorForm } from './components/CodeMonitorForm'
 
 export interface CreateCodeMonitorPageProps extends BreadcrumbsProps, BreadcrumbSetters {
     location: H.Location
+    history: H.History
     authenticatedUser: AuthenticatedUser
 }
 

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -80,4 +80,34 @@ describe('ManageCodeMonitorPage', () => {
         triggerInput = component.find('.test-action-form')
         expect(triggerInput.length).toBe(1)
     })
+
+    test('Save button is disabled when no changes have been made, enabled when changes have been made', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        let submitButton = component.find('.test-submit-monitor')
+        expect(submitButton.prop('disabled')).toBe(true)
+        const nameInput = component.find('.test-name-input')
+        nameInput.simulate('change', { target: { value: 'Test code monitor updated' } })
+        submitButton = component.find('.test-submit-monitor')
+        expect(submitButton.prop('disabled')).toBe(false)
+    })
+
+    test('Cancelling after changes have been made shows confirmation prompt', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        const confirmStub = sinon.stub(window, 'confirm')
+        const nameInput = component.find('.test-name-input')
+        nameInput.simulate('change', { target: { value: 'Test code monitor updated' } })
+        const cancelButton = component.find('.test-cancel-monitor')
+        cancelButton.simulate('click')
+        expect(confirmStub.calledOnce)
+        confirmStub.restore()
+    })
+
+    test('Cancelling without any changes made does not show confirmation prompt', () => {
+        const component = mount(<ManageCodeMonitorPage {...props} />)
+        const confirmStub = sinon.stub(window, 'confirm')
+        const cancelButton = component.find('.test-cancel-monitor')
+        cancelButton.simulate('click')
+        expect(confirmStub.notCalled)
+        confirmStub.restore()
+    })
 })

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
-import * as React from 'react'
+import React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { startWith, catchError, tap } from 'rxjs/operators'

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Observable } from 'rxjs'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { AuthenticatedUser } from '../../../auth'
@@ -11,8 +11,10 @@ import { mergeMap, startWith, catchError, tap } from 'rxjs/operators'
 import { Form } from '../../../../../branded/src/components/Form'
 import { useEventObservable } from '../../../../../shared/src/util/useObservable'
 import { CodeMonitorFields } from '../../../graphql-operations'
+import { isEqual } from 'lodash'
 
 export interface CodeMonitorFormProps {
+    history: H.History
     location: H.Location
     authenticatedUser: AuthenticatedUser
     /**
@@ -34,6 +36,7 @@ interface FormCompletionSteps {
 export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
     authenticatedUser,
     onSubmit,
+    history,
     submitButtonLabel,
     codeMonitor,
 }) => {
@@ -88,13 +91,35 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                     mergeMap(() =>
                         onSubmit(currentCodeMonitorState).pipe(
                             startWith(LOADING),
-                            catchError(error => [asError(error)])
+                            catchError(error => [asError(error)]),
+                            tap(successOrError => {
+                                if (!isErrorLike(successOrError) && successOrError !== LOADING) {
+                                    history.push('/code-monitoring')
+                                }
+                            })
                         )
                     )
                 ),
-            [onSubmit, currentCodeMonitorState]
+            [onSubmit, currentCodeMonitorState, history]
         )
     )
+
+    const initialCodeMonitor = useMemo(() => codeMonitor, [codeMonitor])
+
+    // Determine whether the form has changed. If there was no intial state (i.e. we're creating a monitor), always return
+    // true.
+    const hasChangedFields = useMemo(
+        () => (codeMonitor ? !isEqual(initialCodeMonitor, currentCodeMonitorState) : true),
+        [initialCodeMonitor, codeMonitor, currentCodeMonitorState]
+    )
+
+    const onCancel = useCallback(() => {
+        if (hasChangedFields) {
+            if (confirm('Leave page? All unsaved changes will be lost.')) {
+                history.push('/code-monitoring')
+            }
+        }
+    }, [history, hasChangedFields])
 
     return (
         <Form className="my-4" onSubmit={requestOnSubmit}>
@@ -174,24 +199,19 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                         type="submit"
                         disabled={
                             !formCompletion.actionCompleted ||
-                            isErrorLike(codeMonitorOrError) ||
-                            codeMonitorOrError === LOADING
+                            !formCompletion.triggerCompleted ||
+                            codeMonitorOrError === LOADING ||
+                            !hasChangedFields
                         }
                         className="btn btn-primary mr-2 test-submit-monitor"
                     >
                         {submitButtonLabel}
                     </button>
-                    <button type="button" className="btn btn-outline-secondary">
+                    <button type="button" className="btn btn-outline-secondary test-cancel-monitor" onClick={onCancel}>
                         {/* TODO: this should link somewhere */}
                         Cancel
                     </button>
                 </div>
-                {/** TODO: Error and success states. We will probably redirect the user to another page, so we could remove the success state. */}
-                {!isErrorLike(codeMonitorOrError) && !!codeMonitorOrError && codeMonitorOrError !== LOADING && (
-                    <div className="alert alert-success">
-                        Successfully created monitor {codeMonitorOrError.description}
-                    </div>
-                )}
                 {isErrorLike(codeMonitorOrError) && (
                     <div className="alert alert-danger">Failed to create monitor: {codeMonitorOrError.message}</div>
                 )}

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -115,7 +115,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
 
     const onCancel = useCallback(() => {
         if (hasChangedFields) {
-            if (confirm('Leave page? All unsaved changes will be lost.')) {
+            if (window.confirm('Leave page? All unsaved changes will be lost.')) {
                 history.push('/code-monitoring')
             }
         }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/16498. 

This PR makes three small changes to the code monitoring form: 
- Redirects users to the listing page after they create or update a code monitor
- Enables/disables the submit button based on more specific conditions. On the create page, the submit button will be disabled when the action OR trigger steps are not yet completed. On the manage page, it will be disabled when there have not yet been changes made to the form.
- Clicking cancel on the form will show a confirmation prompt if changes have been made to the form.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
