### PR TITLE
dev(release): use ts-node, add top-level shortuct

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -7,13 +7,8 @@ on our release process and how this tool is used.
 To see all available steps:
 
 ```sh
-yarn build
 yarn run release help # add 'all' to see test commands as well
 ```
 
-Run `yarn run build` to build the tool (_required_ alongside `yarn run release` to make
-sure you are using the latest version of the tool), and `yarn run watch` to build on any
-changes to files.
-
-Before using this tool, please also verify that the [release configuration](./release-config.jsonc)
+Before using this tool, please verify that the [release configuration](./release-config.jsonc)
 is set up correctly.

--- a/dev/release/package.json
+++ b/dev/release/package.json
@@ -3,9 +3,7 @@
   "description": "Scripts for managing release captain duties",
   "private": true,
   "scripts": {
-    "release": "node ./out/release.js",
-    "build": "../../node_modules/.bin/tsc -b .",
-    "watch": "../../node_modules/.bin/tsc -b . -w",
+    "release": "../../node_modules/.bin/ts-node --transpile-only ./src/main.ts",
     "eslint": "../../node_modules/.bin/eslint 'src/**/*.ts'"
   },
   "dependencies": {}

--- a/dev/release/src/main.ts
+++ b/dev/release/src/main.ts
@@ -1,0 +1,21 @@
+import { loadConfig } from './config'
+import { runStep, StepID } from './release'
+
+/**
+ * Release captain automation
+ */
+async function main(): Promise<void> {
+    const config = loadConfig()
+    const args = process.argv.slice(2)
+    if (args.length === 0) {
+        await runStep(config, 'help')
+        console.error('The release tool expects at least 1 argument')
+        return
+    }
+
+    const step = args[0] as StepID
+    const stepArguments = args.slice(1)
+    await runStep(config, step, ...stepArguments)
+}
+
+main().catch(error => console.error(error))

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook -s ui/assets",
     "build-storybook": "build-storybook -c .storybook -s ui/assets",
     "cover-storybook": "nyc --hook-require=false yarn jest .storybook/coverage",
-    "deduplicate": "yarn-deduplicate -s fewer"
+    "deduplicate": "yarn-deduplicate -s fewer",
+    "release": "cd dev/release && yarn run release"
   },
   "browserslist": [
     "last 1 version",


### PR DESCRIPTION
Slight improvements for one of the items https://github.com/sourcegraph/sourcegraph/issues/16207 :

> Would be nice to have a more "CLI-like" experience

* Use `ts-node`, which removes the need for a separate `build` step
   * this seems reasonably speedy, ~1.5s for command runs after the first. I think being able to avoid "forgot to build" scenarios is much more valuable
   * this also kind of negates the need for https://github.com/sourcegraph/sourcegraph/issues/15729 but if we want to change this more (e.g. declare config in a ts class that implements the Config interface) I would do that in a separate PR. I'm not sure why I didn't think of `ts-node` before but I woke up from a nap just now and thought, "doesn't `ts-node` exist?"
* Add a top-level `yarn run release` shortcut that does the exact same thing
   * For example, try `yarn run release _test:config` from project root. For the lazy

### thoughts

I'm not sure what else to cover here - we could introduce flags, but there's not much that requires flags right now (there's another item in #16207 for secrets management, another potential use of flags)

I'm a bit unsure about having this be a properly global CLI, since it is inherently tied to the Sourcegraph commit (most notably through the config)

We could add a `dev` bash script so that we can use a marginally shorter `dev/release.sh [...]` but I feel like the gains from that is marginal

Open to more ideas here!

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
