### PR TITLE
errcode: Use anonymous interfaces

### DIFF
--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -100,11 +100,8 @@ func (e *Mock) NotFound() bool {
 // methods like Repo.Get when the repo is not found. It will also *not* map
 // HTTPStatusCode into not found.
 func IsNotFound(err error) bool {
-	type notFounder interface {
-		NotFound() bool
-	}
 	return isErrorPredicate(err, func(err error) bool {
-		e, ok := err.(notFounder)
+		e, ok := err.(interface{ NotFound() bool })
 		return ok && e.NotFound()
 	})
 }
@@ -112,22 +109,16 @@ func IsNotFound(err error) bool {
 // IsUnauthorized will check if err or one of its causes is an unauthorized
 // error.
 func IsUnauthorized(err error) bool {
-	type unauthorizeder interface {
-		Unauthorized() bool
-	}
 	return isErrorPredicate(err, func(err error) bool {
-		e, ok := err.(unauthorizeder)
+		e, ok := err.(interface{ Unauthorized() bool })
 		return ok && e.Unauthorized()
 	})
 }
 
 // IsBadRequest will check if err or one of its causes is a bad request.
 func IsBadRequest(err error) bool {
-	type badRequester interface {
-		BadRequest() bool
-	}
 	return isErrorPredicate(err, func(err error) bool {
-		badrequest, ok := err.(badRequester)
+		badrequest, ok := err.(interface{ BadRequest() bool })
 		return ok && badrequest.BadRequest()
 	})
 }
@@ -136,11 +127,8 @@ func IsBadRequest(err error) bool {
 // temporary error can be retried. Many errors in the go stdlib implement the
 // temporary interface.
 func IsTemporary(err error) bool {
-	type temporaryer interface {
-		Temporary() bool
-	}
 	return isErrorPredicate(err, func(err error) bool {
-		e, ok := err.(temporaryer)
+		e, ok := err.(interface{ Temporary() bool })
 		return ok && e.Temporary()
 	})
 }
@@ -148,22 +136,16 @@ func IsTemporary(err error) bool {
 // IsTimeout will check if err or one of its causes is a timeout. Many errors
 // in the go stdlib implement the timeout interface.
 func IsTimeout(err error) bool {
-	type timeouter interface {
-		Timeout() bool
-	}
 	return isErrorPredicate(err, func(err error) bool {
-		e, ok := err.(timeouter)
+		e, ok := err.(interface{ Timeout() bool })
 		return ok && e.Timeout()
 	})
 }
 
 // IsNonRetryable will check if err or one of its causes is a error that cannot be retried.
 func IsNonRetryable(err error) bool {
-	type nonRetryabler interface {
-		NonRetryable() bool
-	}
 	return isErrorPredicate(err, func(err error) bool {
-		e, ok := err.(nonRetryabler)
+		e, ok := err.(interface{ NonRetryable() bool })
 		return ok && e.NonRetryable()
 	})
 }


### PR DESCRIPTION
Removes unnecessary interface definitions with awkward names.