### PR TITLE
Update the list of Jetbrains IDEs

### DIFF
--- a/doc/integration/editor.md
+++ b/doc/integration/editor.md
@@ -8,6 +8,6 @@ We currently have plugins for these editors:
 
 <a href="https://atom.io/packages/sourcegraph"><img src="img/atom.svg"/> Atom</a>
 
-<a href="https://plugins.jetbrains.com/plugin/9682-sourcegraph"><img src="img/jetbrains.svg"/> IntelliJ</a>
+<a href="https://plugins.jetbrains.com/plugin/9682-sourcegraph"><img src="img/jetbrains.svg"/> JetBrains IDEs (IntelliJ, PyCharm, GoLand, etc.)</a>
 
 <a href="https://github.com/sourcegraph/sourcegraph-sublime"><img src="img/sublime.svg"/> Sublime Text</a>


### PR DESCRIPTION
The original page only listed IntelliJ.  The Sourcegraph editor plugin will work with other JetBrains IDEs as well.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
