### PR TITLE
search frontend: more streaming search QA fixes

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -222,7 +222,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                 />
 
                 {!results?.progress.done && (
-                    <div className="text-center my-2" data-testid="loading-container">
+                    <div className="text-center my-4" data-testid="loading-container">
                         <LoadingSpinner className="icon-inline" />
                     </div>
                 )}
@@ -236,7 +236,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                 )}
 
                 {results?.progress.done && results?.results.length > 0 && (
-                    <small className="d-block mt-4 text-center">Showing {results?.results.length} results</small>
+                    <small className="d-block my-4 text-center">Showing {results?.results.length} results</small>
                 )}
             </div>
         </div>

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -236,7 +236,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                 )}
 
                 {results?.progress.done && results?.results.length > 0 && (
-                    <small className="d-block mt-2 text-center">Showing {results?.results.length} results</small>
+                    <small className="d-block mt-4 text-center">Showing {results?.results.length} results</small>
                 )}
             </div>
         </div>

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -42,7 +42,8 @@
         }
 
         &-popover {
-            max-width: 350px;
+            width: 350px;
+            padding: 0.5rem;
         }
     }
 }

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -42,7 +42,7 @@
         }
 
         &-popover {
-            width: 350px;
+            width: 20rem;
             padding: 0.5rem;
         }
     }

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme'
 import React from 'react'
-import { Popover } from 'reactstrap'
+import { ButtonDropdown } from 'reactstrap'
 import { Progress } from '../../../stream'
 import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton'
 
@@ -136,18 +136,18 @@ describe('StreamingProgressSkippedButton', () => {
 
         const element = mount(<StreamingProgressSkippedButton progress={progress} />, { attachTo: div })
 
-        let popover = element.find(Popover)
+        let popover = element.find(ButtonDropdown)
         expect(popover.prop('isOpen')).toBe(false)
 
         const button = element.find('.btn.streaming-progress__skipped')
         button.simulate('click')
 
-        popover = element.find(Popover)
+        popover = element.find(ButtonDropdown)
         expect(popover.prop('isOpen')).toBe(true)
 
         button.simulate('click')
 
-        popover = element.find(Popover)
+        popover = element.find(ButtonDropdown)
         expect(popover.prop('isOpen')).toBe(false)
     })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -1,9 +1,8 @@
 import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
-import MenuDownIcon from 'mdi-react/MenuDownIcon'
 import React, { useCallback, useState, useMemo } from 'react'
-import { Button, Popover, PopoverBody } from 'reactstrap'
+import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 import { defaultProgress, StreamingProgressProps } from './StreamingProgress'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
@@ -19,33 +18,25 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingPr
         <>
             {progress.skipped.length > 0 && (
                 <>
-                    <Button
-                        className={classNames('streaming-progress__skipped mb-0 ml-2 d-flex align-items-center', {
-                            'streaming-progress__skipped--warning': skippedWithWarning,
-                        })}
-                        color="secondary"
-                        onClick={toggleOpen}
-                        id="streaming-progress__skipped"
-                    >
-                        {skippedWithWarning ? (
-                            <AlertCircleIcon className="mr-2 icon-inline" />
-                        ) : (
-                            <InformationOutlineIcon className="mr-2 icon-inline" />
-                        )}
-                        Some repositories excluded
-                        <MenuDownIcon className="icon-inline" />
-                    </Button>
-                    <Popover
-                        placement="bottom-start"
-                        isOpen={isOpen}
-                        toggle={toggleOpen}
-                        target="streaming-progress__skipped"
-                        hideArrow={true}
-                    >
-                        <PopoverBody className="streaming-progress__skipped-popover">
+                    <ButtonDropdown isOpen={isOpen} toggle={toggleOpen}>
+                        <DropdownToggle
+                            className={classNames('streaming-progress__skipped mb-0 ml-2 d-flex align-items-center', {
+                                'streaming-progress__skipped--warning': skippedWithWarning,
+                            })}
+                            caret={true}
+                            color="secondary"
+                        >
+                            {skippedWithWarning ? (
+                                <AlertCircleIcon className="mr-2 icon-inline" />
+                            ) : (
+                                <InformationOutlineIcon className="mr-2 icon-inline" />
+                            )}
+                            Some results excluded
+                        </DropdownToggle>
+                        <DropdownMenu className="streaming-progress__skipped-popover">
                             <StreamingProgressSkippedPopover progress={progress} />
-                        </PopoverBody>
-                    </Popover>
+                        </DropdownMenu>
+                    </ButtonDropdown>
                 </>
             )}
         </>

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -17,27 +17,25 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingPr
     return (
         <>
             {progress.skipped.length > 0 && (
-                <>
-                    <ButtonDropdown isOpen={isOpen} toggle={toggleOpen}>
-                        <DropdownToggle
-                            className={classNames('streaming-progress__skipped mb-0 ml-2 d-flex align-items-center', {
-                                'streaming-progress__skipped--warning': skippedWithWarning,
-                            })}
-                            caret={true}
-                            color="secondary"
-                        >
-                            {skippedWithWarning ? (
-                                <AlertCircleIcon className="mr-2 icon-inline" />
-                            ) : (
-                                <InformationOutlineIcon className="mr-2 icon-inline" />
-                            )}
-                            Some results excluded
-                        </DropdownToggle>
-                        <DropdownMenu className="streaming-progress__skipped-popover">
-                            <StreamingProgressSkippedPopover progress={progress} />
-                        </DropdownMenu>
-                    </ButtonDropdown>
-                </>
+                <ButtonDropdown isOpen={isOpen} toggle={toggleOpen}>
+                    <DropdownToggle
+                        className={classNames('streaming-progress__skipped mb-0 ml-2 d-flex align-items-center', {
+                            'streaming-progress__skipped--warning': skippedWithWarning,
+                        })}
+                        caret={true}
+                        color="secondary"
+                    >
+                        {skippedWithWarning ? (
+                            <AlertCircleIcon className="mr-2 icon-inline" />
+                        ) : (
+                            <InformationOutlineIcon className="mr-2 icon-inline" />
+                        )}
+                        Some results excluded
+                    </DropdownToggle>
+                    <DropdownMenu className="streaming-progress__skipped-popover">
+                        <StreamingProgressSkippedPopover progress={progress} />
+                    </DropdownMenu>
+                </ButtonDropdown>
             )}
         </>
     )

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -35,7 +35,7 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<StreamingP
     return (
         <>
             {progress.skipped.map(skipped => (
-                <Alert key={skipped.reason} color={skipped.severity === 'warn' ? 'danger' : 'info'}>
+                <Alert key={skipped.reason} color={skipped.severity === 'warn' ? 'danger' : 'info'} fade={false}>
                     <h4 className="d-flex align-items-center mb-0">
                         {skipped.severity === 'warn' ? (
                             <AlertCircleIcon className="icon-inline mr-2" />

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   <Alert
     closeAriaLabel="Close"
     color="info"
-    fade={true}
+    fade={false}
     isOpen={true}
     key="excluded-fork"
     tag="div"
@@ -73,7 +73,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   >
     <Fade
       appear={true}
-      baseClass="fade"
+      baseClass=""
       baseClassActive="show"
       className="alert alert-info"
       enter={true}
@@ -88,7 +88,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       onExiting={[Function]}
       role="alert"
       tag="div"
-      timeout={150}
+      timeout={0}
       unmountOnExit={true}
     >
       <Transition
@@ -103,11 +103,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         onExit={[Function]}
         onExited={[Function]}
         onExiting={[Function]}
-        timeout={150}
+        timeout={0}
         unmountOnExit={true}
       >
         <div
-          className="alert alert-info fade"
+          className="alert alert-info"
           role="alert"
         >
           <h4
@@ -132,7 +132,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   <Alert
     closeAriaLabel="Close"
     color="info"
-    fade={true}
+    fade={false}
     isOpen={true}
     key="excluded-archive"
     tag="div"
@@ -159,7 +159,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   >
     <Fade
       appear={true}
-      baseClass="fade"
+      baseClass=""
       baseClassActive="show"
       className="alert alert-info"
       enter={true}
@@ -174,7 +174,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       onExiting={[Function]}
       role="alert"
       tag="div"
-      timeout={150}
+      timeout={0}
       unmountOnExit={true}
     >
       <Transition
@@ -189,11 +189,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         onExit={[Function]}
         onExited={[Function]}
         onExiting={[Function]}
-        timeout={150}
+        timeout={0}
         unmountOnExit={true}
       >
         <div
-          className="alert alert-info fade"
+          className="alert alert-info"
           role="alert"
         >
           <h4
@@ -218,7 +218,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   <Alert
     closeAriaLabel="Close"
     color="danger"
-    fade={true}
+    fade={false}
     isOpen={true}
     key="shard-timedout"
     tag="div"
@@ -245,7 +245,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   >
     <Fade
       appear={true}
-      baseClass="fade"
+      baseClass=""
       baseClassActive="show"
       className="alert alert-danger"
       enter={true}
@@ -260,7 +260,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       onExiting={[Function]}
       role="alert"
       tag="div"
-      timeout={150}
+      timeout={0}
       unmountOnExit={true}
     >
       <Transition
@@ -275,11 +275,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         onExit={[Function]}
         onExited={[Function]}
         onExiting={[Function]}
-        timeout={150}
+        timeout={0}
         unmountOnExit={true}
       >
         <div
-          className="alert alert-danger fade"
+          className="alert alert-danger"
           role="alert"
         >
           <h4


### PR DESCRIPTION
- Skipped results popover now dismissed when clicking outside (switched from `<Popover>`, which does not have this functionality, to `<ButtonDropdown>`, which does. `<Popover>` is not part of Bootstrap itself so it acts a bit oddly and doesn't provide a built-in way to dismiss when clicking outside)
  - This should also fix #16415
- Alerts inside the skipped results popover no longer fade in
- Reworded "Some repositories excluded" to "Some results excluded", fixing #16523
- Increased padding at the bottom of the results with the count/progress indicator
