### PR TITLE
search frontend: correctly bold hover tooltip

### DIFF
--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -228,7 +228,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Escaped Character. The character \`q\` is escaped."
+                  "value": "**Escaped Character**. The character \`q\` is escaped."
                 }
               ],
               "range": {
@@ -243,7 +243,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Escaped Character. Match a carriage return."
+                  "value": "**Escaped Character**. Match a carriage return."
                 }
               ],
               "range": {
@@ -258,7 +258,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Escaped Character. Match a new line."
+                  "value": "**Escaped Character**. Match a new line."
                 }
               ],
               "range": {
@@ -273,7 +273,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Escaped Character. Match the character \`.\`."
+                  "value": "**Escaped Character**. Match the character \`.\`."
                 }
               ],
               "range": {
@@ -288,7 +288,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Escaped Character. Match the character \`\\\\\`."
+                  "value": "**Escaped Character**. Match the character \`\\\\\`."
                 }
               ],
               "range": {

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -63,7 +63,7 @@ const toHover = (token: DecoratedToken): string => {
                             description = 'Match a carriage return.'
                             break
                     }
-                    return `**Escaped Character. ${description}`
+                    return `**Escaped Character**. ${description}`
                 }
                 case MetaRegexpKind.LazyQuantifier:
                     return '**Lazy**. Match as few as characters as possible that match the previous expression.'


### PR DESCRIPTION
Quick fix, just a typo of some markdown that needs `**bold**`ing.