### PR TITLE
search frontend: fix highlighting for coalescing operation

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -343,6 +343,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpCharacterClass"
               },
               {
+                "startIndex": 4,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 5,
                 "scopes": "metaRegexpCharacterClass"
               },
@@ -371,6 +375,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpCharacterClass"
               },
               {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 4,
                 "scopes": "metaRegexpCharacterClass"
               },
@@ -387,6 +395,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpCharacterClass"
               },
               {
+                "startIndex": 8,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 9,
                 "scopes": "metaRegexpCharacterClass"
               },
@@ -401,6 +413,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 12,
                 "scopes": "metaRegexpCharacterClass"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "identifier"
               },
               {
                 "startIndex": 14,
@@ -515,6 +531,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
+                "startIndex": 9,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 10,
                 "scopes": "metaRegexpDelimited"
               },
@@ -523,12 +543,20 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
+                "startIndex": 12,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 13,
                 "scopes": "metaRegexpDelimited"
               },
               {
                 "startIndex": 14,
                 "scopes": "metaRegexpAlternative"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "identifier"
               }
             ]
         `)
@@ -556,6 +584,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
+                "startIndex": 8,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 9,
                 "scopes": "metaRegexpDelimited"
               },
@@ -576,6 +608,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaRegexpAlternative"
               },
               {
+                "startIndex": 14,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 15,
                 "scopes": "metaRegexpDelimited"
               },
@@ -594,6 +630,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 19,
                 "scopes": "metaRegexpAlternative"
+              },
+              {
+                "startIndex": 20,
+                "scopes": "identifier"
               },
               {
                 "startIndex": 21,

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -114,7 +114,7 @@ const coalescePatterns = (tokens: DecoratedToken[]): DecoratedToken[] => {
 }
 
 const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
-    let tokens: DecoratedToken[] = []
+    const tokens: DecoratedToken[] = []
     try {
         const ast = new RegExpParser().parsePattern(pattern.value)
         const offset = pattern.range.start
@@ -276,7 +276,6 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
     } catch {
         tokens.push(pattern)
     }
-    tokens = coalescePatterns(tokens)
     // The AST is not necessarily traversed in increasing range. We need
     // to sort by increasing range because the ordering is significant to Monaco.
     tokens.sort((left, right) => {
@@ -285,7 +284,7 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
         }
         return 0
     })
-    return tokens
+    return coalescePatterns(tokens)
 }
 
 const mapStructuralMeta = (pattern: Pattern): DecoratedToken[] => {


### PR DESCRIPTION
Stacked on #16536

Whoops, #16484 sorted ranges after coalescing, but the coalescing operation assumes the tokens are ordered by range. When the visitor happened to visit tokens out of order, the coalescing would merge the wrong members and highlighting ends up wrong, e.g.,

<img width="427" alt="Screen Shot 2020-12-07 at 8 08 50 PM" src="https://user-images.githubusercontent.com/888624/101434995-cf738080-38c8-11eb-80f7-48d7cb9807e4.png">

But now we do the right thing: just sort first, then coalesce. All the updated tests were affected by buggy highlighting previous to this PR.