### PR TITLE
search frontend: add repo revision highlighting

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -831,6 +831,7 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
     test('decorate structural hole ... alias', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('r:foo ...:...', false, SearchPatternType.structural)), true))
             .toMatchInlineSnapshot(`
@@ -858,6 +859,160 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 10,
                 "scopes": "metaStructuralHole"
+              }
+            ]
+        `)
+    })
+
+    test('decorate repo revision syntax, separate revisions', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo@HEAD:v1.2:3')), true)).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "metaRepoRevisionSeparator"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaRevisionSeparator"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaRevisionSeparator"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "metaRevisionLabel"
+              }
+            ]
+        `)
+    })
+
+    test('decorate revision field syntax, separate revisions', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo rev:HEAD:v1.2:3')), true)).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "metaRevisionSeparator"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 22,
+                "scopes": "metaRevisionSeparator"
+              },
+              {
+                "startIndex": 23,
+                "scopes": "metaRevisionLabel"
+              }
+            ]
+        `)
+    })
+
+    test('decorate repo revision syntax, path with wildcard and negation', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:foo@*refs/heads/*:*!refs/heads/release*')), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "metaRepoRevisionSeparator"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaRevisionWildcard"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "metaRevisionPathLike"
+              },
+              {
+                "startIndex": 21,
+                "scopes": "metaRevisionWildcard"
+              },
+              {
+                "startIndex": 22,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 22,
+                "scopes": "metaRevisionSeparator"
+              },
+              {
+                "startIndex": 23,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 23,
+                "scopes": "metaRevisionWildcard"
+              },
+              {
+                "startIndex": 24,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 24,
+                "scopes": "metaRevisionNegate"
+              },
+              {
+                "startIndex": 25,
+                "scopes": "metaRevisionPathLike"
+              },
+              {
+                "startIndex": 43,
+                "scopes": "metaRevisionWildcard"
+              },
+              {
+                "startIndex": 44,
+                "scopes": "metaRevisionLabel"
               }
             ]
         `)

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -32,12 +32,15 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         'editor.hoverHighlightBackground': '#495057',
     },
     rules: [
+        // Sourcegraph base language tokens
         { token: 'identifier', foreground: '#f2f4f8' },
         { token: 'field', foreground: '#569cd6' },
         { token: 'keyword', foreground: '#da77f2' },
         { token: 'openingParen', foreground: '#da77f2' },
         { token: 'closingParen', foreground: '#da77f2' },
         { token: 'comment', foreground: '#ffa94d' },
+        // Sourcegraph decorated language tokens
+        { token: 'metaRepoRevisionSeparator', foreground: '#569cd9' },
         // Regexp pattern highlighting
         { token: 'metaRegexpDelimited', foreground: '#ff6b6b' },
         { token: 'metaRegexpAssertion', foreground: '#ff6b6b' },
@@ -49,6 +52,13 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'metaRegexpAlternative', foreground: '#3bc9db' },
         // Structural pattern highlighting
         { token: 'metaStructuralHole', foreground: '#ff6b6b' },
+        // Revision highlighting
+        { token: 'metaRevisionSeparator', foreground: '#ffa94d' },
+        { token: 'metaRevisionWildcard', foreground: '#3bc9db' },
+        { token: 'metaRevisionNegate', foreground: '#ff6b6b' },
+        { token: 'metaRevisionCommitHash', foreground: '#f2f4f8' },
+        { token: 'metaRevisionLabel', foreground: '#f2f4f8' },
+        { token: 'metaRevisionPathLike', foreground: '#f2f4f8' },
     ],
 })
 
@@ -72,12 +82,15 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         'editor.hoverHighlightBackground': '#dee2e6',
     },
     rules: [
+        // Sourcegraph base language tokens
         { token: 'identifier', foreground: '#2b3750' },
         { token: 'field', foreground: '#268bd2' },
         { token: 'keyword', foreground: '#ae3ec9' },
         { token: 'openingParen', foreground: '#ae3ec9' },
         { token: 'closingParen', foreground: '#ae3ec9' },
         { token: 'comment', foreground: '#d9480f' },
+        // Sourcegraph decorated language tokens
+        { token: 'metaRepoRevisionSeparator', foreground: '#268bd2' },
         // Regexp pattern highlighting
         { token: 'metaRegexpDelimited', foreground: '#c92a2a' },
         { token: 'metaRegexpAssertion', foreground: '#c92a2a' },
@@ -89,6 +102,13 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'metaRegexpAlternative', foreground: '#1098ad' },
         // Structural pattern highlighting
         { token: 'metaStructuralHole', foreground: '#c92a2a' },
+        // Revision highlighting
+        { token: 'metaRevisionSeparator', foreground: '#d9480f' },
+        { token: 'metaRevisionWildcard', foreground: '#1098ad' },
+        { token: 'metaRevisionNegate', foreground: '#c92a2a' },
+        { token: 'metaRevisionCommitHash', foreground: '#2b3750' },
+        { token: 'metaRevisionLabel', foreground: '#2b3750' },
+        { token: 'metaRevisionPathLike', foreground: '#2b3750' },
     ],
 })
 


### PR DESCRIPTION
Stacked on #16539. 

Introduces repo revision highlighting. Useful and also stops incorrect hovers on revision syntax (since repo values are not always pure regular expression syntax). I exercised some restraint highlighting hash-like strings or special strings like `HEAD`  things started feeling too much like a disco ball. This info is still useful for hovers and will feature there.

Excuse my sloppy cropping.

<img width="550" alt="Screen Shot 2020-12-07 at 9 11 10 PM" src="https://user-images.githubusercontent.com/888624/101439212-4b71c680-38d1-11eb-8aa3-65a7945af4a1.png">
<img width="721" alt="Screen Shot 2020-12-07 at 9 03 22 PM" src="https://user-images.githubusercontent.com/888624/101439219-50cf1100-38d1-11eb-934f-1d2a8c94a934.png">
<img width="591" alt="Screen Shot 2020-12-07 at 9 03 05 PM" src="https://user-images.githubusercontent.com/888624/101439221-53316b00-38d1-11eb-992f-787275462cf4.png">

<img width="579" alt="Screen Shot 2020-12-07 at 9 11 19 PM" src="https://user-images.githubusercontent.com/888624/101439242-5e849680-38d1-11eb-9f87-0fdb631eea39.png">
<img width="717" alt="Screen Shot 2020-12-07 at 9 10 42 PM" src="https://user-images.githubusercontent.com/888624/101439245-604e5a00-38d1-11eb-8b62-79c60389c5a1.png">
<img width="547" alt="Screen Shot 2020-12-07 at 9 10 21 PM" src="https://user-images.githubusercontent.com/888624/101439293-75c38400-38d1-11eb-8a01-897e51f5a4fe.png">



The file is getting big, I will split it off later.