### PR TITLE
search: update email template

### DIFF
--- a/enterprise/internal/codemonitors/background/email/templates.go
+++ b/enterprise/internal/codemonitors/background/email/templates.go
@@ -32,7 +32,7 @@ Sourcegraph limits what information is contained in this notification.
     </p>
     <p style="font-size: 20px; line-height: 30px; font-weight: 700">
       {{.Description}}<br />
-      <span style="font-size: 16px; line-height: 24px"
+      <span style="font-size: 16px; line-height: 24px; font-weight: 400"
         >{{.NumberOfResultsWithDetail}}</span
       >
     </p>


### PR DESCRIPTION
sets the font-weight of `.NumberOfResultsWithDetail` to 400 instead of 700.

<img width="682" alt="image" src="https://user-images.githubusercontent.com/26413131/101470098-dab8c180-3945-11eb-8828-a8478d9a5802.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
