### PR TITLE
search: fix totalCount for actions

### DIFF
--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -67,6 +67,17 @@ func (s *Store) DeleteActionsInt64(ctx context.Context, actionIDs []int64, monit
 	return nil
 }
 
+const totalCountActionEmailsFmtStr = `
+SELECT COUNT(*)
+FROM cm_emails
+WHERE monitor = %s;
+`
+
+func (s *Store) TotalCountActionEmails(ctx context.Context, monitorID int64) (count int32, err error) {
+	err = s.QueryRow(ctx, sqlf.Sprintf(totalCountActionEmailsFmtStr, monitorID)).Scan(&count)
+	return count, err
+}
+
 const actionEmailByIDFmtStr = `
 SELECT id, monitor, enabled, priority, header, created_by, created_at, changed_by, changed_at
 FROM cm_emails

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -473,11 +473,10 @@ func (m *monitor) Actions(ctx context.Context, args *graphqlbackend.ListActionAr
 	return m.actionConnectionResolverWithTriggerID(ctx, nil, m.Monitor.ID, args)
 }
 
-func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int, monitorID int64, args *graphqlbackend.ListActionArgs) (c graphqlbackend.MonitorActionConnectionResolver, err error) {
+func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int, monitorID int64, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
 	// For now, we only support emails as actions. Once we add other actions such as
 	// webhooks, we have to query those tables here too.
-	var q *sqlf.Query
-	q, err = r.store.ReadActionEmailQuery(ctx, monitorID, args)
+	q, err := r.store.ReadActionEmailQuery(ctx, monitorID, args)
 	if err != nil {
 		return nil, err
 	}
@@ -490,8 +489,10 @@ func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, tr
 	if err != nil {
 		return nil, err
 	}
-	var totalCount int32
-	totalCount, err = r.store.TotalCountActionEmails(ctx, monitorID)
+	totalCount, err := r.store.TotalCountActionEmails(ctx, monitorID)
+	if err != nil {
+		return nil, err
+	}
 	actions := make([]graphqlbackend.MonitorAction, 0, len(es))
 	for _, e := range es {
 		actions = append(actions, &action{

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -490,6 +490,8 @@ func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, tr
 	if err != nil {
 		return nil, err
 	}
+	var totalCount int32
+	totalCount, err = r.store.TotalCountActionEmails(ctx, monitorID)
 	actions := make([]graphqlbackend.MonitorAction, 0, len(es))
 	for _, e := range es {
 		actions = append(actions, &action{
@@ -500,7 +502,7 @@ func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, tr
 			},
 		})
 	}
-	return &monitorActionConnection{actions: actions}, nil
+	return &monitorActionConnection{actions: actions, totalCount: totalCount}, nil
 }
 
 //
@@ -617,7 +619,8 @@ func (m *monitorTriggerEvent) Actions(ctx context.Context, args *graphqlbackend.
 // ActionConnection
 //
 type monitorActionConnection struct {
-	actions []graphqlbackend.MonitorAction
+	actions    []graphqlbackend.MonitorAction
+	totalCount int32
 }
 
 func (a *monitorActionConnection) Nodes(ctx context.Context) ([]graphqlbackend.MonitorAction, error) {
@@ -625,7 +628,7 @@ func (a *monitorActionConnection) Nodes(ctx context.Context) ([]graphqlbackend.M
 }
 
 func (a *monitorActionConnection) TotalCount(ctx context.Context) (int32, error) {
-	return int32(len(a.actions)), nil
+	return a.totalCount, nil
 }
 
 func (a *monitorActionConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {


### PR DESCRIPTION
Just like #16506, but for actions.

`totalCount` should return the total number of actions and not the size
of the page we currently return.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
