### PR TITLE
Add tests for branded codebase to CI

### DIFF
--- a/client/branded/babel.config.js
+++ b/client/branded/babel.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/** @type {import('@babel/core').TransformOptions} */
+const config = {
+  extends: '../../babel.config.js',
+}
+
+module.exports = config

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -107,6 +107,12 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 	}
 }
 
+func addBrandedTests(pipeline *bk.Pipeline) {
+	pipeline.AddStep(":jest: Test branded client code",
+		bk.Cmd("dev/ci/yarn-test.sh client/branded"),
+		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+}
+
 // Adds PostgreSQL backcompat tests.
 func addPostgresBackcompat(pipeline *bk.Pipeline) {
 	// TODO: We do not test Postgres DB backcompat anymore.

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -116,6 +116,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addBrowserExt,
 			addWebApp,
 			addSharedTests(c),
+			addBrandedTests,
 			addGoTests,
 			addGoBuild,
 			addDockerfileLint,
@@ -136,6 +137,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addSharedTests(c),             // ~4.5m
 			addWebApp,                     // ~3m
 			addBrowserExt,                 // ~2m
+			addBrandedTests,               // ~1.5m
 			addGoTests,                    // ~1.5m
 			addCheck,                      // ~1m
 			addGoBuild,                    // ~0.5m


### PR DESCRIPTION
This was apparently missing in CI. 