### PR TITLE
code-intel: pass hex byte encoded commit hash to query

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -209,7 +209,7 @@ func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 
 	commits := make([]*sqlf.Query, 0, len(graph.Graph()))
 	for commit := range graph.Graph() {
-		commits = append(commits, sqlf.Sprintf("%s", commit))
+		commits = append(commits, sqlf.Sprintf("%s", dbutil.CommitBytea(commit)))
 	}
 
 	commitGraphView, err := scanCommitGraphView(s.Store.Query(ctx, sqlf.Sprintf(
@@ -217,7 +217,7 @@ func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 			SELECT nu.upload_id, encode(nu.commit_bytea, 'hex'), md5(u.root || ':' || u.indexer) as token, nu.distance, nu.ancestor_visible, nu.overwritten
 			FROM lsif_nearest_uploads nu
 			JOIN lsif_uploads u ON u.id = nu.upload_id
-			WHERE nu.repository_id = %s AND encode(nu.commit_bytea, 'hex') IN (%s) AND nu.ancestor_visible
+			WHERE nu.repository_id = %s AND nu.commit_bytea IN (%s) AND nu.ancestor_visible
 		`,
 		repositoryID,
 		sqlf.Join(commits, ", "),


### PR DESCRIPTION
Instead of having postgres encode every rows commit_bytea to string to perform the IN

Explain for the query on a local instance (with 2 repos in lsif_nearest_uploads and ~9k rows)
```
 Nested Loop  (cost=0.00..400.66 rows=42 width=74) (actual time=6.100..6.102 rows=0 loops=1)
   Join Filter: (nu.upload_id = u.id)
   ->  Seq Scan on lsif_nearest_uploads nu  (cost=0.00..393.43 rows=42 width=31) (actual time=6.098..6.098 rows=0 loops=1)
         Filter: (ancestor_visible AND (repository_id = 1) AND (encode(commit_bytea, 'hex'::text) = '\x93274522faf9b3e065cb4e17b424b549aee7e1e6'::text))
         Rows Removed by Filter: 9453
   ->  Materialize  (cost=0.00..4.08 rows=5 width=16) (never executed)
         ->  Seq Scan on lsif_uploads u  (cost=0.00..4.05 rows=5 width=16) (never executed)
```
pghero on dotcom shows that the query takes between 5-13seconds average