### PR TITLE
search frontend: hovers for revision syntax

### DIFF
--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -369,4 +369,126 @@ describe('getHoverResult()', () => {
             }
         `)
     })
+
+    test('smartQuery flag returns hover contents for revision syntax', () => {
+        const scannedQuery = toSuccess(
+            scanSearchQuery(
+                'repo:^foo$@head:v1.3 rev:*refs/heads/*:*!refs/heads/release*',
+                false,
+                SearchPatternType.literal
+            )
+        )
+
+        expect(getHoverResult(scannedQuery, { column: 11 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Search at revision.** Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 11,
+                "endColumn": 12
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 12 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 12,
+                "endColumn": 16
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 16 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Revision separator**. Separates multiple revisions to search across. For example, \`1a35d48:feature:3.15\` searches the repository for matches at commit \`1a35d48\`, or a branch named \`feature\`, or a tag \`3.15\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 16,
+                "endColumn": 17
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 17 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Revision branch name or tag**. Search the branch name or tag at the head commit."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 17,
+                "endColumn": 21
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 26 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 26,
+                "endColumn": 27
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 27 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Revision using git reference path**. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 27,
+                "endColumn": 38
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 41 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Revision negation**. A prefix of a glob pattern or path that does **not** match a set of git objects, like a commit or branch name. Typically used in conjunction with a glob pattern that matches a set of commits or branches, followed by a negated set to exclude. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 41,
+                "endColumn": 42
+              }
+            }
+        `)
+    })
 })


### PR DESCRIPTION
Stacked on #16561

Basic revision hovers for this really confusing syntax.

<img width="1083" alt="Screen Shot 2020-12-08 at 6 29 22 PM" src="https://user-images.githubusercontent.com/888624/101561851-51c07b00-3983-11eb-9142-7d2f466de839.png">

<img width="1152" alt="Screen Shot 2020-12-08 at 6 30 24 PM" src="https://user-images.githubusercontent.com/888624/101561919-774d8480-3983-11eb-819a-b21b82764c52.png">

Still needs a bit of refining but will address in a follow up PR (naming types as git objects, doing better at detecting git refs paths, and `*` actually means something different if it's a prefix).

I toyed with the idea of linking to `git-scm`, but some of those docs are just... more confusing to the unwary, because there's sometimes too much irrelevant info re: this syntax. We might be better off linking to our own.