### PR TITLE
search: connect event resolvers to store

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -99,7 +99,7 @@ type MonitorActionEventConnectionResolver interface {
 
 type MonitorActionEventResolver interface {
 	ID() graphql.ID
-	Status() string
+	Status() (string, error)
 	Message() *string
 	Timestamp() DateTime
 }

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -55,11 +56,53 @@ var ActionJobsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_action_jobs.log_contents"),
 }
 
+const readActionEmailEventsFmtStr = `
+SELECT id, email, trigger_event, state, failure_message, started_at, finished_at, process_after, num_resets, num_failures, log_contents
+FROM cm_action_jobs
+WHERE %s
+`
+
+func (s *Store) ReadActionEmailEvents(ctx context.Context, emailID int64, triggerEventID *int, args *graphqlbackend.ListEventsArgs) (js []*ActionJob, err error) {
+	var where *sqlf.Query
+	if triggerEventID == nil {
+		where = sqlf.Sprintf("email = %s", emailID)
+	} else {
+		where = sqlf.Sprintf("email = %s AND trigger_event = %s", emailID, *triggerEventID)
+	}
+	var rows *sql.Rows
+	rows, err = s.Query(ctx, sqlf.Sprintf(readActionEmailEventsFmtStr, where))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanActionJobs(rows, err)
+}
+
+const totalActionEmailEventsFmtStr = `
+SELECT COUNT(*)
+FROM cm_action_jobs
+WHERE %s
+`
+
+func (s *Store) TotalActionEmailEvents(ctx context.Context, emailID int64, triggerEventID *int) (totalCount int32, err error) {
+	var where *sqlf.Query
+	if triggerEventID == nil {
+		where = sqlf.Sprintf("email = %s", emailID)
+	} else {
+		where = sqlf.Sprintf("email = %s AND trigger_event = %s", emailID, *triggerEventID)
+	}
+	err = s.QueryRow(ctx, sqlf.Sprintf(totalActionEmailEventsFmtStr, where)).Scan(&totalCount)
+	if err != nil {
+		return -1, err
+	}
+	return totalCount, nil
+}
+
 const enqueueActionEmailFmtStr = `
 WITH due AS (
 	SELECT e.id, e.monitor, e.enabled, e.priority, e.header, e.created_by, e.created_at, e.changed_by, e.changed_at
 	FROM cm_emails e INNER JOIN cm_queries q ON e.monitor = q.monitor
-	WHERE q.id = %s
+	WHERE q.id = %s AND e.enabled = true
 ),
 busy AS (
     SELECT DISTINCT email as id FROM cm_action_jobs

--- a/enterprise/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/internal/codemonitors/resolvers/apitest/types.go
@@ -59,6 +59,7 @@ type ActionEmail struct {
 	Priority   string
 	Recipients RecipientsConnection
 	Header     string
+	Events     ActionEventConnection
 }
 
 type RecipientsConnection struct {
@@ -80,6 +81,19 @@ type TriggerEventConnection struct {
 }
 
 type TriggerEvent struct {
+	Id        string
+	Status    string
+	Timestamp string
+	Message   *string
+}
+
+type ActionEventConnection struct {
+	Nodes      []ActionEvent
+	TotalCount int
+	PageInfo   PageInfo
+}
+
+type ActionEvent struct {
 	Id        string
 	Status    string
 	Timestamp string

--- a/enterprise/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/internal/codemonitors/resolvers/main_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
-	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
@@ -137,7 +136,7 @@ func (r *Resolver) insertTestMonitorWithOpts(ctx context.Context, t *testing.T, 
 func newTestResolver(t *testing.T) *Resolver {
 	t.Helper()
 
-	now := timeutil.Now()
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
 	return newResolverWithClock(dbconn.Global, clock).(*Resolver)
 }


### PR DESCRIPTION
This PR replaces the last dummy resolvers for action events
with fully functional resolvers connected to the db. 

While this is not strictly required for version 1 (we don't expose
events to the user yet), it completes the GraphQL API which
is herewith fully functional.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
