### PR TITLE
search: fix totalCount for trigger events

### DIFF
--- a/enterprise/internal/codemonitors/storetest/jobs.go
+++ b/enterprise/internal/codemonitors/storetest/jobs.go
@@ -27,7 +27,7 @@ const setStatusFmtStr = `
 UPDATE %s
 SET state = %s,
     started_at = %s,
-	finished_at = %s
+    finished_at = %s
 WHERE id = %s;
 `
 

--- a/enterprise/internal/codemonitors/storetest/jobs.go
+++ b/enterprise/internal/codemonitors/storetest/jobs.go
@@ -1,0 +1,45 @@
+package storetest
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+type JobTable int
+
+const (
+	TriggerJobs JobTable = iota
+	ActionJobs
+)
+
+type JobState int
+
+const (
+	Queued JobState = iota
+	Processing
+	Completed
+	Errored
+	Failed
+)
+
+const setStatusFmtStr = `
+UPDATE %s
+SET state = %s,
+    started_at = %s,
+	finished_at = %s
+WHERE id = %s;
+`
+
+// quote wraps the given string in a *sqlf.Query so that it is not passed to the database
+// as a parameter. It is necessary to quote things such as table names, columns, and other
+// expressions that are not simple values.
+func quote(s string) *sqlf.Query {
+	return sqlf.Sprintf(s)
+}
+
+func (s *TestStore) SetJobStatus(ctx context.Context, table JobTable, state JobState, id int) error {
+	st := []string{"queued", "processing", "completed", "errored", "failed"}[state]
+	t := []string{"cm_trigger_jobs", "cm_action_jobs"}[table]
+	return s.Exec(ctx, sqlf.Sprintf(setStatusFmtStr, quote(t), st, s.Now(), s.Now(), id))
+}

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -23,7 +23,7 @@ WITH due AS (
     SELECT cm_queries.id as id
     FROM cm_queries INNER JOIN cm_monitors ON cm_queries.monitor = cm_monitors.id
     WHERE (cm_queries.next_run <= clock_timestamp() OR cm_queries.next_run IS NULL)
-	AND cm_monitors.enabled = true
+    AND cm_monitors.enabled = true
 ),
 busy AS (
     SELECT DISTINCT query as id FROM cm_trigger_jobs
@@ -41,8 +41,8 @@ func (s *Store) EnqueueTriggerQueries(ctx context.Context) (err error) {
 const logSearchFmtStr = `
 UPDATE cm_trigger_jobs
 SET query_string = %s,
-	results = %s,
-	num_results = %s
+    results = %s,
+    num_results = %s
 WHERE id = %s
 `
 
@@ -102,7 +102,7 @@ func (s *Store) TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int
 	)
 	err = s.Store.QueryRow(ctx, q).Scan(&totalCount)
 	if err != nil {
-		return -1, nil
+		return -1, err
 	}
 	return totalCount, nil
 }

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -88,6 +88,25 @@ func (s *Store) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, arg
 	return scanTriggerJobs(rows, err)
 }
 
+const totalCountEventsForQueryIDInt64FmtStr = `
+SELECT COUNT(*)
+FROM cm_trigger_jobs
+WHERE ((state = 'completed' AND results IS TRUE) OR (state != 'completed'))
+AND query = %s
+`
+
+func (s *Store) TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (totalCount int32, err error) {
+	q := sqlf.Sprintf(
+		totalCountEventsForQueryIDInt64FmtStr,
+		queryID,
+	)
+	err = s.Store.QueryRow(ctx, q).Scan(&totalCount)
+	if err != nil {
+		return -1, nil
+	}
+	return totalCount, nil
+}
+
 type TriggerJobs struct {
 	Id    int
 	Query int64


### PR DESCRIPTION
just like #16506 and #16545

The actual change is pretty small, but I had to update the tests to make
sure we catch regressions. The challenge is to create a non trivial
state in the database during tests. Since we are dealing with trigger
events , IE completed jobs with at least 1 search results, I had to
make sure the test data contains at least 1 completed job. This bloats
the diff a bit, but it is for a good cause.

Note:
The 2 notifications for "ineffectual assignment to `err`"
(not related to this PR) are fixed here #16588.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
