### PR TITLE
Code monitoring: add get started page when no monitors exist

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.scss
@@ -1,4 +1,19 @@
 .code-monitoring-page {
+    .theme-light & {
+        h3,
+        h4 {
+            // Overriding the custom header colors in web-content styles.
+            color: var(--body-color);
+        }
+    }
+    .theme-dark & {
+        h3,
+        h4 {
+            // Overriding the custom header colors in web-content styles.
+            color: var(--body-color);
+        }
+    }
+
     &__start {
         &-subheading {
             font-size: 16px;
@@ -9,7 +24,9 @@
         }
 
         &-points {
-            color: $gray-17;
+            color: var(--body-color);
+            padding-right: 0;
+            padding-left: 0;
 
             &-panel {
                 &-container {
@@ -29,5 +46,10 @@
                 padding: 1rem;
             }
         }
+    }
+
+    &__learn-more {
+        padding-right: 0;
+        padding-left: 0;
     }
 }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.scss
@@ -1,0 +1,33 @@
+.code-monitoring-page {
+    &__start {
+        &-subheading {
+            font-size: 16px;
+        }
+
+        &-button {
+            width: fit-content;
+        }
+
+        &-points {
+            color: $gray-17;
+
+            &-panel {
+                &-container {
+                    .col,
+                    [class*='col-'] {
+                        &:first-child {
+                            padding-right: 0.75rem;
+                        }
+                        &:not(:first-child) {
+                            padding-left: 0.75rem;
+                        }
+                    }
+                }
+
+                border: 1px solid var(--border-color);
+                border-radius: 4px;
+                padding: 1rem;
+            }
+        }
+    }
+}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -36,3 +36,34 @@ add(
         },
     }
 )
+
+add(
+    'Code monitoring list page empty state',
+    () => (
+        <EnterpriseWebStory>
+            {props => (
+                <CodeMonitoringPage
+                    {...props}
+                    {...additionalProps}
+                    fetchUserCodeMonitors={({ id, first, after }: ListUserCodeMonitorsVariables) =>
+                        of({
+                            nodes: [],
+                            pageInfo: {
+                                endCursor: '',
+                                hasNextPage: false,
+                            },
+                            totalCount: 0,
+                        })
+                    }
+                />
+            )}
+        </EnterpriseWebStory>
+    ),
+    {
+        design: {
+            type: 'figma',
+            url:
+                'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=246%3A11',
+        },
+    }
+)

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,6 +1,6 @@
 import * as H from 'history'
 import classnames from 'classnames'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageHeader } from '../../components/PageHeader'
@@ -12,6 +12,10 @@ import { Link } from '../../../../shared/src/components/Link'
 import { CodeMonitoringProps } from '.'
 import PlusIcon from 'mdi-react/PlusIcon'
 import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
+import { catchError, map, startWith, tap } from 'rxjs/operators'
+import { asError, isErrorLike } from '../../../../shared/src/util/errors'
+import { useObservable } from '../../../../shared/src/util/useObservable'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
 export interface CodeMonitoringPageProps
     extends BreadcrumbsProps,
@@ -35,6 +39,29 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                 after: args.after ?? null,
             }),
         [authenticatedUser, fetchUserCodeMonitors]
+    )
+
+    const LOADING = 'loading' as const
+
+    const userHasCodeMonitors = useObservable(
+        useMemo(
+            () =>
+                fetchUserCodeMonitors({
+                    id: authenticatedUser.id,
+                    first: 1,
+                    after: null,
+                }).pipe(
+                    map(monitors => {
+                        if (monitors.nodes.length > 0) {
+                            return true
+                        }
+                        return false
+                    }),
+                    startWith(LOADING),
+                    catchError(error => [asError(error)])
+                ),
+            [authenticatedUser.id, fetchUserCodeMonitors]
+        )
     )
 
     const [monitorListFilter, setMonitorListFilter] = useState<CodeMonitorFilter>('all')
@@ -61,74 +88,128 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                 }
                 icon={VideoInputAntennaIcon}
                 actions={
-                    <Link to="/code-monitoring/new" className="btn btn-secondary">
-                        <PlusIcon className="icon-inline" />
-                        Create new code monitor
-                    </Link>
+                    userHasCodeMonitors &&
+                    userHasCodeMonitors !== 'loading' &&
+                    !isErrorLike(userHasCodeMonitors) && (
+                        <Link to="/code-monitoring/new" className="btn btn-secondary">
+                            <PlusIcon className="icon-inline" />
+                            Create new code monitor
+                        </Link>
+                    )
                 }
             />
-            <div className="text-muted mb-4">
-                {/* TODO: Add link to docs */}
-                Watch your code for changes and trigger actions to get notifications, send webhooks, and more.{' '}
-                <a href="/">Learn more.</a>
-            </div>
-            <div className="d-flex flex-column">
-                <div className="code-monitoring-page-tabs border-bottom mb-4">
-                    <div className="nav nav-tabs border-bottom-0">
-                        <div className="nav-item">
-                            <div className="nav-link active">Code monitors</div>
+            {userHasCodeMonitors === 'loading' && <LoadingSpinner />}
+            {!userHasCodeMonitors && (
+                <div className="mt-5">
+                    <div className="d-flex flex-column mb-5">
+                        <h2>Get started with code monitoring</h2>
+                        <p className="text-muted code-monitoring-page__start-subheading mb-4">
+                            Watch your code for changes and trigger actions to get notifications, send webhooks, and
+                            more. <a href="">Learn more.</a>
+                        </p>
+                        <Link
+                            to="/code-monitoring/new"
+                            className="code-monitoring-page__start-button btn btn-primary"
+                            type="button"
+                        >
+                            Create your first code monitor →
+                        </Link>
+                    </div>
+                    <div className="code-monitoring-page__start-points container">
+                        <h3>Starting points for your first monitor</h3>
+                        <div className="row no-gutters code-monitoring-page__start-points-panel-container">
+                            <div className="col-6">
+                                <div className="code-monitoring-page__start-points-panel">
+                                    <h3>Watch for AWS secrets in commits</h3>
+                                    <p className="text-muted">
+                                        Use a search query to watch for new search results, and choose how to receive
+                                        notifications in response.
+                                    </p>
+                                </div>
+                            </div>
+                            <div className="col-6">
+                                <div className="code-monitoring-page__start-points-panel">
+                                    <h3>Watch for new consumers of deprecated methods</h3>
+                                    <p className="text-muted">
+                                        Keep an eye on commits with new consumers of deprecated methods to keep your
+                                        code base up-to-date.
+                                    </p>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div className="row mb-5">
-                    <div className="d-flex flex-column col-2 mr-2">
-                        <h3>Filters</h3>
-                        <button
-                            type="button"
-                            className={classnames('btn text-left', { 'btn-primary': monitorListFilter === 'all' })}
-                            onClick={setAllFilter}
-                        >
-                            All
-                        </button>
-                        <button
-                            type="button"
-                            className={classnames('btn text-left', { 'btn-primary': monitorListFilter === 'user' })}
-                            onClick={setUserFilter}
-                        >
-                            Your code monitors
-                        </button>
+            )}
+            {userHasCodeMonitors && userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && (
+                <>
+                    <div className="text-muted mb-4">
+                        {/* TODO: Add link to docs */}
+                        Watch your code for changes and trigger actions to get notifications, send webhooks, and more.{' '}
+                        <a href="/">Learn more.</a>
                     </div>
-                    <div className="d-flex flex-column w-100 col">
-                        <h3 className="mb-2">
-                            {`${monitorListFilter === 'all' ? 'All code monitors' : 'Your code monitors'}`}
-                        </h3>
-                        <FilteredConnection<
-                            CodeMonitorFields,
-                            Omit<CodeMonitorNodeProps, 'node'>,
-                            (ListUserCodeMonitorsResult['node'] & { __typename: 'User' })['monitors']
-                        >
-                            location={props.location}
-                            history={props.history}
-                            defaultFirst={10}
-                            queryConnection={queryConnection}
-                            hideSearch={true}
-                            nodeComponent={CodeMonitorNode}
-                            nodeComponentProps={{
-                                location: props.location,
-                                toggleCodeMonitorEnabled,
-                            }}
-                            noun="code monitor"
-                            pluralNoun="code monitors"
-                            noSummaryIfAllNodesVisible={true}
-                            cursorPaging={true}
-                        />
+                    <div className="d-flex flex-column">
+                        <div className="code-monitoring-page-tabs border-bottom mb-4">
+                            <div className="nav nav-tabs border-bottom-0">
+                                <div className="nav-item">
+                                    <div className="nav-link active">Code monitors</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="row mb-5">
+                            <div className="d-flex flex-column col-2 mr-2">
+                                <h3>Filters</h3>
+                                <button
+                                    type="button"
+                                    className={classnames('btn text-left', {
+                                        'btn-primary': monitorListFilter === 'all',
+                                    })}
+                                    onClick={setAllFilter}
+                                >
+                                    All
+                                </button>
+                                <button
+                                    type="button"
+                                    className={classnames('btn text-left', {
+                                        'btn-primary': monitorListFilter === 'user',
+                                    })}
+                                    onClick={setUserFilter}
+                                >
+                                    Your code monitors
+                                </button>
+                            </div>
+                            <div className="d-flex flex-column w-100 col">
+                                <h3 className="mb-2">
+                                    {`${monitorListFilter === 'all' ? 'All code monitors' : 'Your code monitors'}`}
+                                </h3>
+                                <FilteredConnection<
+                                    CodeMonitorFields,
+                                    Omit<CodeMonitorNodeProps, 'node'>,
+                                    (ListUserCodeMonitorsResult['node'] & { __typename: 'User' })['monitors']
+                                >
+                                    location={props.location}
+                                    history={props.history}
+                                    defaultFirst={10}
+                                    queryConnection={queryConnection}
+                                    hideSearch={true}
+                                    nodeComponent={CodeMonitorNode}
+                                    nodeComponentProps={{
+                                        location: props.location,
+                                        toggleCodeMonitorEnabled,
+                                    }}
+                                    noun="code monitor"
+                                    pluralNoun="code monitors"
+                                    noSummaryIfAllNodesVisible={true}
+                                    cursorPaging={true}
+                                />
+                            </div>
+                        </div>
+                        <div className="mt-5">
+                            {/* TODO: add link */}
+                            We want to hear your feedback! <a href="/">Share your thoughts</a>
+                        </div>
                     </div>
-                </div>
-                <div className="mt-5">
-                    {/* TODO: add link */}
-                    We want to hear your feedback! <a href="/">Share your thoughts</a>
-                </div>
-            </div>
+                </>
+            )}
         </div>
     )
 }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,6 +1,6 @@
 import * as H from 'history'
 import classnames from 'classnames'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import VideoInputAntennaIcon from 'mdi-react/VideoInputAntennaIcon'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageHeader } from '../../components/PageHeader'
@@ -12,7 +12,7 @@ import { Link } from '../../../../shared/src/components/Link'
 import { CodeMonitoringProps } from '.'
 import PlusIcon from 'mdi-react/PlusIcon'
 import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
-import { catchError, map, startWith, tap } from 'rxjs/operators'
+import { catchError, map, startWith } from 'rxjs/operators'
 import { asError, isErrorLike } from '../../../../shared/src/util/errors'
 import { useObservable } from '../../../../shared/src/util/useObservable'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
@@ -75,7 +75,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
     }, [])
 
     return (
-        <div className="container mt-5">
+        <div className="code-monitoring-page container mt-5">
             <PageTitle title="Code Monitoring" />
             <PageHeader
                 title={
@@ -117,7 +117,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                     </div>
                     <div className="code-monitoring-page__start-points container">
                         <h3>Starting points for your first monitor</h3>
-                        <div className="row no-gutters code-monitoring-page__start-points-panel-container">
+                        <div className="row no-gutters code-monitoring-page__start-points-panel-container mb-3">
                             <div className="col-6">
                                 <div className="code-monitoring-page__start-points-panel">
                                     <h3>Watch for AWS secrets in commits</h3>
@@ -125,6 +125,8 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                                         Use a search query to watch for new search results, and choose how to receive
                                         notifications in response.
                                     </p>
+                                    {/* TODO: add link */}
+                                    <a className="btn btn-secondary">View in docs →</a>
                                 </div>
                             </div>
                             <div className="col-6">
@@ -133,6 +135,43 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                                     <p className="text-muted">
                                         Keep an eye on commits with new consumers of deprecated methods to keep your
                                         code base up-to-date.
+                                    </p>
+                                    {/* TODO: add link */}
+                                    <a className="btn btn-secondary">View in docs →</a>
+                                </div>
+                            </div>
+                        </div>
+                        <a className="link">Find more starting points in the docs</a>
+                    </div>
+                    <div className="code-monitoring-page__learn-more container mt-5">
+                        <h3 className="mb-3">Learn more about code monitoring</h3>
+                        <div className="row">
+                            <div className="col-4">
+                                <div>
+                                    <h4>Core concepts</h4>
+                                    <p className="text-muted">
+                                        Craft searches that will monitor your code and trigger actions.{' '}
+                                        {/* TODO: add link */}
+                                        <a className="link">Read the docs</a>
+                                    </p>
+                                </div>
+                            </div>
+                            <div className="col-4">
+                                <div>
+                                    <h4>Starting points and ideas</h4>
+                                    <p className="text-muted">
+                                        Find specific examples of useful code monitors to keep on top of security and
+                                        consistency concerns. {/* TODO: add link */}
+                                        <a className="link">Explore starting points</a>
+                                    </p>
+                                </div>
+                            </div>
+                            <div className="col-4">
+                                <div>
+                                    <h4>Questions and feedback</h4>
+                                    <p className="text-muted">
+                                        We want to hear your feedback. {/* TODO: add link */}
+                                        <a className="link">Share your thoughts</a>
                                     </p>
                                 </div>
                             </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -51,12 +51,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                     first: 1,
                     after: null,
                 }).pipe(
-                    map(monitors => {
-                        if (monitors.nodes.length > 0) {
-                            return true
-                        }
-                        return false
-                    }),
+                    map(monitors => monitors.nodes.length > 0),
                     startWith(LOADING),
                     catchError(error => [asError(error)])
                 ),

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
   useBreadcrumb={[Function]}
 >
   <div
-    className="container mt-5"
+    className="code-monitoring-page container mt-5"
   >
     <PageTitle
       title="Code Monitoring"
@@ -1552,7 +1552,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
   useBreadcrumb={[Function]}
 >
   <div
-    className="container mt-5"
+    className="code-monitoring-page container mt-5"
   >
     <PageTitle
       title="Code Monitoring"
@@ -2176,7 +2176,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
   useBreadcrumb={[Function]}
 >
   <div
-    className="container mt-5"
+    className="code-monitoring-page container mt-5"
   >
     <PageTitle
       title="Code Monitoring"

--- a/client/web/src/enterprise/code-monitoring/index.scss
+++ b/client/web/src/enterprise/code-monitoring/index.scss
@@ -1,2 +1,3 @@
 @import './CreateCodeMonitorPage';
+@import './CodeMonitoringPage';
 @import './components/CodeMonitorForm';


### PR DESCRIPTION
Adds the landing page to the code monitoring page when there are no monitors present. 

Figma: https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93%C2%A0Code-monitoring-actions-%26-notifications?node-id=2116%3A70
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
