### PR TITLE
search backend: remove quotes suggestion for literal mode

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -113,19 +113,6 @@ func alertForStalePermissions() *searchAlert {
 	}
 }
 
-func alertForQuotesInQueryInLiteralMode(p syntax.ParseTree) *searchAlert {
-	return &searchAlert{
-		prometheusType: "no_results__suggest_quotes",
-		title:          "No results. Did you mean to use quotes?",
-		description:    "Your search is interpreted literally and contains quotes. Did you mean to search for quotes?",
-		proposedQueries: []*searchQueryDescription{{
-			description: "Remove quotes",
-			query:       omitQuotes(p),
-			patternType: query.SearchTypeLiteral,
-		}},
-	}
-}
-
 // reposExist returns true if one or more repos resolve. If the attempt
 // returns 0 repos or fails, it returns false. It is a helper function for
 // raising NoResolvedRepos alerts with suggestions when we know the original
@@ -594,18 +581,6 @@ func omitQueryField(p syntax.ParseTree, field string) string {
 		return &e
 	}
 	return syntax.Map(p, omitField).String()
-}
-
-func omitQuotes(p syntax.ParseTree) string {
-	omitQuotes := func(e syntax.Expr) *syntax.Expr {
-
-		if e.Field == "" && strings.HasPrefix(e.Value, `"\"`) && strings.HasSuffix(e.Value, `\""`) {
-			e.Value = strings.TrimSuffix(strings.TrimPrefix(e.Value, `"\"`), `\""`)
-			return &e
-		}
-		return &e
-	}
-	return syntax.Map(p, omitQuotes).String()
 }
 
 // pathParentsByFrequency returns the most common path parents of the given paths.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -2005,10 +2005,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		alert = alertForMissingRepoRevs(r.patternType, resolved.missingRepoRevs)
 	}
 
-	if len(results) == 0 && strings.Contains(r.originalQuery, `"`) && r.patternType == query.SearchTypeLiteral {
-		alert = alertForQuotesInQueryInLiteralMode(r.query.ParseTree())
-	}
-
 	// If we have some results, only log the error instead of returning it,
 	// because otherwise the client would not receive the partial results
 	if len(results) > 0 && multiErr != nil {


### PR DESCRIPTION
Fixes #10793. As before:

> This quotes suggestion logic is overall naïve. It basically just looks for a quote if there are no results, and then throws this alert at you (it doesn't understand that quotes for params aren't part of a pattern, and we should only be throwing the alert if it is part of your pattern). I'm self-assigning to track it, but likely we can address this in a more principled way from scratch with the new query work.

Let's remove it entirely from the backend. Two reasons:

(1) We can handle this entirely in the frontend. Handling it in the backend is more difficult because there's a hard switch with query representation in the backend. Not so with frontend.

(2) Even if we didn't immediately handle it properly in the frontend (detect that the pattern is not quoted), this hint is overall low value. Currently it's just harmful/misleading.

