### PR TITLE
Remove prioritization of changesets without any diffstat

### DIFF
--- a/enterprise/internal/campaigns/store_changesets.go
+++ b/enterprise/internal/campaigns/store_changesets.go
@@ -395,20 +395,19 @@ func listChangesetSyncDataQuery(opts ListChangesetSyncDataOpts) *sqlf.Query {
 // in conjunction with at least one other option (most likely, CampaignID).
 type ListChangesetsOpts struct {
 	LimitOpts
-	Cursor               int64
-	CampaignID           int64
-	IDs                  []int64
-	WithoutDeleted       bool
-	PublicationState     *campaigns.ChangesetPublicationState
-	ReconcilerStates     []campaigns.ReconcilerState
-	ExternalState        *campaigns.ChangesetExternalState
-	ExternalReviewState  *campaigns.ChangesetReviewState
-	ExternalCheckState   *campaigns.ChangesetCheckState
-	OwnedByCampaignID    int64
-	OnlyWithoutDiffStats bool
-	OnlySynced           bool
-	ExternalServiceID    string
-	TextSearch           []ListChangesetsTextSearchExpr
+	Cursor              int64
+	CampaignID          int64
+	IDs                 []int64
+	WithoutDeleted      bool
+	PublicationState    *campaigns.ChangesetPublicationState
+	ReconcilerStates    []campaigns.ReconcilerState
+	ExternalState       *campaigns.ChangesetExternalState
+	ExternalReviewState *campaigns.ChangesetReviewState
+	ExternalCheckState  *campaigns.ChangesetCheckState
+	OwnedByCampaignID   int64
+	OnlySynced          bool
+	ExternalServiceID   string
+	TextSearch          []ListChangesetsTextSearchExpr
 }
 
 type ListChangesetsTextSearchExpr struct {
@@ -538,15 +537,9 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	if opts.OwnedByCampaignID != 0 {
 		preds = append(preds, sqlf.Sprintf("changesets.owned_by_campaign_id = %s", opts.OwnedByCampaignID))
 	}
-
-	if opts.OnlyWithoutDiffStats {
-		preds = append(preds, sqlf.Sprintf("(changesets.diff_stat_added IS NULL OR changesets.diff_stat_changed IS NULL OR changesets.diff_stat_deleted IS NULL)"))
-	}
-
 	if opts.OnlySynced {
 		preds = append(preds, sqlf.Sprintf("changesets.unsynced IS FALSE"))
 	}
-
 	if opts.ExternalServiceID != "" {
 		preds = append(preds, sqlf.Sprintf("repo.external_service_id = %s", opts.ExternalServiceID))
 	}

--- a/enterprise/internal/campaigns/store_changesets_test.go
+++ b/enterprise/internal/campaigns/store_changesets_test.go
@@ -466,22 +466,6 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		}
 
 		{
-			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{OnlyWithoutDiffStats: true})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			want := 1
-			if len(have) != want {
-				t.Fatalf("have %d changesets; want %d", len(have), want)
-			}
-
-			if have[0].ID != changesets[cap(changesets)-1].ID {
-				t.Fatalf("unexpected changeset: have %+v; want %+v", have[0], changesets[cap(changesets)-1])
-			}
-		}
-
-		{
 			gitlabMR := &gitlab.MergeRequest{
 				ID:        gitlab.ID(1),
 				Title:     "Fix a bunch of bugs",


### PR DESCRIPTION
We did this, because in a previous migration we would lose those diffstats, and we wanted those changesets to be back in shape as soon as possible. Given that we now copy it over from the changeset_spec, this is never not known, but computable. We cannot make it non-nullable in GQL and the DB currently, though, because imported changesets that were imported when the changeset was already closed don't have a diffstat either. This also fixes us prioritizing those always on repo-updater startup. 

Closes https://github.com/sourcegraph/sourcegraph/issues/16604