### PR TITLE
Update build steps for Safari browser extension and shorten description field

### DIFF
--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -70,6 +70,24 @@ function buildSafariExtensionApp(): void {
     shelljs.echo('y').exec(`xcrun safari-web-extension-converter ${safariWebExtensionConverterOptions.join(' ')}`)
     shelljs.exec(`xcodebuild ${xcodebuildOptions.join(' ')}`)
     shelljs.mv('./build/Sourcegraph for Safari/build/Release/Sourcegraph for Safari.app', './build/bundles')
+
+    setSafariBuildVersion(version)
+}
+
+/**
+ * Set the version string in the Xcode project that contains the Safari extension.
+ *
+ * See documentation of `agvtool`:
+ * https://developer.apple.com/library/archive/qa/qa1827/_index.html
+ */
+function setSafariBuildVersion(version: string): void {
+    if (typeof version !== 'string') {
+        throw new TypeError('Set Safari build version: version must be a string')
+    }
+    shelljs.pushd('./build/Sourcegraph for Safari')
+    shelljs.exec(`xcrun agvtool new-version -all "${version}"`)
+    shelljs.exec(`xcrun agvtool new-marketing-version -all "${version}"`)
+    shelljs.popd()
 }
 
 export function copyAssets(): void {

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -69,7 +69,12 @@ function buildSafariExtensionApp(): void {
         '--no-open',
     ]
 
-    const xcodebuildOptions = ['-quiet', '-project', '"./build/Sourcegraph for Safari/Sourcegraph for Safari.xcodeproj"', 'build']
+    const xcodebuildOptions = [
+        '-quiet',
+        '-project',
+        '"./build/Sourcegraph for Safari/Sourcegraph for Safari.xcodeproj"',
+        'build',
+    ]
 
     setSafariBuildVersion(version)
 
@@ -186,6 +191,9 @@ function writeManifest(environment: BuildEnvironment, browser: Browser, writeDir
     if (browser === 'safari') {
         // If any modifications need to be done to the manifest for Safari, they
         // can be done here.
+        if (manifest.description!.length > 120) {
+            throw new Error('Manifest description field cannot be longer than 120 characters. (Safari)')
+        }
     }
 
     if (shouldBuildWithInlineExtensions(browser)) {

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -76,27 +76,9 @@ function buildSafariExtensionApp(): void {
         'build',
     ]
 
-    setSafariBuildVersion(version)
-
     shelljs.echo('y').exec(`xcrun safari-web-extension-converter ${safariWebExtensionConverterOptions.join(' ')}`)
     shelljs.exec(`xcodebuild ${xcodebuildOptions.join(' ')}`)
     shelljs.mv('./build/Sourcegraph for Safari/build/Release/Sourcegraph for Safari.app', './build/bundles')
-}
-
-/**
- * Set the version string in the Xcode project that contains the Safari extension.
- *
- * See documentation of `agvtool`:
- * https://developer.apple.com/library/archive/qa/qa1827/_index.html
- */
-function setSafariBuildVersion(version: string): void {
-    if (typeof version !== 'string') {
-        throw new TypeError('Problem setting Safari extension version: the version string is not available')
-    }
-    shelljs.pushd('./build/Sourcegraph for Safari')
-    shelljs.exec(`xcrun agvtool new-version -all "${version}"`)
-    shelljs.exec(`xcrun agvtool new-marketing-version "${version}"`)
-    shelljs.popd()
 }
 
 export function copyAssets(): void {

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -173,8 +173,8 @@ function writeManifest(environment: BuildEnvironment, browser: Browser, writeDir
     if (browser === 'safari') {
         // If any modifications need to be done to the manifest for Safari, they
         // can be done here.
-        if (manifest.description!.length > 120) {
-            throw new Error('Manifest description field cannot be longer than 120 characters. (Safari)')
+        if (manifest.description!.length > 112) {
+            throw new Error('Manifest description field cannot be longer than 112 characters. (Safari)')
         }
     }
 

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -61,12 +61,15 @@ function buildSafariExtensionApp(): void {
         'build/',
         '--app-name',
         '"Sourcegraph for Safari"',
+        '--bundle-identifier',
+        '"com.sourcegraph.Sourcegraph-for-Safari"',
+        '--copy-resources',
         '--swift',
         '--force',
         '--no-open',
     ]
 
-    const xcodebuildOptions = ['-project', '"./build/Sourcegraph for Safari/Sourcegraph for Safari.xcodeproj"', 'build']
+    const xcodebuildOptions = ['-quiet', '-project', '"./build/Sourcegraph for Safari/Sourcegraph for Safari.xcodeproj"', 'build']
 
     setSafariBuildVersion(version)
 
@@ -87,7 +90,7 @@ function setSafariBuildVersion(version: string): void {
     }
     shelljs.pushd('./build/Sourcegraph for Safari')
     shelljs.exec(`xcrun agvtool new-version -all "${version}"`)
-    shelljs.exec(`xcrun agvtool new-marketing-version -all "${version}"`)
+    shelljs.exec(`xcrun agvtool new-marketing-version "${version}"`)
     shelljs.popd()
 }
 

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -61,8 +61,6 @@ function buildSafariExtensionApp(): void {
         'build/',
         '--app-name',
         '"Sourcegraph for Safari"',
-        '--bundle-identifier',
-        '"com.sourcegraph.sourcegraph-safari-extension"',
         '--swift',
         '--force',
         '--no-open',

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -85,7 +85,7 @@ function buildSafariExtensionApp(): void {
  */
 function setSafariBuildVersion(version: string): void {
     if (typeof version !== 'string') {
-        throw new TypeError('Set Safari build version: version must be a string')
+        throw new TypeError('Problem setting Safari extension version: the version string is not available')
     }
     shelljs.pushd('./build/Sourcegraph for Safari')
     shelljs.exec(`xcrun agvtool new-version -all "${version}"`)

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -51,6 +51,9 @@ function ensurePaths(): void {
     shelljs.mkdir('-p', 'build/safari')
 }
 
+/**
+ * Create the Safari extension app Xcode project and build it.
+ */
 function buildSafariExtensionApp(): void {
     const safariWebExtensionConverterOptions = [
         'build/safari',
@@ -67,11 +70,11 @@ function buildSafariExtensionApp(): void {
 
     const xcodebuildOptions = ['-project', '"./build/Sourcegraph for Safari/Sourcegraph for Safari.xcodeproj"', 'build']
 
+    setSafariBuildVersion(version)
+
     shelljs.echo('y').exec(`xcrun safari-web-extension-converter ${safariWebExtensionConverterOptions.join(' ')}`)
     shelljs.exec(`xcodebuild ${xcodebuildOptions.join(' ')}`)
     shelljs.mv('./build/Sourcegraph for Safari/build/Release/Sourcegraph for Safari.app', './build/bundles')
-
-    setSafariBuildVersion(version)
 }
 
 /**

--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "name": "Sourcegraph",
   "manifest_version": 2,
-  "description": "Adds code intelligence to GitHub: hovers, definitions, references. Supports 20+ languages and other popular code hosts.",
+  "description": "Adds code intelligence to GitHub: hovers, definitions, references. Supports 20+ languages and other code hosts.",
   "browser_action": {
     "default_title": "Sourcegraph",
     "default_icon": {

--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "name": "Sourcegraph",
   "manifest_version": 2,
-  "description": "Adds code intelligence to GitHub: hovers, definitions, references. Supports 20+ languages and other popular code hosts, too.",
+  "description": "Adds code intelligence to GitHub: hovers, definitions, references. Supports 20+ languages and other popular code hosts.",
   "browser_action": {
     "default_title": "Sourcegraph",
     "default_icon": {


### PR DESCRIPTION
Updated description: This PR was previously titled "Add build step to set the Safari browser extension version" but during validation of the build for submitting to the App Store, it turned out that modifying the version string is not going to work so I removed that part.

Also during validation for the App Store, the submission failed to validate due to the length of the description field in the manifest.

I slightly shortened the description field to make it fit, and added a check for the length of the field so in case the description is changed the future, we won't go through the whole upload process to find out that the description is too long.