### PR TITLE
Code monitoring: QA

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -10,18 +10,32 @@
         }
 
         &--button {
+            margin-top: calc(16px - 1px);
+            margin-bottom: calc(16px - 1px);
+            margin-left: -1px;
+            margin-right: -1px;
+            border-radius: 4px;
+
             &:hover {
+                margin-left: -2px;
+                margin-right: -2px;
+                margin-top: calc(16px - 2px);
+                margin-bottom: calc(16px - 2px);
                 border: 2px solid #329af0;
             }
 
             .create-monitor-page__trigger--disabled & {
+                margin: 1rem 0;
                 &:hover {
+                    margin: 1rem 0;
                     border: 1px solid var(--border-color);
                 }
             }
 
             .create-monitor-page__actions--disabled & {
+                margin: 1rem 0;
                 &:hover {
+                    margin: 1rem 0;
                     border: 1px solid var(--border-color);
                 }
             }

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -10,17 +10,13 @@
         }
 
         &--button {
-            margin-top: calc(16px - 1px);
-            margin-bottom: calc(16px - 1px);
-            margin-left: -1px;
-            margin-right: -1px;
+            // stylelint-disable-next-line declaration-property-unit-whitelist
+            margin: calc(16px - 1px) -1px;
             border-radius: 4px;
 
             &:hover {
-                margin-left: -2px;
-                margin-right: -2px;
-                margin-top: calc(16px - 2px);
-                margin-bottom: calc(16px - 2px);
+                // stylelint-disable-next-line declaration-property-unit-whitelist
+                margin: calc(16px - 2px) -2px;
                 border: 2px solid #329af0;
             }
 

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -21,17 +21,17 @@
             }
 
             .create-monitor-page__trigger--disabled & {
-                margin: 1rem 0;
                 &:hover {
-                    margin: 1rem 0;
+                    // stylelint-disable-next-line declaration-property-unit-whitelist
+                    margin: calc(16px - 1px) -1px;
                     border: 1px solid var(--border-color);
                 }
             }
 
             .create-monitor-page__actions--disabled & {
-                margin: 1rem 0;
                 &:hover {
-                    margin: 1rem 0;
+                    // stylelint-disable-next-line declaration-property-unit-whitelist
+                    margin: calc(16px - 1px) -1px;
                     border: 1px solid var(--border-color);
                 }
             }

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -118,11 +118,13 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
             if (window.confirm('Leave page? All unsaved changes will be lost.')) {
                 history.push('/code-monitoring')
             }
+        } else {
+            history.push('/code-monitoring')
         }
     }, [history, hasChangedFields])
 
     return (
-        <Form className="my-4" onSubmit={requestOnSubmit}>
+        <Form className="my-4 pb-5" onSubmit={requestOnSubmit}>
             <div className="flex mb-4">
                 Name
                 <div>
@@ -154,7 +156,10 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                         {authenticatedUser.username}
                     </option>
                 </select>
-                <small className="text-muted">Event history and configuration will not be shared.</small>
+                <small className="text-muted">
+                    Event history and configuration will not be shared. Code monitoring currently only supports
+                    individual owners.
+                </small>
             </div>
             <hr className="code-monitor-form__horizontal-rule" />
             <div className="create-monitor-page__triggers mb-4">
@@ -209,7 +214,6 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                         {submitButtonLabel}
                     </button>
                     <button type="button" className="btn btn-outline-secondary test-cancel-monitor" onClick={onCancel}>
-                        {/* TODO: this should link somewhere */}
                         Cancel
                     </button>
                 </div>

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -86,7 +86,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                 <div className="code-monitor-form__card card p-3 my-3">
                     <div className="font-weight-bold">Send email notifications</div>
                     <span className="text-muted">Deliver email notifications to specified recipients.</span>
-                    <div className="mt-4 test-action-form">
+                    <div className="mt-3 test-action-form">
                         Recipients
                         <input
                             type="text"

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -72,11 +72,11 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
             {!showEmailNotificationForm && !actionsCompleted && (
                 <button
                     type="button"
-                    className="code-monitor-form__card card p-3 my-3 w-100 test-action-button"
+                    className="code-monitor-form__card--button card p-3 w-100 test-action-button text-left"
                     onClick={toggleEmailNotificationForm}
                     disabled={disabled}
                 >
-                    <div className="code-monitor-form__card-link btn btn-link font-weight-bold p-0 text-left">
+                    <div className="code-monitor-form__card-link btn-link font-weight-bold p-0">
                         Send email notifications
                     </div>
                     <span className="text-muted">Deliver email notifications to specified recipients.</span>
@@ -104,7 +104,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                             title="Enabled"
                             value={emailNotificationEnabled}
                             onToggle={toggleEmailNotificationEnabled}
-                            className="mr-2"
+                            className="mr-2 my-4"
                         />
                         Enabled
                     </div>
@@ -131,7 +131,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                             <span className="text-muted test-existing-action-email">{authenticatedUser.email}</span>
                         </div>
                         <div className="d-flex">
-                            <div className="flex my-4">
+                            <div className="flex">
                                 <Toggle
                                     title="Enabled"
                                     value={emailNotificationEnabled}

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -86,7 +86,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                 <div className="code-monitor-form__card card p-3 my-3">
                     <div className="font-weight-bold">Send email notifications</div>
                     <span className="text-muted">Deliver email notifications to specified recipients.</span>
-                    <div className="mt-3 test-action-form">
+                    <div className="mt-4 test-action-form">
                         Recipients
                         <input
                             type="text"

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -124,6 +124,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     <span className="text-muted">
                         This trigger will fire when new search results are found for a given search query.
                     </span>
+                    <span className="mt-4">Search query</span>
                     <div className="create-monitor-page__query-input">
                         <input
                             type="text"
@@ -139,7 +140,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                         />
                         {queryState.kind === 'VALID' && (
                             <Link
-                                to={buildSearchURLQuery(query, SearchPatternType.literal, false)}
+                                to={`/search?${buildSearchURLQuery(query, SearchPatternType.literal, false)}`}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="create-monitor-page__query-input-preview-link test-preview-link"

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -108,12 +108,9 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                 <button
                     type="button"
                     onClick={toggleQueryForm}
-                    className="code-monitor-form__card--button card p-3 my-3 w-100 test-trigger-button"
+                    className="code-monitor-form__card--button card p-3 w-100 test-trigger-button text-left"
                 >
-                    <div
-                        onClick={toggleQueryForm}
-                        className="code-monitor-form__card-link btn btn-link font-weight-bold p-0 text-left"
-                    >
+                    <div className="code-monitor-form__card-link btn-link font-weight-bold p-0">
                         When there are new search results
                     </div>
                     <span className="text-muted">


### PR DESCRIPTION
Addresses QA items in https://github.com/sourcegraph/sourcegraph/pull/16544#issuecomment-741661630. 

Missing and will do separately due to complexity with validation: 
- [ ] We ought to show the "Preview results" link in the search query input at all times, not just when there's a complete query
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
