### PR TITLE
external_services: automatically add authorization for GitLab and GitHub on Cloud

### DIFF
--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -3,13 +3,13 @@ package db
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
@@ -217,41 +217,35 @@ func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateE
 	switch opt.Kind {
 	case extsvc.KindGitHub:
 		var c schema.GitHubConnection
-		if err = json.Unmarshal(normalized, &c); err != nil {
+		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
 			return nil, err
-		}
-		if opt.HasNamespace && c.Authorization == nil {
-			errs = multierror.Append(errs, errAuthorizationRequired)
 		}
 		err = e.validateGitHubConnection(ctx, opt.ID, &c)
 
 	case extsvc.KindGitLab:
 		var c schema.GitLabConnection
-		if err = json.Unmarshal(normalized, &c); err != nil {
+		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
 			return nil, err
-		}
-		if opt.HasNamespace && c.Authorization == nil {
-			errs = multierror.Append(errs, errAuthorizationRequired)
 		}
 		err = e.validateGitLabConnection(ctx, opt.ID, &c, opt.AuthProviders)
 
 	case extsvc.KindBitbucketServer:
 		var c schema.BitbucketServerConnection
-		if err = json.Unmarshal(normalized, &c); err != nil {
+		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
 			return nil, err
 		}
 		err = e.validateBitbucketServerConnection(ctx, opt.ID, &c)
 
 	case extsvc.KindBitbucketCloud:
 		var c schema.BitbucketCloudConnection
-		if err = json.Unmarshal(normalized, &c); err != nil {
+		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
 			return nil, err
 		}
 		err = e.validateBitbucketCloudConnection(ctx, opt.ID, &c)
 
 	case extsvc.KindOther:
 		var c schema.OtherExternalServiceConnection
-		if err = json.Unmarshal(normalized, &c); err != nil {
+		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
 			return nil, err
 		}
 		err = validateOtherExternalServiceConnection(&c)
@@ -466,6 +460,53 @@ func (e *ExternalServiceStore) Create(ctx context.Context, confGet func() *conf.
 	})
 	if err != nil {
 		return err
+	}
+
+	// NOTE: For GitHub and GitLab user code host connections on Sourcegraph Cloud,
+	//  we always want to enforce repository permissions using OAuth to prevent
+	//  unexpected resource leaking.
+	if envvar.SourcegraphDotComMode() && es.NamespaceUserID != 0 {
+		switch es.Kind {
+		case extsvc.KindGitHub:
+			var c schema.GitHubConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return err
+			}
+
+			if c.Authorization == nil {
+				c.Authorization = &schema.GitHubAuthorization{}
+
+				normalized, err = jsoniter.Marshal(c)
+				if err != nil {
+					return err
+				}
+			}
+
+		case extsvc.KindGitLab:
+			var c schema.GitLabConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return err
+			}
+
+			if c.Authorization == nil {
+				c.Authorization = &schema.GitLabAuthorization{
+					IdentityProvider: schema.IdentityProvider{
+						Oauth: &schema.OAuthIdentity{
+							Type: "oauth",
+						},
+					},
+				}
+
+				normalized, err = jsoniter.Marshal(c)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// We expect users to edit code host connections via our UI so no JSON with
+		// comments should appear, thus OK to set config as normalized.
+		es.Config = string(normalized)
 	}
 
 	es.CreatedAt = timeutil.Now()

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -193,20 +194,6 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			hasNamespace: true,
 			wantErr:      `field "rateLimit" is not allowed in a user-added external service`,
 		},
-		{
-			name:         "authorization required for GitHub",
-			kind:         extsvc.KindGitHub,
-			config:       `{"url": "https://github.com", "token": "abc", "repos": ["abc/testrepo"]}`,
-			hasNamespace: true,
-			wantErr:      "1 error occurred:\n\t* authorization required\n\n",
-		},
-		{
-			name:         "authorization required for GitLab",
-			kind:         extsvc.KindGitHub,
-			config:       `{"url": "https://gitlab.com", "token": "abc", "repos": ["abc/testrepo"]}`,
-			hasNamespace: true,
-			wantErr:      "1 error occurred:\n\t* authorization required\n\n",
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -233,6 +220,21 @@ func TestExternalServicesStore_Create(t *testing.T) {
 	}
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
+
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
+
+	user, err := Users.Create(ctx,
+		NewUser{
+			Email:           "alice@example.com",
+			Username:        "alice",
+			Password:        "password",
+			EmailIsVerified: true,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a new external service
 	confGet := func() *conf.Unified {
@@ -276,6 +278,27 @@ func TestExternalServicesStore_Create(t *testing.T) {
 }`,
 			},
 			wantUnrestricted: true,
+		},
+
+		{
+			name: "Cloud: auto-add authorization to user code host connections for GitHub",
+			externalService: &types.ExternalService{
+				Kind:            extsvc.KindGitHub,
+				DisplayName:     "GITHUB #4",
+				Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+				NamespaceUserID: user.ID,
+			},
+			wantUnrestricted: false,
+		},
+		{
+			name: "Cloud: auto-add authorization to user code host connections for GitLab",
+			externalService: &types.ExternalService{
+				Kind:            extsvc.KindGitLab,
+				DisplayName:     "GITLAB #1",
+				Config:          `{"url": "https://gitlab.com", "projectQuery": ["none"], "token": "abc"}`,
+				NamespaceUserID: user.ID,
+			},
+			wantUnrestricted: false,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
This PR automatically adds `"authorization"` field to user code host connections on dotcom for GitLab.com and GitHub.com at creation to enforce repository permissions.

The reason I don't do this inside `ValidateConfig` is because I think "validation" shouldn't involve mutating the config.

I'm gonna fix and add corresponding tests if people agree with the current approach.

### TODO

- [x] Tests