### PR TITLE
search: delete old job logs for code monitoring

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -56,7 +56,7 @@ func newTriggerQueryResetter(ctx context.Context, s *cm.Store, metrics codeMonit
 }
 
 func newTriggerJobsLogDeleter(ctx context.Context, store *cm.Store) goroutine.BackgroundRoutine {
-	deleteObsoleteLogs := goroutine.NewHandlerWithErrorMessage(
+	deleteLogs := goroutine.NewHandlerWithErrorMessage(
 		"code_monitors_trigger_jobs_log_deleter",
 		func(ctx context.Context) error {
 			// Delete logs without search results.
@@ -71,7 +71,7 @@ func newTriggerJobsLogDeleter(ctx context.Context, store *cm.Store) goroutine.Ba
 			}
 			return nil
 		})
-	return goroutine.NewPeriodicGoroutine(ctx, 60*time.Minute, deleteObsoleteLogs)
+	return goroutine.NewPeriodicGoroutine(ctx, 60*time.Minute, deleteLogs)
 }
 
 func newActionRunner(ctx context.Context, s *cm.Store, metrics codeMonitorsMetrics) *workerutil.Worker {

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -1,0 +1,81 @@
+package codemonitors
+
+import (
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+const setToCompletedFmtStr = `
+UPDATE cm_trigger_jobs
+SET state = 'completed',
+    started_at = %s,
+    finished_at = %s
+WHERE id = %s;
+`
+
+const getJobIDs = `
+SELECT id
+FROM cm_trigger_jobs;
+`
+
+func TestDeleteOldJobLogs(t *testing.T) {
+	retentionInDays := 7
+	ctx, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t)
+	_, err := s.insertTestMonitor(userCTX, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add 1 job and date it back to a long time ago.
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	longTimeAgo := s.Now().AddDate(0, 0, -(retentionInDays + 1))
+	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, longTimeAgo, longTimeAgo, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add second job.
+	err = s.EnqueueTriggerQueries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, s.Now(), s.Now(), 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.DeleteOldJobLogs(ctx, retentionInDays)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.Query(ctx, sqlf.Sprintf(getJobIDs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var (
+		rowCount int
+		id       int
+	)
+	for rows.Next() {
+		rowCount++
+		if rowCount > 1 {
+			t.Fatalf("got more than 1 row, expected exactly 1 row")
+		}
+		err = rows.Scan(&id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	wantID := 2
+	if id != wantID {
+		t.Fatalf("got %d, expected %d", id, wantID)
+	}
+}


### PR DESCRIPTION
Each time we run a query we log how many seach results it returns.
Currenlty, we delete logs with `num_results = 0` but retain logs with
`num_results>0` forever. This PR introduces a retention policy, which is
set to delete all logs older than 7 days. Once we expose events to
users, we should extend this period to 30 days or more.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
