### PR TITLE
Code monitoring: Fix action editing by passing action IDs

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -105,6 +105,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                             value={`${authenticatedUser.email || ''} (you)`}
                             disabled={true}
                             autoFocus={true}
+                            required={true}
                         />
                         <small className="text-muted">
                             Code monitors are currently limited to sending emails to your primary email address.

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -39,7 +39,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
             setEmailNotificationEnabled(enabled)
             onActionsChange({
                 // TODO farhan: refactor to accomodate more than one action.
-                nodes: [{ id: actions.nodes[0].id, recipients: { nodes: [{ id: authenticatedUser.email }] }, enabled }],
+                nodes: [{ id: actions.nodes[0].id, recipients: { nodes: [{ id: authenticatedUser.id }] }, enabled }],
             })
         },
         [authenticatedUser, onActionsChange, actions.nodes]


### PR DESCRIPTION
I ran into a bug where if you made edits to the action on a code monitor (e.g. toggle the enable/disable), we weren't passing the action ID, so the update wouldn't work. This adds a fix for that. 

I need to make this component not assume that every monitor will have exactly 1 email action, which is true currently and allows us to get by with some hacks. Will do in a follow-up, but want to get this approved so we can merge and test code monitors within our org. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
