### PR TITLE
search frontend: refine revision hovers

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -968,11 +968,11 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 9,
-                "scopes": "metaRevisionWildcard"
+                "scopes": "metaRevisionIncludeGlobMarker"
               },
               {
                 "startIndex": 10,
-                "scopes": "metaRevisionPathLike"
+                "scopes": "metaRevisionReferencePath"
               },
               {
                 "startIndex": 21,
@@ -992,19 +992,11 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 23,
-                "scopes": "metaRevisionWildcard"
-              },
-              {
-                "startIndex": 24,
-                "scopes": "metaRevisionLabel"
-              },
-              {
-                "startIndex": 24,
-                "scopes": "metaRevisionNegate"
+                "scopes": "metaRevisionExcludeGlobMarker"
               },
               {
                 "startIndex": 25,
-                "scopes": "metaRevisionPathLike"
+                "scopes": "metaRevisionReferencePath"
               },
               {
                 "startIndex": 43,

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -81,7 +81,8 @@ export interface MetaField extends BaseMetaToken {
 }
 
 /**
- * A token that is labeled and interpreted as repository revision syntax.
+ * A token that is labeled and interpreted as repository revision syntax in Sourcegraph. Note: there
+ * are syntactic differences from pure Git ref syntax.
  * See https://docs.sourcegraph.com/code_search/reference/queries#repository-revisions.
  */
 export interface MetaRevision extends BaseMetaToken {
@@ -89,13 +90,25 @@ export interface MetaRevision extends BaseMetaToken {
     kind: MetaRevisionKind
 }
 
-export enum MetaRevisionKind {
-    Separator = 'Separator', // is a ':'
-    Label = 'Label', // a branch or tag
+export type MetaRevisionKind = MetaGit | MetaSourcegraph
+
+/**
+ * A custom revision syntax that is only valid in Sourcegraph search queries.
+ */
+export enum MetaSourcegraph {
+    Separator = 'Separator', // a ':' that separates revision patterns
+    IncludeGlobMarker = 'IncludeGlobMarker', // a '*' at the beginning of a revision pattern to mark it as an "include" glob pattern.
+    ExcludeGlobMarker = 'ExcludeGlobMarker', // a '*!' at the beginning of a revision pattern to mark it as an "exclude" glob pattern.
+}
+
+/**
+ * Revision syntax that correspond to git glob pattern syntax, git refs (e.g., branches), or git objects (e.g., commits, tags).
+ */
+export enum MetaGit {
     CommitHash = 'CommitHash', // a commit hash
-    PathLike = 'PathLike', // a path-like pattern, e.g., the refs/heads/ part in *refs/heads/*
+    Label = 'Label', // a catch-all string that refers to a git object or ref, like a branch name or tag
+    ReferencePath = 'ReferencePath', // the part of a revision that refers to a git reference path, like refs/heads/ part in refs/heads/*
     Wildcard = 'Wildcard', // a '*' in glob syntax
-    Negate = 'Negate', // a '!' in glob syntax
 }
 
 /**
@@ -328,42 +341,51 @@ const mapRevisionMeta = (token: Literal): DecoratedToken[] => {
     }
 
     // Appends a decorated token to the list of tokens, and resets the current accumulator to be empty.
-    const appendDecoratedToken = (endIndex: number): void => {
+    const appendDecoratedToken = (endIndex: number, kind?: MetaRevisionKind): void => {
         const value = accumulator.join('')
-        let kind
-        switch (value) {
-            case ':':
-                kind = MetaRevisionKind.Separator
-                break
-            case '*':
-                kind = MetaRevisionKind.Wildcard
-                break
-            case '!':
-                kind = MetaRevisionKind.Negate
-                break
-            default:
-                if (value.includes('/')) {
-                    kind = MetaRevisionKind.PathLike
-                } else if (value.match(/^[\dA-Fa-f]+$/) && value.length > 6) {
-                    kind = MetaRevisionKind.CommitHash
-                } else {
-                    kind = MetaRevisionKind.Label
-                }
+        if (kind === undefined) {
+            if (value.includes('refs/')) {
+                kind = MetaGit.ReferencePath
+            } else if (value.match(/^[\dA-Fa-f]+$/) && value.length > 6) {
+                kind = MetaGit.CommitHash
+            } else {
+                kind = MetaGit.Label
+            }
         }
         const range = { start: offset + endIndex - value.length, end: offset + endIndex }
         decorated.push({ type: 'metaRevision', kind, value, range })
         accumulator = []
     }
 
+    // Return true when we're at the beginning of a revision: at the beginning of the string,
+    // or when the preceding character is a ':' revision separator.
+    const atRevision = (index: number): boolean =>
+        index === 0 || (token.value[index - 1] !== null && token.value[index - 1] === ':')
+
     while (token.value[start] !== undefined) {
         current = nextChar()
         switch (current) {
+            case '*': {
+                appendDecoratedToken(start - 1) // Push the running revision string up to this special syntax.
+                if (atRevision(start - 1) && token.value[start] !== '!') {
+                    // Demarcates that this is an "include" glob pattern that follows.
+                    accumulator.push(current)
+                    appendDecoratedToken(start, MetaSourcegraph.IncludeGlobMarker)
+                } else if (atRevision(start - 1) && token.value[start] === '!') {
+                    // Demarcates that this is an "exclude" glob pattern that follows.
+                    current = nextChar() // Consume the '!'
+                    accumulator.push('*!')
+                    appendDecoratedToken(start, MetaSourcegraph.ExcludeGlobMarker)
+                } else {
+                    accumulator.push(current)
+                    appendDecoratedToken(start, MetaGit.Wildcard)
+                }
+                break
+            }
             case ':':
-            case '*':
-            case '!':
-                appendDecoratedToken(start - 1) // append up to this special character
+                appendDecoratedToken(start - 1)
                 accumulator.push(current)
-                appendDecoratedToken(start)
+                appendDecoratedToken(start, MetaSourcegraph.Separator)
                 break
             default:
                 accumulator.push(current)

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -383,7 +383,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Search at revision.** Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
+                  "value": "**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the \`@\` specifies the repositories to search, the part after the \`@\` specifies which revisions to search."
                 }
               ],
               "range": {
@@ -463,7 +463,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Revision using git reference path**. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
+                  "value": "**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
                 }
               ],
               "range": {

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -447,7 +447,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, \`refs/tags/v3.*\` matches all tags that start with \`v3.\`."
+                  "value": "**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like \`*refs/heads/*\` searches across all repository branches at the head commit."
                 }
               ],
               "range": {
@@ -479,13 +479,13 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Revision negation**. A prefix of a glob pattern or path that does **not** match a set of git objects, like a commit or branch name. Typically used in conjunction with a glob pattern that matches a set of commits or branches, followed by a negated set to exclude. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
+                  "value": "**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, \`*refs/heads/*:*!refs/heads/release*\` searches all branches at the head commit, excluding branches matching \`release*\`."
                 }
               ],
               "range": {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
-                "startColumn": 41,
+                "startColumn": 40,
                 "endColumn": 42
               }
             }

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -7,7 +7,8 @@ import {
     MetaRegexp,
     MetaRegexpKind,
     MetaRevision,
-    MetaRevisionKind,
+    MetaGit,
+    MetaSourcegraph,
 } from './decoratedToken'
 import { resolveFilter } from './filters'
 
@@ -97,11 +98,11 @@ const toRevisionHover = (token: MetaRevision): string => {
     let title: string
     let description: string
     switch (token.kind) {
-        case MetaRevisionKind.CommitHash:
+        case MetaGit.CommitHash:
             title = 'commit hash'
             description = 'Search the repository at this commit.'
             break
-        case MetaRevisionKind.Label:
+        case MetaGit.Label:
             if (token.value.match(/^head$/i)) {
                 title = 'HEAD'
                 description = 'Search the repository at the latest HEAD commit of the default branch.'
@@ -110,25 +111,30 @@ const toRevisionHover = (token: MetaRevision): string => {
             title = 'branch name or tag'
             description = 'Search the branch name or tag at the head commit.'
             break
-        case MetaRevisionKind.Negate:
-            title = 'negation'
-            description =
-                'A prefix of a glob pattern or path that does **not** match a set of git objects, like a commit or branch name. Typically used in conjunction with a glob pattern that matches a set of commits or branches, followed by a negated set to exclude. For example, `*refs/heads/*:*!refs/heads/release*` searches all branches at the head commit, excluding branches matching `release*`.'
-            break
-        case MetaRevisionKind.PathLike:
+        case MetaGit.ReferencePath:
             title = 'using git reference path'
             description =
                 'Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
             break
-        case MetaRevisionKind.Separator:
-            title = 'separator'
-            description =
-                'Separates multiple revisions to search across. For example, `1a35d48:feature:3.15` searches the repository for matches at commit `1a35d48`, or a branch named `feature`, or a tag `3.15`.'
-            break
-        case MetaRevisionKind.Wildcard:
+        case MetaGit.Wildcard:
             title = 'wildcard'
             description =
                 'Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, `refs/tags/v3.*` matches all tags that start with `v3.`.'
+            break
+        case MetaSourcegraph.IncludeGlobMarker:
+            title = 'glob pattern to include'
+            description =
+                'A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
+            break
+        case MetaSourcegraph.ExcludeGlobMarker:
+            title = 'glob pattern to exclude'
+            description =
+                'A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, `*refs/heads/*:*!refs/heads/release*` searches all branches at the head commit, excluding branches matching `release*`.'
+            break
+        case MetaSourcegraph.Separator:
+            title = 'separator'
+            description =
+                'Separates multiple revisions to search across. For example, `1a35d48:feature:3.15` searches the repository for matches at commit `1a35d48`, or a branch named `feature`, or a tag `3.15`.'
             break
     }
     return `**Revision ${title}**. ${description}`

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -7,8 +7,8 @@ import {
     MetaRegexp,
     MetaRegexpKind,
     MetaRevision,
-    MetaGit,
-    MetaSourcegraph,
+    MetaGitRevision,
+    MetaSourcegraphRevision,
 } from './decoratedToken'
 import { resolveFilter } from './filters'
 
@@ -95,49 +95,25 @@ const toRegexpHover = (token: MetaRegexp): string => {
 }
 
 const toRevisionHover = (token: MetaRevision): string => {
-    let title: string
-    let description: string
     switch (token.kind) {
-        case MetaGit.CommitHash:
-            title = 'commit hash'
-            description = 'Search the repository at this commit.'
-            break
-        case MetaGit.Label:
+        case MetaGitRevision.CommitHash:
+            return '**Revision commit hash**. Search the repository at this commit.'
+        case MetaGitRevision.Label:
             if (token.value.match(/^head$/i)) {
-                title = 'HEAD'
-                description = 'Search the repository at the latest HEAD commit of the default branch.'
-                break
+                return '**Revision HEAD**. Search the repository at the latest HEAD commit of the default branch.'
             }
-            title = 'branch name or tag'
-            description = 'Search the branch name or tag at the head commit.'
-            break
-        case MetaGit.ReferencePath:
-            title = 'using git reference path'
-            description =
-                'Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
-            break
-        case MetaGit.Wildcard:
-            title = 'wildcard'
-            description =
-                'Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, `refs/tags/v3.*` matches all tags that start with `v3.`.'
-            break
-        case MetaSourcegraph.IncludeGlobMarker:
-            title = 'glob pattern to include'
-            description =
-                'A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
-            break
-        case MetaSourcegraph.ExcludeGlobMarker:
-            title = 'glob pattern to exclude'
-            description =
-                'A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, `*refs/heads/*:*!refs/heads/release*` searches all branches at the head commit, excluding branches matching `release*`.'
-            break
-        case MetaSourcegraph.Separator:
-            title = 'separator'
-            description =
-                'Separates multiple revisions to search across. For example, `1a35d48:feature:3.15` searches the repository for matches at commit `1a35d48`, or a branch named `feature`, or a tag `3.15`.'
-            break
+            return '**Revision branch name or tag**. Search the branch name or tag at the head commit.'
+        case MetaGitRevision.ReferencePath:
+            return '**Revision using git reference path**. Search the branch name or tag at the head commit. Search across git objects, like commits or branches, that match this git reference path. Typically used in conjunction with glob patterns, where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
+        case MetaGitRevision.Wildcard:
+            return '**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, `refs/tags/v3.*` matches all tags that start with `v3.`.'
+        case MetaSourcegraphRevision.IncludeGlobMarker:
+            return '**Revision glob pattern to include.** A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
+        case MetaSourcegraphRevision.ExcludeGlobMarker:
+            return '**Revision glob pattern to exclude.** A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, `*refs/heads/*:*!refs/heads/release*` searches all branches at the head commit, excluding branches matching `release*`.'
+        case MetaSourcegraphRevision.Separator:
+            return '**Revision separator.** Separates multiple revisions to search across. For example, `1a35d48:feature:3.15` searches the repository for matches at commit `1a35d48`, or a branch named `feature`, or a tag `3.15`.'
     }
-    return `**Revision ${title}**. ${description}`
 }
 
 const toHover = (token: DecoratedToken): string => {

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -108,11 +108,11 @@ const toRevisionHover = (token: MetaRevision): string => {
         case MetaGitRevision.Wildcard:
             return '**Revision wildcard**. Glob syntax to match zero or more characters in a revision. Typically used to match multiple branches or tags based on a git reference path. For example, `refs/tags/v3.*` matches all tags that start with `v3.`.'
         case MetaSourcegraphRevision.IncludeGlobMarker:
-            return '**Revision glob pattern to include.** A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
+            return '**Revision glob pattern to include**. A prefixing indicating that a glob pattern follows. Git references matching the glob pattern are included in the search. Typically used where a pattern like `*refs/heads/*` searches across all repository branches at the head commit.'
         case MetaSourcegraphRevision.ExcludeGlobMarker:
-            return '**Revision glob pattern to exclude.** A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, `*refs/heads/*:*!refs/heads/release*` searches all branches at the head commit, excluding branches matching `release*`.'
+            return '**Revision glob pattern to exclude**. A prefix indicating that git references, like a commit or branch name, should be **excluded** from search based on the glob pattern that follows. Used in conjunction with a glob pattern that matches a set of commits or branches, followed by a a pattern to exclude from the set. For example, `*refs/heads/*:*!refs/heads/release*` searches all branches at the head commit, excluding branches matching `release*`.'
         case MetaSourcegraphRevision.Separator:
-            return '**Revision separator.** Separates multiple revisions to search across. For example, `1a35d48:feature:3.15` searches the repository for matches at commit `1a35d48`, or a branch named `feature`, or a tag `3.15`.'
+            return '**Revision separator**. Separates multiple revisions to search across. For example, `1a35d48:feature:3.15` searches the repository for matches at commit `1a35d48`, or a branch named `feature`, or a tag `3.15`.'
     }
 }
 
@@ -127,7 +127,7 @@ const toHover = (token: DecoratedToken): string => {
         case 'metaRevision':
             return toRevisionHover(token)
         case 'metaRepoRevisionSeparator':
-            return '**Search at revision.** Separates a repository pattern and the revisions to search, like commits or branches. The part before the `@` specifies the repositories to search, the part after the `@` specifies which revisions to search.'
+            return '**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the `@` specifies the repositories to search, the part after the `@` specifies which revisions to search.'
     }
     return ''
 }

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -54,11 +54,12 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'metaStructuralHole', foreground: '#ff6b6b' },
         // Revision highlighting
         { token: 'metaRevisionSeparator', foreground: '#ffa94d' },
-        { token: 'metaRevisionWildcard', foreground: '#3bc9db' },
-        { token: 'metaRevisionNegate', foreground: '#ff6b6b' },
+        { token: 'metaRevisionIncludeGlobMarker', foreground: '#ff6b6b' },
+        { token: 'metaRevisionExcludeGlobMarker', foreground: '#ff6b6b' },
         { token: 'metaRevisionCommitHash', foreground: '#f2f4f8' },
         { token: 'metaRevisionLabel', foreground: '#f2f4f8' },
-        { token: 'metaRevisionPathLike', foreground: '#f2f4f8' },
+        { token: 'metaRevisionReferencePath', foreground: '#f2f4f8' },
+        { token: 'metaRevisionWildcard', foreground: '#3bc9db' },
     ],
 })
 
@@ -104,11 +105,12 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'metaStructuralHole', foreground: '#c92a2a' },
         // Revision highlighting
         { token: 'metaRevisionSeparator', foreground: '#d9480f' },
-        { token: 'metaRevisionWildcard', foreground: '#1098ad' },
-        { token: 'metaRevisionNegate', foreground: '#c92a2a' },
+        { token: 'metaRevisionIncludeGlobMarker', foreground: '#c92a2a' },
+        { token: 'metaRevisionExcludeGlobMarker', foreground: '#c92a2a' },
         { token: 'metaRevisionCommitHash', foreground: '#2b3750' },
         { token: 'metaRevisionLabel', foreground: '#2b3750' },
-        { token: 'metaRevisionPathLike', foreground: '#2b3750' },
+        { token: 'metaRevisionReferencePath', foreground: '#2b3750' },
+        { token: 'metaRevisionWildcard', foreground: '#1098ad' },
     ],
 })
 


### PR DESCRIPTION
Hovers shouldn't be misleading, so I wanted to support the full spectrum of revision syntax. I made some ugly discoveries, documented in #16628. This PR handles all the tricky/obscure details of the revision syntax in hovers. In time it'd be great to change some of the syntax conventions here.

Example: `*` or `*!` at the beginning of a revision string now conveys the true meaning. This is likely not a heavily used syntax/feature, but we do need to be principled and explicit about what's going on here, so that if/when we change things we will have a place in the code logic + tests that tracks it.

<img width="744" alt="Screen Shot 2020-12-10 at 1 51 23 PM" src="https://user-images.githubusercontent.com/888624/101828632-0e831b00-3aef-11eb-90de-0368018e3c24.png">

Part of  #16141.