### PR TITLE
search streaming: hook up onSearchAgain event in excluded results popover

### DIFF
--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -20,7 +20,7 @@ export interface SubmitSearchParameters
         VersionContextProps {
     history: H.History
     query: string
-    source: 'home' | 'nav' | 'repo' | 'tree' | 'filter' | 'type' | 'scopePage' | 'repogroupPage'
+    source: 'home' | 'nav' | 'repo' | 'tree' | 'filter' | 'type' | 'scopePage' | 'repogroupPage' | 'excludedResults'
     searchParameters?: { key: string; value: string }[]
 }
 

--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -6,9 +6,13 @@ import { BrowserRouter } from 'react-router-dom'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 import { FileMatch } from '../../../../../shared/src/components/FileMatch'
+import { VirtualList } from '../../../../../shared/src/components/VirtualList'
 import { SearchPatternType } from '../../../../../shared/src/graphql-operations'
-import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
 import * as GQL from '../../../../../shared/src/graphql/schema'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../../shared/src/telemetry/telemetryService'
+import { SearchResult } from '../../../components/SearchResult'
+import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
+import * as helpers from '../../helpers'
 import { AggregateStreamingSearchResults } from '../../stream'
 import { SearchResultsInfoBar } from '../SearchResultsInfoBar'
 import { VersionContextWarning } from '../VersionContextWarning'
@@ -21,9 +25,6 @@ import {
     REPO_MATCH_RESULT,
     RESULT,
 } from '../../../../../shared/src/util/searchTestHelpers'
-import { VirtualList } from '../../../../../shared/src/components/VirtualList'
-import { SearchResult } from '../../../components/SearchResult'
-import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
 
 describe('StreamingSearchResults', () => {
     const history = createBrowserHistory()
@@ -535,5 +536,22 @@ describe('StreamingSearchResults', () => {
 
         modal = element.find(SavedSearchModal)
         expect(modal.length).toBe(0)
+    })
+
+    it('should start a new search with added params when onSearchAgain event in triggered', () => {
+        const submitSearchMock = jest.spyOn(helpers, 'submitSearch').mockImplementation(() => {})
+        const element = mount(
+            <BrowserRouter>
+                <StreamingSearchResults {...defaultProps} />
+            </BrowserRouter>
+        )
+
+        const progress = element.find(StreamingProgress)
+        act(() => progress.prop('onSearchAgain')(['archived:yes', 'timeout:2m']))
+        element.update()
+
+        expect(helpers.submitSearch).toBeCalledTimes(1)
+        const args = submitSearchMock.mock.calls[0][0]
+        expect(args.query).toBe('r:golang/oauth2 test f:travis archived:yes timeout:2m')
     })
 })

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -23,7 +23,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { SearchResult } from '../../../components/SearchResult'
 import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
 import { VersionContext } from '../../../schema/site.schema'
-import { QueryState } from '../../helpers'
+import { QueryState, submitSearch } from '../../helpers'
 import { SearchAlert } from '../SearchAlert'
 import { LATEST_VERSION } from '../SearchResults'
 import { SearchResultsInfoBar } from '../SearchResultsInfoBar'
@@ -183,6 +183,14 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         )
     }
 
+    const onSearchAgain = useCallback(
+        (additionalFilters: string[]) => {
+            const newQuery = [query, ...additionalFilters].join(' ')
+            submitSearch({ ...props, query: newQuery, source: 'excludedResults' })
+        },
+        [query, props]
+    )
+
     return (
         <div className="test-search-results search-results d-flex flex-column w-100">
             <PageTitle key="page-title" title={query} />
@@ -203,7 +211,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                         allExpanded={allExpanded}
                         onExpandAllResultsToggle={onExpandAllResultsToggle}
                         onSaveQueryClick={onSaveQueryClick}
-                        stats={<StreamingProgress progress={results?.progress} />}
+                        stats={<StreamingProgress progress={results?.progress} onSearchAgain={onSearchAgain} />}
                     />
                 </div>
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react'
 import { storiesOf } from '@storybook/react'
-import { StreamingProgress } from './StreamingProgress'
+import * as React from 'react'
+import sinon from 'sinon'
 import { WebStory } from '../../../../components/WebStory'
 import { Progress } from '../../../stream'
+import { StreamingProgress } from './StreamingProgress'
 
 const { add } = storiesOf('web/search/results/streaming/progress/StreamingProgress', module).addParameters({
     design: {
@@ -12,6 +13,8 @@ const { add } = storiesOf('web/search/results/streaming/progress/StreamingProgre
     chromatic: { viewports: [1200] },
 })
 
+const onSearchAgain = sinon.spy()
+
 add('0 results, in progress', () => {
     const progress: Progress = {
         done: false,
@@ -20,7 +23,7 @@ add('0 results, in progress', () => {
         skipped: [],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
 })
 
 add('1 result from 1 repository, in progress', () => {
@@ -32,7 +35,7 @@ add('1 result from 1 repository, in progress', () => {
         skipped: [],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
 })
 
 add('2 results from 2 repositories, complete, skipped with info', () => {
@@ -65,7 +68,7 @@ add('2 results from 2 repositories, complete, skipped with info', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
 })
 
 add('2 results from 2 repositories, loading, skipped with info', () => {
@@ -98,7 +101,7 @@ add('2 results from 2 repositories, loading, skipped with info', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
 })
 
 add('2 results from 2 repositories, complete, skipped with warning', () => {
@@ -141,7 +144,7 @@ add('2 results from 2 repositories, complete, skipped with warning', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
 })
 
 add('2 results from 2 repositories, loading, skipped with warning', () => {
@@ -184,5 +187,5 @@ add('2 results from 2 repositories, loading, skipped with warning', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
@@ -5,7 +5,7 @@ import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton
 
 export interface StreamingProgressProps {
     progress?: Progress
-    onSearchAgain?: (additionalFilters: string[]) => void
+    onSearchAgain: (additionalFilters: string[]) => void
 }
 
 export const defaultProgress: Progress = {

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { pluralize } from '../../../../../../shared/src/util/strings'
 import { defaultProgress, StreamingProgressProps } from './StreamingProgress'
 
-export const StreamingProgressCount: React.FunctionComponent<StreamingProgressProps> = ({
+export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgressProps, 'progress'>> = ({
     progress = defaultProgress,
 }) => (
     <div

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
@@ -1,16 +1,13 @@
 import { mount } from 'enzyme'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import { ButtonDropdown } from 'reactstrap'
+import sinon from 'sinon'
 import { Progress } from '../../../stream'
 import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton'
+import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
 describe('StreamingProgressSkippedButton', () => {
-    let div: HTMLDivElement
-    beforeEach(() => {
-        div = document.createElement('div')
-        document.body.append(div)
-    })
-
     it('should not show if no skipped items', () => {
         const progress: Progress = {
             done: false,
@@ -19,7 +16,7 @@ describe('StreamingProgressSkippedButton', () => {
             skipped: [],
         }
 
-        const element = mount(<StreamingProgressSkippedButton progress={progress} />, { attachTo: div })
+        const element = mount(<StreamingProgressSkippedButton progress={progress} onSearchAgain={sinon.spy()} />)
         expect(element.find('.streaming-progress__skipped')).toHaveLength(0)
         expect(element.find('.streaming-progress__skipped-popover')).toHaveLength(0)
     })
@@ -54,7 +51,7 @@ describe('StreamingProgressSkippedButton', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedButton progress={progress} />, { attachTo: div })
+        const element = mount(<StreamingProgressSkippedButton progress={progress} onSearchAgain={sinon.spy()} />)
         expect(element.find('.btn.streaming-progress__skipped')).toHaveLength(1)
         expect(element.find('.btn.streaming-progress__skipped.alert.alert-danger')).toHaveLength(0)
     })
@@ -99,7 +96,7 @@ describe('StreamingProgressSkippedButton', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedButton progress={progress} />, { attachTo: div })
+        const element = mount(<StreamingProgressSkippedButton progress={progress} onSearchAgain={sinon.spy()} />)
         expect(element.find('.btn.streaming-progress__skipped')).toHaveLength(1)
         expect(element.find('.btn.streaming-progress__skipped--warning')).toHaveLength(1)
     })
@@ -134,7 +131,7 @@ describe('StreamingProgressSkippedButton', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedButton progress={progress} />, { attachTo: div })
+        const element = mount(<StreamingProgressSkippedButton progress={progress} onSearchAgain={sinon.spy()} />)
 
         let popover = element.find(ButtonDropdown)
         expect(popover.prop('isOpen')).toBe(false)
@@ -149,5 +146,55 @@ describe('StreamingProgressSkippedButton', () => {
 
         popover = element.find(ButtonDropdown)
         expect(popover.prop('isOpen')).toBe(false)
+    })
+
+    it('should close popup and call onSearchAgain callback when popover raises event', () => {
+        const progress: Progress = {
+            done: true,
+            durationMs: 1500,
+            matchCount: 2,
+            repositoriesCount: 2,
+            skipped: [
+                {
+                    reason: 'excluded-fork',
+                    message: '10k forked repositories excluded',
+                    severity: 'info',
+                    title: '10k forked repositories excluded',
+                    suggested: {
+                        title: 'forked:yes',
+                        queryExpression: 'forked:yes',
+                    },
+                },
+                {
+                    reason: 'excluded-archive',
+                    message: '60k archived repositories excluded',
+                    severity: 'info',
+                    title: '60k archived repositories excluded',
+                    suggested: {
+                        title: 'archived:yes',
+                        queryExpression: 'archived:yes',
+                    },
+                },
+            ],
+        }
+
+        const onSearchAgain = sinon.spy()
+
+        const element = mount(<StreamingProgressSkippedButton progress={progress} onSearchAgain={onSearchAgain} />)
+
+        // Open dropdown
+        const button = element.find('.btn.streaming-progress__skipped')
+        button.simulate('click')
+
+        // Trigger onSearchAgain event and check for changes
+        const skippedPopover = element.find(StreamingProgressSkippedPopover)
+        act(() => skippedPopover.prop('onSearchAgain')(['archived:yes']))
+        element.update()
+
+        const dropdown = element.find(ButtonDropdown)
+        expect(dropdown.prop('isOpen')).toBe(false)
+
+        sinon.assert.calledOnce(onSearchAgain)
+        sinon.assert.calledWith(onSearchAgain, ['archived:yes'])
     })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -1,18 +1,27 @@
 import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
-import React, { useCallback, useState, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 import { defaultProgress, StreamingProgressProps } from './StreamingProgress'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
 export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingProgressProps> = ({
     progress = defaultProgress,
+    onSearchAgain,
 }) => {
     const [isOpen, setIsOpen] = useState(false)
     const toggleOpen = useCallback(() => setIsOpen(previous => !previous), [setIsOpen])
 
     const skippedWithWarning = useMemo(() => progress.skipped.some(skipped => skipped.severity === 'warn'), [progress])
+
+    const onSearchAgainWithPopupClose = useCallback(
+        (filters: string[]) => {
+            setIsOpen(false)
+            onSearchAgain(filters)
+        },
+        [setIsOpen, onSearchAgain]
+    )
 
     return (
         <>
@@ -36,7 +45,10 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingPr
                         Some results excluded
                     </DropdownToggle>
                     <DropdownMenu className="streaming-progress__skipped-popover">
-                        <StreamingProgressSkippedPopover progress={progress} />
+                        <StreamingProgressSkippedPopover
+                            progress={progress}
+                            onSearchAgain={onSearchAgainWithPopupClose}
+                        />
                     </DropdownMenu>
                 </ButtonDropdown>
             )}

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.story.tsx
@@ -56,5 +56,5 @@ add('popover', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgressSkippedPopover progress={progress} />}</WebStory>
+    return <WebStory>{() => <StreamingProgressSkippedPopover progress={progress} onSearchAgain={() => {}} />}</WebStory>
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.test.tsx
@@ -46,7 +46,7 @@ describe('StreamingProgressSkippedPopover', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedPopover progress={progress} />)
+        const element = mount(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
         expect(element).toMatchSnapshot()
     })
 
@@ -66,7 +66,7 @@ describe('StreamingProgressSkippedPopover', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedPopover progress={progress} />)
+        const element = mount(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
         expect(element.find(Form)).toHaveLength(0)
     })
 
@@ -90,7 +90,7 @@ describe('StreamingProgressSkippedPopover', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedPopover progress={progress} />)
+        const element = mount(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
         const searchAgainButton = element.find(Button)
         expect(searchAgainButton).toHaveLength(1)
         expect(searchAgainButton.prop('disabled')).toBe(true)
@@ -136,7 +136,7 @@ describe('StreamingProgressSkippedPopover', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedPopover progress={progress} />)
+        const element = mount(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
 
         const checkboxes = element.find(Input)
         expect(checkboxes).toHaveLength(3)
@@ -190,7 +190,7 @@ describe('StreamingProgressSkippedPopover', () => {
             ],
         }
 
-        const element = mount(<StreamingProgressSkippedPopover progress={progress} />)
+        const element = mount(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
 
         const checkboxes = element.find(Input)
         expect(checkboxes).toHaveLength(3)

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -13,7 +13,7 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<StreamingP
     const [selectedSuggestedSearches, setSelectedSuggestedSearches] = useState(new Set<string>())
     const submitHandler = useCallback(
         (event: React.FormEvent) => {
-            onSearchAgain?.([...selectedSuggestedSearches])
+            onSearchAgain([...selectedSuggestedSearches])
             event.preventDefault()
         },
         [selectedSuggestedSearches, onSearchAgain]

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
 <StreamingProgressSkippedPopover
+  onSearchAgain={[Function]}
   progress={
     Object {
       "done": true,


### PR DESCRIPTION
Makes the "Search again" button in the excluded results popover actually work. The selected checkbox items are appended to the query.

![image](https://user-images.githubusercontent.com/206864/101835964-6d499400-3af1-11eb-97ca-605edec477d7.png)
