### PR TITLE
search streaming: re-enable integration test

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -335,8 +335,7 @@ describe('Search', () => {
             }),
         }
 
-        // Skip streaming search tests until streaming search UI is properly implemented
-        test.skip('Streaming search with single repo result', async () => {
+        test('Streaming search with single repo result', async () => {
             const searchStreamEvents: SearchEvent[] = [
                 { type: 'matches', data: [{ type: 'repo', repository: 'github.com/sourcegraph/sourcegraph' }] },
                 { type: 'done', data: {} },


### PR DESCRIPTION
It was disabled while UI was being built, now that it's built we can re-enable again.