### PR TITLE
search streaming: hook up 'Save this search' button

### DIFF
--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -103,7 +103,6 @@ export const routes: readonly LayoutRouteProps<any>[] = [
                     showSavedQueryModal={false}
                     deployType={window.context.deployType}
                     showSavedQueryButton={false}
-                    didSave={false}
                 />
             ) : (
                 <Redirect to="/search" />

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -26,7 +26,6 @@ interface SearchConsolePageProps
             | 'onShowMoreResultsClick'
             | 'onExpandAllResultsToggle'
             | 'onSavedQueryModalClose'
-            | 'onDidCreateSavedQuery'
             | 'onSaveQueryClick'
             | 'shouldDisplayPerformanceWarning'
         >,
@@ -168,7 +167,6 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                                 resultsOrError={resultsOrError}
                                 onExpandAllResultsToggle={onExpandAllResultsToggle}
                                 showSavedQueryButton={false}
-                                onDidCreateSavedQuery={voidCallback}
                                 onSavedQueryModalClose={voidCallback}
                                 onSaveQueryClick={voidCallback}
                                 shouldDisplayPerformanceWarning={shouldDisplayPerformanceWarning}

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -76,7 +76,6 @@ interface SearchResultsState {
 
     // Saved Queries
     showSavedQueryModal: boolean
-    didSaveQuery: boolean
 
     /** The contributions, merged from all extensions, or undefined before the initial emission. */
     contributions?: Evaluated<Contributions>
@@ -98,7 +97,6 @@ export const LATEST_VERSION = 'V2'
 
 export class SearchResults extends React.Component<SearchResultsProps, SearchResultsState> {
     public state: SearchResultsState = {
-        didSaveQuery: false,
         showSavedQueryModal: false,
         allExpanded: false,
         showVersionContextWarning: false,
@@ -268,17 +266,12 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
     }
 
     private showSaveQueryModal = (): void => {
-        this.setState({ showSavedQueryModal: true, didSaveQuery: false })
-    }
-
-    private onDidCreateSavedQuery = (): void => {
-        this.props.telemetryService.log('SavedQueryCreated')
-        this.setState({ showSavedQueryModal: false, didSaveQuery: true })
+        this.setState({ showSavedQueryModal: true })
     }
 
     private onModalClose = (): void => {
         this.props.telemetryService.log('SavedQueriesToggleCreating', { queries: { creating: false } })
-        this.setState({ didSaveQuery: false, showSavedQueryModal: false })
+        this.setState({ showSavedQueryModal: false })
     }
 
     private onDismissWarning = (): void => {
@@ -328,8 +321,6 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                     showSavedQueryModal={this.state.showSavedQueryModal}
                     onSaveQueryClick={this.showSaveQueryModal}
                     onSavedQueryModalClose={this.onModalClose}
-                    onDidCreateSavedQuery={this.onDidCreateSavedQuery}
-                    didSave={this.state.didSaveQuery}
                     shouldDisplayPerformanceWarning={shouldDisplayPerformanceWarning}
                 />
             </div>

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -2,7 +2,6 @@ import * as H from 'history'
 import * as React from 'react'
 import ArrowCollapseVerticalIcon from 'mdi-react/ArrowCollapseVerticalIcon'
 import ArrowExpandVerticalIcon from 'mdi-react/ArrowExpandVerticalIcon'
-import CheckIcon from 'mdi-react/CheckIcon'
 import classNames from 'classnames'
 import DownloadIcon from 'mdi-react/DownloadIcon'
 import FormatQuoteOpenIcon from 'mdi-react/FormatQuoteOpenIcon'
@@ -33,9 +32,7 @@ interface SearchResultsInfoBarProps
 
     // Saved queries
     showSavedQueryButton?: boolean
-    onDidCreateSavedQuery: () => void
     onSaveQueryClick: () => void
-    didSave: boolean
 
     location: H.Location
 
@@ -110,18 +107,8 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                             type="button"
                             onClick={props.onSaveQueryClick}
                             className="btn btn-link nav-link text-decoration-none"
-                            disabled={props.didSave}
                         >
-                            {props.didSave ? (
-                                <>
-                                    <CheckIcon className="icon-inline" /> Query saved
-                                </>
-                            ) : (
-                                <>
-                                    <DownloadIcon className="icon-inline test-save-search-link" /> Save this search
-                                    query
-                                </>
-                            )}
+                            <DownloadIcon className="icon-inline test-save-search-link" /> Save this search query
                         </button>
                     </li>
                 )}

--- a/client/web/src/search/results/SearchResultsList.story.tsx
+++ b/client/web/src/search/results/SearchResultsList.story.tsx
@@ -34,9 +34,7 @@ const defaultProps: SearchResultsListProps = {
 
     showSavedQueryModal: false,
     onSavedQueryModalClose: sinon.spy(),
-    onDidCreateSavedQuery: sinon.spy(),
     onSaveQueryClick: sinon.spy(),
-    didSave: false,
 
     fetchHighlightedFileLines: HIGHLIGHTED_FILE_LINES_REQUEST,
 

--- a/client/web/src/search/results/SearchResultsList.test.tsx
+++ b/client/web/src/search/results/SearchResultsList.test.tsx
@@ -100,9 +100,7 @@ describe('SearchResultsList', () => {
 
         showSavedQueryModal: false,
         onSavedQueryModalClose: sinon.spy(),
-        onDidCreateSavedQuery: sinon.spy(),
         onSaveQueryClick: sinon.spy(),
-        didSave: false,
 
         fetchHighlightedFileLines: HIGHLIGHTED_FILE_LINES_REQUEST,
 

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -71,9 +71,7 @@ export interface SearchResultsListProps
     showSavedQueryButton?: boolean
     showSavedQueryModal: boolean
     onSavedQueryModalClose: () => void
-    onDidCreateSavedQuery: () => void
     onSaveQueryClick: () => void
-    didSave: boolean
 
     interactiveSearchMode: boolean
 

--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../../../../shared/src/util/searchTestHelpers'
 import { VirtualList } from '../../../../../shared/src/components/VirtualList'
 import { SearchResult } from '../../../components/SearchResult'
+import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
 
 describe('StreamingSearchResults', () => {
     const history = createBrowserHistory()
@@ -489,5 +490,50 @@ describe('StreamingSearchResults', () => {
         sinon.assert.calledWith(logSpy, 'SearchResultClicked')
 
         element.unmount()
+    })
+
+    it('should not show saved search modal on first load', () => {
+        const element = mount(
+            <BrowserRouter>
+                <StreamingSearchResults {...defaultProps} />
+            </BrowserRouter>
+        )
+
+        const modal = element.find(SavedSearchModal)
+        expect(modal.length).toBe(0)
+    })
+
+    it('should open saved search modal when triggering event from infobar', () => {
+        const element = mount(
+            <BrowserRouter>
+                <StreamingSearchResults {...defaultProps} />
+            </BrowserRouter>
+        )
+
+        const infobar = element.find(SearchResultsInfoBar)
+        act(() => infobar.prop('onSaveQueryClick')())
+        element.update()
+
+        const modal = element.find(SavedSearchModal)
+        expect(modal.length).toBe(1)
+    })
+
+    it('should close saved search modal if close event triggers', () => {
+        const element = mount(
+            <BrowserRouter>
+                <StreamingSearchResults {...defaultProps} />
+            </BrowserRouter>
+        )
+
+        const infobar = element.find(SearchResultsInfoBar)
+        act(() => infobar.prop('onSaveQueryClick')())
+        element.update()
+
+        let modal = element.find(SavedSearchModal)
+        act(() => modal.prop('onDidCancel')())
+        element.update()
+
+        modal = element.find(SavedSearchModal)
+        expect(modal.length).toBe(0)
     })
 })

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -36,6 +36,7 @@ import FileIcon from 'mdi-react/FileIcon'
 import { isDefined } from '../../../../../shared/src/util/types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import SearchIcon from 'mdi-react/SearchIcon'
+import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
 
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
@@ -75,6 +76,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         history,
         availableVersionContexts,
         previousVersionContext,
+        authenticatedUser,
     } = props
 
     const { query = '', patternType, caseSensitive, versionContext } = parseSearchURL(props.location.search)
@@ -114,9 +116,9 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
     const [allExpanded, setAllExpanded] = useState(false)
     const onExpandAllResultsToggle = useCallback(() => setAllExpanded(oldValue => !oldValue), [setAllExpanded])
 
-    const onDidCreateSavedQuery = useCallback(() => {}, [])
-    const onSaveQueryClick = useCallback(() => {}, [])
-    const didSave = false
+    const [showSavedSearchModal, setShowSavedSearchModal] = useState(false)
+    const onSaveQueryClick = useCallback(() => setShowSavedSearchModal(true), [])
+    const onSaveQueryModalClose = useCallback(() => setShowSavedSearchModal(false), [])
 
     const [showVersionContextWarning, setShowVersionContextWarning] = useState(false)
     useEffect(
@@ -200,8 +202,6 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                         allExpanded={allExpanded}
                         onExpandAllResultsToggle={onExpandAllResultsToggle}
                         onSaveQueryClick={onSaveQueryClick}
-                        onDidCreateSavedQuery={onDidCreateSavedQuery}
-                        didSave={didSave}
                         stats={<StreamingProgress progress={results?.progress} />}
                     />
                 </div>
@@ -210,6 +210,15 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     <VersionContextWarning
                         versionContext={currentVersionContext}
                         onDismissWarning={onDismissVersionContextWarning}
+                    />
+                )}
+
+                {showSavedSearchModal && (
+                    <SavedSearchModal
+                        {...props}
+                        query={query}
+                        authenticatedUser={authenticatedUser}
+                        onDidCancel={onSaveQueryModalClose}
                     />
                 )}
 


### PR DESCRIPTION
Make "Save this search query" button work when streaming search is enabled.

Also removes dead code props from `SearchResultsInfoBar` saved search flow (`didSave` and `onDidCreateSavedQuery`). The saved searches modal redirects to a new page instead, so these props are never actually used.

![Screen Shot 2020-12-10 at 3 15 31 PM](https://user-images.githubusercontent.com/206864/101841534-edc0c280-3afa-11eb-8e18-6c1c3ab38bd6.png)

