### PR TITLE
Firefox does not take an update_url if we are uploading to the store 

### DIFF
--- a/client/browser/scripts/create-source-zip.js
+++ b/client/browser/scripts/create-source-zip.js
@@ -18,7 +18,7 @@ const signale = require('signale')
  */
 
 // Configuration
-const commitId = '350764282631014ea24ccd88fda459a4b19a5669'
+const commitId = '42f4cfe5fc05dbb1e2eb44369e51cf643fe37584'
 const includeCodeIntelExtensions = true
 const rootDirectoryNameForZip = 'sourcegraph-source'
 

--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -35,8 +35,7 @@
   },
   "applications": {
     "gecko": {
-      "id": "sourcegraph-for-firefox@sourcegraph.com",
-      "update_url": "https://storage.googleapis.com/sourcegraph-for-firefox/updates.json"
+      "id": "sourcegraph-for-firefox@sourcegraph.com"
     }
   },
   "dev": {


### PR DESCRIPTION
Firefox does not take an `update_url` in the manifest if we are uploading to the store (vs listing ourselves, when it did). It throws an error in the file validation on upload and won't let you upload, so I'm removing it. 

But if we still want this if we do/need to host ourselves, so I don't know if making this change permanent is the right move, so consider this a PR for that discussion.  
