### PR TITLE
Code monitoring: only create monitor when all fields are complete

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -70,6 +70,7 @@ import {
 import { SearchPatternType } from '../../shared/src/graphql-operations'
 import { HTTPStatusError } from '../../shared/src/backend/fetch'
 import {
+    createCodeMonitor,
     deleteCodeMonitor,
     fetchCodeMonitor,
     fetchUserCodeMonitors,
@@ -466,6 +467,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}
+                                    createCodeMonitor={createCodeMonitor}
                                     fetchUserCodeMonitors={fetchUserCodeMonitors}
                                     fetchCodeMonitor={fetchCodeMonitor}
                                     updateCodeMonitor={updateCodeMonitor}

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -3,6 +3,7 @@ import { CreateCodeMonitorPage } from './CreateCodeMonitorPage'
 import { storiesOf } from '@storybook/react'
 import { AuthenticatedUser } from '../../auth'
 import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
+import sinon from 'sinon'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CreateCodeMonitorPage', module)
 
@@ -16,6 +17,7 @@ add(
                     authenticatedUser={
                         { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser
                     }
+                    createCodeMonitor={sinon.fake()}
                 />
             )}
         </EnterpriseWebStory>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -70,9 +70,10 @@ describe('CreateCodeMonitorPage', () => {
 
     test('createCodeMonitor is not called on submit when trigger or action is incomplete', () => {
         let component = mount(<CreateCodeMonitorPage {...props} />)
-        const nameInput = component.find('.test-name-input')
+        const monitorForm = component.find('.test-monitor-form').first()
+        let nameInput = component.find('.test-name-input')
         nameInput.simulate('change', { target: { value: 'Test updated' } })
-        nameInput.simulate('keypress', { key: 'Enter' })
+        monitorForm.simulate('submit')
         // Pressing enter does not call createCodeMonitor because other fields not complete
         sinon.assert.notCalled(props.createCodeMonitor)
 
@@ -89,7 +90,7 @@ describe('CreateCodeMonitorPage', () => {
         const submitTrigger = component.find('.test-submit-trigger')
         submitTrigger.simulate('click')
 
-        nameInput.simulate('keypress', { key: 'Enter' })
+        monitorForm.simulate('submit')
         // Pressing enter still does not call createCodeMonitor
         sinon.assert.notCalled(props.createCodeMonitor)
 
@@ -99,7 +100,7 @@ describe('CreateCodeMonitorPage', () => {
         submitAction.simulate('click')
 
         // Pressing enter calls createCodeMonitor when all sections are complete
-        nameInput.simulate('keypress', { key: 'Enter' })
+        monitorForm.simulate('submit')
         sinon.assert.calledOnce(props.createCodeMonitor)
         props.createCodeMonitor.resetHistory()
         component.unmount()

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -4,7 +4,10 @@ import * as H from 'history'
 import { AuthenticatedUser } from '../../auth'
 import sinon from 'sinon'
 import { mount } from 'enzyme'
-import { NEVER } from 'rxjs'
+import { NEVER, of } from 'rxjs'
+import { mockCodeMonitor } from './testing/util'
+import { CreateCodeMonitorVariables } from '../../graphql-operations'
+import { act } from 'react-dom/test-utils'
 
 describe('CreateCodeMonitorPage', () => {
     const mockUser = {
@@ -23,7 +26,85 @@ describe('CreateCodeMonitorPage', () => {
         useBreadcrumb: sinon.spy(),
         history,
         deleteCodeMonitor: sinon.spy((id: string) => NEVER),
+        createCodeMonitor: sinon.spy((monitor: CreateCodeMonitorVariables) =>
+            of({ description: mockCodeMonitor.node.description })
+        ),
     }
+    let clock: sinon.SinonFakeTimers
+
+    beforeAll(() => {
+        clock = sinon.useFakeTimers()
+    })
+
+    afterAll(() => {
+        clock.restore()
+    })
+
+    test('createCodeMonitor is called on submit', () => {
+        let component = mount(<CreateCodeMonitorPage {...props} />)
+        const nameInput = component.find('.test-name-input')
+        nameInput.simulate('change', { target: { value: 'Test updated' } })
+
+        const triggerButton = component.find('.test-trigger-button')
+        triggerButton.simulate('click')
+        const triggerInput = component.find('.test-trigger-input')
+        expect(triggerInput.length).toBe(1)
+        act(() => {
+            triggerInput.simulate('change', { target: { value: 'test type:diff patterntype:literal' } })
+            clock.tick(600)
+        })
+        component = component.update()
+        expect(component.find('.is-valid').length).toBe(1)
+        const submitTrigger = component.find('.test-submit-trigger')
+        submitTrigger.simulate('click')
+        const actionButton = component.find('.test-action-button')
+        actionButton.simulate('click')
+        const submitAction = component.find('.test-submit-action')
+        submitAction.simulate('click')
+        const submitMonitor = component.find('.test-submit-monitor')
+        submitMonitor.simulate('submit')
+        sinon.assert.called(props.createCodeMonitor)
+        props.createCodeMonitor.resetHistory()
+        component.unmount()
+    })
+
+    test('createCodeMonitor is not called on submit when trigger or action is incomplete', () => {
+        let component = mount(<CreateCodeMonitorPage {...props} />)
+        const nameInput = component.find('.test-name-input')
+        nameInput.simulate('change', { target: { value: 'Test updated' } })
+        nameInput.simulate('keypress', { key: 'Enter' })
+        // Pressing enter does not call createCodeMonitor because other fields not complete
+        sinon.assert.notCalled(props.createCodeMonitor)
+
+        const triggerButton = component.find('.test-trigger-button')
+        triggerButton.simulate('click')
+        const triggerInput = component.find('.test-trigger-input')
+        expect(triggerInput.length).toBe(1)
+        act(() => {
+            triggerInput.simulate('change', { target: { value: 'test type:diff patterntype:literal' } })
+            clock.tick(600)
+        })
+        component = component.update()
+        expect(component.find('.is-valid').length).toBe(1)
+        const submitTrigger = component.find('.test-submit-trigger')
+        submitTrigger.simulate('click')
+
+        nameInput.simulate('keypress', { key: 'Enter' })
+        // Pressing enter still does not call createCodeMonitor
+        sinon.assert.notCalled(props.createCodeMonitor)
+
+        const actionButton = component.find('.test-action-button')
+        actionButton.simulate('click')
+        const submitAction = component.find('.test-submit-action')
+        submitAction.simulate('click')
+
+        // Pressing enter calls createCodeMonitor when all sections are complete
+        nameInput.simulate('keypress', { key: 'Enter' })
+        sinon.assert.calledOnce(props.createCodeMonitor)
+        props.createCodeMonitor.resetHistory()
+        component.unmount()
+    })
+
     test('Actions area button is disabled while trigger is incomplete', () => {
         const component = mount(<CreateCodeMonitorPage {...props} />)
         const actionButton = component.find('.test-action-button')

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -71,7 +71,7 @@ describe('CreateCodeMonitorPage', () => {
     test('createCodeMonitor is not called on submit when trigger or action is incomplete', () => {
         let component = mount(<CreateCodeMonitorPage {...props} />)
         const monitorForm = component.find('.test-monitor-form').first()
-        let nameInput = component.find('.test-name-input')
+        const nameInput = component.find('.test-name-input')
         nameInput.simulate('change', { target: { value: 'Test updated' } })
         monitorForm.simulate('submit')
         // Pressing enter does not call createCodeMonitor because other fields not complete

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -1,14 +1,17 @@
 import * as H from 'history'
 import React, { useCallback, useMemo } from 'react'
 import { Observable } from 'rxjs'
+import { CodeMonitoringProps } from '.'
 import { AuthenticatedUser } from '../../auth'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../../components/Breadcrumbs'
 import { PageTitle } from '../../components/PageTitle'
 import { CodeMonitorFields, MonitorEmailPriority } from '../../graphql-operations'
-import { createCodeMonitor } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-export interface CreateCodeMonitorPageProps extends BreadcrumbsProps, BreadcrumbSetters {
+export interface CreateCodeMonitorPageProps
+    extends BreadcrumbsProps,
+        BreadcrumbSetters,
+        Pick<CodeMonitoringProps, 'createCodeMonitor'> {
     location: H.Location
     history: H.History
     authenticatedUser: AuthenticatedUser
@@ -25,11 +28,12 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
         )
     )
 
+    const { authenticatedUser, createCodeMonitor } = props
     const createMonitorRequest = useCallback(
         (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> =>
             createCodeMonitor({
                 monitor: {
-                    namespace: props.authenticatedUser.id,
+                    namespace: authenticatedUser.id,
                     description: codeMonitor.description,
                     enabled: codeMonitor.enabled,
                 },
@@ -39,12 +43,12 @@ export const CreateCodeMonitorPage: React.FunctionComponent<CreateCodeMonitorPag
                     email: {
                         enabled: action.enabled,
                         priority: MonitorEmailPriority.NORMAL,
-                        recipients: [props.authenticatedUser.id],
+                        recipients: [authenticatedUser.id],
                         header: '',
                     },
                 })),
             }),
-        [props.authenticatedUser.id]
+        [authenticatedUser.id, createCodeMonitor]
     )
 
     return (

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -140,7 +140,7 @@ describe('ManageCodeMonitorPage', () => {
         nameInput.simulate('change', { target: { value: 'Test code monitor updated' } })
         const cancelButton = component.find('.test-cancel-monitor')
         cancelButton.simulate('click')
-        expect(confirmStub.calledOnce).toBe(true)
+        sinon.assert.calledOnce(confirmStub)
         confirmStub.restore()
     })
 
@@ -149,16 +149,7 @@ describe('ManageCodeMonitorPage', () => {
         const confirmStub = sinon.stub(window, 'confirm')
         const cancelButton = component.find('.test-cancel-monitor')
         cancelButton.simulate('click')
-        expect(confirmStub.notCalled)
-        confirmStub.restore()
-    })
-
-    test('Cancelling without any changes made does not show confirmation prompt', () => {
-        const component = mount(<ManageCodeMonitorPage {...props} />)
-        const confirmStub = sinon.stub(window, 'confirm')
-        const cancelButton = component.find('.test-cancel-monitor')
-        cancelButton.simulate('click')
-        expect(confirmStub.notCalled)
+        sinon.assert.notCalled(confirmStub)
         confirmStub.restore()
     })
 
@@ -171,7 +162,7 @@ describe('ManageCodeMonitorPage', () => {
         const confirmDeleteButton = component.find('.test-confirm-delete-monitor')
         expect(confirmDeleteButton.length).toBe(1)
         confirmDeleteButton.simulate('click')
-        expect(props.deleteCodeMonitor.calledOnce).toBe(true)
+        sinon.assert.calledOnce(props.deleteCodeMonitor)
         expect(props.history.location.pathname).toEqual('/code-monitoring')
     })
 })

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -6,6 +6,13 @@ import { mount } from 'enzyme'
 import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
 import { mockCodeMonitor } from './testing/util'
 import { NEVER, of } from 'rxjs'
+import { act } from 'react-dom/test-utils'
+import {
+    MonitorEditInput,
+    MonitorEditTriggerInput,
+    MonitorEditActionInput,
+    MonitorEmailPriority,
+} from '../../../../shared/src/graphql-operations'
 
 describe('ManageCodeMonitorPage', () => {
     const mockUser = {
@@ -25,7 +32,13 @@ describe('ManageCodeMonitorPage', () => {
         setBreadcrumb: sinon.spy(),
         useBreadcrumb: sinon.spy(),
         fetchUserCodeMonitors: sinon.spy(),
-        updateCodeMonitor: sinon.spy(),
+        updateCodeMonitor: sinon.spy(
+            (
+                monitorEditInput: MonitorEditInput,
+                triggerEditInput: MonitorEditTriggerInput,
+                actionEditInput: MonitorEditActionInput[]
+            ) => of(mockCodeMonitor.node)
+        ),
         fetchCodeMonitor: sinon.spy((id: string) => of(mockCodeMonitor)),
         match: {
             params: { id: 'test-id' },
@@ -39,7 +52,7 @@ describe('ManageCodeMonitorPage', () => {
 
     test('Form is pre-loaded with code monitor data', () => {
         const component = mount(<ManageCodeMonitorPage {...props} />)
-        expect(props.fetchCodeMonitor.calledOnce)
+        expect(props.fetchCodeMonitor.calledOnce).toBe(true)
 
         const nameInput = component.find('.test-name-input')
         expect(nameInput.length).toBe(1)
@@ -50,18 +63,43 @@ describe('ManageCodeMonitorPage', () => {
         expect(currentQueryValue.getDOMNode().innerHTML).toBe('test')
         expect(currentActionEmailValue.getDOMNode().innerHTML).toBe('user@me.com')
         component.unmount()
+        props.fetchCodeMonitor.resetHistory()
     })
 
     test('Updating the form executes the update request', () => {
-        const component = mount(<ManageCodeMonitorPage {...props} />)
+        let component = mount(<ManageCodeMonitorPage {...props} />)
         const nameInput = component.find('.test-name-input')
         const nameValue = nameInput.getDOMNode().getAttribute('value')
         expect(nameValue).toBe('Test code monitor')
-        nameInput.simulate('change', { target: { value: 'Test updated' } })
+        act(() => {
+            nameInput.simulate('change', { target: { value: 'Test updated' } })
+        })
+        component = component.update()
         const submitButton = component.find('.test-submit-monitor')
-        submitButton.simulate('click')
-        expect(props.updateCodeMonitor.calledOnce)
-        expect(props.updateCodeMonitor.calledWith({ ...mockCodeMonitor, name: 'Test code monitor' }))
+        submitButton.simulate('submit')
+        sinon.assert.called(props.updateCodeMonitor)
+        sinon.assert.calledWith(
+            props.updateCodeMonitor,
+            {
+                id: 'test-id',
+                update: { namespace: 'userID', description: 'Test updated', enabled: true },
+            },
+            { id: 'test-0', update: { query: 'test' } },
+            [
+                {
+                    email: {
+                        id: 'test-action-0',
+                        update: {
+                            enabled: true,
+                            priority: MonitorEmailPriority.NORMAL,
+                            recipients: ['userID'],
+                            header: '',
+                        },
+                    },
+                },
+            ]
+        )
+        props.updateCodeMonitor.resetHistory()
         component.unmount()
     })
 
@@ -102,7 +140,7 @@ describe('ManageCodeMonitorPage', () => {
         nameInput.simulate('change', { target: { value: 'Test code monitor updated' } })
         const cancelButton = component.find('.test-cancel-monitor')
         cancelButton.simulate('click')
-        expect(confirmStub.calledOnce)
+        expect(confirmStub.calledOnce).toBe(true)
         confirmStub.restore()
     })
 
@@ -133,7 +171,7 @@ describe('ManageCodeMonitorPage', () => {
         const confirmDeleteButton = component.find('.test-confirm-delete-monitor')
         expect(confirmDeleteButton.length).toBe(1)
         confirmDeleteButton.simulate('click')
-        expect(props.deleteCodeMonitor.calledOnce)
+        expect(props.deleteCodeMonitor.calledOnce).toBe(true)
         expect(props.history.location.pathname).toEqual('/code-monitoring')
     })
 })

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -64,9 +64,8 @@ export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPag
     )
 
     const updateMonitorRequest = React.useCallback(
-        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
-            console.log('hello worldhello worldhello worldhello world')
-            return updateCodeMonitor(
+        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> =>
+            updateCodeMonitor(
                 {
                     id: match.params.id,
                     update: {
@@ -87,8 +86,7 @@ export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPag
                         },
                     },
                 }))
-            )
-        },
+            ),
         [authenticatedUser.id, match.params.id, updateCodeMonitor]
     )
 

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -64,8 +64,9 @@ export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPag
     )
 
     const updateMonitorRequest = React.useCallback(
-        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> =>
-            updateCodeMonitor(
+        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
+            console.log('hello worldhello worldhello worldhello world')
+            return updateCodeMonitor(
                 {
                     id: match.params.id,
                     update: {
@@ -86,7 +87,8 @@ export const ManageCodeMonitorPage: React.FunctionComponent<ManageCodeMonitorPag
                         },
                     },
                 }))
-            ),
+            )
+        },
         [authenticatedUser.id, match.params.id, updateCodeMonitor]
     )
 

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -1,19 +1,20 @@
 import classnames from 'classnames'
 import React, { useCallback, useMemo, useState } from 'react'
-import { Observable } from 'rxjs'
+import { Observable, of } from 'rxjs'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { AuthenticatedUser } from '../../../auth'
 import * as H from 'history'
 import { Toggle } from '../../../../../branded/src/components/Toggle'
 import { FormActionArea } from './FormActionArea'
 import { FormTriggerArea } from './FormTriggerArea'
-import { mergeMap, startWith, catchError, tap } from 'rxjs/operators'
+import { mergeMap, startWith, catchError, tap, filter } from 'rxjs/operators'
 import { Form } from '../../../../../branded/src/components/Form'
 import { useEventObservable } from '../../../../../shared/src/util/useObservable'
 import { CodeMonitorFields } from '../../../graphql-operations'
 import { isEqual } from 'lodash'
 import { CodeMonitoringProps } from '..'
 import { DeleteMonitorModal } from './DeleteMonitorModal'
+import ConsoleIcon from 'mdi-react/ConsoleIcon'
 
 export interface CodeMonitorFormProps extends Partial<Pick<CodeMonitoringProps, 'deleteCodeMonitor'>> {
     history: H.History
@@ -94,19 +95,22 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
             (submit: Observable<React.FormEvent<HTMLFormElement>>) =>
                 submit.pipe(
                     tap(event => event.preventDefault()),
-                    mergeMap(() =>
-                        onSubmit(currentCodeMonitorState).pipe(
-                            startWith(LOADING),
-                            catchError(error => [asError(error)]),
-                            tap(successOrError => {
-                                if (!isErrorLike(successOrError) && successOrError !== LOADING) {
-                                    history.push('/code-monitoring')
-                                }
-                            })
-                        )
-                    )
+                    mergeMap(() => {
+                        if (formCompletion.actionCompleted && formCompletion.triggerCompleted) {
+                            return onSubmit(currentCodeMonitorState).pipe(
+                                startWith(LOADING),
+                                catchError(error => [asError(error)]),
+                                tap(successOrError => {
+                                    if (!isErrorLike(successOrError) && successOrError !== LOADING) {
+                                        history.push('/code-monitoring')
+                                    }
+                                })
+                            )
+                        }
+                        return of(undefined)
+                    })
                 ),
-            [onSubmit, currentCodeMonitorState, history]
+            [onSubmit, currentCodeMonitorState, history, formCompletion]
         )
     )
 

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -94,20 +94,17 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
             (submit: Observable<React.FormEvent<HTMLFormElement>>) =>
                 submit.pipe(
                     tap(event => event.preventDefault()),
-                    mergeMap(() => {
-                        if (formCompletion.actionCompleted && formCompletion.triggerCompleted) {
-                            return onSubmit(currentCodeMonitorState).pipe(
-                                startWith(LOADING),
-                                catchError(error => [asError(error)]),
-                                tap(successOrError => {
-                                    if (!isErrorLike(successOrError) && successOrError !== LOADING) {
-                                        history.push('/code-monitoring')
-                                    }
-                                })
-                            )
-                        }
-                        return of(undefined)
-                    })
+                    filter(() => formCompletion.actionCompleted && formCompletion.triggerCompleted),
+                    mergeMap(() => onSubmit(currentCodeMonitorState).pipe(
+                            startWith(LOADING),
+                            catchError(error => [asError(error)]),
+                            tap(successOrError => {
+                                if (!isErrorLike(successOrError) && successOrError !== LOADING) {
+                                    history.push('/code-monitoring')
+                                }
+                            })
+                        )
+                 )
                 ),
             [onSubmit, currentCodeMonitorState, history, formCompletion]
         )

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -1,13 +1,13 @@
 import classnames from 'classnames'
 import React, { useCallback, useMemo, useState } from 'react'
-import { Observable, of } from 'rxjs'
+import { Observable } from 'rxjs'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { AuthenticatedUser } from '../../../auth'
 import * as H from 'history'
 import { Toggle } from '../../../../../branded/src/components/Toggle'
 import { FormActionArea } from './FormActionArea'
 import { FormTriggerArea } from './FormTriggerArea'
-import { mergeMap, startWith, catchError, tap } from 'rxjs/operators'
+import { mergeMap, startWith, catchError, tap, filter } from 'rxjs/operators'
 import { Form } from '../../../../../branded/src/components/Form'
 import { useEventObservable } from '../../../../../shared/src/util/useObservable'
 import { CodeMonitorFields } from '../../../graphql-operations'
@@ -95,7 +95,8 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                 submit.pipe(
                     tap(event => event.preventDefault()),
                     filter(() => formCompletion.actionCompleted && formCompletion.triggerCompleted),
-                    mergeMap(() => onSubmit(currentCodeMonitorState).pipe(
+                    mergeMap(() =>
+                        onSubmit(currentCodeMonitorState).pipe(
                             startWith(LOADING),
                             catchError(error => [asError(error)]),
                             tap(successOrError => {
@@ -104,7 +105,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                                 }
                             })
                         )
-                 )
+                    )
                 ),
             [onSubmit, currentCodeMonitorState, history, formCompletion]
         )

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -7,14 +7,13 @@ import * as H from 'history'
 import { Toggle } from '../../../../../branded/src/components/Toggle'
 import { FormActionArea } from './FormActionArea'
 import { FormTriggerArea } from './FormTriggerArea'
-import { mergeMap, startWith, catchError, tap, filter } from 'rxjs/operators'
+import { mergeMap, startWith, catchError, tap } from 'rxjs/operators'
 import { Form } from '../../../../../branded/src/components/Form'
 import { useEventObservable } from '../../../../../shared/src/util/useObservable'
 import { CodeMonitorFields } from '../../../graphql-operations'
 import { isEqual } from 'lodash'
 import { CodeMonitoringProps } from '..'
 import { DeleteMonitorModal } from './DeleteMonitorModal'
-import ConsoleIcon from 'mdi-react/ConsoleIcon'
 
 export interface CodeMonitorFormProps extends Partial<Pick<CodeMonitoringProps, 'deleteCodeMonitor'>> {
     history: H.History
@@ -139,7 +138,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
 
     return (
         <>
-            <Form className="my-4 pb-5" onSubmit={requestOnSubmit}>
+            <Form className="my-4 pb-5 test-monitor-form" onSubmit={requestOnSubmit}>
                 <div className="flex mb-4">
                     Name
                     <div>

--- a/client/web/src/enterprise/code-monitoring/index.ts
+++ b/client/web/src/enterprise/code-monitoring/index.ts
@@ -1,5 +1,7 @@
 import { Observable } from 'rxjs'
 import {
+    CreateCodeMonitorResult,
+    CreateCodeMonitorVariables,
     FetchCodeMonitorResult,
     ListCodeMonitors,
     ListUserCodeMonitorsVariables,
@@ -11,6 +13,9 @@ import {
 } from '../../graphql-operations'
 
 export interface CodeMonitoringProps {
+    createCodeMonitor: (
+        monitorInput: CreateCodeMonitorVariables
+    ) => Observable<CreateCodeMonitorResult['createCodeMonitor']>
     fetchUserCodeMonitors: ({ id, first, after }: ListUserCodeMonitorsVariables) => Observable<ListCodeMonitors>
     fetchCodeMonitor: (id: string) => Observable<FetchCodeMonitorResult>
     updateCodeMonitor: (

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -8,7 +8,7 @@ export const mockCodeMonitor = {
             id: 'test-0',
             enabled: true,
             nodes: [
-                { id: 'test-action-0 ', enabled: true, recipients: { nodes: [{ id: 'baz-0', url: '/user/test' }] } },
+                { id: 'test-action-0', enabled: true, recipients: { nodes: [{ id: 'baz-0', url: '/user/test' }] } },
             ],
         },
         trigger: { id: 'test-0', query: 'test' },


### PR DESCRIPTION
@stefanhengl found that on Safari, it was possible to submit the code monitor form when only the name was entered. This PR makes sure we check that the form is complete before sending the creation request.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
