### PR TITLE
search: migrate ids of worker tables from serial to bigserial

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -30,7 +30,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	}
 
 	var got *ActionJob
-	got, err = s.ActionJobForIDInt(ctx, 1)
+	got, err = s.ActionJobForIDInt64(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,8 +104,8 @@ func TestScanActionJobs(t *testing.T) {
 	}
 
 	var (
-		testRecordID             = 1
-		testTriggerEventID       = 1
+		testRecordID       int64 = 1
+		testTriggerEventID int64 = 1
 		testQueryID        int64 = 1
 	)
 
@@ -130,7 +130,7 @@ func TestScanActionJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if record.RecordID() != testRecordID {
+	if int64(record.RecordID()) != testRecordID {
 		t.Fatalf("got %d, want %d", record.RecordID(), testRecordID)
 	}
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -137,7 +137,7 @@ func (r *queryRunner) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 	s := r.Store.With(workerStore)
 
 	var q *cm.MonitorQuery
-	q, err = s.GetQueryByRecordID(ctx, record.RecordID())
+	q, err = s.GetQueryByRecordID(ctx, int64(record.RecordID()))
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (r *queryRunner) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		err := s.EnqueueActionEmailsForQueryIDInt64(ctx, q.Id, record.RecordID())
+		err := s.EnqueueActionEmailsForQueryIDInt64(ctx, q.Id, int64(record.RecordID()))
 		if err != nil {
 			return fmt.Errorf("store.EnqueueActionEmailsForQueryIDInt64: %w", err)
 		}
@@ -166,7 +166,7 @@ func (r *queryRunner) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 		return err
 	}
 	// Log the actual query we ran and whether we got any new results.
-	err = s.LogSearch(ctx, newQuery, numResults, record.RecordID())
+	err = s.LogSearch(ctx, newQuery, numResults, int64(record.RecordID()))
 	if err != nil {
 		return fmt.Errorf("LogSearch: %w", err)
 
@@ -202,7 +202,7 @@ func (r *actionRunner) Handle(ctx context.Context, workerStore dbworkerstore.Sto
 		return fmt.Errorf("type assertion failed")
 	}
 
-	m, err = s.GetActionJobMetadata(ctx, record.RecordID())
+	m, err = s.GetActionJobMetadata(ctx, int64(record.RecordID()))
 	if err != nil {
 		return fmt.Errorf("store.GetActionJobMetadata: %w", err)
 	}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -74,7 +74,7 @@ func TestActionRunner(t *testing.T) {
 
 	var (
 		queryID      int64 = 1
-		triggerEvent       = 1
+		triggerJobID int64 = 1
 		record       *codemonitors.ActionJob
 	)
 	for _, tt := range tests {
@@ -93,15 +93,15 @@ func TestActionRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ts.LogSearch(ctx, testQuery, tt.numResults, triggerEvent)
+			err = ts.LogSearch(ctx, testQuery, tt.numResults, triggerJobID)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ts.EnqueueActionEmailsForQueryIDInt64(ctx, queryID, triggerEvent)
+			err = ts.EnqueueActionEmailsForQueryIDInt64(ctx, queryID, triggerJobID)
 			if err != nil {
 				t.Fatal(err)
 			}
-			record, err = ts.ActionJobForIDInt(ctx, 1)
+			record, err = ts.ActionJobForIDInt64(ctx, 1)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -130,10 +130,10 @@ FROM cm_queries q INNER JOIN cm_trigger_jobs j ON q.id = j.query
 WHERE j.id = %s
 `
 
-func (s *Store) GetQueryByRecordID(ctx context.Context, recordID int) (query *MonitorQuery, err error) {
+func (s *Store) GetQueryByRecordID(ctx context.Context, triggerJobID int64) (query *MonitorQuery, err error) {
 	q := sqlf.Sprintf(
 		getQueryByRecordIDFmtStr,
-		recordID,
+		triggerJobID,
 	)
 	var ms []*MonitorQuery
 	var rows *sql.Rows

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -477,7 +477,7 @@ func (m *monitor) Actions(ctx context.Context, args *graphqlbackend.ListActionAr
 	return m.actionConnectionResolverWithTriggerID(ctx, nil, m.Monitor.ID, args)
 }
 
-func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int, monitorID int64, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
+func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int64, monitorID int64, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
 	// For now, we only support emails as actions. Once we add other actions such as
 	// webhooks, we have to query those tables here too.
 	q, err := r.store.ReadActionEmailQuery(ctx, monitorID, args)
@@ -673,7 +673,7 @@ type monitorEmail struct {
 	// If triggerEventID == nil, all events of this action will be returned.
 	// Otherwise, only those events of this action which are related to the specified
 	// trigger event will be returned.
-	triggerEventID *int
+	triggerEventID *int64
 }
 
 func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.ListRecipientsArgs) (c graphqlbackend.MonitorActionEmailRecipientsConnectionResolver, err error) {

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (r *TriggerJobs) RecordID() int {
-	return r.Id
+	return int(r.Id)
 }
 
 const enqueueTriggerQueryFmtStr = `
@@ -46,8 +46,8 @@ SET query_string = %s,
 WHERE id = %s
 `
 
-func (s *Store) LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error {
-	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, numResults > 0, numResults, recordID))
+func (s *Store) LogSearch(ctx context.Context, queryString string, numResults int, triggerJobID int64) error {
+	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, numResults > 0, numResults, triggerJobID))
 }
 
 const deleteObsoleteJobLogsFmtStr = `
@@ -119,7 +119,7 @@ func (s *Store) TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int
 }
 
 type TriggerJobs struct {
-	Id    int
+	Id    int64
 	Query int64
 
 	// The query we ran including after: filter.

--- a/migrations/frontend/1528395764_migrate_jobs_tables_to_bigserial.down.sql
+++ b/migrations/frontend/1528395764_migrate_jobs_tables_to_bigserial.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE cm_trigger_jobs
+    ALTER COLUMN id SET DATA TYPE int;
+ALTER SEQUENCE cm_trigger_jobs_id_seq as int;
+
+ALTER TABLE cm_action_jobs
+    ALTER COLUMN id SET DATA TYPE int,
+    ALTER COLUMN trigger_event SET DATA type int4;
+ALTER SEQUENCE cm_action_jobs_id_seq as int;
+
+COMMIT;

--- a/migrations/frontend/1528395764_migrate_jobs_tables_to_bigserial.up.sql
+++ b/migrations/frontend/1528395764_migrate_jobs_tables_to_bigserial.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE cm_trigger_jobs
+    ALTER COLUMN id SET DATA TYPE bigint;
+ALTER SEQUENCE cm_trigger_jobs_id_seq as bigint;
+
+ALTER TABLE cm_action_jobs
+    ALTER COLUMN id SET DATA TYPE bigint,
+    ALTER COLUMN trigger_event SET DATA type int8;
+ALTER SEQUENCE cm_action_jobs_id_seq as bigint;
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -160,6 +160,8 @@
 // 1528395762_add_col_num_results_trigger_event.up.sql (327B)
 // 1528395763_remove_old_campaign_tables.down.sql (1.433kB)
 // 1528395763_remove_old_campaign_tables.up.sql (90B)
+// 1528395764_migrate_jobs_tables_to_bigserial.down.sql (293B)
+// 1528395764_migrate_jobs_tables_to_bigserial.up.sql (305B)
 
 package migrations
 
@@ -3428,6 +3430,46 @@ func _1528395763_remove_old_campaign_tablesUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395764_migrate_jobs_tables_to_bigserialDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x8d\x2f\x29\xca\x4c\x4f\x4f\x2d\x8a\xcf\xca\x4f\x2a\xe6\x52\x50\x50\x50\x80\xc8\x3b\xfb\xfb\x84\xfa\xfa\x29\x64\xa6\x28\x04\xbb\x86\x28\xb8\x38\x86\x38\x2a\x84\x44\x06\xb8\x2a\x64\xe6\x95\x58\x43\x8d\x08\x76\x0d\x0c\x75\xf5\x73\xc6\x30\x25\x3e\x33\x25\xbe\x38\xb5\x50\x21\xb1\x18\xa2\x1a\xdd\xc6\xc4\xe4\x92\xcc\xfc\x3c\x12\x2c\xd4\xc1\x54\x06\xb3\x2f\xb5\x2c\x35\xaf\x04\xa1\xa3\xa4\xb2\x20\x15\xa4\xc3\x04\x9b\x1b\x91\xec\xc5\x70\xa2\xb3\xbf\xaf\xaf\x67\x88\x35\x17\x20\x00\x00\xff\xff\xe6\xc0\x2b\x3f\x25\x01\x00\x00")
+
+func _1528395764_migrate_jobs_tables_to_bigserialDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395764_migrate_jobs_tables_to_bigserialDownSql,
+		"1528395764_migrate_jobs_tables_to_bigserial.down.sql",
+	)
+}
+
+func _1528395764_migrate_jobs_tables_to_bigserialDownSql() (*asset, error) {
+	bytes, err := _1528395764_migrate_jobs_tables_to_bigserialDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395764_migrate_jobs_tables_to_bigserial.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbd, 0xb2, 0x14, 0x9f, 0xce, 0x8f, 0x8d, 0x91, 0xe9, 0x6, 0x50, 0xfd, 0xbd, 0x3, 0xbc, 0x5f, 0xa7, 0x7c, 0x77, 0xc8, 0xb1, 0x7a, 0x3e, 0xe1, 0xf, 0x51, 0x1b, 0xe0, 0xdb, 0xe8, 0xc3, 0xe1}}
+	return a, nil
+}
+
+var __1528395764_migrate_jobs_tables_to_bigserialUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x8d\x2f\x29\xca\x4c\x4f\x4f\x2d\x8a\xcf\xca\x4f\x2a\xe6\x52\x50\x50\x50\x80\xc8\x3b\xfb\xfb\x84\xfa\xfa\x29\x64\xa6\x28\x04\xbb\x86\x28\xb8\x38\x86\x38\x2a\x84\x44\x06\xb8\x2a\x24\x65\xa6\x67\xe6\x95\x58\x43\x4d\x09\x76\x0d\x0c\x75\xf5\x73\xc6\x30\x28\x3e\x33\x25\xbe\x38\xb5\x50\x21\xb1\x18\xae\x01\xdd\xde\xc4\xe4\x92\xcc\xfc\x3c\xd2\xac\xd5\xc1\x54\x09\xb3\x35\xb5\x2c\x35\xaf\x04\xa1\xa9\xa4\xb2\x20\x55\x21\x33\xaf\xc4\x02\x9b\x4b\x91\xac\xc6\xe6\x50\x67\x7f\x5f\x5f\xcf\x10\x6b\x2e\x40\x00\x00\x00\xff\xff\xbc\x44\x5c\x29\x31\x01\x00\x00")
+
+func _1528395764_migrate_jobs_tables_to_bigserialUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395764_migrate_jobs_tables_to_bigserialUpSql,
+		"1528395764_migrate_jobs_tables_to_bigserial.up.sql",
+	)
+}
+
+func _1528395764_migrate_jobs_tables_to_bigserialUpSql() (*asset, error) {
+	bytes, err := _1528395764_migrate_jobs_tables_to_bigserialUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395764_migrate_jobs_tables_to_bigserial.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe4, 0xf3, 0x62, 0xf0, 0xe5, 0xc0, 0x0, 0x8c, 0xdd, 0x4c, 0xed, 0x51, 0x62, 0xe5, 0xf2, 0xeb, 0x6d, 0x18, 0x70, 0xc7, 0x1c, 0xcc, 0xf3, 0xf, 0x5f, 0x9c, 0xcb, 0x2a, 0x62, 0x7c, 0x61, 0x62}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -3679,6 +3721,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395762_add_col_num_results_trigger_event.up.sql":                                    _1528395762_add_col_num_results_trigger_eventUpSql,
 	"1528395763_remove_old_campaign_tables.down.sql":                                         _1528395763_remove_old_campaign_tablesDownSql,
 	"1528395763_remove_old_campaign_tables.up.sql":                                           _1528395763_remove_old_campaign_tablesUpSql,
+	"1528395764_migrate_jobs_tables_to_bigserial.down.sql":                                   _1528395764_migrate_jobs_tables_to_bigserialDownSql,
+	"1528395764_migrate_jobs_tables_to_bigserial.up.sql":                                     _1528395764_migrate_jobs_tables_to_bigserialUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -3885,6 +3929,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395762_add_col_num_results_trigger_event.up.sql":                                    {_1528395762_add_col_num_results_trigger_eventUpSql, map[string]*bintree{}},
 	"1528395763_remove_old_campaign_tables.down.sql":                                         {_1528395763_remove_old_campaign_tablesDownSql, map[string]*bintree{}},
 	"1528395763_remove_old_campaign_tables.up.sql":                                           {_1528395763_remove_old_campaign_tablesUpSql, map[string]*bintree{}},
+	"1528395764_migrate_jobs_tables_to_bigserial.down.sql":                                   {_1528395764_migrate_jobs_tables_to_bigserialDownSql, map[string]*bintree{}},
+	"1528395764_migrate_jobs_tables_to_bigserial.up.sql":                                     {_1528395764_migrate_jobs_tables_to_bigserialUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
When I created the tables `cm_trigger_jobs` and `cm_actions_jobs`, which are used by `workerutil` to coordinate job execution, I defined the `id` columns as `serial` because [`workerutil` operates with `int` as IDs and not `int64`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/apiworker/apiclient/types.go#L39). However, this should only ever make a difference if we wanted to support 32-bit systems.

Since we run queries frequently, it is conceivable that we run out of (`serial`) ids within a few years: Assuming we have a 1000 monitors that run once a minute, and with `serial` offering around 2 billion ids ...

2 * 10**9 / (1000 executions/minute * (60 * 24 * 365)minutes/year) = 3.8 years 

This PR constis of 2 commits. The first commit migrates the tables from serial to bigserial. In principle, we could stop there, because the code would still work. However I think it is best to make the assumption explicit, so I replaced all occurences of `int` with `int64` in commit 2.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
