### PR TITLE
Revert "Use RepoNames instead of Repos in search code (#16590)"

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -153,7 +153,7 @@ func (s *repos) List(ctx context.Context, opt db.ReposListOptions) (repos []*typ
 }
 
 // ListDefault calls db.DefaultRepos.List, with tracing.
-func (s *repos) ListDefault(ctx context.Context) (repos []*types.RepoName, err error) {
+func (s *repos) ListDefault(ctx context.Context) (repos []*types.Repo, err error) {
 	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
 	defer func() {
 		if err == nil {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -317,20 +317,20 @@ func repoNamesToStrings(repoNames []api.RepoName) []string {
 	return strings
 }
 
-func toRepositoryResolvers(repos []*types.RepoName) []*RepositoryResolver {
+func toRepositoryResolvers(repos []*types.Repo) []*RepositoryResolver {
 	if len(repos) == 0 {
 		return []*RepositoryResolver{}
 	}
 
 	resolvers := make([]*RepositoryResolver, len(repos))
 	for i := range repos {
-		resolvers[i] = &RepositoryResolver{repo: repos[i].ToRepo()}
+		resolvers[i] = &RepositoryResolver{repo: repos[i]}
 	}
 
 	return resolvers
 }
 
-func toRepoNames(repos []*types.RepoName) []api.RepoName {
+func toRepoNames(repos []*types.Repo) []api.RepoName {
 	names := make([]api.RepoName, len(repos))
 	for i, repo := range repos {
 		names[i] = repo.Name

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -907,7 +907,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 		}
 	}
 
-	var defaultRepos []*types.RepoName
+	var defaultRepos []*types.Repo
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 {
 		start := time.Now()
 		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, search.Indexed(), excludePatterns)
@@ -922,7 +922,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 		}
 	}
 
-	var repos []*types.RepoName
+	var repos []*types.Repo
 	var excluded excludedRepos
 	if len(defaultRepos) > 0 {
 		repos = defaultRepos
@@ -952,7 +952,7 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 			excludedC <- computeExcludedRepositories(ctx, op.query, options)
 		}()
 
-		repos, err = db.Repos.ListRepoNames(ctx, options)
+		repos, err = db.Repos.List(ctx, options)
 		tr.LazyPrintf("Repos.List - done")
 
 		excluded = <-excludedC
@@ -1065,9 +1065,9 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 	}, err
 }
 
-type defaultReposFunc func(ctx context.Context) ([]*types.RepoName, error)
+type defaultReposFunc func(ctx context.Context) ([]*types.Repo, error)
 
-func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, z *searchbackend.Zoekt, excludePatterns []string) ([]*types.RepoName, error) {
+func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, z *searchbackend.Zoekt, excludePatterns []string) ([]*types.Repo, error) {
 	// Get the list of default repos from the db.
 	defaultRepos, err := getRawDefaultRepos(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -206,7 +206,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 		j := 0
 		for i := range repoRevs {
 			repoRevs[i] = &search.RepositoryRevisions{
-				Repo: &types.RepoName{
+				Repo: &types.Repo{
 					ID:   api.RepoID(i),
 					Name: api.RepoName(chars[j] + "/repoName" + strconv.Itoa(i)),
 				},

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -307,7 +307,7 @@ func doSearchCommitsInRepoStream(ctx context.Context, op search.CommitParameters
 		}
 	}()
 
-	repoResolver := &RepositoryResolver{repo: op.RepoRevs.Repo.ToRepo()}
+	repoResolver := &RepositoryResolver{repo: op.RepoRevs.Repo}
 	for event := range events {
 		// if the result is incomplete, git log timed out and the client
 		// should be notified of that.
@@ -570,7 +570,7 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 		unflattened [][]*CommitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
-	common.repos = make([]*types.RepoName, len(args.Repos))
+	common.repos = make([]*types.Repo, len(args.Repos))
 	for i, repo := range args.Repos {
 		common.repos[i] = repo.Repo
 	}

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	// "github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -51,7 +52,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 	repoRevs := &search.RepositoryRevisions{
-		Repo: &types.RepoName{ID: 1, Name: "repo"},
+		Repo: &types.Repo{ID: 1, Name: "repo"},
 		Revs: []search.RevisionSpecifier{{RevSpec: "rev"}},
 	}
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, search.CommitParameters{

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -221,7 +221,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 
 // repoIsLess sorts repositories first by name then by ID, suitable for use
 // with sort.Slice.
-func repoIsLess(i, j *types.RepoName) bool {
+func repoIsLess(i, j *types.Repo) bool {
 	if i.Name != j.Name {
 		return i.Name < j.Name
 	}
@@ -391,7 +391,7 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 	if len(sliced.results) > 0 {
 		// First, identify what repository corresponds to the last result.
 		lastRepoConsumedName, _ := sliced.results[len(sliced.results)-1].searchResultURIs()
-		var lastRepoConsumed *types.RepoName
+		var lastRepoConsumed *types.Repo
 		for _, repo := range p.repositories {
 			if string(repo.Repo.Name) == lastRepoConsumedName {
 				lastRepoConsumed = repo.Repo
@@ -404,7 +404,7 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 		// that out now. For example, a cloning repository could be last or
 		// first in the results and we need to know the position for the cursor
 		// RepositoryOffset.
-		potentialLastRepos := []*types.RepoName{lastRepoConsumed}
+		potentialLastRepos := []*types.Repo{lastRepoConsumed}
 		potentialLastRepos = append(potentialLastRepos, sliced.common.cloning...)
 		potentialLastRepos = append(potentialLastRepos, sliced.common.missing...)
 		sort.Slice(potentialLastRepos, func(i, j int) bool {
@@ -475,11 +475,11 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 
 	// Break results into repositories because for each result we need to add
 	// the respective repository to the new common structure.
-	reposByName := map[string]*types.RepoName{}
+	reposByName := map[string]*types.Repo{}
 	for _, r := range common.repos {
 		reposByName[string(r.Name)] = r
 	}
-	resultsByRepo := map[*types.RepoName][]SearchResultResolver{}
+	resultsByRepo := map[*types.Repo][]SearchResultResolver{}
 	for _, r := range results[:limit] {
 		repoName, _ := r.searchResultURIs()
 		repo := reposByName[repoName]
@@ -549,7 +549,7 @@ func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, last
 		resultCount:      common.resultCount,
 	}
 
-	doAppend := func(dst, src []*types.RepoName) []*types.RepoName {
+	doAppend := func(dst, src []*types.Repo) []*types.Repo {
 		sort.Slice(src, func(i, j int) bool {
 			return repoIsLess(src[i], src[j])
 		})

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -43,9 +43,6 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	repoName := func(name string) *types.RepoName {
-		return &types.RepoName{Name: api.RepoName(name)}
-	}
 	result := mkFileMatch
 	format := func(r slicedSearchResults) string {
 		var b bytes.Buffer
@@ -83,7 +80,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		// Note: this is an intentionally unordered list to ensure we do not
 		// rely on the order of lists in common (which is not guaranteed by
 		// tests).
-		repos: []*types.RepoName{repoName("org/repo1"), repoName("org/repo3"), repoName("org/repo2")},
+		repos: []*types.Repo{repo("org/repo1"), repo("org/repo3"), repo("org/repo2")},
 	}
 	tests := []struct {
 		name          string
@@ -123,7 +120,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.RepoName{repoName("org/repo1")},
+					repos:       []*types.Repo{repo("org/repo1")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset: 0,
@@ -143,7 +140,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 2,
-					repos:       []*types.RepoName{repoName("org/repo1")},
+					repos:       []*types.Repo{repo("org/repo1")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset: 2,
@@ -164,7 +161,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.RepoName{repoName("org/repo2"), repoName("org/repo3")},
+					repos:       []*types.Repo{repo("org/repo2"), repo("org/repo3")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset: 0,
@@ -185,7 +182,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.RepoName{repoName("org/repo1"), repoName("org/repo2")},
+					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset: 0,
@@ -203,7 +200,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				result(repo("org/repo2"), "c.go"),
 			},
 			common: &searchResultsCommon{
-				repos:       []*types.RepoName{repoName("org/repo1"), repoName("org/repo2")},
+				repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
 				resultCount: 3,
 			},
 			offset: 3,
@@ -216,7 +213,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.RepoName{repoName("org/repo2")},
+					repos:       []*types.Repo{repo("org/repo2")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset: 0,
@@ -235,7 +232,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 1,
-					repos:       []*types.RepoName{repoName("org/repo1")},
+					repos:       []*types.Repo{repo("org/repo1")},
 					partial:     make(map[api.RepoName]struct{}),
 				},
 				resultOffset: 2,
@@ -274,9 +271,6 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	repoName := func(name string) *types.RepoName {
-		return &types.RepoName{Name: api.RepoName(name)}
-	}
 	result := func(repo *types.Repo, path, rev string) *FileMatchResolver {
 		fm := mkFileMatch(repo, path)
 		fm.InputRev = &rev
@@ -284,7 +278,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 	}
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
-			Repo: repoName(name),
+			Repo: repo(name),
 			Revs: revs(rev...),
 		}
 	}
@@ -303,7 +297,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			for _, rev := range repoRev.Revs {
 				rev := rev.RevSpec
 				for i := 0; i < 3; i++ {
-					results = append(results, result(repoRev.Repo.ToRepo(), fmt.Sprintf("some/file%d.go", i), rev))
+					results = append(results, result(repoRev.Repo, fmt.Sprintf("some/file%d.go", i), rev))
 				}
 			}
 			common.repos = append(common.repos, repoRev.Repo)
@@ -353,7 +347,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("3"), "some/file0.go", "feature"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:       []*types.RepoName{repoName("1"), repoName("2"), repoName("3")},
+				repos:       []*types.Repo{repo("1"), repo("2"), repo("3")},
 				partial:     map[api.RepoName]struct{}{},
 				resultCount: 10,
 			},
@@ -383,7 +377,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("5"), "some/file2.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:   []*types.RepoName{repoName("3"), repoName("4"), repoName("5")},
+				repos:   []*types.Repo{repo("3"), repo("4"), repo("5")},
 				partial: map[api.RepoName]struct{}{},
 			},
 		},
@@ -406,7 +400,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("1"), "some/file0.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:       []*types.RepoName{repoName("1")},
+				repos:       []*types.Repo{repo("1")},
 				partial:     map[api.RepoName]struct{}{},
 				resultCount: 1,
 			},
@@ -430,7 +424,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("1"), "some/file1.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:       []*types.RepoName{repoName("1")},
+				repos:       []*types.Repo{repo("1")},
 				partial:     map[api.RepoName]struct{}{},
 				resultCount: 1,
 			},
@@ -493,13 +487,10 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	repoName := func(name string) *types.RepoName {
-		return &types.RepoName{Name: api.RepoName(name)}
-	}
 	result := mkFileMatch
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
-			Repo: repoName(name),
+			Repo: repo(name),
 			Revs: revs(rev...),
 		}
 	}
@@ -612,13 +603,10 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 	repo := func(name string) *types.Repo {
 		return &types.Repo{Name: api.RepoName(name)}
 	}
-	repoName := func(name string) *types.RepoName {
-		return &types.RepoName{Name: api.RepoName(name)}
-	}
 	result := mkFileMatch
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
-			Repo: repoName(name),
+			Repo: repo(name),
 			Revs: revs(rev...),
 		}
 	}
@@ -633,12 +621,12 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			result(repo("f"), "a.go"),
 		},
 	}
-	repoMissing := map[string]*types.RepoName{
-		"b": repoName("b"),
-		"e": repoName("e"),
+	repoMissing := map[string]*types.Repo{
+		"b": repo("b"),
+		"e": repo("e"),
 	}
-	repoCloning := map[string]*types.RepoName{
-		"d": repoName("d"),
+	repoCloning := map[string]*types.Repo{
+		"d": repo("d"),
 	}
 	searchRepos := []*search.RepositoryRevisions{
 		repoRevs("a", "master"),
@@ -653,7 +641,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 		for _, repoRev := range batch {
 			if res, ok := repoResults[string(repoRev.Repo.Name)]; ok {
 				results = append(results, res...)
-				common.repos = append(common.repos, &types.RepoName{ID: repoRev.Repo.ID, Name: repoRev.Repo.Name})
+				common.repos = append(common.repos, repoRev.Repo)
 			}
 			if missing, ok := repoMissing[string(repoRev.Repo.Name)]; ok {
 				common.missing = append(common.missing, missing)
@@ -687,7 +675,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial:     map[api.RepoName]struct{}{},
-				repos:       []*types.RepoName{repoName("a")},
+				repos:       []*types.Repo{repo("a")},
 				resultCount: 1,
 			},
 		},
@@ -703,8 +691,8 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial: map[api.RepoName]struct{}{},
-				repos:   []*types.RepoName{repoName("c")},
-				missing: []*types.RepoName{repoName("b")},
+				repos:   []*types.Repo{repo("c")},
+				missing: []*types.Repo{repo("b")},
 			},
 		},
 		{
@@ -720,8 +708,8 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial: map[api.RepoName]struct{}{},
-				repos:   []*types.RepoName{repoName("a"), repoName("c")},
-				missing: []*types.RepoName{repoName("b")},
+				repos:   []*types.Repo{repo("a"), repo("c")},
+				missing: []*types.Repo{repo("b")},
 			},
 		},
 		{
@@ -738,9 +726,9 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial: map[api.RepoName]struct{}{},
-				repos:   []*types.RepoName{repoName("a"), repoName("c"), repoName("f")},
-				cloning: []*types.RepoName{repoName("d")},
-				missing: []*types.RepoName{repoName("b"), repoName("e")},
+				repos:   []*types.Repo{repo("a"), repo("c"), repo("f")},
+				cloning: []*types.Repo{repo("d")},
+				missing: []*types.Repo{repo("b"), repo("e")},
 			},
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -89,7 +89,7 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 			revs = r.RevSpecs()
 		}
 		for _, rev := range revs {
-			results = append(results, &RepositoryResolver{repo: r.Repo.ToRepo(), icon: repoIcon, rev: rev})
+			results = append(results, &RepositoryResolver{repo: r.Repo, icon: repoIcon, rev: rev})
 		}
 	}
 
@@ -146,7 +146,7 @@ func matchRepos(pattern *regexp.Regexp, resolved []*search.RepositoryRevisions) 
 		offset = next
 	}
 
-	repos := make([]*types.RepoName, len(resolved))
+	repos := make([]*types.Repo, len(resolved))
 	for i := range resolved {
 		repos[i] = resolved[i].Repo
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestSearchRepositories(t *testing.T) {
 	repositories := []*search.RepositoryRevisions{
-		{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
-		{Repo: &types.RepoName{ID: 456, Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
-		{Repo: &types.RepoName{ID: 789, Name: "bar/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: &types.Repo{ID: 456, Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
+		{Repo: &types.Repo{ID: 789, Name: "bar/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
 	}
 
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
@@ -150,7 +150,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 			return []*FileMatchResolver{
 				{
@@ -170,7 +170,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo shouldn't be included in results, query has repoHasFile filter ", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: &types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: &types.Repo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
 		}
@@ -185,7 +185,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: &types.Repo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 			return []*FileMatchResolver{
 				{
@@ -205,7 +205,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 	})
 
 	t.Run("repo should be included in results, query has -repoHasFile filter", func(t *testing.T) {
-		repo := &search.RepositoryRevisions{Repo: &types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
+		repo := &search.RepositoryRevisions{Repo: &types.Repo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
 		}
@@ -263,7 +263,7 @@ func BenchmarkSearchRepositories(b *testing.B) {
 	n := 200 * 1000
 	repos := make([]*search.RepositoryRevisions, n)
 	for i := 0; i < n; i++ {
-		repo := &types.RepoName{Name: api.RepoName("github.com/org/repo" + strconv.Itoa(i))}
+		repo := &types.Repo{Name: api.RepoName("github.com/org/repo" + strconv.Itoa(i))}
 		repos[i] = &search.RepositoryRevisions{Repo: repo, Revs: []search.RevisionSpecifier{{}}}
 	}
 	q := "context.WithValue"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -51,11 +51,11 @@ import (
 type searchResultsCommon struct {
 	limitHit bool // whether the limit on results was hit
 
-	repos    []*types.RepoName         // repos that were matched by the repo-related filters
-	searched []*types.RepoName         // repos that were searched
-	indexed  []*types.RepoName         // repos that were searched using an index
-	cloning  []*types.RepoName         // repos that could not be searched because they were still being cloned
-	missing  []*types.RepoName         // repos that could not be searched because they do not exist
+	repos    []*types.Repo             // repos that were matched by the repo-related filters
+	searched []*types.Repo             // repos that were searched
+	indexed  []*types.Repo             // repos that were searched using an index
+	cloning  []*types.Repo             // repos that could not be searched because they were still being cloned
+	missing  []*types.Repo             // repos that could not be searched because they do not exist
 	excluded excludedRepos             // repo counts of excluded repos because the search query doesn't apply to them, but that we want to know about (forks, archives)
 	partial  map[api.RepoName]struct{} // repos that were searched, but have results that were not returned due to exceeded limits
 
@@ -64,7 +64,7 @@ type searchResultsCommon struct {
 	// timedout usually contains repos that haven't finished being fetched yet.
 	// This should only happen for large repos and the searcher caches are
 	// purged.
-	timedout []*types.RepoName
+	timedout []*types.Repo
 
 	indexUnavailable bool // True if indexed search is enabled but was not available during this search.
 }
@@ -109,7 +109,7 @@ func (c *searchResultsCommon) Equal(other *searchResultsCommon) bool {
 	return reflect.DeepEqual(c, other)
 }
 
-func RepositoryResolvers(repos types.RepoNames) []*RepositoryResolver {
+func RepositoryResolvers(repos types.Repos) []*RepositoryResolver {
 	dedupSort(&repos)
 	return toRepositoryResolvers(repos)
 }
@@ -141,7 +141,7 @@ func (c *searchResultsCommon) update(other searchResultsCommon) {
 
 // dedupSort sorts (by ID in ascending order) and deduplicates
 // the given repos in-place.
-func dedupSort(repos *types.RepoNames) {
+func dedupSort(repos *types.Repos) {
 	if len(*repos) == 0 {
 		return
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -27,8 +27,6 @@ import (
 var mockCount = func(_ context.Context, options db.ReposListOptions) (int, error) { return 0, nil }
 
 func assertEqual(t *testing.T, got, want interface{}) {
-	t.Helper()
-
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatalf("(-want +got):\n%s", diff)
 	}
@@ -74,31 +72,31 @@ func TestSearchResults(t *testing.T) {
 		mockDecodedViewerFinalSettings = &schema.Settings{}
 		defer func() { mockDecodedViewerFinalSettings = nil }()
 
-		var calledReposListRepoNames bool
-		db.Mocks.Repos.ListRepoNames = func(_ context.Context, op db.ReposListOptions) ([]*types.RepoName, error) {
-			calledReposListRepoNames = true
+		var calledReposList bool
+		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
+			calledReposList = true
 
 			// Validate that the following options are invariant
-			// when calling the DB through Repos.ListRepoNames, no matter how
+			// when calling the DB through Repos.List, no matter how
 			// many times it is called for a single Search(...) operation.
 			assertEqual(t, op.LimitOffset, limitOffset)
 			assertEqual(t, op.IncludePatterns, []string{"r", "p"})
 
-			return []*types.RepoName{{ID: 1, Name: "repo"}}, nil
+			return []*types.Repo{{ID: 1, Name: "repo"}}, nil
 		}
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
 		db.Mocks.Repos.MockGet(t, 1)
 		db.Mocks.Repos.Count = mockCount
 
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
-			return nil, &searchResultsCommon{repos: []*types.RepoName{{ID: 1, Name: "repo"}}}, nil
+			return nil, &searchResultsCommon{repos: []*types.Repo{{ID: 1, Name: "repo"}}}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
 		for _, v := range searchVersions {
 			testCallResults(t, `repo:r repo:p`, v, []string{"repo:repo"})
-			if !calledReposListRepoNames {
-				t.Error("!calledReposListRepoNames")
+			if !calledReposList {
+				t.Error("!calledReposList")
 			}
 		}
 
@@ -108,16 +106,16 @@ func TestSearchResults(t *testing.T) {
 		mockDecodedViewerFinalSettings = &schema.Settings{}
 		defer func() { mockDecodedViewerFinalSettings = nil }()
 
-		var calledReposListRepoNames bool
-		db.Mocks.Repos.ListRepoNames = func(_ context.Context, op db.ReposListOptions) ([]*types.RepoName, error) {
-			calledReposListRepoNames = true
+		var calledReposList bool
+		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
+			calledReposList = true
 
 			// Validate that the following options are invariant
 			// when calling the DB through Repos.List, no matter how
 			// many times it is called for a single Search(...) operation.
 			assertEqual(t, op.LimitOffset, limitOffset)
 
-			return []*types.RepoName{{ID: 1, Name: "repo"}}, nil
+			return []*types.Repo{{ID: 1, Name: "repo"}}, nil
 		}
 		defer func() { db.Mocks = db.MockStores{} }()
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
@@ -148,15 +146,15 @@ func TestSearchResults(t *testing.T) {
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
-			repo := &types.RepoName{ID: 1, Name: "repo"}
-			fm := mkFileMatch(repo.ToRepo(), "dir/file", 123)
-			return []*FileMatchResolver{fm}, &searchResultsCommon{repos: []*types.RepoName{repo}}, nil
+			repo := &types.Repo{ID: 1, Name: "repo"}
+			fm := mkFileMatch(repo, "dir/file", 123)
+			return []*FileMatchResolver{fm}, &searchResultsCommon{repos: []*types.Repo{repo}}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
 		testCallResults(t, `foo\d "bar*"`, "V1", []string{"dir/file:123"})
-		if !calledReposListRepoNames {
-			t.Error("!calledReposListRepoNames")
+		if !calledReposList {
+			t.Error("!calledReposList")
 		}
 		if !calledSearchRepositories {
 			t.Error("!calledSearchRepositories")
@@ -173,16 +171,16 @@ func TestSearchResults(t *testing.T) {
 		mockDecodedViewerFinalSettings = &schema.Settings{}
 		defer func() { mockDecodedViewerFinalSettings = nil }()
 
-		var calledReposListRepoNames bool
-		db.Mocks.Repos.ListRepoNames = func(_ context.Context, op db.ReposListOptions) ([]*types.RepoName, error) {
-			calledReposListRepoNames = true
+		var calledReposList bool
+		db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
+			calledReposList = true
 
 			// Validate that the following options are invariant
 			// when calling the DB through Repos.List, no matter how
 			// many times it is called for a single Search(...) operation.
 			assertEqual(t, op.LimitOffset, limitOffset)
 
-			return []*types.RepoName{{ID: 1, Name: "repo"}}, nil
+			return []*types.Repo{{ID: 1, Name: "repo"}}, nil
 		}
 		defer func() { db.Mocks = db.MockStores{} }()
 		db.Mocks.Repos.MockGetByName(t, "repo", 1)
@@ -213,15 +211,15 @@ func TestSearchResults(t *testing.T) {
 			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
-			repo := &types.RepoName{ID: 1, Name: "repo"}
-			fm := mkFileMatch(repo.ToRepo(), "dir/file", 123)
-			return []*FileMatchResolver{fm}, &searchResultsCommon{repos: []*types.RepoName{repo}}, nil
+			repo := &types.Repo{ID: 1, Name: "repo"}
+			fm := mkFileMatch(repo, "dir/file", 123)
+			return []*FileMatchResolver{fm}, &searchResultsCommon{repos: []*types.Repo{repo}}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
 		testCallResults(t, `foo\d "bar*"`, "V2", []string{"dir/file:123"})
-		if !calledReposListRepoNames {
-			t.Error("!calledReposListRepoNames")
+		if !calledReposList {
+			t.Error("!calledReposList")
 		}
 		if !calledSearchRepositories {
 			t.Error("!calledSearchRepositories")
@@ -916,8 +914,8 @@ func TestSearchResultsHydration(t *testing.T) {
 		return hydratedRepo, nil
 	}
 
-	db.Mocks.Repos.ListRepoNames = func(_ context.Context, op db.ReposListOptions) ([]*types.RepoName, error) {
-		return []*types.RepoName{{ID: repoWithIDs.ID, Name: repoWithIDs.Name}}, nil
+	db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
+		return []*types.Repo{repoWithIDs}, nil
 	}
 	db.Mocks.Repos.Count = mockCount
 
@@ -980,9 +978,9 @@ func TestSearchResultsHydration(t *testing.T) {
 }
 
 func TestDedupSort(t *testing.T) {
-	repos := make(types.RepoNames, 512)
+	repos := make(types.Repos, 512)
 	for i := range repos {
-		repos[i] = &types.RepoName{ID: api.RepoID(i % 256)}
+		repos[i] = &types.Repo{ID: api.RepoID(i % 256)}
 	}
 
 	rand.Shuffle(len(repos), func(i, j int) {
@@ -1076,7 +1074,7 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 		repoRevs := make([]*search.RepositoryRevisions, test.numRepoRevs)
 		for i := range repoRevs {
 			repoRevs[i] = &search.RepositoryRevisions{
-				Repo: &types.RepoName{ID: api.RepoID(i)},
+				Repo: &types.Repo{ID: api.RepoID(i)},
 			}
 		}
 
@@ -1426,12 +1424,8 @@ func TestEvaluateAnd(t *testing.T) {
 
 			ctx := context.Background()
 
-			db.Mocks.Repos.ListRepoNames = func(_ context.Context, op db.ReposListOptions) ([]*types.RepoName, error) {
-				repoNames := make([]*types.RepoName, len(minimalRepos))
-				for i := range minimalRepos {
-					repoNames[i] = &types.RepoName{ID: minimalRepos[i].ID, Name: minimalRepos[i].Name}
-				}
-				return repoNames, nil
+			db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
+				return minimalRepos, nil
 			}
 			db.Mocks.Repos.Count = func(ctx context.Context, opt db.ReposListOptions) (int, error) {
 				return len(minimalRepos), nil

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -367,7 +367,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		}
 		repoRev := repos.repoRevs[file.Repository]
 		if repoResolvers[repoRev.Repo.Name] == nil {
-			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{repo: repoRev.Repo.ToRepo()}
+			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{repo: repoRev.Repo}
 		}
 		matches[i] = &FileMatchResolver{
 			JPath:     file.FileName,

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -25,18 +25,18 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 	repoName := "indexed/one"
 	indexedFileName := "indexed.go"
 
-	indexedRepo := &types.RepoName{Name: api.RepoName(repoName)}
+	indexedRepo := &types.Repo{Name: api.RepoName(repoName)}
 
-	unindexedRepo := &types.RepoName{Name: api.RepoName("unindexed/one")}
+	unindexedRepo := &types.Repo{Name: api.RepoName("unindexed/one")}
 
-	db.Mocks.Repos.ListRepoNames = func(_ context.Context, op db.ReposListOptions) ([]*types.RepoName, error) {
-		return []*types.RepoName{indexedRepo, unindexedRepo}, nil
+	db.Mocks.Repos.List = func(_ context.Context, op db.ReposListOptions) ([]*types.Repo, error) {
+		return []*types.Repo{indexedRepo, unindexedRepo}, nil
 	}
 	defer func() { db.Mocks = db.MockStores{} }()
 
 	mockSearchFilesInRepo = func(
 		ctx context.Context,
-		repo *types.RepoName,
+		repo *types.Repo,
 		gitserverRepo gitserver.Repo,
 		rev string,
 		info *search.TextPatternInfo,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -102,7 +102,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			resolvers := make([]*searchSuggestionResolver, 0, len(resolved.repoRevs))
 			for _, rev := range resolved.repoRevs {
 				resolvers = append(resolvers, newSearchSuggestionResolver(
-					&RepositoryResolver{repo: rev.Repo.ToRepo()},
+					&RepositoryResolver{repo: rev.Repo},
 					math.MaxInt32,
 				))
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -77,7 +77,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return nil, nil, err
 	}
 
-	common.repos = make([]*types.RepoName, len(repos))
+	common.repos = make([]*types.Repo, len(repos))
 	for i, repo := range repos {
 		common.repos[i] = repo.Repo
 	}
@@ -85,7 +85,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 	var searcherRepos []*search.RepositoryRevisions
 	if indexed.DisableUnindexedSearch {
 		tr.LazyPrintf("disabling unindexed search")
-		common.missing = make([]*types.RepoName, len(indexed.Unindexed))
+		common.missing = make([]*types.Repo, len(indexed.Unindexed))
 		for i, r := range indexed.Unindexed {
 			common.missing[i] = r.Repo
 		}
@@ -248,7 +248,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 		return nil, err
 	}
 
-	repoResolver := NewRepositoryResolver(repoRevs.Repo.ToRepo())
+	repoResolver := NewRepositoryResolver(repoRevs.Repo)
 	commitResolver := &GitCommitResolver{
 		repoResolver: repoResolver,
 		oid:          GitObjectID(commitID),

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -303,15 +303,15 @@ func TestDefaultRepositories(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 
-			var drs []*types.RepoName
+			var drs []*types.Repo
 			for i, name := range tc.defaultsInDb {
-				r := &types.RepoName{
+				r := &types.Repo{
 					ID:   api.RepoID(i),
 					Name: api.RepoName(name),
 				}
 				drs = append(drs, r)
 			}
-			getRawDefaultRepos := func(ctx context.Context) ([]*types.RepoName, error) {
+			getRawDefaultRepos := func(ctx context.Context) ([]*types.Repo, error) {
 				return drs, nil
 			}
 
@@ -635,13 +635,13 @@ func TestVersionContext(t *testing.T) {
 				userSettings:   &schema.Settings{},
 			}
 
-			db.Mocks.Repos.ListRepoNames = func(ctx context.Context, opts db.ReposListOptions) ([]*types.RepoName, error) {
+			db.Mocks.Repos.List = func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
 				if diff := cmp.Diff(tc.wantReposListOptionsNames, opts.Names, cmpopts.EquateEmpty()); diff != "" {
 					t.Fatalf("db.RepostListOptions.Names mismatch (-want, +got):\n%s", diff)
 				}
-				var repos []*types.RepoName
+				var repos []*types.Repo
 				for _, name := range tc.reposGetListNames {
-					repos = append(repos, &types.RepoName{Name: api.RepoName(name)})
+					repos = append(repos, &types.Repo{Name: api.RepoName(name)})
 				}
 				return repos, nil
 			}
@@ -803,8 +803,8 @@ func TestRevisionValidation(t *testing.T) {
 	}
 	defer func() { git.Mocks.ResolveRevision = nil }()
 
-	db.Mocks.Repos.ListRepoNames = func(ctx context.Context, opts db.ReposListOptions) ([]*types.RepoName, error) {
-		return []*types.RepoName{{Name: "repoFoo"}}, nil
+	db.Mocks.Repos.List = func(ctx context.Context, opts db.ReposListOptions) ([]*types.Repo, error) {
+		return []*types.Repo{{Name: "repoFoo"}}, nil
 	}
 	defer func() { db.Mocks.Repos.List = nil }()
 
@@ -817,7 +817,7 @@ func TestRevisionValidation(t *testing.T) {
 		{
 			repoFilters: []string{"repoFoo@revBar:^revBas"},
 			wantRepoRevs: []*search.RepositoryRevisions{{
-				Repo: &types.RepoName{Name: "repoFoo"},
+				Repo: &types.Repo{Name: "repoFoo"},
 				Revs: []search.RevisionSpecifier{
 					{
 						RevSpec:        "revBar",
@@ -836,7 +836,7 @@ func TestRevisionValidation(t *testing.T) {
 		{
 			repoFilters: []string{"repoFoo@*revBar:*!revBas"},
 			wantRepoRevs: []*search.RepositoryRevisions{{
-				Repo: &types.RepoName{Name: "repoFoo"},
+				Repo: &types.Repo{Name: "repoFoo"},
 				Revs: []search.RevisionSpecifier{
 					{
 						RevSpec:        "",
@@ -855,7 +855,7 @@ func TestRevisionValidation(t *testing.T) {
 		{
 			repoFilters: []string{"repoFoo@revBar:^revQux"},
 			wantRepoRevs: []*search.RepositoryRevisions{{
-				Repo: &types.RepoName{Name: "repoFoo"},
+				Repo: &types.Repo{Name: "repoFoo"},
 				Revs: []search.RevisionSpecifier{
 					{
 						RevSpec:        "revBar",
@@ -866,7 +866,7 @@ func TestRevisionValidation(t *testing.T) {
 				ListRefs: nil,
 			}},
 			wantMissingRepoRevisions: []*search.RepositoryRevisions{{
-				Repo: &types.RepoName{Name: "repoFoo"},
+				Repo: &types.Repo{Name: "repoFoo"},
 				Revs: []search.RevisionSpecifier{
 					{
 						RevSpec:        "^revQux",
@@ -897,7 +897,7 @@ func TestRevisionValidation(t *testing.T) {
 		{
 			repoFilters: []string{"repoFoo"},
 			wantRepoRevs: []*search.RepositoryRevisions{{
-				Repo: &types.RepoName{Name: "repoFoo"},
+				Repo: &types.Repo{Name: "repoFoo"},
 				Revs: []search.RevisionSpecifier{
 					{
 						RevSpec:        "",
@@ -974,7 +974,7 @@ func TestRepoGroupValuesToRegexp(t *testing.T) {
 
 func repoRev(revSpec string) *search.RepositoryRevisions {
 	return &search.RepositoryRevisions{
-		Repo: &types.RepoName{ID: api.RepoID(0), Name: "test/repo"},
+		Repo: &types.Repo{ID: api.RepoID(0), Name: "test/repo"},
 		Revs: []search.RevisionSpecifier{
 			{RevSpec: revSpec},
 		},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -170,9 +170,9 @@ func (lm *lineMatch) LimitHit() bool {
 	return lm.JLimitHit
 }
 
-var mockSearchFilesInRepo func(ctx context.Context, repo *types.RepoName, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
+var mockSearchFilesInRepo func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
 
-func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *types.RepoName, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]*FileMatchResolver, bool, error) {
+func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]*FileMatchResolver, bool, error) {
 	if mockSearchFilesInRepo != nil {
 		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout)
 	}
@@ -200,7 +200,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 	}
 
 	workspace := fileMatchURI(repo.Name, rev, "")
-	repoResolver := &RepositoryResolver{repo: repo.ToRepo()}
+	repoResolver := &RepositoryResolver{repo: repo}
 	resolvers := make([]*FileMatchResolver, 0, len(matches))
 	for _, fm := range matches {
 		lineMatches := make([]*lineMatch, 0, len(fm.LineMatches))
@@ -351,7 +351,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	var searcherRepos []*search.RepositoryRevisions
 	if indexed.DisableUnindexedSearch {
 		tr.LazyPrintf("disabling unindexed search")
-		common.missing = make([]*types.RepoName, len(indexed.Unindexed))
+		common.missing = make([]*types.Repo, len(indexed.Unindexed))
 		for i, r := range indexed.Unindexed {
 			common.missing[i] = r.Repo
 		}
@@ -604,7 +604,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	if err != nil {
 		return nil, common, err
 	}
-	common.repos = make([]*types.RepoName, len(repos))
+	common.repos = make([]*types.Repo, len(repos))
 	for i, repo := range repos {
 		common.repos[i] = repo.Repo
 	}
@@ -621,7 +621,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 // repositories that are limited / excluded.
 //
 // A slice to the input list is returned, it is not copied.
-func limitSearcherRepos(unindexed []*search.RepositoryRevisions, limit int) (searcherRepos []*search.RepositoryRevisions, limitedSearcherRepos []*types.RepoName) {
+func limitSearcherRepos(unindexed []*search.RepositoryRevisions, limit int) (searcherRepos []*search.RepositoryRevisions, limitedSearcherRepos []*types.Repo) {
 	totalRepoRevs := 0
 	limitedRepos := 0
 	for _, repoRevs := range unindexed {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestSearchFilesInRepos(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo *types.RepoName, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
@@ -114,7 +114,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 }
 
 func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo *types.RepoName, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo *types.Repo, gitserverRepo gitserver.Repo, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
@@ -221,15 +221,15 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 			// treat empty list as preferring master
 			revs = []search.RevisionSpecifier{{RevSpec: ""}}
 		}
-		r[i] = &search.RepositoryRevisions{Repo: &types.RepoName{Name: api.RepoName(repoName)}, Revs: revs}
+		r[i] = &search.RepositoryRevisions{Repo: &types.Repo{Name: api.RepoName(repoName)}, Revs: revs}
 	}
 	return r
 }
 
-func mkRepos(names ...string) []*types.RepoName {
-	var repos []*types.RepoName
+func mkRepos(names ...string) []*types.Repo {
+	var repos []*types.Repo
 	for _, name := range names {
-		repos = append(repos, &types.RepoName{Name: api.RepoName(name)})
+		repos = append(repos, &types.Repo{Name: api.RepoName(name)})
 	}
 	return repos
 }
@@ -253,7 +253,7 @@ func TestLimitSearcherRepos(t *testing.T) {
 				continue
 			}
 			result = append(result, &search.RepositoryRevisions{
-				Repo: &types.RepoName{Name: api.RepoName(repo)},
+				Repo: &types.Repo{Name: api.RepoName(repo)},
 				Revs: []search.RevisionSpecifier{{RevSpec: rev}},
 			})
 		}
@@ -265,7 +265,7 @@ func TestLimitSearcherRepos(t *testing.T) {
 		limit       int
 		input       []*search.RepositoryRevisions
 		want        []*search.RepositoryRevisions
-		wantLimited []*types.RepoName
+		wantLimited []*types.Repo
 	}{
 		{
 			name:        "non_limited",

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -395,7 +395,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		limitHit = true
 	}
 
-	var getRepoInputRev func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool)
+	var getRepoInputRev func(file *zoekt.FileMatch) (repo *types.Repo, revs []string, ok bool)
 
 	if args.Mode == search.ZoektGlobalSearch {
 		m := map[string]*search.RepositoryRevisions{}
@@ -413,7 +413,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 			}
 			m[string(repo.Repo.Name)] = repo
 		}
-		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
+		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.Repo, revs []string, ok bool) {
 			repoRev := m[file.Repository]
 			if repoRev == nil {
 				return nil, nil, false
@@ -421,7 +421,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 			return repoRev.Repo, repoRev.RevSpecs(), true
 		}
 	} else {
-		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
+		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.Repo, revs []string, ok bool) {
 			repo, inputRevs := repos.GetRepoInputRev(file)
 			return repo, inputRevs, true
 		}
@@ -442,7 +442,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		}
 		repoResolver := repoResolvers[repo.Name]
 		if repoResolver == nil {
-			repoResolver = &RepositoryResolver{repo: repo.ToRepo()}
+			repoResolver = &RepositoryResolver{repo: repo}
 			repoResolvers[repo.Name] = repoResolver
 		}
 
@@ -818,7 +818,7 @@ func (rb *indexedRepoRevs) Add(reporev *search.RepositoryRevisions, repo *zoekt.
 }
 
 // GetRepoInputRev returns the repo and inputRev associated with file.
-func (rb *indexedRepoRevs) GetRepoInputRev(file *zoekt.FileMatch) (repo *types.RepoName, inputRevs []string) {
+func (rb *indexedRepoRevs) GetRepoInputRev(file *zoekt.FileMatch) (repo *types.Repo, inputRevs []string) {
 	repoRev := rb.repoRevs[file.Repository]
 
 	inputRevs = make([]string, 0, len(file.Branches))

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -853,7 +853,7 @@ func zoektRPC(s zoekt.Searcher) (zoekt.Searcher, func()) {
 func TestZoektIndexedRepos_single(t *testing.T) {
 	repoRev := func(revSpec string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
-			Repo: &types.RepoName{ID: api.RepoID(0), Name: "test/repo"},
+			Repo: &types.Repo{ID: api.RepoID(0), Name: "test/repo"},
 			Revs: []search.RevisionSpecifier{
 				{RevSpec: revSpec},
 			},

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -205,7 +205,7 @@ type reposListServer struct {
 	// interface for testing.
 	Repos interface {
 		// ListDefault returns the repositories to index on Sourcegraph.com
-		ListDefault(context.Context) ([]*types.RepoName, error)
+		ListDefault(context.Context) ([]*types.Repo, error)
 		// List returns a list of repositories
 		List(context.Context, db.ReposListOptions) ([]*types.Repo, error)
 	}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -150,10 +150,10 @@ type mockRepos struct {
 	repos        []string
 }
 
-func (r *mockRepos) ListDefault(context.Context) ([]*types.RepoName, error) {
-	var repos []*types.RepoName
+func (r *mockRepos) ListDefault(context.Context) ([]*types.Repo, error) {
+	var repos []*types.Repo
 	for _, name := range r.defaultRepos {
-		repos = append(repos, &types.RepoName{
+		repos = append(repos, &types.Repo{
 			Name: api.RepoName(name),
 		})
 	}

--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -16,22 +16,22 @@ import (
 const defaultReposMaxAge = time.Minute
 
 type cachedRepos struct {
-	repos   []*types.RepoName
+	repos   []*types.Repo
 	fetched time.Time
 }
 
-func (c *cachedRepos) Repos() []*types.RepoName {
+func (c *cachedRepos) Repos() []*types.Repo {
 	if c == nil || time.Since(c.fetched) > defaultReposMaxAge {
 		return nil
 	}
-	return append([]*types.RepoName{}, c.repos...)
+	return append([]*types.Repo{}, c.repos...)
 }
 
 type defaultRepos struct {
 	cache atomic.Value
 }
 
-func (s *defaultRepos) List(ctx context.Context) (results []*types.RepoName, err error) {
+func (s *defaultRepos) List(ctx context.Context) (results []*types.Repo, err error) {
 	cached, _ := s.cache.Load().(*cachedRepos)
 	if repos := cached.Repos(); repos != nil {
 		return repos, nil
@@ -70,9 +70,9 @@ UNION
 		return nil, errors.Wrap(err, "querying default_repos table")
 	}
 	defer rows.Close()
-	var repos []*types.RepoName
+	var repos []*types.Repo
 	for rows.Next() {
-		var r types.RepoName
+		var r types.Repo
 		if err := rows.Scan(&r.ID, &r.Name); err != nil {
 			return nil, errors.Wrap(err, "scanning row from default_repos table")
 		}
@@ -84,7 +84,7 @@ UNION
 
 	s.cache.Store(&cachedRepos{
 		// Copy since repos will be mutated by the caller
-		repos:   append([]*types.RepoName{}, repos...),
+		repos:   append([]*types.Repo{}, repos...),
 		fetched: time.Now(),
 	})
 

--- a/internal/db/default_repos_test.go
+++ b/internal/db/default_repos_test.go
@@ -20,7 +20,7 @@ func Test_defaultRepos_List(t *testing.T) {
 	}
 	tcs := []struct {
 		name  string
-		repos []*types.RepoName
+		repos []*types.Repo
 	}{
 		{
 			name:  "empty case",
@@ -28,7 +28,7 @@ func Test_defaultRepos_List(t *testing.T) {
 		},
 		{
 			name: "one repo",
-			repos: []*types.RepoName{
+			repos: []*types.Repo{
 				{
 					ID:   api.RepoID(0),
 					Name: "github.com/foo/bar",
@@ -37,7 +37,7 @@ func Test_defaultRepos_List(t *testing.T) {
 		},
 		{
 			name: "a few repos",
-			repos: []*types.RepoName{
+			repos: []*types.Repo{
 				{
 					ID:   api.RepoID(0),
 					Name: "github.com/foo/bar",
@@ -69,8 +69,8 @@ func Test_defaultRepos_List(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sort.Sort(types.RepoNames(repos))
-			sort.Sort(types.RepoNames(tc.repos))
+			sort.Sort(types.Repos(repos))
+			sort.Sort(types.Repos(tc.repos))
 			if diff := cmp.Diff(repos, tc.repos, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -105,7 +105,7 @@ func Test_defaultRepos_List(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		want := []*types.RepoName{
+		want := []*types.Repo{
 			{
 				ID:   api.RepoID(10),
 				Name: "github.com/foo/bar10",

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -588,9 +588,6 @@ func (s *RepoStore) ListRepoNames(ctx context.Context, opt ReposListOptions) (re
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if Mocks.Repos.ListRepoNames != nil {
-		return Mocks.Repos.ListRepoNames(ctx, opt)
-	}
 	s.ensureStore()
 
 	var repos []*types.RepoName

--- a/internal/db/repos_mock.go
+++ b/internal/db/repos_mock.go
@@ -9,13 +9,12 @@ import (
 )
 
 type MockRepos struct {
-	Get           func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
-	GetByName     func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
-	GetByIDs      func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
-	List          func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
-	ListRepoNames func(v0 context.Context, v1 ReposListOptions) ([]*types.RepoName, error)
-	Create        func(ctx context.Context, repos ...*types.Repo) (err error)
-	Count         func(ctx context.Context, opt ReposListOptions) (int, error)
+	Get       func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
+	GetByName func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
+	GetByIDs  func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
+	List      func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
+	Create    func(ctx context.Context, repos ...*types.Repo) (err error)
+	Count     func(ctx context.Context, opt ReposListOptions) (int, error)
 }
 
 func (s *MockRepos) MockGet(t *testing.T, wantRepo api.RepoID) (called *bool) {
@@ -64,19 +63,6 @@ func (s *MockRepos) MockList(t testing.TB, wantRepos ...api.RepoName) (called *b
 		repos := make([]*types.Repo, len(wantRepos))
 		for i, repo := range wantRepos {
 			repos[i] = &types.Repo{Name: repo}
-		}
-		return repos, nil
-	}
-	return
-}
-
-func (s *MockRepos) MockListRepoNames(t testing.TB, wantRepos ...api.RepoName) (called *bool) {
-	called = new(bool)
-	s.ListRepoNames = func(ctx context.Context, opt ReposListOptions) ([]*types.RepoName, error) {
-		*called = true
-		repos := make([]*types.RepoName, len(wantRepos))
-		for i, repo := range wantRepos {
-			repos[i] = &types.RepoName{Name: repo}
 		}
 		return repos, nil
 	}

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -56,7 +56,7 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	Repo *types.RepoName
+	Repo *types.Repo
 	Revs []RevisionSpecifier
 
 	// resolveOnce protects resolvedRevs

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -88,6 +88,12 @@ type Repo struct {
 	Metadata interface{}
 }
 
+// RepoName represents a source code repository name and its ID.
+type RepoName struct {
+	ID   api.RepoID
+	Name api.RepoName
+}
+
 // CloneURLs returns all the clone URLs this repo is clonable from.
 func (r *Repo) CloneURLs() []string {
 	urls := make([]string, 0, len(r.Sources))
@@ -367,26 +373,6 @@ func (rs Repos) Filter(pred func(*Repo) bool) (fs Repos) {
 	}
 	return fs
 }
-
-// RepoName represents a source code repository name and its ID.
-type RepoName struct {
-	ID   api.RepoID
-	Name api.RepoName
-}
-
-func (r *RepoName) ToRepo() *Repo {
-	return &Repo{
-		ID:   r.ID,
-		Name: r.Name,
-	}
-}
-
-// RepoNames is an utility type with convenience methods for operating on lists of repo names
-type RepoNames []*RepoName
-
-func (rs RepoNames) Len() int           { return len(rs) }
-func (rs RepoNames) Less(i, j int) bool { return rs[i].ID < rs[j].ID }
-func (rs RepoNames) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
 
 type CodeHostRepository struct {
 	Name       string


### PR DESCRIPTION
This reverts commit e4b838e989e12e0935939a54e798248bfc0f033e and PR #16590
