### PR TITLE
Add how-to for creating multiple changesets in single repository

### DIFF
--- a/doc/campaigns/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/campaigns/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -9,7 +9,7 @@
 <p>
 <span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
 </p>
-<p><b>We're very much looking for input and feedback on this feature.</b></p>
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either [contact us directly](https://about.sourcegraph.com/contact), [file an issue](https://github.com/sourcegraph/sourcegraph), or [tweet at us](https://twitter.com/srcgraph).</p>
 
 <p>It's available in Sourcegraph 3.23 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23.0 and later.</p>
 </aside>

--- a/doc/campaigns/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/campaigns/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -1,0 +1,64 @@
+# Creating multiple changesets in large repositories
+
+<style>
+.markdown-body h2 { margin-top: 50px; }
+.markdown-body pre.chroma { font-size: 0.75em; }
+</style>
+
+<aside class="experimental">
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on. We're very much looking for feedback.
+<br />
+It's available in Sourcegraph 3.23 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23.0 and later.
+</aside>
+
+Campaigns can produce a lot of changes in a single repository and it might make sense to split up the changes into multiple changesets, so that each changeset can be reviewed and merged independently.
+
+By using [`transformChanges`](../references/campaign_spec_yaml_reference.md#transformchanges) in your campaign spec you can group the changes produced in one repository by directory and create a changeset for each group:
+
+The following campaign spec uses the `transformChanges` property to create multiple changesets in a single repository by grouping the changes made in different directories:
+
+```yaml
+name: hello-world
+description: Add Hello World to READMEs
+
+# Find all repositories that contain a README.md file.
+on:
+  - repositoriesMatchingQuery: file:README.md
+
+# In each repository, run this command. Each repository's resulting diff is captured.
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+
+# Transform the changes produced in each repository.
+transformChanges:
+  # Group the file diffs by directory and produce one additional changeset per group.
+  # Changes that haven't been grouped will be be in the standard changeset.
+  group:
+    - directory: client
+      branch: hello-world-client # will replace the `branch` in the `changesetTemplate`
+    - directory: docker-images
+      repository: github.com/sourcegraph/sourcegraph # Optional: only apply the rule in this repository
+      branch: hello-world-infra
+    - directory: monitoring
+      repository: github.com/sourcegraph/sourcegraph
+      branch: hello-world-monitoring
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Hello World
+  body: My first campaign!
+  branch: hello-world # This branch is the default branch and will be
+                      # overwritten for each additional changeset.
+  commit:
+    message: Append Hello World to all README.md files
+  published: false # Do not publish any changes to the code hosts yet
+```
+
+This campaign spec will produce up to 4 changesets in the `github.com/sourcegraph/sourcegraph` repository: one changeset with all the changes in the `client` directory, one changeset for the changes in `docker-images`, one changeset for changes in `monitoring`, and one changeset for the changes in the other directories.
+
+Since code hosts and git don't allow creating multiple, _different_ changesets on the same branch, we need to specify the `branch` that will be used for the additional changesets. That `branch` will overwrite the default branch specified in `changesetTemplate`.
+
+In case no changes have been made in a `directory` specified in a `group`, no additional changeset will be produced.
+
+If the optional `repository` property is specified only the changes in that repository will be grouped.

--- a/doc/campaigns/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/campaigns/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -6,16 +6,23 @@
 </style>
 
 <aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on. We're very much looking for feedback.
-<br />
-It's available in Sourcegraph 3.23 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23.0 and later.
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+<p><b>We're very much looking for input and feedback on this feature.</b></p>
+
+<p>It's available in Sourcegraph 3.23 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23.0 and later.</p>
 </aside>
 
-Campaigns can produce a lot of changes in a single repository and it might make sense to split up the changes into multiple changesets, so that each changeset can be reviewed and merged independently.
+## Overview
 
-By using [`transformChanges`](../references/campaign_spec_yaml_reference.md#transformchanges) in your campaign spec you can group the changes produced in one repository by directory and create a changeset for each group:
+Campaigns can produce a lot of changes in a single repository and in order to make reviewing and merging them easier, it might make sense to split the changes up into multiple changesets.
 
-The following campaign spec uses the `transformChanges` property to create multiple changesets in a single repository by grouping the changes made in different directories:
+That can be done by using [`transformChanges`](../references/campaign_spec_yaml_reference.md#transformchanges) in the campaign spec to group the changes produced in one single repository by directory and create a changeset for each group.
+
+## Using `transformChanges`
+
+The following campaign spec uses the `transformChanges` property to create up to 4 changesets in a single repository by grouping the changes made in different directories:
 
 ```yaml
 name: hello-world
@@ -55,10 +62,17 @@ changesetTemplate:
   published: false # Do not publish any changes to the code hosts yet
 ```
 
-This campaign spec will produce up to 4 changesets in the `github.com/sourcegraph/sourcegraph` repository: one changeset with all the changes in the `client` directory, one changeset for the changes in `docker-images`, one changeset for changes in `monitoring`, and one changeset for the changes in the other directories.
+This campaign spec will produce up to 4 changesets in the `github.com/sourcegraph/sourcegraph` repository:
 
-Since code hosts and git don't allow creating multiple, _different_ changesets on the same branch, we need to specify the `branch` that will be used for the additional changesets. That `branch` will overwrite the default branch specified in `changesetTemplate`.
+1. a changeset with the changes in the `client` directory
+1. a changeset with the changes in `docker-images`
+1. a changeset with the changes in `monitoring`
+1. a changeset with the changes in the other directories.
+
+Since code hosts and git don't allow creating multiple, _different_ changesets on the same branch, it is **required** to specify the `branch` that will be used for the additional changesets. That `branch` will overwrite the default branch specified in `changesetTemplate`.
 
 In case no changes have been made in a `directory` specified in a `group`, no additional changeset will be produced.
 
 If the optional `repository` property is specified only the changes in that repository will be grouped.
+
+See the [campaign spec YAML reference on `transformChanges`](../references/campaign_spec_yaml_reference.md#transformchanges) for more details.

--- a/doc/campaigns/how-tos/index.md
+++ b/doc/campaigns/how-tos/index.md
@@ -10,3 +10,4 @@ The following is a list of how-tos that show how to use [Sourcegraph campaigns](
 - [Closing or deleting a campaign](closing_or_deleting_a_campaign.md)
 - [Site admin configuration for campaigns](site_admin_configuration.md)
 - [Configuring user credentials for campaigns](configuring_user_credentials.md)
+- <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)

--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -87,6 +87,7 @@ Create a campaign by specifying a search query to get a list of repositories and
 - [Closing or deleting a campaign](how-tos/closing_or_deleting_a_campaign.md)
 - [Site admin configuration for campaigns](how-tos/site_admin_configuration.md)
 - [Configuring user credentials for campaigns](how-tos/configuring_user_credentials.md)
+- <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 
 ## Tutorials
 

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -514,9 +514,13 @@ A list of groups to define which file diffs to group together to create an addit
 
 The **order of the list matters**, since each file diff's filepath is matched against the `directory` of a group and the **last match** is used.
 
+If no changes have been produced in a `directory` then no changeset will be created.
+
 ## [`transformChanges.group.directory`](#transformchanges-group-directory)
 
 The name of the directory in which file diffs should be grouped together.
+
+The name is relative to the root of the repository.
 
 ## [`transformChanges.group.branch`](#transformchanges-group-branch)
 
@@ -526,4 +530,4 @@ The branch that should be used for this additional changeset. This **overwrites 
 
 ## [`transformChanges.group.repository`](#transformchanges-repository)
 
-Optional: the file diffs matching the given directory will only be grouped in a repository with that name configured on your Sourcegraph instance.
+Optional: the file diffs matching the given directory will only be grouped in a repository with that name, as configured on your Sourcegraph instance.


### PR DESCRIPTION
This is the follow-up to https://github.com/sourcegraph/sourcegraph/pull/16235 and adds a how-to for using `transformChanges` to create multiple changesets in a single repository.

Preview: https://docs.sourcegraph.com/@mrn-multi-changeset-how-to/campaigns/how-tos/creating_multiple_changesets_in_large_repositories