### PR TITLE
Update prometheus quay.io/prometheus/busybox-linux-amd64 image

### DIFF
--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -20,7 +20,7 @@ RUN ls '/generated/prometheus'
 
 # Prepare final image
 # hadolint ignore=DL3007
-FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:248b7ec76e03e6b4fbb796fc3cdd2f91dad45546a6d7dee61c322475e0e8a08f
+FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:fca3819d670cdaee0d785499fda202ea01c0640ca0803d26ae6dbf2a1c8c041c
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
Buildkite jobs are failing as the image does not exist anymore https://buildkite.com/sourcegraph/sourcegraph/builds/82511#83f36848-58fd-45b7-9e7b-b5d0e796f0ef
