### PR TITLE
Display branch name next to repository in changeset list

### DIFF
--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -145,7 +145,13 @@ const queryChangesets: typeof _queryChangesets = () =>
                 reconcilerState: ChangesetReconcilerState.COMPLETED,
                 publicationState: ChangesetPublicationState.PUBLISHED,
                 error: null,
-                currentSpec: { id: 'spec-rand-id-1' },
+                currentSpec: {
+                    id: 'spec-rand-id-1',
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        headRef: 'my-branch',
+                    },
+                },
             },
             {
                 __typename: 'ExternalChangeset',
@@ -174,7 +180,13 @@ const queryChangesets: typeof _queryChangesets = () =>
                 reconcilerState: ChangesetReconcilerState.ERRORED,
                 publicationState: ChangesetPublicationState.UNPUBLISHED,
                 error: 'Cannot create PR, insufficient token scope.',
-                currentSpec: { id: 'spec-rand-id-2' },
+                currentSpec: {
+                    id: 'spec-rand-id-2',
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        headRef: 'my-branch',
+                    },
+                },
             },
         ],
     })

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -146,7 +146,13 @@ const queryChangesets: typeof _queryChangesets = () =>
                 reconcilerState: ChangesetReconcilerState.COMPLETED,
                 publicationState: ChangesetPublicationState.PUBLISHED,
                 error: null,
-                currentSpec: { id: 'spec-rand-id-1' },
+                currentSpec: {
+                    id: 'spec-rand-id-1',
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        headRef: 'my-branch',
+                    },
+                },
             },
             {
                 __typename: 'ExternalChangeset',
@@ -175,7 +181,13 @@ const queryChangesets: typeof _queryChangesets = () =>
                 reconcilerState: ChangesetReconcilerState.ERRORED,
                 publicationState: ChangesetPublicationState.UNPUBLISHED,
                 error: 'Cannot create PR, insufficient token scope.',
-                currentSpec: { id: 'spec-rand-id-2' },
+                currentSpec: {
+                    id: 'spec-rand-id-2',
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        headRef: 'my-branch',
+                    },
+                },
             },
         ],
     })

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -156,6 +156,12 @@ export const externalChangesetFieldsFragment = gql`
         nextSyncAt
         currentSpec {
             id
+            description {
+                __typename
+                ... on GitBranchChangesetDescription {
+                    headRef
+                }
+            }
         }
     }
 

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.story.tsx
@@ -51,7 +51,13 @@ const nodes: ChangesetFields[] = [
             },
             reviewState: ChangesetReviewState.COMMENTED,
             error: null,
-            currentSpec: { id: 'spec-rand-id-1' },
+            currentSpec: {
+                id: 'spec-rand-id-1',
+                description: {
+                    __typename: 'GitBranchChangesetDescription',
+                    headRef: 'my-branch',
+                },
+            },
         })
     ),
     ...Object.values(ChangesetExternalState).map(

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -72,7 +72,7 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                 </Link>{' '}
                 {!isImporting(node) && (
                     <div className="d-block d-sm-inline-block">
-                        <span className="badge badge-primary">{headReference(node)}</span>
+                        <span className="badge badge-secondary text-monospace">{headReference(node)}</span>
                     </div>
                 )}
             </span>

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -88,8 +88,12 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
 function isImporting(node: ExternalChangesetFields): boolean {
     return (
         [ChangesetReconcilerState.QUEUED, ChangesetReconcilerState.PROCESSING].includes(node.reconcilerState) &&
-        !node.title
+        !hasHeadReference(node)
     )
+}
+
+function importingFailed(node: ExternalChangesetFields): boolean {
+    return !hasHeadReference(node) && node.reconcilerState === ChangesetReconcilerState.ERRORED
 }
 
 function headReference(node: ExternalChangesetFields): string | undefined {
@@ -105,8 +109,4 @@ function hasHeadReference(
     currentSpec: ChangesetSpecFields & { description: GitBranchChangesetDescriptionFields }
 } {
     return node.currentSpec?.description.__typename === 'GitBranchChangesetDescription'
-}
-
-function importingFailed(node: ExternalChangesetFields): boolean {
-    return node.reconcilerState === ChangesetReconcilerState.ERRORED && !node.title
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -69,7 +69,12 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
             <span className="mr-2 d-block d-mdinline-block">
                 <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
                     {node.repository.name}
-                </Link>
+                </Link>{' '}
+                {!isImporting(node) && (
+                    <div className="d-block d-sm-inline-block">
+                        <span className="badge badge-primary">{headReference(node)}</span>
+                    </div>
+                )}
             </span>
             {node.publicationState === ChangesetPublicationState.PUBLISHED && (
                 <ChangesetLastSynced changeset={node} viewerCanAdminister={viewerCanAdminister} />
@@ -83,6 +88,13 @@ function isImporting(node: ExternalChangesetFields): boolean {
         [ChangesetReconcilerState.QUEUED, ChangesetReconcilerState.PROCESSING].includes(node.reconcilerState) &&
         !node.title
     )
+}
+
+function headReference(node: ExternalChangesetFields): string | undefined {
+    if (!isImporting(node) && node.currentSpec?.description.__typename === 'GitBranchChangesetDescription') {
+        return node.currentSpec?.description.headRef
+    }
+    return undefined
 }
 
 function importingFailed(node: ExternalChangesetFields): boolean {

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -3,6 +3,8 @@ import {
     ExternalChangesetFields,
     ChangesetExternalState,
     ChangesetPublicationState,
+    ChangesetSpecFields,
+    GitBranchChangesetDescriptionFields,
 } from '../../../../graphql-operations'
 import { LinkOrSpan } from '../../../../../../shared/src/components/LinkOrSpan'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
@@ -70,7 +72,7 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                 <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
                     {node.repository.name}
                 </Link>{' '}
-                {!isImporting(node) && (
+                {hasHeadReference(node) && (
                     <div className="d-block d-sm-inline-block">
                         <span className="badge badge-secondary text-monospace">{headReference(node)}</span>
                     </div>
@@ -91,10 +93,18 @@ function isImporting(node: ExternalChangesetFields): boolean {
 }
 
 function headReference(node: ExternalChangesetFields): string | undefined {
-    if (!isImporting(node) && node.currentSpec?.description.__typename === 'GitBranchChangesetDescription') {
+    if (hasHeadReference(node)) {
         return node.currentSpec?.description.headRef
     }
     return undefined
+}
+
+function hasHeadReference(
+    node: ExternalChangesetFields
+): node is ExternalChangesetFields & {
+    currentSpec: ChangesetSpecFields & { description: GitBranchChangesetDescriptionFields }
+} {
+    return node.currentSpec?.description.__typename === 'GitBranchChangesetDescription'
 }
 
 function importingFailed(node: ExternalChangesetFields): boolean {

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.story.tsx
@@ -56,7 +56,13 @@ add('All external states', () => {
                                     url: 'http://test.test/sourcegraph/sourcegraph',
                                 },
                                 reviewState: ChangesetReviewState.COMMENTED,
-                                currentSpec: { id: 'spec-rand-id-1' },
+                                currentSpec: {
+                                    id: 'spec-rand-id-1',
+                                    description: {
+                                        __typename: 'GitBranchChangesetDescription',
+                                        headRef: 'my-branch',
+                                    },
+                                },
                             }}
                             viewerCanAdminister={boolean('viewerCanAdminister', true)}
                             queryExternalChangesetWithFileDiffs={() =>
@@ -116,7 +122,13 @@ add('Unpublished', () => {
                             url: 'http://test.test/sourcegraph/sourcegraph',
                         },
                         reviewState: null,
-                        currentSpec: { id: 'spec-rand-id-1' },
+                        currentSpec: {
+                            id: 'spec-rand-id-1',
+                            description: {
+                                __typename: 'GitBranchChangesetDescription',
+                                headRef: 'my-branch',
+                            },
+                        },
                     }}
                     viewerCanAdminister={boolean('viewerCanAdminister', true)}
                     queryExternalChangesetWithFileDiffs={() =>

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -203,7 +203,13 @@ const CampaignChangesets: (variables: CampaignChangesetsVariables) => CampaignCh
                     },
                     reviewState: ChangesetReviewState.APPROVED,
                     title: 'The changeset title',
-                    currentSpec: { id: 'spec-rand-id-1' },
+                    currentSpec: {
+                        id: 'spec-rand-id-1',
+                        description: {
+                            __typename: 'GitBranchChangesetDescription',
+                            headRef: 'my-branch',
+                        },
+                    },
                 },
             ],
         },


### PR DESCRIPTION
After adding `transformChanges` in https://github.com/sourcegraph/sourcegraph/pull/16235 it's now possible for multiple changesets to be in the same repository, with _different branches_ but the same repository/title, etc.

Problem: without displaying the branch, all changesets in one repository look the same in the list (except for the diffstat).

So I added the branch name next to the changeset. It looks like this:

<img width="1179" alt="screenshot_2020-12-11_15 02 21@2x" src="https://user-images.githubusercontent.com/1185253/101912558-34c5bb00-3bc2-11eb-89ad-f8e9942a2714.png">

It solves the problem, but I'm not 100% whether this couldn't be better.

Multiple other options I had in mind:
1. Only display the branch name if it differs from `changesetTemplate.branch`. Problems with that: it might draw unjustified attention to these "special cases" and it will break if we, in the future, allow changing `changesetTemplate.branch` per repository.
2. Display base branch and head branch. That's what we do on the preview page but it becomes noisy pretty fast and doesn't add a lot of value.
3. I also changed the badge color from `badge-primary` to `badge-secondary` because with primary everything looked really, really overloaded.

@rrhyne what do you think?