### PR TITLE
search: include sample of skipped repos in message

### DIFF
--- a/cmd/frontend/graphqlbackend/search_progress.go
+++ b/cmd/frontend/graphqlbackend/search_progress.go
@@ -74,7 +74,7 @@ func repositoryMissingHandler(resultsResolver *SearchResultsResolver) (search.Sk
 func shardTimeoutHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
 	// This is not the same, but once we expose this more granular details
 	// from our backend it will be shard specific.
-	return skippedReposHandler(resultsResolver.Timedout(), "timedout", "could not be searched in time", search.Skipped{
+	return skippedReposHandler(resultsResolver.Timedout(), "timed out", "could not be searched in time", search.Skipped{
 		Reason:   search.ShardTimeout,
 		Severity: search.SeverityWarn,
 	})

--- a/cmd/frontend/graphqlbackend/search_progress.go
+++ b/cmd/frontend/graphqlbackend/search_progress.go
@@ -24,54 +24,41 @@ func plural(one, many string, n int) string {
 	return many
 }
 
-func repositoryCloningHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
-	repos := resultsResolver.Cloning()
+func skippedReposHandler(repos []*RepositoryResolver, titleVerb, messageReason string, base search.Skipped) (search.Skipped, bool) {
 	if len(repos) == 0 {
 		return search.Skipped{}, false
 	}
 
 	amount := number(len(repos))
-	return search.Skipped{
-		Reason: search.RepositoryCloning,
-		Title:  fmt.Sprintf("%s cloning", amount),
-		// TODO sample of repos in message
-		Message:  fmt.Sprintf("%s %s could not be searched since %s still cloning. Try searching again or reducing the scope of your query with `repo:`,  `repogroup:` or other filters.", amount, plural("repository", "repositories", len(repos)), plural("it is", "they are", len(repos))),
+	base.Title = fmt.Sprintf("%s %s", amount, titleVerb)
+	// TODO sample of repos in message
+	base.Message = fmt.Sprintf("%s %s %s. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.", amount, plural("repository", "repositories", len(repos)), messageReason)
+	return base, true
+}
+
+func repositoryCloningHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
+	repos := resultsResolver.Cloning()
+	messageReason := fmt.Sprintf("could not be searched since %s still cloning", plural("it is", "they are", len(repos)))
+	return skippedReposHandler(repos, "cloning", messageReason, search.Skipped{
+		Reason:   search.RepositoryCloning,
 		Severity: search.SeverityInfo,
-	}, true
+	})
 }
 
 func repositoryMissingHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
-	repos := resultsResolver.Missing()
-	if len(repos) == 0 {
-		return search.Skipped{}, false
-	}
-
-	amount := number(len(repos))
-	return search.Skipped{
-		Reason: search.RepositoryMissing,
-		Title:  fmt.Sprintf("%s missing", amount),
-		// TODO sample of repos in message
-		Message:  fmt.Sprintf("%s %s could not be searched. Try reducing the scope of your query with `repo:`, `repogroup:` or other filters.", amount, plural("repository", "repositories", len(repos))),
+	return skippedReposHandler(resultsResolver.Missing(), "missing", "could not be searched", search.Skipped{
+		Reason:   search.RepositoryMissing,
 		Severity: search.SeverityInfo,
-	}, true
+	})
 }
 
 func shardTimeoutHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
 	// This is not the same, but once we expose this more granular details
 	// from our backend it will be shard specific.
-	repos := resultsResolver.Timedout()
-	if len(repos) == 0 {
-		return search.Skipped{}, false
-	}
-
-	amount := number(len(repos))
-	return search.Skipped{
-		Reason: search.ShardTimeout,
-		Title:  fmt.Sprintf("%s timedout", amount),
-		// TODO sample of repos in message
-		Message:  fmt.Sprintf("%s %s could not be searched in time. Try reducing the scope of your query with `repo:`, `repogroup:` or other filters.", amount, plural("repository", "repositories", len(repos))),
+	return skippedReposHandler(resultsResolver.Timedout(), "timedout", "could not be searched in time", search.Skipped{
+		Reason:   search.ShardTimeout,
 		Severity: search.SeverityWarn,
-	}, true
+	})
 }
 
 func shardMatchLimitHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {

--- a/cmd/frontend/graphqlbackend/search_progress_test.go
+++ b/cmd/frontend/graphqlbackend/search_progress_test.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"flag"
+	"fmt"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -11,8 +12,18 @@ import (
 var updateGolden = flag.Bool("update", false, "Update testdata goldens")
 
 func TestSearchProgress(t *testing.T) {
+	var timedout100 []*types.Repo
+	for i := 0; i < 100; i++ {
+		timedout100 = append(timedout100, mkRepos(fmt.Sprintf("timedout-%d", i))...)
+	}
+
 	cases := map[string]*SearchResultsResolver{
 		"empty": {},
+		"timedout100": {
+			searchResultsCommon: searchResultsCommon{
+				timedout: timedout100,
+			},
+		},
 		"all": {
 			SearchResults: []SearchResultResolver{mkFileMatch(&types.Repo{Name: "found-1"}, "dir/file", 123)},
 			searchResultsCommon: searchResultsCommon{

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
@@ -24,7 +24,7 @@
    },
    {
     "reason": "shard-timeout",
-    "title": "1 timedout",
+    "title": "1 timed out",
     "message": "`timedout-1` could not be searched in time. Try searching again or reducing the scope of your query with `repo:`,  `repogroup:` or other filters.",
     "severity": "warn"
    },

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
@@ -7,13 +7,13 @@
    {
     "reason": "repository-missing",
     "title": "1 missing",
-    "message": "1 repository could not be searched. Try reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
+    "message": "1 repository could not be searched. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
     "severity": "info"
    },
    {
     "reason": "repository-cloning",
     "title": "1 cloning",
-    "message": "1 repository could not be searched since it is still cloning. Try searching again or reducing the scope of your query with `repo:`,  `repogroup:` or other filters.",
+    "message": "1 repository could not be searched since it is still cloning. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
     "severity": "info"
    },
    {
@@ -25,7 +25,7 @@
    {
     "reason": "shard-timeout",
     "title": "1 timedout",
-    "message": "1 repository could not be searched in time. Try reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
+    "message": "1 repository could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
     "severity": "warn"
    },
    {

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
@@ -6,14 +6,14 @@
   "skipped": [
    {
     "reason": "repository-missing",
-    "title": "1 missing",
-    "message": "1 repository could not be searched. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
+    "title": "2 missing",
+    "message": "2 repositories could not be searched. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `missing-2`\n* `missing-1`",
     "severity": "info"
    },
    {
     "reason": "repository-cloning",
     "title": "1 cloning",
-    "message": "1 repository could not be searched since it is still cloning. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
+    "message": "`cloning-1` could not be searched since it is still cloning. Try searching again or reducing the scope of your query with `repo:`,  `repogroup:` or other filters.",
     "severity": "info"
    },
    {
@@ -25,7 +25,7 @@
    {
     "reason": "shard-timeout",
     "title": "1 timedout",
-    "message": "1 repository could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.",
+    "message": "`timedout-1` could not be searched in time. Try searching again or reducing the scope of your query with `repo:`,  `repogroup:` or other filters.",
     "severity": "warn"
    },
    {

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/timedout100.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/timedout100.json
@@ -6,7 +6,7 @@
   "skipped": [
    {
     "reason": "shard-timeout",
-    "title": "100 timedout",
+    "title": "100 timed out",
     "message": "100 repositories could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `timedout-60`\n* `timedout-48`\n* `timedout-46`\n* `timedout-89`\n* `timedout-10`\n* `timedout-17`\n* `timedout-71`\n* `timedout-8`\n* `timedout-92`\n* `timedout-81`\n* ...",
     "severity": "warn"
    }

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/timedout100.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/timedout100.json
@@ -1,0 +1,14 @@
+{
+  "done": false,
+  "repositoriesCount": 0,
+  "matchCount": 0,
+  "durationMs": 0,
+  "skipped": [
+   {
+    "reason": "shard-timeout",
+    "title": "100 timedout",
+    "message": "100 repositories could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `timedout-60`\n* `timedout-48`\n* `timedout-46`\n* `timedout-89`\n* `timedout-10`\n* `timedout-17`\n* `timedout-71`\n* `timedout-8`\n* `timedout-92`\n* `timedout-81`\n* ...",
+    "severity": "warn"
+   }
+  ]
+ }

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/binary"
 	"reflect"
 	"sort"
 	"strings"
@@ -229,7 +231,9 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 func mkRepos(names ...string) []*types.Repo {
 	var repos []*types.Repo
 	for _, name := range names {
-		repos = append(repos, &types.Repo{Name: api.RepoName(name)})
+		sum := md5.Sum([]byte(name))
+		id := api.RepoID(binary.BigEndian.Uint64(sum[:]))
+		repos = append(repos, &types.Repo{ID: id, Name: api.RepoName(name)})
 	}
 	return repos
 }
@@ -253,7 +257,7 @@ func TestLimitSearcherRepos(t *testing.T) {
 				continue
 			}
 			result = append(result, &search.RepositoryRevisions{
-				Repo: &types.Repo{Name: api.RepoName(repo)},
+				Repo: mkRepos(repo)[0],
 				Revs: []search.RevisionSpecifier{{RevSpec: rev}},
 			})
 		}


### PR DESCRIPTION
This is to improve the skipped messages. We include a sample of the repositories skipped in the message. If there is only 1 skipped repository, we more prominently show its name.

To achieve this change we did some refactoring since there is a lot of commonality between the skipped handlers involving repos. You can review this commit by commit.