### PR TITLE
graphqlbackend: downgrade syncExternalService background log to warn

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -245,7 +245,7 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *deleteEx
 	// service, so kick off in the background.
 	go func() {
 		if err := syncExternalService(context.Background(), es); err != nil {
-			log15.Error("Performing final sync after external service deletion", "err", err)
+			log15.Warn("Performing final sync after external service deletion", "err", err)
 		}
 	}()
 


### PR DESCRIPTION
It fails in tests so it shows up in the logs. Given this isn't worthy of
error level, the easiest fix is to just downgrade it to warning.