### PR TITLE
executor: Fix too many open files

### DIFF
--- a/enterprise/internal/apiworker/command/run.go
+++ b/enterprise/internal/apiworker/command/run.go
@@ -131,10 +131,9 @@ func monitorCommand(cmd *exec.Cmd, pipeReaderWaitGroup *sync.WaitGroup) (int, er
 
 	pipeReaderWaitGroup.Wait()
 
-	state, err := cmd.Process.Wait()
-	if err != nil {
+	if err := cmd.Wait(); err != nil {
 		return 0, err
 	}
 
-	return state.ExitCode(), nil
+	return cmd.ProcessState.ExitCode(), nil
 }


### PR DESCRIPTION
It is necessary to call `cmd.Wait` to release pipe resources used internally by stdout/err reader goroutines.