### PR TITLE
search backend: support all search results in sort comparator

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -282,10 +282,6 @@ func (r *RepositoryResolver) ToCommitSearchResult() (*CommitSearchResultResolver
 	return nil, false
 }
 
-func (r *RepositoryResolver) searchResultURIs() (string, string) {
-	return string(r.repo.Name), ""
-}
-
 func (r *RepositoryResolver) resultCount() int32 {
 	return 1
 }

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -70,12 +70,6 @@ func (r *CommitSearchResultResolver) ToCommitSearchResult() (*CommitSearchResult
 	return r, true
 }
 
-func (r *CommitSearchResultResolver) searchResultURIs() (string, string) {
-	// Diffs aren't going to be returned with other types of results
-	// and are already ordered in the desired order, so we'll just leave them in place.
-	return "~", "~" // lexicographically last in ASCII
-}
-
 func (r *CommitSearchResultResolver) resultCount() int32 {
 	return 1
 }

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -343,7 +343,7 @@ func repoOfResult(result SearchResultResolver) string {
 		return "~" // lexicographically last.
 	}
 	// Unreachable.
-	return ""
+	panic("unreachable: repoOfResult expects RepositoryResolver, FileMatchResolver, or CommitSearchResultResolver")
 }
 
 // execute executes the repository pagination plan by invoking the executor to

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -328,6 +328,24 @@ type repoPaginationPlan struct {
 // returned.
 type executor func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *searchResultsCommon, error)
 
+// repoOfResult is a helper function to resolve the repo associated with a result type.
+func repoOfResult(result SearchResultResolver) string {
+	switch r := result.(type) {
+	case *RepositoryResolver:
+		return string(r.repo.Name)
+	case *FileMatchResolver:
+		return r.Repo.Name()
+	case *CommitSearchResultResolver:
+		// Pagination does not support commit searches at the
+		// moment. Ideally we want to return the repo associated
+		// with a commit, but the commit result type does not
+		// clearly expose the repo it is associated with.
+		return "~" // lexicographically last.
+	}
+	// Unreachable.
+	return ""
+}
+
 // execute executes the repository pagination plan by invoking the executor to
 // search batches of repositories.
 //
@@ -390,7 +408,7 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 
 	if len(sliced.results) > 0 {
 		// First, identify what repository corresponds to the last result.
-		lastRepoConsumedName, _ := sliced.results[len(sliced.results)-1].searchResultURIs()
+		lastRepoConsumedName := repoOfResult(sliced.results[len(sliced.results)-1])
 		var lastRepoConsumed *types.Repo
 		for _, repo := range p.repositories {
 			if string(repo.Repo.Name) == lastRepoConsumedName {
@@ -454,7 +472,7 @@ type slicedSearchResults struct {
 func sliceSearchResults(results []SearchResultResolver, common *searchResultsCommon, offset, limit int) (final slicedSearchResults) {
 	firstRepo := ""
 	if len(results[:offset]) > 0 {
-		firstRepo, _ = results[offset].searchResultURIs()
+		firstRepo = repoOfResult(results[offset])
 	}
 	// First we handle the case of having few enough results that we do not
 	// need to slice anything.
@@ -462,7 +480,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 		results = results[offset:]
 		final.results = results
 		if len(final.results) > 0 {
-			lastResultRepo, _ := final.results[len(final.results)-1].searchResultURIs()
+			lastResultRepo := repoOfResult(final.results[len(final.results)-1])
 			final.common = sliceSearchResultsCommon(common, firstRepo, lastResultRepo)
 		} else {
 			final.common = sliceSearchResultsCommon(common, firstRepo, "")
@@ -481,8 +499,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 	}
 	resultsByRepo := map[*types.Repo][]SearchResultResolver{}
 	for _, r := range results[:limit] {
-		repoName, _ := r.searchResultURIs()
-		repo := reposByName[repoName]
+		repo := reposByName[repoOfResult(r)]
 		resultsByRepo[repo] = append(resultsByRepo[repo], r)
 	}
 
@@ -498,7 +515,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 	// resume fetching results starting at b3.
 	var lastResultRepo string
 	for _, r := range originalResults[:offset+limit] {
-		repo, _ := r.searchResultURIs()
+		repo := repoOfResult(r)
 		if repo != lastResultRepo {
 			final.resultOffset = 0
 		} else {
@@ -506,7 +523,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 		}
 		lastResultRepo = repo
 	}
-	nextRepo, _ := results[limit].searchResultURIs()
+	nextRepo := repoOfResult(results[limit])
 	if nextRepo != lastResultRepo {
 		final.resultOffset = 0
 	} else {
@@ -519,7 +536,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 	finalResults := make([]SearchResultResolver, 0, limit)
 	finalResultCount := int32(0)
 	for _, r := range results[:limit] {
-		repoName, _ := r.searchResultURIs()
+		repoName := repoOfResult(r)
 		if _, ok := seenRepos[repoName]; ok {
 			continue
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -2068,12 +2068,18 @@ func compareFileLengths(left, right string, exactFilePatterns map[string]struct{
 
 func compareDates(left, right *time.Time) bool {
 	if left == nil || right == nil {
-		return false
+		return left != nil // Place the value that is defined first.
 	}
 	return (*left).After(*right)
 }
 
-// FIXME
+// compareSearchResults sorts repository matches, file matches, and commits.
+// Repositories and filenames are sorted alphabetically. As a refinement, if any
+// filename matches a value in a non-empty set exactFilePatterns, then such
+// filenames are listed earlier.
+//
+// Commits are sorted by date. Commits are not associated with repositories, and
+// will always list after repository or file match results, if any.
 func compareSearchResults(left, right SearchResultResolver, exactFilePatterns map[string]struct{}) bool {
 	sortKeys := func(result SearchResultResolver) (string, string, *time.Time) {
 		switch r := result.(type) {
@@ -2088,7 +2094,7 @@ func compareSearchResults(left, right SearchResultResolver, exactFilePatterns ma
 			return "~", "~", &r.commit.commit.Author.Date
 		}
 		// Unreachable.
-		return "", "", nil
+		panic("unreachable: compareSearchResults expects RepositoryResolver, FileMatchResolver, or CommitSearchResultResolver")
 	}
 
 	arepo, afile, adate := sortKeys(left)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -2040,8 +2040,6 @@ func isContextError(ctx context.Context, err error) bool {
 //
 // Note: Any new result types added here also need to be handled properly in search_results.go:301 (sparklines)
 type SearchResultResolver interface {
-	searchResultURIGetter
-
 	ToRepository() (*RepositoryResolver, bool)
 	ToFileMatch() (*FileMatchResolver, bool)
 	ToCommitSearchResult() (*CommitSearchResultResolver, bool)
@@ -2049,35 +2047,61 @@ type SearchResultResolver interface {
 	resultCount() int32
 }
 
-type searchResultURIGetter interface {
-	// SearchResultURIs returns the repo name and file uri respectively
-	searchResultURIs() (string, string)
+// compareFileLengths sorts file paths such that they appear earlier if they
+// match file: patterns in the query exactly.
+func compareFileLengths(left, right string, exactFilePatterns map[string]struct{}) bool {
+	_, aMatch := exactFilePatterns[path.Base(left)]
+	_, bMatch := exactFilePatterns[path.Base(right)]
+	if aMatch || bMatch {
+		if aMatch && bMatch {
+			// Prefer shorter file names (ie root files come first)
+			if len(left) != len(right) {
+				return len(left) < len(right)
+			}
+			return left < right
+		}
+		// Prefer exact match
+		return aMatch
+	}
+	return left < right
 }
 
-// compareSearchResults sorts alphabetically unless one of the filenames is contained in exactFilePatterns,
-// in which case exact matches are sorted by length of their file path and then alphabetically.
-func compareSearchResults(a, b searchResultURIGetter, exactFilePatterns map[string]struct{}) bool {
-	arepo, afile := a.searchResultURIs()
-	brepo, bfile := b.searchResultURIs()
+func compareDates(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return (*left).After(*right)
+}
+
+// FIXME
+func compareSearchResults(left, right SearchResultResolver, exactFilePatterns map[string]struct{}) bool {
+	sortKeys := func(result SearchResultResolver) (string, string, *time.Time) {
+		switch r := result.(type) {
+		case *RepositoryResolver:
+			return string(r.repo.Name), "", nil
+		case *FileMatchResolver:
+			return r.Repo.Name(), r.JPath, nil
+		case *CommitSearchResultResolver:
+			// Commits are relatively sorted by date, and after repo
+			// or path names. We use ~ as the key for repo and
+			// paths,lexicographically last in ASCII.
+			return "~", "~", &r.commit.commit.Author.Date
+		}
+		// Unreachable.
+		return "", "", nil
+	}
+
+	arepo, afile, adate := sortKeys(left)
+	brepo, bfile, bdate := sortKeys(right)
 
 	if arepo == brepo {
 		if len(exactFilePatterns) == 0 {
-			return afile < bfile
-		}
-		_, aMatch := exactFilePatterns[path.Base(afile)]
-		_, bMatch := exactFilePatterns[path.Base(bfile)]
-		if aMatch || bMatch {
-			if aMatch && bMatch {
-				// Prefer shorter file names (ie root files come first)
-				if len(afile) != len(bfile) {
-					return len(afile) < len(bfile)
-				}
+			if afile != bfile {
 				return afile < bfile
 			}
-			// prefer exact match
-			return aMatch
+			return compareDates(adate, bdate)
 		}
-		return afile < bfile
+		return compareFileLengths(afile, bfile, exactFilePatterns)
 	}
 	return arepo < brepo
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1246,125 +1246,123 @@ func TestGetExactFilePatterns(t *testing.T) {
 	}
 }
 
-type mockSearchResultURIGetter struct {
-	repo string
-	file string
-}
-
-func (m mockSearchResultURIGetter) searchResultURIs() (string, string) {
-	return m.repo, m.file
-}
-
 func TestCompareSearchResults(t *testing.T) {
+	makeResult := func(repo, file string) *FileMatchResolver {
+		return &FileMatchResolver{
+			Repo:  &RepositoryResolver{repo: &types.Repo{Name: api.RepoName(repo)}},
+			JPath: file,
+		}
+	}
+
 	tests := []struct {
 		name              string
-		a                 searchResultURIGetter
-		b                 searchResultURIGetter
+		a                 *FileMatchResolver
+		b                 *FileMatchResolver
 		exactFilePatterns map[string]struct{}
 		aIsLess           bool
 	}{
 		{
 			name:              "prefer exact match",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
+			a:                 makeResult("arepo", "afile"),
+			b:                 makeResult("arepo", "file"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           false,
 		},
 		{
 			name:              "reverse a and b",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
+			a:                 makeResult("arepo", "file"),
+			b:                 makeResult("arepo", "afile"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           true,
 		},
 		{
 			name:              "alphabetical order if exactFilePatterns is empty",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
+			a:                 makeResult("arepo", "afile"),
+			b:                 makeResult("arepo", "file"),
 			exactFilePatterns: map[string]struct{}{},
 			aIsLess:           true,
 		},
 		{
 			name:              "alphabetical order if exactFilePatterns is nil",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "bfile"},
+			a:                 makeResult("arepo", "afile"),
+			b:                 makeResult("arepo", "bfile"),
 			exactFilePatterns: nil,
 			aIsLess:           true,
 		},
 		{
 			name:              "same length, different files",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "bfile"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
+			a:                 makeResult("arepo", "bfile"),
+			b:                 makeResult("arepo", "afile"),
 			exactFilePatterns: nil,
 			aIsLess:           false,
 		},
 		{
 			name:              "exact matches with different length",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "adir1/file"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "dir1/file"},
+			a:                 makeResult("arepo", "adir1/file"),
+			b:                 makeResult("arepo", "dir1/file"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           false,
 		},
 		{
 			name:              "exact matches with same length",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "dir2/file"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "dir1/file"},
+			a:                 makeResult("arepo", "dir2/file"),
+			b:                 makeResult("arepo", "dir1/file"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           false,
 		},
 		{
 			name:              "no match",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "afile"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: "bfile"},
+			a:                 makeResult("arepo", "afile"),
+			b:                 makeResult("arepo", "bfile"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           true,
 		},
 		{
 			name:              "different repo, 1 exact match",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
-			b:                 mockSearchResultURIGetter{repo: "brepo", file: "afile"},
+			a:                 makeResult("arepo", "file"),
+			b:                 makeResult("brepo", "afile"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           true,
 		},
 		{
 			name:              "different repo, no exact patterns",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
-			b:                 mockSearchResultURIGetter{repo: "brepo", file: "afile"},
+			a:                 makeResult("arepo", "file"),
+			b:                 makeResult("brepo", "afile"),
 			exactFilePatterns: nil,
 			aIsLess:           true,
 		},
 		{
 			name:              "different repo, 2 exact matches",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
-			b:                 mockSearchResultURIGetter{repo: "brepo", file: "file"},
+			a:                 makeResult("arepo", "file"),
+			b:                 makeResult("brepo", "file"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           true,
 		},
 		{
 			name:              "repo matches only",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: ""},
-			b:                 mockSearchResultURIGetter{repo: "brepo", file: ""},
+			a:                 makeResult("arepo", ""),
+			b:                 makeResult("brepo", ""),
 			exactFilePatterns: nil,
 			aIsLess:           true,
 		},
 		{
 			name:              "repo match and file match, same repo",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: "file"},
-			b:                 mockSearchResultURIGetter{repo: "arepo", file: ""},
+			a:                 makeResult("arepo", "file"),
+			b:                 makeResult("arepo", ""),
 			exactFilePatterns: nil,
 			aIsLess:           false,
 		},
 		{
 			name:              "repo match and file match, different repos",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: ""},
-			b:                 mockSearchResultURIGetter{repo: "brepo", file: "file"},
+			a:                 makeResult("arepo", ""),
+			b:                 makeResult("brepo", "file"),
 			exactFilePatterns: nil,
 			aIsLess:           true,
 		},
 		{
 			name:              "prefer repo matches",
-			a:                 mockSearchResultURIGetter{repo: "arepo", file: ""},
-			b:                 mockSearchResultURIGetter{repo: "brepo", file: "file"},
+			a:                 makeResult("arepo", ""),
+			b:                 makeResult("brepo", "file"),
 			exactFilePatterns: map[string]struct{}{"file": {}},
 			aIsLess:           true,
 		},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -130,10 +130,6 @@ func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
 	fm.JLimitHit = fm.JLimitHit || src.JLimitHit
 }
 
-func (fm *FileMatchResolver) searchResultURIs() (string, string) {
-	return fm.Repo.Name(), fm.JPath
-}
-
 func (fm *FileMatchResolver) resultCount() int32 {
 	rc := len(fm.symbols) + fm.MatchCount
 	if rc > 0 {


### PR DESCRIPTION
Fixes #16642. 

I wanted a function that would (at least) sort commit results part of a search expressions like `(type:commit thing) or (type:commit other-thing)` but compatible with type `SearchResultResolver`. I added changes in #16642 because it was frustrating/time-consuming to work this into `compareSearchResults`. Well, now I did this more time-consuming work to try clean things up. Changes:

This type/interface was used for two separate purposes:

```go
type searchResultURIGetter interface {
	// SearchResultURIs returns the repo name and file uri respectively
	searchResultURIs() (string, string)
}
```

First: keys for sorting, while ignoring commit results in the overall sort function
Second: resolving the repo URI for repo and file matches in pagination (and subsequently only caring about the first value of what the function returned, not the second).

This is ugly. I removed this type and (1) inlined a small function to extract the keys for sorting in the sorting context, and (2) added a helper function for pagination to use that only returns the repo name it actually cares about (with an explicit branch for commit search when we can support that).

I feel this is objectively better than spreading this small utility interface across 3 files, with a layer of indirection, and ad-hoc usage (e.g., ignore commits for sorting or file path values in pagination) in the two different contexts.



