### PR TITLE
search backend: remove no-op for repo result merges

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -757,7 +757,6 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 				count++
 				continue
 			}
-
 			// merge line matches with a file match that already exists.
 			rightFileMatch.appendMatches(leftFileMatch)
 			rightFileMatches[leftFileMatch.uri] = rightFileMatch
@@ -770,10 +769,7 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 				// no overlap with existing matches.
 				merged = append(merged, leftMatch)
 				count++
-				continue
 			}
-
-			rightRepoMatches[string(leftRepoMatch.URL())] = rightRepoMatch
 			continue
 		}
 


### PR DESCRIPTION
Stacked on #16641.

Removes a redundant operation when merging repo results. See inline comment.