### PR TITLE
search frontend: add regexp query intel to structural holes

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -770,11 +770,96 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 7,
-                "scopes": "metaStructuralHole"
+                "scopes": "metaStructuralRegexpHole"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaStructuralVariable"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "metaStructuralRegexpSeparator"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "metaRegexpCharacterClass"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "metaRegexpEscapedCharacter"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "metaRegexpCharacterClass"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "metaStructuralRegexpHole"
               },
               {
                 "startIndex": 16,
                 "scopes": "identifier"
+              }
+            ]
+        `)
+    })
+
+    test('decorate structural holes with valid inlined regexp, no variable', () => {
+        expect(
+            getMonacoTokens(toSuccess(scanSearchQuery('repo:foo :[~a?|b*]', false, SearchPatternType.structural)), true)
+        ).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaStructuralRegexpHole"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "metaStructuralVariable"
+              },
+              {
+                "startIndex": 11,
+                "scopes": "metaStructuralRegexpSeparator"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaRegexpRangeQuantifier"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "metaRegexpAlternative"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "metaRegexpRangeQuantifier"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "metaStructuralRegexpHole"
               }
             ]
         `)

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -52,6 +52,9 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'metaRegexpAlternative', foreground: '#3bc9db' },
         // Structural pattern highlighting
         { token: 'metaStructuralHole', foreground: '#ff6b6b' },
+        { token: 'metaStructuralRegexpHole', foreground: '#ff6b6b' },
+        { token: 'metaStructuralVariable', foreground: '#f2f4f8' },
+        { token: 'metaStructuralRegexpSeparator', foreground: '#ffa94d' },
         // Revision highlighting
         { token: 'metaRevisionSeparator', foreground: '#ffa94d' },
         { token: 'metaRevisionIncludeGlobMarker', foreground: '#ff6b6b' },
@@ -103,6 +106,9 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'metaRegexpAlternative', foreground: '#1098ad' },
         // Structural pattern highlighting
         { token: 'metaStructuralHole', foreground: '#c92a2a' },
+        { token: 'metaStructuralRegexpHole', foreground: '#c92a2a' },
+        { token: 'metaStructuralVariable', foreground: '#2b3750' },
+        { token: 'metaStructuralRegexpSeparator', foreground: '#d9480f' },
         // Revision highlighting
         { token: 'metaRevisionSeparator', foreground: '#d9480f' },
         { token: 'metaRevisionIncludeGlobMarker', foreground: '#c92a2a' },


### PR DESCRIPTION
As description, adds regex highlighting + hovers to embedded regexp in structural holes:

<img width="892" alt="Screen Shot 2020-12-11 at 6 42 42 PM" src="https://user-images.githubusercontent.com/888624/101969549-0eb01300-3be2-11eb-93c9-7bbfccc03a47.png">
