### PR TITLE
campaigns: implement licence checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search indexer tuned to wait longer before assuming a deadlock has occurred. Previously if the indexserver had many cores (40+) and indexed a monorepo it could give up. [#16110](https://github.com/sourcegraph/sourcegraph/pull/16110)
 - The total size of all Git repositories and the lines of code for indexed branches will be sent back in pings as part of critical telemetry. [#16188](https://github.com/sourcegraph/sourcegraph/pull/16188)
 - The `gitserver` container now has a dependency on Postgres. This does not require any additional configuration unless access to Postgres requires a sidecar proxy / firewall rules. [#16121](https://github.com/sourcegraph/sourcegraph/pull/16121)
+- Licensing is now enforced for campaigns: creating a campaign with more than five changesets requires a valid license. Please [contact Sourcegraph with any licensing questions](https://about.sourcegraph.com/contact/sales/). [#15715](https://github.com/sourcegraph/sourcegraph/issues/15715)
 
 ### Fixed
 

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.story.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.story.tsx
@@ -1,0 +1,34 @@
+import { storiesOf } from '@storybook/react'
+import { radios } from '@storybook/addon-knobs'
+import React from 'react'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { CampaignListIntro } from './CampaignListIntro'
+
+const { add } = storiesOf('web/campaigns/CampaignListIntro', module).addDecorator(story => (
+    <div className="p-3 container web-content">{story()}</div>
+))
+
+add('Intro', () => (
+    <EnterpriseWebStory>
+        {() => (
+            <CampaignListIntro licensed={stateToInput(radios('licensed', LicensingState, LicensingState.Loading))} />
+        )}
+    </EnterpriseWebStory>
+))
+
+enum LicensingState {
+    Licensed = 'Licensed',
+    Unlicensed = 'Unlicensed',
+    Loading = 'Loading',
+}
+
+function stateToInput(state: LicensingState): boolean | undefined {
+    switch (state) {
+        case LicensingState.Licensed:
+            return true
+        case LicensingState.Unlicensed:
+            return false
+        default:
+            return undefined
+    }
+}

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.story.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.story.tsx
@@ -8,14 +8,6 @@ const { add } = storiesOf('web/campaigns/CampaignListIntro', module).addDecorato
     <div className="p-3 container web-content">{story()}</div>
 ))
 
-add('Intro', () => (
-    <EnterpriseWebStory>
-        {() => (
-            <CampaignListIntro licensed={stateToInput(radios('licensed', LicensingState, LicensingState.Loading))} />
-        )}
-    </EnterpriseWebStory>
-))
-
 enum LicensingState {
     Licensed = 'Licensed',
     Unlicensed = 'Unlicensed',
@@ -31,4 +23,12 @@ function stateToInput(state: LicensingState): boolean | undefined {
         default:
             return undefined
     }
+}
+
+for (const state of Object.values(LicensingState)) {
+    add(state, () => (
+        <EnterpriseWebStory>
+            {() => <CampaignListIntro licensed={stateToInput(radios('licensed', LicensingState, state))} />}
+        </EnterpriseWebStory>
+    ))
 }

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -70,7 +70,7 @@ const CampaignChangelogAlert: React.FunctionComponent = () => (
 )
 
 const CampaignUnlicensedAlert: React.FunctionComponent = () => (
-    <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-trial">
+    <div className="campaign-list-intro__alert">
         <div className="campaign-list-intro__card card p-2 h-100">
             <div className="card-body d-flex align-items-start">
                 {/* d-none d-sm-block ensure that we hide the icon on XS displays. */}
@@ -88,5 +88,5 @@ const CampaignUnlicensedAlert: React.FunctionComponent = () => (
                 </div>
             </div>
         </div>
-    </DismissibleAlert>
+    </div>
 )

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -6,28 +6,28 @@ export interface CampaignListIntroProps {
     licensed: boolean | undefined
 }
 
-export const CampaignListIntro: React.FunctionComponent<CampaignListIntroProps> = ({ licensed }) => {
-    if (licensed !== false) {
-        return (
-            <div className="row">
-                <div className="col-12 mb-2">
-                    <CampaignChangelogAlert />
-                </div>
-            </div>
-        )
-    }
-
-    return (
-        <div className="row">
-            <div className="col-12 col-md-6 mb-2">
-                <CampaignUnlicensedAlert />
-            </div>
-            <div className="col-12 col-md-6 mb-2">
+export const CampaignListIntro: React.FunctionComponent<CampaignListIntroProps> = ({ licensed }) => (
+    <div className="row mb-2">
+        {licensed === true ? (
+            <div className="col-12">
                 <CampaignChangelogAlert />
             </div>
-        </div>
-    )
-}
+        ) : (
+            <>
+                {licensed === false && (
+                    <>
+                        <div className="col-12 col-md-6">
+                            <CampaignUnlicensedAlert />
+                        </div>
+                        <div className="col-12 col-md-6">
+                            <CampaignChangelogAlert />
+                        </div>
+                    </>
+                )}
+            </>
+        )}
+    </div>
+)
 
 const CampaignChangelogAlert: React.FunctionComponent = () => (
     <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-changelog-3.23">

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -11,7 +11,7 @@ export const CampaignListIntro: React.FunctionComponent<CampaignListIntroProps> 
         return (
             <div className="row">
                 <div className="col-12 mb-2">
-                    <CampaignChangelog />
+                    <CampaignChangelogAlert />
                 </div>
             </div>
         )
@@ -20,32 +20,16 @@ export const CampaignListIntro: React.FunctionComponent<CampaignListIntroProps> 
     return (
         <div className="row">
             <div className="col-12 col-md-6 mb-2">
-                <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-trial">
-                    <div className="campaign-list-intro__card card p-2 h-100">
-                        <div className="card-body d-flex align-items-start">
-                            {/* d-none d-sm-block ensure that we hide the icon on XS displays. */}
-                            <SourcegraphIcon className="mr-3 col-2 mt-2 d-none d-sm-block" />
-                            <div>
-                                <h4>Campaigns trial</h4>
-                                <p className="text-muted mb-0">
-                                    Campaigns will be a paid feature in a future release. In the meantime, we invite you
-                                    to trial the ability to make large scale changes across many repositories and code
-                                    hosts. If you’d like to discuss use cases and features,{' '}
-                                    <a href="https://about.sourcegraph.com/contact/sales/">please get in touch</a>!
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </DismissibleAlert>
+                <CampaignUnlicensedAlert />
             </div>
             <div className="col-12 col-md-6 mb-2">
-                <CampaignChangelog />
+                <CampaignChangelogAlert />
             </div>
         </div>
     )
 }
 
-const CampaignChangelog: React.FunctionComponent = () => (
+const CampaignChangelogAlert: React.FunctionComponent = () => (
     <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-changelog-3.23">
         <div className="campaign-list-intro__card card h-100 p-2">
             <div className="card-body">
@@ -80,6 +64,26 @@ const CampaignChangelog: React.FunctionComponent = () => (
                         of only showing the desired state
                     </li>
                 </ul>
+            </div>
+        </div>
+    </DismissibleAlert>
+)
+
+const CampaignUnlicensedAlert: React.FunctionComponent = () => (
+    <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-trial">
+        <div className="campaign-list-intro__card card p-2 h-100">
+            <div className="card-body d-flex align-items-start">
+                {/* d-none d-sm-block ensure that we hide the icon on XS displays. */}
+                <SourcegraphIcon className="mr-3 col-2 mt-2 d-none d-sm-block" />
+                <div>
+                    <h4>Campaigns trial</h4>
+                    <p className="text-muted mb-0">
+                        Campaigns will be a paid feature in a future release. In the meantime, we invite you to trial
+                        the ability to make large scale changes across many repositories and code hosts. If you’d like
+                        to discuss use cases and features,{' '}
+                        <a href="https://about.sourcegraph.com/contact/sales/">please get in touch</a>!
+                    </p>
+                </div>
             </div>
         </div>
     </DismissibleAlert>

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -79,8 +79,7 @@ const CampaignUnlicensedAlert: React.FunctionComponent = () => (
                     <h4>Campaigns trial</h4>
                     <p className="text-muted">
                         Campaigns is a paid feature of Sourcegraph. All users can create sample campaigns with up to
-                        five changesets without a license.{' '}
-                        <em>Note: Add limit:5 to your query to return only 5 repositories.</em>
+                        five changesets without a license.
                     </p>
                     <p className="text-muted mb-0">
                         <a href="https://about.sourcegraph.com/contact/sales/">Contact sales</a> to obtain a trial

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -77,11 +77,14 @@ const CampaignUnlicensedAlert: React.FunctionComponent = () => (
                 <SourcegraphIcon className="mr-3 col-2 mt-2 d-none d-sm-block" />
                 <div>
                     <h4>Campaigns trial</h4>
+                    <p className="text-muted">
+                        Campaigns is a paid feature of Sourcegraph. All users can create sample campaigns with up to
+                        five changesets without a license.{' '}
+                        <em>Note: Add limit:5 to your query to return only 5 repositories.</em>
+                    </p>
                     <p className="text-muted mb-0">
-                        Campaigns will be a paid feature in a future release. In the meantime, we invite you to trial
-                        the ability to make large scale changes across many repositories and code hosts. If you’d like
-                        to discuss use cases and features,{' '}
-                        <a href="https://about.sourcegraph.com/contact/sales/">please get in touch</a>!
+                        <a href="https://about.sourcegraph.com/contact/sales/">Contact sales</a> to obtain a trial
+                        license.
                     </p>
                 </div>
             </div>

--- a/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListIntro.tsx
@@ -2,68 +2,85 @@ import React from 'react'
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 import { SourcegraphIcon } from '../../../auth/icons'
 
-export const CampaignListIntro: React.FunctionComponent = () => (
-    <div className="row">
-        <div className="col-12 col-md-6 mb-2">
-            <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-trial">
-                <div className="campaign-list-intro__card card p-2 h-100">
-                    <div className="card-body d-flex align-items-start">
-                        {/* d-none d-sm-block ensure that we hide the icon on XS displays. */}
-                        <SourcegraphIcon className="mr-3 col-2 mt-2 d-none d-sm-block" />
-                        <div>
-                            <h4>Campaigns trial</h4>
-                            <p className="text-muted mb-0">
-                                Campaigns will be a paid feature in a future release. In the meantime, we invite you to
-                                trial the ability to make large scale changes across many repositories and code hosts.
-                                If you’d like to discuss use cases and features,{' '}
-                                <a href="https://about.sourcegraph.com/contact/sales/">please get in touch</a>!
-                            </p>
+export interface CampaignListIntroProps {
+    licensed: boolean | undefined
+}
+
+export const CampaignListIntro: React.FunctionComponent<CampaignListIntroProps> = ({ licensed }) => {
+    if (licensed !== false) {
+        return (
+            <div className="row">
+                <div className="col-12 mb-2">
+                    <CampaignChangelog />
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="row">
+            <div className="col-12 col-md-6 mb-2">
+                <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-trial">
+                    <div className="campaign-list-intro__card card p-2 h-100">
+                        <div className="card-body d-flex align-items-start">
+                            {/* d-none d-sm-block ensure that we hide the icon on XS displays. */}
+                            <SourcegraphIcon className="mr-3 col-2 mt-2 d-none d-sm-block" />
+                            <div>
+                                <h4>Campaigns trial</h4>
+                                <p className="text-muted mb-0">
+                                    Campaigns will be a paid feature in a future release. In the meantime, we invite you
+                                    to trial the ability to make large scale changes across many repositories and code
+                                    hosts. If you’d like to discuss use cases and features,{' '}
+                                    <a href="https://about.sourcegraph.com/contact/sales/">please get in touch</a>!
+                                </p>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </DismissibleAlert>
+                </DismissibleAlert>
+            </div>
+            <div className="col-12 col-md-6 mb-2">
+                <CampaignChangelog />
+            </div>
         </div>
-        <div className="col-12 col-md-6 mb-2">
-            <DismissibleAlert
-                className="campaign-list-intro__alert"
-                partialStorageKey="campaign-list-intro-changelog-3.23"
-            >
-                <div className="campaign-list-intro__card card h-100 p-2">
-                    <div className="card-body">
-                        <h4>New campaigns features in version 3.23</h4>
-                        <ul className="text-muted mb-0 pl-3">
-                            <li>Changesets in a campaign can be searched by title and repository name</li>
-                            <li>
-                                Multiple changesets can be created from a single repository using the experimental{' '}
-                                <a
-                                    href="https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#transformchanges"
-                                    target="_blank"
-                                    rel="noopener"
-                                    className="text-monospace"
-                                >
-                                    transformChanges
-                                </a>{' '}
-                                block in a campaign spec
-                            </li>
-                            <li>
-                                Steps in campaign specs can now{' '}
-                                <a
-                                    href="https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#examples-7"
-                                    target="_blank"
-                                    rel="noopener"
-                                >
-                                    pass environment variables
-                                </a>{' '}
-                                on to containers
-                            </li>
-                            <li>
-                                The preview of a campaign spec now includes detailed information about what will change,
-                                instead of only showing the desired state
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </DismissibleAlert>
+    )
+}
+
+const CampaignChangelog: React.FunctionComponent = () => (
+    <DismissibleAlert className="campaign-list-intro__alert" partialStorageKey="campaign-list-intro-changelog-3.23">
+        <div className="campaign-list-intro__card card h-100 p-2">
+            <div className="card-body">
+                <h4>New campaigns features in version 3.23</h4>
+                <ul className="text-muted mb-0 pl-3">
+                    <li>Changesets in a campaign can be searched by title and repository name</li>
+                    <li>
+                        Multiple changesets can be created from a single repository using the experimental{' '}
+                        <a
+                            href="https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#transformchanges"
+                            target="_blank"
+                            rel="noopener"
+                            className="text-monospace"
+                        >
+                            transformChanges
+                        </a>{' '}
+                        block in a campaign spec
+                    </li>
+                    <li>
+                        Steps in campaign specs can now{' '}
+                        <a
+                            href="https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#examples-7"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            pass environment variables
+                        </a>{' '}
+                        on to containers
+                    </li>
+                    <li>
+                        The preview of a campaign spec now includes detailed information about what will change, instead
+                        of only showing the desired state
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
+    </DismissibleAlert>
 )

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.story.tsx
@@ -24,8 +24,24 @@ const queryCampaigns = () =>
         totalCount: Object.values(nodes).length,
     })
 
+const campaignsNotLicensed = () => of(false)
+
+const campaignsLicensed = () => of(true)
+
 add('List of campaigns', () => (
-    <EnterpriseWebStory>{props => <CampaignListPage {...props} queryCampaigns={queryCampaigns} />}</EnterpriseWebStory>
+    <EnterpriseWebStory>
+        {props => (
+            <CampaignListPage {...props} queryCampaigns={queryCampaigns} areCampaignsLicensed={campaignsLicensed} />
+        )}
+    </EnterpriseWebStory>
+))
+
+add('Licensing not enforced', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CampaignListPage {...props} queryCampaigns={queryCampaigns} areCampaignsLicensed={campaignsNotLicensed} />
+        )}
+    </EnterpriseWebStory>
 ))
 
 add('No campaigns', () => {
@@ -46,7 +62,9 @@ add('No campaigns', () => {
     )
     return (
         <EnterpriseWebStory>
-            {props => <CampaignListPage {...props} queryCampaigns={queryCampaigns} />}
+            {props => (
+                <CampaignListPage {...props} queryCampaigns={queryCampaigns} areCampaignsLicensed={campaignsLicensed} />
+            )}
         </EnterpriseWebStory>
     )
 })
@@ -69,7 +87,14 @@ add('All campaigns tab empty', () => {
     )
     return (
         <EnterpriseWebStory>
-            {props => <CampaignListPage {...props} queryCampaigns={queryCampaigns} openTab="campaigns" />}
+            {props => (
+                <CampaignListPage
+                    {...props}
+                    queryCampaigns={queryCampaigns}
+                    areCampaignsLicensed={campaignsLicensed}
+                    openTab="campaigns"
+                />
+            )}
         </EnterpriseWebStory>
     )
 })

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useState, useMemo } from 'react'
-import { queryCampaigns as _queryCampaigns, queryCampaignsByNamespace } from './backend'
+import { areCampaignsLicensed, queryCampaigns as _queryCampaigns, queryCampaignsByNamespace } from './backend'
 import { RouteComponentProps } from 'react-router'
 import { FilteredConnection, FilteredConnectionFilter } from '../../../components/FilteredConnection'
 import { CampaignNode, CampaignNodeProps } from './CampaignNode'
@@ -21,6 +21,7 @@ import { CampaignListIntro } from './CampaignListIntro'
 import { filter, map, tap, withLatestFrom } from 'rxjs/operators'
 import { Observable, ReplaySubject } from 'rxjs'
 import classNames from 'classnames'
+import { useObservable } from '../../../../../shared/src/util/useObservable'
 
 export interface CampaignListPageProps extends TelemetryProps, Pick<RouteComponentProps, 'history' | 'location'> {
     displayNamespace?: boolean
@@ -104,6 +105,7 @@ export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = 
             ),
         [queryCampaigns, isFirstFetch, openTab]
     )
+    const licensed: boolean | undefined = useObservable(useMemo(() => areCampaignsLicensed(), []))
 
     return (
         <>
@@ -116,7 +118,7 @@ export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = 
             <p className="text-muted">
                 Run custom code over hundreds of repositories and manage the resulting changesets
             </p>
-            <CampaignListIntro />
+            <CampaignListIntro licensed={licensed} />
             <CampaignListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
             {selectedTab === 'gettingStarted' && <CampaignsListEmpty />}
             {selectedTab === 'campaigns' && (

--- a/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
+++ b/client/web/src/enterprise/campaigns/list/CampaignListPage.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useCallback, useState, useMemo } from 'react'
-import { areCampaignsLicensed, queryCampaigns as _queryCampaigns, queryCampaignsByNamespace } from './backend'
+import {
+    areCampaignsLicensed as _areCampaignsLicensed,
+    queryCampaigns as _queryCampaigns,
+    queryCampaignsByNamespace,
+} from './backend'
 import { RouteComponentProps } from 'react-router'
 import { FilteredConnection, FilteredConnectionFilter } from '../../../components/FilteredConnection'
 import { CampaignNode, CampaignNodeProps } from './CampaignNode'
@@ -27,6 +31,8 @@ export interface CampaignListPageProps extends TelemetryProps, Pick<RouteCompone
     displayNamespace?: boolean
     /** For testing only. */
     queryCampaigns?: typeof _queryCampaigns
+    /** For testing only. */
+    areCampaignsLicensed?: typeof _areCampaignsLicensed
     /** For testing only. */
     openTab?: SelectedTab
 }
@@ -66,6 +72,7 @@ type SelectedTab = 'campaigns' | 'gettingStarted'
  */
 export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = ({
     queryCampaigns = _queryCampaigns,
+    areCampaignsLicensed = _areCampaignsLicensed,
     displayNamespace = true,
     location,
     openTab,
@@ -105,7 +112,7 @@ export const CampaignListPage: React.FunctionComponent<CampaignListPageProps> = 
             ),
         [queryCampaigns, isFirstFetch, openTab]
     )
-    const licensed: boolean | undefined = useObservable(useMemo(() => areCampaignsLicensed(), []))
+    const licensed: boolean | undefined = useObservable(useMemo(() => areCampaignsLicensed(), [areCampaignsLicensed]))
 
     return (
         <>

--- a/client/web/src/enterprise/campaigns/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/list/backend.ts
@@ -169,5 +169,5 @@ export const areCampaignsLicensed = (): Observable<boolean> =>
         `
     ).pipe(
         map(dataOrThrowErrors),
-        map(data => !!data.site?.productSubscription?.license?.tags.includes('campaigns'))
+        map(data => !!data.site.productSubscription.license?.tags.includes('campaigns'))
     )

--- a/client/web/src/enterprise/campaigns/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/list/backend.ts
@@ -6,6 +6,8 @@ import {
     CampaignsResult,
     CampaignsByNamespaceResult,
     CampaignsByNamespaceVariables,
+    AreCampaignsLicensedResult,
+    AreCampaignsLicensedVariables,
 } from '../../../graphql-operations'
 import { requestGraphQL } from '../../../backend/graphql'
 
@@ -150,4 +152,22 @@ export const queryCampaignsByNamespace = ({
                 totalCount: data.node.allCampaigns.totalCount,
             }
         })
+    )
+
+export const areCampaignsLicensed = (): Observable<boolean> =>
+    requestGraphQL<AreCampaignsLicensedResult, AreCampaignsLicensedVariables>(
+        gql`
+            query AreCampaignsLicensed {
+                site {
+                    productSubscription {
+                        license {
+                            tags
+                        }
+                    }
+                }
+            }
+        `
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => !!data.site?.productSubscription?.license?.tags.includes('campaigns'))
     )

--- a/client/web/src/enterprise/campaigns/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/list/backend.ts
@@ -154,8 +154,8 @@ export const queryCampaignsByNamespace = ({
         })
     )
 
-export const areCampaignsLicensed = (): Observable<boolean> =>
-    requestGraphQL<AreCampaignsLicensedResult, AreCampaignsLicensedVariables>(
+export function areCampaignsLicensed(): Observable<boolean> {
+    return requestGraphQL<AreCampaignsLicensedResult, AreCampaignsLicensedVariables>(
         gql`
             query AreCampaignsLicensed {
                 enterpriseLicenseHasFeature(feature: "campaigns")
@@ -165,3 +165,4 @@ export const areCampaignsLicensed = (): Observable<boolean> =>
         map(dataOrThrowErrors),
         map(data => data.enterpriseLicenseHasFeature)
     )
+}

--- a/client/web/src/enterprise/campaigns/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/list/backend.ts
@@ -158,16 +158,10 @@ export const areCampaignsLicensed = (): Observable<boolean> =>
     requestGraphQL<AreCampaignsLicensedResult, AreCampaignsLicensedVariables>(
         gql`
             query AreCampaignsLicensed {
-                site {
-                    productSubscription {
-                        license {
-                            tags
-                        }
-                    }
-                }
+                enterpriseLicenseHasFeature(feature: "campaigns")
             }
         `
     ).pipe(
         map(dataOrThrowErrors),
-        map(data => !!data.site.productSubscription.license?.tags.includes('campaigns'))
+        map(data => data.enterpriseLicenseHasFeature)
     )

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -474,6 +474,7 @@ describe('Campaigns', () => {
                 // Change overrides to make campaign appear closed.
                 testContext.overrideGraphQL({
                     ...commonWebGraphQlResults,
+                    ...campaignLicenseGraphQlResults,
                     ...mockCommonGraphQLResponses(entityType, { closedAt: subDays(new Date(), 1).toISOString() }),
                     CampaignChangesets,
                     ChangesetCountsOverTime,

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -368,6 +368,15 @@ describe('Campaigns', () => {
                         totalCount: 1,
                     },
                 }),
+                AreCampaignsLicensed: () => ({
+                    site: {
+                        productSubscription: {
+                            license: {
+                                tags: ['campaigns'],
+                            },
+                        },
+                    },
+                }),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/campaigns')
             await driver.page.waitForSelector('.test-campaign-list-page')

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -439,6 +439,7 @@ describe('Campaigns', () => {
             it(`displays a single campaign for ${entityType}`, async () => {
                 testContext.overrideGraphQL({
                     ...commonWebGraphQlResults,
+                    ...campaignLicenseGraphQlResults,
                     ...mockCommonGraphQLResponses(entityType),
                     CampaignChangesets,
                     ChangesetCountsOverTime,

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -369,13 +369,7 @@ describe('Campaigns', () => {
                     },
                 }),
                 AreCampaignsLicensed: () => ({
-                    site: {
-                        productSubscription: {
-                            license: {
-                                tags: ['campaigns'],
-                            },
-                        },
-                    },
+                    enterpriseLicenseHasFeature: true,
                 }),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/campaigns')

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -351,10 +351,17 @@ describe('Campaigns', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
 
+    const campaignLicenseGraphQlResults = {
+        AreCampaignsLicensed: () => ({
+            enterpriseLicenseHasFeature: true,
+        }),
+    }
+
     describe('Campaigns list', () => {
         it('lists global campaigns', async () => {
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
+                ...campaignLicenseGraphQlResults,
                 Campaigns: () => ({
                     campaigns: {
                         nodes: [campaignListNode],
@@ -367,9 +374,6 @@ describe('Campaigns', () => {
                     allCampaigns: {
                         totalCount: 1,
                     },
-                }),
-                AreCampaignsLicensed: () => ({
-                    enterpriseLicenseHasFeature: true,
                 }),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/campaigns')
@@ -393,6 +397,7 @@ describe('Campaigns', () => {
         it('lists user campaigns', async () => {
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
+                ...campaignLicenseGraphQlResults,
                 ...mockCommonGraphQLResponses('user'),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/users/alice/campaigns')
@@ -411,6 +416,7 @@ describe('Campaigns', () => {
         it('lists org campaigns', async () => {
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
+                ...campaignLicenseGraphQlResults,
                 ...mockCommonGraphQLResponses('org'),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/campaigns')

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -21,6 +21,7 @@ type Services struct {
 	CampaignsResolver         graphqlbackend.CampaignsResolver
 	CodeIntelResolver         graphqlbackend.CodeIntelResolver
 	CodeMonitorsResolver      graphqlbackend.CodeMonitorsResolver
+	LicenseResolver           graphqlbackend.LicenseResolver
 }
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The
@@ -43,6 +44,7 @@ func DefaultServices() Services {
 		AuthzResolver:             graphqlbackend.DefaultAuthzResolver,
 		CampaignsResolver:         graphqlbackend.DefaultCampaignsResolver,
 		CodeMonitorsResolver:      graphqlbackend.DefaultCodeMonitorsResolver,
+		LicenseResolver:           graphqlbackend.DefaultLicenseResolver,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -338,11 +338,12 @@ func prometheusGraphQLRequestName(requestName string) string {
 	return "other"
 }
 
-func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz AuthzResolver, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
+func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz AuthzResolver, codeMonitors CodeMonitorsResolver, license LicenseResolver) (*graphql.Schema, error) {
 	resolver := &schemaResolver{
 		CampaignsResolver: defaultCampaignsResolver{},
 		AuthzResolver:     defaultAuthzResolver{},
 		CodeIntelResolver: defaultCodeIntelResolver{},
+		LicenseResolver:   defaultLicenseResolver{},
 	}
 	if campaigns != nil {
 		EnterpriseResolvers.campaignsResolver = campaigns
@@ -359,6 +360,10 @@ func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz A
 	if codeMonitors != nil {
 		EnterpriseResolvers.codeMonitorsResolver = codeMonitors
 		resolver.CodeMonitorsResolver = codeMonitors
+	}
+	if license != nil {
+		EnterpriseResolvers.licenseResolver = license
+		resolver.LicenseResolver = license
 	}
 	return graphql.ParseSchema(
 		Schema,
@@ -553,6 +558,7 @@ type schemaResolver struct {
 	AuthzResolver
 	CodeIntelResolver
 	CodeMonitorsResolver
+	LicenseResolver
 }
 
 // EnterpriseResolvers holds the instances of resolvers which are enabled only
@@ -562,11 +568,13 @@ var EnterpriseResolvers = struct {
 	authzResolver        AuthzResolver
 	campaignsResolver    CampaignsResolver
 	codeMonitorsResolver CodeMonitorsResolver
+	licenseResolver      LicenseResolver
 }{
 	codeIntelResolver:    defaultCodeIntelResolver{},
 	authzResolver:        defaultAuthzResolver{},
 	campaignsResolver:    defaultCampaignsResolver{},
 	codeMonitorsResolver: defaultCodeMonitorsResolver{},
+	licenseResolver:      defaultLicenseResolver{},
 }
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/license.go
+++ b/cmd/frontend/graphqlbackend/license.go
@@ -1,0 +1,21 @@
+package graphqlbackend
+
+import "context"
+
+type LicenseResolver interface {
+	EnterpriseLicenseHasFeature(ctx context.Context, args *EnterpriseLicenseHasFeatureArgs) (bool, error)
+}
+
+type EnterpriseLicenseHasFeatureArgs struct {
+	Feature string
+}
+
+type defaultLicenseResolver struct{}
+
+var DefaultLicenseResolver = defaultLicenseResolver{}
+
+func (defaultLicenseResolver) EnterpriseLicenseHasFeature(ctx context.Context, args *EnterpriseLicenseHasFeatureArgs) (bool, error) {
+	// By definition, no enterprise features are available in the open source
+	// version of Sourcegraph.
+	return false, nil
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -692,7 +692,8 @@ type Mutation {
     The returned CampaignSpec is immutable and expires after a certain period of time (if not used
     in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
 
-    If campaigns are unlicensed, an error with the error code ErrCampaignsUnlicensed is returned.
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
     """
     createCampaignSpec(
         """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -691,6 +691,8 @@ type Mutation {
 
     The returned CampaignSpec is immutable and expires after a certain period of time (if not used
     in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
+
+    If campaigns are unlicensed, an error with the error code ErrCampaignsUnlicensed is returned.
     """
     createCampaignSpec(
         """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2959,6 +2959,12 @@ type Query {
     the configured code hosts are able to see.
     """
     affiliatedRepositories(user: ID!, codeHost: ID, query: String): CodeHostRepositoryConnection!
+
+    """
+    Checks whether the given feature is enabled on Sourcegraph. Open source
+    installations will always return false for any feature.
+    """
+    enterpriseLicenseHasFeature(feature: String!): Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -684,6 +684,8 @@ type Mutation {
 
     The returned CampaignSpec is immutable and expires after a certain period of time (if not used
     in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
+
+    If campaigns are unlicensed, an error with the error code ErrCampaignsUnlicensed is returned.
     """
     createCampaignSpec(
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -685,7 +685,7 @@ type Mutation {
     The returned CampaignSpec is immutable and expires after a certain period of time (if not used
     in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
 
-    If campaigns are unlicensed, an error with the error code ErrCampaignsUnlicensed is returned.
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
     """
     createCampaignSpec(
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -685,7 +685,8 @@ type Mutation {
     The returned CampaignSpec is immutable and expires after a certain period of time (if not used
     in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
 
-    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
     """
     createCampaignSpec(
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2952,6 +2952,12 @@ type Query {
     the configured code hosts are able to see.
     """
     affiliatedRepositories(user: ID!, codeHost: ID, query: String): CodeHostRepositoryConnection!
+
+    """
+    Checks whether the given feature is enabled on Sourcegraph. Open source
+    installations will always return false for any feature.
+    """
+    enterpriseLicenseHasFeature(feature: String!): Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -17,7 +17,7 @@ func mustParseGraphQLSchema(t *testing.T) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil, nil)
+		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil, nil, nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -211,7 +211,7 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 		return errors.New("dbconn.Global is nil when trying to parse GraphQL schema")
 	}
 
-	schema, err := graphqlbackend.NewSchema(enterprise.CampaignsResolver, enterprise.CodeIntelResolver, enterprise.AuthzResolver, enterprise.CodeMonitorsResolver)
+	schema, err := graphqlbackend.NewSchema(enterprise.CampaignsResolver, enterprise.CodeIntelResolver, enterprise.AuthzResolver, enterprise.CodeMonitorsResolver, enterprise.LicenseResolver)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -45,7 +45,7 @@ func mustParseGraphQLSchema(t *testing.T, db *sql.DB) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = graphqlbackend.NewSchema(nil, nil, NewResolver(db, clock), nil)
+		parsedSchema, parseSchemaErr = graphqlbackend.NewSchema(nil, nil, NewResolver(db, clock), nil, nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/enforcement"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -97,6 +98,8 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 			ExpiresAtValue: info.ExpiresAt,
 		}, nil
 	}
+
+	enterpriseServices.LicenseResolver = resolvers.LicenseResolver{}
 
 	goroutine.Go(func() {
 		licensing.StartMaxUserCount(&usersStore{})

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -77,7 +77,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestCampaignsListing(t *testing.T) {
 	store := store.New(dbconn.Global)
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -83,7 +83,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -60,7 +60,7 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
@@ -70,7 +70,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
@@ -98,7 +98,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		OwnedByCampaign:  campaign.ID,
 	})
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -110,7 +110,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	addChangeset(t, ctx, cstore, changeset3, campaign.ID)
 	addChangeset(t, ctx, cstore, changeset4, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -170,7 +170,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -96,7 +96,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	addChangeset(t, ctx, cstore, changeset, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -70,7 +70,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -63,7 +63,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -177,7 +177,7 @@ func TestChangesetResolver(t *testing.T) {
 	// Associate the changeset with a campaign, so it's considered in syncer logic.
 	addChangeset(t, ctx, cstore, syncedGitHubChangeset, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
@@ -52,7 +52,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/errors.go
+++ b/enterprise/internal/campaigns/resolvers/errors.go
@@ -30,6 +30,14 @@ func (e ErrCampaignsDisabledForUser) Extensions() map[string]interface{} {
 	return map[string]interface{}{"code": "ErrCampaignsDisabledForUser"}
 }
 
+// ErrCampaignsUnlicensed wraps an underlying licensing.featureNotActivatedError
+// to add an error code.
+type ErrCampaignsUnlicensed struct{ error }
+
+func (e ErrCampaignsUnlicensed) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrCampaignsUnlicensed"}
+}
+
 type ErrCampaignsDotCom struct{}
 
 func (e ErrCampaignsDotCom) Error() string {

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -38,7 +38,7 @@ func TestPermissionLevels(t *testing.T) {
 
 	cstore := store.New(dbconn.Global)
 	sr := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -758,7 +758,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	cstore := store.New(dbconn.Global)
 	sr := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -72,10 +72,6 @@ func campaignsCreateAccess(ctx context.Context) error {
 // checkLicense returns a user-facing error if the campaigns feature is not purchased
 // with the current license or any error occurred while validating the license.
 func checkLicense() error {
-	if !licensing.EnforceTiers {
-		return nil
-	}
-
 	if err := licensing.Check(licensing.FeatureCampaigns); err != nil {
 		if licensing.IsFeatureNotActivated(err) {
 			return err

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/search"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/service"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -67,6 +68,27 @@ func campaignsCreateAccess(ctx context.Context) error {
 	}
 	return nil
 }
+
+// checkLicense returns a user-facing error if the campaigns feature is not purchased
+// with the current license or any error occurred while validating the license.
+func checkLicense() error {
+	if !licensing.EnforceTiers {
+		return nil
+	}
+
+	if err := licensing.Check(licensing.FeatureCampaigns); err != nil {
+		if licensing.IsFeatureNotActivated(err) {
+			return err
+		}
+		return errors.New("Unable to check license feature, please refer to logs for actual error message.")
+	}
+	return nil
+}
+
+// maxUnlicensedChangesets is the maximum number of changesets that can be
+// attached to a campaign when Sourcegraph is unlicensed or the campaign feature
+// is disabled.
+const maxUnlicensedChangesets = 5
 
 func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbackend.ChangesetResolver, error) {
 	if err := campaignsEnabled(ctx); err != nil {
@@ -333,6 +355,16 @@ func (r *Resolver) CreateCampaignSpec(ctx context.Context, args *graphqlbackend.
 
 	if err := campaignsCreateAccess(ctx); err != nil {
 		return nil, err
+	}
+
+	if err := checkLicense(); err != nil {
+		if licensing.IsFeatureNotActivated(err) {
+			if len(args.ChangesetSpecs) > maxUnlicensedChangesets {
+				return nil, ErrCampaignsUnlicensed{err}
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	opts := service.CreateCampaignSpecOpts{RawSpec: args.CampaignSpec}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -133,7 +133,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 		"default configuration": {
 			changesetSpecs: changesetSpecs,
 			disableFeature: false,
-			wantErr:        false,
+			wantErr:        true,
 		},
 		"no licence, but under the limit": {
 			changesetSpecs: changesetSpecs[0:maxUnlicensedChangesets],
@@ -148,9 +148,6 @@ func TestCreateCampaignSpec(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			if tc.disableFeature {
-				oldEnforce := licensing.EnforceTiers
-				licensing.EnforceTiers = true
-
 				oldMock := licensing.MockCheckFeature
 				licensing.MockCheckFeature = func(feature licensing.Feature) error {
 					if feature == licensing.FeatureCampaigns {
@@ -160,7 +157,6 @@ func TestCreateCampaignSpec(t *testing.T) {
 				}
 
 				defer func() {
-					licensing.EnforceTiers = oldEnforce
 					licensing.MockCheckFeature = oldMock
 				}()
 			}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -33,7 +33,7 @@ import (
 func TestNullIDResilience(t *testing.T) {
 	sr := &Resolver{store: store.New(dbconn.Global)}
 
-	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestApplyCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -521,7 +521,7 @@ func TestCreateCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -595,7 +595,7 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -846,7 +846,7 @@ func TestCreateCampaignsCredential(t *testing.T) {
 	cstore := store.New(dbconn.Global)
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +910,7 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 	cstore := store.New(dbconn.Global)
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/service"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -100,15 +101,19 @@ func TestCreateCampaignSpec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changesetSpec := &campaigns.ChangesetSpec{
-		Spec: &campaigns.ChangesetSpecDescription{
-			BaseRepository: graphqlbackend.MarshalRepositoryID(repo.ID),
-		},
-		RepoID: repo.ID,
-		UserID: userID,
-	}
-	if err := cstore.CreateChangesetSpec(ctx, changesetSpec); err != nil {
-		t.Fatal(err)
+	// Create enough changeset specs to hit the licence check.
+	changesetSpecs := make([]*campaigns.ChangesetSpec, maxUnlicensedChangesets+1)
+	for i := range changesetSpecs {
+		changesetSpecs[i] = &campaigns.ChangesetSpec{
+			Spec: &campaigns.ChangesetSpecDescription{
+				BaseRepository: graphqlbackend.MarshalRepositoryID(repo.ID),
+			},
+			RepoID: repo.ID,
+			UserID: userID,
+		}
+		if err := cstore.CreateChangesetSpec(ctx, changesetSpecs[i]); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	r := &Resolver{store: cstore}
@@ -118,48 +123,106 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
-	changesetSpecID := marshalChangesetSpecRandID(changesetSpec.RandID)
 	rawSpec := ct.TestRawCampaignSpec
 
-	input := map[string]interface{}{
-		"namespace":      userAPIID,
-		"campaignSpec":   rawSpec,
-		"changesetSpecs": []graphql.ID{changesetSpecID},
-	}
-
-	var response struct{ CreateCampaignSpec apitest.CampaignSpec }
-
-	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
-	apitest.MustExec(actorCtx, t, s, input, &response, mutationCreateCampaignSpec)
-
-	var unmarshaled interface{}
-	err = json.Unmarshal([]byte(rawSpec), &unmarshaled)
-	if err != nil {
-		t.Fatal(err)
-	}
-	have := response.CreateCampaignSpec
-
-	want := apitest.CampaignSpec{
-		ID:            have.ID,
-		CreatedAt:     have.CreatedAt,
-		ExpiresAt:     have.ExpiresAt,
-		OriginalInput: rawSpec,
-		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
-		ApplyURL:      fmt.Sprintf("/users/%s/campaigns/apply/%s", user.Username, have.ID),
-		Namespace:     apitest.UserOrg{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
-		Creator:       &apitest.User{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
-		ChangesetSpecs: apitest.ChangesetSpecConnection{
-			Nodes: []apitest.ChangesetSpec{
-				{
-					Typename: "VisibleChangesetSpec",
-					ID:       string(changesetSpecID),
-				},
-			},
+	for name, tc := range map[string]struct {
+		changesetSpecs []*campaigns.ChangesetSpec
+		disableFeature bool
+		wantErr        bool
+	}{
+		"default configuration": {
+			changesetSpecs: changesetSpecs,
+			disableFeature: false,
+			wantErr:        false,
 		},
-	}
+		"no licence, but under the limit": {
+			changesetSpecs: changesetSpecs[0:maxUnlicensedChangesets],
+			disableFeature: true,
+			wantErr:        false,
+		},
+		"no licence, over the limit": {
+			changesetSpecs: changesetSpecs,
+			disableFeature: true,
+			wantErr:        true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.disableFeature {
+				oldEnforce := licensing.EnforceTiers
+				licensing.EnforceTiers = true
 
-	if diff := cmp.Diff(want, have); diff != "" {
-		t.Fatalf("unexpected response (-want +got):\n%s", diff)
+				oldMock := licensing.MockCheckFeature
+				licensing.MockCheckFeature = func(feature licensing.Feature) error {
+					if feature == licensing.FeatureCampaigns {
+						return licensing.NewFeatureNotActivatedError("no campaigns for you!")
+					}
+					return nil
+				}
+
+				defer func() {
+					licensing.EnforceTiers = oldEnforce
+					licensing.MockCheckFeature = oldMock
+				}()
+			}
+
+			changesetSpecIDs := make([]graphql.ID, len(tc.changesetSpecs))
+			for i, spec := range tc.changesetSpecs {
+				changesetSpecIDs[i] = marshalChangesetSpecRandID(spec.RandID)
+			}
+
+			input := map[string]interface{}{
+				"namespace":      userAPIID,
+				"campaignSpec":   rawSpec,
+				"changesetSpecs": changesetSpecIDs,
+			}
+
+			var response struct{ CreateCampaignSpec apitest.CampaignSpec }
+
+			actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+			errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateCampaignSpec)
+			if tc.wantErr {
+				if errs == nil {
+					t.Error("unexpected lack of errors")
+				}
+			} else {
+				if errs != nil {
+					t.Errorf("unexpected error(s): %+v", errs)
+				}
+
+				var unmarshaled interface{}
+				err = json.Unmarshal([]byte(rawSpec), &unmarshaled)
+				if err != nil {
+					t.Fatal(err)
+				}
+				have := response.CreateCampaignSpec
+
+				wantNodes := make([]apitest.ChangesetSpec, len(changesetSpecIDs))
+				for i, id := range changesetSpecIDs {
+					wantNodes[i] = apitest.ChangesetSpec{
+						Typename: "VisibleChangesetSpec",
+						ID:       string(id),
+					}
+				}
+
+				want := apitest.CampaignSpec{
+					ID:            have.ID,
+					CreatedAt:     have.CreatedAt,
+					ExpiresAt:     have.ExpiresAt,
+					OriginalInput: rawSpec,
+					ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
+					ApplyURL:      fmt.Sprintf("/users/%s/campaigns/apply/%s", user.Username, have.ID),
+					Namespace:     apitest.UserOrg{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
+					Creator:       &apitest.User{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
+					ChangesetSpecs: apitest.ChangesetSpecConnection{
+						Nodes: wantNodes,
+					},
+				}
+
+				if diff := cmp.Diff(want, have); diff != "" {
+					t.Fatalf("unexpected response (-want +got):\n%s", diff)
+				}
+			}
+		})
 	}
 }
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -296,7 +296,7 @@ func TestQueryMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r)
+	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -532,7 +532,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r)
+	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/licensing/resolvers/resolvers.go
+++ b/enterprise/internal/licensing/resolvers/resolvers.go
@@ -12,10 +12,6 @@ type LicenseResolver struct{}
 var _ graphqlbackend.LicenseResolver = LicenseResolver{}
 
 func (LicenseResolver) EnterpriseLicenseHasFeature(ctx context.Context, args *graphqlbackend.EnterpriseLicenseHasFeatureArgs) (bool, error) {
-	if !licensing.EnforceTiers {
-		return true, nil
-	}
-
 	if err := licensing.Check(licensing.Feature(args.Feature)); err != nil {
 		if licensing.IsFeatureNotActivated(err) {
 			return false, nil

--- a/enterprise/internal/licensing/resolvers/resolvers.go
+++ b/enterprise/internal/licensing/resolvers/resolvers.go
@@ -1,0 +1,28 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+)
+
+type LicenseResolver struct{}
+
+var _ graphqlbackend.LicenseResolver = LicenseResolver{}
+
+func (LicenseResolver) EnterpriseLicenseHasFeature(ctx context.Context, args *graphqlbackend.EnterpriseLicenseHasFeatureArgs) (bool, error) {
+	if !licensing.EnforceTiers {
+		return true, nil
+	}
+
+	if err := licensing.Check(licensing.Feature(args.Feature)); err != nil {
+		if licensing.IsFeatureNotActivated(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}

--- a/enterprise/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/internal/licensing/resolvers/resolvers_test.go
@@ -1,0 +1,115 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+)
+
+func TestEnterpriseLicenseHasFeature(t *testing.T) {
+	ctx := context.Background()
+	r := &LicenseResolver{}
+
+	buildMock := func(allow ...licensing.Feature) func(feature licensing.Feature) error {
+		return func(feature licensing.Feature) error {
+			for _, allowed := range allow {
+				if feature == allowed {
+					return nil
+				}
+			}
+
+			return licensing.NewFeatureNotActivatedError("feature not allowed")
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		args    *graphqlbackend.EnterpriseLicenseHasFeatureArgs
+		mock    func(feature licensing.Feature) error
+		want    bool
+		wantErr bool
+	}{
+		"real feature, enabled": {
+			args: &graphqlbackend.EnterpriseLicenseHasFeatureArgs{
+				Feature: string(licensing.FeatureCampaigns),
+			},
+			mock:    buildMock(licensing.FeatureCampaigns),
+			want:    true,
+			wantErr: false,
+		},
+		"real feature, disabled": {
+			args: &graphqlbackend.EnterpriseLicenseHasFeatureArgs{
+				Feature: string(licensing.FeatureMonitoring),
+			},
+			mock:    buildMock(licensing.FeatureCampaigns),
+			want:    false,
+			wantErr: false,
+		},
+		"fake feature, enabled": {
+			args: &graphqlbackend.EnterpriseLicenseHasFeatureArgs{
+				Feature: "foo",
+			},
+			mock:    buildMock("foo"),
+			want:    true,
+			wantErr: false,
+		},
+		"fake feature, disabled": {
+			args: &graphqlbackend.EnterpriseLicenseHasFeatureArgs{
+				Feature: "foo",
+			},
+			mock:    buildMock("bar"),
+			want:    false,
+			wantErr: false,
+		},
+		"error from check": {
+			args: &graphqlbackend.EnterpriseLicenseHasFeatureArgs{
+				Feature: string(licensing.FeatureMonitoring),
+			},
+			mock: func(feature licensing.Feature) error {
+				return errors.New("this is a different error")
+			},
+			want:    false,
+			wantErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			oldEnforce := licensing.EnforceTiers
+			oldMock := licensing.MockCheckFeature
+			licensing.EnforceTiers = true
+			licensing.MockCheckFeature = tc.mock
+			defer func() {
+				licensing.EnforceTiers = oldEnforce
+				licensing.MockCheckFeature = oldMock
+			}()
+
+			have, err := r.EnterpriseLicenseHasFeature(ctx, tc.args)
+			if err != nil {
+				if !tc.wantErr {
+					t.Errorf("got error when no error was expected: %v", err)
+				}
+			} else if tc.wantErr {
+				t.Error("did not get expected error")
+			}
+
+			if have != tc.want {
+				t.Errorf("unexpected has feature response: have=%v want=%v", have, tc.want)
+			}
+		})
+
+		t.Run(name+" without enforcement", func(t *testing.T) {
+			oldEnforce := licensing.EnforceTiers
+			licensing.EnforceTiers = false
+			defer func() { licensing.EnforceTiers = oldEnforce }()
+
+			have, err := r.EnterpriseLicenseHasFeature(ctx, tc.args)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !have {
+				t.Error("unexpected disallowance when tiers aren't enforced")
+			}
+		})
+	}
+}

--- a/enterprise/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/internal/licensing/resolvers/resolvers_test.go
@@ -72,12 +72,9 @@ func TestEnterpriseLicenseHasFeature(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			oldEnforce := licensing.EnforceTiers
 			oldMock := licensing.MockCheckFeature
-			licensing.EnforceTiers = true
 			licensing.MockCheckFeature = tc.mock
 			defer func() {
-				licensing.EnforceTiers = oldEnforce
 				licensing.MockCheckFeature = oldMock
 			}()
 
@@ -95,23 +92,6 @@ func TestEnterpriseLicenseHasFeature(t *testing.T) {
 			if have.EnterpriseLicenseHasFeature != tc.want {
 				t.Errorf("unexpected has feature response: have=%v want=%v", have, tc.want)
 			}
-		})
-
-		t.Run(name+" without enforcement", func(t *testing.T) {
-			oldEnforce := licensing.EnforceTiers
-			licensing.EnforceTiers = false
-			defer func() { licensing.EnforceTiers = oldEnforce }()
-
-			var have struct{ EnterpriseLicenseHasFeature bool }
-			if err := apitest.Exec(ctx, t, schema, map[string]interface{}{
-				"feature": tc.feature,
-			}, &have, query); err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if !have.EnterpriseLicenseHasFeature {
-				t.Error("unexpected disallowance when tiers aren't enforced")
-			}
-
 		})
 	}
 }


### PR DESCRIPTION
This PR implements the newer licensing behaviour discussed at sprint planning: campaigns may be used without a licence for campaigns with no more than five changesets, but attempting to create a campaign spec with more than that results in an error.

Closes #15715.