### PR TITLE
repo-updater: Skip listing conflicting repos when sourcing fails

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -267,18 +267,20 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx Store, externalServ
 	// Now fetch any possible name conflicts.
 	// Repo names must be globally unique, if there's conflict we need to deterministically choose one.
 	var conflicting types.Repos
-	if conflicting, err = tx.ListRepos(ctx, StoreListReposArgs{Names: sourced.Names()}); err != nil {
-		return errors.Wrap(err, "syncer.sync.store.list-repos")
-	}
-	conflicting = conflicting.Filter(func(r *types.Repo) bool {
-		for _, id := range r.ExternalServiceIDs() {
-			if id == externalServiceID {
-				return false
-			}
+	if len(sourced) > 0 {
+		if conflicting, err = tx.ListRepos(ctx, StoreListReposArgs{Names: sourced.Names()}); err != nil {
+			return errors.Wrap(err, "syncer.sync.store.list-repos")
 		}
+		conflicting = conflicting.Filter(func(r *types.Repo) bool {
+			for _, id := range r.ExternalServiceIDs() {
+				if id == externalServiceID {
+					return false
+				}
+			}
 
-		return true
-	})
+			return true
+		})
+	}
 
 	// Add the conflicts to the list of repos fetched from the db.
 	// NewDiff modifies the storedServiceRepos slice so we clone it before passing it


### PR DESCRIPTION
This commit makes it so we don't list conflicting repos when sourcing
fails. When `len(sourced) == 0`, by construction, there won't be any
conflicting repos.

What was happening instead, was that we were loading all repos from the
repo table, because `sourced.Names()` was empty, and no other predicates
were included in the resulting query.

This bug was introduced in https://github.com/sourcegraph/sourcegraph/pull/16516,
which made it so we don't abort the sync when there are authorization
errors during sourcing, so that we'd end up removing repos associated with that external
service in that event.

Fixes #16679



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
