### PR TITLE
dev(release): fix caching behaviour for version confirmation

### DIFF
--- a/dev/release/src/campaigns.ts
+++ b/dev/release/src/campaigns.ts
@@ -1,5 +1,5 @@
 import { CreatedChangeset } from './github'
-import { readLine } from './util'
+import { readLine, cacheFolder } from './util'
 import YAML from 'yaml'
 import execa from 'execa'
 import fetch from 'node-fetch'
@@ -21,7 +21,7 @@ export async function sourcegraphCLIConfig(): Promise<SourcegraphCLIConfig> {
     await commandExists('src') // CLI must be present for campaigns interactions
     return {
         SRC_ENDPOINT: DEFAULT_SRC_ENDPOINT,
-        SRC_ACCESS_TOKEN: await readLine('k8s.sgdev.org src-cli token: ', '.secrets/src-cli.txt'),
+        SRC_ACCESS_TOKEN: await readLine('k8s.sgdev.org src-cli token: ', `${cacheFolder}/src-cli.txt`),
     }
 }
 

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -1,6 +1,6 @@
-import { readLine, getWeekNumber } from './util'
+import { cacheFolder, readLine, getWeekNumber } from './util'
 import * as semver from 'semver'
-import { readFileSync } from 'fs'
+import { readFileSync, unlinkSync } from 'fs'
 import { parse as parseJSONC } from '@sqs/jsonc-parser'
 
 /**
@@ -30,10 +30,15 @@ export interface Config {
 }
 
 /**
+ * Default path of JSONC containing release configuration.
+ */
+const configPath = 'release-config.jsonc'
+
+/**
  * Loads configuration from predefined path. It does not do any special validation.
  */
 export function loadConfig(): Config {
-    return parseJSONC(readFileSync('release-config.jsonc').toString()) as Config
+    return parseJSONC(readFileSync(configPath).toString()) as Config
 }
 
 /**
@@ -60,19 +65,23 @@ export async function releaseVersions(
     // Verify the configured upcoming release. The response is cached and expires in a
     // week, after which the captain is required to confirm again.
     const now = new Date()
-    const cachedVersion = `.secrets/current_release_${now.getUTCFullYear()}_${getWeekNumber(now)}.txt`
+    const cachedVersionResponse = `${cacheFolder}/current_release_${now.getUTCFullYear()}_${getWeekNumber(now)}.txt`
     const confirmVersion = await readLine(
-        `Please confirm the upcoming release version (configured: '${config.upcomingRelease}'): `,
-        cachedVersion
+        `Please confirm the upcoming release version configured in '${configPath}' (currently '${config.upcomingRelease}'): `,
+        cachedVersionResponse
     )
     const parsedConfirmed = semver.parse(confirmVersion, parseOptions)
+    let error = ''
     if (!parsedConfirmed) {
-        throw new Error(`Provided version '${confirmVersion}' is not valid semver (in ${cachedVersion})`)
+        error = `Provided version '${confirmVersion}' is not valid semver`
+    } else if (semver.neq(parsedConfirmed, parsedUpcoming)) {
+        error = `Provided version '${confirmVersion}' and config.upcomingRelease '${config.upcomingRelease}' to not match - please update the release configuration at '${configPath}' and try again`
     }
-    if (semver.neq(parsedConfirmed, parsedUpcoming)) {
-        throw new Error(
-            `Provided version '${confirmVersion}' and config.upcomingRelease '${config.upcomingRelease}' to not match - please update the release configuration, or confirm the version in your cached answer (in ${cachedVersion})`
-        )
+
+    // If error, abort and remove the cached response (since it is invalid anyway)
+    if (error !== '') {
+        unlinkSync(cachedVersionResponse)
+        throw new Error(error)
     }
 
     const versions = {

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -75,7 +75,7 @@ export async function releaseVersions(
     if (!parsedConfirmed) {
         error = `Provided version '${confirmVersion}' is not valid semver`
     } else if (semver.neq(parsedConfirmed, parsedUpcoming)) {
-        error = `Provided version '${confirmVersion}' and config.upcomingRelease '${config.upcomingRelease}' to not match - please update the release configuration at '${configPath}' and try again`
+        error = `Provided version '${confirmVersion}' and config.upcomingRelease '${config.upcomingRelease}' do not match - please update the release configuration at '${configPath}' and try again`
     }
 
     // If error, abort and remove the cached response (since it is invalid anyway)

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -1,5 +1,5 @@
 import Octokit from '@octokit/rest'
-import { readLine, formatDate, timezoneLink } from './util'
+import { readLine, formatDate, timezoneLink, cacheFolder } from './util'
 import { promisify } from 'util'
 import * as semver from 'semver'
 import { mkdtemp as original_mkdtemp } from 'fs'
@@ -12,7 +12,7 @@ const mkdtemp = promisify(original_mkdtemp)
 export async function getAuthenticatedGitHubClient(): Promise<Octokit> {
     const githubPAT = await readLine(
         'Enter a GitHub personal access token with "repo" scope (https://github.com/settings/tokens/new): ',
-        '.secrets/github.txt'
+        `${cacheFolder}/github.txt`
     )
     const trimmedGithubPAT = githubPAT.trim()
     return new Octokit({ auth: trimmedGithubPAT })

--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -2,17 +2,17 @@ import { google, calendar_v3 } from 'googleapis'
 import { OAuth2Client } from 'googleapis-common'
 import open from 'open'
 import { Credentials } from 'google-auth-library'
-import { readLine } from './util'
+import { readLine, cacheFolder } from './util'
 import { readFile, writeFile } from 'mz/fs'
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar.events']
-const TOKEN_PATH = '.secrets/google-calendar-token.json'
+const TOKEN_PATH = `${cacheFolder}/google-calendar-token.json`
 
 export async function getClient(): Promise<OAuth2Client> {
     const credentials = JSON.parse(
         await readLine(
             'Paste Google Calendar credentials (1Password "Release automation Google Calendar API App credentials"): ',
-            '.secrets/google-calendar-credentials.json'
+            `${cacheFolder}/google-calendar-credentials.json`
         )
     )
     const { client_secret, client_id, redirect_uris } = credentials.installed

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -13,9 +13,9 @@ import {
 import * as changelog from './changelog'
 import * as campaigns from './campaigns'
 import { Config, releaseVersions } from './config'
-import { formatDate, timezoneLink } from './util'
+import { cacheFolder, formatDate, timezoneLink } from './util'
 import { addMinutes, isWeekend, eachDayOfInterval, addDays, subDays } from 'date-fns'
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync, rmdirSync, writeFileSync } from 'fs'
 import * as path from 'path'
 import commandExists from 'command-exists'
 
@@ -36,6 +36,8 @@ export type StepID =
     | 'release:add-to-campaign'
     | 'release:finalize'
     | 'release:close'
+    // util
+    | 'util:clear-cache'
     // testing
     | '_test:google-calendar'
     | '_test:slack'
@@ -258,7 +260,7 @@ If you have changes that should go into this patch release, <${patchRequestTempl
                         owner: 'sourcegraph',
                         repo: 'sourcegraph',
                         base: 'main',
-                        head: `publish-${release.version}`,
+                        head: `changelog-${release.version}`,
                         title: prMessage,
                         commitMessage: prMessage,
                         edits: [
@@ -281,7 +283,7 @@ If you have changes that should go into this patch release, <${patchRequestTempl
                                 // Update changelog
                                 writeFileSync(changelogPath, changelogContents)
                             },
-                        ], // Changes already done
+                        ],
                     },
                 ],
                 dryRun: config.dryRun.changesets,
@@ -610,6 +612,13 @@ Campaign: ${campaignURL}`,
 @${config.captainGitHubUsername}: Please complete the post-release steps before closing this issue.`,
                 })
             }
+        },
+    },
+    {
+        id: 'util:clear-cache',
+        description: 'Clear release tool cache',
+        run: () => {
+            rmdirSync(cacheFolder, { recursive: true })
         },
     },
     {

--- a/dev/release/src/slack.ts
+++ b/dev/release/src/slack.ts
@@ -1,10 +1,10 @@
 import got from 'got'
-import { readLine } from './util'
+import { readLine, cacheFolder } from './util'
 
 export async function postMessage(message: string, channel: string): Promise<void> {
     const webhookURL = await readLine(
         `Enter the Slack webhook URL corresponding to the #${channel} channel (https://api.slack.com/apps/APULW2LKS/incoming-webhooks?): `,
-        `.secrets/slackWebhookURL-${channel}.txt`
+        `${cacheFolder}/slackWebhookURL-${channel}.txt`
     )
     await got.post(webhookURL, {
         body: JSON.stringify({ text: message, link_names: true }),

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -24,6 +24,8 @@ export function timezoneLink(date: Date, linkName: string): string {
     })}_${date.getUTCFullYear()}_in_UTC?${encodeURI(linkName)}`
 }
 
+export const cacheFolder = './.secrets'
+
 export async function readLine(prompt: string, cacheFile?: string): Promise<string> {
     if (!cacheFile) {
         return readLineNoCache(prompt)


### PR DESCRIPTION
For a bug noted in https://github.com/sourcegraph/sourcegraph/issues/16207, where providing an invalid version during the confirmation would cause a lot of pains. This change:

* Removes cached version if validation fails
* Improves error messages about release configuration
* Adds a utility command for clearing the cache

Validated new behaviour by failing confirmation a few times before I get it right:

```
~/Projects/sourcegraph/sourcegraph main* 6s
❯ yarn run release release:status
yarn run v1.22.4
$ cd dev/release && yarn run release release:status
$ ../../node_modules/.bin/ts-node --transpile-only ./src/main.ts release:status
Please confirm the upcoming release version (configured: '3.23.0'): 3.21.0
Error: Provided version '3.21.0' and config.upcomingRelease '3.23.0' to not match - please update the release configuration at 'release-config.jsonc' and try again

~/Projects/sourcegraph/sourcegraph main*
❯ yarn run release release:status
yarn run v1.22.4
$ cd dev/release && yarn run release release:status
$ ../../node_modules/.bin/ts-node --transpile-only ./src/main.ts release:status
Please confirm the upcoming release version (configured: '3.23.0'): 3.22.0
Error: Provided version '3.22.0' and config.upcomingRelease '3.23.0' to not match - please update the release configuration at 'release-config.jsonc' and try again

~/Projects/sourcegraph/sourcegraph main* 7s
❯ yarn run release release:status
yarn run v1.22.4
$ cd dev/release && yarn run release release:status
$ ../../node_modules/.bin/ts-node --transpile-only ./src/main.ts release:status
Please confirm the upcoming release version (configured: '3.23.0'): 3.23.0
Using versions: { upcoming: 3.23.0, previous: 3.22.0 }
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
