### PR TITLE
Remove httpcli from campaigns resolvers and service packages

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -13,14 +13,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 var _ graphqlbackend.CampaignResolver = &campaignResolver{}
 
 type campaignResolver struct {
-	store       *store.Store
-	httpFactory *httpcli.Factory
+	store *store.Store
 	*campaigns.Campaign
 
 	// Cache the namespace on the resolver, since it's accessed more than once.
@@ -259,5 +257,5 @@ func (r *campaignResolver) CurrentSpec(ctx context.Context) (graphqlbackend.Camp
 		return nil, err
 	}
 
-	return &campaignSpecResolver{store: r.store, httpFactory: r.httpFactory, campaignSpec: campaignSpec}, nil
+	return &campaignSpecResolver{store: r.store, campaignSpec: campaignSpec}, nil
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_connection.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection.go
@@ -9,15 +9,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 var _ graphqlbackend.CampaignsConnectionResolver = &campaignsConnectionResolver{}
 
 type campaignsConnectionResolver struct {
-	store       *store.Store
-	httpFactory *httpcli.Factory
-	opts        store.ListCampaignsOpts
+	store *store.Store
+	opts  store.ListCampaignsOpts
 
 	// cache results because they are used by multiple fields
 	once      sync.Once
@@ -33,7 +31,7 @@ func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacke
 	}
 	resolvers := make([]graphqlbackend.CampaignResolver, 0, len(nodes))
 	for _, c := range nodes {
-		resolvers = append(resolvers, &campaignResolver{store: r.store, httpFactory: r.httpFactory, Campaign: c})
+		resolvers = append(resolvers, &campaignResolver{store: r.store, Campaign: c})
 	}
 	return resolvers, nil
 }

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -20,13 +20,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/syncer"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type changesetResolver struct {
-	store       *store.Store
-	httpFactory *httpcli.Factory
+	store *store.Store
 
 	changeset *campaigns.Changeset
 
@@ -52,17 +50,16 @@ type changesetResolver struct {
 	specErr  error
 }
 
-func NewChangesetResolverWithNextSync(store *store.Store, httpFactory *httpcli.Factory, changeset *campaigns.Changeset, repo *types.Repo, nextSyncAt *time.Time) *changesetResolver {
-	r := NewChangesetResolver(store, httpFactory, changeset, repo)
+func NewChangesetResolverWithNextSync(store *store.Store, changeset *campaigns.Changeset, repo *types.Repo, nextSyncAt *time.Time) *changesetResolver {
+	r := NewChangesetResolver(store, changeset, repo)
 	r.attemptedPreloadNextSyncAt = true
 	r.preloadedNextSyncAt = nextSyncAt
 	return r
 }
 
-func NewChangesetResolver(store *store.Store, httpFactory *httpcli.Factory, changeset *campaigns.Changeset, repo *types.Repo) *changesetResolver {
+func NewChangesetResolver(store *store.Store, changeset *campaigns.Changeset, repo *types.Repo) *changesetResolver {
 	return &changesetResolver{
 		store:        store,
-		httpFactory:  httpFactory,
 		repo:         repo,
 		repoResolver: graphqlbackend.NewRepositoryResolver(repo),
 		changeset:    changeset,
@@ -200,7 +197,7 @@ func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.
 		}
 	}
 
-	return &campaignsConnectionResolver{store: r.store, httpFactory: r.httpFactory, opts: opts}, nil
+	return &campaignsConnectionResolver{store: r.store, opts: opts}, nil
 }
 
 func (r *changesetResolver) CreatedAt() graphqlbackend.DateTime {
@@ -337,7 +334,7 @@ func (r *changesetResolver) CurrentSpec(ctx context.Context) (graphqlbackend.Vis
 		return nil, err
 	}
 
-	return NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, r.repo, spec), nil
+	return NewChangesetSpecResolverWithRepo(r.store, r.repo, spec), nil
 }
 
 func (r *changesetResolver) Labels(ctx context.Context) ([]graphqlbackend.ChangesetLabelResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -13,13 +13,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type changesetsConnectionResolver struct {
-	store       *store.Store
-	httpFactory *httpcli.Factory
+	store *store.Store
 
 	opts store.ListChangesetsOpts
 	// 🚨 SECURITY: If the given opts do not reveal hidden information about a
@@ -62,7 +60,7 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 			preloadedNextSyncAt = &nextSyncAt
 		}
 
-		resolvers = append(resolvers, NewChangesetResolverWithNextSync(r.store, r.httpFactory, c, reposByID[c.RepoID], preloadedNextSyncAt))
+		resolvers = append(resolvers, NewChangesetResolverWithNextSync(r.store, c, reposByID[c.RepoID], preloadedNextSyncAt))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/resolvers/changeset_event.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event.go
@@ -6,12 +6,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 type changesetEventResolver struct {
 	store             *store.Store
-	httpFactory       *httpcli.Factory
 	changesetResolver *changesetResolver
 	*campaigns.ChangesetEvent
 }

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection.go
@@ -9,12 +9,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 type changesetEventsConnectionResolver struct {
 	store             *store.Store
-	httpFactory       *httpcli.Factory
 	changesetResolver *changesetResolver
 	first             int
 	cursor            int64
@@ -35,7 +33,6 @@ func (r *changesetEventsConnectionResolver) Nodes(ctx context.Context) ([]graphq
 	for _, c := range changesetEvents {
 		resolvers = append(resolvers, &changesetEventResolver{
 			store:             r.store,
-			httpFactory:       r.httpFactory,
 			changesetResolver: r.changesetResolver,
 			ChangesetEvent:    c,
 		})

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -11,15 +11,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 var _ graphqlbackend.ChangesetSpecConnectionResolver = &changesetSpecConnectionResolver{}
 
 type changesetSpecConnectionResolver struct {
-	store       *store.Store
-	httpFactory *httpcli.Factory
+	store *store.Store
 
 	opts           store.ListChangesetSpecsOpts
 	campaignSpecID int64
@@ -77,7 +75,7 @@ func (r *changesetSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 		// In that case we'll set it anyway to nil and changesetSpecResolver
 		// will treat it as "hidden".
 
-		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, r.httpFactory, repo, c).WithPreviewer(previewer))
+		resolvers = append(resolvers, NewChangesetSpecResolverWithRepo(r.store, repo, c).WithPreviewer(previewer))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/campaigns/service/service.go
+++ b/enterprise/internal/campaigns/service/service.go
@@ -21,15 +21,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-// NewService returns a Service.
-func NewService(store *store.Store, cf *httpcli.Factory) *Service {
-	return NewServiceWithClock(store, cf, store.Clock())
+// New returns a Service.
+func New(store *store.Store) *Service {
+	return NewWithClock(store, store.Clock())
 }
 
 // NewServiceWithClock returns a Service the given clock used
 // to generate timestamps.
-func NewServiceWithClock(store *store.Store, cf *httpcli.Factory, clock func() time.Time) *Service {
-	svc := &Service{store: store, sourcer: repos.NewSourcer(cf), clock: clock}
+func NewWithClock(store *store.Store, clock func() time.Time) *Service {
+	svc := &Service{store: store, sourcer: repos.NewSourcer(httpcli.NewExternalHTTPClientFactory()), clock: clock}
 
 	return svc
 }

--- a/enterprise/internal/campaigns/service/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service/service_apply_campaign_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -39,7 +38,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 	store := store.NewWithClock(dbconn.Global, clock)
-	svc := NewService(store, httpcli.NewExternalHTTPClientFactory())
+	svc := New(store)
 
 	t.Run("campaignSpec without changesetSpecs", func(t *testing.T) {
 		t.Run("new campaign", func(t *testing.T) {

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -36,7 +36,7 @@ func TestServicePermissionLevels(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 
 	s := store.New(dbconn.Global)
-	svc := NewService(s, nil)
+	svc := New(s)
 
 	admin := ct.CreateTestUser(t, true)
 	user := ct.CreateTestUser(t, false)
@@ -179,7 +179,7 @@ func TestService(t *testing.T) {
 	fakeSource := &ct.FakeChangesetSource{}
 	sourcer := repos.NewFakeSourcer(nil, fakeSource)
 
-	svc := NewService(s, nil)
+	svc := New(s)
 	svc.sourcer = sourcer
 
 	t.Run("DeleteCampaign", func(t *testing.T) {
@@ -760,7 +760,7 @@ func TestService(t *testing.T) {
 
 		// Create a fresh service for this test as to not mess with state
 		// possibly used by other tests.
-		testSvc := NewService(s, nil)
+		testSvc := New(s)
 		testSvc.sourcer = sourcer
 
 		rs, _ := ct.CreateBbsTestRepos(t, ctx, dbconn.Global, 1)


### PR DESCRIPTION
Stacked on top of https://github.com/sourcegraph/sourcegraph/pull/16686

This was never passed in from the outside, and the frontend doesn't have one on disposal it seems. Given that repo-updater does essentially the same thing for the syncer, I think it's fine to get rid of it and just pass-in nil. The external services create their own CLI instance anyways when none is passed in, so this feels like useless boilerplate and like something that can be easily forgotten to pass around either. 