### PR TITLE
Improve go integration in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,10 @@
     },
   ],
   "editor.formatOnSave": true,
-  "go.docsTool": "gogetdoc",
+  "go.useLanguageServer": true,
+  "gopls": {
+    "local": "github.com/sourcegraph/sourcegraph",
+  },
   "jest.pathToJest": "yarn -s test",
   "jest.showCoverageOnLoad": false,
   "jest.autoEnable": false, // until we confirm people like it


### PR DESCRIPTION
This PR does two things:
- It enables the go language server by default, which is the way better tool for navigating code than just relying on the standard tools
- It passes -local to the language server so it correctly orders the dependencies on save