### PR TITLE
search frontend: add basic query hovers for structural syntax

### DIFF
--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -65,6 +65,7 @@ export enum MetaRegexpKind {
  */
 export interface MetaStructural extends BaseMetaToken {
     type: 'metaStructural'
+    groupRange?: CharacterRange
     kind: MetaStructuralKind
 }
 
@@ -441,6 +442,7 @@ const mapStructuralMeta = (pattern: Pattern): DecoratedToken[] => {
                         type: 'metaStructural',
                         kind: MetaStructuralKind.RegexpHole,
                         range: { start: range.start, end: variableStart },
+                        groupRange: range,
                         value: ':[',
                     },
                     {
@@ -465,6 +467,7 @@ const mapStructuralMeta = (pattern: Pattern): DecoratedToken[] => {
                         type: 'metaStructural',
                         kind: MetaStructuralKind.RegexpHole,
                         range: { start: patternRange.end, end: patternRange.end + 1 },
+                        groupRange: range,
                         value: ']',
                     },
                 ] as DecoratedToken[])
@@ -488,7 +491,8 @@ const mapStructuralMeta = (pattern: Pattern): DecoratedToken[] => {
                     }
                     start = start + 2
                     // Append the value of '...' after advancing.
-                    appendDecoratedToken(start - 3, MetaStructuralKind.Hole)
+                    token.push('...')
+                    appendDecoratedToken(start, MetaStructuralKind.Hole)
                     continue
                 }
                 token.push('.')

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -491,4 +491,103 @@ describe('getHoverResult()', () => {
             }
         `)
     })
+
+    test('smartQuery flag returns hover contents for structural syntax', () => {
+        const scannedQuery = toSuccess(scanSearchQuery(':[var~\\w+] ...', false, SearchPatternType.structural))
+
+        expect(getHoverResult(scannedQuery, { column: 1 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 11
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 3 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Hole variable**. A descriptive name for the syntax matched by this hole."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 3,
+                "endColumn": 6
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 6 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Regular expression separator**. Indicates the start of a regular expression that this hole should match."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 6,
+                "endColumn": 7
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 9 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**One or more**. Match one or more of the previous expression."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 9,
+                "endColumn": 10
+              }
+            }
+        `)
+        expect(getHoverResult(scannedQuery, { column: 10 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Regular expression hole**. Match the regular expression defined inside this hole."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 1,
+                "endColumn": 11
+              }
+            }
+        `)
+
+        expect(getHoverResult(scannedQuery, { column: 12 }, true)).toMatchInlineSnapshot(`
+            {
+              "contents": [
+                {
+                  "value": "**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description."
+                }
+              ],
+              "range": {
+                "startLineNumber": 1,
+                "endLineNumber": 1,
+                "startColumn": 12,
+                "endColumn": 15
+              }
+            }
+        `)
+    })
 })

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -9,6 +9,8 @@ import {
     MetaRevision,
     MetaGitRevision,
     MetaSourcegraphRevision,
+    MetaStructural,
+    MetaStructuralKind,
 } from './decoratedToken'
 import { resolveFilter } from './filters'
 
@@ -94,6 +96,19 @@ const toRegexpHover = (token: MetaRegexp): string => {
     }
 }
 
+const toStructuralHover = (token: MetaStructural): string => {
+    switch (token.kind) {
+        case MetaStructuralKind.Hole:
+            return '**Structural hole**. Matches code structures contextually. See the [syntax reference](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference) for a complete description.'
+        case MetaStructuralKind.RegexpHole:
+            return '**Regular expression hole**. Match the regular expression defined inside this hole.'
+        case MetaStructuralKind.Variable:
+            return '**Hole variable**. A descriptive name for the syntax matched by this hole.'
+        case MetaStructuralKind.RegexpSeparator:
+            return '**Regular expression separator**. Indicates the start of a regular expression that this hole should match.'
+    }
+}
+
 const toRevisionHover = (token: MetaRevision): string => {
     switch (token.kind) {
         case MetaGitRevision.CommitHash:
@@ -128,6 +143,8 @@ const toHover = (token: DecoratedToken): string => {
             return toRevisionHover(token)
         case 'metaRepoRevisionSeparator':
             return '**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the `@` specifies the repositories to search, the part after the `@` specifies which revisions to search.'
+        case 'metaStructural':
+            return toStructuralHover(token)
     }
     return ''
 }
@@ -189,6 +206,9 @@ export const getHoverResult = (
                 values.push(toHover(token))
                 range = toMonacoRange(token.groupRange ? token.groupRange : token.range)
                 break
+            case 'metaStructural':
+                values.push(toHover(token))
+                range = toMonacoRange(token.groupRange ? token.groupRange : token.range)
         }
     })
     return {


### PR DESCRIPTION
Stacked on #16684.

Adds basic hovers for structural holes, and refines hover details for regular expression holes. Example:

<img width="562" alt="Screen Shot 2020-12-13 at 1 06 48 AM" src="https://user-images.githubusercontent.com/888624/102006645-b8c19500-3cdf-11eb-8b75-a3d923f6346e.png">
