### PR TITLE
Make campaigns pkg the only entry-point for external usage of campaigns code

### DIFF
--- a/enterprise/cmd/frontend/internal/campaigns/CODENOTIFY
+++ b/enterprise/cmd/frontend/internal/campaigns/CODENOTIFY
@@ -1,2 +1,0 @@
-**/* @LawnGnome
-**/* @eseliger

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -12,15 +12,14 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executor"
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
@@ -36,7 +35,7 @@ var initFunctions = map[string]func(ctx context.Context, enterpriseServices *ent
 	"licensing":    licensing.Init,
 	"executor":     executor.Init,
 	"codeintel":    codeintel.Init,
-	"campaigns":    campaigns.Init,
+	"campaigns":    campaigns.InitFrontend,
 	"codemonitors": codemonitors.Init,
 }
 

--- a/enterprise/internal/campaigns/background.go
+++ b/enterprise/internal/campaigns/background.go
@@ -1,0 +1,40 @@
+package campaigns
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/background"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/syncer"
+	ossDB "github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+)
+
+// InitBackgroundJobs starts all jobs required to run campaigns. Currently, it is called from
+// repo-updater and in the future will be the main entry point for the campaigns worker.
+func InitBackgroundJobs(
+	ctx context.Context,
+	db *sql.DB,
+	rstore repos.Store,
+	cf *httpcli.Factory,
+	// TODO(eseliger): Remove this parameter as the sunset of repo-updater is approaching.
+	// We should switch to our own polling mechanism instead of using repo-updaters.
+	server *repoupdater.Server,
+) {
+	cstore := store.NewWithClock(db, timeutil.Now)
+
+	repoStore := ossDB.NewRepoStoreWith(cstore)
+	esStore := ossDB.NewExternalServicesStoreWith(cstore)
+
+	syncRegistry := syncer.NewSyncRegistry(ctx, cstore, repoStore, esStore, cf)
+	if server != nil {
+		server.ChangesetSyncRegistry = syncRegistry
+	}
+
+	go goroutine.MonitorBackgroundRoutines(ctx, background.Routines(ctx, db, cstore, rstore, cf)...)
+}

--- a/enterprise/internal/campaigns/background/background.go
+++ b/enterprise/internal/campaigns/background/background.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
-func StartBackgroundJobs(ctx context.Context, db *sql.DB, campaignsStore *store.Store, repoStore repos.Store, cf *httpcli.Factory) {
+func Routines(ctx context.Context, db *sql.DB, campaignsStore *store.Store, repoStore repos.Store, cf *httpcli.Factory) []goroutine.BackgroundRoutine {
 	sourcer := repos.NewSourcer(cf)
 
 	metrics := newMetrics()
@@ -21,6 +21,5 @@ func StartBackgroundJobs(ctx context.Context, db *sql.DB, campaignsStore *store.
 		newWorkerResetter(campaignsStore, metrics),
 		newSpecExpireWorker(ctx, campaignsStore),
 	}
-
-	go goroutine.MonitorBackgroundRoutines(ctx, routines...)
+	return routines
 }

--- a/enterprise/internal/campaigns/background/workers.go
+++ b/enterprise/internal/campaigns/background/workers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/reconciler"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/repos"

--- a/enterprise/internal/campaigns/doc.go
+++ b/enterprise/internal/campaigns/doc.go
@@ -1,0 +1,3 @@
+// This package is the main root for all our code. It is meant to be
+// the only campaigns enterprise package to be used outside this folder.
+package campaigns

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -32,8 +32,8 @@ type Resolver struct {
 	store *store.Store
 }
 
-// NewResolver returns a new Resolver whose store uses the given db
-func NewResolver(db *sql.DB) graphqlbackend.CampaignsResolver {
+// New returns a new Resolver whose store uses the given db
+func New(db *sql.DB) graphqlbackend.CampaignsResolver {
 	return &Resolver{store: store.New(db)}
 }
 


### PR DESCRIPTION
To make it easy to use campaigns from other packages, the main package becomes the "glue" to expose a simple to use interface for campaigns then. Before, many packages had to be used and combined.