### PR TITLE
Deglobalize CODENOTIFY settings for eseliger

### DIFF
--- a/CODENOTIFY
+++ b/CODENOTIFY
@@ -1,10 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
 **/CODEOWNERS @nicksnyder
-
-cmd/frontend/graphqlbackend/campaigns.go @eseliger
-enterprise/internal/campaigns/**/* @eseliger
-enterprise/cmd/frontend/internal/campaigns/**/* @eseliger
-internal/campaigns/**/* @eseliger
-client/web/src/enterprise/campaigns/**/* @eseliger
-client/web/src/integration/campaigns.test.ts @eseliger

--- a/client/web/src/enterprise/campaigns/CODENOTIFY
+++ b/client/web/src/enterprise/campaigns/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger

--- a/client/web/src/integration/CODENOTIFY
+++ b/client/web/src/integration/CODENOTIFY
@@ -1,1 +1,2 @@
 campaigns* @LawnGnome
+campaigns* @eseliger

--- a/cmd/frontend/graphqlbackend/CODENOTIFY
+++ b/cmd/frontend/graphqlbackend/CODENOTIFY
@@ -9,3 +9,4 @@ site_monitoring.go @bobheadxi
 
 # Campaigns
 campaigns.go @LawnGnome
+campaigns.go @eseliger

--- a/doc/CODENOTIFY
+++ b/doc/CODENOTIFY
@@ -1,2 +1,1 @@
 **/* @christinaforney
-user/campaigns/**/* @eseliger

--- a/doc/campaigns/CODENOTIFY
+++ b/doc/campaigns/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger

--- a/enterprise/cmd/frontend/internal/campaigns/CODENOTIFY
+++ b/enterprise/cmd/frontend/internal/campaigns/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger

--- a/enterprise/internal/campaigns/CODENOTIFY
+++ b/enterprise/internal/campaigns/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger

--- a/internal/campaigns/CODENOTIFY
+++ b/internal/campaigns/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger

--- a/internal/db/CODENOTIFY
+++ b/internal/db/CODENOTIFY
@@ -1,4 +1,7 @@
 external* @LawnGnome
 namespaces* @LawnGnome
 repos* @LawnGnome
+external* @eseliger
+namespaces* @eseliger
+repos* @eseliger
 repos_perm* @unknwon

--- a/internal/extsvc/CODENOTIFY
+++ b/internal/extsvc/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger

--- a/internal/src-cli/CODENOTIFY
+++ b/internal/src-cli/CODENOTIFY
@@ -1,1 +1,2 @@
 **/* @LawnGnome
+**/* @eseliger


### PR DESCRIPTION
In my first attempt, I didn't know it's possible to define codenotify settings per directory, so I added them to the global config. This migrates it to the folder-based approach and adds some I missed back then.