### PR TITLE
code monitoring: always show preview link in trigger area

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.scss
@@ -1,18 +1,4 @@
 .create-monitor-page {
-    &__query-input {
-        position: relative;
-        &-preview-link {
-            position: absolute;
-            right: 0.375rem;
-            top: 1rem;
-            padding-right: 1.5rem;
-        }
-
-        &-field {
-            padding-right: 8rem;
-        }
-    }
-
     &__actions {
         &--disabled {
             color: $gray-17 !important;

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -1,3 +1,5 @@
+@import './FormTriggerArea';
+
 .code-monitor-form {
     &__card {
         border-radius: 4px;

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -1,0 +1,33 @@
+.trigger-area {
+    &__query-input {
+        display: flex;
+        align-items: center;
+
+        &-preview-link {
+            white-space: nowrap;
+            font-size: 12px;
+            background-color: var(--color-bg-2);
+            border: 1px solid var(--input-border-color);
+            border-top-right-radius: 2px;
+            border-bottom-right-radius: 2px;
+
+            &-text {
+                display: flex;
+                align-items: center;
+                line-height: 1rem;
+                height: 1rem;
+            }
+
+            &-icon {
+                max-height: 1rem;
+                max-width: 1rem;
+            }
+        }
+
+        &-field {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+            padding-right: 8rem;
+        }
+    }
+}

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -125,29 +125,36 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                         This trigger will fire when new search results are found for a given search query.
                     </span>
                     <span className="mt-4">Search query</span>
-                    <div className="create-monitor-page__query-input">
-                        <input
-                            type="text"
-                            className={classnames(
-                                'create-monitor-page__query-input-field form-control my-2 test-trigger-input',
-                                deriveInputClassName(queryState)
-                            )}
-                            onChange={nextQueryFieldChange}
-                            value={queryState.value}
-                            required={true}
-                            autoFocus={true}
-                            ref={queryInputReference}
-                        />
-                        {queryState.kind === 'VALID' && (
-                            <Link
-                                to={`/search?${buildSearchURLQuery(query, SearchPatternType.literal, false)}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="create-monitor-page__query-input-preview-link test-preview-link"
-                            >
-                                Preview results <OpenInNewIcon className="icon-inline" />
-                            </Link>
-                        )}
+                    <div>
+                        <div className="trigger-area__query-input">
+                            <input
+                                type="text"
+                                className={classnames(
+                                    'trigger-area__query-input-field form-control my-2 test-trigger-input',
+                                    deriveInputClassName(queryState)
+                                )}
+                                onChange={nextQueryFieldChange}
+                                value={queryState.value}
+                                required={true}
+                                autoFocus={true}
+                                ref={queryInputReference}
+                            />
+                            <div className="trigger-area__query-input-preview-link p-2">
+                                <Link
+                                    to={`/search?${buildSearchURLQuery(
+                                        queryState.value,
+                                        SearchPatternType.literal,
+                                        false
+                                    )}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="trigger-area__query-input-preview-link-text test-preview-link"
+                                >
+                                    Preview results{' '}
+                                    <OpenInNewIcon className="trigger-area__query-input-preview-link-icon ml-1 icon-inline" />
+                                </Link>
+                            </div>
+                        </div>
                         {queryState.kind === 'INVALID' && (
                             <small className="invalid-feedback mb-4 test-trigger-error">{queryState.reason}</small>
                         )}

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -109,14 +109,12 @@ describe('Code monitoring', () => {
             expect(await driver.page.evaluate(() => document.querySelector('.test-trigger-error')?.textContent)).toBe(
                 'Code monitors require queries to specify either `type:commit` or `type:diff`.'
             )
-            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-preview-link').length)).toBe(0)
             await driver.page.type('.test-trigger-input', ' type:diff')
             await driver.page.waitForSelector('.is-invalid')
             await driver.page.waitForSelector('.test-trigger-error')
             expect(await driver.page.evaluate(() => document.querySelector('.test-trigger-error')?.textContent)).toBe(
                 'Code monitors require queries to specify a `patternType:` of literal, regexp, or structural.'
             )
-            expect(await driver.page.evaluate(() => document.querySelectorAll('.test-preview-link').length)).toBe(0)
             await driver.page.type('.test-trigger-input', ' patterntype:literal')
             await driver.page.waitForSelector('.is-valid')
             await driver.page.waitForSelector('.test-preview-link')


### PR DESCRIPTION
Addresses the final item in https://github.com/sourcegraph/sourcegraph/pull/16544#issuecomment-741661630. Always shows the preview link, not only when the query is validated.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
