### PR TITLE
ratelimit: Key monitors by "resource"

### DIFF
--- a/internal/extsvc/github/user_test.go
+++ b/internal/extsvc/github/user_test.go
@@ -50,7 +50,7 @@ func TestListRepositoryCollaborators(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, save := newV3Client(t, "ListRepositoryCollaborators_"+test.name)
+			client, save := newV3TestClient(t, "ListRepositoryCollaborators_"+test.name)
 			defer save()
 
 			users, _, err := client.ListRepositoryCollaborators(context.Background(), test.owner, test.repo, 1)

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -57,6 +57,19 @@ type V3Client struct {
 // apiURL must point to the base URL of the GitHub API. See the docstring for
 // V3Client.apiURL.
 func NewV3Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V3Client {
+	return newV3Client(apiURL, a, "rest", cli)
+}
+
+// NewV3SearchClient creates a new GitHub API client intended for use with the search API with an optional default
+// authenticator.
+//
+// apiURL must point to the base URL of the GitHub API. See the docstring for
+// V3Client.apiURL.
+func NewV3SearchClient(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V3Client {
+	return newV3Client(apiURL, a, "search", cli)
+}
+
+func newV3Client(apiURL *url.URL, a auth.Authenticator, resource string, cli httpcli.Doer) *V3Client {
 	apiURL = canonicalizedURL(apiURL)
 	if gitHubDisable {
 		cli = disabledClient{}
@@ -82,7 +95,7 @@ func NewV3Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V3Cli
 	}
 
 	rl := ratelimit.DefaultRegistry.Get(apiURL.String())
-	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, &ratelimit.Monitor{HeaderPrefix: "X-"})
+	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, resource, &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V3Client{
 		apiURL:           apiURL,
@@ -100,14 +113,6 @@ func NewV3Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V3Cli
 // authenticator instance (most likely a token).
 func (c *V3Client) WithAuthenticator(a auth.Authenticator) *V3Client {
 	return NewV3Client(c.apiURL, a, c.httpClient)
-}
-
-// WithSeparateRateLimitMonitor returns a new V3Client that uses the same configuration as
-// the current V3Client, except the rate limit monitor not from the global shared pool.
-func (c *V3Client) WithSeparateRateLimitMonitor() *V3Client {
-	client := NewV3Client(c.apiURL, c.auth, c.httpClient)
-	client.rateLimitMonitor = &ratelimit.Monitor{HeaderPrefix: "X-"}
-	return client
 }
 
 // RateLimitMonitor exposes the rate limit monitor.

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -60,8 +60,8 @@ func NewV3Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V3Cli
 	return newV3Client(apiURL, a, "rest", cli)
 }
 
-// NewV3SearchClient creates a new GitHub API client intended for use with the search API with an optional default
-// authenticator.
+// NewV3SearchClient creates a new GitHub API client intended for use with the
+// search API with an optional default authenticator.
 //
 // apiURL must point to the base URL of the GitHub API. See the docstring for
 // V3Client.apiURL.

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -130,7 +130,7 @@ func TestListAffiliatedRepositories(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, save := newV3Client(t, "ListAffiliatedRepositories_"+test.name)
+			client, save := newV3TestClient(t, "ListAffiliatedRepositories_"+test.name)
 			defer save()
 
 			repos, _, _, err := client.ListAffiliatedRepositories(context.Background(), test.visibility, 1)
@@ -146,7 +146,7 @@ func TestListAffiliatedRepositories(t *testing.T) {
 }
 
 func TestGetAuthenticatedUserOrgs(t *testing.T) {
-	cli, save := newV3Client(t, "GetAuthenticatedUserOrgs")
+	cli, save := newV3TestClient(t, "GetAuthenticatedUserOrgs")
 	defer save()
 
 	ctx := context.Background()
@@ -184,7 +184,7 @@ func TestV3Client_WithAuthenticator(t *testing.T) {
 	}
 }
 
-func newV3Client(t testing.TB, name string) (*V3Client, func()) {
+func newV3TestClient(t testing.TB, name string) (*V3Client, func()) {
 	t.Helper()
 
 	cf, save := httptestutil.NewGitHubRecorderFactory(t, update(name), name)

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -79,7 +79,7 @@ func NewV4Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V4Cli
 	}
 
 	rl := ratelimit.DefaultRegistry.Get(apiURL.String())
-	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, &ratelimit.Monitor{HeaderPrefix: "X-"})
+	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V4Client{
 		apiURL:           apiURL,

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -184,7 +184,7 @@ func (p *ClientProvider) newClient(baseURL *url.URL, a auth.Authenticator, httpC
 	projCache := rcache.NewWithTTL(key, int(cacheTTL/time.Second))
 
 	rl := ratelimit.DefaultRegistry.Get(baseURL.String())
-	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(baseURL.String(), tokenHash, &ratelimit.Monitor{})
+	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(baseURL.String(), tokenHash, "", &ratelimit.Monitor{})
 
 	return &Client{
 		baseURL:          baseURL,
@@ -256,7 +256,7 @@ func (c *Client) WithAuthenticator(a auth.Authenticator) *Client {
 
 	cc := *c
 	cc.rateLimiter = ratelimit.DefaultRegistry.Get(cc.baseURL.String())
-	cc.rateLimitMonitor = ratelimit.DefaultMonitorRegistry.GetOrSet(cc.baseURL.String(), tokenHash, &ratelimit.Monitor{})
+	cc.rateLimitMonitor = ratelimit.DefaultMonitorRegistry.GetOrSet(cc.baseURL.String(), tokenHash, "", &ratelimit.Monitor{})
 	cc.Auth = a
 
 	return &cc

--- a/internal/ratelimit/monitor.go
+++ b/internal/ratelimit/monitor.go
@@ -26,11 +26,15 @@ type MonitorRegistry struct {
 	monitors map[string]*Monitor
 }
 
-// GetOrSet fetches the rate limit monitor associated with the given code host / token tuple.
-// If none has been configured yet, the provided monitor will be set.
-func (r *MonitorRegistry) GetOrSet(baseURL, authHash string, monitor *Monitor) *Monitor {
+// GetOrSet fetches the rate limit monitor associated with the given code host /
+// token tuple and an optional resource key. If none has been configured yet, the
+// provided monitor will be set.
+func (r *MonitorRegistry) GetOrSet(baseURL, authHash string, resource string, monitor *Monitor) *Monitor {
 	baseURL = normaliseURL(baseURL)
 	key := baseURL + ":" + authHash
+	if len(resource) > 0 {
+		key = key + ":" + resource
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.monitors[key]; !ok {

--- a/internal/ratelimit/monitor.go
+++ b/internal/ratelimit/monitor.go
@@ -29,7 +29,7 @@ type MonitorRegistry struct {
 // GetOrSet fetches the rate limit monitor associated with the given code host /
 // token tuple and an optional resource key. If none has been configured yet, the
 // provided monitor will be set.
-func (r *MonitorRegistry) GetOrSet(baseURL, authHash string, resource string, monitor *Monitor) *Monitor {
+func (r *MonitorRegistry) GetOrSet(baseURL, authHash, resource string, monitor *Monitor) *Monitor {
 	baseURL = normaliseURL(baseURL)
 	key := baseURL + ":" + authHash
 	if len(resource) > 0 {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -126,7 +126,7 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 		githubDotCom:     githubDotCom,
 		v3Client:         github.NewV3Client(apiURL, token, cli),
 		v4Client:         github.NewV4Client(apiURL, token, cli),
-		searchClient:     github.NewV3Client(apiURL, token, cli).WithSeparateRateLimitMonitor(),
+		searchClient:     github.NewV3SearchClient(apiURL, token, cli),
 		originalHostname: originalHostname,
 	}, nil
 }


### PR DESCRIPTION
Our monitors were only keyed by api url and token, but GitHub has
different rate limits for rest, search and graphql so we now include the
resource type in our key.

Part of: https://github.com/sourcegraph/sourcegraph/issues/16455