### PR TITLE
Replace calls to repo-updater ListRepos method

### DIFF
--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -50,7 +50,9 @@ func enterpriseInit(
 
 	cStore := campaignsStore.NewWithClock(db, timeutil.Now)
 
-	syncRegistry := campaigns.NewSyncRegistry(ctx, cStore, repoStore, cf)
+	rStore := ossDB.NewRepoStoreWith(cStore)
+	esStore := ossDB.NewExternalServicesStoreWith(cStore)
+	syncRegistry := campaigns.NewSyncRegistry(ctx, cStore, rStore, esStore, cf)
 	if server != nil {
 		server.ChangesetSyncRegistry = syncRegistry
 	}

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -822,7 +822,7 @@ func reopenAfterDetach(ch *campaigns.Changeset) bool {
 func loadRepo(ctx context.Context, tx RepoStore, id api.RepoID) (*types.Repo, error) {
 	r, err := tx.Get(ctx, id)
 	if err != nil {
-		if _, isNotFoundError := err.(*db.RepoNotFoundErr); isNotFoundError {
+		if errcode.IsNotFound(err) {
 			return nil, errors.Errorf("repo not found: %d", id)
 		}
 		return nil, err

--- a/enterprise/internal/campaigns/reconciler.go
+++ b/enterprise/internal/campaigns/reconciler.go
@@ -2,7 +2,6 @@ package campaigns
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net/url"
 	"sort"
@@ -137,14 +136,16 @@ func (e *executor) ExecutePlan(ctx context.Context, plan *ReconcilerPlan) (err e
 		return nil
 	}
 
-	reposStore := repos.NewDBStore(e.tx.Handle().DB(), sql.TxOptions{})
+	reposStore := db.NewRepoStoreWith(e.tx)
 
 	e.repo, err = loadRepo(ctx, reposStore, e.ch.RepoID)
 	if err != nil {
 		return errors.Wrap(err, "failed to load repository")
 	}
 
-	e.extSvc, err = loadExternalService(ctx, reposStore, e.repo)
+	esStore := db.NewExternalServicesStoreWith(e.tx)
+
+	e.extSvc, err = loadExternalService(ctx, esStore, e.repo)
 	if err != nil {
 		return errors.Wrap(err, "failed to load external service")
 	}
@@ -819,21 +820,22 @@ func reopenAfterDetach(ch *campaigns.Changeset) bool {
 }
 
 func loadRepo(ctx context.Context, tx RepoStore, id api.RepoID) (*types.Repo, error) {
-	rs, err := tx.ListRepos(ctx, repos.StoreListReposArgs{IDs: []api.RepoID{id}})
+	r, err := tx.Get(ctx, id)
 	if err != nil {
+		if _, isNotFoundError := err.(*db.RepoNotFoundErr); isNotFoundError {
+			return nil, errors.Errorf("repo not found: %d", id)
+		}
 		return nil, err
 	}
-	if len(rs) != 1 {
-		return nil, errors.Errorf("repo not found: %d", id)
-	}
-	return rs[0], nil
+
+	return r, nil
 }
 
-func loadExternalService(ctx context.Context, reposStore RepoStore, repo *types.Repo) (*types.ExternalService, error) {
+func loadExternalService(ctx context.Context, esStore ExternalServiceStore, repo *types.Repo) (*types.ExternalService, error) {
 	var externalService *types.ExternalService
-	args := repos.StoreListExternalServicesArgs{IDs: repo.ExternalServiceIDs()}
+	args := db.ExternalServicesListOptions{IDs: repo.ExternalServiceIDs()}
 
-	es, err := reposStore.ListExternalServices(ctx, args)
+	es, err := esStore.List(ctx, args)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -164,7 +164,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ee.SyncChangeset(ctx, repoStore, cstore, githubSrc, githubRepo, c); err != nil {
+		if err := ee.SyncChangeset(ctx, cstore, githubSrc, githubRepo, c); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -164,7 +164,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ee.SyncChangeset(ctx, rstore, cstore, githubSrc, githubRepo, c); err != nil {
+		if err := ee.SyncChangeset(ctx, repoStore, cstore, githubSrc, githubRepo, c); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -23,10 +24,11 @@ import (
 
 // SyncRegistry manages a ChangesetSyncer per code host
 type SyncRegistry struct {
-	Ctx         context.Context
-	SyncStore   SyncStore
-	RepoStore   RepoStore
-	HTTPFactory *httpcli.Factory
+	Ctx                  context.Context
+	SyncStore            SyncStore
+	RepoStore            RepoStore
+	ExternalServiceStore ExternalServiceStore
+	HTTPFactory          *httpcli.Factory
 
 	// Used to receive high priority sync requests
 	priorityNotify chan []int64
@@ -37,23 +39,27 @@ type SyncRegistry struct {
 }
 
 type RepoStore interface {
-	ListExternalServices(context.Context, repos.StoreListExternalServicesArgs) ([]*types.ExternalService, error)
-	ListRepos(context.Context, repos.StoreListReposArgs) ([]*types.Repo, error)
+	Get(ctx context.Context, id api.RepoID) (*types.Repo, error)
+}
+
+type ExternalServiceStore interface {
+	List(context.Context, db.ExternalServicesListOptions) ([]*types.ExternalService, error)
 }
 
 // NewSyncRegistry creates a new sync registry which starts a syncer for each code host and will update them
 // when external services are changed, added or removed.
-func NewSyncRegistry(ctx context.Context, store SyncStore, repoStore RepoStore, cf *httpcli.Factory) *SyncRegistry {
+func NewSyncRegistry(ctx context.Context, store SyncStore, repoStore RepoStore, esStore ExternalServiceStore, cf *httpcli.Factory) *SyncRegistry {
 	r := &SyncRegistry{
-		Ctx:            ctx,
-		SyncStore:      store,
-		RepoStore:      repoStore,
-		HTTPFactory:    cf,
-		priorityNotify: make(chan []int64, 500),
-		syncers:        make(map[string]*ChangesetSyncer),
+		Ctx:                  ctx,
+		SyncStore:            store,
+		RepoStore:            repoStore,
+		ExternalServiceStore: esStore,
+		HTTPFactory:          cf,
+		priorityNotify:       make(chan []int64, 500),
+		syncers:              make(map[string]*ChangesetSyncer),
 	}
 
-	services, err := repoStore.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{})
+	services, err := esStore.List(ctx, db.ExternalServicesListOptions{})
 	if err != nil {
 		log15.Error("Fetching initial external services", "err", err)
 	}
@@ -94,12 +100,13 @@ func (s *SyncRegistry) Add(extSvc *types.ExternalService) {
 	ctx, cancel := context.WithCancel(s.Ctx)
 
 	syncer := &ChangesetSyncer{
-		syncStore:      s.SyncStore,
-		httpFactory:    s.HTTPFactory,
-		reposStore:     s.RepoStore,
-		codeHostURL:    normalised,
-		cancel:         cancel,
-		priorityNotify: make(chan []int64, 500),
+		syncStore:            s.SyncStore,
+		httpFactory:          s.HTTPFactory,
+		reposStore:           s.RepoStore,
+		externalServiceStore: s.ExternalServiceStore,
+		codeHostURL:          normalised,
+		cancel:               cancel,
+		priorityNotify:       make(chan []int64, 500),
 	}
 
 	s.syncers[normalised] = syncer
@@ -201,9 +208,10 @@ func externalServiceSyncerKey(kind, config string) (string, error) {
 // A ChangesetSyncer periodically syncs metadata of changesets
 // saved in the database.
 type ChangesetSyncer struct {
-	syncStore   SyncStore
-	httpFactory *httpcli.Factory
-	reposStore  RepoStore
+	syncStore            SyncStore
+	httpFactory          *httpcli.Factory
+	reposStore           RepoStore
+	externalServiceStore ExternalServiceStore
 
 	codeHostURL string
 
@@ -472,7 +480,7 @@ func (s *ChangesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 		return err
 	}
 
-	externalService, err := loadExternalService(ctx, s.reposStore, repo)
+	externalService, err := loadExternalService(ctx, s.externalServiceStore, repo)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/syncer.go
+++ b/enterprise/internal/campaigns/syncer.go
@@ -490,12 +490,12 @@ func (s *ChangesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 	if err != nil {
 		return err
 	}
-	return SyncChangeset(ctx, s.reposStore, s.syncStore, source, repo, cs)
+	return SyncChangeset(ctx, s.syncStore, source, repo, cs)
 }
 
 // SyncChangeset refreshes the metadata of the given changeset and
 // updates them in the database.
-func SyncChangeset(ctx context.Context, repoStore RepoStore, syncStore SyncStore, source repos.ChangesetSource, repo *types.Repo, c *campaigns.Changeset) (err error) {
+func SyncChangeset(ctx context.Context, syncStore SyncStore, source repos.ChangesetSource, repo *types.Repo, c *campaigns.Changeset) (err error) {
 	repoChangeset := &repos.Changeset{Repo: repo, Changeset: c}
 	if err := source.LoadChangeset(ctx, repoChangeset); err != nil {
 		_, ok := err.(repos.ChangesetNotFoundError)

--- a/enterprise/internal/campaigns/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks.go
@@ -2,7 +2,6 @@ package campaigns
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -19,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -63,8 +63,8 @@ func (h Webhook) getRepoForPR(
 	pr PR,
 	externalServiceID string,
 ) (*types.Repo, error) {
-	reposTx := repos.NewDBStore(tx.DB(), sql.TxOptions{})
-	rs, err := reposTx.ListRepos(ctx, repos.StoreListReposArgs{
+	reposTx := db.NewRepoStoreWith(tx)
+	rs, err := reposTx.List(ctx, db.ReposListOptions{
 		ExternalRepos: []api.ExternalRepoSpec{
 			{
 				ID:          pr.RepoExternalID,

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -135,7 +135,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		})
 		defer state.Unmock()
 
-		err = SyncChangeset(ctx, repoStore, s, githubSrc, githubRepo, changeset)
+		err = SyncChangeset(ctx, s, githubSrc, githubRepo, changeset)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -322,7 +322,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				t.Fatal(err)
 			}
 
-			err = SyncChangeset(ctx, repoStore, s, bitbucketSource, bitbucketRepo, ch)
+			err = SyncChangeset(ctx, s, bitbucketSource, bitbucketRepo, ch)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks_test.go
@@ -135,7 +135,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		})
 		defer state.Unmock()
 
-		err = SyncChangeset(ctx, rstore, s, githubSrc, githubRepo, changeset)
+		err = SyncChangeset(ctx, repoStore, s, githubSrc, githubRepo, changeset)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -322,7 +322,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				t.Fatal(err)
 			}
 
-			err = SyncChangeset(ctx, rstore, s, bitbucketSource, bitbucketRepo, ch)
+			err = SyncChangeset(ctx, repoStore, s, bitbucketSource, bitbucketRepo, ch)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -51,6 +51,11 @@ func NewExternalServicesStoreWithDB(db dbutil.DB) *ExternalServiceStore {
 	return &ExternalServiceStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
+// NewExternalServicesStoreWithDB instantiates and returns a new ExternalServicesStore with prepared statements.
+func NewExternalServicesStoreWith(other basestore.ShareableStore) *ExternalServiceStore {
+	return &ExternalServiceStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
 func (e *ExternalServiceStore) With(other basestore.ShareableStore) *ExternalServiceStore {
 	return &ExternalServiceStore{Store: e.Store.With(other)}
 }


### PR DESCRIPTION
This replaces all the calls to repo-updater's Store#ListRepos method from outside of repo-updater. These calls were replaced by the `internal/db/RepoStore#List` and `internal/db/RepoStore#Get` method.

Fixes #14710