### PR TITLE
monitoring: streamline providing of generator options

### DIFF
--- a/dev/grafana.sh
+++ b/dev/grafana.sh
@@ -32,7 +32,7 @@ docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
 
 # Generate Grafana dashboards
 pushd monitoring >/dev/null || exit 1
-DEV=true RELOAD=false go generate
+RELOAD=false go generate
 popd >/dev/null || exit 1
 
 # Log file location: since we log outside of the Docker container, we should

--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -55,7 +55,7 @@ done
 
 $generate_graphql && { go generate github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend || failed=true; }
 $generate_dashboards && { docker-images/grafana/jsonnet/build.sh || failed=true; }
-$generate_monitoring && { pushd monitoring >/dev/null && DEV=true go generate && popd >/dev/null || failed=true; }
+$generate_monitoring && { pushd monitoring >/dev/null && go generate && popd >/dev/null || failed=true; }
 $generate_schema && { go generate github.com/sourcegraph/sourcegraph/schema || failed=true; }
 
 if $all_cmds; then

--- a/dev/prometheus.sh
+++ b/dev/prometheus.sh
@@ -35,7 +35,7 @@ docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
 cp ${PROM_TARGETS} "${CONFIG_DIR}"/prometheus_targets.yml
 
 pushd monitoring >/dev/null || exit 1
-DEV=true RELOAD=false go generate
+RELOAD=false go generate
 popd >/dev/null || exit 1
 
 PROMETHEUS_LOGS="${HOME}/.sourcegraph-dev/logs/prometheus"

--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -3,14 +3,28 @@
 package main
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
+func optsFromEnv() monitoring.GenerateOptions {
+	return monitoring.GenerateOptions{
+		DisablePrune: getEnvBool("NO_PRUNE", false),
+		LiveReload:   getEnvBool("RELOAD", false),
+
+		GrafanaDir:    getEnvStr("GRAFANA_DIR", "../docker-images/grafana/config/provisioning/dashboards/sourcegraph/"),
+		PrometheusDir: getEnvStr("PROMETHEUS_DIR", "../docker-images/prometheus/config/"),
+		DocsDir:       getEnvStr("DOCS_DIR", "../doc/admin/observability/"),
+	}
+}
+
 func main() {
 	// Runs the monitoring generator. Ensure that any dashboards created or removed are
 	// updated in the arguments here as required.
-	monitoring.Generate(
+	monitoring.Generate(optsFromEnv(),
 		definitions.Frontend(),
 		definitions.GitServer(),
 		definitions.GitHubProxy(),
@@ -26,4 +40,22 @@ func main() {
 		definitions.Prometheus(),
 		definitions.ExecutorAndExecutorQueue(),
 	)
+}
+
+func getEnvStr(key, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return defaultValue
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	if v, ok := os.LookupEnv(key); ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			panic(err)
+		}
+		return b
+	}
+	return defaultValue
 }

--- a/monitoring/monitoring/README.md
+++ b/monitoring/monitoring/README.md
@@ -14,8 +14,9 @@ To learn more about the generator\, see the top\-level program: https://github.c
 
 ## Index
 
-- [func Generate(containers ...*Container)](<#func-generate>)
+- [func Generate(opts GenerateOptions, containers ...*Container)](<#func-generate>)
 - [type Container](<#type-container>)
+- [type GenerateOptions](<#type-generateoptions>)
 - [type Group](<#type-group>)
 - [type Observable](<#type-observable>)
   - [func (o Observable) WithCritical(a *ObservableAlertDefinition) Observable](<#func-observable-withcritical>)
@@ -38,10 +39,10 @@ To learn more about the generator\, see the top\-level program: https://github.c
 - [type UnitType](<#type-unittype>)
 
 
-## func [Generate](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L25>)
+## func [Generate](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L36>)
 
 ```go
-func Generate(containers ...*Container)
+func Generate(opts GenerateOptions, containers ...*Container)
 ```
 
 Generate is the main Sourcegraph monitoring generator entrypoint\.
@@ -66,6 +67,24 @@ type Container struct {
 
     // Groups of observable information about the container.
     Groups []Group
+}
+```
+
+## type [GenerateOptions](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L21-L33>)
+
+```go
+type GenerateOptions struct {
+    // Toggles pruning of dangling generated assets through simple heuristic, should be disabled during builds
+    DisablePrune bool
+    // Trigger reload of active Prometheus or Grafana instance (requires respective output directories)
+    LiveReload bool
+
+    // Output directory for generated Grafana assets
+    GrafanaDir string
+    // Output directory for generated Prometheus assets
+    PrometheusDir string
+    // Output directory for generated documentation
+    DocsDir string
 }
 ```
 

--- a/monitoring/monitoring/README.md
+++ b/monitoring/monitoring/README.md
@@ -39,7 +39,7 @@ To learn more about the generator\, see the top\-level program: https://github.c
 - [type UnitType](<#type-unittype>)
 
 
-## func [Generate](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L36>)
+## func [Generate](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L37>)
 
 ```go
 func Generate(opts GenerateOptions, containers ...*Container)
@@ -70,7 +70,9 @@ type Container struct {
 }
 ```
 
-## type [GenerateOptions](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L21-L33>)
+## type [GenerateOptions](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/generator.go#L22-L34>)
+
+GenerateOptions declares options for the monitoring generator\.
 
 ```go
 type GenerateOptions struct {

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -7,62 +7,55 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/grafana-tools/sdk"
 	"gopkg.in/yaml.v2"
 )
 
-var isDev, _ = strconv.ParseBool(os.Getenv("DEV"))
-var noPrune, _ = strconv.ParseBool(os.Getenv("NO_PRUNE"))
-
 const alertSuffix = "_alert_rules.yml"
 
+const alertSolutionsFile = "alert_solutions.md"
+
+type GenerateOptions struct {
+	// Toggles pruning of dangling generated assets through simple heuristic, should be disabled during builds
+	DisablePrune bool
+	// Trigger reload of active Prometheus or Grafana instance (requires respective output directories)
+	LiveReload bool
+
+	// Output directory for generated Grafana assets
+	GrafanaDir string
+	// Output directory for generated Prometheus assets
+	PrometheusDir string
+	// Output directory for generated documentation
+	DocsDir string
+}
+
 // Generate is the main Sourcegraph monitoring generator entrypoint.
-func Generate(containers ...*Container) {
+func Generate(opts GenerateOptions, containers ...*Container) {
 	println("Regenerating monitoring...")
-
-	grafanaDir, ok := os.LookupEnv("GRAFANA_DIR")
-	if !ok {
-		grafanaDir = "../docker-images/grafana/config/provisioning/dashboards/sourcegraph/"
-	}
-	prometheusDir, ok := os.LookupEnv("PROMETHEUS_DIR")
-	if !ok {
-		prometheusDir = "../docker-images/prometheus/config/"
-	}
-	docSolutionsFile, ok := os.LookupEnv("DOC_SOLUTIONS_FILE")
-	if !ok {
-		docSolutionsFile = "../doc/admin/observability/alert_solutions.md"
-	}
-
-	reloadValue, ok := os.LookupEnv("RELOAD")
-	if !ok && isDev {
-		reloadValue = "true"
-	}
-	reload, _ := strconv.ParseBool(reloadValue)
 
 	var filelist []string
 	for _, container := range containers {
 		if err := container.validate(); err != nil {
 			log.Fatal(fmt.Sprintf("container %q: %+v", container.Name, err))
 		}
-		if grafanaDir != "" {
+		if opts.GrafanaDir != "" {
 			board := container.dashboard()
 			data, err := json.MarshalIndent(board, "", "  ")
 			if err != nil {
 				log.Fatal(err)
 			}
 			// #nosec G306  prometheus runs as nobody
-			err = ioutil.WriteFile(filepath.Join(grafanaDir, container.Name+".json"), data, 0666)
+			err = ioutil.WriteFile(filepath.Join(opts.GrafanaDir, container.Name+".json"), data, 0666)
 			if err != nil {
 				log.Fatal(err)
 			}
 			filelist = append(filelist, container.Name+".json")
 
-			if reload {
+			// Reload specific dashboard
+			if opts.LiveReload {
 				ctx := context.Background()
 				client := sdk.NewClient("http://127.0.0.1:3370", "admin:admin", sdk.DefaultHTTPClient)
 				_, err := client.SetDashboard(ctx, *board, sdk.SetDashboardParams{Overwrite: true})
@@ -72,7 +65,7 @@ func Generate(containers ...*Container) {
 			}
 		}
 
-		if prometheusDir != "" {
+		if opts.PrometheusDir != "" {
 			promAlertsFile := container.promAlertsFile()
 			data, err := yaml.Marshal(promAlertsFile)
 			if err != nil {
@@ -81,17 +74,18 @@ func Generate(containers ...*Container) {
 			fileName := strings.Replace(container.Name, "-", "_", -1) + alertSuffix
 			filelist = append(filelist, fileName)
 			// #nosec G306  grafana runs as UID 472
-			err = ioutil.WriteFile(filepath.Join(prometheusDir, fileName), data, 0666)
+			err = ioutil.WriteFile(filepath.Join(opts.PrometheusDir, fileName), data, 0666)
 			if err != nil {
 				log.Fatal(err)
 			}
 		}
 	}
-	if !noPrune {
-		deleteRemnants(filelist, grafanaDir, prometheusDir)
+	if !opts.DisablePrune {
+		deleteRemnants(filelist, opts.GrafanaDir, opts.PrometheusDir)
 	}
 
-	if prometheusDir != "" && reload {
+	if opts.PrometheusDir != "" && opts.LiveReload {
+		// Reload all Prometheus rules
 		resp, err := http.Post("http://127.0.0.1:9090/-/reload", "", nil)
 		if err != nil {
 			log.Fatal("reloading Prometheus rules, got error:", err)
@@ -101,14 +95,14 @@ func Generate(containers ...*Container) {
 			log.Fatal("reloading Prometheus rules, got status code:", resp.StatusCode)
 		}
 	}
-	if reload && grafanaDir != "" && prometheusDir != "" {
+	if opts.LiveReload && opts.GrafanaDir != "" && opts.PrometheusDir != "" {
 		fmt.Println("Reloaded Prometheus rules & Grafana dashboards")
 	}
 
-	if docSolutionsFile != "" {
+	if opts.DocsDir != "" {
 		solutions := generateDocs(containers)
 		// #nosec G306
-		err := ioutil.WriteFile(docSolutionsFile, solutions, 0666)
+		err := ioutil.WriteFile(filepath.Join(opts.DocsDir, alertSolutionsFile), solutions, 0666)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -18,6 +18,7 @@ const alertSuffix = "_alert_rules.yml"
 
 const alertSolutionsFile = "alert_solutions.md"
 
+// GenerateOptions declares options for the monitoring generator.
 type GenerateOptions struct {
 	// Toggles pruning of dangling generated assets through simple heuristic, should be disabled during builds
 	DisablePrune bool


### PR DESCRIPTION
* Remove repetition in env lookup code
* Consolidate config in a struct we can document, and move generation of defaults out of the `monitoring` package into the `main` program
   * The relative paths make more sense with this move, and tries to keep the `monitoring` package as purely generator code concerns
* Remove unused `DEV` variable

This PR is for an item in https://github.com/sourcegraph/sourcegraph/issues/16117
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
