### PR TITLE
Exit early on setup-deps

### DIFF
--- a/dev/ci/test/setup-deps.sh
+++ b/dev/ci/test/setup-deps.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 asdf install
 yarn
 yarn generate

--- a/dev/ci/test/setup-deps.sh
+++ b/dev/ci/test/setup-deps.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 asdf install
 yarn
 yarn generate
-yes | gcloud auth configure-docker
+echo yes | gcloud auth configure-docker
 
 apt-get install -y gcc python3-dev python3-setuptools
 pip3 install --no-cache-dir -U crcmod


### PR DESCRIPTION
We had CI runs fail on a command and continue
making debugging the root-cause hard.
eg. https://buildkite.com/sourcegraph/qa/builds/997#f0836819-a628-4dca-a5b1-21f96001c3cd/63-178

This makes scripts fail early and run in "strict mode".
