### PR TITLE
codeintel: Refrain from using git log --all in directed path

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/background/commit_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commit_updater.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
@@ -105,7 +106,8 @@ func (u *CommitUpdater) tryUpdate(ctx context.Context, repositoryID, dirtyToken 
 		oldestCommitDateWithUpload = oldestCommitDateWithUpload.Add(-time.Second)
 
 		graph, err = u.gitserverClient.CommitGraph(ctx, repositoryID, gitserver.CommitGraphOptions{
-			Since: &oldestCommitDateWithUpload,
+			AllRefs: true,
+			Since:   &oldestCommitDateWithUpload,
 		})
 		if err != nil {
 			return errors.Wrap(err, "gitserver.CommitGraph")

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -65,9 +66,10 @@ func (c *CommitGraph) Graph() map[string][]string { return c.graph }
 func (c *CommitGraph) Order() []string            { return c.order }
 
 type CommitGraphOptions struct {
-	Commit string
-	Limit  int
-	Since  *time.Time
+	Commit  string
+	AllRefs bool
+	Limit   int
+	Since   *time.Time
 }
 
 // CommitGraph returns the commit graph for the given repository as a mapping from a commit
@@ -81,7 +83,10 @@ func (c *Client) CommitGraph(ctx context.Context, repositoryID int, opts CommitG
 	}})
 	defer endObservation(1, observation.Args{})
 
-	commands := []string{"log", "--all", "--pretty=%H %P", "--topo-order"}
+	commands := []string{"log", "--pretty=%H %P", "--topo-order"}
+	if opts.AllRefs {
+		commands = append(commands, "--all")
+	}
 	if opts.Commit != "" {
 		commands = append(commands, opts.Commit)
 	}


### PR DESCRIPTION
CommitGraph is used in two places:

- In the commit updater (offline, periodic process) that needs to get as much as the git graph as possible since a certain time, and
- In the code intel API when checking for the closest upload of an _unknown_ commit (a commit that was pushed after the last index was uploaded)

In the former case, we want `--all` to scoop as much of the non-main/master branch as possible so feature branches also get code intelligence.

In the latter case, `--all` is actively harmful. It returns detached segments of the git graph that can't help us out, and blows a good proportion of our output limit. We have been seeing on dotcom newer commits with no code intelligence, which was traced to `git log` output not listing the ancestor within 50 output lines.