### PR TITLE
postgres_exporter: Target correct pg variable

### DIFF
--- a/dev/postgres_exporter.sh
+++ b/dev/postgres_exporter.sh
@@ -17,7 +17,7 @@ PGHOST=${PGHOST-$(get_pg_env HOST)}
 PGUSER=${PGUSER-$(get_pg_env USER)}
 PGPORT=${PGPORT-$(get_pg_env PORT)}
 # we need to be able to query schema_migrations table
-PGDATABASE=${PGDATABASE-$(get_pg_env DATABASE)}
+PGDATABASE=${PGDATABASE-$(get_pg_env DBNAME)}
 
 ADJUSTED_HOST=${PGHOST:-127.0.0.1}
 if [[ ("$ADJUSTED_HOST" == "localhost" || "$ADJUSTED_HOST" == "127.0.0.1" || -f "$ADJUSTED_HOST") && "$OSTYPE" != "linux-gnu" ]]; then


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C07KZF47K/p1607985014462800

This fixes the dev environment startup by using the expected variable from `psql \set`.