### PR TITLE
search: enable smart query flag by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Changesets in a campaign can now be searched by title and repository name. [#15781](https://github.com/sourcegraph/sourcegraph/issues/15781)
 - Experimental: [`transformChanges` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#transformchanges) is now available as a feature preview to allow users to create multiple changesets in a single repository. [#16235](https://github.com/sourcegraph/sourcegraph/pull/16235)
 - The `gitUpdateInterval` site setting was added to allow custom git update intervals based on repository names. [#16765](https://github.com/sourcegraph/sourcegraph/pull/16765)
+- Various additions to syntax highlighting and hover tooltips in the search query bar (e.g., regular expressions). Can be disabled with `{ "experimentalFeatures": { "enableSmartQuery": false } }` in case of unlikely adverse effects. [#16742](https://github.com/sourcegraph/sourcegraph/pull/16742)
 
 ### Changed
 

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -68,7 +68,7 @@ export function experimentalFeaturesFromSettings(
         showEnterpriseHomePanels = true, // Default to true if not set
         showMultilineSearchConsole = false,
         showQueryBuilder = false,
-        enableSmartQuery = false,
+        enableSmartQuery = true,
     } = experimentalFeatures
 
     return {

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -87,7 +87,7 @@
         "enableSmartQuery": {
           "description": "Enables contextual syntax highlighting and hovers for search queries in the web app",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": { "pointer": true }
         },
         "enableFastResultLoading": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -92,7 +92,7 @@ const SettingsSchemaJSON = `{
         "enableSmartQuery": {
           "description": "Enables contextual syntax highlighting and hovers for search queries in the web app",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": { "pointer": true }
         },
         "enableFastResultLoading": {


### PR DESCRIPTION
Lots we can still improve, but we're in a good place to turn it on by default.