### PR TITLE
search frontend: fix hovers for chars in character class

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -504,7 +504,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 1,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassMember"
               },
               {
                 "startIndex": 2,
@@ -669,7 +669,11 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 6,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassMember"
+              },
+              {
+                "startIndex": 7,
+                "scopes": "metaRegexpCharacterClassMember"
               },
               {
                 "startIndex": 8,

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -56,6 +56,7 @@ export enum MetaRegexpKind {
     EscapedCharacter = 'EscapedCharacter', // like \(
     CharacterSet = 'CharacterSet', // like \s
     CharacterClass = 'CharacterClass', // like [a-z]
+    CharacterClassMember = 'CharacterClassMember', // a character inside a charcter class like [abcd]
     LazyQuantifier = 'LazyQuantifier', // the ? after a range quantifier
     RangeQuantifier = 'RangeQuantifier', // like +
 }
@@ -129,8 +130,6 @@ export interface MetaRepoRevisionSeparator extends BaseMetaToken {
  * Coalesces consecutive pattern tokens. Used, for example, when parsing
  * literal characters like 'f', 'o', 'o' in regular expressions, which are
  * coalesced to 'foo' for hovers.
- *
- * @param tokens
  */
 const coalescePatterns = (tokens: DecoratedToken[]): DecoratedToken[] => {
     let previous: Pattern | undefined
@@ -307,6 +306,16 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                         range: { start: offset + node.start, end: offset + node.end },
                         value: node.raw,
                         kind: MetaRegexpKind.EscapedCharacter,
+                    })
+                    return
+                }
+                if (node.parent.type === 'CharacterClass') {
+                    // This character is inside a character class like [abcd] and is contextually special for hover tooltips.
+                    tokens.push({
+                        type: 'metaRegexp',
+                        range: { start: offset + node.start, end: offset + node.end },
+                        value: node.raw,
+                        kind: MetaRegexpKind.CharacterClassMember,
                     })
                     return
                 }

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -50,6 +50,8 @@ const toRegexpHover = (token: MetaRegexp): string => {
                 case '\\S':
                     return '**Negated whitespace**. Match any character that is **not** a whitespace character like a space, line break, or tab.'
             }
+        case MetaRegexpKind.CharacterClassMember:
+            return `**Character**. This character class matches the character \`${token.value}\`.`
         case MetaRegexpKind.Delimited:
             return '**Group**. Groups together multiple expressions to match.'
         case MetaRegexpKind.EscapedCharacter: {

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -48,6 +48,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'metaRegexpEscapedCharacter', foreground: '#ffa8a8' },
         { token: 'metaRegexpCharacterSet', foreground: '#da77f2' },
         { token: 'metaRegexpCharacterClass', foreground: '#da77f2' },
+        { token: 'metaRegexpCharacterClassMember', foreground: '#f2f4f8' },
         { token: 'metaRegexpRangeQuantifier', foreground: '#3bc9db' },
         { token: 'metaRegexpAlternative', foreground: '#3bc9db' },
         // Structural pattern highlighting
@@ -102,6 +103,7 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'metaRegexpEscapedCharacter', foreground: '#af5200' },
         { token: 'metaRegexpCharacterSet', foreground: '#ae3ec9' },
         { token: 'metaRegexpCharacterClass', foreground: '#ae3ec9' },
+        { token: 'metaRegexpCharacterClassMember', foreground: '#2b3750' },
         { token: 'metaRegexpRangeQuantifier', foreground: '#1098ad' },
         { token: 'metaRegexpAlternative', foreground: '#1098ad' },
         // Structural pattern highlighting


### PR DESCRIPTION
We coalesce characters that form part of a string to search. But characters inside a regex character class mean they'll match a character, not a string.

Previously:

<img width="270" alt="Screen Shot 2020-12-14 at 10 02 48 PM" src="https://user-images.githubusercontent.com/888624/102173389-20025500-3e58-11eb-930f-dabb47206584.png">


Now:

<img width="545" alt="Screen Shot 2020-12-14 at 10 01 34 PM" src="https://user-images.githubusercontent.com/888624/102173311-fba67880-3e57-11eb-8b21-a424106a12a2.png">
