### PR TITLE
search frontend: more precise regexp range hover tooltip

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -336,15 +336,15 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 2,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 3,
-                "scopes": "metaRegexpCharacterClass"
+                "scopes": "metaRegexpCharacterClassRangeHyphen"
               },
               {
                 "startIndex": 4,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 5,
@@ -368,15 +368,15 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 1,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 2,
-                "scopes": "metaRegexpCharacterClass"
+                "scopes": "metaRegexpCharacterClassRangeHyphen"
               },
               {
                 "startIndex": 3,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 4,
@@ -388,15 +388,15 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 6,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 7,
-                "scopes": "metaRegexpCharacterClass"
+                "scopes": "metaRegexpCharacterClassRangeHyphen"
               },
               {
                 "startIndex": 8,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 9,
@@ -408,15 +408,15 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 11,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 12,
-                "scopes": "metaRegexpCharacterClass"
+                "scopes": "metaRegexpCharacterClassRangeHyphen"
               },
               {
                 "startIndex": 13,
-                "scopes": "identifier"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
                 "startIndex": 14,
@@ -646,7 +646,7 @@ describe('getMonacoTokens()', () => {
     test('decorate escaped characters', () => {
         expect(
             getMonacoTokens(
-                toSuccess(scanSearchQuery('[\\--\\abc] \\|\\.|\\(\\)', false, SearchPatternType.regexp)),
+                toSuccess(scanSearchQuery('[--\\\\abc] \\|\\.|\\(\\)', false, SearchPatternType.regexp)),
                 true
             )
         ).toMatchInlineSnapshot(`
@@ -657,15 +657,23 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 1,
-                "scopes": "metaRegexpEscapedCharacter"
+                "scopes": "metaRegexpCharacterClassRange"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "metaRegexpCharacterClassRangeHyphen"
               },
               {
                 "startIndex": 3,
-                "scopes": "metaRegexpCharacterClass"
+                "scopes": "metaRegexpCharacterClassRange"
               },
               {
-                "startIndex": 4,
+                "startIndex": 3,
                 "scopes": "metaRegexpEscapedCharacter"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaRegexpCharacterClassMember"
               },
               {
                 "startIndex": 6,

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -56,6 +56,8 @@ export enum MetaRegexpKind {
     EscapedCharacter = 'EscapedCharacter', // like \(
     CharacterSet = 'CharacterSet', // like \s
     CharacterClass = 'CharacterClass', // like [a-z]
+    CharacterClassRange = 'CharacterClassRange', // the a-z part in [a-z]
+    CharacterClassRangeHyphen = 'CharacterClassRangeHyphen', // the - part in [a-z]
     CharacterClassMember = 'CharacterClassMember', // a character inside a charcter class like [abcd]
     LazyQuantifier = 'LazyQuantifier', // the ? after a range quantifier
     RangeQuantifier = 'RangeQuantifier', // like +
@@ -247,15 +249,36 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                 })
             },
             onCharacterClassRangeEnter(node: CharacterClassRange) {
-                // highlight the '-' in [a-z]. Take care to use node.min.end, because we
-                // don't want to highlight the first '-' in [--z], nor an escaped '-' with a
-                // two-character offset as in [\--z].
-                tokens.push({
-                    type: 'metaRegexp',
-                    range: { start: offset + node.min.end, end: offset + node.min.end + 1 },
-                    value: '-',
-                    kind: MetaRegexpKind.CharacterClass,
-                })
+                // Push the min and max characters of the range to associate them with the
+                // same groupRange for hovers.
+                tokens.push(
+                    ...([
+                        {
+                            type: 'metaRegexp',
+                            range: { start: offset + node.min.start, end: offset + node.min.end },
+                            groupRange: { start: offset + node.start, end: offset + node.end },
+                            value: node.raw,
+                            kind: MetaRegexpKind.CharacterClassRange,
+                        },
+                        // Highlight the '-' in [a-z]. Take care to use node.min.end, because we
+                        // don't want to highlight the first '-' in [--z], nor an escaped '-' with a
+                        // two-character offset as in [\--z].
+                        {
+                            type: 'metaRegexp',
+                            range: { start: offset + node.min.end, end: offset + node.min.end + 1 },
+                            groupRange: { start: offset + node.start, end: offset + node.end },
+                            value: node.raw,
+                            kind: MetaRegexpKind.CharacterClassRangeHyphen,
+                        },
+                        {
+                            type: 'metaRegexp',
+                            range: { start: offset + node.max.start, end: offset + node.max.end },
+                            groupRange: { start: offset + node.start, end: offset + node.end },
+                            value: node.raw,
+                            kind: MetaRegexpKind.CharacterClassRange,
+                        },
+                    ] as DecoratedToken[])
+                )
             },
             onQuantifierEnter(node: Quantifier) {
                 // the lazy quantifier ? adds one
@@ -301,13 +324,23 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
             onCharacterEnter(node: Character) {
                 if (node.end - node.start > 1 && node.raw.startsWith('\\')) {
                     // This is an escaped value like `\.`, `\u0065`, `\x65`.
+                    // If this escaped value is part of a range, like [a-\\],
+                    // set the group range to associate it with hovers.
+                    const groupRange =
+                        node.parent.type === 'CharacterClassRange'
+                            ? { start: offset + node.parent.start, end: offset + node.parent.end }
+                            : undefined
                     tokens.push({
                         type: 'metaRegexp',
                         range: { start: offset + node.start, end: offset + node.end },
+                        groupRange,
                         value: node.raw,
                         kind: MetaRegexpKind.EscapedCharacter,
                     })
                     return
+                }
+                if (node.parent.type === 'CharacterClassRange') {
+                    return // This unescaped character is handled by onCharacterClassRangeEnter.
                 }
                 if (node.parent.type === 'CharacterClass') {
                     // This character is inside a character class like [abcd] and is contextually special for hover tooltips.

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -252,32 +252,30 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
                 // Push the min and max characters of the range to associate them with the
                 // same groupRange for hovers.
                 tokens.push(
-                    ...([
-                        {
-                            type: 'metaRegexp',
-                            range: { start: offset + node.min.start, end: offset + node.min.end },
-                            groupRange: { start: offset + node.start, end: offset + node.end },
-                            value: node.raw,
-                            kind: MetaRegexpKind.CharacterClassRange,
-                        },
-                        // Highlight the '-' in [a-z]. Take care to use node.min.end, because we
-                        // don't want to highlight the first '-' in [--z], nor an escaped '-' with a
-                        // two-character offset as in [\--z].
-                        {
-                            type: 'metaRegexp',
-                            range: { start: offset + node.min.end, end: offset + node.min.end + 1 },
-                            groupRange: { start: offset + node.start, end: offset + node.end },
-                            value: node.raw,
-                            kind: MetaRegexpKind.CharacterClassRangeHyphen,
-                        },
-                        {
-                            type: 'metaRegexp',
-                            range: { start: offset + node.max.start, end: offset + node.max.end },
-                            groupRange: { start: offset + node.start, end: offset + node.end },
-                            value: node.raw,
-                            kind: MetaRegexpKind.CharacterClassRange,
-                        },
-                    ] as DecoratedToken[])
+                    {
+                        type: 'metaRegexp',
+                        range: { start: offset + node.min.start, end: offset + node.min.end },
+                        groupRange: { start: offset + node.start, end: offset + node.end },
+                        value: node.raw,
+                        kind: MetaRegexpKind.CharacterClassRange,
+                    },
+                    // Highlight the '-' in [a-z]. Take care to use node.min.end, because we
+                    // don't want to highlight the first '-' in [--z], nor an escaped '-' with a
+                    // two-character offset as in [\--z].
+                    {
+                        type: 'metaRegexp',
+                        range: { start: offset + node.min.end, end: offset + node.min.end + 1 },
+                        groupRange: { start: offset + node.start, end: offset + node.end },
+                        value: node.raw,
+                        kind: MetaRegexpKind.CharacterClassRangeHyphen,
+                    },
+                    {
+                        type: 'metaRegexp',
+                        range: { start: offset + node.max.start, end: offset + node.max.end },
+                        groupRange: { start: offset + node.start, end: offset + node.end },
+                        value: node.raw,
+                        kind: MetaRegexpKind.CharacterClassRange,
+                    }
                 )
             },
             onQuantifierEnter(node: Quantifier) {

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -50,6 +50,9 @@ const toRegexpHover = (token: MetaRegexp): string => {
                 case '\\S':
                     return '**Negated whitespace**. Match any character that is **not** a whitespace character like a space, line break, or tab.'
             }
+        case MetaRegexpKind.CharacterClassRange:
+        case MetaRegexpKind.CharacterClassRangeHyphen:
+            return `**Character range**. Match a character in the range \`${token.value}\`.`
         case MetaRegexpKind.CharacterClassMember:
             return `**Character**. This character class matches the character \`${token.value}\`.`
         case MetaRegexpKind.Delimited:

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -49,6 +49,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'metaRegexpCharacterSet', foreground: '#da77f2' },
         { token: 'metaRegexpCharacterClass', foreground: '#da77f2' },
         { token: 'metaRegexpCharacterClassMember', foreground: '#f2f4f8' },
+        { token: 'metaRegexpCharacterClassRange', foreground: '#f2f4f8' },
+        { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#da77f2' },
         { token: 'metaRegexpRangeQuantifier', foreground: '#3bc9db' },
         { token: 'metaRegexpAlternative', foreground: '#3bc9db' },
         // Structural pattern highlighting
@@ -104,6 +106,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'metaRegexpCharacterSet', foreground: '#ae3ec9' },
         { token: 'metaRegexpCharacterClass', foreground: '#ae3ec9' },
         { token: 'metaRegexpCharacterClassMember', foreground: '#2b3750' },
+        { token: 'metaRegexpCharacterClassRange', foreground: '#2b3750' },
+        { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#ae3ec9' },
         { token: 'metaRegexpRangeQuantifier', foreground: '#1098ad' },
         { token: 'metaRegexpAlternative', foreground: '#1098ad' },
         // Structural pattern highlighting


### PR DESCRIPTION
Stacked on #16744. 

Previously, when hovering on the end of a range like `a-z`:

<img width="276" alt="Screen Shot 2020-12-14 at 11 30 30 PM" src="https://user-images.githubusercontent.com/888624/102179445-665db100-3e64-11eb-8b48-86cf5f017354.png">

Now:

<img width="452" alt="Screen Shot 2020-12-14 at 11 26 23 PM" src="https://user-images.githubusercontent.com/888624/102179336-30203180-3e64-11eb-91f6-1ec3c777b4fe.png">

I would love to say this better in prose, like `a` to `z`, but there are some tricky cases to handle (escaped ranges, like `--\\` while still preserving highlighting of escaped characters but not otherwise) and that solution would benefit from moar types, but I don't want to make such a heavyweight change right now.
