### PR TITLE
search: searchResultsCommon.repos is a map

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -564,10 +563,6 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 		unflattened [][]*CommitSearchResultResolver
 		common      = &searchResultsCommon{}
 	)
-	common.repos = make([]*types.Repo, len(args.Repos))
-	for i, repo := range args.Repos {
-		common.repos[i] = repo.Repo
-	}
 	for _, repoRev := range args.Repos {
 		wg.Add(1)
 		go func(repoRev *search.RepositoryRevisions) {

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -562,6 +562,7 @@ func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, last
 	final := &searchResultsCommon{
 		limitHit:         false, // irrelevant in paginated search
 		indexUnavailable: common.indexUnavailable,
+		repos:            make(map[api.RepoID]*types.Repo),
 		partial:          make(map[api.RepoID]struct{}),
 		resultCount:      common.resultCount,
 	}
@@ -577,6 +578,7 @@ func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, last
 			if firstResultRepo != "" && string(r.Name) < firstResultRepo {
 				continue
 			}
+			final.repos[r.ID] = r
 			dst = append(dst, r)
 			if string(r.Name) == lastResultRepo {
 				break
@@ -584,7 +586,17 @@ func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, last
 		}
 		return dst
 	}
-	final.repos = doAppend(final.repos, common.repos)
+
+	for _, r := range common.repos {
+		if lastResultRepo == "" || string(r.Name) > lastResultRepo {
+			continue
+		}
+		if firstResultRepo != "" && string(r.Name) < firstResultRepo {
+			continue
+		}
+		final.repos[r.ID] = r
+	}
+
 	final.searched = doAppend(final.searched, common.searched)
 	final.indexed = doAppend(final.indexed, common.indexed)
 	final.cloning = doAppend(final.cloning, common.cloning)

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -41,7 +41,9 @@ func TestSearchPagination_unmarshalSearchCursor(t *testing.T) {
 
 func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	repo := func(name string) *types.Repo {
-		return &types.Repo{Name: api.RepoName(name)}
+		// Backcompat extract ID from name.
+		id := name[len(name)-1] - '0'
+		return &types.Repo{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
 	result := mkFileMatch
 	format := func(r slicedSearchResults) string {
@@ -52,8 +54,13 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.Repo.innerRepo.Name, fm.JPath)
 		}
 		fmt.Fprintln(&b, "common.repos:")
-		for i, r := range r.common.repos {
-			fmt.Fprintf(&b, "	[%d] %s\n", i, r.Name)
+		var repos []string
+		for _, r := range r.common.repos {
+			repos = append(repos, string(r.Name))
+		}
+		sort.Strings(repos)
+		for _, r := range repos {
+			fmt.Fprintf(&b, "	%s\n", r)
 		}
 		fmt.Fprintf(&b, "common.resultCount: %v\n", r.common.resultCount)
 		fmt.Fprintf(&b, "resultOffset: %d\n", r.resultOffset)
@@ -80,7 +87,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		// Note: this is an intentionally unordered list to ensure we do not
 		// rely on the order of lists in common (which is not guaranteed by
 		// tests).
-		repos: []*types.Repo{repo("org/repo1"), repo("org/repo3"), repo("org/repo2")},
+		repos: reposMap(repo("org/repo1"), repo("org/repo3"), repo("org/repo2")),
 	}
 	tests := []struct {
 		name          string
@@ -120,7 +127,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.Repo{repo("org/repo1")},
+					repos:       reposMap(repo("org/repo1")),
 					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
@@ -140,7 +147,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 2,
-					repos:       []*types.Repo{repo("org/repo1")},
+					repos:       reposMap(repo("org/repo1")),
 					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 2,
@@ -161,7 +168,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.Repo{repo("org/repo2"), repo("org/repo3")},
+					repos:       reposMap(repo("org/repo2"), repo("org/repo3")),
 					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
@@ -182,7 +189,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+					repos:       reposMap(repo("org/repo1"), repo("org/repo2")),
 					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
@@ -200,7 +207,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				result(repo("org/repo2"), "c.go"),
 			},
 			common: &searchResultsCommon{
-				repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
+				repos:       reposMap(repo("org/repo1"), repo("org/repo2")),
 				resultCount: 3,
 			},
 			offset: 3,
@@ -213,7 +220,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 3,
-					repos:       []*types.Repo{repo("org/repo2")},
+					repos:       reposMap(repo("org/repo2")),
 					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
@@ -232,7 +239,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				},
 				common: &searchResultsCommon{
 					resultCount: 1,
-					repos:       []*types.Repo{repo("org/repo1")},
+					repos:       reposMap(repo("org/repo1")),
 					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 2,
@@ -243,19 +250,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := sliceSearchResults(test.results, test.common, test.offset, test.limit)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Logf("got != want")
-				gotFormatted := format(got)
-				wantFormatted := format(test.want)
-				t.Logf("got:\n%s\n", gotFormatted)
-				t.Logf("want:\n%s\n", wantFormatted)
-				dmp := diffmatchpatch.New()
-				t.Error("diff(got, want):\n", dmp.DiffPrettyText(dmp.DiffMain(wantFormatted, gotFormatted, true)))
-
-				if wantFormatted == gotFormatted {
-					dmp = diffmatchpatch.New()
-					t.Error("diff(got, want):\n", dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(test.want), spew.Sdump(got), true)))
-				}
+			if diff := cmp.Diff(format(test.want), format(got)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -269,7 +265,9 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		return revs
 	}
 	repo := func(name string) *types.Repo {
-		return &types.Repo{Name: api.RepoName(name)}
+		// Backcompat extract ID from name.
+		id := name[len(name)-1] - '0'
+		return &types.Repo{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
 	result := func(repo *types.Repo, path, rev string) *FileMatchResolver {
 		fm := mkFileMatch(repo, path)
@@ -292,7 +290,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 	var searchedBatches [][]*search.RepositoryRevisions
 	resultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
 		searchedBatches = append(searchedBatches, batch)
-		common = &searchResultsCommon{}
+		common = &searchResultsCommon{repos: reposMap()}
 		for _, repoRev := range batch {
 			for _, rev := range repoRev.Revs {
 				rev := rev.RevSpec
@@ -300,7 +298,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 					results = append(results, result(repoRev.Repo, fmt.Sprintf("some/file%d.go", i), rev))
 				}
 			}
-			common.repos = append(common.repos, repoRev.Repo)
+			common.repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 		return
 	}
@@ -347,7 +345,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("3"), "some/file0.go", "feature"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:       []*types.Repo{repo("1"), repo("2"), repo("3")},
+				repos:       reposMap(repo("1"), repo("2"), repo("3")),
 				partial:     map[api.RepoID]struct{}{},
 				resultCount: 10,
 			},
@@ -377,7 +375,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("5"), "some/file2.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:   []*types.Repo{repo("3"), repo("4"), repo("5")},
+				repos:   reposMap(repo("3"), repo("4"), repo("5")),
 				partial: map[api.RepoID]struct{}{},
 			},
 		},
@@ -400,7 +398,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("1"), "some/file0.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:       []*types.Repo{repo("1")},
+				repos:       reposMap(repo("1")),
 				partial:     map[api.RepoID]struct{}{},
 				resultCount: 1,
 			},
@@ -424,7 +422,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repo("1"), "some/file1.go", "master"),
 			},
 			wantCommon: &searchResultsCommon{
-				repos:       []*types.Repo{repo("1")},
+				repos:       reposMap(repo("1")),
 				partial:     map[api.RepoID]struct{}{},
 				resultCount: 1,
 			},
@@ -438,6 +436,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 1, ResultOffset: 0, Finished: true},
 			wantCommon: &searchResultsCommon{
+				repos:   reposMap(),
 				partial: map[api.RepoID]struct{}{},
 			},
 		},
@@ -464,8 +463,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			if !cmp.Equal(test.wantResults, results) {
 				t.Error("wantResults != results", cmp.Diff(test.wantResults, results))
 			}
-			if !cmp.Equal(test.wantCommon, common) {
-				t.Error("wantCommon != common", cmp.Diff(test.wantCommon, common))
+			if diff := cmp.Diff(test.wantCommon, common, cmpopts.EquateEmpty()); diff != "" {
+				t.Error("wantCommon != common", diff)
 			}
 			if !cmp.Equal(test.wantErr, err) {
 				t.Error("wantErr != err", cmp.Diff(test.wantErr, err))
@@ -485,7 +484,9 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		return revs
 	}
 	repo := func(name string) *types.Repo {
-		return &types.Repo{Name: api.RepoName(name)}
+		// Backcompat extract ID from name.
+		id := name[len(name)-1] - '0'
+		return &types.Repo{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
 	result := mkFileMatch
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
@@ -512,10 +513,10 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		repoRevs("2", "master"),
 	}
 	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
-		common = &searchResultsCommon{}
+		common = &searchResultsCommon{repos: reposMap()}
 		for _, repoRev := range batch {
 			results = append(results, repoResults[string(repoRev.Repo.Name)]...)
-			common.repos = append(common.repos, repoRev.Repo)
+			common.repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 		return
 	}
@@ -601,7 +602,9 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 		return revs
 	}
 	repo := func(name string) *types.Repo {
-		return &types.Repo{Name: api.RepoName(name)}
+		// Backcompat extract ID from name.
+		id := name[len(name)-1] - 'a' + 1
+		return &types.Repo{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
 	result := mkFileMatch
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
@@ -637,11 +640,11 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 		repoRevs("f", "master"),
 	}
 	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
-		common = &searchResultsCommon{}
+		common = &searchResultsCommon{repos: reposMap()}
 		for _, repoRev := range batch {
 			if res, ok := repoResults[string(repoRev.Repo.Name)]; ok {
 				results = append(results, res...)
-				common.repos = append(common.repos, repoRev.Repo)
+				common.repos[repoRev.Repo.ID] = repoRev.Repo
 			}
 			if missing, ok := repoMissing[string(repoRev.Repo.Name)]; ok {
 				common.missing = append(common.missing, missing)
@@ -675,7 +678,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial:     map[api.RepoID]struct{}{},
-				repos:       []*types.Repo{repo("a")},
+				repos:       reposMap(repo("a")),
 				resultCount: 1,
 			},
 		},
@@ -691,7 +694,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial: map[api.RepoID]struct{}{},
-				repos:   []*types.Repo{repo("c")},
+				repos:   reposMap(repo("b"), repo("c")),
 				missing: []*types.Repo{repo("b")},
 			},
 		},
@@ -708,7 +711,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial: map[api.RepoID]struct{}{},
-				repos:   []*types.Repo{repo("a"), repo("c")},
+				repos:   reposMap(repo("a"), repo("b"), repo("c")),
 				missing: []*types.Repo{repo("b")},
 			},
 		},
@@ -726,7 +729,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				partial: map[api.RepoID]struct{}{},
-				repos:   []*types.Repo{repo("a"), repo("c"), repo("f")},
+				repos:   reposMap(repo("a"), repo("b"), repo("c"), repo("d"), repo("e"), repo("f")),
 				cloning: []*types.Repo{repo("d")},
 				missing: []*types.Repo{repo("b"), repo("e")},
 			},
@@ -757,4 +760,12 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			}
 		})
 	}
+}
+
+func reposMap(repos ...*types.Repo) map[api.RepoID]*types.Repo {
+	m := make(map[api.RepoID]*types.Repo, len(repos))
+	for _, r := range repos {
+		m[r.ID] = r
+	}
+	return m
 }

--- a/cmd/frontend/graphqlbackend/search_progress_test.go
+++ b/cmd/frontend/graphqlbackend/search_progress_test.go
@@ -28,7 +28,7 @@ func TestSearchProgress(t *testing.T) {
 			SearchResults: []SearchResultResolver{mkFileMatch(&types.Repo{Name: "found-1"}, "dir/file", 123)},
 			searchResultsCommon: searchResultsCommon{
 				limitHit: true,
-				repos:    mkRepos("found-1", "missing-1", "missing-2", "cloning-1", "timedout-1"),
+				repos:    reposMap(mkRepos("found-1", "missing-1", "missing-2", "cloning-1", "timedout-1")...),
 				missing:  mkRepos("missing-1", "missing-2"),
 				cloning:  mkRepos("cloning-1"),
 				timedout: mkRepos("timedout-1"),

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 var mockSearchRepositories func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error)
@@ -146,17 +145,12 @@ func matchRepos(pattern *regexp.Regexp, resolved []*search.RepositoryRevisions) 
 		offset = next
 	}
 
-	repos := make([]*types.Repo, len(resolved))
-	for i := range resolved {
-		repos[i] = resolved[i].Repo
-	}
-
 	var matched []*search.RepositoryRevisions
 	for w := 0; w < workers; w++ {
 		matched = append(matched, <-results...)
 	}
 
-	return &searchResultsCommon{repos: repos}, matched
+	return &searchResultsCommon{}, matched
 }
 
 // reposToAdd determines which repositories should be included in the result set based on whether they fit in the subset

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -240,11 +240,8 @@ func TestMatchRepos(t *testing.T) {
 	in := append(want, makeRepositoryRevisions("beef/bam", "qux/bas")...)
 	pattern := regexp.MustCompile("foo")
 
-	common, repos := matchRepos(pattern, in)
+	_, repos := matchRepos(pattern, in)
 
-	if !(len(common.repos) == len(in)) {
-		t.Fatalf("expected %d, got %d", len(in), len(common.repos))
-	}
 	// because of the concurrency we cannot rely on the order of "repos" to be the
 	// same as "want". Hence we create map of repo names and compare those.
 	toMap := func(reporevs []*search.RepositoryRevisions) map[string]struct{} {

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -240,7 +240,7 @@ func TestMatchRepos(t *testing.T) {
 	in := append(want, makeRepositoryRevisions("beef/bam", "qux/bas")...)
 	pattern := regexp.MustCompile("foo")
 
-	_, repos := matchRepos(pattern, in)
+	repos := matchRepos(pattern, in)
 
 	// because of the concurrency we cannot rely on the order of "repos" to be the
 	// same as "want". Hence we create map of repo names and compare those.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -50,13 +50,20 @@ import (
 type searchResultsCommon struct {
 	limitHit bool // whether the limit on results was hit
 
-	repos    []*types.Repo           // repos that were matched by the repo-related filters
-	searched []*types.Repo           // repos that were searched
-	indexed  []*types.Repo           // repos that were searched using an index
-	cloning  []*types.Repo           // repos that could not be searched because they were still being cloned
-	missing  []*types.Repo           // repos that could not be searched because they do not exist
-	excluded excludedRepos           // repo counts of excluded repos because the search query doesn't apply to them, but that we want to know about (forks, archives)
-	partial  map[api.RepoID]struct{} // repos that were searched, but have results that were not returned due to exceeded limits
+	// repos that were matched by the repo-related filters. This should only
+	// be set once by search, when we have resolved repos.
+	//
+	// TODO All other fields are sets of repo IDs. They can only contain repos
+	// that are in this map.
+	repos map[api.RepoID]*types.Repo
+
+	searched []*types.Repo // repos that were searched
+	indexed  []*types.Repo // repos that were searched using an index
+	cloning  []*types.Repo // repos that could not be searched because they were still being cloned
+	missing  []*types.Repo // repos that could not be searched because they do not exist
+	excluded excludedRepos // repo counts of excluded repos because the search query doesn't apply to them, but that we want to know about (forks, archives)
+
+	partial map[api.RepoID]struct{} // repos that were searched, but have results that were not returned due to exceeded limits
 
 	maxResultsCount, resultCount int32
 
@@ -73,7 +80,15 @@ func (c *searchResultsCommon) LimitHit() bool {
 }
 
 func (c *searchResultsCommon) Repositories() []*RepositoryResolver {
-	return RepositoryResolvers(c.repos)
+	repos := c.repos
+	resolvers := make([]*RepositoryResolver, 0, len(repos))
+	for _, r := range repos {
+		resolvers = append(resolvers, &RepositoryResolver{innerRepo: r})
+	}
+	sort.Slice(resolvers, func(a, b int) bool {
+		return resolvers[a].innerRepo.ID < resolvers[b].innerRepo.ID
+	})
+	return resolvers
 }
 
 func (c *searchResultsCommon) RepositoriesCount() int32 {
@@ -119,7 +134,13 @@ func (c *searchResultsCommon) update(other searchResultsCommon) {
 	c.limitHit = c.limitHit || other.limitHit
 	c.indexUnavailable = c.indexUnavailable || other.indexUnavailable
 
-	c.repos = append(c.repos, other.repos...)
+	if c.repos == nil {
+		c.repos = other.repos
+	} else {
+		for id, r := range other.repos {
+			c.repos[id] = r
+		}
+	}
 	c.searched = append(c.searched, other.searched...)
 	c.indexed = append(c.indexed, other.indexed...)
 	c.cloning = append(c.cloning, other.cloning...)
@@ -1921,9 +1942,24 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	if alertResult != nil {
 		return alertResult, nil
 	}
-	args.RepoPromise.Resolve(resolved.repoRevs)
 
-	agg.report(ctx, nil, &searchResultsCommon{excluded: resolved.excludedRepos}, nil)
+	// Send down our first bit of progress.
+	{
+		repos := make(map[api.RepoID]*types.Repo, len(resolved.repoRevs))
+		for _, repoRev := range resolved.repoRevs {
+			repos[repoRev.Repo.ID] = repoRev.Repo
+		}
+
+		agg.report(ctx, nil, &searchResultsCommon{
+			repos:    repos,
+			excluded: resolved.excludedRepos,
+		}, nil)
+	}
+
+	// Resolve repo promise so searches waiting on it can proceed. We do this
+	// after reporting the above progress to ensure we don't get search
+	// results before the above reporting.
+	args.RepoPromise.Resolve(resolved.repoRevs)
 
 	// Apply search limits and generate warnings before firing off workers.
 	// This currently limits diff and commit search to a set number of

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -89,7 +89,7 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.Count = mockCount
 
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
-			return nil, &searchResultsCommon{repos: []*types.Repo{{ID: 1, Name: "repo"}}}, nil
+			return nil, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -148,7 +148,7 @@ func TestSearchResults(t *testing.T) {
 			}
 			repo := &types.Repo{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
-			return []*FileMatchResolver{fm}, &searchResultsCommon{repos: []*types.Repo{repo}}, nil
+			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -213,7 +213,7 @@ func TestSearchResults(t *testing.T) {
 			}
 			repo := &types.Repo{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
-			return []*FileMatchResolver{fm}, &searchResultsCommon{repos: []*types.Repo{repo}}, nil
+			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -77,11 +77,6 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		return nil, nil, err
 	}
 
-	common.repos = make([]*types.Repo, len(repos))
-	for i, repo := range repos {
-		common.repos[i] = repo.Repo
-	}
-
 	var searcherRepos []*search.RepositoryRevisions
 	if indexed.DisableUnindexedSearch {
 		tr.LazyPrintf("disabling unindexed search")

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -574,15 +574,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 		return nil, common, searchErr
 	}
 
-	repos, err := getRepos(ctx, args.RepoPromise)
-	if err != nil {
-		return nil, common, err
-	}
-	common.repos = make([]*types.Repo, len(repos))
-	for i, repo := range repos {
-		common.repos[i] = repo.Repo
-	}
-
 	flattened := flattenFileMatches(unflattened, int(args.PatternInfo.FileMatchLimit))
 	return flattened, common, nil
 }


### PR DESCRIPTION
This is the first in a series of changes to searchResultsCommon to make
it more efficient as well as concurrency safe. We need to make it
concurrency safe such that we can report its intermediate states for
streaming.

This change changes searchResultsCommon.repos from a slice into a
map. In general our use of slices doesn't really make sense, since
whenever we read we do a "dedupSort" which mutates the slice. What we
really want is a set. Then at final read time we can sort.

To support this change we also only set "repos" once, at the time of
repos being resolved. We unnecessarily did it inside of each search
backend. For pagination this works slightly differently, so we still
support updating repos as pagination goes over the repo batches.

We intend to simplify the other searchResultsCommon fields since they
should always be subsets of repos. This is for the purpose of making it
possible to stream progress updates.