### PR TITLE
Decouple repo-updater store from the rest of the codebase

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -1,7 +1,6 @@
 package httpapi
 
 import (
-	"database/sql"
 	"log"
 	"net/http"
 	"reflect"
@@ -13,6 +12,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -23,10 +23,10 @@ import (
 	frontendsearch "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -56,7 +56,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Re
 	m.Get(apirouter.RepoRefresh).Handler(trace.TraceRoute(handler(serveRepoRefresh)))
 
 	gh := webhooks.GitHubWebhook{
-		Repos: repos.NewDBStore(dbconn.Global, sql.TxOptions{}),
+		ExternalServices: db.NewExternalServicesStoreWithDB(dbconn.Global),
 	}
 
 	webhookhandlers.Init(&gh)

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
 func TestCampaignConnectionResolver(t *testing.T) {
@@ -33,10 +31,10 @@ func TestCampaignConnectionResolver(t *testing.T) {
 	userID := ct.CreateTestUser(t, true).ID
 
 	cstore := store.New(dbconn.Global)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/campaign-connection-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/campaign-connection-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -21,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
 func TestCampaignSpecResolver(t *testing.T) {
@@ -33,10 +31,10 @@ func TestCampaignSpecResolver(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 
 	cstore := store.New(dbconn.Global)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
-
 	repoStore := db.NewRepoStoreWith(cstore)
-	repo := newGitHubTestRepo("github.com/sourcegraph/campaign-spec-test", newGitHubExternalService(t, rstore))
+	esStore := db.NewExternalServicesStoreWith(cstore)
+
+	repo := newGitHubTestRepo("github.com/sourcegraph/campaign-spec-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
 func TestChangesetConnectionResolver(t *testing.T) {
@@ -33,11 +31,11 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	userID := ct.CreateTestUser(t, false).ID
 
 	cstore := store.New(dbconn.Global)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-connection-test", newGitHubExternalService(t, rstore))
-	inaccessibleRepo := newGitHubTestRepo("github.com/sourcegraph/private", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-connection-test", newGitHubExternalService(t, esStore))
+	inaccessibleRepo := newGitHubTestRepo("github.com/sourcegraph/private", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo, inaccessibleRepo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"os"
 	"reflect"
 	"testing"
@@ -80,8 +79,8 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 
 	userID := ct.CreateTestUser(t, false).ID
 
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWithDB(dbconn.Global)
+	esStore := db.NewExternalServicesStoreWithDB(dbconn.Global)
 
 	githubExtSvc := &types.ExternalService{
 		Kind:        extsvc.KindGitHub,
@@ -93,7 +92,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}),
 	}
 
-	err := rstore.UpsertExternalServices(ctx, githubExtSvc)
+	err := esStore.Upsert(ctx, githubExtSvc)
 	if err != nil {
 		t.Fatal(t)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -20,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -37,10 +35,10 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 	cstore := store.NewWithClock(dbconn.Global, clock)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-event-connection-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-event-connection-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
@@ -17,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -341,7 +339,7 @@ func (c *changesetSpecPreviewer) PlanForChangesetSpec(ctx context.Context, chang
 		return nil, err
 	}
 	// And then dry-run the rewirer to simulate how the changeset would look like after an _apply_ operation.
-	rewirer := rewirer.New(store.RewirerMappings{mapping}, campaign, repos.NewDBStore(c.store.DB(), sql.TxOptions{}))
+	rewirer := rewirer.New(store.RewirerMappings{mapping}, campaign)
 	changesets, err := rewirer.Rewire(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -41,13 +39,13 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
 	rs := make([]*types.Repo, 0, 3)
 	for i := 0; i < cap(rs); i++ {
 		name := fmt.Sprintf("github.com/sourcegraph/test-changeset-spec-connection-repo-%d", i)
-		r := newGitHubTestRepo(name, newGitHubExternalService(t, rstore))
+		r := newGitHubTestRepo(name, newGitHubExternalService(t, esStore))
 		if err := repoStore.Create(ctx, r); err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -33,7 +31,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	userID := ct.CreateTestUser(t, false).ID
 
 	cstore := store.New(dbconn.Global)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
 	// Creating user with matching email to the changeset spec author.
 	user, err := db.Users.Create(ctx, db.NewUser{
@@ -47,7 +45,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	}
 
 	repoStore := db.NewRepoStoreWith(cstore)
-	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-spec-resolver-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-spec-resolver-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -36,10 +34,10 @@ func TestChangesetResolver(t *testing.T) {
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 	cstore := store.NewWithClock(dbconn.Global, clock)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
+	esStore := db.NewExternalServicesStoreWith(cstore)
 	repoStore := db.NewRepoStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-resolver-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/changeset-resolver-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -121,7 +120,7 @@ func parseJSONTime(t testing.TB, ts string) time.Time {
 	return timestamp
 }
 
-func newGitHubExternalService(t *testing.T, store repos.Store) *types.ExternalService {
+func newGitHubExternalService(t *testing.T, store *db.ExternalServiceStore) *types.ExternalService {
 	t.Helper()
 
 	clock := dbtesting.NewFakeClock(time.Now(), 0)
@@ -135,8 +134,7 @@ func newGitHubExternalService(t *testing.T, store repos.Store) *types.ExternalSe
 		UpdatedAt:   now,
 	}
 
-	// create a few external services
-	if err := store.UpsertExternalServices(context.Background(), &svc); err != nil {
+	if err := store.Upsert(context.Background(), &svc); err != nil {
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -129,7 +129,7 @@ func newGitHubExternalService(t *testing.T, store *db.ExternalServiceStore) *typ
 	svc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
-		Config:      `{"url": "https://github.com"}`,
+		Config:      `{"url": "https://github.com", "authorization": {}}`,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -129,9 +129,10 @@ func newGitHubExternalService(t *testing.T, store *db.ExternalServiceStore) *typ
 	svc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
-		Config:      `{"url": "https://github.com", "authorization": {}}`,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		// The authorization field is needed to enforce permissions
+		Config:    `{"url": "https://github.com", "authorization": {}}`,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 
 	if err := store.Upsert(context.Background(), &svc); err != nil {

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -27,7 +26,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -94,10 +92,10 @@ func TestCreateCampaignSpec(t *testing.T) {
 	userID := user.ID
 
 	cstore := store.New(dbconn.Global)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/create-campaign-spec-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/create-campaign-spec-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}
@@ -209,10 +207,10 @@ func TestCreateChangesetSpec(t *testing.T) {
 	userID := ct.CreateTestUser(t, true).ID
 
 	cstore := store.New(dbconn.Global)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/create-changeset-spec-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/create-changeset-spec-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}
@@ -284,10 +282,10 @@ func TestApplyCampaign(t *testing.T) {
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 	cstore := store.NewWithClock(dbconn.Global, clock)
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWith(cstore)
+	esStore := db.NewExternalServicesStoreWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/apply-campaign-test", newGitHubExternalService(t, rstore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/apply-campaign-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/rewirer/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer.go
@@ -9,21 +9,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type ChangesetRewirer struct {
 	mappings store.RewirerMappings
 	campaign *campaigns.Campaign
-	rstore   repos.Store
 }
 
-func New(mappings store.RewirerMappings, campaign *campaigns.Campaign, rstore repos.Store) *ChangesetRewirer {
+func New(mappings store.RewirerMappings, campaign *campaigns.Campaign) *ChangesetRewirer {
 	return &ChangesetRewirer{
 		mappings: mappings,
 		campaign: campaign,
-		rstore:   rstore,
 	}
 }
 

--- a/enterprise/internal/campaigns/service/service_apply_campaign.go
+++ b/enterprise/internal/campaigns/service/service_apply_campaign.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -12,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -110,8 +108,6 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 		}
 	}
 
-	rstore := repos.NewDBStore(tx.DB(), sql.TxOptions{})
-
 	// Now we need to wire up the ChangesetSpecs of the new CampaignSpec
 	// correctly with the Changesets so that the reconciler can create/update
 	// them.
@@ -129,7 +125,7 @@ func (s *Service) ApplyCampaign(ctx context.Context, opts ApplyCampaignOpts) (ca
 	}
 
 	// And execute the mapping.
-	rewirer := rewirer.New(mappings, campaign, rstore)
+	rewirer := rewirer.New(mappings, campaign)
 	changesets, err := rewirer.Rewire(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/campaigns/store/campaign_specs_test.go
+++ b/enterprise/internal/campaigns/store/campaign_specs_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/campaignutils/overridable"
+
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
-func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock ct.Clock) {
+func testStoreCampaignSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	campaignSpecs := make([]*campaigns.CampaignSpec, 0, 3)
 
 	t.Run("Create", func(t *testing.T) {

--- a/enterprise/internal/campaigns/store/campaigns_test.go
+++ b/enterprise/internal/campaigns/store/campaigns_test.go
@@ -11,10 +11,9 @@ import (
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
-func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock ct.Clock) {
+func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	cs := make([]*campaigns.Campaign, 0, 3)
 
 	t.Run("Create", func(t *testing.T) {
@@ -468,7 +467,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, _ repos.Sto
 	})
 }
 
-func testUserDeleteCascades(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock ct.Clock) {
+func testUserDeleteCascades(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	orgID := ct.InsertTestOrg(t, "user-delete-cascades")
 	user := ct.CreateTestUser(t, false)
 

--- a/enterprise/internal/campaigns/store/changeset_events_test.go
+++ b/enterprise/internal/campaigns/store/changeset_events_test.go
@@ -9,10 +9,9 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
-func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, _ repos.Store, clock ct.Clock) {
+func testStoreChangesetEvents(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	issueComment := &github.IssueComment{
 		DatabaseID: 443827703,
 		Author: github.Actor{

--- a/enterprise/internal/campaigns/store/changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store/changeset_specs_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, rs repos.Store, clock ct.Clock) {
-	repo := ct.TestRepo(t, rs, extsvc.KindGitHub)
-	deletedRepo := ct.TestRepo(t, rs, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
+func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
+	repoStore := db.NewRepoStoreWith(s)
+	esStore := db.NewExternalServicesStoreWith(s)
 
-	repoStore := db.NewRepoStoreWith(s.Store)
+	repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
+	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
 
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/campaigns/store/changesets_test.go
+++ b/enterprise/internal/campaigns/store/changesets_test.go
@@ -21,11 +21,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore repos.Store, clock ct.Clock) {
+func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	githubActor := github.Actor{
 		AvatarURL: "https://avatars2.githubusercontent.com/u/1185253",
 		Login:     "mrnugget",
@@ -44,11 +43,12 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 		HeadRefName:  "campaigns/test",
 	}
 
-	repo := ct.TestRepo(t, reposStore, extsvc.KindGitHub)
-	otherRepo := ct.TestRepo(t, reposStore, extsvc.KindGitHub)
-	gitlabRepo := ct.TestRepo(t, reposStore, extsvc.KindGitLab)
+	rs := db.NewRepoStoreWith(s)
+	es := db.NewExternalServicesStoreWith(s)
 
-	rs := db.NewRepoStoreWith(reposStore.(*repos.DBStore))
+	repo := ct.TestRepo(t, es, extsvc.KindGitHub)
+	otherRepo := ct.TestRepo(t, es, extsvc.KindGitHub)
+	gitlabRepo := ct.TestRepo(t, es, extsvc.KindGitLab)
 
 	if err := rs.Create(ctx, repo, otherRepo, gitlabRepo); err != nil {
 		t.Fatal(err)
@@ -1108,7 +1108,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, reposStore
 	})
 }
 
-func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store, reposStore repos.Store, clock ct.Clock) {
+func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	githubActor := github.Actor{
 		AvatarURL: "https://avatars2.githubusercontent.com/u/1185253",
 		Login:     "mrnugget",
@@ -1148,10 +1148,12 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 		IncludesCreatedEdit: false,
 	}
 
-	githubRepo := ct.TestRepo(t, reposStore, extsvc.KindGitHub)
-	gitlabRepo := ct.TestRepo(t, reposStore, extsvc.KindGitLab)
+	rs := db.NewRepoStoreWith(s)
+	es := db.NewExternalServicesStoreWith(s)
 
-	rs := db.NewRepoStoreWith(s.Store)
+	githubRepo := ct.TestRepo(t, es, extsvc.KindGitHub)
+	gitlabRepo := ct.TestRepo(t, es, extsvc.KindGitLab)
+
 	if err := rs.Create(ctx, githubRepo, gitlabRepo); err != nil {
 		t.Fatal(err)
 	}
@@ -1354,7 +1356,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 	})
 }
 
-func testStoreListChangesetsTextSearch(t *testing.T, ctx context.Context, s *Store, reposStore repos.Store, clock ct.Clock) {
+func testStoreListChangesetsTextSearch(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
 	// This is similar to the setup in testStoreChangesets(), but we need a more
 	// fine grained set of changesets to handle the different scenarios. Namely,
 	// we need to cover:
@@ -1413,13 +1415,15 @@ func testStoreListChangesetsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		return cs
 	}
 
+	rs := db.NewRepoStoreWith(s)
+	es := db.NewExternalServicesStoreWith(s)
+
 	// Set up repositories for each code host type we want to test.
 	var (
-		githubRepo = ct.TestRepo(t, reposStore, extsvc.KindGitHub)
-		bbsRepo    = ct.TestRepo(t, reposStore, extsvc.KindBitbucketServer)
-		gitlabRepo = ct.TestRepo(t, reposStore, extsvc.KindGitLab)
+		githubRepo = ct.TestRepo(t, es, extsvc.KindGitHub)
+		bbsRepo    = ct.TestRepo(t, es, extsvc.KindBitbucketServer)
+		gitlabRepo = ct.TestRepo(t, es, extsvc.KindGitLab)
 	)
-	rs := db.NewRepoStoreWith(reposStore.(*repos.DBStore))
 	if err := rs.Create(ctx, githubRepo, bbsRepo, gitlabRepo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/store/store_test.go
+++ b/enterprise/internal/campaigns/store/store_test.go
@@ -7,11 +7,10 @@ import (
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
-type storeTestFunc func(*testing.T, context.Context, *Store, repos.Store, ct.Clock)
+type storeTestFunc func(*testing.T, context.Context, *Store, ct.Clock)
 
 // storeTest converts a storeTestFunc into a func(*testing.T) in which all
 // dependencies are set up and injected into the storeTestFunc.
@@ -26,8 +25,6 @@ func storeTest(db *sql.DB, f storeTestFunc) func(*testing.T) {
 		tx := dbtest.NewTx(t, db)
 		s := NewWithClock(tx, c.Now)
 
-		rs := repos.NewDBStore(db, sql.TxOptions{})
-
-		f(t, context.Background(), s, rs, c)
+		f(t, context.Background(), s, c)
 	}
 }

--- a/enterprise/internal/campaigns/testing/repos.go
+++ b/enterprise/internal/campaigns/testing/repos.go
@@ -66,7 +66,8 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) (
 			Url:             "https://github.com",
 			Token:           "SECRETTOKEN",
 			RepositoryQuery: []string{"none"},
-			Authorization:   &schema.GitHubAuthorization{},
+			// This field is needed to enforce permissions
+			Authorization: &schema.GitHubAuthorization{},
 		}),
 	}
 

--- a/enterprise/internal/campaigns/testing/repos.go
+++ b/enterprise/internal/campaigns/testing/repos.go
@@ -9,15 +9,15 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	idb "github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func TestRepo(t *testing.T, store repos.Store, serviceKind string) *types.Repo {
+func TestRepo(t *testing.T, store *db.ExternalServiceStore, serviceKind string) *types.Repo {
 	t.Helper()
 
 	clock := dbtesting.NewFakeClock(time.Now(), 0)
@@ -31,7 +31,7 @@ func TestRepo(t *testing.T, store repos.Store, serviceKind string) *types.Repo {
 		UpdatedAt:   now,
 	}
 
-	if err := store.UpsertExternalServices(context.Background(), &svc); err != nil {
+	if err := store.Upsert(context.Background(), &svc); err != nil {
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 
@@ -56,8 +56,8 @@ func TestRepo(t *testing.T, store repos.Store, serviceKind string) *types.Repo {
 func CreateTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	rstore := repos.NewDBStore(db, sql.TxOptions{})
 	repoStore := idb.NewRepoStoreWithDB(db)
+	esStore := idb.NewExternalServicesStoreWithDB(db)
 
 	ext := &types.ExternalService{
 		Kind:        extsvc.KindGitHub,
@@ -67,13 +67,13 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) (
 			Token: "SECRETTOKEN",
 		}),
 	}
-	if err := rstore.UpsertExternalServices(ctx, ext); err != nil {
+	if err := esStore.Upsert(ctx, ext); err != nil {
 		t.Fatal(err)
 	}
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepo(t, rstore, extsvc.KindGitHub)
+		r := TestRepo(t, esStore, extsvc.KindGitHub)
 		r.Sources = map[string]*types.SourceInfo{ext.URN(): {
 			ID:       ext.URN(),
 			CloneURL: "https://secrettoken@github.com/" + string(r.Name),
@@ -93,8 +93,8 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) (
 func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	rstore := repos.NewDBStore(db, sql.TxOptions{})
 	repoStore := idb.NewRepoStoreWithDB(db)
+	esStore := idb.NewExternalServicesStoreWithDB(db)
 
 	ext := &types.ExternalService{
 		Kind:        extsvc.KindGitLab,
@@ -104,13 +104,13 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count 
 			Token: "SECRETTOKEN",
 		}),
 	}
-	if err := rstore.UpsertExternalServices(ctx, ext); err != nil {
+	if err := esStore.Upsert(ctx, ext); err != nil {
 		t.Fatal(err)
 	}
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepo(t, rstore, extsvc.KindGitLab)
+		r := TestRepo(t, esStore, extsvc.KindGitLab)
 		r.Sources = map[string]*types.SourceInfo{ext.URN(): {
 			ID:       ext.URN(),
 			CloneURL: "https://git:gitlab-token@gitlab.com/" + string(r.Name),
@@ -130,8 +130,8 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count 
 func CreateBbsTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	rstore := repos.NewDBStore(db, sql.TxOptions{})
 	repoStore := idb.NewRepoStoreWithDB(db)
+	esStore := idb.NewExternalServicesStoreWithDB(db)
 
 	ext := &types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
@@ -141,13 +141,13 @@ func CreateBbsTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int
 			Token: "SECRETTOKEN",
 		}),
 	}
-	if err := rstore.UpsertExternalServices(ctx, ext); err != nil {
+	if err := esStore.Upsert(ctx, ext); err != nil {
 		t.Fatal(err)
 	}
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepo(t, rstore, extsvc.KindBitbucketServer)
+		r := TestRepo(t, esStore, extsvc.KindBitbucketServer)
 		r.Sources = map[string]*types.SourceInfo{
 			ext.URN(): {
 				ID:       ext.URN(),

--- a/enterprise/internal/campaigns/webhooks/webhooks_gitlab.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_gitlab.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -24,8 +24,8 @@ import (
 
 type GitLabWebhook struct{ *Webhook }
 
-func NewGitLabWebhook(store *store.Store, repos repos.Store, now func() time.Time) *GitLabWebhook {
-	return &GitLabWebhook{&Webhook{store, repos, now, extsvc.TypeGitLab}}
+func NewGitLabWebhook(store *store.Store, externalServices *db.ExternalServiceStore, now func() time.Time) *GitLabWebhook {
+	return &GitLabWebhook{&Webhook{store, externalServices, now, extsvc.TypeGitLab}}
 }
 
 // ServeHTTP implements the http.Handler interface.
@@ -107,7 +107,7 @@ func (h *GitLabWebhook) getExternalServiceFromRawID(ctx context.Context, raw str
 		return nil, errors.Wrap(err, "parsing the raw external service ID")
 	}
 
-	es, err := h.Repos.ListExternalServices(ctx, repos.StoreListExternalServicesArgs{
+	es, err := h.ExternalServices.List(ctx, db.ExternalServicesListOptions{
 		IDs:   []int64{id},
 		Kinds: []string{extsvc.KindGitLab},
 	})

--- a/enterprise/internal/campaigns/webhooks/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_test.go
@@ -56,8 +56,8 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		defer save()
 
 		secret := "secret"
-		rstore := repos.NewDBStore(db, sql.TxOptions{})
 		repoStore := idb.NewRepoStoreWithDB(db)
+		esStore := idb.NewExternalServicesStoreWithDB(db)
 		extSvc := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "GitHub",
@@ -69,7 +69,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			}),
 		}
 
-		err := rstore.UpsertExternalServices(ctx, extSvc)
+		err := esStore.Upsert(ctx, extSvc)
 		if err != nil {
 			t.Fatal(t)
 		}
@@ -141,7 +141,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		hook := NewGitHubWebhook(s, rstore, clock)
+		hook := NewGitHubWebhook(s, esStore, clock)
 
 		fixtureFiles, err := filepath.Glob("testdata/fixtures/webhooks/github/*.json")
 		if err != nil {
@@ -160,7 +160,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
 						handler := webhooks.GitHubWebhook{
-							Repos: rstore,
+							ExternalServices: esStore,
 						}
 						hook.Register(&handler)
 
@@ -229,8 +229,8 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		defer save()
 
 		secret := "secret"
-		rstore := repos.NewDBStore(db, sql.TxOptions{})
 		repoStore := idb.NewRepoStoreWithDB(db)
+		esStore := idb.NewExternalServicesStoreWithDB(db)
 		extSvc := &types.ExternalService{
 			Kind:        extsvc.KindBitbucketServer,
 			DisplayName: "Bitbucket",
@@ -244,7 +244,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			}),
 		}
 
-		err := rstore.UpsertExternalServices(ctx, extSvc)
+		err := esStore.Upsert(ctx, extSvc)
 		if err != nil {
 			t.Fatal(t)
 		}
@@ -328,7 +328,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			}
 		}
 
-		hook := NewBitbucketServerWebhook(s, rstore, clock, "testhook")
+		hook := NewBitbucketServerWebhook(s, esStore, clock, "testhook")
 
 		fixtureFiles, err := filepath.Glob("testdata/fixtures/webhooks/bitbucketserver/*.json")
 		if err != nil {

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -9,6 +9,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -441,34 +442,6 @@ func (o *ObservedStore) Done(err error) error {
 	}(time.Now())
 
 	return o.store.(TxStore).Done(err)
-}
-
-// GetExternalService calls into the inner Store and registers the observed results.
-func (o *ObservedStore) GetExternalService(ctx context.Context, id int64) (es *types.ExternalService, err error) {
-	tr, ctx := o.trace(ctx, "Store.GetExternalService")
-	tr.LogFields(
-		otlog.Object("id", id),
-	)
-
-	defer func(began time.Time) {
-		secs := time.Since(began).Seconds()
-
-		o.metrics.ListExternalServices.Observe(secs, 1, &err)
-		logging.Log(o.log, "store.get-external-service", &err,
-			"id", fmt.Sprintf("%+v", id),
-			"count", 1,
-		)
-
-		tr.LogFields(
-			otlog.Int("count", 1),
-			otlog.Object("names", es.DisplayName),
-			otlog.Object("urns", es.URN()),
-		)
-		tr.SetError(err)
-		tr.Finish()
-	}(time.Now())
-
-	return o.store.GetExternalService(ctx, id)
 }
 
 // ListExternalServices calls into the inner Store and registers the observed results.

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -27,7 +27,6 @@ import (
 
 // A Store exposes methods to read and write repos and external services.
 type Store interface {
-	GetExternalService(ctx context.Context, id int64) (*types.ExternalService, error)
 	ListExternalServices(context.Context, StoreListExternalServicesArgs) ([]*types.ExternalService, error)
 	UpsertExternalServices(ctx context.Context, svcs ...*types.ExternalService) error
 
@@ -202,35 +201,6 @@ func (s *DBStore) Transact(ctx context.Context) (TxStore, error) {
 	}
 	return &DBStore{Store: txBase}, nil
 }
-
-func (s *DBStore) GetExternalService(ctx context.Context, id int64) (*types.ExternalService, error) {
-	query := sqlf.Sprintf(
-		getExternalServiceQueryFmtstr,
-		id,
-	)
-	svc := types.ExternalService{}
-	err := scanExternalService(&svc, s.QueryRow(ctx, query))
-	return &svc, err
-}
-
-const getExternalServiceQueryFmtstr = `
--- source: cmd/repo-updated/repos/store.go:DBStore.GetExternalService
-SELECT
-  id,
-  kind,
-  display_name,
-  config,
-  created_at,
-  updated_at,
-  deleted_at,
-  last_sync_at,
-  next_sync_at,
-  namespace_user_id,
-  unrestricted
-FROM external_services
-WHERE id = %s
-AND deleted_at IS NULL
-`
 
 // ListExternalServices lists all stored external services matching the given args.
 func (s *DBStore) ListExternalServices(ctx context.Context, args StoreListExternalServicesArgs) (svcs []*types.ExternalService, _ error) {

--- a/internal/usagestats/campaigns_test.go
+++ b/internal/usagestats/campaigns_test.go
@@ -2,7 +2,6 @@ package usagestats
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -23,8 +21,9 @@ func TestCampaignsUsageStatistics(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 
 	// Create stub repo.
-	rstore := repos.NewDBStore(dbconn.Global, sql.TxOptions{})
 	repoStore := db.NewRepoStoreWithDB(dbconn.Global)
+	esStore := db.NewExternalServicesStoreWithDB(dbconn.Global)
+
 	now := time.Now()
 	svc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
@@ -33,7 +32,7 @@ func TestCampaignsUsageStatistics(t *testing.T) {
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
-	if err := rstore.UpsertExternalServices(ctx, &svc); err != nil {
+	if err := esStore.Upsert(ctx, &svc); err != nil {
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 	repo := &types.Repo{


### PR DESCRIPTION
This PR decouples the repo-updater [Store](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/repos/store.go?utm_source=VSCode-1.1.0#L29:7) from the rest of the codebase by replacing all calls done from the Campaigns and Frontend by the [db.ExternalService](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/db/external_services.go#L35:6) store.
