### PR TITLE
zoekt: do visibility checks when constructing partial

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -8,10 +8,12 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 var matchHoleRegexp = lazyregexp.New(splitOnHolesPattern())
@@ -263,7 +265,7 @@ func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPat
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[string]struct{}, err error) {
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoName]struct{}, err error) {
 	if len(repos.repoRevs) == 0 {
 		return nil, false, nil, nil
 	}
@@ -329,31 +331,11 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		return nil, false, nil, nil
 	}
 
-	// Zoekt did not evaluate some files in repositories or ignored some repositories. Record skipped repos.
-	reposLimitHit = make(map[string]struct{})
-	if limitHit {
-		for _, file := range resp.Files {
-			if _, ok := reposLimitHit[file.Repository]; !ok {
-				reposLimitHit[file.Repository] = struct{}{}
-			}
-		}
-	}
-
-	if fileMatchLimit := int(args.PatternInfo.FileMatchLimit); len(resp.Files) > fileMatchLimit {
-		// Trim files based on count.
-		fileMatchesInSkippedRepos := resp.Files[fileMatchLimit:]
-		resp.Files = resp.Files[:fileMatchLimit]
-
-		if !limitHit {
-			// Record skipped repos with trimmed files.
-			for _, file := range fileMatchesInSkippedRepos {
-				if _, ok := reposLimitHit[file.Repository]; !ok {
-					reposLimitHit[file.Repository] = struct{}{}
-				}
-			}
-		}
-		limitHit = true
-	}
+	limitHit, files, partial := zoektLimitMatches(limitHit, int(args.PatternInfo.FileMatchLimit), resp.Files, func(file *zoekt.FileMatch) (repo *types.Repo, revs []string, ok bool) {
+		repo, inputRevs := repos.GetRepoInputRev(file)
+		return repo, inputRevs, true
+	})
+	resp.Files = files
 
 	maxLineMatches := 25 + k
 	matches := make([]*FileMatchResolver, len(resp.Files))
@@ -378,5 +360,5 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		}
 	}
 
-	return matches, limitHit, reposLimitHit, nil
+	return matches, limitHit, partial, nil
 }

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -139,7 +139,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 				common.indexed = append(common.indexed, repo.Repo)
 			}
 			for repo := range reposLimitHit {
-				common.partial[api.RepoName(repo)] = struct{}{}
+				common.partial[repo] = struct{}{}
 			}
 		}
 		if limitHit {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -521,7 +521,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 					// for dynamic filter purposes. Note, reposLimitHit may include repos that did not have any results
 					// returned in the original result set, because indexed search has `limitHit` for the
 					// entire search rather than per repo as in non-indexed search.
-					common.partial[api.RepoName(repo)] = struct{}{}
+					common.partial[repo] = struct{}{}
 				}
 			}
 			if limitHit {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -101,7 +101,7 @@ func TestIndexedSearch(t *testing.T) {
 		wantMatchInputRevs []string
 		wantUnindexed      []*search.RepositoryRevisions
 		wantLimitHit       bool
-		wantReposLimitHit  map[string]struct{}
+		wantReposLimitHit  map[api.RepoName]struct{}
 		wantErr            bool
 	}{
 		{
@@ -188,9 +188,8 @@ func TestIndexedSearch(t *testing.T) {
 				},
 				since: func(time.Time) time.Duration { return 0 },
 			},
-			wantLimitHit:      false,
-			wantReposLimitHit: map[string]struct{}{},
-			wantMatchCount:    5,
+			wantLimitHit:   false,
+			wantMatchCount: 5,
 			wantMatchURLs: []string{
 				"git://foo/bar#baz.go",
 				"git://foo/foobar#baz.go",
@@ -223,8 +222,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 				since: func(time.Time) time.Duration { return 0 },
 			},
-			wantLimitHit:      false,
-			wantReposLimitHit: map[string]struct{}{},
+			wantLimitHit: false,
 			wantMatchURLs: []string{
 				"git://foo/bar?HEAD#baz.go",
 				"git://foo/bar?dev#baz.go",


### PR DESCRIPTION
The zoekt code in graphqlbackend would leak potentially private
repository names via the "partial" set we construct. This is since we
directly put names into the partial field before validating if the user
had access to it.

In practice this would not occur since we could never get the repo from
the DB (so the resolver could not be created) and the set of global
repositories only contains public repos.

This PR deduplicates code between structural and normal indexed
search. It also aligns the types closer to what we have in
searchResultsCommon, which makes a future change cleaner.