### PR TITLE
search: make searchResultsCommon.partial based on RepoID

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -73,6 +73,11 @@ func (r *RepositoryResolver) ID() graphql.ID {
 	return MarshalRepositoryID(r.repo.ID)
 }
 
+// For internal use
+func (r *RepositoryResolver) repoID() api.RepoID {
+	return r.repo.ID
+}
+
 func MarshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
 
 func UnmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -276,7 +276,7 @@ func paginatedSearchFilesInRepos(ctx context.Context, args *search.TextParameter
 			// searchFilesInRepos can return a nil structure, but the executor
 			// requires a non-nil one always (which is more sane).
 			fileCommon = &searchResultsCommon{
-				partial: map[api.RepoName]struct{}{},
+				partial: map[api.RepoID]struct{}{},
 			}
 		}
 		// fileResults is not sorted so we must sort it now. fileCommon may or
@@ -562,7 +562,7 @@ func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, last
 	final := &searchResultsCommon{
 		limitHit:         false, // irrelevant in paginated search
 		indexUnavailable: common.indexUnavailable,
-		partial:          make(map[api.RepoName]struct{}),
+		partial:          make(map[api.RepoID]struct{}),
 		resultCount:      common.resultCount,
 	}
 

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -100,7 +100,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 0,
 					repos:       nil,
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
 				limitHit:     false,
@@ -121,7 +121,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 3,
 					repos:       []*types.Repo{repo("org/repo1")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -141,7 +141,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 2,
 					repos:       []*types.Repo{repo("org/repo1")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 2,
 				limitHit:     true,
@@ -162,7 +162,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 3,
 					repos:       []*types.Repo{repo("org/repo2"), repo("org/repo3")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -183,7 +183,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 3,
 					repos:       []*types.Repo{repo("org/repo1"), repo("org/repo2")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -214,7 +214,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 3,
 					repos:       []*types.Repo{repo("org/repo2")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 0,
 				limitHit:     false,
@@ -233,7 +233,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				common: &searchResultsCommon{
 					resultCount: 1,
 					repos:       []*types.Repo{repo("org/repo1")},
-					partial:     make(map[api.RepoName]struct{}),
+					partial:     make(map[api.RepoID]struct{}),
 				},
 				resultOffset: 2,
 				limitHit:     true,
@@ -348,7 +348,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				repos:       []*types.Repo{repo("1"), repo("2"), repo("3")},
-				partial:     map[api.RepoName]struct{}{},
+				partial:     map[api.RepoID]struct{}{},
 				resultCount: 10,
 			},
 		},
@@ -378,7 +378,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				repos:   []*types.Repo{repo("3"), repo("4"), repo("5")},
-				partial: map[api.RepoName]struct{}{},
+				partial: map[api.RepoID]struct{}{},
 			},
 		},
 		{
@@ -401,7 +401,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				repos:       []*types.Repo{repo("1")},
-				partial:     map[api.RepoName]struct{}{},
+				partial:     map[api.RepoID]struct{}{},
 				resultCount: 1,
 			},
 		},
@@ -425,7 +425,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCommon: &searchResultsCommon{
 				repos:       []*types.Repo{repo("1")},
-				partial:     map[api.RepoName]struct{}{},
+				partial:     map[api.RepoID]struct{}{},
 				resultCount: 1,
 			},
 		},
@@ -438,7 +438,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 1, ResultOffset: 0, Finished: true},
 			wantCommon: &searchResultsCommon{
-				partial: map[api.RepoName]struct{}{},
+				partial: map[api.RepoID]struct{}{},
 			},
 		},
 	}
@@ -674,7 +674,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repo("a"), "a.go"),
 			},
 			wantCommon: &searchResultsCommon{
-				partial:     map[api.RepoName]struct{}{},
+				partial:     map[api.RepoID]struct{}{},
 				repos:       []*types.Repo{repo("a")},
 				resultCount: 1,
 			},
@@ -690,7 +690,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repo("c"), "a.go"),
 			},
 			wantCommon: &searchResultsCommon{
-				partial: map[api.RepoName]struct{}{},
+				partial: map[api.RepoID]struct{}{},
 				repos:   []*types.Repo{repo("c")},
 				missing: []*types.Repo{repo("b")},
 			},
@@ -707,7 +707,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repo("c"), "a.go"),
 			},
 			wantCommon: &searchResultsCommon{
-				partial: map[api.RepoName]struct{}{},
+				partial: map[api.RepoID]struct{}{},
 				repos:   []*types.Repo{repo("a"), repo("c")},
 				missing: []*types.Repo{repo("b")},
 			},
@@ -725,7 +725,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repo("f"), "a.go"),
 			},
 			wantCommon: &searchResultsCommon{
-				partial: map[api.RepoName]struct{}{},
+				partial: map[api.RepoID]struct{}{},
 				repos:   []*types.Repo{repo("a"), repo("c"), repo("f")},
 				cloning: []*types.Repo{repo("d")},
 				missing: []*types.Repo{repo("b"), repo("e")},

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -265,7 +265,7 @@ func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPat
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoName]struct{}, err error) {
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoID]struct{}, err error) {
 	if len(repos.repoRevs) == 0 {
 		return nil, false, nil, nil
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -70,7 +70,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 	ctx, cancelAll := context.WithCancel(ctx)
 	defer cancelAll()
 
-	common = &searchResultsCommon{partial: make(map[api.RepoName]struct{})}
+	common = &searchResultsCommon{partial: make(map[api.RepoID]struct{})}
 
 	indexed, err := newIndexedSearchRequest(ctx, args, symbolRequest)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -305,7 +305,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	common = &searchResultsCommon{partial: make(map[api.RepoName]struct{})}
+	common = &searchResultsCommon{partial: make(map[api.RepoID]struct{})}
 
 	indexedTyp := textRequest
 	if args.PatternInfo.IsStructuralPat {
@@ -478,7 +478,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 					}
 					if repoLimitHit {
 						// We did not return all results in this repository.
-						common.partial[repoRev.Repo.Name] = struct{}{}
+						common.partial[repoRev.Repo.ID] = struct{}{}
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, false, err); fatalErr != nil {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -199,7 +199,7 @@ func (s *indexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
 	return s.repos.repoRevs
 }
 
-func (s *indexedSearchRequest) Search(ctx context.Context) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[api.RepoName]struct{}, err error) {
+func (s *indexedSearchRequest) Search(ctx context.Context) (fm []*FileMatchResolver, limitHit bool, reposLimitHit map[api.RepoID]struct{}, err error) {
 	if s.args == nil {
 		return nil, false, nil, nil
 	}
@@ -305,7 +305,7 @@ var errNoResultsInTimeout = errors.New("no results found in specified timeout")
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoName]struct{}, err error) {
+func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoID]struct{}, err error) {
 	if args == nil {
 		return nil, false, nil, nil
 	}
@@ -452,7 +452,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 // limit. Additionally it calculates the set of repos with partial
 // results. This information is not returned by zoekt, so if zoekt indicates a
 // limit has been hit, we include all repos in partial.
-func zoektLimitMatches(limitHit bool, limit int, files []zoekt.FileMatch, getRepoInputRev func(file *zoekt.FileMatch) (repo *types.Repo, revs []string, ok bool)) (bool, []zoekt.FileMatch, map[api.RepoName]struct{}) {
+func zoektLimitMatches(limitHit bool, limit int, files []zoekt.FileMatch, getRepoInputRev func(file *zoekt.FileMatch) (repo *types.Repo, revs []string, ok bool)) (bool, []zoekt.FileMatch, map[api.RepoID]struct{}) {
 	var resultFiles []zoekt.FileMatch
 	var partialFiles []zoekt.FileMatch
 
@@ -469,7 +469,7 @@ func zoektLimitMatches(limitHit bool, limit int, files []zoekt.FileMatch, getRep
 		}
 	}
 
-	partial := make(map[api.RepoName]struct{})
+	partial := make(map[api.RepoID]struct{})
 	last := ""
 	for _, file := range partialFiles {
 		// PERF: skip lookup if it is the same repo as the last result
@@ -479,7 +479,7 @@ func zoektLimitMatches(limitHit bool, limit int, files []zoekt.FileMatch, getRep
 		last = file.Repository
 
 		if repo, _, ok := getRepoInputRev(&file); ok {
-			partial[repo.Name] = struct{}{}
+			partial[repo.ID] = struct{}{}
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -101,7 +101,7 @@ func TestIndexedSearch(t *testing.T) {
 		wantMatchInputRevs []string
 		wantUnindexed      []*search.RepositoryRevisions
 		wantLimitHit       bool
-		wantReposLimitHit  map[api.RepoName]struct{}
+		wantReposLimitHit  map[api.RepoID]struct{}
 		wantErr            bool
 	}{
 		{


### PR DESCRIPTION
Smaller and makes it more inline with how we should be refering to
repositories. This will also make an upcoming change clearer.

Based on https://github.com/sourcegraph/sourcegraph/pull/16755