### PR TITLE
doc(admin): document logging format

### DIFF
--- a/doc/admin/observability/index.md
+++ b/doc/admin/observability/index.md
@@ -24,6 +24,8 @@ If you are investigating a specific production issue, consult the [troubleshooti
 
 ## Logs
 
+### Log levels
+
 A Sourcegraph service's log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values (from most to least verbose) are:
 
 * `dbug`: Debug. Output all logs. Default in cluster deployments.
@@ -32,7 +34,13 @@ A Sourcegraph service's log level is configured via the environment variable `SR
 * `eror`: Error.
 * `crit`: Critical.
 
-If you are having issues with repository syncing, view the output of `repo-updater`'s logs.
+### Log format
+
+A Sourcegraph service's log output format is configured via the environment variable `SRC_LOG_FORMAT`. The valid values are:
+
+* `condensed`: Optimized for human readability.
+* `json`: Machine-readable JSON format.
+* `logfmt`: The [logfmt](https://github.com/kr/logfmt) format.
 
 ## Health checks
 

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
@@ -92,6 +93,8 @@ func LogEntryLevelString(l log15.Lvl) string {
 	}
 }
 
+// Init initializes log15's root logger based on Sourcegraph-wide logging configuration
+// variables. See https://docs.sourcegraph.com/admin/observability#logs
 func Init(options ...Option) {
 	opts := &Options{}
 	for _, setter := range options {


### PR DESCRIPTION
Documents what `logging.Init` does, and includes admin-facing documentation for the logging format configuration

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
