### PR TITLE
search: add mutation to trigger actions immediately

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -19,6 +19,7 @@ type CodeMonitorsResolver interface {
 	ToggleCodeMonitor(ctx context.Context, args *ToggleCodeMonitorArgs) (MonitorResolver, error)
 	DeleteCodeMonitor(ctx context.Context, args *DeleteCodeMonitorArgs) (*EmptyResponse, error)
 	UpdateCodeMonitor(ctx context.Context, args *UpdateCodeMonitorArgs) (MonitorResolver, error)
+	ResetTriggerQueryTimestamps(ctx context.Context, args *ResetTriggerQueryTimestampsArgs) (*EmptyResponse, error)
 }
 
 type MonitorConnectionResolver interface {
@@ -154,6 +155,10 @@ type DeleteCodeMonitorArgs struct {
 	Id graphql.ID
 }
 
+type ResetTriggerQueryTimestampsArgs struct {
+	Id graphql.ID
+}
+
 type CreateMonitorArgs struct {
 	Namespace   graphql.ID
 	Description string
@@ -213,5 +218,9 @@ func (d defaultCodeMonitorsResolver) DeleteCodeMonitor(ctx context.Context, args
 }
 
 func (d defaultCodeMonitorsResolver) UpdateCodeMonitor(ctx context.Context, args *UpdateCodeMonitorArgs) (MonitorResolver, error) {
+	return nil, codeMonitorsOnlyInEnterprise
+}
+
+func (d defaultCodeMonitorsResolver) ResetTriggerQueryTimestamps(ctx context.Context, args *ResetTriggerQueryTimestampsArgs) (*EmptyResponse, error) {
 	return nil, codeMonitorsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -822,6 +822,16 @@ type Mutation {
         """
         actions: [MonitorEditActionInput!]!
     ): Monitor!
+    """
+    Reset the timestamps of a trigger query. The query will be queued immediately and return
+    all results without a limit on the timeframe. Only site admins may perform this mutation.
+    """
+    resetTriggerQueryTimestamps(
+        """
+        The id of the trigger query.
+        """
+        id: ID!
+    ): EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -815,6 +815,16 @@ type Mutation {
         """
         actions: [MonitorEditActionInput!]!
     ): Monitor!
+    """
+    Reset the timestamps of a trigger query. The query will be queued immediately and return
+    all results without a limit on the timeframe. Only site admins may perform this mutation.
+    """
+    resetTriggerQueryTimestamps(
+        """
+        The id of the trigger query.
+        """
+        id: ID!
+    ): EmptyResponse!
 }
 
 """

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -164,6 +164,27 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 	return m, nil
 }
 
+// ResetTriggerQueryTimestamps is a convenience function which resets the
+// timestamps `next_run` and `last_result` with the purpose to trigger associated
+// actions (emails, webhooks) immediately. This is useful during development and
+// troubleshooting. Only site admins can call this functions.
+func (r *Resolver) ResetTriggerQueryTimestamps(ctx context.Context, args *graphqlbackend.ResetTriggerQueryTimestampsArgs) (*graphqlbackend.EmptyResponse, error) {
+	err := backend.CheckCurrentUserIsSiteAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var queryIDInt64 int64
+	err = relay.UnmarshalSpec(args.Id, &queryIDInt64)
+	if err != nil {
+		return nil, err
+	}
+	err = r.store.ResetTriggerQueryTimestamps(ctx, queryIDInt64)
+	if err != nil {
+		return nil, err
+	}
+	return &graphqlbackend.EmptyResponse{}, nil
+}
+
 func (r *Resolver) actionIDsForMonitorIDInt64(ctx context.Context, monitorID int64) (actionIDs []graphql.ID, err error) {
 	limit := 50
 	var (


### PR DESCRIPTION
Feedback from the first testers of code monitoring was that it would be
great if there was the possibility to trigger actions immediately and
not to wait for a commit to happen. This PR adds a mutation that allows
just that. For now, the mutation is restricted to site admins. The plan
is to add a button to the UI behind a sub-feature flag to allow site
admins to troubleshoot or test the configuration.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
