### PR TITLE
search: zoekt returns searchResultsCommon

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -79,11 +79,6 @@ func (r *RepositoryResolver) IDInt32() api.RepoID {
 	return r.innerRepo.ID
 }
 
-// For internal use
-func (r *RepositoryResolver) repoID() api.RepoID {
-	return r.repo.ID
-}
-
 func MarshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
 
 func UnmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -286,7 +286,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 			// are @ and :, both of which are disallowed in git refs
 			filter = filter + fmt.Sprintf(`@%s`, rev)
 		}
-		_, limitHit := sr.searchResultsCommon.partial[repo.repoID()]
+		_, limitHit := sr.searchResultsCommon.partial[repo.IDInt32()]
 		// Increment number of matches per repo. Add will override previous entry for uri
 		repoToMatchCount[uri] += lineMatchCount
 		add(filter, uri, repoToMatchCount[uri], limitHit, "repo", scoreDefault)

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -223,7 +223,7 @@ func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {
 			// treat empty list as preferring master
 			revs = []search.RevisionSpecifier{{RevSpec: ""}}
 		}
-		r[i] = &search.RepositoryRevisions{Repo: &types.Repo{Name: api.RepoName(repoName)}, Revs: revs}
+		r[i] = &search.RepositoryRevisions{Repo: mkRepos(repoName)[0], Revs: revs}
 	}
 	return r
 }


### PR DESCRIPTION
This reduces the need to interpet what zoekt returns in its
results. This is a step towards unifying all our backends to returning
searchResultsCommon, matches and an error. This makes it possible for us
to stream progress with results.

Based on https://github.com/sourcegraph/sourcegraph/pull/16756