### PR TITLE
repo-updater: Allow custom git update interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When a newer version of a campaign spec is uploaded, a message is now displayed when viewing the campaign or an outdated campaign spec. [#14532](https://github.com/sourcegraph/sourcegraph/issues/14532)
 - Changesets in a campaign can now be searched by title and repository name. [#15781](https://github.com/sourcegraph/sourcegraph/issues/15781)
 - Experimental: [`transformChanges` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#transformchanges) is now available as a feature preview to allow users to create multiple changesets in a single repository. [#16235](https://github.com/sourcegraph/sourcegraph/pull/16235)
+- The `gitUpdateInterval` site setting was added to allow custom git update intervals based on repository names. [#16765](https://github.com/sourcegraph/sourcegraph/pull/16765)
 
 ### Changed
 

--- a/internal/conf/validate_custom.go
+++ b/internal/conf/validate_custom.go
@@ -2,7 +2,9 @@ package conf
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -59,6 +61,12 @@ func validateCustom(cfg Unified) (problems Problems) {
 			invalid(NewSiteProblem(`externalURL must be a valid URL`))
 		} else if eURL.Path != "/" && eURL.Path != "" {
 			invalid(NewSiteProblem(`externalURL must not be a non-root URL`))
+		}
+	}
+
+	for _, rule := range cfg.GitUpdateInterval {
+		if _, err := regexp.Compile(rule.Pattern); err != nil {
+			invalid(NewSiteProblem(fmt.Sprintf("GitUpdateIntervalRule pattern is not valid regex: %q", rule.Pattern)))
 		}
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1207,6 +1207,8 @@ type SiteConfiguration struct {
 	GitCloneURLToRepositoryName []*CloneURLToRepositoryName `json:"git.cloneURLToRepositoryName,omitempty"`
 	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
+	// GitUpdateInterval description: JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
+	GitUpdateInterval []*UpdateIntervalRule `json:"gitUpdateInterval,omitempty"`
 	// GithubClientID description: Client ID for GitHub. (DEPRECATED)
 	GithubClientID string `json:"githubClientID,omitempty"`
 	// GithubClientSecret description: Client secret for GitHub. (DEPRECATED)
@@ -1288,6 +1290,12 @@ type TlsExternal struct {
 type TransformChanges struct {
 	// Group description: A list of groups of changes in a repository that each create a separate, additional changeset for this repository, with all ungrouped changes being in the default changeset.
 	Group []interface{} `json:"group,omitempty"`
+}
+type UpdateIntervalRule struct {
+	// Interval description: An integer representing the number of minutes to wait until the next update
+	Interval int `json:"interval"`
+	// Pattern description: A regular expression matching a repo name
+	Pattern string `json:"pattern"`
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -303,6 +303,28 @@
       "default": false,
       "group": "External services"
     },
+    "gitUpdateInterval" : {
+      "description": "JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.",
+      "type": "array",
+      "items": {
+        "title": "UpdateIntervalRule",
+        "type": "object",
+        "required": ["pattern", "interval"],
+        "additionalProperties": false,
+        "properties": {
+          "pattern": {
+            "description": "A regular expression matching a repo name",
+            "type": "string"
+          },
+          "interval": {
+            "description": "An integer representing the number of minutes to wait until the next update",
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "group": "External services"
+    },
     "disablePublicRepoRedirects": {
       "description": "Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -303,7 +303,7 @@
       "default": false,
       "group": "External services"
     },
-    "gitUpdateInterval" : {
+    "gitUpdateInterval": {
       "description": "JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.",
       "type": "array",
       "items": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -314,7 +314,8 @@
         "properties": {
           "pattern": {
             "description": "A regular expression matching a repo name",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "interval": {
             "description": "An integer representing the number of minutes to wait until the next update",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -308,7 +308,7 @@ const SiteSchemaJSON = `{
       "default": false,
       "group": "External services"
     },
-    "gitUpdateInterval" : {
+    "gitUpdateInterval": {
       "description": "JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.",
       "type": "array",
       "items": {

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -308,6 +308,28 @@ const SiteSchemaJSON = `{
       "default": false,
       "group": "External services"
     },
+    "gitUpdateInterval" : {
+      "description": "JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.",
+      "type": "array",
+      "items": {
+        "title": "UpdateIntervalRule",
+        "type": "object",
+        "required": ["pattern", "interval"],
+        "additionalProperties": false,
+        "properties": {
+          "pattern": {
+            "description": "A regular expression matching a repo name",
+            "type": "string"
+          },
+          "interval": {
+            "description": "An integer representing the number of minutes to wait until the next update",
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "group": "External services"
+    },
     "disablePublicRepoRedirects": {
       "description": "Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -319,7 +319,8 @@ const SiteSchemaJSON = `{
         "properties": {
           "pattern": {
             "description": "A regular expression matching a repo name",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "interval": {
             "description": "An integer representing the number of minutes to wait until the next update",


### PR DESCRIPTION
Add a new site configuration option, `gitUpdateInterval`

An admin can add an array of rules with the following form:

```json
"gitUpdateInterval": [
    {
      "pattern": "github.com",
      "interval": 10
    },
    {
      "pattern": "gitlab.com/abc",
      "interval": 15
    },
  ]
}
```

We'll check this list of rules from top to bottom and the first pattern to match the repo name will be chosen. If no patterns match we fall back to our current backoff heuristic.

The config was added at the site level since a repo can belong to a number of external services so if we defined it in external service config we could have conflicting rules.

Closes: https://github.com/sourcegraph/sourcegraph/issues/15926