### PR TITLE
gitserver: fetch gerrit changeset refs

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1371,6 +1371,8 @@ func (s *Server) doRepoUpdate2(repo api.RepoName) error {
 			"+refs/merge-requests/*:refs/merge-requests/*",
 			// Bitbucket pull requests
 			"+refs/pull-requests/*:refs/pull-requests/*",
+			// Gerrit changesets
+			"+refs/changes/*:refs/changes/*",
 			// Possibly deprecated refs for sourcegraph zap experiment?
 			"+refs/sourcegraph/*:refs/sourcegraph/*")
 	}


### PR DESCRIPTION
We currently hardcode the list of refs we fetch to just the code hosts
we support. The original motivation behind this was to make fetches
faster. However, we have likely reached the point we should fetch
everything. I will leave that for another PR incase it causes
issues. For now lets add in gerrit to the allow list.

Fixes https://github.com/sourcegraph/sourcegraph/issues/16387