### PR TITLE
search: ensure repo test IDs are greater than 0

### DIFF
--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/all.json
@@ -7,7 +7,7 @@
    {
     "reason": "repository-missing",
     "title": "2 missing",
-    "message": "2 repositories could not be searched. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `missing-2`\n* `missing-1`",
+    "message": "2 repositories could not be searched. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `missing-1`\n* `missing-2`",
     "severity": "info"
    },
    {

--- a/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/timedout100.json
+++ b/cmd/frontend/graphqlbackend/testdata/golden/TestSearchProgress/timedout100.json
@@ -7,7 +7,7 @@
    {
     "reason": "shard-timeout",
     "title": "100 timed out",
-    "message": "100 repositories could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `timedout-60`\n* `timedout-48`\n* `timedout-46`\n* `timedout-89`\n* `timedout-10`\n* `timedout-17`\n* `timedout-71`\n* `timedout-8`\n* `timedout-92`\n* `timedout-81`\n* ...",
+    "message": "100 repositories could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `repogroup:` or other filters.\n* `timedout-33`\n* `timedout-19`\n* `timedout-80`\n* `timedout-34`\n* `timedout-69`\n* `timedout-28`\n* `timedout-0`\n* `timedout-86`\n* `timedout-78`\n* `timedout-52`\n* ...",
     "severity": "warn"
    }
   ]

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -233,6 +233,12 @@ func mkRepos(names ...string) []*types.Repo {
 	for _, name := range names {
 		sum := md5.Sum([]byte(name))
 		id := api.RepoID(binary.BigEndian.Uint64(sum[:]))
+		if id < 0 {
+			id = -(id / 2)
+		}
+		if id == 0 {
+			id++
+		}
 		repos = append(repos, &types.Repo{ID: id, Name: api.RepoName(name)})
 	}
 	return repos


### PR DESCRIPTION
Noticed this in some tests. Just added this so the invariants are the
same as returned from the DB.