### PR TITLE
search: only allocate searchCommonPartial if non-empty

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -151,11 +151,11 @@ func (c *searchResultsCommon) update(other searchResultsCommon) {
 	c.resultCount += other.resultCount
 
 	if c.partial == nil {
-		c.partial = make(map[api.RepoID]struct{})
-	}
-
-	for repo := range other.partial {
-		c.partial[repo] = struct{}{}
+		c.partial = other.partial
+	} else {
+		for repo := range other.partial {
+			c.partial[repo] = struct{}{}
+		}
 	}
 }
 


### PR DESCRIPTION
This is the same trick we use for repos.