### PR TITLE
Add other code hosts to chrome description

### DIFF
--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "name": "Sourcegraph",
   "manifest_version": 2,
-  "description": "Adds code intelligence to GitHub: hovers, definitions, references. Supports 20+ languages and other code hosts.",
+  "description": "Adds code intelligence to GitHub, GitLab, Bitbucket Server, and Phabricator: hovers, definitions, references. Supports 20+ languages and other code hosts.",
   "browser_action": {
     "default_title": "Sourcegraph",
     "default_icon": {

--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "name": "Sourcegraph",
   "manifest_version": 2,
-  "description": "Adds code intelligence to GitHub, GitLab, Bitbucket Server, and Phabricator: hovers, definitions, references. Supports 20+ languages and other code hosts.",
+  "description": "Adds code intelligence to GitHub, GitLab, Bitbucket Server, Phabricator: hovers, definitions, references. Supports 20+ languages.",
   "browser_action": {
     "default_title": "Sourcegraph",
     "default_icon": {

--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "name": "Sourcegraph",
   "manifest_version": 2,
-  "description": "Adds code intelligence to GitHub, GitLab, Bitbucket Server, Phabricator: hovers, definitions, references. Supports 20+ languages.",
+  "description": "Adds code intelligence to GitHub, GitLab, and other hosts: hovers, definitions, references. For 20+ languages.",
   "browser_action": {
     "default_title": "Sourcegraph",
     "default_icon": {


### PR DESCRIPTION
Current summary: 
![image](https://user-images.githubusercontent.com/11967660/102243079-9f6f4300-3eaf-11eb-9245-9ee92ceb74d2.png)

We want to include other code hosts as well, added in this change. 

Chrome notes there is a [132 character limit](https://developer.chrome.com/docs/extensions/mv2/manifest/description/). This is 129 characters. 