### PR TITLE
Try to test our pipeline...

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps_test.go
+++ b/enterprise/dev/ci/ci/pipeline-steps_test.go
@@ -1,0 +1,88 @@
+package ci
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
+
+	bk "github.com/sourcegraph/sourcegraph/internal/buildkite"
+)
+
+func Test_addDockerImages(t *testing.T) {
+	crono := time.Now()
+	tests := []struct {
+		name  string
+		c     Config
+		final bool
+		want  func(*bk.Pipeline)
+	}{
+		{
+			"base, always deploy main, regardless of other fields",
+			Config{
+				now:                 crono,
+				branch:              "main",
+				version:             "na",
+				commit:              "na",
+				mustIncludeCommit:   nil,
+				changedFiles:        nil,
+				taggedRelease:       true,
+				releaseBranch:       false,
+				isBextReleaseBranch: false,
+				isBextNightly:       false,
+				isRenovateBranch:    true,
+				patch:               false,
+				patchNoTest:         false,
+				isQuick:             false,
+				isMasterDryRun:      true,
+				profilingEnabled:    false,
+			},
+			true,
+			func(pipeline *bk.Pipeline) {
+				//expect insiders docker images
+				c := Config{
+					now:                 crono,
+					branch:              "main",
+					version:             "na",
+					commit:              "na",
+					mustIncludeCommit:   nil,
+					changedFiles:        nil,
+					taggedRelease:       true,
+					releaseBranch:       false,
+					isBextReleaseBranch: false,
+					isBextNightly:       false,
+					isRenovateBranch:    true,
+					patch:               false,
+					patchNoTest:         false,
+					isQuick:             false,
+					isMasterDryRun:      true,
+					profilingEnabled:    false,
+				}
+
+				addDockerImage := func(c Config, app string, insiders bool) func(*bk.Pipeline) {
+					return addFinalDockerImage(c, app, insiders)
+				}
+				for _, dockerImage := range images.SourcegraphDockerImages {
+					addDockerImage(c, dockerImage, true)(pipeline)
+				}
+			},
+		},
+	}
+	// these need to be outside the test scope allow for the delve to pick up changes to them
+	pipeline := &bk.Pipeline{}
+	sparePipeline := &bk.Pipeline{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addDockerImages(tt.c, tt.final)
+
+			// we create a list of functions that are applied to the pipeline so we need to mimic that here to test
+			got(pipeline) //this is 100% the opposite of a pure function
+
+			tt.want(sparePipeline)
+			if !reflect.DeepEqual(pipeline, sparePipeline) {
+				t.Fatal("did not generate equivalent pipelines")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is an attempt to test our build pipeline...

In the spirit of untested code is broken code I tried to add some testing to make sure that `main` always creates the final insider images. 

I'm not sure if this should be merged but it should illustrate either my lack of Go skills or that we should consider a different approach to our buildkite config generation. I personally think this could be done much better by a DAG approach used by other CI systems like [Tekton](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#configuring-the-task-execution-order). 
This would allow config issues to be caught at "compile-time" rather than "build-time".

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
