### PR TITLE
search: use common.update rather than directly mutating common

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -1330,31 +1330,36 @@ func sortSearchSuggestions(s []*searchSuggestionResolver) {
 }
 
 // handleRepoSearchResult handles the limitHit and searchErr returned by a search function,
-// updating common as to reflect that new information. If searchErr is a fatal error,
+// returning common as to reflect that new information. If searchErr is a fatal error,
 // it returns a non-nil error; otherwise, if searchErr == nil or a non-fatal error, it returns a
 // nil error.
-func handleRepoSearchResult(common *searchResultsCommon, repoRev *search.RepositoryRevisions, limitHit, timedOut bool, searchErr error) (fatalErr error) {
-	common.limitHit = common.limitHit || limitHit
+func handleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timedOut bool, searchErr error) (common searchResultsCommon, fatalErr error) {
+	if limitHit {
+		common.limitHit = true
+		common.partial = map[api.RepoID]struct{}{repoRev.Repo.ID: {}}
+	}
 	if vcs.IsRepoNotExist(searchErr) {
 		if vcs.IsCloneInProgress(searchErr) {
-			common.cloning = append(common.cloning, repoRev.Repo)
+			common.cloning = []*types.Repo{repoRev.Repo}
 		} else {
-			common.missing = append(common.missing, repoRev.Repo)
+			common.missing = []*types.Repo{repoRev.Repo}
 		}
 	} else if gitserver.IsRevisionNotFound(searchErr) {
 		if len(repoRev.Revs) == 0 || len(repoRev.Revs) == 1 && repoRev.Revs[0].RevSpec == "" {
 			// If we didn't specify an input revision, then the repo is empty and can be ignored.
 		} else {
-			return searchErr
+			return common, searchErr
 		}
 	} else if errcode.IsNotFound(searchErr) {
-		common.missing = append(common.missing, repoRev.Repo)
+		common.missing = []*types.Repo{repoRev.Repo}
 	} else if errcode.IsTimeout(searchErr) || errcode.IsTemporary(searchErr) || timedOut {
-		common.timedout = append(common.timedout, repoRev.Repo)
+		common.timedout = []*types.Repo{repoRev.Repo}
 	} else if searchErr != nil {
-		return searchErr
+		return common, searchErr
+	} else {
+		common.searched = []*types.Repo{repoRev.Repo}
 	}
-	return nil
+	return common, nil
 }
 
 // getRepos is a wrapper around p.Get. It returns an error if the promise

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -579,10 +579,12 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 			}
 			mu.Lock()
 			defer mu.Unlock()
-			if fatalErr := handleRepoSearchResult(common, repoRev, repoLimitHit, repoTimedOut, searchErr); fatalErr != nil {
+			repoCommon, fatalErr := handleRepoSearchResult(repoRev, repoLimitHit, repoTimedOut, searchErr)
+			if fatalErr != nil {
 				err = errors.Wrapf(searchErr, "failed to search commit %s %s", params.ErrorName, repoRev.String())
 				cancel()
 			}
+			common.update(&repoCommon)
 			if len(results) > 0 {
 				unflattened = append(unflattened, results)
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -154,16 +154,14 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 			}
 			mu.Lock()
 			defer mu.Unlock()
-			limitHit := symbolCount(res) > limit
-			repoErr = handleRepoSearchResult(common, repoRevs, limitHit, false, repoErr)
-			if repoErr != nil {
+			repoCommon, fatalErr := handleRepoSearchResult(repoRevs, len(repoSymbols) > limit, false, repoErr)
+			if fatalErr != nil {
 				if ctx.Err() == nil || errors.Cause(repoErr) != ctx.Err() {
 					// Only record error if it's not directly caused by a context error.
 					run.Error(repoErr)
 				}
-			} else {
-				common.searched = append(common.searched, repoRevs.Repo)
 			}
+			common.update(&repoCommon)
 			if repoSymbols != nil {
 				addMatches(repoSymbols)
 			}


### PR DESCRIPTION
This moves us closer to communicating results as a (common, matches)
pair. Additionally it fixes a few bugs where we didn't set some fields
in other search types. For example symbol and commit search now both
correctly report limitHit, partial and searched. Previously they would
not set those fields. In the case of limitHit symbol search was using
the global limit hit rather than the per repo limitHit.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
