### PR TITLE
workerutil: Initialize worker components with unique names

### DIFF
--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiserver"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
@@ -40,6 +41,7 @@ func QueueOptions(db dbutil.DB, config *Config) apiserver.QueueOptions {
 func newWorkerStore(db dbutil.DB) dbworkerstore.Store {
 	handle := basestore.NewHandleWithDB(db, sql.TxOptions{})
 	options := dbworkerstore.Options{
+		Name:              "precise_code_intel_index_worker_store",
 		TableName:         "lsif_indexes",
 		ViewName:          "lsif_indexes_with_repository_name u",
 		ColumnExpressions: store.IndexColumnsWithNullRank,

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/apiclient"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/apiworker/command"
@@ -67,6 +68,7 @@ func (c *Config) APIWorkerOptions(transport http.RoundTripper) apiworker.Options
 
 func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 	return workerutil.WorkerOptions{
+		Name:        "precise_code_intel_index_worker",
 		NumHandlers: c.MaximumNumJobs,
 		Interval:    c.QueuePollInterval,
 		Metrics:     makeWorkerMetrics(),

--- a/enterprise/cmd/frontend/internal/codeintel/background/resetters.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/resetters.go
@@ -12,7 +12,7 @@ import (
 // transaction.
 func NewUploadResetter(s DBStore, interval time.Duration, operations *operations) *dbworker.Resetter {
 	return dbworker.NewResetter(store.WorkerutilUploadStore(s), dbworker.ResetterOptions{
-		Name:     "upload resetter",
+		Name:     "precise_code_intel_upload_worker_resetter",
 		Interval: interval,
 		Metrics: dbworker.ResetterMetrics{
 			RecordResets:        operations.numUploadResets,
@@ -27,7 +27,7 @@ func NewUploadResetter(s DBStore, interval time.Duration, operations *operations
 // transaction.
 func NewIndexResetter(s DBStore, interval time.Duration, operations *operations) *dbworker.Resetter {
 	return dbworker.NewResetter(store.WorkerutilIndexStore(s), dbworker.ResetterOptions{
-		Name:     "index resetter",
+		Name:     "precise_code_intel_index_worker_resetter",
 		Interval: interval,
 		Metrics: dbworker.ResetterMetrics{
 			RecordResets:        operations.numIndexResets,

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -33,6 +33,7 @@ func NewWorker(
 	}
 
 	return dbworker.NewWorker(rootContext, store.WorkerutilUploadStore(dbStore), handler, workerutil.WorkerOptions{
+		Name:        "precise_code_intel_upload_worker",
 		NumHandlers: numProcessorRoutines,
 		Interval:    pollInterval,
 		Metrics:     workerMetrics,

--- a/enterprise/internal/campaigns/background/workers.go
+++ b/enterprise/internal/campaigns/background/workers.go
@@ -36,6 +36,7 @@ func newWorker(
 	r := &reconciler.Reconciler{GitserverClient: gitClient, Sourcer: sourcer, Store: s}
 
 	options := workerutil.WorkerOptions{
+		Name:        "campaigns_reconciler_worker",
 		NumHandlers: 5,
 		Interval:    5 * time.Second,
 		Metrics: workerutil.WorkerMetrics{
@@ -53,7 +54,7 @@ func newWorkerResetter(s *store.Store, metrics campaignsMetrics) *dbworker.Reset
 	workerStore := createDBWorkerStore(s)
 
 	options := dbworker.ResetterOptions{
-		Name:     "campaigns_reconciler_resetter",
+		Name:     "campaigns_reconciler_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics: dbworker.ResetterMetrics{
 			Errors:              metrics.errors,
@@ -72,6 +73,7 @@ func scanFirstChangesetRecord(rows *sql.Rows, err error) (workerutil.Record, boo
 
 func createDBWorkerStore(s *store.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:                 "campaigns_reconciler_worker_store",
 		TableName:            "changesets",
 		AlternateColumnNames: map[string]string{"state": "reconciler_state"},
 		ColumnExpressions:    store.ChangesetColumns,

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -485,6 +486,7 @@ func (s *Store) makeIndexWorkQueueStore() dbworkerstore.Store {
 
 func WorkerutilIndexStore(s basestore.ShareableStore) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:              "precise_code_intel_index_worker_store",
 		TableName:         "lsif_indexes",
 		ViewName:          "lsif_indexes_with_repository_name u",
 		ColumnExpressions: indexColumnsWithNullRank,

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -576,6 +577,7 @@ func (s *Store) makeUploadWorkQueueStore() dbworkerstore.Store {
 
 func WorkerutilUploadStore(s basestore.ShareableStore) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:              "precise_code_intel_upload_worker_store",
 		TableName:         "lsif_uploads",
 		ViewName:          "lsif_uploads_with_repository_name u",
 		ColumnExpressions: uploadColumnsWithNullRank,

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -23,6 +23,7 @@ const (
 
 func newTriggerQueryRunner(ctx context.Context, s *cm.Store, metrics codeMonitorsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
+		Name:        "code_monitors_trigger_jobs_worker",
 		NumHandlers: 1,
 		Interval:    5 * time.Second,
 		Metrics:     workerutil.WorkerMetrics{HandleOperation: metrics.handleOperation},
@@ -44,7 +45,7 @@ func newTriggerQueryResetter(ctx context.Context, s *cm.Store, metrics codeMonit
 	workerStore := createDBWorkerStoreForTriggerJobs(s)
 
 	options := dbworker.ResetterOptions{
-		Name:     "code_monitors_query_resetter",
+		Name:     "code_monitors_trigger_jobs_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics: dbworker.ResetterMetrics{
 			Errors:              metrics.errors,
@@ -76,6 +77,7 @@ func newTriggerJobsLogDeleter(ctx context.Context, store *cm.Store) goroutine.Ba
 
 func newActionRunner(ctx context.Context, s *cm.Store, metrics codeMonitorsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
+		Name:        "code_monitors_action_jobs_worker",
 		NumHandlers: 1,
 		Interval:    5 * time.Second,
 		Metrics:     workerutil.WorkerMetrics{HandleOperation: metrics.handleOperation},
@@ -88,7 +90,7 @@ func newActionJobResetter(ctx context.Context, s *cm.Store, metrics codeMonitors
 	workerStore := createDBWorkerStoreForActionJobs(s)
 
 	options := dbworker.ResetterOptions{
-		Name:     "code_monitors_action_resetter",
+		Name:     "code_monitors_action_jobs_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics: dbworker.ResetterMetrics{
 			Errors:              metrics.errors,
@@ -101,6 +103,7 @@ func newActionJobResetter(ctx context.Context, s *cm.Store, metrics codeMonitors
 
 func createDBWorkerStoreForTriggerJobs(s *cm.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:              "code_monitors_trigger_jobs_worker_store",
 		TableName:         "cm_trigger_jobs",
 		ColumnExpressions: cm.TriggerJobsColumns,
 		Scan:              cm.ScanTriggerJobs,
@@ -113,6 +116,7 @@ func createDBWorkerStoreForTriggerJobs(s *cm.Store) dbworkerstore.Store {
 
 func createDBWorkerStoreForActionJobs(s *cm.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:              "code_monitors_action_jobs_worker_store",
 		TableName:         "cm_action_jobs",
 		ColumnExpressions: cm.ActionJobsColumns,
 		Scan:              cm.ScanActionJobs,

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -54,6 +54,7 @@ func NewSyncWorker(ctx context.Context, db dbutil.DB, handler dbworker.Handler, 
 	}...)
 
 	store := store.New(dbHandle, store.Options{
+		Name:              "repo_sync_worker_store",
 		TableName:         "external_service_sync_jobs",
 		ViewName:          "external_service_sync_jobs_with_next_sync_at",
 		Scan:              scanSingleJob,
@@ -74,7 +75,7 @@ func NewSyncWorker(ctx context.Context, db dbutil.DB, handler dbworker.Handler, 
 	})
 
 	resetter := dbworker.NewResetter(store, dbworker.ResetterOptions{
-		Name:     "sync-worker",
+		Name:     "repo_sync_worker_resetter",
 		Interval: 5 * time.Minute,
 		Metrics:  newResetterMetrics(opts.PrometheusRegisterer),
 	})

--- a/internal/workerutil/dbworker/resetter.go
+++ b/internal/workerutil/dbworker/resetter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/efritz/glock"
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
@@ -43,6 +44,10 @@ func NewResetter(store store.Store, options ResetterOptions) *Resetter {
 }
 
 func newResetter(store store.Store, options ResetterOptions, clock glock.Clock) *Resetter {
+	if options.Name == "" {
+		panic("no name supplied to github.com/sourcegraph/sourcegraph/internal/dbworker/newResetter")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Resetter{

--- a/internal/workerutil/dbworker/resetter_test.go
+++ b/internal/workerutil/dbworker/resetter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/efritz/glock"
 	"github.com/prometheus/client_golang/prometheus"
+
 	storemocks "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store/mocks"
 )
 
@@ -13,6 +14,7 @@ func TestResetter(t *testing.T) {
 	store := storemocks.NewMockStore()
 	clock := glock.NewMockClock()
 	options := ResetterOptions{
+		Name:     "test",
 		Interval: time.Second,
 		Metrics: ResetterMetrics{
 			RecordResets:        prometheus.NewCounter(prometheus.CounterOpts{}),

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
@@ -140,6 +141,7 @@ func setupStoreTest(t *testing.T) {
 }
 
 var defaultTestStoreOptions = Options{
+	Name:              "test",
 	TableName:         "workerutil_test w",
 	Scan:              testScanFirstRecord,
 	OrderByExpression: sqlf.Sprintf("w.uploaded_at"),

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -103,6 +104,10 @@ var _ Store = &store{}
 
 // Options configure the behavior of Store over a particular set of tables, columns, and expressions.
 type Options struct {
+	// Name denotes the name of the store used to distinguish log messages and emitted metrics. The
+	// store constructor will fail if this field is not supplied.
+	Name string
+
 	// TableName is the name of the table containing work records.
 	//
 	// The target table (and the target view referenced by `ViewName`) must have the following columns
@@ -199,6 +204,10 @@ func New(handle *basestore.TransactableHandle, options Options) Store {
 
 // newStore creates a new store with the given database handle and options.
 func newStore(handle *basestore.TransactableHandle, options Options) *store {
+	if options.Name == "" {
+		panic("no name supplied to github.com/sourcegraph/sourcegraph/internal/dbworker/store:newStore")
+	}
+
 	if options.ViewName == "" {
 		options.ViewName = options.TableName
 	}

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -182,6 +183,7 @@ func TestStoreDequeueView(t *testing.T) {
 	}
 
 	options := Options{
+		Name:              "test",
 		TableName:         "workerutil_test w",
 		ViewName:          "workerutil_test_view v",
 		Scan:              testScanFirstRecordView,
@@ -266,6 +268,7 @@ func TestStoreDequeueRetryAfter(t *testing.T) {
 	}
 
 	options := Options{
+		Name:          "test",
 		TableName:     defaultTestStoreOptions.TableName,
 		StalledMaxAge: defaultTestStoreOptions.StalledMaxAge,
 
@@ -311,6 +314,7 @@ func TestStoreDequeueRetryAfterDisabled(t *testing.T) {
 	}
 
 	options := Options{
+		Name:          "test",
 		TableName:     defaultTestStoreOptions.TableName,
 		StalledMaxAge: defaultTestStoreOptions.StalledMaxAge,
 

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -28,7 +28,9 @@ type Worker struct {
 }
 
 type WorkerOptions struct {
-	// Name denotes the name of the worker used to distinguish log messages.
+	// Name denotes the name of the worker used to distinguish log messages and
+	// emitted metrics. The worker constructor will fail if this field is not
+	// supplied.
 	Name string
 
 	// NumHandlers is the maximum number of handlers that can be invoked
@@ -52,6 +54,10 @@ func NewWorker(ctx context.Context, store Store, handler Handler, options Worker
 }
 
 func newWorker(ctx context.Context, store Store, handler Handler, options WorkerOptions, clock glock.Clock) *Worker {
+	if options.Name == "" {
+		panic("no name supplied to github.com/sourcegraph/sourcegraph/internal/workerutil:newWorker")
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	handlerSemaphore := make(chan struct{}, options.NumHandlers)

--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/efritz/glock"
+
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -25,6 +26,7 @@ func TestWorkerHandlerSuccess(t *testing.T) {
 	handler := NewMockHandler()
 	clock := glock.NewMockClock()
 	options := WorkerOptions{
+		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
 		Metrics: WorkerMetrics{
@@ -65,6 +67,7 @@ func TestWorkerHandlerFailure(t *testing.T) {
 	handler := NewMockHandler()
 	clock := glock.NewMockClock()
 	options := WorkerOptions{
+		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
 		Metrics: WorkerMetrics{
@@ -113,6 +116,7 @@ func TestWorkerHandlerNonRetryableFailure(t *testing.T) {
 	handler := NewMockHandler()
 	clock := glock.NewMockClock()
 	options := WorkerOptions{
+		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
 		Metrics: WorkerMetrics{
@@ -164,6 +168,7 @@ func TestWorkerConcurrent(t *testing.T) {
 			handler := NewMockHandlerWithHooks()
 			clock := glock.NewMockClock()
 			options := WorkerOptions{
+				Name:        "test",
 				NumHandlers: numHandlers,
 				Interval:    time.Second,
 				Metrics: WorkerMetrics{
@@ -250,6 +255,7 @@ func TestWorkerBlockingPreDequeueHook(t *testing.T) {
 	handler := NewMockHandlerWithPreDequeue()
 	clock := glock.NewMockClock()
 	options := WorkerOptions{
+		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
 		Metrics: WorkerMetrics{
@@ -278,6 +284,7 @@ func TestWorkerConditionalPreDequeueHook(t *testing.T) {
 	handler := NewMockHandlerWithPreDequeue()
 	clock := glock.NewMockClock()
 	options := WorkerOptions{
+		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
 		Metrics: WorkerMetrics{


### PR DESCRIPTION
I'm adding observability things to these components soon and they need to be distinguishable before that.