### PR TITLE
Speed up coverage collection for storybooks

### DIFF
--- a/.buildkite/pipeline.async.yml
+++ b/.buildkite/pipeline.async.yml
@@ -1,5 +1,6 @@
 env:
   ENTERPRISE: "1"
+  CHROMATIC: "1"
   FORCE_COLOR: "3"
 
 steps:

--- a/.buildkite/pipeline.async.yml
+++ b/.buildkite/pipeline.async.yml
@@ -1,6 +1,6 @@
 env:
   ENTERPRISE: "1"
-  CHROMATIC: "1"
+  MINIFY: "1"
   FORCE_COLOR: "3"
 
 steps:

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,7 @@ const TerserPlugin = require('terser-webpack-plugin')
 
 const monacoEditorPaths = [path.resolve(__dirname, '..', 'node_modules', 'monaco-editor')]
 
-const isChromatic = !!process.env.CHROMATIC
+const shouldMinify = !!process.env.MINIFY
 
 const config = {
   stories: ['../client/**/*.story.tsx'],
@@ -18,15 +18,15 @@ const config = {
    */
   webpackFinal: config => {
     // Include sourcemaps
-    config.mode = isChromatic ? 'production' : 'development'
-    config.devtool = isChromatic ? 'source-map' : 'cheap-module-eval-source-map'
+    config.mode = shouldMinify ? 'production' : 'development'
+    config.devtool = shouldMinify ? 'source-map' : 'cheap-module-eval-source-map'
     const definePlugin = config.plugins.find(plugin => plugin instanceof DefinePlugin)
     // @ts-ignore
     definePlugin.definitions.NODE_ENV = JSON.stringify(config.mode)
     // @ts-ignore
     definePlugin.definitions['process.env'].NODE_ENV = JSON.stringify(config.mode)
 
-    if (isChromatic) {
+    if (shouldMinify) {
       config.optimization = {
         minimize: true,
         minimizer: [

--- a/client/shared/src/testing/coverage.ts
+++ b/client/shared/src/testing/coverage.ts
@@ -57,15 +57,7 @@ export async function recordCoverage(browser: Browser): Promise<void> {
                 }
                 return
             }
-            await Promise.all(
-                Object.values(coverage).map(async fileCoverage => {
-                    await writeFile(
-                        `.nyc_output/${uuid.v4()}.json`,
-                        JSON.stringify({ [fileCoverage.path]: fileCoverage }),
-                        { flag: 'wx' }
-                    )
-                })
-            )
+            await writeFile(`.nyc_output/${uuid.v4()}.json`, JSON.stringify(coverage), { flag: 'wx' })
         })
     )
 }

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -97,7 +97,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.AutomaticRetry(5),
 			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("yarn gulp generate"),
-			bk.Env("CHROMATIC", "1"),
+			bk.Env("MINIFY", "1"),
 			bk.Cmd(chromaticCommand))
 
 		// Shared tests


### PR DESCRIPTION
1. Reduces file count of output coverage files, reducing compute time for combined coverage file and prevents vscode from crashing when the folder was open (created some couple of 10 thousand files per test run)
2. Enables terser in the coverage build, which reduces page load times in puppeteer, getting the test execution time down. Build time is going up but it's still a small boost and with growing number of storybooks I assume this to be outgrowing the penalty on the build time even more. 