### PR TITLE
Code monitoring: Fix action button moving on hover when disabled

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -25,8 +25,6 @@
             .create-monitor-page__trigger--disabled & {
                 margin: 1rem 0;
                 &:hover {
-                    // stylelint-disable-next-line declaration-property-unit-whitelist
-                    margin: calc(16px - 1px) -1px;
                     border: 1px solid var(--border-color);
                 }
             }
@@ -34,8 +32,6 @@
             .create-monitor-page__actions--disabled & {
                 margin: 1rem 0;
                 &:hover {
-                    // stylelint-disable-next-line declaration-property-unit-whitelist
-                    margin: calc(16px - 1px) -1px;
                     border: 1px solid var(--border-color);
                 }
             }


### PR DESCRIPTION
When hovering over the **Actions** area in the code monitoring form while disabled, the button shifts. Remove the custom margins on hover to make sure it doesn't shift. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
