### PR TITLE
Code monitoring: improve patternType validation

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -1,6 +1,6 @@
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import classnames from 'classnames'
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef } from 'react'
 import { Link } from '../../../../../shared/src/components/Link'
 import { FilterType } from '../../../../../shared/src/search/interactive/util'
 import { buildSearchURLQuery } from '../../../../../shared/src/util/url'
@@ -50,6 +50,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                             filter.value &&
                                             isDiffOrCommit(filter.value.quotedValue)))
                             )
+                            const hasPattern = tokens.term.filter(term => term.type === 'pattern').length > 0
                             const hasPatternTypeFilter = filters.some(
                                 filter =>
                                     filter.type === 'filter' &&
@@ -63,8 +64,8 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                             if (!hasTypeDiffOrCommitFilter) {
                                 return 'Code monitors require queries to specify either `type:commit` or `type:diff`.'
                             }
-                            if (!hasPatternTypeFilter) {
-                                return 'Code monitors require queries to specify a `patternType:` of literal, regexp, or structural.'
+                            if (!hasPatternTypeFilter && hasPattern) {
+                                return 'Code monitors require queries to specify a `patternType:` of literal or regexp.'
                             }
                         }
                         return 'Failed to parse query'

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -1,6 +1,6 @@
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import classnames from 'classnames'
-import React, { useState, useCallback, useMemo, useRef } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { Link } from '../../../../../shared/src/components/Link'
 import { FilterType } from '../../../../../shared/src/search/interactive/util'
 import { buildSearchURLQuery } from '../../../../../shared/src/util/url'

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -50,7 +50,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                             filter.value &&
                                             isDiffOrCommit(filter.value.quotedValue)))
                             )
-                            const hasPattern = tokens.term.filter(term => term.type === 'pattern').length > 0
+                            const hasPattern = tokens.term.some(term => term.type === 'pattern')
                             const hasPatternTypeFilter = filters.some(
                                 filter =>
                                     filter.type === 'filter' &&

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -113,7 +113,7 @@ describe('Code monitoring', () => {
             await driver.page.waitForSelector('.is-invalid')
             await driver.page.waitForSelector('.test-trigger-error')
             expect(await driver.page.evaluate(() => document.querySelector('.test-trigger-error')?.textContent)).toBe(
-                'Code monitors require queries to specify a `patternType:` of literal, regexp, or structural.'
+                'Code monitors require queries to specify a `patternType:` of literal or regexp.'
             )
             await driver.page.type('.test-trigger-input', ' patterntype:literal')
             await driver.page.waitForSelector('.is-valid')


### PR DESCRIPTION
This updates the validation logic in the code monitoring form:
* only show the error message that we require a `PatternType` if a pattern exists.
* in the patternType error message, remove `structural`, since it's not currently supported


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
