### PR TITLE
Code monitoring: fix: show form validation error message

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -1,7 +1,7 @@
 .trigger-area {
     &__query-input {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
 
         &-preview-link {
             white-space: nowrap;
@@ -22,6 +22,10 @@
                 max-height: 1rem;
                 max-width: 1rem;
             }
+        }
+
+        &-error-message {
+            font-size: 12px;
         }
 
         &-field {

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -1,0 +1,35 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import sinon from 'sinon'
+import { FormTriggerArea } from './FormTriggerArea'
+
+describe('FormTriggerArea', () => {
+    let clock: sinon.SinonFakeTimers
+
+    beforeAll(() => {
+        clock = sinon.useFakeTimers()
+    })
+
+    afterAll(() => {
+        clock.restore()
+    })
+
+    test('Error message is shown when query is invalid', () => {
+        let component = mount(
+            <FormTriggerArea
+                query="test"
+                triggerCompleted={false}
+                onQueryChange={sinon.spy()}
+                setTriggerCompleted={sinon.spy()}
+            />
+        )
+        act(() => {
+            const triggerButton = component.find('.test-trigger-button')
+            triggerButton.simulate('click')
+            clock.tick(600)
+        })
+        component = component.update()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -126,21 +126,36 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     </span>
                     <span className="mt-4">Search query</span>
                     <div>
-                        <div className="trigger-area__query-input">
-                            <input
-                                type="text"
-                                className={classnames(
-                                    'trigger-area__query-input-field form-control my-2 test-trigger-input',
-                                    deriveInputClassName(queryState)
+                        <div className="trigger-area__query-input mb-4">
+                            <div className="d-flex flex-column flex-grow-1">
+                                <input
+                                    type="text"
+                                    className={classnames(
+                                        'trigger-area__query-input-field form-control my-2 test-trigger-input',
+                                        deriveInputClassName(queryState)
+                                    )}
+                                    onChange={nextQueryFieldChange}
+                                    value={queryState.value}
+                                    required={true}
+                                    autoFocus={true}
+                                    ref={queryInputReference}
+                                    spellCheck={false}
+                                />
+                                {queryState.kind === 'INVALID' && (
+                                    <small className="trigger-area__query-input-error-message invalid-feedback test-trigger-error">
+                                        {queryState.reason}
+                                    </small>
                                 )}
-                                onChange={nextQueryFieldChange}
-                                value={queryState.value}
-                                required={true}
-                                autoFocus={true}
-                                ref={queryInputReference}
-                                spellCheck={false}
-                            />
-                            <div className="trigger-area__query-input-preview-link p-2">
+                                {(queryState.kind === 'NOT_VALIDATED' ||
+                                    queryState.kind === 'VALID' ||
+                                    queryState.kind === 'LOADING') && (
+                                    <small className="text-muted mt-1">
+                                        Code monitors only support <code className="bg-code">type:diff</code> and{' '}
+                                        <code className="bg-code">type:commit</code> search queries.
+                                    </small>
+                                )}
+                            </div>
+                            <div className="trigger-area__query-input-preview-link p-2 my-2">
                                 <Link
                                     to={`/search?${buildSearchURLQuery(
                                         queryState.value,
@@ -156,17 +171,6 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                 </Link>
                             </div>
                         </div>
-                        {queryState.kind === 'INVALID' && (
-                            <small className="invalid-feedback mb-4 test-trigger-error">{queryState.reason}</small>
-                        )}
-                        {(queryState.kind === 'NOT_VALIDATED' || queryState.kind === 'VALID') && (
-                            <div className="d-flex mb-4 flex-column">
-                                <small className="text-muted">
-                                    Code monitors only support <code className="bg-code">type:diff</code> and{' '}
-                                    <code className="bg-code">type:commit</code> search queries.
-                                </small>
-                            </div>
-                        )}
                     </div>
                     <div>
                         <button

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
+<FormTriggerArea
+  onQueryChange={[Function]}
+  query="test"
+  setTriggerCompleted={[Function]}
+  triggerCompleted={false}
+>
+  <h3>
+    Trigger
+  </h3>
+  <div
+    className="code-monitor-form__card card p-3 my-3"
+  >
+    <div
+      className="font-weight-bold"
+    >
+      When there are new search results
+    </div>
+    <span
+      className="text-muted"
+    >
+      This trigger will fire when new search results are found for a given search query.
+    </span>
+    <span
+      className="mt-4"
+    >
+      Search query
+    </span>
+    <div>
+      <div
+        className="trigger-area__query-input mb-4"
+      >
+        <div
+          className="d-flex flex-column flex-grow-1"
+        >
+          <input
+            autoFocus={true}
+            className="trigger-area__query-input-field form-control my-2 test-trigger-input is-invalid"
+            onChange={[Function]}
+            required={true}
+            spellCheck={false}
+            type="text"
+            value="test"
+          />
+          <small
+            className="trigger-area__query-input-error-message invalid-feedback test-trigger-error"
+          >
+            Code monitors require queries to specify either \`type:commit\` or \`type:diff\`.
+          </small>
+        </div>
+        <div
+          className="trigger-area__query-input-preview-link p-2 my-2"
+        >
+          <AnchorLink
+            className="trigger-area__query-input-preview-link-text test-preview-link"
+            rel="noopener noreferrer"
+            target="_blank"
+            to="/search?q=test&patternType=literal"
+          >
+            <a
+              className="trigger-area__query-input-preview-link-text test-preview-link"
+              href="/search?q=test&patternType=literal"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Preview results
+               
+              <Memo(OpenInNewIcon)
+                className="trigger-area__query-input-preview-link-icon ml-1 icon-inline"
+              />
+            </a>
+          </AnchorLink>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        className="btn btn-secondary mr-1 test-submit-trigger"
+        disabled={true}
+        onClick={[Function]}
+        type="submit"
+      >
+        Continue
+      </button>
+      <button
+        className="btn btn-outline-secondary"
+        onClick={[Function]}
+        type="button"
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+  <small
+    className="text-muted"
+  >
+     
+    What other events would you like to monitor?
+     
+    <a
+      href="mailto:feedback@sourcegraph.com"
+      rel="noopener"
+      target="_blank"
+    >
+      Share feedback.
+    </a>
+  </small>
+</FormTriggerArea>
+`;


### PR DESCRIPTION
This fixes an issue where the error messages when validating a query in the code monitor form no longer appeared. The bootstrap class `invalid-feedback` only works when it is a direct sibling of the input being validated, so it broke when we added the new preview results button. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
