### PR TITLE
Code monitoring: Only show send test email option for enabled monitors

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
@@ -1,0 +1,54 @@
+import { CodeMonitorNode } from './CodeMonitoringNode'
+import * as React from 'react'
+import * as H from 'history'
+import { AuthenticatedUser } from '../../auth'
+import sinon from 'sinon'
+import { mount } from 'enzyme'
+import { mockCodeMonitor } from './testing/util'
+
+describe('CreateCodeMonitorPage', () => {
+    const mockUser = {
+        id: 'userID',
+        username: 'username',
+        email: 'user@me.com',
+        siteAdmin: true,
+    } as AuthenticatedUser
+
+    const history = H.createMemoryHistory()
+
+    test('Shows "Send test email" option to site admins on enabled code monitors', () => {
+        const component = mount(
+            <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
+                location={history.location}
+                node={mockCodeMonitor.node}
+                authentictedUser={mockUser}
+            />
+        )
+        expect(component.find('.test-send-test-email').length).toBe(1)
+    })
+
+    test('Does not show "Send test email" option when code monitor is disabled', () => {
+        const component = mount(
+            <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
+                location={history.location}
+                node={{ ...mockCodeMonitor.node, enabled: false }}
+                authentictedUser={mockUser}
+            />
+        )
+        expect(component.find('.test-send-test-email').length).toBe(0)
+    })
+
+    test('Does not show "Send test email" option to non-site admins', () => {
+        const component = mount(
+            <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
+                location={history.location}
+                node={mockCodeMonitor.node}
+                authentictedUser={{ ...mockUser, siteAdmin: false }}
+            />
+        )
+        expect(component.find('.test-send-test-email').length).toBe(0)
+    })
+})

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
@@ -84,7 +84,7 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                     {node.actions.nodes.length > 0 && (
                         <div className="d-flex text-muted">
                             New search result → Sends email notifications{' '}
-                            {authentictedUser.siteAdmin && hasEnabledAction && (
+                            {authentictedUser.siteAdmin && hasEnabledAction && node.enabled && (
                                 <button
                                     type="button"
                                     className="btn btn-link p-0 border-0 ml-2"

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
@@ -87,7 +87,7 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                             {authentictedUser.siteAdmin && hasEnabledAction && node.enabled && (
                                 <button
                                     type="button"
-                                    className="btn btn-link p-0 border-0 ml-2"
+                                    className="btn btn-link p-0 border-0 ml-2 test-send-test-email"
                                     onClick={sendEmailRequest}
                                 >
                                     Send test email


### PR DESCRIPTION
We only want to show the option to send a test email on code monitors which are enabled.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
