### PR TITLE
monitoring: Disable custom repo-updater pod availability alert

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3789,7 +3789,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions:**
 
-- _repo-updater: less than 90% percentage pods available for 1m0s_
+- _repo-updater: less than 90% percentage pods available for 10m0s_
 
 **Possible solutions:**
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -458,8 +458,7 @@ func RepoUpdater() *monitoring.Container {
 				Hidden: true,
 				Rows: []monitoring.Row{
 					{
-						shared.KubernetesPodsAvailable("repo-updater", monitoring.ObservableOwnerCloud).
-							WithCritical(monitoring.Alert().LessOrEqual(90).For(1 * time.Minute)),
+						shared.KubernetesPodsAvailable("repo-updater", monitoring.ObservableOwnerCloud),
 					},
 				},
 			},


### PR DESCRIPTION
A 1m window is too small, and makes us receive pages for normal
deployments. We want to get alerted on container restarts, but requires
kube-state-metrics, which we don't yet have.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
