### PR TITLE
github: Don't record rate limit for 401 response

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -841,8 +841,8 @@ func (s *Syncer) setOrResetLastSyncErr(serviceID int64, perr *error) {
 	s.syncErrors[serviceID] = err
 }
 
-// SyncErrors returns all errors that was produced in the last Sync run per external sevice. If
-// no error was produced, this returns an empty slice.
+// SyncErrors returns all errors that were produced in the last Sync run per
+// external service. If no error was produced, this returns an empty slice.
 // Errors are sorted by external service id.
 func (s *Syncer) SyncErrors() []error {
 	s.syncErrorsMu.Lock()

--- a/internal/workerutil/dbworker/handler.go
+++ b/internal/workerutil/dbworker/handler.go
@@ -9,7 +9,7 @@ import (
 
 // Handler is a version of workerutil.Handler that refines the store type.
 type Handler interface {
-	// Handle processes a single record. The store provided by this method a store backed
+	// Handle processes a single record. The store provided by this method is a store backed
 	// by the transaction that is locking the given record. If use of a database is necessary
 	// within this handler, other stores should take the underlying handler to keep work
 	// within the same transaction.


### PR DESCRIPTION
If we do, the next call we make can block for up to an hour since our
rate limit monitor RecommendedWaitForBackgroundOp function believes
we've just run out of tokens.

Instead, we ignore the rate limits returned and fail fast on subsequent
steps.

Our background syncer already backs off on 401 errors.
