### PR TITLE
search: support streaming commit search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -73,20 +73,6 @@ func (r *CommitSearchResultResolver) resultCount() int32 {
 	return 1
 }
 
-func searchCommitLogInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, info *search.CommitPatternInfo, query query.QueryInfo) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
-	var terms []string
-	if info.Pattern != "" {
-		terms = append(terms, info.Pattern)
-	}
-	return searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:           repoRevs,
-		PatternInfo:        info,
-		Query:              query,
-		Diff:               false,
-		ExtraMessageValues: terms,
-	})
-}
-
 func commitParametersToDiffParameters(ctx context.Context, op *search.CommitParameters) (*search.DiffParameters, error) {
 	args := []string{
 		"--no-prefix",
@@ -635,7 +621,17 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 }
 
 func commitLogSearcher(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) ([]*CommitSearchResultResolver, bool, bool, error) {
-	return searchCommitLogInRepo(ctx, repoRev, args.PatternInfo, args.Query)
+	var terms []string
+	if args.PatternInfo.Pattern != "" {
+		terms = append(terms, args.PatternInfo.Pattern)
+	}
+	return searchCommitsInRepo(ctx, search.CommitParameters{
+		RepoRevs:           repoRev,
+		PatternInfo:        args.PatternInfo,
+		Query:              args.Query,
+		Diff:               false,
+		ExtraMessageValues: terms,
+	})
 }
 
 // searchCommitLogInRepos searches a set of repos for matching commits.

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -620,22 +620,22 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 	})
 }
 
-func commitLogSearcher(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) ([]*CommitSearchResultResolver, bool, bool, error) {
-	var terms []string
-	if args.PatternInfo.Pattern != "" {
-		terms = append(terms, args.PatternInfo.Pattern)
-	}
-	return searchCommitsInRepo(ctx, search.CommitParameters{
-		RepoRevs:           repoRev,
-		PatternInfo:        args.PatternInfo,
-		Query:              args.Query,
-		Diff:               false,
-		ExtraMessageValues: terms,
-	})
-}
-
 // searchCommitLogInRepos searches a set of repos for matching commits.
 func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+	commitLogSearcher := func(ctx context.Context, repoRev *search.RepositoryRevisions, args *search.TextParametersForCommitParameters) ([]*CommitSearchResultResolver, bool, bool, error) {
+		var terms []string
+		if args.PatternInfo.Pattern != "" {
+			terms = append(terms, args.PatternInfo.Pattern)
+		}
+		return searchCommitsInRepo(ctx, search.CommitParameters{
+			RepoRevs:           repoRev,
+			PatternInfo:        args.PatternInfo,
+			Query:              args.Query,
+			Diff:               false,
+			ExtraMessageValues: terms,
+		})
+	}
+
 	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
 		TraceName: "searchCommitLogsInRepos",
 		ErrorName: "commits",

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -627,13 +627,15 @@ func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForC
 		if args.PatternInfo.Pattern != "" {
 			terms = append(terms, args.PatternInfo.Pattern)
 		}
-		return searchCommitsInRepo(ctx, search.CommitParameters{
+		commitParams := search.CommitParameters{
 			RepoRevs:           repoRev,
 			PatternInfo:        args.PatternInfo,
 			Query:              args.Query,
 			Diff:               false,
 			ExtraMessageValues: terms,
-		})
+		}
+
+		return searchCommitsInRepo(ctx, commitParams)
 	}
 
 	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1802,8 +1802,8 @@ func (a *aggregator) doCommitSearch(ctx context.Context, tp *search.TextParamete
 		return
 	}
 
-	commitResults, commitCommon, err := searchCommitLogInRepos(ctx, args)
-	a.report(ctx, commitResults, commitCommon, errors.Wrap(err, "commit search failed"))
+	commitResults, commitCommon, err := searchCommitLogInRepos(ctx, args, a.resultChannel)
+	a.collect(ctx, commitResults, commitCommon, errors.Wrap(err, "commit search failed"))
 }
 
 // isGlobalSearch returns true if the query does not contain repo, repogroup, or


### PR DESCRIPTION
We added streaming support to diff search. Along the way we refactored
everything to make it possible to easily support commit search
streaming. This does the requisite changes.

Co-authored-by: @stefanhengl 
