### PR TITLE
Remove ListRepos in favor of internal/db/RepoStore#List

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/db"
+	idb "github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -348,7 +348,7 @@ func testServerSetRepoEnabled(t *testing.T, store repos.Store) func(t *testing.T
 					t.Fatalf("failed to prepare store: %v", err)
 				}
 
-				s := &Server{Store: store}
+				s := &Server{Store: store, RepoLister: store.RepoStore()}
 				srv := httptest.NewServer(s.Handler())
 				defer srv.Close()
 				cli := repoupdater.Client{URL: srv.URL}
@@ -384,7 +384,7 @@ func testServerSetRepoEnabled(t *testing.T, store repos.Store) func(t *testing.T
 					ids = append(ids, s.ID)
 				}
 
-				svcs, err := store.ExternalServiceStore().List(ctx, db.ExternalServicesListOptions{
+				svcs, err := store.ExternalServiceStore().List(ctx, idb.ExternalServicesListOptions{
 					IDs:              ids,
 					OrderByDirection: "ASC",
 				})
@@ -432,11 +432,12 @@ func testServerEnqueueRepoUpdate(t *testing.T, store repos.Store) func(t *testin
 		}
 
 		type testCase struct {
-			name  string
-			store repos.Store
-			repo  api.RepoName
-			res   *protocol.RepoUpdateResponse
-			err   string
+			name       string
+			store      repos.Store
+			repoLister repos.Lister
+			repo       api.RepoName
+			res        *protocol.RepoUpdateResponse
+			err        string
 		}
 
 		var testCases []testCase
@@ -444,26 +445,29 @@ func testServerEnqueueRepoUpdate(t *testing.T, store repos.Store) func(t *testin
 			func() testCase {
 				err := errors.New("boom")
 				return testCase{
-					name: "returns an error on store failure",
-					store: &storeWithErrors{
-						Store:        store,
+					name:  "returns an error on store failure",
+					store: store,
+					repoLister: &repoListerWithErrors{
+						RepoStore:    store.RepoStore(),
 						ListReposErr: err,
 					},
 					err: `store.list-repos: boom`,
 				}
 			}(),
 			testCase{
-				name:  "missing repo",
-				store: store, // empty store
-				repo:  "foo",
-				err:   `repo "foo" not found in store`,
+				name:       "missing repo",
+				store:      store,
+				repoLister: store.RepoStore(), // empty store
+				repo:       "foo",
+				err:        `repo "foo" not found in store`,
 			},
 			func() testCase {
 				repo := repo.Clone()
 				return testCase{
-					name:  "existing repo",
-					store: store,
-					repo:  repo.Name,
+					name:       "existing repo",
+					store:      store,
+					repoLister: store.RepoStore(),
+					repo:       repo.Name,
 					res: &protocol.RepoUpdateResponse{
 						ID:   repo.ID,
 						Name: string(repo.Name),
@@ -477,7 +481,7 @@ func testServerEnqueueRepoUpdate(t *testing.T, store repos.Store) func(t *testin
 			ctx := context.Background()
 
 			t.Run(tc.name, func(t *testing.T) {
-				s := &Server{Store: tc.store, Scheduler: &fakeScheduler{}}
+				s := &Server{Store: tc.store, RepoLister: tc.repoLister, Scheduler: &fakeScheduler{}}
 				srv := httptest.NewServer(s.Handler())
 				defer srv.Close()
 				cli := repoupdater.Client{URL: srv.URL}
@@ -578,7 +582,7 @@ func testServerRepoExternalServices(t *testing.T, store repos.Store) func(t *tes
 			err:    "repository with ID 42 does not exist",
 		}}
 
-		s := &Server{Store: store}
+		s := &Server{Store: store, RepoLister: store.RepoStore()}
 		srv := httptest.NewServer(s.Handler())
 		defer srv.Close()
 		cli := repoupdater.Client{URL: srv.URL}
@@ -773,19 +777,21 @@ func testServerStatusMessages(t *testing.T, store repos.Store) func(t *testing.T
 				}
 
 				if tc.sourcerErr != nil || tc.listRepoErr != nil {
-					store = &storeWithErrors{
-						Store:        store,
+					repoLister := &repoListerWithErrors{
+						RepoStore:    store.RepoStore(),
 						ListReposErr: tc.listRepoErr,
 					}
+
 					sourcer := repos.NewFakeSourcer(tc.sourcerErr, repos.NewFakeSource(githubService, nil))
 					// Run Sync so that possibly `LastSyncErrors` is set
 					syncer.Sourcer = sourcer
-					_ = syncer.SyncExternalService(ctx, store, githubService.ID, time.Millisecond)
+					_ = syncer.SyncExternalService(ctx, store, repoLister, githubService.ID, time.Millisecond)
 				}
 
 				s := &Server{
 					Syncer:          syncer,
 					Store:           store,
+					RepoLister:      store.RepoStore(),
 					GitserverClient: gitserverClient,
 				}
 
@@ -1240,7 +1246,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore repos.Store) func(t
 					syncer := &repos.Syncer{
 						Now: clock.Now,
 					}
-					s := &Server{Syncer: syncer, Store: store}
+					s := &Server{Syncer: syncer, Store: store, RepoLister: store.RepoStore()}
 					if tc.githubDotComSource != nil {
 						s.SourcegraphDotComMode = true
 						s.GithubDotComSource = tc.githubDotComSource
@@ -1277,7 +1283,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore repos.Store) func(t
 						if tc.assertDelay != 0 {
 							time.Sleep(tc.assertDelay)
 						}
-						rs, err := store.ListRepos(ctx, repos.StoreListReposArgs{})
+						rs, err := store.RepoStore().List(ctx, idb.ReposListOptions{})
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -1404,15 +1410,7 @@ func formatJSON(s string) string {
 type storeWithErrors struct {
 	repos.Store
 
-	ListReposErr   error
 	UpsertReposErr error
-}
-
-func (s *storeWithErrors) ListRepos(ctx context.Context, args repos.StoreListReposArgs) ([]*types.Repo, error) {
-	if s.ListReposErr != nil {
-		return nil, s.ListReposErr
-	}
-	return s.Store.ListRepos(ctx, args)
 }
 
 func (s *storeWithErrors) UpsertRepos(ctx context.Context, repos ...*types.Repo) error {
@@ -1420,4 +1418,17 @@ func (s *storeWithErrors) UpsertRepos(ctx context.Context, repos ...*types.Repo)
 		return s.UpsertReposErr
 	}
 	return s.Store.UpsertRepos(ctx, repos...)
+}
+
+type repoListerWithErrors struct {
+	*idb.RepoStore
+
+	ListReposErr error
+}
+
+func (s *repoListerWithErrors) List(ctx context.Context, args idb.ReposListOptions) ([]*types.Repo, error) {
+	if s.ListReposErr != nil {
+		return nil, s.ListReposErr
+	}
+	return s.RepoStore.List(ctx, args)
 }

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -1407,19 +1407,6 @@ func formatJSON(s string) string {
 	return formatted
 }
 
-type storeWithErrors struct {
-	repos.Store
-
-	UpsertReposErr error
-}
-
-func (s *storeWithErrors) UpsertRepos(ctx context.Context, repos ...*types.Repo) error {
-	if s.UpsertReposErr != nil {
-		return s.UpsertReposErr
-	}
-	return s.Store.UpsertRepos(ctx, repos...)
-}
-
 type repoListerWithErrors struct {
 	*idb.RepoStore
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -48,7 +48,7 @@ const port = "3182"
 
 // EnterpriseInit is a function that allows enterprise code to be triggered when dependencies
 // created in Main are ready for use.
-type EnterpriseInit func(db *sql.DB, store repos.Store, cf *httpcli.Factory, server *repoupdater.Server) []debugserver.Dumper
+type EnterpriseInit func(db *sql.DB, lister repos.Lister, cf *httpcli.Factory, server *repoupdater.Server) []debugserver.Dumper
 
 func Main(enterpriseInit EnterpriseInit) {
 	ctx := context.Background()
@@ -121,6 +121,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	scheduler := repos.NewUpdateScheduler()
 	server := &repoupdater.Server{
 		Store:           store,
+		RepoLister:      store.RepoStore(),
 		Scheduler:       scheduler,
 		GitserverClient: gitserver.DefaultClient,
 	}
@@ -137,7 +138,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	// All dependencies ready
 	var debugDumpers []debugserver.Dumper
 	if enterpriseInit != nil {
-		debugDumpers = enterpriseInit(db, store, cf, server)
+		debugDumpers = enterpriseInit(db, store.RepoStore(), cf, server)
 	}
 
 	if envvar.SourcegraphDotComMode() {

--- a/enterprise/cmd/repo-updater/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/authz/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	authzGitHub "github.com/sourcegraph/sourcegraph/internal/authz/github"
@@ -68,7 +69,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	cli := extsvcGitHub.NewV3Client(uri, &auth.OAuthBearerToken{Token: token}, doer)
 
 	testDB := dbtest.NewDB(t, *dsn)
-	ctx := context.Background()
+	ctx := actor.WithInternalActor(context.Background())
 
 	reposStore := repos.NewDBStore(testDB, sql.TxOptions{})
 
@@ -123,7 +124,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	}
 
 	permsStore := edb.NewPermsStore(testDB, timeutil.Now)
-	syncer := NewPermsSyncer(reposStore, permsStore, timeutil.Now, nil)
+	syncer := NewPermsSyncer(reposStore.RepoStore(), permsStore, timeutil.Now, nil)
 
 	err = syncer.syncRepoPerms(ctx, repo.ID, false)
 	if err != nil {

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -449,8 +449,6 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(err, "set repository pending permissions")
 	}
 
-	fmt.Println(8)
-
 	log15.Debug("PermsSyncer.syncRepoPerms.synced", "repoID", repo.ID, "name", repo.Name, "count", len(extAccountIDs))
 	return nil
 }

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -36,7 +36,7 @@ type PermsSyncer struct {
 	// The priority queue to maintain the permissions syncing requests.
 	queue *requestQueue
 	// The database interface for any repos and external services operations.
-	reposStore repos.Store
+	reposStore repos.Lister
 	// The database interface for any permissions operations.
 	permsStore *edb.PermsStore
 	// The mockable function to return the current time.
@@ -49,14 +49,14 @@ type PermsSyncer struct {
 
 // NewPermsSyncer returns a new permissions syncing manager.
 func NewPermsSyncer(
-	reposStore repos.Store,
+	reposLister repos.Lister,
 	permsStore *edb.PermsStore,
 	clock func() time.Time,
 	rateLimiterRegistry *ratelimit.Registry,
 ) *PermsSyncer {
 	return &PermsSyncer{
 		queue:               newRequestQueue(),
-		reposStore:          reposStore,
+		reposStore:          reposLister,
 		permsStore:          permsStore,
 		clock:               clock,
 		rateLimiterRegistry: rateLimiterRegistry,
@@ -284,9 +284,9 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	var rs []*types.Repo
 	if len(repoSpecs) > 0 {
 		// Get corresponding internal database IDs
-		rs, err = s.reposStore.ListRepos(ctx, repos.StoreListReposArgs{
+		rs, err = s.reposStore.List(ctx, db.ReposListOptions{
 			ExternalRepos: repoSpecs,
-			PrivateOnly:   true,
+			OnlyPrivate:   true,
 		})
 		if err != nil {
 			return errors.Wrap(err, "list external repositories")
@@ -320,7 +320,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms", "")
 	defer save(requestTypeRepo, int32(repoID), &err)
 
-	rs, err := s.reposStore.ListRepos(ctx, repos.StoreListReposArgs{
+	rs, err := s.reposStore.List(ctx, db.ReposListOptions{
 		IDs: []api.RepoID{repoID},
 	})
 	if err != nil {
@@ -448,6 +448,8 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	} else if err = txs.SetRepoPendingPermissions(ctx, accounts, p); err != nil {
 		return errors.Wrap(err, "set repository pending permissions")
 	}
+
+	fmt.Println(8)
 
 	log15.Debug("PermsSyncer.syncRepoPerms.synced", "repoID", repo.ID, "name", repo.Name, "count", len(extAccountIDs))
 	return nil

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -38,7 +38,7 @@ func main() {
 
 func enterpriseInit(
 	db *sql.DB,
-	repoStore repos.Store,
+	repoLister repos.Lister,
 	cf *httpcli.Factory,
 	server *repoupdater.Server,
 ) (debugDumpers []debugserver.Dumper) {
@@ -51,7 +51,7 @@ func enterpriseInit(
 	// TODO(jchen): This is an unfortunate compromise to not rewrite ossDB.ExternalServices for now.
 	dbconn.Global = db
 	permsStore := edb.NewPermsStore(db, timeutil.Now)
-	permsSyncer := authz.NewPermsSyncer(repoStore, permsStore, timeutil.Now, ratelimit.DefaultRegistry)
+	permsSyncer := authz.NewPermsSyncer(repoLister, permsStore, timeutil.Now, ratelimit.DefaultRegistry)
 	go startBackgroundPermsSync(ctx, permsSyncer, db)
 	debugDumpers = append(debugDumpers, permsSyncer)
 	if server != nil {

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -62,8 +62,6 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/UpsertRepos", testStoreUpsertRepos},
 		{"DBStore/UpsertSources", testStoreUpsertSources},
 		{"DBStore/EnqueueSyncJobs", testStoreEnqueueSyncJobs(db, dbstore)},
-		{"DBStore/ListRepos", testStoreListRepos},
-		{"DBStore/ListRepos/Pagination", testStoreListReposPagination},
 		{"DBStore/ListExternalRepoSpecs", testStoreListExternalRepoSpecs(db)},
 		{"DBStore/SetClonedRepos", testStoreSetClonedRepos},
 		{"DBStore/CountNotClonedRepos", testStoreCountNotClonedRepos},

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -28,9 +27,9 @@ import (
 
 // A Store exposes methods to read and write repos and external services.
 type Store interface {
+	RepoStore() *idb.RepoStore
 	ExternalServiceStore() *idb.ExternalServiceStore
 
-	ListRepos(context.Context, StoreListReposArgs) ([]*types.Repo, error)
 	UpsertRepos(ctx context.Context, repos ...*types.Repo) error
 	ListExternalRepoSpecs(context.Context) (map[api.ExternalRepoSpec]struct{}, error)
 	UpsertSources(ctx context.Context, inserts, updates, deletes map[api.RepoID][]types.SourceInfo) error
@@ -47,36 +46,6 @@ type Store interface {
 	InsertRepos(context.Context, ...*types.Repo) error
 	DeleteRepos(ctx context.Context, ids ...api.RepoID) error
 }
-
-// StoreListReposArgs is a query arguments type used by
-// the ListRepos method of Store implementations.
-type StoreListReposArgs struct {
-	// Names of repos to list. When zero-valued, this is omitted from the predicate set.
-	Names []string
-	// IDs of repos to list. When zero-valued, this is omitted from the predicate set.
-	IDs []api.RepoID
-	// Kinds of repos to list. When zero-valued, this is omitted from the predicate set.
-	Kinds []string
-	// ExternalRepos of repos to list. When zero-valued, this is omitted from the predicate set.
-	ExternalRepos []api.ExternalRepoSpec
-	// ExternalServiceID, if non zero, will only return repos added by the given external service.
-	// The id is that of the external_services table NOT the external_service_id in the repo table
-	ExternalServiceID int64
-	// Limit the total number of repos returned. Zero means no limit
-	Limit int64
-	// PerPage determines the number of repos returned on each page. Zero means it defaults to 10000.
-	PerPage int64
-	// Only include private repositories.
-	PrivateOnly bool
-	// Only include cloned repositories.
-	ClonedOnly bool
-
-	// UseOr decides between ANDing or ORing the predicates together.
-	UseOr bool
-}
-
-// ErrNoResults is returned by Store method invocations that yield no result set.
-var ErrNoResults = errors.New("store: no results")
 
 // A Transactor can initialize and return a TxStore which operates
 // within the context of a transaction.
@@ -171,6 +140,11 @@ func (s *DBStore) Transact(ctx context.Context) (TxStore, error) {
 		return nil, errors.Wrap(err, "starting transaction")
 	}
 	return &DBStore{Store: txBase}, nil
+}
+
+// RepoStore returns a db.RepoStore using the same database handle.
+func (s *DBStore) RepoStore() *idb.RepoStore {
+	return idb.NewRepoStoreWith(s)
 }
 
 // ExternalServiceStore returns a db.ExternalServiceStore using the same database handle.
@@ -355,145 +329,6 @@ FROM repo_ids
 WHERE deleted_at IS NULL
 AND repo.id = repo_ids.id::int
 `
-
-// ListRepos lists all stored repos that match the given arguments.
-func (s *DBStore) ListRepos(ctx context.Context, args StoreListReposArgs) (repos []*types.Repo, _ error) {
-	listQuery, err := listReposQuery(args)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating list repos query function")
-	}
-	return repos, s.paginate(ctx, args.Limit, args.PerPage, 0, listQuery,
-		func(sc scanner) (last, count int64, err error) {
-			var r types.Repo
-			if err := scanRepo(&r, sc); err != nil {
-				return 0, 0, err
-			}
-			repos = append(repos, &r)
-			return int64(r.ID), 1, nil
-		},
-	)
-}
-
-const listReposQueryFmtstr = `
--- source: internal/repos/store.go:DBStore.ListRepos
-SELECT
-  id,
-  name,
-  uri,
-  description,
-  created_at,
-  updated_at,
-  deleted_at,
-  external_service_type,
-  repo.external_service_id,
-  external_id,
-  archived,
-  cloned,
-  fork,
-  private,
-  (
-	SELECT
-	  json_agg(
-	    json_build_object(
-          'CloneURL', esr.clone_url,
-          'ID', esr.external_service_id,
-          'Kind', LOWER(svcs.kind)
-	    )
-	  )
-	FROM external_service_repos AS esr
-	JOIN external_services AS svcs ON esr.external_service_id = svcs.id
-	WHERE
-	    esr.repo_id = repo.id
-	  AND
-	    svcs.deleted_at IS NULL
-  ),
-  metadata
--- repo or repo joined with external_service_repos
-FROM %s
-WHERE id > %s
--- preds
-AND %s
-AND deleted_at IS NULL
--- join filters
-AND %s
-ORDER BY id ASC LIMIT %s
-`
-
-func listReposQuery(args StoreListReposArgs) (paginatedQuery, error) {
-	var preds []*sqlf.Query
-
-	if len(args.Names) > 0 {
-		encodedNames, err := json.Marshal(args.Names)
-		if err != nil {
-			return nil, errors.Wrap(err, "marshalling name args")
-		}
-		preds = append(preds, sqlf.Sprintf("name = ANY(ARRAY(SELECT jsonb_array_elements_text(%s))::citext[])", encodedNames))
-	}
-
-	if len(args.IDs) > 0 {
-		ids := make([]*sqlf.Query, 0, len(args.IDs))
-		for _, id := range args.IDs {
-			if id != 0 {
-				ids = append(ids, sqlf.Sprintf("%d", id))
-			}
-		}
-		preds = append(preds, sqlf.Sprintf("id IN (%s)", sqlf.Join(ids, ",")))
-	}
-
-	if len(args.Kinds) > 0 {
-		ks := make([]*sqlf.Query, 0, len(args.Kinds))
-		for _, kind := range args.Kinds {
-			ks = append(ks, sqlf.Sprintf("%s", strings.ToLower(kind)))
-		}
-		preds = append(preds,
-			sqlf.Sprintf("LOWER(external_service_type) IN (%s)", sqlf.Join(ks, ",")))
-	}
-
-	if len(args.ExternalRepos) > 0 {
-		er := make([]*sqlf.Query, 0, len(args.ExternalRepos))
-		for _, spec := range args.ExternalRepos {
-			er = append(er, sqlf.Sprintf("(external_id = %s AND external_service_type = %s AND external_service_id = %s)", spec.ID, spec.ServiceType, spec.ServiceID))
-		}
-		preds = append(preds, sqlf.Sprintf("(%s)", sqlf.Join(er, "\n OR ")))
-	}
-
-	fromClause := sqlf.Sprintf("repo")
-	joinFilter := sqlf.Sprintf("TRUE")
-	if args.ExternalServiceID != 0 {
-		fromClause = sqlf.Sprintf("repo JOIN external_service_repos e ON repo.id = e.repo_id")
-		joinFilter = sqlf.Sprintf("e.external_service_id = %d", args.ExternalServiceID)
-	}
-
-	if args.PrivateOnly {
-		preds = append(preds, sqlf.Sprintf("private = TRUE"))
-	}
-
-	if args.ClonedOnly {
-		preds = append(preds, sqlf.Sprintf("cloned = TRUE"))
-	}
-
-	if len(preds) == 0 {
-		preds = append(preds, sqlf.Sprintf("TRUE"))
-	}
-
-	var predQ *sqlf.Query
-	if args.UseOr {
-		predQ = sqlf.Join(preds, "\n OR ")
-	} else {
-		predQ = sqlf.Join(preds, "\n AND ")
-	}
-
-	return func(cursor, limit int64) *sqlf.Query {
-		return sqlf.Sprintf(
-			listReposQueryFmtstr,
-			fromClause,
-			cursor,
-			sqlf.Sprintf("(%s)", predQ),
-			joinFilter,
-			limit,
-		)
-	}, nil
-}
 
 func (s *DBStore) ListExternalRepoSpecs(ctx context.Context) (map[api.ExternalRepoSpec]struct{}, error) {
 	const ListExternalRepoSpecsQueryFmtstr = `

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -15,13 +15,6 @@ import (
 	idb "github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -939,13 +932,6 @@ func nullStringColumn(s string) *string {
 	return &s
 }
 
-func nullInt32Column(i int32) *int32 {
-	if i == 0 {
-		return nil
-	}
-	return &i
-}
-
 func metadataColumn(metadata interface{}) (msg json.RawMessage, err error) {
 	switch m := metadata.(type) {
 	case nil:
@@ -1003,94 +989,4 @@ func closeErr(c io.Closer, err *error) {
 	if e := c.Close(); err != nil && *err == nil {
 		*err = e
 	}
-}
-
-func scanExternalService(svc *types.ExternalService, s scanner) error {
-	return s.Scan(
-		&svc.ID,
-		&svc.Kind,
-		&svc.DisplayName,
-		&svc.Config,
-		&svc.CreatedAt,
-		&dbutil.NullTime{Time: &svc.UpdatedAt},
-		&dbutil.NullTime{Time: &svc.DeletedAt},
-		&dbutil.NullTime{Time: &svc.LastSyncAt},
-		&dbutil.NullTime{Time: &svc.NextSyncAt},
-		&dbutil.NullInt32{N: &svc.NamespaceUserID},
-		&svc.Unrestricted,
-	)
-}
-
-func scanRepo(r *types.Repo, s scanner) error {
-	var sources dbutil.NullJSONRawMessage
-	var metadata json.RawMessage
-	err := s.Scan(
-		&r.ID,
-		&r.Name,
-		&dbutil.NullString{S: &r.URI},
-		&r.Description,
-		&r.CreatedAt,
-		&dbutil.NullTime{Time: &r.UpdatedAt},
-		&dbutil.NullTime{Time: &r.DeletedAt},
-		&dbutil.NullString{S: &r.ExternalRepo.ServiceType},
-		&dbutil.NullString{S: &r.ExternalRepo.ServiceID},
-		&dbutil.NullString{S: &r.ExternalRepo.ID},
-		&r.Archived,
-		&r.Cloned,
-		&r.Fork,
-		&r.Private,
-		&sources,
-		&metadata,
-	)
-	if err != nil {
-		return err
-	}
-
-	type sourceInfo struct {
-		ID       int64
-		CloneURL string
-		Kind     string
-	}
-	r.Sources = make(map[string]*types.SourceInfo)
-
-	if sources.Raw != nil {
-		var srcs []sourceInfo
-		if err = json.Unmarshal(sources.Raw, &srcs); err != nil {
-			return errors.Wrap(err, "scanRepo: failed to unmarshal sources")
-		}
-		for _, src := range srcs {
-			urn := extsvc.URN(src.Kind, src.ID)
-			r.Sources[urn] = &types.SourceInfo{
-				ID:       urn,
-				CloneURL: src.CloneURL,
-			}
-		}
-	}
-
-	typ, ok := extsvc.ParseServiceType(r.ExternalRepo.ServiceType)
-	if !ok {
-		return nil
-	}
-	switch typ {
-	case extsvc.TypeGitHub:
-		r.Metadata = new(github.Repository)
-	case extsvc.TypeGitLab:
-		r.Metadata = new(gitlab.Project)
-	case extsvc.TypeBitbucketServer:
-		r.Metadata = new(bitbucketserver.Repo)
-	case extsvc.TypeBitbucketCloud:
-		r.Metadata = new(bitbucketcloud.Repo)
-	case extsvc.TypeAWSCodeCommit:
-		r.Metadata = new(awscodecommit.Repository)
-	case extsvc.TypeGitolite:
-		r.Metadata = new(gitolite.Repo)
-	default:
-		return nil
-	}
-
-	if err = json.Unmarshal(metadata, r.Metadata); err != nil {
-		return errors.Wrapf(err, "scanRepo: failed to unmarshal %q metadata", typ)
-	}
-
-	return nil
 }


### PR DESCRIPTION
This PR removes `ListRepos` from the repo-updater store in favor of [internal/db/RepoStore#List](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/db/repos.go?utm_source=VSCode-1.1.0#L563:23).