### PR TITLE
codeintel: Reduce gitserver errors for missing revisions

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -43,7 +43,7 @@ func (c *Client) Head(ctx context.Context, repositoryID int) (_ string, err erro
 
 // CommitDate returns the time that the given commit was committed.
 func (c *Client) CommitDate(ctx context.Context, repositoryID int, commit string) (_ time.Time, err error) {
-	ctx, endObservation := with(ctx, c.operations.commitDate, &err, observation.Args{LogFields: []log.Field{
+	ctx, endObservation := c.operations.commitDate.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 	}})
@@ -156,7 +156,7 @@ func ParseCommitGraph(pair []string) *CommitGraph {
 
 // RawContents returns the contents of a file in a particular commit of a repository.
 func (c *Client) RawContents(ctx context.Context, repositoryID int, commit, file string) (_ []byte, err error) {
-	ctx, endObservation := with(ctx, c.operations.rawContents, &err, observation.Args{LogFields: []log.Field{
+	ctx, endObservation := c.operations.rawContents.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 		log.String("file", file),
@@ -175,7 +175,7 @@ func (c *Client) RawContents(ctx context.Context, repositoryID int, commit, file
 // of git ls-tree. The keys of the resulting map are the input (unsanitized) dirnames, and the value of
 // that key are the files nested under that directory.
 func (c *Client) DirectoryChildren(ctx context.Context, repositoryID int, commit string, dirnames []string) (_ map[string][]string, err error) {
-	ctx, endObservation := with(ctx, c.operations.directoryChildren, &err, observation.Args{LogFields: []log.Field{
+	ctx, endObservation := c.operations.directoryChildren.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 	}})
@@ -252,7 +252,7 @@ func parseDirectoryChildren(dirnames, paths []string) map[string][]string {
 
 // FileExists determines whether a file exists in a particular commit of a repository.
 func (c *Client) FileExists(ctx context.Context, repositoryID int, commit, file string) (_ bool, err error) {
-	ctx, endObservation := with(ctx, c.operations.fileExists, &err, observation.Args{LogFields: []log.Field{
+	ctx, endObservation := c.operations.fileExists.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 		log.String("file", file),
@@ -282,7 +282,7 @@ func (c *Client) FileExists(ctx context.Context, repositoryID int, commit, file 
 // ListFiles returns a list of root-relative file paths matching the given pattern in a particular
 // commit of a repository.
 func (c *Client) ListFiles(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) (_ []string, err error) {
-	ctx, endObservation := with(ctx, c.operations.listFiles, &err, observation.Args{LogFields: []log.Field{
+	ctx, endObservation := c.operations.listFiles.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 		log.String("pattern", pattern.String()),
@@ -325,17 +325,4 @@ func (c *Client) repositoryIDToRepo(ctx context.Context, repositoryID int) (api.
 	}
 
 	return api.RepoName(repoName), nil
-}
-
-// with calls With on the given operation, but masks the error pointer in the case
-// that the error is due to an unknown revision. This function should be used over
-// calling With directly in this package whenever we use a revision that was stored
-// in a code intelligence-owned data store. These commits can fall out of sync with
-// gitserver and upstream callers are expected to handle these cases appropriately.
-func with(ctx context.Context, op *observation.Operation, err *error, args observation.Args) (context.Context, observation.FinishFunc) {
-	if err != nil && gitserver.IsRevisionNotFound(*err) {
-		err = nil
-	}
-
-	return op.With(ctx, err, args)
 }

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -3,6 +3,7 @@ package gitserver
 import (
 	"fmt"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -30,6 +31,7 @@ func makeOperations(observationContext *observation.Context) *operations {
 			Name:         fmt.Sprintf("codeintel.gitserver.%s", name),
 			MetricLabels: []string{name},
 			Metrics:      metrics,
+			ErrorFilter:  gitserver.IsRevisionNotFound,
 		})
 	}
 


### PR DESCRIPTION
If we hit a revision not found error in the codeintel client, we do not want to treat these as _alertable_ errors as they are generally expected due to force-pushing over commits which codeintel holds references to.

We should move the handling of this class of errors up the stack. We still return the original error, we just don't emit a metric for it.

https://github.com/sourcegraph/sourcegraph/pull/16844 handles this error on the commit graph updater side. A future effort will need to do the same thing for the index schedulers.