### PR TITLE
streaming search: stream complete and error now tracked by observable lifecycle

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -20,10 +20,10 @@ const history = createBrowserHistory()
 history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })
 
 const streamingSearchResult: AggregateStreamingSearchResults = {
+    state: 'complete',
     results: [...MULTIPLE_SEARCH_RESULT.results, REPO_MATCH_RESULT] as GQL.SearchResult[],
     filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
     progress: {
-        done: true,
         durationMs: 500,
         matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
         skipped: [],
@@ -69,10 +69,10 @@ add('standard render', () => <WebStory>{() => <StreamingSearchResults {...defaul
 
 add('no results', () => {
     const result: AggregateStreamingSearchResults = {
+        state: 'complete',
         results: [],
         filters: [],
         progress: {
-            done: true,
             durationMs: 500,
             matchCount: 0,
             skipped: [],
@@ -106,10 +106,10 @@ add('search with quotes', () => {
 
 add('progress with warnings', () => {
     const result: AggregateStreamingSearchResults = {
+        state: 'complete',
         results: MULTIPLE_SEARCH_RESULT.results,
         filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
         progress: {
-            done: true,
             durationMs: 500,
             matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
             skipped: [
@@ -178,10 +178,10 @@ add('loading with no results', () => (
 
 add('loading with some results', () => {
     const result: AggregateStreamingSearchResults = {
+        state: 'loading',
         results: MULTIPLE_SEARCH_RESULT.results,
         filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
         progress: {
-            done: false,
             durationMs: 500,
             matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
             skipped: [],
@@ -193,10 +193,10 @@ add('loading with some results', () => {
 
 add('server-side alert', () => {
     const result: AggregateStreamingSearchResults = {
+        state: 'complete',
         results: MULTIPLE_SEARCH_RESULT.results,
         filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
         progress: {
-            done: true,
             durationMs: 500,
             matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
             skipped: [],
@@ -213,10 +213,10 @@ add('server-side alert', () => {
 
 add('server-side alert with no results', () => {
     const result: AggregateStreamingSearchResults = {
+        state: 'complete',
         results: [],
         filters: [],
         progress: {
-            done: true,
             durationMs: 500,
             matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
             skipped: [],

--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -31,10 +31,10 @@ describe('StreamingSearchResults', () => {
     history.replace({ search: 'q=r:golang/oauth2+test+f:travis' })
 
     const streamingSearchResult: AggregateStreamingSearchResults = {
+        state: 'complete',
         results: MULTIPLE_SEARCH_RESULT.results,
         filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
         progress: {
-            done: true,
             durationMs: 500,
             matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
             skipped: [],

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -211,7 +211,13 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                         allExpanded={allExpanded}
                         onExpandAllResultsToggle={onExpandAllResultsToggle}
                         onSaveQueryClick={onSaveQueryClick}
-                        stats={<StreamingProgress progress={results?.progress} onSearchAgain={onSearchAgain} />}
+                        stats={
+                            <StreamingProgress
+                                progress={results?.progress || { durationMs: 0, matchCount: 0, skipped: [] }}
+                                state={results?.state || 'loading'}
+                                onSearchAgain={onSearchAgain}
+                            />
+                        }
                     />
                 </div>
 
@@ -248,13 +254,13 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     items={results?.results.map(result => renderResult(result)).filter(isDefined) || []}
                 />
 
-                {!results?.progress.done && (
+                {(!results || results?.state === 'loading') && (
                     <div className="text-center my-4" data-testid="loading-container">
                         <LoadingSpinner className="icon-inline" />
                     </div>
                 )}
 
-                {results?.progress.done && !results?.alert && results?.results.length === 0 && (
+                {results?.state === 'complete' && !results?.alert && results?.results.length === 0 && (
                     <div className="alert alert-info d-flex m-2">
                         <h3 className="m-0">
                             <SearchIcon className="icon-inline" /> No results
@@ -262,7 +268,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     </div>
                 )}
 
-                {results?.progress.done && results?.results.length > 0 && (
+                {results?.state === 'complete' && results?.results.length > 0 && (
                     <small className="d-block my-4 text-center">Showing {results?.results.length} results</small>
                 )}
             </div>

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
@@ -17,30 +17,35 @@ const onSearchAgain = sinon.spy()
 
 add('0 results, in progress', () => {
     const progress: Progress = {
-        done: false,
         durationMs: 0,
         matchCount: 0,
         skipped: [],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
+    return (
+        <WebStory>
+            {() => <StreamingProgress progress={progress} state="loading" onSearchAgain={onSearchAgain} />}
+        </WebStory>
+    )
 })
 
 add('1 result from 1 repository, in progress', () => {
     const progress: Progress = {
-        done: false,
         durationMs: 500,
         matchCount: 1,
         repositoriesCount: 1,
         skipped: [],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
+    return (
+        <WebStory>
+            {() => <StreamingProgress progress={progress} state="loading" onSearchAgain={onSearchAgain} />}
+        </WebStory>
+    )
 })
 
 add('2 results from 2 repositories, complete, skipped with info', () => {
     const progress: Progress = {
-        done: true,
         durationMs: 1500,
         matchCount: 2,
         repositoriesCount: 2,
@@ -68,12 +73,15 @@ add('2 results from 2 repositories, complete, skipped with info', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
+    return (
+        <WebStory>
+            {() => <StreamingProgress progress={progress} state="complete" onSearchAgain={onSearchAgain} />}
+        </WebStory>
+    )
 })
 
 add('2 results from 2 repositories, loading, skipped with info', () => {
     const progress: Progress = {
-        done: false,
         durationMs: 1500,
         matchCount: 2,
         repositoriesCount: 2,
@@ -101,12 +109,15 @@ add('2 results from 2 repositories, loading, skipped with info', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
+    return (
+        <WebStory>
+            {() => <StreamingProgress progress={progress} state="loading" onSearchAgain={onSearchAgain} />}
+        </WebStory>
+    )
 })
 
 add('2 results from 2 repositories, complete, skipped with warning', () => {
     const progress: Progress = {
-        done: true,
         durationMs: 1500,
         matchCount: 2,
         repositoriesCount: 2,
@@ -144,12 +155,15 @@ add('2 results from 2 repositories, complete, skipped with warning', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
+    return (
+        <WebStory>
+            {() => <StreamingProgress progress={progress} state="complete" onSearchAgain={onSearchAgain} />}
+        </WebStory>
+    )
 })
 
 add('2 results from 2 repositories, loading, skipped with warning', () => {
     const progress: Progress = {
-        done: false,
         durationMs: 1500,
         matchCount: 2,
         repositoriesCount: 2,
@@ -187,5 +201,9 @@ add('2 results from 2 repositories, loading, skipped with warning', () => {
         ],
     }
 
-    return <WebStory>{() => <StreamingProgress progress={progress} onSearchAgain={onSearchAgain} />}</WebStory>
+    return (
+        <WebStory>
+            {() => <StreamingProgress progress={progress} state="loading" onSearchAgain={onSearchAgain} />}
+        </WebStory>
+    )
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
@@ -1,18 +1,12 @@
 import * as React from 'react'
-import { Progress } from '../../../stream'
+import { Progress, StreamingReultsState } from '../../../stream'
 import { StreamingProgressCount } from './StreamingProgressCount'
 import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton'
 
 export interface StreamingProgressProps {
-    progress?: Progress
+    state: StreamingReultsState
+    progress: Progress
     onSearchAgain: (additionalFilters: string[]) => void
-}
-
-export const defaultProgress: Progress = {
-    done: false,
-    durationMs: 0,
-    matchCount: 0,
-    skipped: [],
 }
 
 export const StreamingProgress: React.FunctionComponent<StreamingProgressProps> = props => (

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import { Progress, StreamingReultsState } from '../../../stream'
+import { Progress, StreamingResultsState } from '../../../stream'
 import { StreamingProgressCount } from './StreamingProgressCount'
 import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton'
 
 export interface StreamingProgressProps {
-    state: StreamingReultsState
+    state: StreamingResultsState
     progress: Progress
     onSearchAgain: (additionalFilters: string[]) => void
 }

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -6,36 +6,33 @@ import { StreamingProgressCount } from './StreamingProgressCount'
 describe('StreamingProgressCount', () => {
     it('should render correctly for 0 items in progress', () => {
         const progress: Progress = {
-            done: false,
             durationMs: 0,
             matchCount: 0,
             skipped: [],
         }
 
-        expect(mount(<StreamingProgressCount progress={progress} />)).toMatchSnapshot()
+        expect(mount(<StreamingProgressCount state="loading" progress={progress} />)).toMatchSnapshot()
     })
 
     it('should render correctly for 1 item complete', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1250,
             matchCount: 1,
             repositoriesCount: 1,
             skipped: [],
         }
 
-        expect(mount(<StreamingProgressCount progress={progress} />)).toMatchSnapshot()
+        expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
     })
 
     it('should render correctly for 123 items complete', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1250,
             matchCount: 123,
             repositoriesCount: 500,
             skipped: [],
         }
 
-        expect(mount(<StreamingProgressCount progress={progress} />)).toMatchSnapshot()
+        expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
     })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -2,14 +2,15 @@ import classNames from 'classnames'
 import CalculatorIcon from 'mdi-react/CalculatorIcon'
 import * as React from 'react'
 import { pluralize } from '../../../../../../shared/src/util/strings'
-import { defaultProgress, StreamingProgressProps } from './StreamingProgress'
+import { StreamingProgressProps } from './StreamingProgress'
 
-export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgressProps, 'progress'>> = ({
-    progress = defaultProgress,
+export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgressProps, 'progress' | 'state'>> = ({
+    progress,
+    state,
 }) => (
     <div
         className={classNames('streaming-progress__count d-flex align-items-center', {
-            'streaming-progress__count--in-progress': !progress.done,
+            'streaming-progress__count--in-progress': state === 'loading',
         })}
     >
         <CalculatorIcon className="mr-2 icon-inline" />

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.test.tsx
@@ -10,7 +10,6 @@ import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopov
 describe('StreamingProgressSkippedButton', () => {
     it('should not show if no skipped items', () => {
         const progress: Progress = {
-            done: false,
             durationMs: 0,
             matchCount: 0,
             skipped: [],
@@ -23,7 +22,6 @@ describe('StreamingProgressSkippedButton', () => {
 
     it('should be in info state with only info items', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -58,7 +56,6 @@ describe('StreamingProgressSkippedButton', () => {
 
     it('should be in warning state with at least one warning item', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -103,7 +100,6 @@ describe('StreamingProgressSkippedButton', () => {
 
     it('should open and close popover when button is clicked', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -150,7 +146,6 @@ describe('StreamingProgressSkippedButton', () => {
 
     it('should close popup and call onSearchAgain callback when popover raises event', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -3,13 +3,13 @@ import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
-import { defaultProgress, StreamingProgressProps } from './StreamingProgress'
+import { StreamingProgressProps } from './StreamingProgress'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
-export const StreamingProgressSkippedButton: React.FunctionComponent<StreamingProgressProps> = ({
-    progress = defaultProgress,
-    onSearchAgain,
-}) => {
+export const StreamingProgressSkippedButton: React.FunctionComponent<Pick<
+    StreamingProgressProps,
+    'progress' | 'onSearchAgain'
+>> = ({ progress, onSearchAgain }) => {
     const [isOpen, setIsOpen] = useState(false)
     const toggleOpen = useCallback(() => setIsOpen(previous => !previous), [setIsOpen])
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.story.tsx
@@ -17,7 +17,6 @@ const { add } = storiesOf(
 
 add('popover', () => {
     const progress: Progress = {
-        done: true,
         durationMs: 1500,
         matchCount: 2,
         repositoriesCount: 2,

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.test.tsx
@@ -8,7 +8,6 @@ import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopov
 describe('StreamingProgressSkippedPopover', () => {
     it('should render correctly', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -52,7 +51,6 @@ describe('StreamingProgressSkippedPopover', () => {
 
     it('should not show Search Again section if no suggested searches are set', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -72,7 +70,6 @@ describe('StreamingProgressSkippedPopover', () => {
 
     it('should have Search Again button disabled by default', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -98,7 +95,6 @@ describe('StreamingProgressSkippedPopover', () => {
 
     it('should enable Search Again button if at least one item is checked', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -152,7 +148,6 @@ describe('StreamingProgressSkippedPopover', () => {
 
     it('should disable Search Again button if unchecking all items', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,
@@ -212,7 +207,6 @@ describe('StreamingProgressSkippedPopover', () => {
 
     it('should call onSearchAgain with selected items when button is clicked', () => {
         const progress: Progress = {
-            done: true,
             durationMs: 1500,
             matchCount: 2,
             repositoriesCount: 2,

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -4,12 +4,12 @@ import SearchIcon from 'mdi-react/SearchIcon'
 import React, { useCallback, useState } from 'react'
 import { Alert, Button, Form, FormGroup, Input, Label } from 'reactstrap'
 import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighlightedSearchQuery'
-import { defaultProgress, StreamingProgressProps } from './StreamingProgress'
+import { StreamingProgressProps } from './StreamingProgress'
 
-export const StreamingProgressSkippedPopover: React.FunctionComponent<StreamingProgressProps> = ({
-    progress = defaultProgress,
-    onSearchAgain,
-}) => {
+export const StreamingProgressSkippedPopover: React.FunctionComponent<Pick<
+    StreamingProgressProps,
+    'progress' | 'onSearchAgain'
+>> = ({ progress, onSearchAgain }) => {
     const [selectedSuggestedSearches, setSelectedSuggestedSearches] = useState(new Set<string>())
     const submitHandler = useCallback(
         (event: React.FormEvent) => {

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
 <StreamingProgressCount
   progress={
     Object {
-      "done": false,
       "durationMs": 0,
       "matchCount": 0,
       "skipped": Array [],
     }
   }
+  state="loading"
 >
   <div
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
@@ -31,13 +31,13 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
 <StreamingProgressCount
   progress={
     Object {
-      "done": true,
       "durationMs": 1250,
       "matchCount": 1,
       "repositoriesCount": 1,
       "skipped": Array [],
     }
   }
+  state="complete"
 >
   <div
     className="streaming-progress__count d-flex align-items-center"
@@ -64,13 +64,13 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
 <StreamingProgressCount
   progress={
     Object {
-      "done": true,
       "durationMs": 1250,
       "matchCount": 123,
       "repositoriesCount": 500,
       "skipped": Array [],
     }
   }
+  state="complete"
 >
   <div
     className="streaming-progress__count d-flex align-items-center"

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
   onSearchAgain={[Function]}
   progress={
     Object {
-      "done": true,
       "durationMs": 1500,
       "matchCount": 2,
       "repositoriesCount": 2,

--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable id-length */
-import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber } from 'rxjs'
-import { defaultIfEmpty, map, scan } from 'rxjs/operators'
+import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber, Notification } from 'rxjs'
+import { defaultIfEmpty, map, materialize, scan } from 'rxjs/operators'
 import * as GQL from '../../../shared/src/graphql/schema'
+import { asError, isErrorLike } from '../../../shared/src/util/errors'
 import { SearchPatternType } from '../graphql-operations'
 
 // This is an initial proof of concept implementation of search streaming.
@@ -72,11 +73,6 @@ type RepositoryMatch = { type: 'repo' } & Pick<FileMatch, 'repository' | 'branch
  * Should be replaced when a new ones come in.
  */
 export interface Progress {
-    /**
-     * True if this is the final progress update for this stream
-     */
-    done: boolean
-
     /**
      * The number of repositories matching the repo: filter. Is set once they
      * are resolved.
@@ -276,18 +272,22 @@ function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
     return gqlCommit as GQL.ICommitSearchResult
 }
 
+export type StreamingReultsState = 'loading' | 'error' | 'complete'
+
 export interface AggregateStreamingSearchResults {
+    state: StreamingReultsState
     results: GQL.SearchResult[]
     alert?: Alert
     filters: Filter[]
     progress: Progress
+    error?: Error
 }
 
 const emptyAggregateResults: AggregateStreamingSearchResults = {
+    state: 'loading',
     results: [],
     filters: [],
     progress: {
-        done: false,
         durationMs: 0,
         matchCount: 0,
         skipped: [],
@@ -311,39 +311,63 @@ function toGQLSearchResult(match: Match): GQL.SearchResult {
  * Converts a stream of SearchEvents into AggregateStreamingSearchResults
  */
 const switchAggregateSearchResults: OperatorFunction<SearchEvent, AggregateStreamingSearchResults> = pipe(
-    scan((results: AggregateStreamingSearchResults, newEvent: SearchEvent) => {
-        switch (newEvent.type) {
-            case 'matches':
-                return {
-                    ...results,
-                    // Matches are additive
-                    results: results.results.concat(newEvent.data.map(toGQLSearchResult)),
-                }
+    materialize(),
+    scan(
+        (
+            results: AggregateStreamingSearchResults,
+            newEvent: Notification<SearchEvent>
+        ): AggregateStreamingSearchResults => {
+            switch (newEvent.kind) {
+                case 'N': {
+                    switch (newEvent.value?.type) {
+                        case 'matches':
+                            return {
+                                ...results,
+                                // Matches are additive
+                                results: results.results.concat(newEvent.value.data.map(toGQLSearchResult)),
+                            }
 
-            case 'progress':
-                return {
-                    ...results,
-                    // Progress updates replace
-                    progress: newEvent.data,
-                }
+                        case 'progress':
+                            return {
+                                ...results,
+                                // Progress updates replace
+                                progress: newEvent.value.data,
+                            }
 
-            case 'filters':
-                return {
-                    ...results,
-                    // New filter results replace all previous ones
-                    filters: newEvent.data,
-                }
+                        case 'filters':
+                            return {
+                                ...results,
+                                // New filter results replace all previous ones
+                                filters: newEvent.value.data,
+                            }
 
-            case 'alert':
-                return {
-                    ...results,
-                    alert: newEvent.data,
-                }
+                        case 'alert':
+                            return {
+                                ...results,
+                                alert: newEvent.value.data,
+                            }
 
-            default:
-                return results
-        }
-    }, emptyAggregateResults),
+                        default:
+                            return results
+                    }
+                }
+                case 'E':
+                    return {
+                        ...results,
+                        error: asError(newEvent.error),
+                        state: 'error',
+                    }
+                case 'C':
+                    return {
+                        ...results,
+                        state: 'complete',
+                    }
+                default:
+                    return results
+            }
+        },
+        emptyAggregateResults
+    ),
     defaultIfEmpty(emptyAggregateResults)
 )
 
@@ -385,7 +409,18 @@ const messageHandlers: {
         }),
     error: (type, eventSource, observer) =>
         fromEvent(eventSource, type).subscribe(error => {
-            observer.error(error)
+            if (isErrorLike(error)) {
+                observer.error(error)
+            } else {
+                // The EventSource API can return a DOM event that is not an Error object
+                // (e.g. doesn't have the message property), so we need to construct our own here.
+                // See https://developer.mozilla.org/en-US/docs/Web/API/EventSource/error_event
+                observer.error(
+                    new Error(
+                        'There was a network error retrieving search results. Check your Internet connection and try again.'
+                    )
+                )
+            }
             eventSource.close()
         }),
     matches: observeMessages,

--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -274,14 +274,24 @@ function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
 
 export type StreamingResultsState = 'loading' | 'error' | 'complete'
 
-export interface AggregateStreamingSearchResults {
+interface BaseAggregateResults {
     state: StreamingResultsState
     results: GQL.SearchResult[]
     alert?: Alert
     filters: Filter[]
     progress: Progress
-    error?: Error
 }
+
+interface SuccessfulAggregateResults extends BaseAggregateResults {
+    state: 'loading' | 'complete'
+}
+
+interface ErrorAggregateResults extends BaseAggregateResults {
+    state: 'error'
+    error: Error
+}
+
+export type AggregateStreamingSearchResults = SuccessfulAggregateResults | ErrorAggregateResults
 
 const emptyAggregateResults: AggregateStreamingSearchResults = {
     state: 'loading',

--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -378,7 +378,7 @@ const switchAggregateSearchResults: OperatorFunction<SearchEvent, AggregateStrea
         },
         emptyAggregateResults
     ),
-    defaultIfEmpty(emptyAggregateResults)
+    defaultIfEmpty(emptyAggregateResults as AggregateStreamingSearchResults)
 )
 
 const observeMessages = <T extends SearchEvent>(

--- a/client/web/src/search/stream.tsx
+++ b/client/web/src/search/stream.tsx
@@ -272,10 +272,10 @@ function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
     return gqlCommit as GQL.ICommitSearchResult
 }
 
-export type StreamingReultsState = 'loading' | 'error' | 'complete'
+export type StreamingResultsState = 'loading' | 'error' | 'complete'
 
 export interface AggregateStreamingSearchResults {
-    state: StreamingReultsState
+    state: StreamingResultsState
     results: GQL.SearchResult[]
     alert?: Alert
     filters: Filter[]


### PR DESCRIPTION
- Removed `done` field from Progress API, fixes #16833
- Stream completion and error states are now tracked in the accumulated results, as well as any error emitted. This way, we can show an error message in addition to any results returned so far. (Thanks @lguychard  for the suggestion to use the `materialize` operator!)
- Client-side errors that are not error-likes (e.g. connection issues) are now converted to errors

This contains some work originally done as part of #16734 but it makes more sense to do this first and then build visual error handling on top of this.

The changeset looks big but most of it if just changing tests from using `progress.done` to `state`.