### PR TITLE
workerutil: Standardize metrics

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -71,7 +71,7 @@ func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 		Name:        "precise_code_intel_index_worker",
 		NumHandlers: c.MaximumNumJobs,
 		Interval:    c.QueuePollInterval,
-		Metrics:     makeWorkerMetrics(),
+		Metrics:     makeWorkerMetrics(c.QueueName),
 	}
 }
 

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -171,20 +170,7 @@ func mustRegisterQueueMetric(observationContext *observation.Context, workerStor
 }
 
 func makeWorkerMetrics(observationContext *observation.Context) workerutil.WorkerMetrics {
-	metrics := metrics.NewOperationMetrics(
-		observationContext.Registerer,
-		"upload_queue_processor",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of records processed"),
-	)
-
-	return workerutil.WorkerMetrics{
-		HandleOperation: observationContext.Operation(observation.Op{
-			Name:         "Processor.Process",
-			MetricLabels: []string{"process"},
-			Metrics:      metrics,
-		}),
-	}
+	return workerutil.NewMetrics(observationContext, "codeintel_upload_queue_processor", nil)
 }
 
 func initializeUploadStore(ctx context.Context, uploadStore uploadstore.Store) error {

--- a/enterprise/internal/campaigns/background/metrics.go
+++ b/enterprise/internal/campaigns/background/metrics.go
@@ -4,16 +4,17 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
+
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
 type campaignsMetrics struct {
-	handleOperation *observation.Operation
-	resets          prometheus.Counter
-	resetFailures   prometheus.Counter
-	errors          prometheus.Counter
+	workerMetrics workerutil.WorkerMetrics
+	resets        prometheus.Counter
+	resetFailures prometheus.Counter
+	errors        prometheus.Counter
 }
 
 func newMetrics() campaignsMetrics {
@@ -22,19 +23,6 @@ func newMetrics() campaignsMetrics {
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
-
-	metrics := metrics.NewOperationMetrics(
-		observationContext.Registerer,
-		"campaigns_reconciler",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of changesets reconciled"),
-	)
-
-	handleOperation := observationContext.Operation(observation.Op{
-		Name:         "Reconciler.Process",
-		MetricLabels: []string{"process"},
-		Metrics:      metrics,
-	})
 
 	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_campaigns_background_reconciler_reset_failures_total",
@@ -55,9 +43,9 @@ func newMetrics() campaignsMetrics {
 	observationContext.Registerer.MustRegister(errors)
 
 	return campaignsMetrics{
-		handleOperation: handleOperation,
-		resets:          resets,
-		resetFailures:   resetFailures,
-		errors:          errors,
+		workerMetrics: workerutil.NewMetrics(observationContext, "campaigns_reconciler", nil),
+		resets:        resets,
+		resetFailures: resetFailures,
+		errors:        errors,
 	}
 }

--- a/enterprise/internal/campaigns/background/workers.go
+++ b/enterprise/internal/campaigns/background/workers.go
@@ -39,9 +39,7 @@ func newWorker(
 		Name:        "campaigns_reconciler_worker",
 		NumHandlers: 5,
 		Interval:    5 * time.Second,
-		Metrics: workerutil.WorkerMetrics{
-			HandleOperation: metrics.handleOperation,
-		},
+		Metrics:     metrics.workerMetrics,
 	}
 
 	workerStore := createDBWorkerStore(s)

--- a/enterprise/internal/codeintel/stores/dbstore/worker.go
+++ b/enterprise/internal/codeintel/stores/dbstore/worker.go
@@ -20,7 +20,7 @@ const StalledUploadMaxAge = time.Second * 5
 // "queued" on its next reset.
 const UploadMaxNumResets = 3
 
-var uploadWorkerStore = dbworkerstore.Options{
+var uploadWorkerStoreOptions = dbworkerstore.Options{
 	Name:              "precise_code_intel_upload_worker_store",
 	TableName:         "lsif_uploads",
 	ViewName:          "lsif_uploads_with_repository_name u",
@@ -32,7 +32,7 @@ var uploadWorkerStore = dbworkerstore.Options{
 }
 
 func WorkerutilUploadStore(s basestore.ShareableStore) dbworkerstore.Store {
-	return dbworkerstore.New(s.Handle(), uploadWorkerStore)
+	return dbworkerstore.New(s.Handle(), uploadWorkerStoreOptions)
 }
 
 // StalledIndexMaxAge is the maximum allowable duration between updating the state of an
@@ -46,7 +46,7 @@ const StalledIndexMaxAge = time.Second * 5
 // "queued" on its next reset.
 const IndexMaxNumResets = 3
 
-var indexWorkerStore = dbworkerstore.Options{
+var indexWorkerStoreOptions = dbworkerstore.Options{
 	Name:              "precise_code_intel_index_worker_store",
 	TableName:         "lsif_indexes",
 	ViewName:          "lsif_indexes_with_repository_name u",
@@ -58,5 +58,5 @@ var indexWorkerStore = dbworkerstore.Options{
 }
 
 func WorkerutilIndexStore(s basestore.ShareableStore) dbworkerstore.Store {
-	return dbworkerstore.New(s.Handle(), indexWorkerStore)
+	return dbworkerstore.New(s.Handle(), indexWorkerStoreOptions)
 }

--- a/enterprise/internal/codemonitors/background/metrics.go
+++ b/enterprise/internal/codemonitors/background/metrics.go
@@ -4,16 +4,17 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
+
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
 type codeMonitorsMetrics struct {
-	handleOperation *observation.Operation
-	resets          prometheus.Counter
-	resetFailures   prometheus.Counter
-	errors          prometheus.Counter
+	workerMetrics workerutil.WorkerMetrics
+	resets        prometheus.Counter
+	resetFailures prometheus.Counter
+	errors        prometheus.Counter
 }
 
 func newMetricsForTriggerQueries() codeMonitorsMetrics {
@@ -22,19 +23,6 @@ func newMetricsForTriggerQueries() codeMonitorsMetrics {
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
-
-	metrics := metrics.NewOperationMetrics(
-		observationContext.Registerer,
-		"code_monitors_trigger_queries",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of queries run"),
-	)
-
-	handleOperation := observationContext.Operation(observation.Op{
-		Name:         "Query.Run",
-		MetricLabels: []string{"process"},
-		Metrics:      metrics,
-	})
 
 	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_codemonitors_query_reset_failures_total",
@@ -55,10 +43,10 @@ func newMetricsForTriggerQueries() codeMonitorsMetrics {
 	observationContext.Registerer.MustRegister(errors)
 
 	return codeMonitorsMetrics{
-		handleOperation: handleOperation,
-		resets:          resets,
-		resetFailures:   resetFailures,
-		errors:          errors,
+		workerMetrics: workerutil.NewMetrics(observationContext, "code_monitors_trigger_queries", nil),
+		resets:        resets,
+		resetFailures: resetFailures,
+		errors:        errors,
 	}
 }
 
@@ -68,19 +56,6 @@ func newActionMetrics() codeMonitorsMetrics {
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
-
-	metrics := metrics.NewOperationMetrics(
-		observationContext.Registerer,
-		"code_monitors_actions",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of actions run"),
-	)
-
-	handleOperation := observationContext.Operation(observation.Op{
-		Name:         "Action.Run",
-		MetricLabels: []string{"process"},
-		Metrics:      metrics,
-	})
 
 	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_codemonitors_action_reset_failures_total",
@@ -101,9 +76,9 @@ func newActionMetrics() codeMonitorsMetrics {
 	observationContext.Registerer.MustRegister(errors)
 
 	return codeMonitorsMetrics{
-		handleOperation: handleOperation,
-		resets:          resets,
-		resetFailures:   resetFailures,
-		errors:          errors,
+		workerMetrics: workerutil.NewMetrics(observationContext, "code_monitors_actions", nil),
+		resets:        resets,
+		resetFailures: resetFailures,
+		errors:        errors,
 	}
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -26,7 +26,7 @@ func newTriggerQueryRunner(ctx context.Context, s *cm.Store, metrics codeMonitor
 		Name:        "code_monitors_trigger_jobs_worker",
 		NumHandlers: 1,
 		Interval:    5 * time.Second,
-		Metrics:     workerutil.WorkerMetrics{HandleOperation: metrics.handleOperation},
+		Metrics:     metrics.workerMetrics,
 	}
 	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForTriggerJobs(s), &queryRunner{s}, options)
 	return worker
@@ -80,7 +80,7 @@ func newActionRunner(ctx context.Context, s *cm.Store, metrics codeMonitorsMetri
 		Name:        "code_monitors_action_jobs_worker",
 		NumHandlers: 1,
 		Interval:    5 * time.Second,
-		Metrics:     workerutil.WorkerMetrics{HandleOperation: metrics.handleOperation},
+		Metrics:     metrics.workerMetrics,
 	}
 	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForActionJobs(s), &actionRunner{s}, options)
 	return worker

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -69,9 +68,7 @@ func NewSyncWorker(ctx context.Context, db dbutil.DB, handler dbworker.Handler, 
 		Name:        "repo_sync_worker",
 		NumHandlers: opts.NumHandlers,
 		Interval:    opts.WorkerInterval,
-		Metrics: workerutil.WorkerMetrics{
-			HandleOperation: newObservationOperation(opts.PrometheusRegisterer),
-		},
+		Metrics:     newWorkerMetrics(opts.PrometheusRegisterer),
 	})
 
 	resetter := dbworker.NewResetter(store, dbworker.ResetterOptions{
@@ -87,7 +84,7 @@ func NewSyncWorker(ctx context.Context, db dbutil.DB, handler dbworker.Handler, 
 	return worker, resetter
 }
 
-func newObservationOperation(r prometheus.Registerer) *observation.Operation {
+func newWorkerMetrics(r prometheus.Registerer) workerutil.WorkerMetrics {
 	var observationContext *observation.Context
 
 	if r == nil {
@@ -100,18 +97,7 @@ func newObservationOperation(r prometheus.Registerer) *observation.Operation {
 		}
 	}
 
-	m := metrics.NewOperationMetrics(
-		observationContext.Registerer,
-		"repo_updater_external_service_syncer",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of results returned"),
-	)
-
-	return observationContext.Operation(observation.Op{
-		Name:         "Syncer.Process",
-		MetricLabels: []string{"process"},
-		Metrics:      m,
-	})
+	return workerutil.NewMetrics(observationContext, "repo_updater_external_service_syncer", nil)
 }
 
 func newResetterMetrics(r prometheus.Registerer) dbworker.ResetterMetrics {

--- a/internal/workerutil/observability.go
+++ b/internal/workerutil/observability.go
@@ -1,0 +1,77 @@
+package workerutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type WorkerMetrics struct {
+	operations *operations
+	numJobs    prometheus.Gauge
+}
+
+type operations struct {
+	handle *observation.Operation
+}
+
+// NewMetrics creates and registers the following metrics for a generic worker instance.
+//
+//   - {prefix}_duration_seconds_bucket: handler operation latency histogram
+//   - {prefix}_total: number of handler operations
+//   - {prefix}_error_total: number of handler operations resulting in an error
+//   - {prefix}_handlers: the number of active handler routines
+//
+// The given labels are emitted on each metric.
+func NewMetrics(observationContext *observation.Context, prefix string, labels map[string]string) WorkerMetrics {
+	keys := make([]string, 0, len(labels))
+	values := make([]string, 0, len(labels))
+	for key, value := range labels {
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+
+	gauge := func(name, help string) prometheus.Gauge {
+		gaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: fmt.Sprintf("src_%s_%s", prefix, name),
+			Help: help,
+		}, keys)
+
+		observationContext.Registerer.MustRegister(gaugeVec)
+		return gaugeVec.WithLabelValues(values...)
+	}
+
+	numJobs := gauge(
+		"handlers",
+		"The number of active handlers.",
+	)
+
+	return WorkerMetrics{
+		operations: makeOperations(observationContext, prefix, keys, values),
+		numJobs:    numJobs,
+	}
+}
+
+func makeOperations(observationContext *observation.Context, prefix string, keys, values []string) *operations {
+	metrics := metrics.NewOperationMetrics(
+		observationContext.Registerer,
+		prefix,
+		metrics.WithLabels(append(keys, "op")...),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:         fmt.Sprintf("worker.%s", name),
+			MetricLabels: append(append([]string{}, values...), name),
+			Metrics:      metrics,
+		})
+	}
+
+	return &operations{
+		handle: op("Handle"),
+	}
+}

--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -29,9 +29,7 @@ func TestWorkerHandlerSuccess(t *testing.T) {
 		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
-		Metrics: WorkerMetrics{
-			HandleOperation: observation.TestContext.Operation(observation.Op{}),
-		},
+		Metrics:     NewMetrics(&observation.TestContext, "", nil),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, store, true, nil)
@@ -70,9 +68,7 @@ func TestWorkerHandlerFailure(t *testing.T) {
 		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
-		Metrics: WorkerMetrics{
-			HandleOperation: observation.TestContext.Operation(observation.Op{}),
-		},
+		Metrics:     NewMetrics(&observation.TestContext, "", nil),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, store, true, nil)
@@ -119,9 +115,7 @@ func TestWorkerHandlerNonRetryableFailure(t *testing.T) {
 		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
-		Metrics: WorkerMetrics{
-			HandleOperation: observation.TestContext.Operation(observation.Op{}),
-		},
+		Metrics:     NewMetrics(&observation.TestContext, "", nil),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, store, true, nil)
@@ -171,9 +165,7 @@ func TestWorkerConcurrent(t *testing.T) {
 				Name:        "test",
 				NumHandlers: numHandlers,
 				Interval:    time.Second,
-				Metrics: WorkerMetrics{
-					HandleOperation: observation.TestContext.Operation(observation.Op{}),
-				},
+				Metrics:     NewMetrics(&observation.TestContext, "", nil),
 			}
 
 			for i := 0; i < NumTestRecords; i++ {
@@ -258,9 +250,7 @@ func TestWorkerBlockingPreDequeueHook(t *testing.T) {
 		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
-		Metrics: WorkerMetrics{
-			HandleOperation: observation.TestContext.Operation(observation.Op{}),
-		},
+		Metrics:     NewMetrics(&observation.TestContext, "", nil),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, store, true, nil)
@@ -287,9 +277,7 @@ func TestWorkerConditionalPreDequeueHook(t *testing.T) {
 		Name:        "test",
 		NumHandlers: 1,
 		Interval:    time.Second,
-		Metrics: WorkerMetrics{
-			HandleOperation: observation.TestContext.Operation(observation.Op{}),
-		},
+		Metrics:     NewMetrics(&observation.TestContext, "", nil),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, store, true, nil)

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -28,7 +28,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 						{
 							Name:            "upload_queue_growth_rate",
 							Description:     "upload queue growth rate every 5m",
-							Query:           `sum(increase(src_upload_queue_uploads_total[30m])) / sum(increase(src_upload_queue_processor_total[30m]))`,
+							Query:           `sum(increase(src_upload_queue_uploads_total[30m])) / sum(increase(src_codeintel_upload_queue_processor_total[30m]))`,
 							DataMayNotExist: true,
 
 							Warning:           monitoring.Alert().GreaterOrEqual(5),
@@ -39,7 +39,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 						{
 							Name:              "upload_process_errors",
 							Description:       "upload process errors every 5m",
-							Query:             `sum(increase(src_upload_queue_processor_errors_total[5m]))`,
+							Query:             `sum(increase(src_codeintel_upload_queue_processor_errors_total[5m]))`,
 							DataMayNotExist:   true,
 							Warning:           monitoring.Alert().GreaterOrEqual(20),
 							PanelOptions:      monitoring.PanelOptions().LegendFormat("errors"),


### PR DESCRIPTION
I want to add additional metrics to the worker process, but it's currently difficult as I'd have to create metrics and register them in a half dozen call sites.

This standardizes the metrics emitted by the worker so that you only have to pass a prometheus register. I don't believe these metrics are currently tracked in grafana, but if so yell at me quick and I'll fix it.