### PR TITLE
Merge unsynced and publication state together

### DIFF
--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -319,7 +319,8 @@ func (e *executor) importChangeset(ctx context.Context) error {
 		return err
 	}
 
-	e.ch.Unsynced = false
+	// The changeset finished importing, so it is published now.
+	e.ch.PublicationState = campaigns.ChangesetPublicationStatePublished
 
 	return nil
 }

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -98,9 +98,8 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 		},
 		"import": {
 			changeset: ct.TestChangesetOpts{
-				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 				ExternalID:       githubPR.ID,
-				Unsynced:         true,
 			},
 			plan: &Plan{
 				Ops: Operations{campaigns.ReconcilerOperationImport},
@@ -113,7 +112,6 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 				ExternalID:       githubPR.ID,
 				ExternalBranch:   githubHeadRef,
 				ExternalState:    campaigns.ChangesetExternalStateOpen,
-				Unsynced:         false,
 				Title:            githubPR.Title,
 				Body:             githubPR.Body,
 				DiffStat:         state.DiffStat,
@@ -121,9 +119,8 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 		},
 		"import and not-found error": {
 			changeset: ct.TestChangesetOpts{
-				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 				ExternalID:       githubPR.ID,
-				Unsynced:         true,
 			},
 			plan: &Plan{
 				Ops: Operations{campaigns.ReconcilerOperationImport},

--- a/enterprise/internal/campaigns/reconciler/plan.go
+++ b/enterprise/internal/campaigns/reconciler/plan.go
@@ -112,7 +112,7 @@ func DeterminePlan(previousSpec, currentSpec *campaigns.ChangesetSpec, ch *campa
 	// If it doesn't have a spec, it's an imported changeset and we can't do
 	// anything.
 	if currentSpec == nil {
-		if ch.Unsynced {
+		if ch.Unpublished() {
 			pl.SetOp(campaigns.ReconcilerOperationImport)
 		}
 		return pl, nil

--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -8,6 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/state"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
@@ -174,10 +175,9 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 
 	publishedState := campaigns.ChangesetPublicationStatePublished
 	opts := store.ListChangesetsOpts{
-		CampaignID:       r.Campaign.ID,
-		PublicationState: &publishedState,
+		CampaignID: r.Campaign.ID,
 		// Only load fully-synced changesets, so that the data we use for computing the changeset counts is complete.
-		OnlySynced: true,
+		PublicationState: &publishedState,
 	}
 	cs, _, err := r.store.ListChangesets(ctx, opts)
 	if err != nil {

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -150,8 +150,7 @@ func TestChangesetResolver(t *testing.T) {
 		Repo:                repo.ID,
 		ExternalServiceType: "github",
 		ExternalID:          "9876",
-		Unsynced:            true,
-		PublicationState:    campaigns.ChangesetPublicationStatePublished,
+		PublicationState:    campaigns.ChangesetPublicationStateUnpublished,
 		ReconcilerState:     campaigns.ReconcilerStateQueued,
 	})
 
@@ -268,7 +267,7 @@ func TestChangesetResolver(t *testing.T) {
 				ExternalID:       "9876",
 				Repository:       apitest.Repository{Name: string(repo.Name)},
 				Labels:           []apitest.Label{},
-				PublicationState: string(campaigns.ChangesetPublicationStatePublished),
+				PublicationState: string(campaigns.ChangesetPublicationStateUnpublished),
 				ReconcilerState:  string(campaigns.ReconcilerStateQueued),
 			},
 		},

--- a/enterprise/internal/campaigns/rewirer/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer.go
@@ -135,11 +135,10 @@ func (r *ChangesetRewirer) createTrackingChangeset(repo *types.Repo, externalID 
 		ExternalID:  externalID,
 		// Note: no CurrentSpecID, because we merely track this one
 
-		PublicationState: campaigns.ChangesetPublicationStatePublished,
+		PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 
 		// Enqueue it so the reconciler syncs it.
 		ReconcilerState: campaigns.ReconcilerStateQueued,
-		Unsynced:        true,
 	}
 
 	return newChangeset

--- a/enterprise/internal/campaigns/service/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service/service_apply_campaign_test.go
@@ -228,9 +228,8 @@ func TestServiceApplyCampaign(t *testing.T) {
 			ct.AssertChangeset(t, c1, ct.ChangesetAssertions{
 				Repo:             spec1.RepoID,
 				ExternalID:       "1234",
-				Unsynced:         true,
 				ReconcilerState:  campaigns.ReconcilerStateQueued,
-				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 			})
 
 			c2 := cs.Find(campaigns.WithCurrentSpecID(spec2.ID))
@@ -359,9 +358,8 @@ func TestServiceApplyCampaign(t *testing.T) {
 				CurrentSpec:      0,
 				PreviousSpec:     0,
 				ExternalID:       "1234",
-				Unsynced:         true,
 				ReconcilerState:  campaigns.ReconcilerStateQueued,
-				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 			})
 
 			c2 := cs.Find(campaigns.WithExternalID(spec2.Spec.ExternalID))
@@ -370,9 +368,8 @@ func TestServiceApplyCampaign(t *testing.T) {
 				CurrentSpec:      0,
 				PreviousSpec:     0,
 				ExternalID:       "5678",
-				Unsynced:         true,
 				ReconcilerState:  campaigns.ReconcilerStateQueued,
-				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 			})
 
 			c3 := cs.Find(campaigns.WithCurrentSpecID(spec3.ID))
@@ -728,8 +725,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 			ct.ReloadAndAssertChangeset(t, ctx, store, c1, ct.ChangesetAssertions{
 				Repo:             spec1Opts.Repo,
 				ExternalID:       "1234",
-				Unsynced:         true,
-				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 
 				ReconcilerState: campaigns.ReconcilerStateQueued,
 				FailureMessage:  nil,

--- a/enterprise/internal/campaigns/store/changesets.go
+++ b/enterprise/internal/campaigns/store/changesets.go
@@ -53,7 +53,6 @@ var ChangesetColumns = []*sqlf.Query{
 	sqlf.Sprintf("changesets.process_after"),
 	sqlf.Sprintf("changesets.num_resets"),
 	sqlf.Sprintf("changesets.num_failures"),
-	sqlf.Sprintf("changesets.unsynced"),
 	sqlf.Sprintf("changesets.closing"),
 }
 
@@ -88,7 +87,6 @@ var changesetInsertColumns = []*sqlf.Query{
 	sqlf.Sprintf("process_after"),
 	sqlf.Sprintf("num_resets"),
 	sqlf.Sprintf("num_failures"),
-	sqlf.Sprintf("unsynced"),
 	sqlf.Sprintf("closing"),
 }
 
@@ -138,7 +136,6 @@ func (s *Store) changesetWriteQuery(q string, includeID bool, c *campaigns.Chang
 		nullTimeColumn(c.ProcessAfter),
 		c.NumResets,
 		c.NumFailures,
-		c.Unsynced,
 		c.Closing,
 	}
 
@@ -180,7 +177,7 @@ func (s *Store) CreateChangeset(ctx context.Context, c *campaigns.Changeset) err
 var createChangesetQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store.go:CreateChangeset
 INSERT INTO changesets (%s)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING %s
 `
 
@@ -331,7 +328,7 @@ func (s *Store) ListChangesetSyncData(ctx context.Context, opts ListChangesetSyn
 	results := make([]*campaigns.ChangesetSyncData, 0)
 	err := s.query(ctx, q, func(sc scanner) (err error) {
 		var h campaigns.ChangesetSyncData
-		if err = scanChangesetSyncData(&h, sc); err != nil {
+		if err := scanChangesetSyncData(&h, sc); err != nil {
 			return err
 		}
 		results = append(results, &h)
@@ -409,7 +406,6 @@ type ListChangesetsOpts struct {
 	ExternalReviewState *campaigns.ChangesetReviewState
 	ExternalCheckState  *campaigns.ChangesetCheckState
 	OwnedByCampaignID   int64
-	OnlySynced          bool
 	ExternalServiceID   string
 	TextSearch          []ListChangesetsTextSearchExpr
 }
@@ -541,9 +537,6 @@ func listChangesetsQuery(opts *ListChangesetsOpts) *sqlf.Query {
 	if opts.OwnedByCampaignID != 0 {
 		preds = append(preds, sqlf.Sprintf("changesets.owned_by_campaign_id = %s", opts.OwnedByCampaignID))
 	}
-	if opts.OnlySynced {
-		preds = append(preds, sqlf.Sprintf("changesets.unsynced IS FALSE"))
-	}
 	if opts.ExternalServiceID != "" {
 		preds = append(preds, sqlf.Sprintf("repo.external_service_id = %s", opts.ExternalServiceID))
 	}
@@ -584,7 +577,7 @@ func (s *Store) UpdateChangeset(ctx context.Context, cs *campaigns.Changeset) er
 var updateChangesetQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store_changesets.go:UpdateChangeset
 UPDATE changesets
-SET (%s) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+SET (%s) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 WHERE id = %s
 RETURNING
   %s
@@ -758,7 +751,6 @@ func scanChangeset(t *campaigns.Changeset, s scanner) error {
 		&dbutil.NullTime{Time: &t.ProcessAfter},
 		&t.NumResets,
 		&t.NumFailures,
-		&t.Unsynced,
 		&t.Closing,
 	)
 	if err != nil {
@@ -828,7 +820,8 @@ const getChangesetStatsFmtstr = `
 -- source: enterprise/internal/campaigns/store_changesets.go:GetChangesetsStats
 SELECT
 	COUNT(*) AS total,
-	COUNT(*) FILTER (WHERE changesets.publication_state = 'UNPUBLISHED') AS unpublished,
+	-- Include all changesets that aren't published yet and are not imported.
+	COUNT(*) FILTER (WHERE changesets.publication_state = 'UNPUBLISHED' AND current_spec_id IS NOT NULL) AS unpublished,
 	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'CLOSED') AS closed,
 	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'DRAFT') AS draft,
 	COUNT(*) FILTER (WHERE changesets.publication_state = 'PUBLISHED' AND changesets.external_state = 'MERGED') AS merged,

--- a/enterprise/internal/campaigns/store/changesets_test.go
+++ b/enterprise/internal/campaigns/store/changesets_test.go
@@ -100,8 +100,11 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 				NumResets:       18,
 				NumFailures:     25,
 
-				Unsynced: i != 0,
-				Closing:  true,
+				Closing: true,
+			}
+
+			if i != 0 {
+				th.PublicationState = campaigns.ChangesetPublicationStateUnpublished
 			}
 
 			// Only set these fields on a subset to make sure that
@@ -533,13 +536,13 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 				opts: ListChangesetsOpts{
 					PublicationState: &statePublished,
 				},
-				wantCount: 3,
+				wantCount: 1,
 			},
 			{
 				opts: ListChangesetsOpts{
 					PublicationState: &stateUnpublished,
 				},
-				wantCount: 0,
+				wantCount: 2,
 			},
 			{
 				opts: ListChangesetsOpts{
@@ -606,12 +609,6 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			{
 				opts: ListChangesetsOpts{
 					OwnedByCampaignID: int64(1),
-				},
-				wantCount: 1,
-			},
-			{
-				opts: ListChangesetsOpts{
-					OnlySynced: true,
 				},
 				wantCount: 1,
 			},
@@ -896,11 +893,11 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		})
 
 		c4 := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-			Repo:            repo.ID,
-			Campaign:        campaignID,
-			OwnedByCampaign: 0,
-			Unsynced:        true,
-			ReconcilerState: campaigns.ReconcilerStateQueued,
+			Repo:             repo.ID,
+			Campaign:         campaignID,
+			OwnedByCampaign:  0,
+			PublicationState: campaigns.ChangesetPublicationStateUnpublished,
+			ReconcilerState:  campaigns.ReconcilerStateQueued,
 		})
 
 		c5 := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
@@ -936,9 +933,9 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		})
 
 		ct.ReloadAndAssertChangeset(t, ctx, s, c4, ct.ChangesetAssertions{
-			Repo:            repo.ID,
-			ReconcilerState: campaigns.ReconcilerStateQueued,
-			Unsynced:        true,
+			Repo:             repo.ID,
+			ReconcilerState:  campaigns.ReconcilerStateQueued,
+			PublicationState: campaigns.ChangesetPublicationStateUnpublished,
 		})
 
 		ct.ReloadAndAssertChangeset(t, ctx, s, c5, ct.ChangesetAssertions{

--- a/enterprise/internal/campaigns/syncer/syncer.go
+++ b/enterprise/internal/campaigns/syncer/syncer.go
@@ -459,7 +459,6 @@ func SyncChangeset(ctx context.Context, syncStore SyncStore, source repos.Change
 	}
 	defer func() { err = tx.Done(err) }()
 
-	c.Unsynced = false
 	if err := tx.UpdateChangeset(ctx, c); err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/testing/changeset.go
+++ b/enterprise/internal/campaigns/testing/changeset.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -34,8 +35,7 @@ type TestChangesetOpts struct {
 
 	OwnedByCampaign int64
 
-	Unsynced bool
-	Closing  bool
+	Closing bool
 
 	Metadata interface{}
 }
@@ -82,8 +82,7 @@ func BuildChangeset(opts TestChangesetOpts) *campaigns.Changeset {
 
 		OwnedByCampaignID: opts.OwnedByCampaign,
 
-		Unsynced: opts.Unsynced,
-		Closing:  opts.Closing,
+		Closing: opts.Closing,
 
 		ReconcilerState: opts.ReconcilerState,
 		NumFailures:     opts.NumFailures,
@@ -117,7 +116,6 @@ type ChangesetAssertions struct {
 	ExternalID       string
 	ExternalBranch   string
 	DiffStat         *diff.Stat
-	Unsynced         bool
 	Closing          bool
 
 	Title string
@@ -176,10 +174,6 @@ func AssertChangeset(t *testing.T, c *campaigns.Changeset, a ChangesetAssertions
 
 	if diff := cmp.Diff(a.DiffStat, c.DiffStat()); diff != "" {
 		t.Fatalf("changeset DiffStat wrong. (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(a.Unsynced, c.Unsynced); diff != "" {
-		t.Fatalf("changeset Unsynced wrong. (-want +got):\n%s", diff)
 	}
 
 	if diff := cmp.Diff(a.Closing, c.Closing); diff != "" {
@@ -255,7 +249,6 @@ func SetChangesetPublished(t *testing.T, ctx context.Context, s UpdateChangesete
 	c.PublicationState = campaigns.ChangesetPublicationStatePublished
 	c.ReconcilerState = campaigns.ReconcilerStateCompleted
 	c.ExternalState = campaigns.ChangesetExternalStateOpen
-	c.Unsynced = false
 
 	if err := s.UpdateChangeset(ctx, c); err != nil {
 		t.Fatalf("failed to update changeset: %s", err)

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -201,10 +201,6 @@ type Changeset struct {
 	NumResets       int64
 	NumFailures     int64
 
-	// Unsynced is true if the changeset tracks an external changeset but the
-	// data hasn't been synced yet.
-	Unsynced bool
-
 	// Closing is set to true (along with the ReocncilerState) when the
 	// reconciler should close the changeset.
 	Closing bool
@@ -218,14 +214,6 @@ func (c *Changeset) Clone() *Changeset {
 	tt := *c
 	tt.CampaignIDs = c.CampaignIDs[:len(c.CampaignIDs):len(c.CampaignIDs)]
 	return &tt
-}
-
-// PublishedAndSynced returns whether the Changeset has been published on the
-// code host and is fully synced.
-// This can be used as a check before accessing the fields based on synced
-// metadata, such as Title or Body, etc.
-func (c *Changeset) PublishedAndSynced() bool {
-	return !c.Unsynced && c.PublicationState.Published()
 }
 
 // Published returns whether the Changeset's PublicationState is Published.

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -167,7 +167,6 @@ Referenced by:
  finished_at           | timestamp with time zone | 
  process_after         | timestamp with time zone | 
  num_resets            | integer                  | not null default 0
- unsynced              | boolean                  | not null default false
  closing               | boolean                  | not null default false
  num_failures          | integer                  | not null default 0
  log_contents          | text                     | 

--- a/migrations/frontend/1528395770_drop_unsynced.down.sql
+++ b/migrations/frontend/1528395770_drop_unsynced.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE changesets ADD COLUMN IF NOT EXISTS unsynced boolean NOT NULL DEFAULT false;
+UPDATE changesets SET unsynced = true, publication_state = 'PUBLISHED' WHERE publication_state = 'UNPUBLISHED' AND current_spec_id IS NULL AND owned_by_campaign_id IS NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395770_drop_unsynced.up.sql
+++ b/migrations/frontend/1528395770_drop_unsynced.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+UPDATE changesets SET publication_state = 'UNPUBLISHED' WHERE unsynced = true;
+ALTER TABLE changesets DROP COLUMN IF EXISTS unsynced;
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -172,6 +172,8 @@
 // 1528395768_compress_nearest_uploads.up.sql (228B)
 // 1528395769_drop_added_to_campaign.down.sql (115B)
 // 1528395769_drop_added_to_campaign.up.sql (81B)
+// 1528395770_drop_unsynced.down.sql (279B)
+// 1528395770_drop_unsynced.up.sql (151B)
 
 package migrations
 
@@ -3680,6 +3682,46 @@ func _1528395769_drop_added_to_campaignUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395770_drop_unsyncedDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x6c\xce\xb1\x6e\xc3\x20\x14\x85\xe1\x9d\xa7\x38\x5b\x96\xbe\x81\x95\x01\x07\xd2\x20\x61\x1c\xc5\xa0\x76\x43\x18\xdf\xa6\x96\x5c\x6c\x19\xac\x2a\x6f\x5f\xb5\x1d\x9a\x4a\x99\xff\xef\x5e\x9d\x5a\x3e\x2b\x53\x31\xc6\xb5\x95\x17\x58\x5e\x6b\x89\xf8\x1e\xd2\x95\x32\x95\x0c\x2e\x04\x0e\xad\x76\x8d\x81\x3a\xc2\xb4\x16\xf2\x55\x75\xb6\xc3\x96\xf2\x2d\x45\x1a\xd0\xcf\xf3\x44\x21\xfd\x34\xe3\xb4\x86\x90\x47\xee\xb4\xc5\x5b\x98\x32\x55\xcc\x9d\x05\xb7\xff\x7e\x76\xd2\xfe\x9d\xef\x51\xd6\x8d\x9e\xb0\x6c\xfd\x34\xc6\x50\xc6\x39\xf9\x5c\x42\x21\xec\xb1\x3b\xbb\x5a\xab\xee\x24\xc5\x0e\x2f\x27\x79\x91\x8f\x95\x33\x77\x8e\x1b\x81\xb8\xad\x2b\xa5\xe2\xf3\x42\xd1\x8f\x03\x54\xf7\xbb\xec\xbb\xcd\x9f\x89\x06\xdf\xdf\x7c\x0c\x1f\x4b\x18\xaf\xe9\x0e\x54\x8c\x1d\xda\xa6\x51\xb6\x62\x5f\x01\x00\x00\xff\xff\xc8\xf8\x12\x06\x17\x01\x00\x00")
+
+func _1528395770_drop_unsyncedDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395770_drop_unsyncedDownSql,
+		"1528395770_drop_unsynced.down.sql",
+	)
+}
+
+func _1528395770_drop_unsyncedDownSql() (*asset, error) {
+	bytes, err := _1528395770_drop_unsyncedDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395770_drop_unsynced.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xda, 0x1, 0x6, 0x52, 0x65, 0x50, 0x5b, 0xcd, 0xb, 0xb9, 0xa6, 0xe7, 0xd3, 0x14, 0x15, 0x4, 0xbe, 0x2e, 0x75, 0x5e, 0x2f, 0x46, 0x28, 0x6f, 0x5a, 0xa2, 0x5d, 0x5f, 0x82, 0x3d, 0x2d, 0x4}}
+	return a, nil
+}
+
+var __1528395770_drop_unsyncedUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x54\xcc\x4b\xaa\xc2\x30\x14\x06\xe0\xf9\x59\xc5\x3f\xeb\x22\x42\x07\x7d\x9c\x7b\x1b\x48\x1f\x34\x27\xe8\x4c\x6a\x0c\x5a\x90\x28\x26\x19\xb8\x7b\x67\x82\x0b\xf8\xbe\x96\xff\xf5\xa4\x88\xdc\xd2\x37\xc2\xf0\xb7\x2d\x5e\x43\x0a\x39\xc1\xb2\xe0\x59\xce\xf7\xdd\x6f\x79\x7f\xc4\x53\xca\x5b\x0e\xa8\x51\xb9\x69\x71\xad\xd1\x76\xe0\xbe\xc2\x61\xe0\x95\x51\x62\x7a\x47\x1f\x2e\xa8\x91\x5f\x25\x28\x6a\x8c\xf0\x0a\x69\x5a\xf3\x73\xf6\xeb\xbc\xa0\x9b\x8d\x1b\x27\xe8\x3f\xf0\x51\x5b\xb1\x5f\xad\x88\xba\x79\x1c\xb5\x28\xfa\x04\x00\x00\xff\xff\x4a\x70\xa5\x2e\x97\x00\x00\x00")
+
+func _1528395770_drop_unsyncedUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395770_drop_unsyncedUpSql,
+		"1528395770_drop_unsynced.up.sql",
+	)
+}
+
+func _1528395770_drop_unsyncedUpSql() (*asset, error) {
+	bytes, err := _1528395770_drop_unsyncedUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395770_drop_unsynced.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe8, 0xe1, 0x51, 0xa7, 0x2e, 0xf0, 0xfe, 0xba, 0x92, 0x46, 0xa5, 0x44, 0x17, 0xf0, 0x37, 0x7, 0x91, 0xbc, 0x1a, 0x9, 0x87, 0xd6, 0xee, 0xa0, 0x7e, 0x2e, 0xc0, 0x45, 0x1e, 0x8b, 0x54, 0x7b}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -3943,6 +3985,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395768_compress_nearest_uploads.up.sql":                                             _1528395768_compress_nearest_uploadsUpSql,
 	"1528395769_drop_added_to_campaign.down.sql":                                             _1528395769_drop_added_to_campaignDownSql,
 	"1528395769_drop_added_to_campaign.up.sql":                                               _1528395769_drop_added_to_campaignUpSql,
+	"1528395770_drop_unsynced.down.sql":                                                      _1528395770_drop_unsyncedDownSql,
+	"1528395770_drop_unsynced.up.sql":                                                        _1528395770_drop_unsyncedUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -4161,6 +4205,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395768_compress_nearest_uploads.up.sql":                                             {_1528395768_compress_nearest_uploadsUpSql, map[string]*bintree{}},
 	"1528395769_drop_added_to_campaign.down.sql":                                             {_1528395769_drop_added_to_campaignDownSql, map[string]*bintree{}},
 	"1528395769_drop_added_to_campaign.up.sql":                                               {_1528395769_drop_added_to_campaignUpSql, map[string]*bintree{}},
+	"1528395770_drop_unsynced.down.sql":                                                      {_1528395770_drop_unsyncedDownSql, map[string]*bintree{}},
+	"1528395770_drop_unsynced.up.sql":                                                        {_1528395770_drop_unsyncedUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
Unsynced can actually be derived from publication state, so why have two different ways for branch and imported changesets. This PR merges the two into a unified solution, making the publication state the single source of truth. Also, this makes more sense with the default value we have for the column in the database.