### PR TITLE
Offset the limitation of directory decorations in a note and imply that it might display on the code host someday

### DIFF
--- a/doc/extensions/authoring/tutorials/file_decorations.md
+++ b/doc/extensions/authoring/tutorials/file_decorations.md
@@ -4,7 +4,7 @@
 
 Extensions can decorate files in the file tree and/or directory page with text content and/or a `<meter/>` element. In this tutorial, you'll build an extension that decorates directories with the length of their names.
 
-Caveat: file decorations are only displayed on Sourcegraph, not on code hosts.
+> Note: Currently, file decorations are only displayed on Sourcegraph, not on code hosts.
 
 ## Prerequisites
 


### PR DESCRIPTION
Felt worth offsetting and I want to open the door for customers to ask "when would this be available on the code host" if they want that, rather than make it sound like an intentional decision to not do this. 