### PR TITLE
repo-updater: remove store interface

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -30,7 +30,7 @@ import (
 
 // Server is a repoupdater server.
 type Server struct {
-	repos.Store
+	*repos.Store
 	*repos.Syncer
 	RepoLister            repos.Lister
 	SourcegraphDotComMode bool
@@ -119,7 +119,7 @@ func (s *Server) handleRepoExternalServices(w http.ResponseWriter, r *http.Reque
 		OrderByDirection: "ASC",
 	}
 
-	es, err := s.Store.ExternalServiceStore().List(r.Context(), args)
+	es, err := s.Store.ExternalServiceStore.List(r.Context(), args)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return
@@ -157,7 +157,7 @@ func (s *Server) handleExcludeRepo(w http.ResponseWriter, r *http.Request) {
 		OrderByDirection: "ASC",
 	}
 
-	es, err := s.Store.ExternalServiceStore().List(r.Context(), args)
+	es, err := s.Store.ExternalServiceStore.List(r.Context(), args)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return
@@ -189,7 +189,7 @@ func (s *Server) handleExcludeRepo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err = s.Store.ExternalServiceStore().Upsert(r.Context(), es...)
+	err = s.Store.ExternalServiceStore.Upsert(r.Context(), es...)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)
 		return

--- a/enterprise/cmd/repo-updater/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/authz/integration_test.go
@@ -71,14 +71,14 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	testDB := dbtest.NewDB(t, *dsn)
 	ctx := actor.WithInternalActor(context.Background())
 
-	reposStore := repos.NewDBStore(testDB, sql.TxOptions{})
+	reposStore := repos.NewStore(testDB, sql.TxOptions{})
 
 	svc := types.ExternalService{
 		Kind:      extsvc.KindGitHub,
 		CreatedAt: timeutil.Now(),
 		Config:    `{"url": "https://github.com", "authorization": {}}`,
 	}
-	err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
+	err = reposStore.ExternalServiceStore.Upsert(ctx, &svc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			},
 		},
 	}
-	err = reposStore.RepoStore().Create(ctx, &repo)
+	err = reposStore.RepoStore.Create(ctx, &repo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	}
 
 	permsStore := edb.NewPermsStore(testDB, timeutil.Now)
-	syncer := NewPermsSyncer(reposStore.RepoStore(), permsStore, timeutil.Now, nil)
+	syncer := NewPermsSyncer(reposStore.RepoStore, permsStore, timeutil.Now, nil)
 
 	err = syncer.syncRepoPerms(ctx, repo.ID, false)
 	if err != nil {

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -125,12 +125,12 @@ func (s GitoliteSource) makeRepo(repo *gitolite.Repo) *types.Repo {
 type GitolitePhabricatorMetadataSyncer struct {
 	sem     *semaphore.Weighted // Only one sync at a time, like it was done before.
 	counter int64               // Only sync every 10th time, like it was done before.
-	store   Store               // Use to load the external services that yielded a given repo.
+	store   *Store              // Use to load the external services that yielded a given repo.
 }
 
 // NewGitolitePhabricatorMetadataSyncer returns a GitolitePhabricatorMetadataSyncer with
 // the given parameters.
-func NewGitolitePhabricatorMetadataSyncer(s Store) *GitolitePhabricatorMetadataSyncer {
+func NewGitolitePhabricatorMetadataSyncer(s *Store) *GitolitePhabricatorMetadataSyncer {
 	return &GitolitePhabricatorMetadataSyncer{
 		sem:     semaphore.NewWeighted(1),
 		counter: -1,
@@ -173,7 +173,7 @@ func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*t
 		return nil
 	}
 
-	es, err := s.store.ExternalServiceStore().List(ctx, db.ExternalServicesListOptions{IDs: ids})
+	es, err := s.store.ExternalServiceStore.List(ctx, db.ExternalServicesListOptions{IDs: ids})
 	if err != nil {
 		return errors.Wrap(err, "gitolite-phabricator-metadata-syncer.store.list-external-services")
 	}

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -31,7 +31,7 @@ func TestIntegration(t *testing.T) {
 
 	db := dbtest.NewDB(t, *dsn)
 
-	store := repos.NewDBStore(db, sql.TxOptions{
+	store := repos.NewStore(db, sql.TxOptions{
 		Isolation: sql.LevelReadCommitted,
 	})
 
@@ -51,7 +51,7 @@ func TestIntegration(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		test func(*testing.T, repos.Store) func(*testing.T)
+		test func(*testing.T, *repos.Store) func(*testing.T)
 	}{
 		{"DBStore/SyncRateLimiters", testSyncRateLimiters},
 		{"DBStore/UpsertRepos", testStoreUpsertRepos},

--- a/internal/repos/phabricator.go
+++ b/internal/repos/phabricator.go
@@ -183,11 +183,11 @@ func (s *PhabricatorSource) client(ctx context.Context) (*phabricator.Client, er
 }
 
 // RunPhabricatorRepositorySyncWorker runs the worker that syncs repositories from Phabricator to Sourcegraph
-func RunPhabricatorRepositorySyncWorker(ctx context.Context, s Store) {
+func RunPhabricatorRepositorySyncWorker(ctx context.Context, s *Store) {
 	cf := httpcli.NewExternalHTTPClientFactory()
 
 	for {
-		phabs, err := s.ExternalServiceStore().List(ctx, db.ExternalServicesListOptions{
+		phabs, err := s.ExternalServiceStore.List(ctx, db.ExternalServicesListOptions{
 			Kinds: []string{extsvc.KindPhabricator},
 		})
 		if err != nil {

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -23,8 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// Store implements the Store interface for reading and writing repos directly
-// from the Postgres database.
+// A Store exposes methods to read and write repos and external services.
 type Store struct {
 	*basestore.Store
 

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -23,97 +23,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// A Store exposes methods to read and write repos and external services.
-type Store interface {
-	RepoStore() *idb.RepoStore
-	ExternalServiceStore() *idb.ExternalServiceStore
-
-	UpsertRepos(ctx context.Context, repos ...*types.Repo) error
-	ListExternalRepoSpecs(context.Context) (map[api.ExternalRepoSpec]struct{}, error)
-	UpsertSources(ctx context.Context, inserts, updates, deletes map[api.RepoID][]types.SourceInfo) error
-	SetClonedRepos(ctx context.Context, repoNames ...string) error
-	CountNotClonedRepos(ctx context.Context) (uint64, error)
-	CountUserAddedRepos(ctx context.Context) (uint64, error)
-
-	// EnqueueSyncJobs enqueues sync jobs per external service where their next_sync_at is due.
-	// If ignoreSiteAdmin is true then we only sync user added external services.
-	EnqueueSyncJobs(ctx context.Context, ignoreSiteAdmin bool) error
-}
-
-// A Transactor can initialize and return a TxStore which operates
-// within the context of a transaction.
-type Transactor interface {
-	Transact(context.Context) (TxStore, error)
-}
-
-// A TxStore is a Store that operates within the context of a transaction.
-// Done should be called to terminate the underlying transaction. Once a TxStore
-// is done, it can't be used further. Initiate a new one from its original
-// Transactor.
-type TxStore interface {
-	Store
-	Done(error) error
-}
-
-// repoRecord is the json representation of a repository as used in this package
-// Postgres CTEs.
-type repoRecord struct {
-	ID                  api.RepoID      `json:"id"`
-	Name                string          `json:"name"`
-	URI                 *string         `json:"uri,omitempty"`
-	Description         string          `json:"description"`
-	CreatedAt           time.Time       `json:"created_at"`
-	UpdatedAt           *time.Time      `json:"updated_at,omitempty"`
-	DeletedAt           *time.Time      `json:"deleted_at,omitempty"`
-	ExternalServiceType *string         `json:"external_service_type,omitempty"`
-	ExternalServiceID   *string         `json:"external_service_id,omitempty"`
-	ExternalID          *string         `json:"external_id,omitempty"`
-	Archived            bool            `json:"archived"`
-	Fork                bool            `json:"fork"`
-	Private             bool            `json:"private"`
-	Metadata            json.RawMessage `json:"metadata"`
-	Sources             json.RawMessage `json:"sources,omitempty"`
-}
-
-func newRepoRecord(r *types.Repo) (*repoRecord, error) {
-	metadata, err := metadataColumn(r.Metadata)
-	if err != nil {
-		return nil, errors.Wrapf(err, "newRecord: metadata marshalling failed")
-	}
-
-	sources, err := sourcesColumn(r.ID, r.Sources)
-	if err != nil {
-		return nil, errors.Wrapf(err, "newRecord: sources marshalling failed")
-	}
-
-	return &repoRecord{
-		ID:                  r.ID,
-		Name:                string(r.Name),
-		URI:                 nullStringColumn(r.URI),
-		Description:         r.Description,
-		CreatedAt:           r.CreatedAt.UTC(),
-		UpdatedAt:           nullTimeColumn(r.UpdatedAt.UTC()),
-		DeletedAt:           nullTimeColumn(r.DeletedAt.UTC()),
-		ExternalServiceType: nullStringColumn(r.ExternalRepo.ServiceType),
-		ExternalServiceID:   nullStringColumn(r.ExternalRepo.ServiceID),
-		ExternalID:          nullStringColumn(r.ExternalRepo.ID),
-		Archived:            r.Archived,
-		Fork:                r.Fork,
-		Private:             r.Private,
-		Metadata:            metadata,
-		Sources:             sources,
-	}, nil
-}
-
-// WithStore is a store that can take a db handle and return
-// a new Store implementation that uses it.
-type WithStore interface {
-	With(dbutil.DB) Store
-}
-
-// DBStore implements the Store interface for reading and writing repos directly
+// Store implements the Store interface for reading and writing repos directly
 // from the Postgres database.
-type DBStore struct {
+type Store struct {
 	*basestore.Store
 
 	// Logger used by the store. Defaults to log15.Root().
@@ -122,26 +34,43 @@ type DBStore struct {
 	Metrics StoreMetrics
 	// Used for tracing calls to store methods. Uses opentracing.GlobalTracer() by default.
 	Tracer trace.Tracer
+	// RepoStore is a db.RepoStore using the same database handle.
+	RepoStore *idb.RepoStore
+	// ExternalServiceStore is a db.ExternalServiceStore using the same database handle.
+	ExternalServiceStore *idb.ExternalServiceStore
+	// Used to mock calls to certain methods.
+	Mocks MockStore
 
 	txtrace *trace.Trace
 	txctx   context.Context
 }
 
-// NewDBStore instantiates and returns a new DBStore with prepared statements.
-func NewDBStore(db dbutil.DB, txOpts sql.TxOptions) *DBStore {
-	return &DBStore{
-		Store:  basestore.NewWithDB(db, txOpts),
-		Log:    log15.Root(),
-		Tracer: trace.Tracer{Tracer: opentracing.GlobalTracer()},
+// NewStore instantiates and returns a new DBStore with prepared statements.
+func NewStore(db dbutil.DB, txOpts sql.TxOptions) *Store {
+	s := basestore.NewWithDB(db, txOpts)
+	return &Store{
+		Store:                s,
+		RepoStore:            idb.NewRepoStoreWith(s),
+		ExternalServiceStore: idb.NewExternalServicesStoreWith(s),
+		Log:                  log15.Root(),
+		Tracer:               trace.Tracer{Tracer: opentracing.GlobalTracer()},
 	}
 }
 
-func (s *DBStore) With(other basestore.ShareableStore) *DBStore {
-	return &DBStore{Store: s.Store.With(other)}
+func (s *Store) With(other basestore.ShareableStore) *Store {
+	return &Store{
+		Store:                s.Store.With(other),
+		RepoStore:            s.RepoStore.With(other),
+		ExternalServiceStore: s.ExternalServiceStore.With(other),
+		Log:                  s.Log,
+		Metrics:              s.Metrics,
+		Tracer:               s.Tracer,
+		Mocks:                s.Mocks,
+	}
 }
 
 // Transact returns a TxStore whose methods operate within the context of a transaction.
-func (s *DBStore) Transact(ctx context.Context) (stx TxStore, err error) {
+func (s *Store) Transact(ctx context.Context) (stx *Store, err error) {
 	tr, ctx := s.trace(ctx, "Store.Transact")
 
 	defer func(began time.Time) {
@@ -159,18 +88,21 @@ func (s *DBStore) Transact(ctx context.Context) (stx TxStore, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "starting transaction")
 	}
-	return &DBStore{
-		Store:   txBase,
-		Log:     s.Log,
-		Metrics: s.Metrics,
-		Tracer:  s.Tracer,
-		txtrace: tr,
-		txctx:   ctx,
+	return &Store{
+		Store:                txBase,
+		RepoStore:            s.RepoStore.With(txBase),
+		ExternalServiceStore: s.ExternalServiceStore.With(txBase),
+		Log:                  s.Log,
+		Metrics:              s.Metrics,
+		Tracer:               s.Tracer,
+		Mocks:                s.Mocks,
+		txtrace:              tr,
+		txctx:                ctx,
 	}, nil
 }
 
 // Done calls into the inner Store Done method.
-func (s *DBStore) Done(err error) error {
+func (s *Store) Done(err error) error {
 	tr := s.txtrace
 	tr.LogFields(otlog.String("event", "Store.Done"))
 
@@ -195,17 +127,7 @@ func (s *DBStore) Done(err error) error {
 	return s.Store.Done(err)
 }
 
-// RepoStore returns a db.RepoStore using the same database handle.
-func (s *DBStore) RepoStore() *idb.RepoStore {
-	return idb.NewRepoStoreWith(s)
-}
-
-// ExternalServiceStore returns a db.ExternalServiceStore using the same database handle.
-func (s *DBStore) ExternalServiceStore() *idb.ExternalServiceStore {
-	return idb.NewExternalServicesStoreWith(s)
-}
-
-func (s *DBStore) trace(ctx context.Context, family string) (*trace.Trace, context.Context) {
+func (s *Store) trace(ctx context.Context, family string) (*trace.Trace, context.Context) {
 	txctx := s.txctx
 	if txctx == nil {
 		txctx = ctx
@@ -215,7 +137,7 @@ func (s *DBStore) trace(ctx context.Context, family string) (*trace.Trace, conte
 	return tr, ctx
 }
 
-func (s *DBStore) ListExternalRepoSpecs(ctx context.Context) (ids map[api.ExternalRepoSpec]struct{}, err error) {
+func (s *Store) ListExternalRepoSpecs(ctx context.Context) (ids map[api.ExternalRepoSpec]struct{}, err error) {
 	tr, ctx := s.trace(ctx, "Store.ListExternalRepoSpecs")
 
 	defer func(began time.Time) {
@@ -276,7 +198,7 @@ type externalServiceRepo struct {
 	CloneURL          string `json:"clone_url"`
 }
 
-func (s *DBStore) UpsertSources(ctx context.Context, inserts, updates, deletes map[api.RepoID][]types.SourceInfo) (err error) {
+func (s *Store) UpsertSources(ctx context.Context, inserts, updates, deletes map[api.RepoID][]types.SourceInfo) (err error) {
 	tr, ctx := s.trace(ctx, "Store.UpsertSources")
 	tr.LogFields(otlog.Int("count", len(inserts)+len(deletes)))
 
@@ -417,7 +339,7 @@ delete_sources AS (
 // SetClonedRepos updates cloned status for all repositories.
 // All repositories whose name is in repoNames will have their cloned column set to true
 // and every other repository will have it set to false.
-func (s *DBStore) SetClonedRepos(ctx context.Context, repoNames ...string) (err error) {
+func (s *Store) SetClonedRepos(ctx context.Context, repoNames ...string) (err error) {
 	tr, ctx := s.trace(ctx, "Store.SetClonedRepos")
 	tr.LogFields(otlog.Int("count", len(repoNames)))
 
@@ -459,7 +381,7 @@ WHERE repo.id IN (SELECT id FROM cloned_repos) AND NOT cloned
 `
 
 // CountNotClonedRepos returns the number of repos whose cloned column is true.
-func (s *DBStore) CountNotClonedRepos(ctx context.Context) (count uint64, err error) {
+func (s *Store) CountNotClonedRepos(ctx context.Context) (count uint64, err error) {
 	tr, ctx := s.trace(ctx, "Store.CountNotClonedRepos")
 
 	defer func(began time.Time) {
@@ -487,7 +409,7 @@ SELECT COUNT(*) FROM repo WHERE deleted_at IS NULL AND NOT cloned
 
 // CountUserAddedRepos counts the total number of repos that have been added
 // by user owned external services.
-func (s *DBStore) CountUserAddedRepos(ctx context.Context) (count uint64, err error) {
+func (s *Store) CountUserAddedRepos(ctx context.Context) (count uint64, err error) {
 	tr, ctx := s.trace(ctx, "Store.CountUserAddedRepos")
 
 	defer func(began time.Time) {
@@ -530,7 +452,7 @@ WHERE
 // parameters
 type paginatedQuery func(cursor, limit int64) *sqlf.Query
 
-func (s *DBStore) paginate(ctx context.Context, limit, perPage int64, cursor int64, q paginatedQuery, scan scanFunc) (err error) {
+func (s *Store) paginate(ctx context.Context, limit, perPage int64, cursor int64, q paginatedQuery, scan scanFunc) (err error) {
 	const defaultPerPageLimit = 10000
 
 	if perPage <= 0 {
@@ -564,7 +486,7 @@ func (s *DBStore) paginate(ctx context.Context, limit, perPage int64, cursor int
 	return err
 }
 
-func (s *DBStore) list(ctx context.Context, q *sqlf.Query, scan scanFunc) (last, count int64, err error) {
+func (s *Store) list(ctx context.Context, q *sqlf.Query, scan scanFunc) (last, count int64, err error) {
 	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return 0, 0, err
@@ -578,7 +500,10 @@ func (s *DBStore) list(ctx context.Context, q *sqlf.Query, scan scanFunc) (last,
 // The cloned column is not updated by this function.
 // This method does NOT update sources in the external_services_repo table.
 // Use UpsertSources for that purpose.
-func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*types.Repo) (err error) {
+func (s *Store) UpsertRepos(ctx context.Context, repos ...*types.Repo) (err error) {
+	if s.Mocks.UpsertRepos != nil {
+		return s.Mocks.UpsertRepos(ctx, repos...)
+	}
 	tr, ctx := s.trace(ctx, "Store.UpsertRepos")
 	tr.LogFields(otlog.Int("count", len(repos)))
 
@@ -673,7 +598,7 @@ func (s *DBStore) UpsertRepos(ctx context.Context, repos ...*types.Repo) (err er
 	return nil
 }
 
-func (s *DBStore) EnqueueSyncJobs(ctx context.Context, ignoreSiteAdmin bool) (err error) {
+func (s *Store) EnqueueSyncJobs(ctx context.Context, ignoreSiteAdmin bool) (err error) {
 	tr, ctx := s.trace(ctx, "Store.EnqueueSyncJobs")
 
 	defer func(began time.Time) {
@@ -712,7 +637,7 @@ SELECT id from due EXCEPT SELECT id from busy
 `
 
 // ListSyncJobs returns all sync jobs.
-func (s *DBStore) ListSyncJobs(ctx context.Context) ([]SyncJob, error) {
+func (s *Store) ListSyncJobs(ctx context.Context) ([]SyncJob, error) {
 	q := sqlf.Sprintf(`
 		SELECT
 			id,
@@ -972,4 +897,59 @@ func closeErr(c io.Closer, err *error) {
 	if e := c.Close(); err != nil && *err == nil {
 		*err = e
 	}
+}
+
+// repoRecord is the json representation of a repository as used in this package
+// Postgres CTEs.
+type repoRecord struct {
+	ID                  api.RepoID      `json:"id"`
+	Name                string          `json:"name"`
+	URI                 *string         `json:"uri,omitempty"`
+	Description         string          `json:"description"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           *time.Time      `json:"updated_at,omitempty"`
+	DeletedAt           *time.Time      `json:"deleted_at,omitempty"`
+	ExternalServiceType *string         `json:"external_service_type,omitempty"`
+	ExternalServiceID   *string         `json:"external_service_id,omitempty"`
+	ExternalID          *string         `json:"external_id,omitempty"`
+	Archived            bool            `json:"archived"`
+	Fork                bool            `json:"fork"`
+	Private             bool            `json:"private"`
+	Metadata            json.RawMessage `json:"metadata"`
+	Sources             json.RawMessage `json:"sources,omitempty"`
+}
+
+func newRepoRecord(r *types.Repo) (*repoRecord, error) {
+	metadata, err := metadataColumn(r.Metadata)
+	if err != nil {
+		return nil, errors.Wrapf(err, "newRecord: metadata marshalling failed")
+	}
+
+	sources, err := sourcesColumn(r.ID, r.Sources)
+	if err != nil {
+		return nil, errors.Wrapf(err, "newRecord: sources marshalling failed")
+	}
+
+	return &repoRecord{
+		ID:                  r.ID,
+		Name:                string(r.Name),
+		URI:                 nullStringColumn(r.URI),
+		Description:         r.Description,
+		CreatedAt:           r.CreatedAt.UTC(),
+		UpdatedAt:           nullTimeColumn(r.UpdatedAt.UTC()),
+		DeletedAt:           nullTimeColumn(r.DeletedAt.UTC()),
+		ExternalServiceType: nullStringColumn(r.ExternalRepo.ServiceType),
+		ExternalServiceID:   nullStringColumn(r.ExternalRepo.ServiceID),
+		ExternalID:          nullStringColumn(r.ExternalRepo.ID),
+		Archived:            r.Archived,
+		Fork:                r.Fork,
+		Private:             r.Private,
+		Metadata:            metadata,
+		Sources:             sources,
+	}, nil
+}
+
+// MockStore is used to mock calls to certain DBStore methods.
+type MockStore struct {
+	UpsertRepos func(ctx context.Context, repos ...*types.Repo) (err error)
 }

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
+func testStoreUpsertRepos(t *testing.T, store *repos.Store) func(*testing.T) {
 	clock := dbtesting.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
@@ -172,7 +172,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		})
 
-		t.Run("many repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("many repos", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			want := mkRepos(7, repositories...)
 
 			if err := tx.UpsertRepos(ctx, want...); err != nil {
@@ -188,7 +188,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Fatalf("UpsertRepos didn't assign an ID to all repos: %v", noID.Names())
 			}
 
-			have, err := tx.RepoStore().List(ctx, idb.ReposListOptions{
+			have, err := tx.RepoStore.List(ctx, idb.ReposListOptions{
 				ServiceTypes: kinds,
 			})
 			if err != nil {
@@ -215,7 +215,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Errorf("UpsertRepos error: %s", err)
 			} else if err = tx.UpsertSources(ctx, want.Clone().Sources(), nil, nil); err != nil {
 				t.Fatalf("UpsertSources error: %s", err)
-			} else if have, err = tx.RepoStore().List(ctx, idb.ReposListOptions{}); err != nil {
+			} else if have, err = tx.RepoStore.List(ctx, idb.ReposListOptions{}); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := cmp.Diff(have, []*types.Repo(want), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -226,7 +226,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 
 			if err = tx.UpsertRepos(ctx, deleted...); err != nil {
 				t.Fatalf("UpsertRepos error: %s", err)
-			} else if have, err = tx.RepoStore().List(ctx, args); err != nil {
+			} else if have, err = tx.RepoStore.List(ctx, args); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := cmp.Diff(have, []*types.Repo(nil), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -237,7 +237,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Errorf("UpsertRepos error: %s", err)
 			} else if err = tx.UpsertSources(ctx, want.Clone().Sources(), nil, nil); err != nil {
 				t.Fatalf("UpsertSources error: %s", err)
-			} else if have, err = tx.RepoStore().List(ctx, idb.ReposListOptions{}); err != nil {
+			} else if have, err = tx.RepoStore.List(ctx, idb.ReposListOptions{}); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := cmp.Diff(have, []*types.Repo(want), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -255,7 +255,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Fatalf("UpsertRepos want error: %s", err)
 			} else if err = tx.UpsertSources(ctx, want.Sources(), nil, nil); err != nil {
 				t.Fatalf("UpsertSources error: %s", err)
-			} else if have, err = tx.RepoStore().List(ctx, idb.ReposListOptions{}); err != nil {
+			} else if have, err = tx.RepoStore.List(ctx, idb.ReposListOptions{}); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := cmp.Diff(have, []*types.Repo(want), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -264,7 +264,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		}))
 
-		t.Run("many repos soft-deleted and single repo reinserted", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("many repos soft-deleted and single repo reinserted", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			all := mkRepos(7, repositories...)
 
 			if err := tx.UpsertRepos(ctx, all...); err != nil {
@@ -280,7 +280,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Fatalf("UpsertRepos didn't assign an ID to all repos: %v", noID.Names())
 			}
 
-			have, err := tx.RepoStore().List(ctx, idb.ReposListOptions{
+			have, err := tx.RepoStore.List(ctx, idb.ReposListOptions{
 				ServiceTypes: kinds,
 			})
 			if err != nil {
@@ -296,7 +296,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 
 			if err = tx.UpsertRepos(ctx, allDeleted...); err != nil {
 				t.Fatalf("UpsertRepos error: %s", err)
-			} else if have, err = tx.RepoStore().List(ctx, args); err != nil {
+			} else if have, err = tx.RepoStore.List(ctx, args); err != nil {
 				t.Errorf("ListRepos error: %s", err)
 			} else if diff := cmp.Diff(have, []*types.Repo(nil), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ListRepos:\n%s", diff)
@@ -315,7 +315,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Fatalf("UpsertSources error: %s", err)
 			}
 
-			if have, err = tx.RepoStore().List(ctx, idb.ReposListOptions{}); err != nil {
+			if have, err = tx.RepoStore.List(ctx, idb.ReposListOptions{}); err != nil {
 				t.Fatalf("ListRepos error: %s", err)
 			}
 			if diff := cmp.Diff(have, []*types.Repo(want), cmpopts.EquateEmpty()); diff != "" {
@@ -323,7 +323,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		}))
 
-		t.Run("it shouldn't modify the cloned column", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("it shouldn't modify the cloned column", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			// UpsertRepos shouldn't set the cloned column to true
 			r := mkRepos(1, repositories...)[0]
 			r.Cloned = true
@@ -360,7 +360,7 @@ func testStoreUpsertRepos(t *testing.T, store repos.Store) func(*testing.T) {
 	}
 }
 
-func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
+func testStoreUpsertSources(t *testing.T, store *repos.Store) func(*testing.T) {
 	clock := dbtesting.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
@@ -418,7 +418,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		})
 
-		t.Run("delete repo", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("delete repo", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			want := mkRepos(7, repositories...)
 
 			if err := tx.UpsertRepos(ctx, want...); err != nil {
@@ -433,7 +433,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 
 			// delete a repository
 			want[0].DeletedAt = now
-			if err := tx.RepoStore().Delete(ctx, want[0].ID); err != nil {
+			if err := tx.RepoStore.Delete(ctx, want[0].ID); err != nil {
 				t.Fatalf("UpsertRepos error: %s", err)
 			}
 
@@ -446,7 +446,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 			// it should not contain any source
 			want[0].Sources = nil
 
-			got, err := tx.RepoStore().List(ctx, idb.ReposListOptions{})
+			got, err := tx.RepoStore.List(ctx, idb.ReposListOptions{})
 			if err != nil {
 				t.Fatalf("ListRepos error: %s", err)
 			}
@@ -456,7 +456,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		}))
 
-		t.Run("delete external service", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("delete external service", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			origRepos := mkRepos(7, repositories...)
 
 			if err := tx.UpsertRepos(ctx, origRepos...); err != nil {
@@ -472,13 +472,13 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 			// delete an external service
 			svc := servicesPerKind[extsvc.KindGitHub]
 			svc.DeletedAt = now
-			if err := tx.ExternalServiceStore().Upsert(ctx, svc); err != nil {
+			if err := tx.ExternalServiceStore.Upsert(ctx, svc); err != nil {
 				t.Fatalf("Upsert externalServices error: %s", err)
 			}
 
 			// un delete it
 			svc.DeletedAt = time.Time{}
-			if err := tx.ExternalServiceStore().Upsert(ctx, svc); err != nil {
+			if err := tx.ExternalServiceStore.Upsert(ctx, svc); err != nil {
 				t.Fatalf("Upsert externalServices error: %s", err)
 			}
 
@@ -495,7 +495,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 				}
 			})
 
-			got, err := tx.RepoStore().List(ctx, idb.ReposListOptions{})
+			got, err := tx.RepoStore.List(ctx, idb.ReposListOptions{})
 			if err != nil {
 				t.Fatalf("ListRepos error: %s", err)
 			}
@@ -505,7 +505,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		}))
 
-		t.Run("inserts updates and deletes", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("inserts updates and deletes", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			want := mkRepos(7, repositories...)
 
 			if err := tx.UpsertRepos(ctx, want...); err != nil {
@@ -518,7 +518,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 				t.Fatalf("UpsertSources error: %s", err)
 			}
 
-			have, err := tx.RepoStore().List(ctx, idb.ReposListOptions{})
+			have, err := tx.RepoStore.List(ctx, idb.ReposListOptions{})
 			if err != nil {
 				t.Fatalf("ListRepos error: %s", err)
 			}
@@ -547,7 +547,7 @@ func testStoreUpsertSources(t *testing.T, store repos.Store) func(*testing.T) {
 			// by the time it become orphaned.
 			want = append(want[:1], want[2:]...)
 
-			have, err = tx.RepoStore().List(ctx, idb.ReposListOptions{})
+			have, err = tx.RepoStore.List(ctx, idb.ReposListOptions{})
 			if err != nil {
 				t.Fatalf("ListRepos error: %s", err)
 			}
@@ -563,7 +563,7 @@ func isCloned(r *types.Repo) bool {
 	return r.Cloned
 }
 
-func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
+func testStoreSetClonedRepos(t *testing.T, store *repos.Store) func(*testing.T) {
 	servicesPerKind := createExternalServices(t, store)
 
 	return func(t *testing.T) {
@@ -588,10 +588,10 @@ func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 			})
 		}
 
-		check := func(t testing.TB, ctx context.Context, tx repos.Store, wantNames []string) {
+		check := func(t testing.TB, ctx context.Context, tx *repos.Store, wantNames []string) {
 			t.Helper()
 
-			res, err := tx.RepoStore().List(ctx, idb.ReposListOptions{})
+			res, err := tx.RepoStore.List(ctx, idb.ReposListOptions{})
 			if err != nil {
 				t.Fatalf("ListRepos error: %s", err)
 			}
@@ -612,10 +612,10 @@ func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 			}
 		})
 
-		t.Run("many repo names", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("many repo names", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			stored := mkRepos(9, repositories...)
 
-			if err := tx.RepoStore().Create(ctx, stored...); err != nil {
+			if err := tx.RepoStore.Create(ctx, stored...); err != nil {
 				t.Fatalf("InsertRepos error: %s", err)
 			}
 
@@ -646,7 +646,7 @@ func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 			check(t, ctx, tx, names)
 		}))
 
-		t.Run("repo names in mixed case", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("repo names in mixed case", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			stored := mkRepos(9, repositories...)
 			for i := range stored {
 				if i%2 == 0 {
@@ -654,7 +654,7 @@ func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 				}
 			}
 
-			if err := tx.RepoStore().Create(ctx, stored...); err != nil {
+			if err := tx.RepoStore.Create(ctx, stored...); err != nil {
 				t.Fatalf("InsertRepos error: %s", err)
 			}
 
@@ -677,7 +677,7 @@ func testStoreSetClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
 	}
 }
 
-func testStoreCountNotClonedRepos(t *testing.T, store repos.Store) func(*testing.T) {
+func testStoreCountNotClonedRepos(t *testing.T, store *repos.Store) func(*testing.T) {
 	return func(t *testing.T) {
 		servicesPerKind := createExternalServices(t, store)
 
@@ -714,10 +714,10 @@ func testStoreCountNotClonedRepos(t *testing.T, store repos.Store) func(*testing
 			}
 		})
 
-		t.Run("multiple cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("multiple cloned repos", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			stored := mkRepos(10, repositories...)
 
-			if err := tx.RepoStore().Create(ctx, stored...); err != nil {
+			if err := tx.RepoStore.Create(ctx, stored...); err != nil {
 				t.Fatalf("InsertRepos error: %s", err)
 			}
 
@@ -739,10 +739,10 @@ func testStoreCountNotClonedRepos(t *testing.T, store repos.Store) func(*testing
 			}
 		}))
 
-		t.Run("deleted non cloned repos", transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		t.Run("deleted non cloned repos", transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			stored := mkRepos(10, repositories...)
 
-			if err := tx.RepoStore().Create(ctx, stored...); err != nil {
+			if err := tx.RepoStore.Create(ctx, stored...); err != nil {
 				t.Fatalf("InsertRepos error: %s", err)
 			}
 
@@ -756,7 +756,7 @@ func testStoreCountNotClonedRepos(t *testing.T, store repos.Store) func(*testing
 			sort.Strings(cloned)
 			deletedCloned := stored[8:]
 
-			if err := tx.RepoStore().Delete(ctx, deletedCloned.IDs()...); err != nil {
+			if err := tx.RepoStore.Delete(ctx, deletedCloned.IDs()...); err != nil {
 				t.Fatalf("UpsertRepos error: %s", err)
 			}
 
@@ -786,8 +786,8 @@ func hasID(ids ...api.RepoID) func(r *types.Repo) bool {
 	}
 }
 
-func testStoreListExternalRepoSpecs(db *sql.DB) func(t *testing.T, repoStore repos.Store) func(*testing.T) {
-	return func(t *testing.T, store repos.Store) func(*testing.T) {
+func testStoreListExternalRepoSpecs(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(*testing.T) {
+	return func(t *testing.T, store *repos.Store) func(*testing.T) {
 		return func(t *testing.T) {
 			ctx := context.Background()
 
@@ -823,13 +823,13 @@ VALUES
 	}
 }
 
-func testSyncRateLimiters(t *testing.T, store repos.Store) func(*testing.T) {
+func testSyncRateLimiters(t *testing.T, store *repos.Store) func(*testing.T) {
 	clock := dbtesting.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	return func(t *testing.T) {
 		ctx := context.Background()
-		transact(ctx, store, func(t testing.TB, tx repos.Store) {
+		transact(ctx, store, func(t testing.TB, tx *repos.Store) {
 			toCreate := 501 // Larger than default page size in order to test pagination
 			services := make([]*types.ExternalService, 0, toCreate)
 			for i := 0; i < toCreate; i++ {
@@ -856,12 +856,12 @@ func testSyncRateLimiters(t *testing.T, store repos.Store) func(*testing.T) {
 				services = append(services, svc)
 			}
 
-			if err := tx.ExternalServiceStore().Upsert(ctx, services...); err != nil {
+			if err := tx.ExternalServiceStore.Upsert(ctx, services...); err != nil {
 				t.Fatalf("failed to setup store: %v", err)
 			}
 
 			registry := ratelimit.NewRegistry()
-			syncer := repos.NewRateLimitSyncer(registry, tx.ExternalServiceStore())
+			syncer := repos.NewRateLimitSyncer(registry, tx.ExternalServiceStore)
 			err := syncer.SyncRateLimiters(ctx)
 			if err != nil {
 				t.Fatal(err)
@@ -874,8 +874,8 @@ func testSyncRateLimiters(t *testing.T, store repos.Store) func(*testing.T) {
 	}
 }
 
-func testStoreEnqueueSyncJobs(db *sql.DB, store *repos.DBStore) func(t *testing.T, store repos.Store) func(*testing.T) {
-	return func(t *testing.T, _ repos.Store) func(*testing.T) {
+func testStoreEnqueueSyncJobs(db *sql.DB, store *repos.Store) func(t *testing.T, store *repos.Store) func(*testing.T) {
+	return func(t *testing.T, _ *repos.Store) func(*testing.T) {
 		t.Helper()
 
 		clock := dbtesting.NewFakeClock(time.Now(), 0)
@@ -956,7 +956,7 @@ func testStoreEnqueueSyncJobs(db *sql.DB, store *repos.DBStore) func(t *testing.
 					})
 					stored := tc.stored.Clone()
 
-					if err := store.ExternalServiceStore().Upsert(ctx, stored...); err != nil {
+					if err := store.ExternalServiceStore.Upsert(ctx, stored...); err != nil {
 						t.Fatalf("failed to setup store: %v", err)
 					}
 
@@ -1022,66 +1022,37 @@ func generateExternalServices(n int, base ...*types.ExternalService) types.Exter
 	return es
 }
 
-func transact(ctx context.Context, s repos.Store, test func(testing.TB, repos.Store)) func(*testing.T) {
+func transact(ctx context.Context, s *repos.Store, test func(testing.TB, *repos.Store)) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
-		tr, ok := s.(repos.Transactor)
+		var err error
+		txStore := s
 
-		if ok {
-			txstore, err := tr.Transact(ctx)
+		if !s.InTransaction() {
+			txStore, err = s.Transact(ctx)
 			if err != nil {
 				t.Fatalf("failed to start transaction: %v", err)
 			}
-			defer txstore.Done(errRollback)
-			s = &noopTxStore{TB: t, Store: txstore}
+			defer txStore.Done(errRollback)
 		}
 
-		test(t, s)
+		test(t, txStore)
 	}
 }
 
-type noopTxStore struct {
-	testing.TB
-	repos.Store
-	count int
-}
-
-func (tx *noopTxStore) Transact(context.Context) (repos.TxStore, error) {
-	if tx.count != 0 {
-		return nil, fmt.Errorf("noopTxStore: %d current transactions", tx.count)
-	}
-	tx.count++
-	// noop
-	return tx, nil
-}
-
-func (tx *noopTxStore) Done(err error) error {
-	tx.Helper()
-
-	if tx.count != 1 {
-		tx.Fatal("no current transactions")
-	}
-	if err != nil {
-		tx.Fatal(fmt.Sprintf("unexpected error in noopTxStore: %v", err))
-	}
-	tx.count--
-
-	return nil
-}
-
-func createExternalServices(t *testing.T, store repos.Store) map[string]*types.ExternalService {
+func createExternalServices(t *testing.T, store *repos.Store) map[string]*types.ExternalService {
 	clock := dbtesting.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	svcs := mkExternalServices(now)
 
 	// create a few external services
-	if err := store.ExternalServiceStore().Upsert(context.Background(), svcs...); err != nil {
+	if err := store.ExternalServiceStore.Upsert(context.Background(), svcs...); err != nil {
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 
-	services, err := store.ExternalServiceStore().List(context.Background(), idb.ExternalServicesListOptions{})
+	services, err := store.ExternalServiceStore.List(context.Background(), idb.ExternalServicesListOptions{})
 	if err != nil {
 		t.Fatal("failed to list external services")
 	}

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -14,10 +14,10 @@ import (
 	dbws "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
-func testSyncWorkerPlumbing(db *sql.DB) func(t *testing.T, repoStore repos.Store) func(t *testing.T) {
+func testSyncWorkerPlumbing(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(t *testing.T) {
 	// The reason we need two higher level functions is because we need access to the *sql.DB struct but also
 	// need to satisfy the signature expected by integration tests.
-	return func(t *testing.T, repoStore repos.Store) func(t *testing.T) {
+	return func(t *testing.T, repoStore *repos.Store) func(t *testing.T) {
 		return func(t *testing.T) {
 			ctx := context.Background()
 			testSvc := &types.ExternalService{
@@ -27,7 +27,7 @@ func testSyncWorkerPlumbing(db *sql.DB) func(t *testing.T, repoStore repos.Store
 			}
 
 			// Create external service
-			err := repoStore.ExternalServiceStore().Upsert(ctx, testSvc)
+			err := repoStore.ExternalServiceStore.Upsert(ctx, testSvc)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR removes the store interface and renames DBStore into Store.
It also adds a simple mock type to be used by tests who wants to mock calls to UpsertRepos.