### PR TITLE
search backend: invalidate repo resolver cache for multiple revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Imported changesets acquired an extra button to download the "generated diff", which did nothing, since imported changesets don't have a generated diff. This button has been removed. [#16778](https://github.com/sourcegraph/sourcegraph/issues/16778)
-
 - Quoted global filter values (case, patterntype) are now properly extracted and set in URL parameters. [#16186](https://github.com/sourcegraph/sourcegraph/issues/16186)
+- Fixed an issue that prevented search expressions of the form `repo:foo (rev:a or rev:b)` from evaluating all revisions [#16873](https://github.com/sourcegraph/sourcegraph/pull/16873)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1120,18 +1120,22 @@ func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchR
 }
 
 // invalidateRepoCache returns whether resolved repos should be invalidated when
-// evaluating subexpressions. If a query contains more than one repo or repogroup
-// field, we should invalidate resolved repos, since multiple repo or repogroups
-// imply that different repos may need to be resolved.
+// evaluating subexpressions. If a query contains more than one repo, revision,
+// or repogroup field, we should invalidate resolved repos, since multiple
+// repos, revisions, or repogroups imply that different repos may need to be
+// resolved.
 func invalidateRepoCache(q []query.Node) bool {
-	var seenRepo, seenRepoGroup int
+	var seenRepo, seenRevision, seenRepoGroup int
 	query.VisitField(q, "repo", func(_ string, _ bool, _ query.Annotation) {
 		seenRepo += 1
+	})
+	query.VisitField(q, "rev", func(_ string, _ bool, _ query.Annotation) {
+		seenRevision += 1
 	})
 	query.VisitField(q, "repogroup", func(_ string, _ bool, _ query.Annotation) {
 		seenRepoGroup += 1
 	})
-	return seenRepo+seenRepoGroup > 1
+	return seenRepo+seenRepoGroup > 1 || seenRevision > 1
 }
 
 func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolver, err error) {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -786,12 +786,14 @@ func TestSearch(t *testing.T) {
 				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) author:felix yarn`,
 			},
 			{
-				name:  `Or distributive property on rev`,
-				query: `repo:^github\.com/sgtest/go-diff$ (rev:garo/lsif-indexing-campaign or rev:test-already-exist-pr) file:README.md`,
+				name:            `Or distributive property on rev`,
+				query:           `repo:^github\.com/sgtest/mux$ (rev:v1.7.3 or revision:v1.7.2)`,
+				exactMatchCount: 2,
 			},
 			{
-				name:  `Or distributive property on rev`,
-				query: `repo:^github\.com/sgtest/go-diff$ (rev:garo/lsif-indexing-campaign or rev:test-already-exist-pr)`,
+				name:            `Or distributive property on rev with file`,
+				query:           `repo:^github\.com/sgtest/mux$ (rev:v1.7.3 or revision:v1.7.2) file:README.md`,
+				exactMatchCount: 2,
 			},
 			{
 				name:  `Or distributive property on repo`,


### PR DESCRIPTION
Queries of the form `repo:foo (rev:a or rev:b)` would not give two results if both `rev:a` and `rev:b` exists, because we would not invalidate the cache for multiple `rev` filters, only multiple `repo` filters. We should be invalidating it for multiple `rev` filters too. This did not affect queries of the form `repo:foo@a or repo:foo@b`, because the check would see two repos and make the cache invalidate.

We had integration tests, but they were too weak: they only checked for any result (and for these, there was just 1, where we expected more than 1). I will audit more of the tests later to make sure we are getting "at least" or exactly amount of results that we expect.