### PR TITLE
db: Include LastSyncError on external service

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -131,8 +131,12 @@ func (r *externalServiceResolver) WebhookURL() (*string, error) {
 }
 
 func (r *externalServiceResolver) Warning() *string {
-	if r.warning == "" {
+	warning := r.warning
+	if r.externalService != nil && len(r.externalService.LastSyncError) > 0 {
+		warning = warning + `\n` + r.externalService.LastSyncError
+	}
+	if len(warning) == 0 {
 		return nil
 	}
-	return &r.warning
+	return &warning
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -127,6 +127,7 @@ type ExternalService struct {
 	NextSyncAt      time.Time
 	NamespaceUserID int32
 	Unrestricted    bool
+	LastSyncError   string
 }
 
 func cmp(a, b string) int {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -406,7 +406,12 @@ type ExternalService struct {
 	LastSyncAt      time.Time
 	NextSyncAt      time.Time
 	NamespaceUserID int32
-	Unrestricted    bool // Whether access to repositories belong to this external service is unrestricted.
+	// Whether access to repositories belong to this external service is
+	// unrestricted.
+	Unrestricted bool
+	// A read only field populated with the error related to the most recent
+	// background sync of this external service.
+	LastSyncError string
 }
 
 // URN returns a unique resource identifier of this external service,


### PR DESCRIPTION
We now join with the external_service_sync_jobs table and include the
error from the most recent sync of the external service.

Some thoughts:

I decided to include the error in the external service object itself so that we could get everything in one query.
Perhaps it would be better to only query for it from the resolver on demand? 

I also needed to add the field to the `api.ExternalService` type which seems unnecessary. Also, why do we actually need a separate type here? 

The way we return the errors to the client is really messy with string concatenation. Maybe we should use this as an opportunity to include a 'Warnings' array instead and deprecate  `Warning`?