### PR TITLE
search: move blocking searchCommitsInRepo to tests

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -217,17 +217,6 @@ type searchCommitsInRepoEvent struct {
 	Error error
 }
 
-// searchCommitsInRepo is a blocking version of searchCommitsInRepoStream.
-func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
-	for event := range searchCommitsInRepoStream(ctx, op) {
-		results = append(results, event.Results...)
-		limitHit = event.LimitHit
-		timedOut = event.TimedOut
-		err = event.Error
-	}
-	return results, limitHit, timedOut, err
-}
-
 // searchCommitsInRepoStream searchs for commits based on op.
 //
 // The returned channel must be read until closed, otherwise you may leak

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -280,3 +280,14 @@ func Benchmark_highlightMatches(b *testing.B) {
 		_ = highlightMatches(rx, lines)
 	}
 }
+
+// searchCommitsInRepo is a blocking version of searchCommitsInRepoStream.
+func searchCommitsInRepo(ctx context.Context, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
+	for event := range searchCommitsInRepoStream(ctx, op) {
+		results = append(results, event.Results...)
+		limitHit = event.LimitHit
+		timedOut = event.TimedOut
+		err = event.Error
+	}
+	return results, limitHit, timedOut, err
+}


### PR DESCRIPTION
We only use the streaming version in graphqlbackend. The blocking
version is a convenience for tests.

