### PR TITLE
github-proxy: Remove rate limit monitoring

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1574,48 +1574,6 @@ To learn more about Sourcegraph's alerting, see [our alerting documentation](htt
 
 <br />
 
-## github-proxy: github_core_rate_limit_remaining
-
-<p class="subtitle">cloud: remaining calls to GitHub before hitting the rate limit</p>
-
-**Descriptions:**
-
-- _github-proxy: less than 500 remaining calls to GitHub before hitting the rate limit for 5m0s_
-
-**Possible solutions:**
-
-- Try restarting the pod to get a different public IP.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "critical_github-proxy_github_core_rate_limit_remaining"
-]
-```
-
-<br />
-
-## github-proxy: github_search_rate_limit_remaining
-
-<p class="subtitle">cloud: remaining calls to GitHub search before hitting the rate limit</p>
-
-**Descriptions:**
-
-- _github-proxy: less than 5 remaining calls to GitHub search before hitting the rate limit_
-
-**Possible solutions:**
-
-- Try restarting the pod to get a different public IP.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_github-proxy_github_search_rate_limit_remaining"
-]
-```
-
-<br />
-
 ## github-proxy: github_proxy_waiting_requests
 
 <p class="subtitle">cloud: number of requests waiting on the global mutex</p>

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -18,31 +18,9 @@ func GitHubProxy() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:              "github_core_rate_limit_remaining",
-							Description:       "remaining calls to GitHub before hitting the rate limit",
-							Query:             `src_github_rate_limit_remaining{resource="core"}`,
-							DataMayNotExist:   true,
-							Critical:          monitoring.Alert().LessOrEqual(500).For(5 * time.Minute),
-							PanelOptions:      monitoring.PanelOptions().LegendFormat("calls remaining"),
-							Owner:             monitoring.ObservableOwnerCloud,
-							PossibleSolutions: `Try restarting the pod to get a different public IP.`,
-						},
-						{
-							Name:              "github_search_rate_limit_remaining",
-							Description:       "remaining calls to GitHub search before hitting the rate limit",
-							Query:             `src_github_rate_limit_remaining{resource="search"}`,
-							DataMayNotExist:   true,
-							Warning:           monitoring.Alert().LessOrEqual(5),
-							PanelOptions:      monitoring.PanelOptions().LegendFormat("calls remaining"),
-							Owner:             monitoring.ObservableOwnerCloud,
-							PossibleSolutions: `Try restarting the pod to get a different public IP.`,
-						},
-					},
-					{
-						{
 							Name:            "github_proxy_waiting_requests",
 							Description:     "number of requests waiting on the global mutex",
-							Query:           `github_proxy_waiting_requests`,
+							Query:           `max(github_proxy_waiting_requests)`,
 							DataMayNotExist: true,
 							Warning:         monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),
 							PanelOptions:    monitoring.PanelOptions().LegendFormat("requests waiting"),


### PR DESCRIPTION
We now do this in repo-updater instead

Closes: https://github.com/sourcegraph/sourcegraph/issues/16751