### PR TITLE
api: Expose LastSyncError on ExternalService

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -137,8 +137,8 @@ func (r *externalServiceResolver) Warning() *string {
 	return &r.warning
 }
 
-func (r *externalServiceResolver) LatestSyncError(ctx context.Context) (*string, error) {
-	latestError, err := db.ExternalServices.GetLatestSyncError(ctx, r.externalService.ID)
+func (r *externalServiceResolver) LastSyncError(ctx context.Context) (*string, error) {
+	latestError, err := db.ExternalServices.GetLastSyncError(ctx, r.externalService.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -136,3 +136,14 @@ func (r *externalServiceResolver) Warning() *string {
 	}
 	return &r.warning
 }
+
+func (r *externalServiceResolver) LatestSyncError(ctx context.Context) (*string, error) {
+	latestError, err := db.ExternalServices.GetLatestSyncError(ctx, r.externalService.ID)
+	if err != nil {
+		return nil, err
+	}
+	if latestError == "" {
+		return nil, nil
+	}
+	return &latestError, nil
+}

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -658,7 +658,7 @@ func TestExternalServices(t *testing.T) {
 			}
 		`,
 		},
-		// LatestSyncError included
+		// LastSyncError included
 		{
 			Schema: mustParseGraphQLSchema(t),
 			Query: `

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -207,6 +207,7 @@ func TestAddExternalService(t *testing.T) {
 	db.Mocks.ExternalServices.Create = func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error {
 		return nil
 	}
+
 	t.Cleanup(func() {
 		db.Mocks.Users = db.MockUsers{}
 		db.Mocks.ExternalServices = db.MockExternalServices{}
@@ -608,6 +609,9 @@ func TestExternalServices(t *testing.T) {
 
 		return 2, nil
 	}
+	db.Mocks.ExternalServices.GetLatestSyncError = func(id int64) (string, error) {
+		return "Oops", nil
+	}
 	defer func() {
 		db.Mocks.Users = db.MockUsers{}
 		db.Mocks.ExternalServices = db.MockExternalServices{}
@@ -650,6 +654,27 @@ func TestExternalServices(t *testing.T) {
 			{
 				"externalServices": {
 					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE="}]
+				}
+			}
+		`,
+		},
+		// LatestSyncError included
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+			{
+				externalServices(namespace: "VXNlcjoy") {
+					nodes {
+						id
+						latestSyncError
+					}
+				}
+			}
+		`,
+			ExpectedResult: `
+			{
+				"externalServices": {
+					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE=","latestSyncError":"Oops"}]
 				}
 			}
 		`,

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -674,7 +674,7 @@ func TestExternalServices(t *testing.T) {
 			ExpectedResult: `
 			{
 				"externalServices": {
-					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE=","latestSyncError":"Oops"}]
+					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE=","lastSyncError":"Oops"}]
 				}
 			}
 		`,

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -609,7 +609,7 @@ func TestExternalServices(t *testing.T) {
 
 		return 2, nil
 	}
-	db.Mocks.ExternalServices.GetLatestSyncError = func(id int64) (string, error) {
+	db.Mocks.ExternalServices.GetLastSyncError = func(id int64) (string, error) {
 		return "Oops", nil
 	}
 	defer func() {
@@ -666,7 +666,7 @@ func TestExternalServices(t *testing.T) {
 				externalServices(namespace: "VXNlcjoy") {
 					nodes {
 						id
-						latestSyncError
+						lastSyncError
 					}
 				}
 			}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3964,7 +3964,7 @@ type ExternalService implements Node {
     External services are synced with code hosts in the background. This optional field
     will contain any errors that occured during the most recent completed sync.
     """
-    latestSyncError: String
+    lastSyncError: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3959,6 +3959,12 @@ type ExternalService implements Node {
     not break the API and stay backwards compatible.
     """
     warning: String
+
+    """
+    External services are synced with code hosts in the background. This optional field
+    will contain any errors that occured during the most recent completed sync.
+    """
+    latestSyncError: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3952,6 +3952,12 @@ type ExternalService implements Node {
     not break the API and stay backwards compatible.
     """
     warning: String
+
+    """
+    External services are synced with code hosts in the background. This optional field
+    will contain any errors that occured during the most recent completed sync.
+    """
+    latestSyncError: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3957,7 +3957,7 @@ type ExternalService implements Node {
     External services are synced with code hosts in the background. This optional field
     will contain any errors that occured during the most recent completed sync.
     """
-    latestSyncError: String
+    lastSyncError: String
 }
 
 """

--- a/internal/db/basestore/store.go
+++ b/internal/db/basestore/store.go
@@ -3,7 +3,6 @@ package basestore
 import (
 	"context"
 	"database/sql"
-
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -447,7 +447,7 @@ func (e *ExternalServiceStore) validateDuplicateRateLimits(ctx context.Context, 
 // started, otherwise a panic would occur once pkg/conf's deadlock detector
 // determines a deadlock occurred.
 //
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
+// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 // Otherwise, `es.NamespaceUserID` must be specified (i.e. non-nil) for
 // a user-added external service.
 //
@@ -728,7 +728,7 @@ func (e externalServiceNotFoundError) NotFound() bool {
 
 // Delete deletes an external service.
 //
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
+// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *ExternalServiceStore) Delete(ctx context.Context, id int64) error {
 	if Mocks.ExternalServices.Delete != nil {
 		return Mocks.ExternalServices.Delete(ctx, id)
@@ -751,7 +751,7 @@ func (e *ExternalServiceStore) Delete(ctx context.Context, id int64) error {
 
 // GetByID returns the external service for id.
 //
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
+// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *ExternalServiceStore) GetByID(ctx context.Context, id int64) (*types.ExternalService, error) {
 	if Mocks.ExternalServices.GetByID != nil {
 		return Mocks.ExternalServices.GetByID(id)
@@ -770,6 +770,28 @@ func (e *ExternalServiceStore) GetByID(ctx context.Context, id int64) (*types.Ex
 		return nil, externalServiceNotFoundError{id: id}
 	}
 	return ess[0], nil
+}
+
+// GetLatestSyncError returns the error associated with the latest sync of the
+// supplied external service.
+//
+// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
+func (e *ExternalServiceStore) GetLatestSyncError(ctx context.Context, id int64) (string, error) {
+	e.ensureStore()
+
+	q := sqlf.Sprintf(`
+SELECT failure_message from external_service_sync_jobs
+WHERE external_service_id = %d
+AND state IN ('completed','errored')
+ORDER BY finished_at DESC
+LIMIT 1
+`, id)
+
+	latestError, _, err := basestore.ScanFirstString(e.Query(ctx, q))
+	if err != nil {
+		return "", err
+	}
+	return latestError, nil
 }
 
 // List returns external services under given namespace.
@@ -866,7 +888,7 @@ func (e *ExternalServiceStore) list(ctx context.Context, opt ExternalServicesLis
 
 // Count counts all external services that satisfy the options (ignoring limit and offset).
 //
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin.
+// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *ExternalServiceStore) Count(ctx context.Context, opt ExternalServicesListOptions) (int, error) {
 	if Mocks.ExternalServices.Count != nil {
 		return Mocks.ExternalServices.Count(ctx, opt)

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -777,6 +777,9 @@ func (e *ExternalServiceStore) GetByID(ctx context.Context, id int64) (*types.Ex
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
 func (e *ExternalServiceStore) GetLatestSyncError(ctx context.Context, id int64) (string, error) {
+	if Mocks.ExternalServices.GetLatestSyncError != nil {
+		return Mocks.ExternalServices.GetLatestSyncError(id)
+	}
 	e.ensureStore()
 
 	q := sqlf.Sprintf(`
@@ -905,10 +908,11 @@ func (e *ExternalServiceStore) Count(ctx context.Context, opt ExternalServicesLi
 
 // MockExternalServices mocks the external services store.
 type MockExternalServices struct {
-	Create  func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
-	Delete  func(ctx context.Context, id int64) error
-	GetByID func(id int64) (*types.ExternalService, error)
-	List    func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
-	Update  func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
-	Count   func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
+	Create             func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
+	Delete             func(ctx context.Context, id int64) error
+	GetByID            func(id int64) (*types.ExternalService, error)
+	GetLatestSyncError func(id int64) (string, error)
+	List               func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
+	Update             func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
+	Count              func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
 }

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -772,11 +772,11 @@ func (e *ExternalServiceStore) GetByID(ctx context.Context, id int64) (*types.Ex
 	return ess[0], nil
 }
 
-// GetLatestSyncError returns the error associated with the latest sync of the
+// GetLastSyncError returns the error associated with the latest sync of the
 // supplied external service.
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
-func (e *ExternalServiceStore) GetLatestSyncError(ctx context.Context, id int64) (string, error) {
+func (e *ExternalServiceStore) GetLastSyncError(ctx context.Context, id int64) (string, error) {
 	if Mocks.ExternalServices.GetLatestSyncError != nil {
 		return Mocks.ExternalServices.GetLatestSyncError(id)
 	}
@@ -790,8 +790,8 @@ ORDER BY finished_at DESC
 LIMIT 1
 `, id)
 
-	latestError, _, err := basestore.ScanFirstString(e.Query(ctx, q))
-	return latestError, err
+	lastError, _, err := basestore.ScanFirstString(e.Query(ctx, q))
+	return lastError, err
 }
 
 // List returns external services under given namespace.

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -791,10 +791,7 @@ LIMIT 1
 `, id)
 
 	latestError, _, err := basestore.ScanFirstString(e.Query(ctx, q))
-	if err != nil {
-		return "", err
-	}
-	return latestError, nil
+	return latestError, err
 }
 
 // List returns external services under given namespace.

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -777,8 +777,8 @@ func (e *ExternalServiceStore) GetByID(ctx context.Context, id int64) (*types.Ex
 //
 // 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
 func (e *ExternalServiceStore) GetLastSyncError(ctx context.Context, id int64) (string, error) {
-	if Mocks.ExternalServices.GetLatestSyncError != nil {
-		return Mocks.ExternalServices.GetLatestSyncError(id)
+	if Mocks.ExternalServices.GetLastSyncError != nil {
+		return Mocks.ExternalServices.GetLastSyncError(id)
 	}
 	e.ensureStore()
 
@@ -905,11 +905,11 @@ func (e *ExternalServiceStore) Count(ctx context.Context, opt ExternalServicesLi
 
 // MockExternalServices mocks the external services store.
 type MockExternalServices struct {
-	Create             func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
-	Delete             func(ctx context.Context, id int64) error
-	GetByID            func(id int64) (*types.ExternalService, error)
-	GetLatestSyncError func(id int64) (string, error)
-	List               func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
-	Update             func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
-	Count              func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
+	Create           func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
+	Delete           func(ctx context.Context, id int64) error
+	GetByID          func(id int64) (*types.ExternalService, error)
+	GetLastSyncError func(id int64) (string, error)
+	List             func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
+	Update           func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
+	Count            func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
 }

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -590,7 +590,7 @@ func TestGetLatestSyncError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	latestSyncError, err := (&ExternalServiceStore{}).GetLatestSyncError(ctx, es.ID)
+	latestSyncError, err := (&ExternalServiceStore{}).GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -609,7 +609,7 @@ VALUES ($1,$2,'errored')
 		t.Fatal(err)
 	}
 
-	latestSyncError, err = (&ExternalServiceStore{}).GetLatestSyncError(ctx, es.ID)
+	latestSyncError, err = (&ExternalServiceStore{}).GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -563,7 +563,7 @@ func TestExternalServicesStore_GetByID(t *testing.T) {
 	}
 }
 
-func TestGetLatestSyncError(t *testing.T) {
+func TestGetLastSyncError(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -590,12 +590,12 @@ func TestGetLatestSyncError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	latestSyncError, err := (&ExternalServiceStore{}).GetLastSyncError(ctx, es.ID)
+	lastSyncError, err := (&ExternalServiceStore{}).GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if latestSyncError != "" {
-		t.Fatalf("Expected empty error, have %q", latestSyncError)
+	if lastSyncError != "" {
+		t.Fatalf("Expected empty error, have %q", lastSyncError)
 	}
 
 	// Add sync error
@@ -609,12 +609,12 @@ VALUES ($1,$2,'errored')
 		t.Fatal(err)
 	}
 
-	latestSyncError, err = (&ExternalServiceStore{}).GetLastSyncError(ctx, es.ID)
+	lastSyncError, err = (&ExternalServiceStore{}).GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if latestSyncError != expectedError {
-		t.Fatalf("Expected %q, have %q", expectedError, latestSyncError)
+	if lastSyncError != expectedError {
+		t.Fatalf("Expected %q, have %q", expectedError, lastSyncError)
 	}
 }
 


### PR DESCRIPTION
Add a new `LastSyncError` field on the `ExternalService` node in our API

This returns the optional sync error that exists on the most recent sync for an external service.

Note that currently errors caused by bad credentials will NOT show up since we don't treat that as an error and instead simply remove all repos for the external service. Another PR will handle this special case. 