### PR TITLE
search: refactor alertOnSearchLimit

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"regexp"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -498,6 +500,33 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 		}
 	}
 	return buildAlert(proposedQueries, description)
+}
+
+func alertForDiffCommitSearch(multiErr *multierror.Error) (newMultiErr *multierror.Error, alert *searchAlert) {
+	tErr := &DiffCommitTimeLimitErr{}
+	rErr := &DiffCommitRepoLimitErr{}
+	if multiErr != nil {
+		for _, err := range multiErr.Errors {
+			if ok := errors.As(err, rErr); ok {
+				alert = &searchAlert{
+					prometheusType: "exceeded_diff_commit_search_limit",
+					title:          fmt.Sprintf("Too many matching repositories for %s search to handle", rErr.ResultType),
+					description:    fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(rErr.ResultType), rErr.Max),
+				}
+				continue
+			}
+			if errors.As(err, tErr) {
+				alert = &searchAlert{
+					prometheusType: "exceeded_diff_commit_with_time_search_limit",
+					title:          fmt.Sprintf("Too many matching repositories for %s search to handle", tErr.ResultType),
+					description:    fmt.Sprintf(`%s search can currently only handle searching over %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`, strings.Title(tErr.ResultType), tErr.Max),
+				}
+				continue
+			}
+			newMultiErr = multierror.Append(newMultiErr, err)
+		}
+	}
+	return newMultiErr, alert
 }
 
 // alertForStructuralSearch filters certain errors from multiErr and converts

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -515,7 +515,7 @@ func alertForDiffCommitSearch(multiErr *multierror.Error) (newMultiErr *multierr
 				}
 				continue
 			}
-			if errors.As(err, tErr) {
+			if ok := errors.As(err, tErr); ok {
 				alert = &searchAlert{
 					prometheusType: "exceeded_diff_commit_with_time_search_limit",
 					title:          fmt.Sprintf("Too many matching repositories for %s search to handle", tErr.ResultType),

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -506,8 +506,8 @@ func alertForDiffCommitSearch(multiErr *multierror.Error) (newMultiErr *multierr
 	if multiErr == nil {
 		return newMultiErr, alert
 	}
-	rErr := &DiffCommitRepoLimitErr{}
-	tErr := &DiffCommitTimeLimitErr{}
+	rErr := &RepoLimitErr{}
+	tErr := &TimeLimitErr{}
 	for _, err := range multiErr.Errors {
 		if ok := errors.As(err, rErr); ok {
 			alert = &searchAlert{

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -163,17 +163,17 @@ func TestAlertForDiffCommitSearchLimits(t *testing.T) {
 	}{
 		{
 			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{ResultType: "diff", Max: 50}),
+			multiErr:             multierror.Append(&multierror.Error{}, RepoLimitErr{ResultType: "diff", Max: 50}),
 			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{ResultType: "commit", Max: 50}),
+			multiErr:             multierror.Append(&multierror.Error{}, RepoLimitErr{ResultType: "commit", Max: 50}),
 			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
-			multiErr:             multierror.Append(&multierror.Error{}, DiffCommitTimeLimitErr{ResultType: "commit", Max: 10000}),
+			multiErr:             multierror.Append(&multierror.Error{}, TimeLimitErr{ResultType: "commit", Max: 10000}),
 			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -162,33 +162,18 @@ func TestAlertForDiffCommitSearchLimits(t *testing.T) {
 		wantAlertDescription string
 	}{
 		{
-			name: "diff_search_warns_on_repos_greater_than_search_limit",
-			multiErr: multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{
-				DiffCommitErr: DiffCommitErr{
-					ResultType: "diff",
-					Max:        50,
-				},
-			}),
+			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
+			multiErr:             multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{ResultType: "diff", Max: 50}),
 			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
-			name: "commit_search_warns_on_repos_greater_than_search_limit",
-			multiErr: multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{
-				DiffCommitErr: DiffCommitErr{
-					ResultType: "commit",
-					Max:        50,
-				},
-			}),
+			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
+			multiErr:             multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{ResultType: "commit", Max: 50}),
 			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
-			name: "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
-			multiErr: multierror.Append(&multierror.Error{}, DiffCommitTimeLimitErr{
-				DiffCommitErr: DiffCommitErr{
-					ResultType: "commit",
-					Max:        10000,
-				},
-			}),
+			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
+			multiErr:             multierror.Append(&multierror.Error{}, DiffCommitTimeLimitErr{ResultType: "commit", Max: 10000}),
 			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -150,6 +152,56 @@ func TestAddQueryRegexpField(t *testing.T) {
 				t.Errorf("got %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestAlertForDiffCommitSearchLimits(t *testing.T) {
+	cases := []struct {
+		name                 string
+		multiErr             *multierror.Error
+		wantAlertDescription string
+	}{
+		{
+			name: "diff_search_warns_on_repos_greater_than_search_limit",
+			multiErr: multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{
+				DiffCommitErr: DiffCommitErr{
+					ResultType: "diff",
+					Max:        50,
+				},
+			}),
+			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+		},
+		{
+			name: "commit_search_warns_on_repos_greater_than_search_limit",
+			multiErr: multierror.Append(&multierror.Error{}, DiffCommitRepoLimitErr{
+				DiffCommitErr: DiffCommitErr{
+					ResultType: "commit",
+					Max:        50,
+				},
+			}),
+			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+		},
+		{
+			name: "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
+			multiErr: multierror.Append(&multierror.Error{}, DiffCommitTimeLimitErr{
+				DiffCommitErr: DiffCommitErr{
+					ResultType: "commit",
+					Max:        10000,
+				},
+			}),
+			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+		},
+	}
+
+	for _, test := range cases {
+		haveMultiErr, alert := alertForDiffCommitSearch(test.multiErr)
+		if haveMultiErr != nil {
+			t.Fatalf("the alert should have been filtered from the multierror")
+		}
+		haveAlertDescription := alert.description
+		if diff := cmp.Diff(test.wantAlertDescription, haveAlertDescription); diff != "" {
+			t.Fatalf("test %s, mismatched alert (-want, +got):\n%s", test.name, diff)
+		}
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1629,14 +1629,14 @@ type DiffCommitError struct {
 	Max        int
 }
 
-type DiffCommitRepoLimitErr DiffCommitError
-type DiffCommitTimeLimitErr DiffCommitError
+type RepoLimitErr DiffCommitError
+type TimeLimitErr DiffCommitError
 
-func (DiffCommitRepoLimitErr) Error() string {
+func (RepoLimitErr) Error() string {
 	return "repo limit error"
 }
 
-func (DiffCommitTimeLimitErr) Error() string {
+func (TimeLimitErr) Error() string {
 	return "time limit error"
 }
 
@@ -1656,10 +1656,10 @@ func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameter
 
 	limits := searchLimits()
 	if max := limits.CommitDiffMaxRepos; !hasTimeFilter && len(repos) > max {
-		return DiffCommitRepoLimitErr{ResultType: resultType, Max: max}
+		return RepoLimitErr{ResultType: resultType, Max: max}
 	}
 	if max := limits.CommitDiffWithTimeFilterMaxRepos; hasTimeFilter && len(repos) > max {
-		return DiffCommitTimeLimitErr{ResultType: resultType, Max: max}
+		return TimeLimitErr{ResultType: resultType, Max: max}
 	}
 	return nil
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1891,10 +1891,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
 	tr.LazyPrintf("resultTypes: %v", resultTypes)
 	var (
-		requiredWg sync.WaitGroup
-		optionalWg sync.WaitGroup
-		// Alert is a potential alert shown to the user.
-		alert           *searchAlert
+		requiredWg      sync.WaitGroup
+		optionalWg      sync.WaitGroup
 		seenResultTypes = make(map[string]struct{})
 	)
 
@@ -2050,6 +2048,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		common.excluded.forks,
 		common.excluded.archived,
 		len(common.timedout))
+
+	var alert *searchAlert
 
 	multiErr, newAlert := alertForDiffCommitSearch(multiErr)
 	if newAlert != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1624,17 +1624,21 @@ func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, st
 	return resolved, nil, nil
 }
 
-type DiffCommitErr struct {
+type DiffCommitError struct {
 	ResultType string
 	Max        int
 }
 
-func (DiffCommitErr) Error() string {
-	return "diff commit error"
+type DiffCommitRepoLimitErr DiffCommitError
+type DiffCommitTimeLimitErr DiffCommitError
+
+func (DiffCommitRepoLimitErr) Error() string {
+	return "repo limit error"
 }
 
-type DiffCommitRepoLimitErr = DiffCommitErr
-type DiffCommitTimeLimitErr = DiffCommitErr
+func (DiffCommitTimeLimitErr) Error() string {
+	return "time limit error"
+}
 
 func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameters, resultType string) error {
 	repos, err := getRepos(ctx, args.RepoPromise)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1002,73 +1002,52 @@ func TestDedupSort(t *testing.T) {
 	}
 }
 
-func TestCommitAndDiffSearchLimits(t *testing.T) {
+func TestCheckDiffCommitSearchLimits(t *testing.T) {
 	cases := []struct {
-		name                 string
-		resultTypes          []string
-		numRepoRevs          int
-		fields               map[string][]*searchquerytypes.Value
-		wantResultTypes      []string
-		wantAlertDescription string
+		name        string
+		resultType  string
+		numRepoRevs int
+		fields      map[string][]*searchquerytypes.Value
+		wantError   error
 	}{
 		{
-			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
-			resultTypes:          []string{"diff"},
-			numRepoRevs:          51,
-			wantResultTypes:      []string{}, // diff is removed from the resultTypes
-			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+			name:        "diff_search_warns_on_repos_greater_than_search_limit",
+			resultType:  "diff",
+			numRepoRevs: 51,
+			wantError:   DiffCommitRepoLimitErr{ResultType: "diff", Max: 50},
 		},
 		{
-			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
-			resultTypes:          []string{"commit"},
-			numRepoRevs:          51,
-			wantResultTypes:      []string{}, // diff is removed from the resultTypes
-			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+			name:        "commit_search_warns_on_repos_greater_than_search_limit",
+			resultType:  "commit",
+			numRepoRevs: 51,
+			wantError:   DiffCommitRepoLimitErr{ResultType: "commit", Max: 50},
 		},
 		{
-			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
-			fields:               map[string][]*searchquerytypes.Value{"after": nil},
-			resultTypes:          []string{"commit"},
-			numRepoRevs:          20000,
-			wantResultTypes:      []string{},
-			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+			name:        "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
+			fields:      map[string][]*searchquerytypes.Value{"after": nil},
+			resultType:  "commit",
+			numRepoRevs: 20000,
+			wantError:   DiffCommitTimeLimitErr{ResultType: "commit", Max: 10000},
 		},
 		{
-			name:                 "no_warning_when_commit_search_within_search_limit",
-			resultTypes:          []string{"commit"},
-			numRepoRevs:          50,
-			wantResultTypes:      []string{"commit"}, // commit is preserved in resultTypes
-			wantAlertDescription: "",
+			name:        "no_warning_when_commit_search_within_search_limit",
+			resultType:  "commit",
+			numRepoRevs: 50,
+			wantError:   nil,
 		},
 		{
-			name:                 "no_search_limit_on_queries_including_after_filter",
-			fields:               map[string][]*searchquerytypes.Value{"after": nil},
-			resultTypes:          []string{"file"},
-			numRepoRevs:          200,
-			wantResultTypes:      []string{"file"},
-			wantAlertDescription: "",
+			name:        "no_search_limit_on_queries_including_after_filter",
+			fields:      map[string][]*searchquerytypes.Value{"after": nil},
+			resultType:  "commit",
+			numRepoRevs: 200,
+			wantError:   nil,
 		},
 		{
-			name:                 "no_search_limit_on_queries_including_before_filter",
-			fields:               map[string][]*searchquerytypes.Value{"before": nil},
-			resultTypes:          []string{"file"},
-			numRepoRevs:          200,
-			wantResultTypes:      []string{"file"},
-			wantAlertDescription: "",
-		},
-		{
-			name:                 "no_search_limit_on_repos_for_file_search",
-			resultTypes:          []string{"file"},
-			numRepoRevs:          200,
-			wantResultTypes:      []string{"file"},
-			wantAlertDescription: "",
-		},
-		{
-			name:                 "multiple_result_type_search_is_affected",
-			resultTypes:          []string{"file", "commit"},
-			numRepoRevs:          200,
-			wantResultTypes:      []string{},
-			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
+			name:        "no_search_limit_on_queries_including_before_filter",
+			fields:      map[string][]*searchquerytypes.Value{"before": nil},
+			resultType:  "commit",
+			numRepoRevs: 200,
+			wantError:   nil,
 		},
 	}
 
@@ -1080,29 +1059,16 @@ func TestCommitAndDiffSearchLimits(t *testing.T) {
 			}
 		}
 
-		haveResultTypes, alert := alertOnSearchLimit(test.resultTypes, &search.TextParameters{
-			RepoPromise: (&search.Promise{}).Resolve(repoRevs),
-			Query:       &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},
-		})
+		haveErr := checkDiffCommitSearchLimits(
+			context.Background(),
+			&search.TextParameters{
+				RepoPromise: (&search.Promise{}).Resolve(repoRevs),
+				Query:       &query.OrdinaryQuery{Query: &query.Query{Fields: test.fields}},
+			},
+			test.resultType)
 
-		haveAlertDescription := ""
-		if alert != nil {
-			haveAlertDescription = *alert.Description()
-		}
-
-		if diff := cmp.Diff(test.wantAlertDescription, haveAlertDescription); diff != "" {
-			t.Fatalf("test %s, mismatched alert (-want, +got):\n%s", test.name, diff)
-		}
-		if !reflect.DeepEqual(haveResultTypes, test.wantResultTypes) {
-			haveResultType := "is empty"
-			wantResultType := "is empty"
-			if len(haveResultTypes) > 0 {
-				haveResultType = haveResultTypes[0]
-			}
-			if len(test.wantResultTypes) > 0 {
-				wantResultType = test.wantResultTypes[0]
-			}
-			t.Fatalf("test %s, have result type: %q, want result type: %q", test.name, haveResultType, wantResultType)
+		if diff := cmp.Diff(test.wantError, haveErr); diff != "" {
+			t.Fatalf("test %s, mismatched error (-want, +got):\n%s", test.name, diff)
 		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1014,20 +1014,20 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 			name:        "diff_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "diff",
 			numRepoRevs: 51,
-			wantError:   DiffCommitRepoLimitErr{ResultType: "diff", Max: 50},
+			wantError:   RepoLimitErr{ResultType: "diff", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "commit",
 			numRepoRevs: 51,
-			wantError:   DiffCommitRepoLimitErr{ResultType: "commit", Max: 50},
+			wantError:   RepoLimitErr{ResultType: "commit", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
 			fields:      map[string][]*searchquerytypes.Value{"after": nil},
 			resultType:  "commit",
 			numRepoRevs: 20000,
-			wantError:   DiffCommitTimeLimitErr{ResultType: "commit", Max: 10000},
+			wantError:   TimeLimitErr{ResultType: "commit", Max: 10000},
 		},
 		{
 			name:        "no_warning_when_commit_search_within_search_limit",


### PR DESCRIPTION
Currently, `alertOnSearchLimits` mutates `resultTypes` and acts as an
implicit `if`. With this change, we move the check for search limits inside
the diff/commit searchers. The searchers return a `multiErr` which we
convert to an alert afterward (similar to how we do it for structural
search).

This is nice because we push the alert handling to the end of `doResults`.
In the future, we can extract this logic out of `doResults` and let
it simply return an error.

I split the existing test case into two test cases, one checking if the
correct error is returned, and one checking if the error is converted
into the correct alert.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
