### PR TITLE
repo-updater: Expose unauthorized error during sync

### DIFF
--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -305,7 +305,7 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 				// If the source is unauthorized we should treat this as if zero repos were returned as it indicates
 				// that the source no longer has access to its repos
 				name:    string(tc.repo.Name) + "/unauthorized",
-				sourcer: repos.NewFakeSourcer(&errUnauthorized{}),
+				sourcer: repos.NewFakeSourcer(&repos.ErrUnauthorized{}),
 				store:   s,
 				stored: types.Repos{tc.repo.With(
 					types.Opt.RepoSources(tc.svc.URN()),
@@ -315,7 +315,7 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 					types.Opt.RepoSources(tc.svc.URN(), svcdup.URN()),
 				)}},
 				svcs: []*types.ExternalService{tc.svc},
-				err:  "<nil>",
+				err:  "bad credentials",
 			},
 			testCase{
 				// It's expected that there could be multiple stored sources but only one will ever be returned
@@ -2262,14 +2262,4 @@ func assertDeletedRepoCount(ctx context.Context, t *testing.T, db *sql.DB, want 
 	if rowCount != want {
 		t.Fatalf("Expected %d rows, got %d", want, rowCount)
 	}
-}
-
-type errUnauthorized struct{}
-
-func (u *errUnauthorized) Error() string {
-	return "not authorised"
-}
-
-func (u *errUnauthorized) Unauthorized() bool {
-	return true
 }


### PR DESCRIPTION
During sync, if we encounter bad credentials we treat this as a special
case where instead of bailing out we continue the sync as if zero repos
were sourced. We don't want to treat it as a hard error since then we
won't back off and the repos will continue to be associated with the
external service.

However, we DO want to record that there was an issue during sync so
this change returns an error back to our workerutil handler so that the
error is at least recorded against the external service. This in turn
allows us to surface the error to the user via the
ExternalService.LastSyncError field in our API.

Also note that the error is returned after we've updated the NextSyncAt
field so backoff will continue to work.
