### PR TITLE
search: run type:repo queries against maxRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -847,6 +847,11 @@ func searchLimits() schema.SearchLimits {
 	return limits
 }
 
+func hasTypeRepo(q query.QueryInfo) bool {
+	fields := q.Fields()
+	return len(fields["type"]) == 1 && fields["type"][0].Value() == "repo"
+}
+
 func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedRepositories, error) {
 	var err error
 	tr, ctx := trace.New(ctx, "resolveRepositories", op.String())
@@ -908,7 +913,8 @@ func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedReposit
 	}
 
 	var defaultRepos []*types.RepoName
-	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 {
+
+	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !hasTypeRepo(op.query) {
 		start := time.Now()
 		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, search.Indexed(), excludePatterns)
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -849,7 +849,15 @@ func searchLimits() schema.SearchLimits {
 
 func hasTypeRepo(q query.QueryInfo) bool {
 	fields := q.Fields()
-	return len(fields["type"]) == 1 && fields["type"][0].Value() == "repo"
+	if len(fields["type"]) == 0 {
+		return false
+	}
+	for _, t := range fields["type"] {
+		if t.Value() == "repo" {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveRepositories(ctx context.Context, op resolveRepoOp) (resolvedRepositories, error) {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -1038,7 +1038,6 @@ func TestTypeRepo(t *testing.T) {
 			if got := hasTypeRepo(q); got != tt.wantHasTypeRepo {
 				t.Fatalf("got %t, expected %t", got, tt.wantHasTypeRepo)
 			}
-
 		})
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -1001,3 +1001,44 @@ func TestGetReposWrongUnderlyingType(t *testing.T) {
 		t.Errorf("Expected error, got nil")
 	}
 }
+
+func TestTypeRepo(t *testing.T) {
+	tests := []struct {
+		query           string
+		wantHasTypeRepo bool
+	}{
+		{
+			query:           "sourcegraph type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "sourcegraph repohasfile:Dockerfile type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "repo:sourcegraph type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "repo:sourcegraph",
+			wantHasTypeRepo: false,
+		},
+		{
+			query:           "repository",
+			wantHasTypeRepo: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			q, err := query.ProcessAndOr(tt.query, query.ParserOptions{SearchType: query.SearchTypeLiteral})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := hasTypeRepo(q); got != tt.wantHasTypeRepo {
+				t.Fatalf("got %t, expected %t", got, tt.wantHasTypeRepo)
+			}
+
+		})
+	}
+}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -1002,13 +1002,21 @@ func TestGetReposWrongUnderlyingType(t *testing.T) {
 	}
 }
 
-func TestTypeRepo(t *testing.T) {
+func TestHasTypeRepo(t *testing.T) {
 	tests := []struct {
 		query           string
 		wantHasTypeRepo bool
 	}{
 		{
 			query:           "sourcegraph type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "sourcegraph type:symbol type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "(sourcegraph type:repo) or (goreman type:repo)",
 			wantHasTypeRepo: true,
 		},
 		{
@@ -1025,6 +1033,10 @@ func TestTypeRepo(t *testing.T) {
 		},
 		{
 			query:           "repository",
+			wantHasTypeRepo: false,
+		},
+		{
+			query:           "",
 			wantHasTypeRepo: false,
 		},
 	}


### PR DESCRIPTION
Fixes #15182

This bug should only affect Sourcegraph.com because on Sourcegraph.com we
have different sets of repositories for scoped vs. unscoped queries.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
