### PR TITLE
db: Return stale default repos and update in background

### DIFF
--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -20,22 +22,61 @@ type cachedRepos struct {
 	fetched time.Time
 }
 
-func (c *cachedRepos) Repos() []*types.RepoName {
-	if c == nil || time.Since(c.fetched) > defaultReposMaxAge {
-		return nil
+// Repos returns the current cached repos and boolean value indicating
+// whether an update is required
+func (c *cachedRepos) Repos() ([]*types.RepoName, bool) {
+	if c == nil {
+		return nil, true
 	}
-	return append([]*types.RepoName{}, c.repos...)
+	if c.repos == nil {
+		return nil, true
+	}
+	return append([]*types.RepoName{}, c.repos...), time.Since(c.fetched) > defaultReposMaxAge
 }
 
 type defaultRepos struct {
 	cache atomic.Value
+	mu    sync.Mutex
 }
 
 func (s *defaultRepos) List(ctx context.Context) (results []*types.RepoName, err error) {
 	cached, _ := s.cache.Load().(*cachedRepos)
-	if repos := cached.Repos(); repos != nil {
+	repos, needsUpdate := cached.Repos()
+	if !needsUpdate {
 		return repos, nil
 	}
+
+	// We don't have any repos yet, fetch them
+	if len(repos) == 0 {
+		return s.refreshCache(ctx)
+	}
+
+	// We have existing repos, return the stale data and start background refresh
+	go func() {
+		newCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		_, err := s.refreshCache(newCtx)
+		if err != nil {
+			log15.Error("Refreshing default repos cache", "error", err)
+		}
+	}()
+	return repos, nil
+}
+
+func (s *defaultRepos) refreshCache(ctx context.Context) ([]*types.RepoName, error) {
+	s.mu.Lock()
+	// Check whether another routine already did the work
+	cached, _ := s.cache.Load().(*cachedRepos)
+	repos, needsUpdate := cached.Repos()
+	if !needsUpdate {
+		s.mu.Unlock()
+		return repos, nil
+	}
+	defer s.mu.Unlock()
+
+	// Reset fetched repos
+	repos = repos[0:0]
 
 	const q = `
 -- source: internal/db/default_repos.go:defaultRepos.List
@@ -67,10 +108,9 @@ UNION
 `
 	rows, err := dbconn.Global.QueryContext(ctx, q)
 	if err != nil {
-		return nil, errors.Wrap(err, "querying default_repos table")
+		return nil, errors.Wrap(err, "fetching repos")
 	}
 	defer rows.Close()
-	var repos []*types.RepoName
 	for rows.Next() {
 		var r types.RepoName
 		if err := rows.Scan(&r.ID, &r.Name); err != nil {

--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -66,14 +66,13 @@ func (s *defaultRepos) List(ctx context.Context) (results []*types.RepoName, err
 
 func (s *defaultRepos) refreshCache(ctx context.Context) ([]*types.RepoName, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	// Check whether another routine already did the work
 	cached, _ := s.cache.Load().(*cachedRepos)
 	repos, needsUpdate := cached.Repos()
 	if !needsUpdate {
-		s.mu.Unlock()
 		return repos, nil
 	}
-	defer s.mu.Unlock()
 
 	// Reset fetched repos
 	repos = repos[0:0]

--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -67,6 +67,7 @@ func (s *defaultRepos) List(ctx context.Context) (results []*types.RepoName, err
 func (s *defaultRepos) refreshCache(ctx context.Context) ([]*types.RepoName, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	// Check whether another routine already did the work
 	cached, _ := s.cache.Load().(*cachedRepos)
 	repos, needsUpdate := cached.Repos()
@@ -74,8 +75,10 @@ func (s *defaultRepos) refreshCache(ctx context.Context) ([]*types.RepoName, err
 		return repos, nil
 	}
 
-	// Reset fetched repos
-	repos = repos[0:0]
+	// We can reset the slice here so we don't allocate another one
+	if repos != nil {
+		repos = repos[0:0]
+	}
 
 	const q = `
 -- source: internal/db/default_repos.go:defaultRepos.List


### PR DESCRIPTION
Currently any request that fetches default repos that are stale will
trigger an update. This change instead triggers the update in the
background and returns the stale repos immediatley. It also ensures that
only one routine per instance will perform the update.
