### PR TITLE
Don't update changeset diffstat on changeset spec change

### DIFF
--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -89,7 +89,6 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 		return err
 	}
 
-	upsertChangesetEvents := true
 	for _, op := range plan.Ops.ExecutionOrder() {
 		switch op {
 		case campaigns.ReconcilerOperationSync:
@@ -131,14 +130,12 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 		}
 	}
 
-	if upsertChangesetEvents {
-		events := e.ch.Events()
-		state.SetDerivedState(ctx, e.ch, events)
+	events := e.ch.Events()
+	state.SetDerivedState(ctx, e.ch, events)
 
-		if err := e.tx.UpsertChangesetEvents(ctx, events...); err != nil {
-			log15.Error("UpsertChangesetEvents", "err", err)
-			return err
-		}
+	if err := e.tx.UpsertChangesetEvents(ctx, events...); err != nil {
+		log15.Error("UpsertChangesetEvents", "err", err)
+		return err
 	}
 
 	return e.tx.UpdateChangeset(ctx, e.ch)

--- a/enterprise/internal/campaigns/rewirer/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer.go
@@ -116,10 +116,6 @@ func (r *ChangesetRewirer) updateChangesetToNewSpec(c *campaigns.Changeset, spec
 	// Ensure that the changeset is attached to the campaign
 	c.CampaignIDs = append(c.CampaignIDs, r.campaignID)
 
-	// Copy over diff stat from the new spec.
-	diffStat := spec.DiffStat()
-	c.SetDiffStat(&diffStat)
-
 	// We need to enqueue it for the changeset reconciler, so the
 	// reconciler wakes up, compares old and new spec and, if
 	// necessary, updates the changesets accordingly.


### PR DESCRIPTION
The diff is not yet updated at this point and hence it caused confusion in the UI where the diffstat was out of sync with the actual diff.
Since `SetDerivedState` is called after all code host operations and that one does `SetDiffStat` anyways, this just defers updating the diff stat of the changeset to after the commits have been pushed.

Closes https://github.com/sourcegraph/sourcegraph/issues/16196