### PR TITLE
Code monitoring (fix): wrap long queries in trigger area

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -34,4 +34,8 @@
             padding-right: 8rem;
         }
     }
+
+    &__query-label {
+        white-space: pre-wrap;
+    }
 }

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -193,7 +193,9 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     <div className="d-flex justify-content-between align-items-center">
                         <div>
                             <div className="font-weight-bold">When there are new search results</div>
-                            <code className="text-muted test-existing-query">{query}</code>
+                            <code className="trigger-area__query-label text-break text-muted test-existing-query">
+                                {query}
+                            </code>
                         </div>
                         <div>
                             <button


### PR DESCRIPTION
Fixes an issue where long queries would overflow on the code monitor form: 
![image (9)](https://user-images.githubusercontent.com/16265452/102634580-fb2a1c80-418c-11eb-8801-39a65749c803.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
