### PR TITLE
Code monitoring: hide send test email button behind feature flag

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
@@ -16,6 +16,19 @@ describe('CreateCodeMonitorPage', () => {
 
     const history = H.createMemoryHistory()
 
+    test('Does not show "Send test email" option when showCodeMonitoringTestEmailButton is false', () => {
+        const component = mount(
+            <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
+                location={history.location}
+                node={mockCodeMonitor.node}
+                authentictedUser={mockUser}
+                showCodeMonitoringTestEmailButton={false}
+            />
+        )
+        expect(component.find('.test-send-test-email').length).toBe(0)
+    })
+
     test('Shows "Send test email" option to site admins on enabled code monitors', () => {
         const component = mount(
             <CodeMonitorNode
@@ -23,6 +36,7 @@ describe('CreateCodeMonitorPage', () => {
                 location={history.location}
                 node={mockCodeMonitor.node}
                 authentictedUser={mockUser}
+                showCodeMonitoringTestEmailButton={true}
             />
         )
         expect(component.find('.test-send-test-email').length).toBe(1)
@@ -35,6 +49,7 @@ describe('CreateCodeMonitorPage', () => {
                 location={history.location}
                 node={{ ...mockCodeMonitor.node, enabled: false }}
                 authentictedUser={mockUser}
+                showCodeMonitoringTestEmailButton={true}
             />
         )
         expect(component.find('.test-send-test-email').length).toBe(0)
@@ -47,6 +62,7 @@ describe('CreateCodeMonitorPage', () => {
                 location={history.location}
                 node={mockCodeMonitor.node}
                 authentictedUser={{ ...mockUser, siteAdmin: false }}
+                showCodeMonitoringTestEmailButton={true}
             />
         )
         expect(component.find('.test-send-test-email').length).toBe(0)

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
@@ -16,6 +16,7 @@ export interface CodeMonitorNodeProps extends Pick<CodeMonitoringProps, 'toggleC
     node: CodeMonitorFields
     location: H.Location
     authentictedUser: AuthenticatedUser
+    showCodeMonitoringTestEmailButton: boolean
 }
 
 const LOADING = 'LOADING' as const
@@ -25,6 +26,7 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
     location,
     node,
     authentictedUser,
+    showCodeMonitoringTestEmailButton,
 }: CodeMonitorNodeProps) => {
     const [enabled, setEnabled] = useState<boolean>(node.enabled)
 
@@ -84,15 +86,18 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                     {node.actions.nodes.length > 0 && (
                         <div className="d-flex text-muted">
                             New search result → Sends email notifications{' '}
-                            {authentictedUser.siteAdmin && hasEnabledAction && node.enabled && (
-                                <button
-                                    type="button"
-                                    className="btn btn-link p-0 border-0 ml-2 test-send-test-email"
-                                    onClick={sendEmailRequest}
-                                >
-                                    Send test email
-                                </button>
-                            )}
+                            {showCodeMonitoringTestEmailButton &&
+                                authentictedUser.siteAdmin &&
+                                hasEnabledAction &&
+                                node.enabled && (
+                                    <button
+                                        type="button"
+                                        className="btn btn-link p-0 border-0 ml-2 test-send-test-email"
+                                        onClick={sendEmailRequest}
+                                    >
+                                        Send test email
+                                    </button>
+                                )}
                         </div>
                     )}
                 </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -8,6 +8,7 @@ import { of } from 'rxjs'
 import { mockCodeMonitorNodes } from './testing/util'
 import sinon from 'sinon'
 import { EnterpriseWebStory } from '../components/EnterpriseWebStory'
+import { EMPTY_SETTINGS_CASCADE } from '../../../../shared/src/settings/settings'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/CodeMonitoringPage', module)
 
@@ -23,6 +24,7 @@ const additionalProps = {
             totalCount: 12,
         }),
     toggleCodeMonitorEnabled: sinon.fake(),
+    settingsCascade: EMPTY_SETTINGS_CASCADE,
 }
 
 add(

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -7,6 +7,7 @@ import { AuthenticatedUser } from '../../auth'
 import { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-operations'
 import sinon from 'sinon'
 import { mockCodeMonitorNodes } from './testing/util'
+import { EMPTY_SETTINGS_CASCADE } from '../../../../shared/src/settings/settings'
 
 const history = H.createBrowserHistory({})
 history.replace({ pathname: '/code-monitoring' })
@@ -27,6 +28,7 @@ const additionalProps = {
             totalCount: 12,
         }),
     toggleCodeMonitorEnabled: sinon.spy((id: string, enabled: boolean) => of({ id: 'test', enabled: true })),
+    settingsCascade: EMPTY_SETTINGS_CASCADE,
 }
 
 const generateMockFetchMonitors = (count: number) => ({ id, first, after }: ListUserCodeMonitorsVariables) => {

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -15,11 +15,14 @@ import { catchError, map, startWith } from 'rxjs/operators'
 import { asError, isErrorLike } from '../../../../shared/src/util/errors'
 import { useObservable } from '../../../../shared/src/util/useObservable'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
+import { Settings } from '../../schema/settings.schema'
 
 export interface CodeMonitoringPageProps
     extends BreadcrumbsProps,
         BreadcrumbSetters,
-        Pick<CodeMonitoringProps, 'fetchUserCodeMonitors' | 'toggleCodeMonitorEnabled'> {
+        Pick<CodeMonitoringProps, 'fetchUserCodeMonitors' | 'toggleCodeMonitorEnabled'>,
+        SettingsCascadeProps<Settings> {
     authenticatedUser: AuthenticatedUser
     location: H.Location
     history: H.History
@@ -246,6 +249,11 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                                     nodeComponentProps={{
                                         authentictedUser: props.authenticatedUser,
                                         location: props.location,
+                                        showCodeMonitoringTestEmailButton:
+                                            (!isErrorLike(props.settingsCascade.final) &&
+                                                props.settingsCascade.final?.experimentalFeatures
+                                                    ?.showCodeMonitoringTestEmailButton) ||
+                                            false,
                                         toggleCodeMonitorEnabled,
                                     }}
                                     noun="code monitor"

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -21,6 +21,12 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
   history="[History]"
   location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
+  settingsCascade={
+    Object {
+      "final": Object {},
+      "subjects": Array [],
+    }
+  }
   toggleCodeMonitorEnabled={[Function]}
   useBreadcrumb={[Function]}
 >
@@ -176,6 +182,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                   "username": "alice",
                 },
                 "location": "[Location path=/code-monitoring]",
+                "showCodeMonitoringTestEmailButton": false,
                 "toggleCodeMonitorEnabled": [Function],
               }
             }
@@ -473,6 +480,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       "username": "alice",
                     },
                     "location": "[Location path=/code-monitoring]",
+                    "showCodeMonitoringTestEmailButton": false,
                     "toggleCodeMonitorEnabled": [Function],
                   }
                 }
@@ -522,6 +530,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -633,6 +642,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -744,6 +754,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -855,6 +866,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -966,6 +978,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -1077,6 +1090,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -1188,6 +1202,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -1299,6 +1314,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -1410,6 +1426,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -1521,6 +1538,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -1637,6 +1655,12 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
   history="[History]"
   location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
+  settingsCascade={
+    Object {
+      "final": Object {},
+      "subjects": Array [],
+    }
+  }
   toggleCodeMonitorEnabled={[Function]}
   useBreadcrumb={[Function]}
 >
@@ -1792,6 +1816,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                   "username": "alice",
                 },
                 "location": "[Location path=/code-monitoring]",
+                "showCodeMonitoringTestEmailButton": false,
                 "toggleCodeMonitorEnabled": [Function],
               }
             }
@@ -1907,6 +1932,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                       "username": "alice",
                     },
                     "location": "[Location path=/code-monitoring]",
+                    "showCodeMonitoringTestEmailButton": false,
                     "toggleCodeMonitorEnabled": [Function],
                   }
                 }
@@ -1956,6 +1982,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -2067,6 +2094,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -2178,6 +2206,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -2294,6 +2323,12 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
   history="[History]"
   location="[Location path=/code-monitoring]"
   setBreadcrumb={[Function]}
+  settingsCascade={
+    Object {
+      "final": Object {},
+      "subjects": Array [],
+    }
+  }
   toggleCodeMonitorEnabled={[Function]}
   useBreadcrumb={[Function]}
 >
@@ -2449,6 +2484,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   "username": "alice",
                 },
                 "location": "[Location path=/code-monitoring]",
+                "showCodeMonitoringTestEmailButton": false,
                 "toggleCodeMonitorEnabled": [Function],
               }
             }
@@ -2798,6 +2834,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       "username": "alice",
                     },
                     "location": "[Location path=/code-monitoring]",
+                    "showCodeMonitoringTestEmailButton": false,
                     "toggleCodeMonitorEnabled": [Function],
                   }
                 }
@@ -2847,6 +2884,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -2958,6 +2996,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3069,6 +3108,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3180,6 +3220,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3291,6 +3332,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3402,6 +3444,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3513,6 +3556,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3624,6 +3668,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3735,6 +3780,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3846,6 +3892,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -3957,6 +4004,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div
@@ -4068,6 +4116,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                         },
                       }
                     }
+                    showCodeMonitoringTestEmailButton={false}
                     toggleCodeMonitorEnabled={[Function]}
                   >
                     <div

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 import { CodeMonitoringProps } from '..'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
+import { SettingsCascadeProps } from '../../../../../shared/src/settings/settings'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { AuthenticatedUser } from '../../../auth'
@@ -21,7 +22,8 @@ interface Props
         PlatformContextProps,
         BreadcrumbsProps,
         BreadcrumbSetters,
-        CodeMonitoringProps {
+        CodeMonitoringProps,
+        SettingsCascadeProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1119,6 +1119,8 @@ type SettingsExperimentalFeatures struct {
 	SearchStreaming *bool `json:"searchStreaming,omitempty"`
 	// ShowBadgeAttachments description: Enables the UI indicators for code intelligence precision.
 	ShowBadgeAttachments *bool `json:"showBadgeAttachments,omitempty"`
+	// ShowCodeMonitoringTestEmailButton description: Enables the 'Send test email' debugging button for code monitoring.
+	ShowCodeMonitoringTestEmailButton *bool `json:"showCodeMonitoringTestEmailButton,omitempty"`
 	// ShowEnterpriseHomePanels description: Enabled the homepage panels in the Enterprise homepage
 	ShowEnterpriseHomePanels *bool `json:"showEnterpriseHomePanels,omitempty"`
 	// ShowMultilineSearchConsole description: Enables the multiline search console at search/console

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -30,6 +30,12 @@
           "default": false,
           "!go": { "pointer": true }
         },
+        "showCodeMonitoringTestEmailButton": {
+          "description": "Enables the 'Send test email' debugging button for code monitoring.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
         "searchStats": {
           "description": "Enables a new page that shows language statistics about the results for a search query.",
           "type": "boolean",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -35,6 +35,12 @@ const SettingsSchemaJSON = `{
           "default": false,
           "!go": { "pointer": true }
         },
+        "showCodeMonitoringTestEmailButton": {
+          "description": "Enables the 'Send test email' debugging button for code monitoring.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
         "searchStats": {
           "description": "Enables a new page that shows language statistics about the results for a search query.",
           "type": "boolean",


### PR DESCRIPTION
Hides the send test email button behind a feature flag `experimentalFeatures.showCodeMonitoringTestEmailButton`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
