### PR TITLE
search: monitor frontend performance in Prometheus

### DIFF
--- a/client/shared/src/components/CodeExcerpt.test.tsx
+++ b/client/shared/src/components/CodeExcerpt.test.tsx
@@ -50,6 +50,7 @@ describe('CodeExcerpt', () => {
         className: 'file-match__item-code-excerpt',
         fetchHighlightedFileRangeLines: () =>
             of(HIGHLIGHTED_FILE_LINES_SIMPLE).pipe(map(ranges => ranges[0].slice(startLine, endLine))),
+        isFirst: false,
     }
 
     it('renders correct number of rows', () => {

--- a/client/shared/src/components/CodeExcerpt.tsx
+++ b/client/shared/src/components/CodeExcerpt.tsx
@@ -26,11 +26,13 @@ interface Props extends Repo {
     startLine: number
     /** The 0-based (exclusive) line number that this code excerpt ends at */
     endLine: number
+    /** Whether or not this is the first result being shown or not. */
+    isFirst: boolean
     isLightTheme: boolean
     className?: string
     /** A function to fetch the range of lines this code excerpt will display. It will be provided
      * the same start and end lines properties that were provided as component props */
-    fetchHighlightedFileRangeLines: (startLine: number, endLine: number) => Observable<string[]>
+    fetchHighlightedFileRangeLines: (isFirst: boolean, startLine: number, endLine: number) => Observable<string[]>
 }
 
 interface HighlightRange {
@@ -69,17 +71,18 @@ export class CodeExcerpt extends React.PureComponent<Props, State> {
             combineLatest([this.propsChanges, this.visibilityChanges])
                 .pipe(
                     filter(([, isVisible]) => isVisible),
-                    map(([{ repoName, filePath, commitID, isLightTheme, startLine, endLine }]) => ({
+                    map(([{ repoName, filePath, commitID, isLightTheme, isFirst, startLine, endLine }]) => ({
                         repoName,
                         filePath,
                         commitID,
                         isLightTheme,
+                        isFirst,
                         startLine,
                         endLine,
                     })),
                     distinctUntilChanged((a, b) => isEqual(a, b)),
-                    switchMap(({ repoName, filePath, commitID, isLightTheme, startLine, endLine }) =>
-                        props.fetchHighlightedFileRangeLines(startLine, endLine)
+                    switchMap(({ repoName, filePath, commitID, isLightTheme, isFirst, startLine, endLine }) =>
+                        props.fetchHighlightedFileRangeLines(isFirst, startLine, endLine)
                     ),
                     catchError(error => [asError(error)])
                 )

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -5,7 +5,7 @@ import { pluralize } from '../util/strings'
 import * as GQL from '../graphql/schema'
 import { SettingsCascadeProps } from '../settings/settings'
 import { FetchFileParameters } from './CodeExcerpt'
-import { FileMatchChildren } from './FileMatchChildren'
+import { EventLogger, FileMatchChildren } from './FileMatchChildren'
 import { RepoFileLink } from './RepoFileLink'
 import { Props as ResultContainerProps, ResultContainer } from './ResultContainer'
 import { BadgeAttachmentRenderOptions } from 'sourcegraph'
@@ -37,10 +37,14 @@ export interface MatchItem {
 
 interface Props extends SettingsCascadeProps {
     location: H.Location
+    eventLogger?: EventLogger
     /**
      * The file match search result.
      */
     result: FileLineMatch
+
+    /* Called when the first result has fully loaded. */
+    onFirstResultLoad?: () => void
 
     /**
      * Formatted repository name to be displayed in repository link. If not

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -15,10 +15,17 @@ import { isErrorLike } from '../util/errors'
 import { ISymbol, IHighlightLineRange } from '../graphql/schema'
 import { map } from 'rxjs/operators'
 
+export interface EventLogger {
+    log: (eventLabel: string, eventProperties?: any) => void
+}
+
 interface FileMatchProps extends SettingsCascadeProps, ThemeProps {
     location: H.Location
+    eventLogger?: EventLogger
     items: MatchItem[]
     result: FileLineMatch
+    /* Called when the first result has fully loaded. */
+    onFirstResultLoad?: () => void
     /**
      * Whether or not to show all matches for this file, or only a subset.
      */
@@ -75,10 +82,11 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         props.settingsCascade.final.experimentalFeatures &&
         props.settingsCascade.final.experimentalFeatures.enableFastResultLoading
 
-    const { result, isLightTheme, fetchHighlightedFileLineRanges } = props
+    const { result, isLightTheme, fetchHighlightedFileLineRanges, eventLogger, onFirstResultLoad } = props
     const fetchHighlightedFileRangeLines = React.useCallback(
-        (startLine, endLine) =>
-            fetchHighlightedFileLineRanges(
+        (isFirst, startLine, endLine) => {
+            const startTime = Date.now()
+            return fetchHighlightedFileLineRanges(
                 {
                     repoName: result.repository.name,
                     commitID: result.file.commit.oid,
@@ -96,13 +104,25 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                 },
                 false
             ).pipe(
-                map(lines =>
-                    optimizeHighlighting
+                map(lines => {
+                    isFirst && onFirstResultLoad && onFirstResultLoad()
+                    eventLogger &&
+                        eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime })
+                    return optimizeHighlighting
                         ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
                         : lines[0].slice(startLine, endLine)
-                )
-            ),
-        [result, isLightTheme, fetchHighlightedFileLineRanges, grouped, optimizeHighlighting]
+                })
+            )
+        },
+        [
+            result,
+            isLightTheme,
+            fetchHighlightedFileLineRanges,
+            grouped,
+            optimizeHighlighting,
+            eventLogger,
+            onFirstResultLoad,
+        ]
     )
 
     if (NO_SEARCH_HIGHLIGHTING) {
@@ -127,7 +147,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                     </code>
                 </Link>
             ))}
-            {grouped.map(group => (
+            {grouped.map((group, index) => (
                 <div
                     key={`linematch:${result.file.url}${group.position.line}:${group.position.character}`}
                     className="file-match-children__item-code-wrapper test-file-match-children-item-wrapper"
@@ -149,6 +169,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                             className="file-match-children__item-code-excerpt"
                             isLightTheme={isLightTheme}
                             fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
+                            isFirst={index === 0}
                         />
                     </Link>
 

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -105,9 +105,8 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                 false
             ).pipe(
                 map(lines => {
-                    isFirst && onFirstResultLoad && onFirstResultLoad()
-                    eventLogger &&
-                        eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime })
+                    if (isFirst && onFirstResultLoad) onFirstResultLoad()
+                    if (eventLogger) eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime })
                     return optimizeHighlighting
                         ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
                         : lines[0].slice(startLine, endLine)

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -105,8 +105,12 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                 false
             ).pipe(
                 map(lines => {
-                    if (isFirst && onFirstResultLoad) { onFirstResultLoad() }
-                    if (eventLogger) { eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime }) }
+                    if (isFirst && onFirstResultLoad) {
+                        onFirstResultLoad()
+                    }
+                    if (eventLogger) {
+                        eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime })
+                    }
                     return optimizeHighlighting
                         ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
                         : lines[0].slice(startLine, endLine)

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -105,8 +105,8 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                 false
             ).pipe(
                 map(lines => {
-                    if (isFirst && onFirstResultLoad) onFirstResultLoad()
-                    if (eventLogger) eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime })
+                    if (isFirst && onFirstResultLoad) { onFirstResultLoad() }
+                    if (eventLogger) { eventLogger.log('search.latencies.frontend.code-load', { durationMs: Date.now() - startTime }) }
                     return optimizeHighlighting
                         ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
                         : lines[0].slice(startLine, endLine)

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -23,7 +23,7 @@ import { ErrorLike, isErrorLike, asError } from '../../../../shared/src/util/err
 import { PageTitle } from '../../components/PageTitle'
 import { Settings } from '../../schema/settings.schema'
 import { ThemeProps } from '../../../../shared/src/theme'
-import { EventLogger } from '../../tracking/eventLogger'
+import { eventLogger, EventLogger } from '../../tracking/eventLogger'
 import { isSearchResults, submitSearch, toggleSearchFilter, getSearchTypeFromQuery, QueryState } from '../helpers'
 import { queryTelemetryData } from '../queryTelemetry'
 import { SearchResultsFilterBars, DynamicSearchFilter } from './SearchResultsFilterBars'
@@ -74,6 +74,9 @@ interface SearchResultsState {
     resultsOrError?: GQL.ISearchResults
     allExpanded: boolean
 
+    /* The time when loading the search results started. */
+    loadingStarted: number
+
     // Saved Queries
     showSavedQueryModal: boolean
 
@@ -100,6 +103,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         showSavedQueryModal: false,
         allExpanded: false,
         showVersionContextWarning: false,
+        loadingStarted: 0,
     }
     /** Emits on componentDidUpdate with the new props */
     private componentUpdates = new Subject<SearchResultsProps>()
@@ -161,6 +165,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                             [
                                 {
                                     resultsOrError: undefined,
+                                    loadingStarted: Date.now(),
                                     didSave: false,
                                     activeType: getSearchTypeFromQuery(query),
                                 },
@@ -278,6 +283,13 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
         this.setState({ showVersionContextWarning: false })
     }
 
+    private onFirstResultLoad = (): void => {
+        const patternType = parseSearchURLPatternType(this.props.location.search)
+        eventLogger.log('search.latencies.frontend.' + patternType + '.first-result', {
+            durationMs: Date.now() - this.state.loadingStarted,
+        })
+    }
+
     public render(): JSX.Element | null {
         const query = parseSearchURLQuery(this.props.location.search)
         const filters = this.getFilters()
@@ -315,6 +327,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
                 <SearchResultsList
                     {...this.props}
                     resultsOrError={this.state.resultsOrError}
+                    onFirstResultLoad={this.onFirstResultLoad}
                     onShowMoreResultsClick={this.showMoreResults}
                     onExpandAllResultsToggle={this.onExpandAllResultsToggle}
                     allExpanded={this.state.allExpanded}

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -285,7 +285,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
 
     private onFirstResultLoad = (): void => {
         const patternType = parseSearchURLPatternType(this.props.location.search)
-        eventLogger.log(`search.latencies.frontend.${patternType ? patternType : "unknown"}.first-result`, {
+        eventLogger.log(`search.latencies.frontend.${patternType || 'unknown'}.first-result`, {
             durationMs: Date.now() - this.state.loadingStarted,
         })
     }

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -285,7 +285,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
 
     private onFirstResultLoad = (): void => {
         const patternType = parseSearchURLPatternType(this.props.location.search)
-        eventLogger.log('search.latencies.frontend.' + patternType + '.first-result', {
+        eventLogger.log(`search.latencies.frontend.${patternType}.first-result`, {
             durationMs: Date.now() - this.state.loadingStarted,
         })
     }

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -285,7 +285,7 @@ export class SearchResults extends React.Component<SearchResultsProps, SearchRes
 
     private onFirstResultLoad = (): void => {
         const patternType = parseSearchURLPatternType(this.props.location.search)
-        eventLogger.log(`search.latencies.frontend.${patternType}.first-result`, {
+        eventLogger.log(`search.latencies.frontend.${patternType ? patternType : "unknown"}.first-result`, {
             durationMs: Date.now() - this.state.loadingStarted,
         })
     }

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -62,6 +62,9 @@ export interface SearchResultsListProps
     onShowMoreResultsClick?: () => void
     navbarSearchQueryState: QueryState
 
+    /* Called when the first result has fully loaded. */
+    onFirstResultLoad?: () => void
+
     // Expand all feature
     allExpanded: boolean
     onExpandAllResultsToggle: () => void
@@ -418,7 +421,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                         onShowMoreItems={this.onBottomHit(results.results.length)}
                                         onVisibilityChange={this.nextItemVisibilityChange}
                                         items={results.results
-                                            .map(result => this.renderResult(result))
+                                            .map((result, index) => this.renderResult(result, index === 0))
                                             .filter(isDefined)}
                                         containment={this.scrollableElementRef || undefined}
                                         onRef={this.nextVirtualListContainerElement}
@@ -492,13 +495,18 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
         )
     }
 
-    private renderResult(result: GQL.GenericSearchResultInterface | GQL.IFileMatch): JSX.Element | undefined {
+    private renderResult(
+        result: GQL.GenericSearchResultInterface | GQL.IFileMatch,
+        isFirst: boolean
+    ): JSX.Element | undefined {
         switch (result.__typename) {
             case 'FileMatch':
                 return (
                     <FileMatch
                         key={'file:' + result.file.url}
                         location={this.props.location}
+                        eventLogger={eventLogger}
+                        onFirstResultLoad={isFirst ? this.props.onFirstResultLoad : undefined}
                         icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
                         result={result}
                         onSelect={this.logEvent}

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -39,6 +39,7 @@ import {
     resolveVersionContext,
 } from '../..'
 import { ErrorAlert } from '../../../components/alerts'
+import { eventLogger } from '../../../tracking/eventLogger'
 
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
@@ -167,6 +168,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     <FileMatch
                         key={'file:' + result.file.url}
                         location={location}
+                        eventLogger={eventLogger}
                         icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
                         result={result}
                         onSelect={logSearchResultClicked}

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -95,7 +95,6 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 	}
 
 	if strings.HasPrefix(args.Event, "search.latencies.frontend.") {
-		fmt.Println(args.Event, string(payload))
 		if err := exportPrometheusSearchLatencies(args.Event, payload); err != nil {
 			log15.Error("export prometheus search latencies", "error", err)
 		}

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -3,13 +3,19 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
@@ -88,6 +94,14 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 		}
 	}
 
+	if strings.HasPrefix(args.Event, "search.latencies.frontend.") {
+		fmt.Println(args.Event, string(payload))
+		if err := exportPrometheusSearchLatencies(args.Event, payload); err != nil {
+			log15.Error("export prometheus search latencies", "error", err)
+		}
+		return nil, nil // Future(slimsag): implement actual event logging for these events
+	}
+
 	actor := actor.FromContext(ctx)
 	return nil, usagestats.LogEvent(ctx, usagestats.Event{
 		EventName:    args.Event,
@@ -97,4 +111,36 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 		Source:       args.Source,
 		Argument:     payload,
 	})
+}
+
+var (
+	searchLatenciesFrontendCodeLoad = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_search_latency_frontend_code_load_ms",
+		Help:    "Milliseconds the webapp frontend spends waiting for search result code snippets to load.",
+		Buckets: trace.UserLatencyBuckets,
+	}, nil)
+	searchLatenciesFrontendFirstResult = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_search_latency_frontend_first_result_ms",
+		Help:    "Milliseconds the webapp frontend spends waiting for the first search result to load.",
+		Buckets: trace.UserLatencyBuckets,
+	}, []string{"type"})
+)
+
+// exportPrometheusSearchLatencies exports Prometheus search latency metrics given a GraphQL
+// LogEvent payload.
+func exportPrometheusSearchLatencies(event string, payload json.RawMessage) error {
+	var v struct {
+		DurationMS float64 `json:"durationMs"`
+	}
+	if err := json.Unmarshal([]byte(payload), &v); err != nil {
+		return err
+	}
+	if event == "search.latencies.frontend.code-load" {
+		searchLatenciesFrontendCodeLoad.WithLabelValues().Observe(v.DurationMS)
+	}
+	if strings.HasPrefix(event, "search.latencies.frontend.") && strings.HasSuffix(event, ".first-result") {
+		searchType := strings.TrimSuffix(strings.TrimPrefix(event, "search.latencies.frontend."), ".first-result")
+		searchLatenciesFrontendFirstResult.WithLabelValues(searchType).Observe(v.DurationMS)
+	}
+	return nil
 }


### PR DESCRIPTION
I am working on getting frontend performance for search into our standard pings, see https://github.com/sourcegraph/sourcegraph/pull/16861.

But, this turned out to be a *lot* more complex than I thought, and I need help from other people to finish it (e.g. analytics team to update BigQuery schema, help me confirm it is being collected, etc.) And it's Friday, I will be on holiday break starting next week and most others already are.

But I *really* need to have this data recorded _anywhere_ for Sourcegraph.com over the next few weeks, so that when I return I can start measuring the perf difference of https://github.com/sourcegraph/sourcegraph/pull/16571 and turn it on by default in our Jan release.

So here's what this PR does:

1. It implements event logging in the frontend, in the exact same way that is needed for actual ping telemetry via #16861
2. It _intercepts_ those ping events on the backend, and records Prometheus histogram metrics for them. This means we'll be collecting this data in Prometheus for Sourcegraph.com and when I return I'll have the data I need. This is good to have in Prometheus, anyway, because we could e.g. set up alerting on it.

This is a subset of #16861 basically, and after this PR #16861 should be easier to land. There are only two issues with this approach:

1. It doesn't record `search.latencies.frontend.<type>.first-result` metrics for non-text-results (diff, commit, search, etc.) because these are rendered in a different frontend code path. I will fix this in #16861 later.
2. It doesn't record `search.latencies.frontend.<type>.first-result` metrics when the streaming search feature flag is turned on. It *does* record `search.latencies.frontend.code-load` , though. I will fix this in #16861 as well.

Because I think this is urgent, I will ask for prompt review from whoever is available, and if nobody is available I will merge as-is and ask for post-merge review. I'll accept responsibility for all risks involved with doing this :)

Signed-off-by: Stephen Gutekanst <stephen.gutekanst@gmail.com>
