### PR TITLE
Fix indenting of "Clone the deploy-sourcegraph" repository bullet item

### DIFF
--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -26,9 +26,9 @@ The Kubernetes manifests for a Sourcegraph on Kubernetes installation are in the
 
    - If you are using GCP, you'll need to give your user the ability to create roles in Kubernetes [(see GCP's documentation)](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control):
 
-     ```bash
-     kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
-     ```
+       ```bash
+       kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
+       ```
 
 - Clone the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository and check out the version tag you wish to deploy.
 


### PR DESCRIPTION
Adding spaces to the fenced code block for GCP kubectl config.  Doing this so the "Clone the deploy-sourcegraph repository" step which follows is a bullet in the main list rather than a sub-bullet of "Make sure you have configured kubectl to access your cluster".  
Reference: https://gist.github.com/clintel/1155906



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
