### PR TITLE
search: remove alert handling from doResults

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -673,6 +673,9 @@ func alertForError(err error) *searchAlert {
 
 // unhandledError returns the first unhandled error we find.
 func unhandledError(e error) (u error) {
+	if e == nil {
+		return nil
+	}
 	var errs []error
 	switch e.(type) {
 	case *multierror.Error:

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -164,23 +164,23 @@ func TestAlertForDiffCommitSearchLimits(t *testing.T) {
 	}{
 		{
 			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             multierror.Append(&multierror.Error{}, RepoLimitErr{ResultType: "diff", Max: 50}),
+			multiErr:             multierror.Append(&multierror.Error{}, errRepoLimit{ResultType: "diff", Max: 50}),
 			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             multierror.Append(&multierror.Error{}, RepoLimitErr{ResultType: "commit", Max: 50}),
+			multiErr:             multierror.Append(&multierror.Error{}, errRepoLimit{ResultType: "commit", Max: 50}),
 			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
-			multiErr:             multierror.Append(&multierror.Error{}, TimeLimitErr{ResultType: "commit", Max: 10000}),
+			multiErr:             multierror.Append(&multierror.Error{}, errTimeLimit{ResultType: "commit", Max: 10000}),
 			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 	}
 
 	for _, test := range cases {
-		alert := alertForDiffCommitSearch(test.multiErr)
+		alert := alertForError(test.multiErr)
 		haveAlertDescription := alert.description
 		if diff := cmp.Diff(test.wantAlertDescription, haveAlertDescription); diff != "" {
 			t.Fatalf("test %s, mismatched alert (-want, +got):\n%s", test.name, diff)
@@ -220,7 +220,7 @@ func TestErrorToAlertStructuralSearch(t *testing.T) {
 			Errors:      test.errors,
 			ErrorFormat: multierror.ListFormatFunc,
 		}
-		haveAlert := alertForStructuralSearch(multiErr)
+		haveAlert := alertForError(multiErr)
 		if haveAlert != nil && haveAlert.title != test.wantAlertTitle {
 			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.title, test.wantAlertTitle)
 		}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -180,10 +180,7 @@ func TestAlertForDiffCommitSearchLimits(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		haveMultiErr, alert := alertForDiffCommitSearch(test.multiErr)
-		if haveMultiErr != nil {
-			t.Fatalf("the alert should have been filtered from the multierror")
-		}
+		alert := alertForDiffCommitSearch(test.multiErr)
 		haveAlertDescription := alert.description
 		if diff := cmp.Diff(test.wantAlertDescription, haveAlertDescription); diff != "" {
 			t.Fatalf("test %s, mismatched alert (-want, +got):\n%s", test.name, diff)
@@ -223,12 +220,7 @@ func TestErrorToAlertStructuralSearch(t *testing.T) {
 			Errors:      test.errors,
 			ErrorFormat: multierror.ListFormatFunc,
 		}
-		haveMultiErr, haveAlert := alertForStructuralSearch(multiErr)
-
-		if !reflect.DeepEqual(haveMultiErr.Errors, test.wantErrors) {
-			t.Fatalf("test %s, have errors: %q, want: %q", test.name, haveMultiErr.Errors, test.wantErrors)
-		}
-
+		haveAlert := alertForStructuralSearch(multiErr)
 		if haveAlert != nil && haveAlert.title != test.wantAlertTitle {
 			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.title, test.wantAlertTitle)
 		}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -164,17 +164,17 @@ func TestAlertForDiffCommitSearchLimits(t *testing.T) {
 	}{
 		{
 			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             multierror.Append(&multierror.Error{}, &errRepoLimit{ResultType: "diff", Max: 50}),
+			multiErr:             multierror.Append(&multierror.Error{}, &repoLimitError{ResultType: "diff", Max: 50}),
 			wantAlertDescription: `Diff search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             multierror.Append(&multierror.Error{}, &errRepoLimit{ResultType: "commit", Max: 50}),
+			multiErr:             multierror.Append(&multierror.Error{}, &repoLimitError{ResultType: "commit", Max: 50}),
 			wantAlertDescription: `Commit search can currently only handle searching over 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 		{
 			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
-			multiErr:             multierror.Append(&multierror.Error{}, &errTimeLimit{ResultType: "commit", Max: 10000}),
+			multiErr:             multierror.Append(&multierror.Error{}, &timeLimitError{ResultType: "commit", Max: 10000}),
 			wantAlertDescription: `Commit search can currently only handle searching over 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search. Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/6826`,
 		},
 	}
@@ -399,28 +399,28 @@ func TestAlertForError(t *testing.T) {
 		},
 		{
 			name:      "multi-error with 1 known error",
-			multiErr:  multierror.Append(&multierror.Error{}, &errRepoLimit{ResultType: "diff", Max: 50}),
-			wantAlert: alertForRepoLimitErr(&errRepoLimit{ResultType: "diff", Max: 50}),
+			multiErr:  multierror.Append(&multierror.Error{}, &repoLimitError{ResultType: "diff", Max: 50}),
+			wantAlert: alertForRepoLimitErr(&repoLimitError{ResultType: "diff", Max: 50}),
 		},
 		{
 			name:      "multi-error with pointer to 1 known error",
-			multiErr:  multierror.Append(&multierror.Error{}, &errRepoLimit{ResultType: "diff", Max: 50}),
-			wantAlert: alertForRepoLimitErr(&errRepoLimit{ResultType: "diff", Max: 50}),
+			multiErr:  multierror.Append(&multierror.Error{}, &repoLimitError{ResultType: "diff", Max: 50}),
+			wantAlert: alertForRepoLimitErr(&repoLimitError{ResultType: "diff", Max: 50}),
 		},
 		{
 			name:      "multi-error with other errors",
-			multiErr:  multierror.Append(&multierror.Error{}, fmt.Errorf("other error"), &errRepoLimit{ResultType: "diff", Max: 50}, fmt.Errorf("other error")),
-			wantAlert: alertForRepoLimitErr(&errRepoLimit{ResultType: "diff", Max: 50}),
+			multiErr:  multierror.Append(&multierror.Error{}, fmt.Errorf("other error"), &repoLimitError{ResultType: "diff", Max: 50}, fmt.Errorf("other error")),
+			wantAlert: alertForRepoLimitErr(&repoLimitError{ResultType: "diff", Max: 50}),
 		},
 		{
-			name:      "prioritize errStructuralSearchNotSet 1",
-			multiErr:  multierror.Append(&multierror.Error{}, &errRepoLimit{ResultType: "diff", Max: 50}, &errStructuralSearchNotSet{"foo"}),
-			wantAlert: alertForStructuralSearchNotSet(&errStructuralSearchNotSet{"foo"}),
+			name:      "prioritize structuralSearchNotSetError 1",
+			multiErr:  multierror.Append(&multierror.Error{}, &repoLimitError{ResultType: "diff", Max: 50}, &structuralSearchNotSetError{"foo"}),
+			wantAlert: alertForStructuralSearchNotSet(&structuralSearchNotSetError{"foo"}),
 		},
 		{
-			name:      "prioritize errStructuralSearchNotSet 2",
-			multiErr:  multierror.Append(&multierror.Error{}, &errStructuralSearchNotSet{"foo"}, &errRepoLimit{ResultType: "diff", Max: 50}),
-			wantAlert: alertForStructuralSearchNotSet(&errStructuralSearchNotSet{"foo"}),
+			name:      "prioritize structuralSearchNotSetError 2",
+			multiErr:  multierror.Append(&multierror.Error{}, &structuralSearchNotSetError{"foo"}, &repoLimitError{ResultType: "diff", Max: 50}),
+			wantAlert: alertForStructuralSearchNotSet(&structuralSearchNotSetError{"foo"}),
 		},
 	}
 	for _, tt := range tests {
@@ -442,12 +442,12 @@ func TestContainsUnhandledError(t *testing.T) {
 	}{
 		{
 			name:    "multi-error with 1 unknown error",
-			err:     multierror.Append(&multierror.Error{}, fmt.Errorf("unknown error"), &errTimeLimit{}),
+			err:     multierror.Append(&multierror.Error{}, fmt.Errorf("unknown error"), &timeLimitError{}),
 			wantErr: fmt.Errorf("unknown error"),
 		},
 		{
 			name:    "multi-error only known errors",
-			err:     multierror.Append(&multierror.Error{}, &errRepoLimit{ResultType: "diff", Max: 50}, &errStructuralSearchNotSet{"foo"}, &errTimeLimit{}),
+			err:     multierror.Append(&multierror.Error{}, &repoLimitError{ResultType: "diff", Max: 50}, &structuralSearchNotSetError{"foo"}, &timeLimitError{}),
 			wantErr: nil,
 		},
 		{
@@ -462,8 +462,8 @@ func TestContainsUnhandledError(t *testing.T) {
 		},
 		{
 			name:    "unknown error wraps known error",
-			err:     fmt.Errorf("unknown %w", &errTimeLimit{}),
-			wantErr: fmt.Errorf("unknown %w", &errTimeLimit{}),
+			err:     fmt.Errorf("unknown %w", &timeLimitError{}),
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -189,7 +189,10 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	var alert *searchAlert
 
 	if len(resolved.MissingRepoRevs) > 0 {
-		alert = alertForMissingRepoRevs(r.patternType, resolved.MissingRepoRevs)
+		alert = alertForMissingRepoRevs(errMissingRepoRevs{
+			patternType:     r.patternType,
+			missingRepoRevs: resolved.MissingRepoRevs,
+		})
 	}
 
 	log15.Info("next cursor for paginated search request",

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -189,7 +189,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	var alert *searchAlert
 
 	if len(resolved.MissingRepoRevs) > 0 {
-		alert = alertForMissingRepoRevs(errMissingRepoRevs{
+		alert = alertForMissingRepoRevs(&errMissingRepoRevs{
 			patternType:     r.patternType,
 			missingRepoRevs: resolved.MissingRepoRevs,
 		})

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -189,7 +189,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	var alert *searchAlert
 
 	if len(resolved.MissingRepoRevs) > 0 {
-		alert = alertForMissingRepoRevs(&errMissingRepoRevs{
+		alert = alertForMissingRepoRevs(&missingRepoRevsError{
 			patternType:     r.patternType,
 			missingRepoRevs: resolved.MissingRepoRevs,
 		})

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -2069,6 +2069,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 
 	r.sortResults(ctx, results)
 
+	// Don't set the field alert here. The caller is responsible for converting the
+	// returned error into an appropriate alert.
 	resultsResolver := SearchResultsResolver{
 		start:         start,
 		Stats:         common,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1960,6 +1960,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return nil, err
 	}
 	if alertResult != nil {
+		// LOCAL: send alert and return
 		return alertResult, nil
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -2097,14 +2097,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	return &resultsResolver, multiErr.ErrorOrNil()
 }
 
-type errStructuralSearchNotSet struct {
-	originalQuery string
-}
-
-func (errStructuralSearchNotSet) Error() string {
-	return "structural search not set"
-}
-
 type errMissingRepoRevs struct {
 	patternType     query.SearchType
 	missingRepoRevs []*search.RepositoryRevisions
@@ -2112,43 +2104,6 @@ type errMissingRepoRevs struct {
 
 func (errMissingRepoRevs) Error() string {
 	return "missing repository revisions"
-}
-
-var errStructuralSearchMem = fmt.Errorf("structural search needs more memory")
-var errStructuralSearchSearcher = fmt.Errorf("searcher needs more memory")
-
-type errStructuralSearchNoIndexedRepos struct {
-	msg string
-}
-
-func (errStructuralSearchNoIndexedRepos) Error() string {
-	return "no indexed repositories for structural search"
-}
-
-// convertErrorsForStructuralSearch converts certain text-based errors to
-// sentinel errors and returns a new multierr. len(multierr) is an invariant.
-func convertErrorsForStructuralSearch(multiErr *multierror.Error) (newMultiErr *multierror.Error) {
-	if multiErr == nil {
-		return newMultiErr
-	}
-	for _, err := range multiErr.Errors {
-		if strings.Contains(err.Error(), "Worker_oomed") || strings.Contains(err.Error(), "Worker_exited_abnormally") {
-			newMultiErr = multierror.Append(newMultiErr, errStructuralSearchMem)
-		} else if strings.Contains(err.Error(), "Out of memory") {
-			newMultiErr = multierror.Append(newMultiErr, errStructuralSearchSearcher)
-		} else if strings.Contains(err.Error(), "no indexed repositories for structural search") {
-			var msg string
-			if envvar.SourcegraphDotComMode() {
-				msg = "The good news is you can index any repository you like in a self-install. It takes less than 5 minutes to set up: https://docs.sourcegraph.com/#quickstart"
-			} else {
-				msg = "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."
-			}
-			newMultiErr = multierror.Append(newMultiErr, errStructuralSearchNoIndexedRepos{msg: msg})
-		} else {
-			newMultiErr = multierror.Append(newMultiErr, err)
-		}
-	}
-	return newMultiErr
 }
 
 // isContextError returns true if ctx.Err() is not nil or if err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1198,11 +1198,7 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 			rr.alert = alert
 		}
 	}
-	if err2, ok := containsUnhandledError(err); ok {
-		err = err2
-	} else {
-		err = nil
-	}
+	err = unhandledError(err)
 	// If we have some results, only log the error instead of returning it.
 	// Otherwise the client would not receive the partial results or see the alert.
 	if len(rr.SearchResults) > 0 && err != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1625,11 +1625,11 @@ type DiffCommitError struct {
 type errRepoLimit DiffCommitError
 type errTimeLimit DiffCommitError
 
-func (errRepoLimit) Error() string {
+func (*errRepoLimit) Error() string {
 	return "repo limit error"
 }
 
-func (errTimeLimit) Error() string {
+func (*errTimeLimit) Error() string {
 	return "time limit error"
 }
 
@@ -1649,10 +1649,10 @@ func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameter
 
 	limits := searchrepos.SearchLimits()
 	if max := limits.CommitDiffMaxRepos; !hasTimeFilter && len(repos) > max {
-		return errRepoLimit{ResultType: resultType, Max: max}
+		return &errRepoLimit{ResultType: resultType, Max: max}
 	}
 	if max := limits.CommitDiffWithTimeFilterMaxRepos; hasTimeFilter && len(repos) > max {
-		return errTimeLimit{ResultType: resultType, Max: max}
+		return &errTimeLimit{ResultType: resultType, Max: max}
 	}
 	return nil
 }
@@ -2058,11 +2058,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	tr.LazyPrintf("results=%d %s", len(results), &common)
 
 	if len(results) == 0 && r.patternType != query.SearchTypeStructural && comby.MatchHoleRegexp.MatchString(r.originalQuery) {
-		multiErr = multierror.Append(multiErr, errStructuralSearchNotSet{originalQuery: r.originalQuery})
+		multiErr = multierror.Append(multiErr, &errStructuralSearchNotSet{originalQuery: r.originalQuery})
 	}
 
 	if len(resolved.MissingRepoRevs) > 0 {
-		multiErr = multierror.Append(multiErr, errMissingRepoRevs{r.patternType, resolved.MissingRepoRevs})
+		multiErr = multierror.Append(multiErr, &errMissingRepoRevs{r.patternType, resolved.MissingRepoRevs})
 	}
 
 	multiErr = convertErrorsForStructuralSearch(multiErr)
@@ -2086,7 +2086,7 @@ type errMissingRepoRevs struct {
 	missingRepoRevs []*search.RepositoryRevisions
 }
 
-func (errMissingRepoRevs) Error() string {
+func (*errMissingRepoRevs) Error() string {
 	return "missing repository revisions"
 }
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -863,20 +863,20 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 			name:        "diff_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "diff",
 			numRepoRevs: 51,
-			wantError:   &errRepoLimit{ResultType: "diff", Max: 50},
+			wantError:   &repoLimitError{ResultType: "diff", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "commit",
 			numRepoRevs: 51,
-			wantError:   &errRepoLimit{ResultType: "commit", Max: 50},
+			wantError:   &repoLimitError{ResultType: "commit", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
 			fields:      []query.Node{query.Parameter{Field: "after"}},
 			resultType:  "commit",
 			numRepoRevs: 20000,
-			wantError:   &errTimeLimit{ResultType: "commit", Max: 10000},
+			wantError:   &timeLimitError{ResultType: "commit", Max: 10000},
 		},
 		{
 			name:        "no_warning_when_commit_search_within_search_limit",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -863,20 +863,20 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 			name:        "diff_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "diff",
 			numRepoRevs: 51,
-			wantError:   RepoLimitErr{ResultType: "diff", Max: 50},
+			wantError:   errRepoLimit{ResultType: "diff", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "commit",
 			numRepoRevs: 51,
-			wantError:   RepoLimitErr{ResultType: "commit", Max: 50},
+			wantError:   errRepoLimit{ResultType: "commit", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
 			fields:      []query.Node{query.Parameter{Field: "after"}},
 			resultType:  "commit",
 			numRepoRevs: 20000,
-			wantError:   TimeLimitErr{ResultType: "commit", Max: 10000},
+			wantError:   errTimeLimit{ResultType: "commit", Max: 10000},
 		},
 		{
 			name:        "no_warning_when_commit_search_within_search_limit",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -9,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
@@ -1268,5 +1271,48 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Errorf("wrong results length. want=%d, have=%d\n", len(zoektFileMatches), results.MatchCount())
 			}
 		})
+	}
+}
+
+func TestConvertErrorsForStructuralSearch(t *testing.T) {
+	cases := []struct {
+		name       string
+		errors     []error
+		wantErrors []error
+	}{
+		{
+			name:       "multierr_is_unaffected",
+			errors:     []error{errors.New("some error")},
+			wantErrors: []error{errors.New("some error")},
+		},
+		{
+			name: "convert_text_errors_to_typed_errors",
+			errors: []error{
+				errors.New("some error"),
+				errors.New("Worker_oomed"),
+				errors.New("some other error"),
+				errors.New("Out of memory"),
+				errors.New("yet another error"),
+				errors.New("no indexed repositories for structural search"),
+			},
+			wantErrors: []error{
+				errors.New("some error"),
+				errStructuralSearchMem,
+				errors.New("some other error"),
+				errStructuralSearchSearcher,
+				errors.New("yet another error"),
+				errStructuralSearchNoIndexedRepos{msg: "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."},
+			},
+		},
+	}
+	for _, test := range cases {
+		multiErr := &multierror.Error{
+			Errors:      test.errors,
+			ErrorFormat: multierror.ListFormatFunc,
+		}
+		haveMultiErr := convertErrorsForStructuralSearch(multiErr)
+		if !reflect.DeepEqual(haveMultiErr.Errors, test.wantErrors) {
+			t.Fatalf("test %s, have errors: %q, want: %q", test.name, haveMultiErr.Errors, test.wantErrors)
+		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -10,8 +9,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
@@ -1271,48 +1268,5 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Errorf("wrong results length. want=%d, have=%d\n", len(zoektFileMatches), results.MatchCount())
 			}
 		})
-	}
-}
-
-func TestConvertErrorsForStructuralSearch(t *testing.T) {
-	cases := []struct {
-		name       string
-		errors     []error
-		wantErrors []error
-	}{
-		{
-			name:       "multierr_is_unaffected",
-			errors:     []error{errors.New("some error")},
-			wantErrors: []error{errors.New("some error")},
-		},
-		{
-			name: "convert_text_errors_to_typed_errors",
-			errors: []error{
-				errors.New("some error"),
-				errors.New("Worker_oomed"),
-				errors.New("some other error"),
-				errors.New("Out of memory"),
-				errors.New("yet another error"),
-				errors.New("no indexed repositories for structural search"),
-			},
-			wantErrors: []error{
-				errors.New("some error"),
-				errStructuralSearchMem,
-				errors.New("some other error"),
-				errStructuralSearchSearcher,
-				errors.New("yet another error"),
-				errStructuralSearchNoIndexedRepos{msg: "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."},
-			},
-		},
-	}
-	for _, test := range cases {
-		multiErr := &multierror.Error{
-			Errors:      test.errors,
-			ErrorFormat: multierror.ListFormatFunc,
-		}
-		haveMultiErr := convertErrorsForStructuralSearch(multiErr)
-		if !reflect.DeepEqual(haveMultiErr.Errors, test.wantErrors) {
-			t.Fatalf("test %s, have errors: %q, want: %q", test.name, haveMultiErr.Errors, test.wantErrors)
-		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -863,20 +863,20 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 			name:        "diff_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "diff",
 			numRepoRevs: 51,
-			wantError:   errRepoLimit{ResultType: "diff", Max: 50},
+			wantError:   &errRepoLimit{ResultType: "diff", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit",
 			resultType:  "commit",
 			numRepoRevs: 51,
-			wantError:   errRepoLimit{ResultType: "commit", Max: 50},
+			wantError:   &errRepoLimit{ResultType: "commit", Max: 50},
 		},
 		{
 			name:        "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
 			fields:      []query.Node{query.Parameter{Field: "after"}},
 			resultType:  "commit",
 			numRepoRevs: 20000,
-			wantError:   errTimeLimit{ResultType: "commit", Max: 10000},
+			wantError:   &errTimeLimit{ResultType: "commit", Max: 10000},
 		},
 		{
 			name:        "no_warning_when_commit_search_within_search_limit",

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -188,7 +188,7 @@ type errStructuralSearchNotSet struct {
 	originalQuery string
 }
 
-func (errStructuralSearchNotSet) Error() string {
+func (*errStructuralSearchNotSet) Error() string {
 	return "structural search not set"
 }
 
@@ -199,7 +199,7 @@ type errStructuralSearchNoIndexedRepos struct {
 	msg string
 }
 
-func (errStructuralSearchNoIndexedRepos) Error() string {
+func (*errStructuralSearchNoIndexedRepos) Error() string {
 	return "no indexed repositories for structural search"
 }
 
@@ -221,7 +221,7 @@ func convertErrorsForStructuralSearch(multiErr *multierror.Error) (newMultiErr *
 			} else {
 				msg = "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."
 			}
-			newMultiErr = multierror.Append(newMultiErr, errStructuralSearchNoIndexedRepos{msg: msg})
+			newMultiErr = multierror.Append(newMultiErr, &errStructuralSearchNoIndexedRepos{msg: msg})
 		} else {
 			newMultiErr = multierror.Append(newMultiErr, err)
 		}

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -184,22 +184,22 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	}
 }
 
-type errStructuralSearchNotSet struct {
+type structuralSearchNotSetError struct {
 	originalQuery string
 }
 
-func (*errStructuralSearchNotSet) Error() string {
+func (*structuralSearchNotSetError) Error() string {
 	return "structural search not set"
 }
 
-var errStructuralSearchMem = fmt.Errorf("structural search needs more memory")
-var errStructuralSearchSearcher = fmt.Errorf("searcher needs more memory")
+var structuralSearchMemError = fmt.Errorf("structural search needs more memory")
+var structuralSearchSearcherError = fmt.Errorf("searcher needs more memory")
 
-type errStructuralSearchNoIndexedRepos struct {
+type structuralSearchNoIndexedReposError struct {
 	msg string
 }
 
-func (*errStructuralSearchNoIndexedRepos) Error() string {
+func (*structuralSearchNoIndexedReposError) Error() string {
 	return "no indexed repositories for structural search"
 }
 
@@ -211,9 +211,9 @@ func convertErrorsForStructuralSearch(multiErr *multierror.Error) (newMultiErr *
 	}
 	for _, err := range multiErr.Errors {
 		if strings.Contains(err.Error(), "Worker_oomed") || strings.Contains(err.Error(), "Worker_exited_abnormally") {
-			newMultiErr = multierror.Append(newMultiErr, errStructuralSearchMem)
+			newMultiErr = multierror.Append(newMultiErr, structuralSearchMemError)
 		} else if strings.Contains(err.Error(), "Out of memory") {
-			newMultiErr = multierror.Append(newMultiErr, errStructuralSearchSearcher)
+			newMultiErr = multierror.Append(newMultiErr, structuralSearchSearcherError)
 		} else if strings.Contains(err.Error(), "no indexed repositories for structural search") {
 			var msg string
 			if envvar.SourcegraphDotComMode() {
@@ -221,7 +221,7 @@ func convertErrorsForStructuralSearch(multiErr *multierror.Error) (newMultiErr *
 			} else {
 				msg = "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."
 			}
-			newMultiErr = multierror.Append(newMultiErr, &errStructuralSearchNoIndexedRepos{msg: msg})
+			newMultiErr = multierror.Append(newMultiErr, &structuralSearchNoIndexedReposError{msg: msg})
 		} else {
 			newMultiErr = multierror.Append(newMultiErr, err)
 		}

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -159,7 +159,7 @@ func TestConvertErrorsForStructuralSearch(t *testing.T) {
 				errors.New("some other error"),
 				errStructuralSearchSearcher,
 				errors.New("yet another error"),
-				errStructuralSearchNoIndexedRepos{msg: "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."},
+				&errStructuralSearchNoIndexedRepos{msg: "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."},
 			},
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -155,11 +155,11 @@ func TestConvertErrorsForStructuralSearch(t *testing.T) {
 			},
 			wantErrors: []error{
 				errors.New("some error"),
-				errStructuralSearchMem,
+				structuralSearchMemError,
 				errors.New("some other error"),
-				errStructuralSearchSearcher,
+				structuralSearchSearcherError,
 				errors.New("yet another error"),
-				&errStructuralSearchNoIndexedRepos{msg: "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."},
+				&structuralSearchNoIndexedReposError{msg: "Learn more about managing indexed repositories in our documentation: https://docs.sourcegraph.com/admin/search#indexed-search."},
 			},
 		},
 	}


### PR DESCRIPTION
This prepares our codebase for streaming alerts, by bundling the logic around alerts in a function `alertForErr(err)`, which we can call from streaming as well as batch search.

We move most of the alert handling from `doResults` 1 layer up to `resultsWithTimeoutSuggestion`. `doResults` is called from other call sites too, but none of the other callers checks for alerts. We still have to change `determineRepos` to return a simple error instead of an alert and an error, but I reserve this for the next PR.

Notes:
- I updated this PR significantly since the last review, so I think it is good to review it again.
- The function `unhandledError` could be simplified a bit if we changed `doResults` to return a multi-error instead of an error interface. However, I think it is ok to add a bit of complexity here to maintain the convention of returning `error`.