### PR TITLE
release: new tracking issues for docker and upgrades

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -18,6 +18,7 @@
     "upcomingRelease": "3.23.0",
 
     // Release dates
+    "oneWorkingDayAfterRelease": "21 December 2020 10:00 PST",
     "releaseDateTime": "20 December 2020 10:00 PST",
     "oneWorkingDayBeforeRelease": "18 December 2020 10:00 PST",
     "fourWorkingDaysBeforeRelease": "15 December 2020 10:00 PST",

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -19,6 +19,7 @@ export interface Config {
     oneWorkingDayBeforeRelease: string
     fourWorkingDaysBeforeRelease: string
     fiveWorkingDaysBeforeRelease: string
+    oneWorkingDayAfterRelease: string
 
     slackAnnounceChannel: string
 

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -34,6 +34,16 @@ const templates = {
         repo: 'about',
         path: 'handbook/engineering/releases/patch_release_issue_template.md',
     },
+    upgradeMangedInstanceIssue: {
+        owner: 'sourceraph',
+        repo: 'about',
+        path: 'handbook/engineering/releases/upgrade_managed_issue_template.md'
+    },
+    releaseDockerIssue: {
+        owner: 'sourcegraph',
+        repo: 'about',
+        path: 'handbook/engineering/releases/release_deploy_sourcegraph_docker_template.md'
+    }
 }
 
 /**
@@ -53,6 +63,7 @@ export async function ensureReleaseTrackingIssue({
     assignees: string[]
     releaseDateTime: Date
     oneWorkingDayBeforeRelease: Date
+    oneWorkingDayAfterRelease: Date
     fourWorkingDaysBeforeRelease: Date
     fiveWorkingDaysBeforeRelease: Date
     dryRun: boolean
@@ -136,6 +147,120 @@ export async function ensurePatchReleaseIssue({
             repo: 'sourcegraph',
             assignees,
             body: issueBody,
+            labels: ['release-tracking'],
+        },
+        dryRun
+    )
+}
+
+/**
+ * Ensures a release docker ($MAJOR.$MINOR) tracking issue has been created with the given
+ * parameters using `templates.releaseIssue`.
+ */
+export async function ensureReleaseDockerTrackingIssue({
+    version,
+    assignees,
+    oneWorkingDayAfterRelease,
+    dryRun,
+}: {
+    version: semver.SemVer
+    assignees: string[]
+    oneWorkingDayAfterRelease: Date
+    dryRun: boolean
+}): Promise<{ url: string; created: boolean }> {
+    const octokit = await getAuthenticatedGitHubClient()
+    console.log(`Preparing issue from ${JSON.stringify(templates.releaseDockerIssue)}`)
+    const issueTemplate = await getContent(octokit, templates.releaseDockerIssue)
+    const majorMinor = `${version.major}.${version.minor}`
+    const issueBody = issueTemplate
+        .replace(/\$MAJOR/g, version.major.toString())
+        .replace(/\$MINOR/g, version.minor.toString())
+        .replace(/\$PATCH/g, version.patch.toString())
+        .replace(
+            /\$ONE_WORKING_DAY_AFTER_RELEASE/g,
+            dateMarkdown(oneWorkingDayAfterRelease, `One working day before ${majorMinor} release`)
+        )
+
+    // Release milestones are not as emphasised now as they used to be, since most teams
+    // use sprints shorter than releases to track their work. For reference, if one is
+    // available we apply it to this tracking issue, otherwise just leave it without a
+    // milestone.
+    let milestoneNumber: number | undefined
+    const milestone = await getReleaseMilestone(octokit, version)
+    if (!milestone) {
+        console.log(
+            `Milestone ${JSON.stringify(releaseMilestoneName(version))} is closed or not found — omitting from issue.`
+        )
+    } else {
+        milestoneNumber = milestone ? milestone.number : undefined
+    }
+
+    return ensureIssue(
+        octokit,
+        {
+            title: trackingIssueTitle(version),
+            owner: 'sourcegraph',
+            repo: 'sourcegraph',
+            assignees,
+            body: issueBody,
+            milestone: milestoneNumber,
+            labels: ['release-tracking'],
+        },
+        dryRun
+    )
+}
+
+/**
+ * Ensures a upgrade managed instances to ($MAJOR.$MINOR) tracking issue has been created with the given
+ * parameters using `templates.releaseIssue`.
+ */
+export async function ensureUpgradeManagedTrackingIssue({
+    version,
+    assignees,
+    oneWorkingDayAfterRelease,
+    dryRun,
+}: {
+    version: semver.SemVer
+    assignees: string[]
+    oneWorkingDayAfterRelease: Date
+    dryRun: boolean
+}): Promise<{ url: string; created: boolean }> {
+    const octokit = await getAuthenticatedGitHubClient()
+    console.log(`Preparing issue from ${JSON.stringify(templates.upgradeMangedInstanceIssue)}`)
+    const issueTemplate = await getContent(octokit, templates.upgradeMangedInstanceIssue)
+    const majorMinor = `${version.major}.${version.minor}`
+    const issueBody = issueTemplate
+        .replace(/\$MAJOR/g, version.major.toString())
+        .replace(/\$MINOR/g, version.minor.toString())
+        .replace(/\$PATCH/g, version.patch.toString())
+        .replace(
+            /\$ONE_WORKING_DAY_AFTER_RELEASE/g,
+            dateMarkdown(oneWorkingDayAfterRelease, `One working day before ${majorMinor} release`)
+        )
+
+    // Release milestones are not as emphasised now as they used to be, since most teams
+    // use sprints shorter than releases to track their work. For reference, if one is
+    // available we apply it to this tracking issue, otherwise just leave it without a
+    // milestone.
+    let milestoneNumber: number | undefined
+    const milestone = await getReleaseMilestone(octokit, version)
+    if (!milestone) {
+        console.log(
+            `Milestone ${JSON.stringify(releaseMilestoneName(version))} is closed or not found — omitting from issue.`
+        )
+    } else {
+        milestoneNumber = milestone ? milestone.number : undefined
+    }
+
+    return ensureIssue(
+        octokit,
+        {
+            title: trackingIssueTitle(version),
+            owner: 'sourcegraph',
+            repo: 'sourcegraph',
+            assignees,
+            body: issueBody,
+            milestone: milestoneNumber,
             labels: ['release-tracking'],
         },
         dryRun

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -154,63 +154,6 @@ export async function ensurePatchReleaseIssue({
 }
 
 /**
- * Ensures a release docker ($MAJOR.$MINOR) tracking issue has been created with the given
- * parameters using `templates.releaseIssue`.
- */
-export async function ensureReleaseDockerTrackingIssue({
-    version,
-    assignees,
-    oneWorkingDayAfterRelease,
-    dryRun,
-}: {
-    version: semver.SemVer
-    assignees: string[]
-    oneWorkingDayAfterRelease: Date
-    dryRun: boolean
-}): Promise<{ url: string; created: boolean }> {
-    const octokit = await getAuthenticatedGitHubClient()
-    console.log(`Preparing issue from ${JSON.stringify(templates.releaseDockerIssue)}`)
-    const issueTemplate = await getContent(octokit, templates.releaseDockerIssue)
-    const majorMinor = `${version.major}.${version.minor}`
-    const issueBody = issueTemplate
-        .replace(/\$MAJOR/g, version.major.toString())
-        .replace(/\$MINOR/g, version.minor.toString())
-        .replace(/\$PATCH/g, version.patch.toString())
-        .replace(
-            /\$ONE_WORKING_DAY_AFTER_RELEASE/g,
-            dateMarkdown(oneWorkingDayAfterRelease, `One working day before ${majorMinor} release`)
-        )
-
-    // Release milestones are not as emphasised now as they used to be, since most teams
-    // use sprints shorter than releases to track their work. For reference, if one is
-    // available we apply it to this tracking issue, otherwise just leave it without a
-    // milestone.
-    let milestoneNumber: number | undefined
-    const milestone = await getReleaseMilestone(octokit, version)
-    if (!milestone) {
-        console.log(
-            `Milestone ${JSON.stringify(releaseMilestoneName(version))} is closed or not found — omitting from issue.`
-        )
-    } else {
-        milestoneNumber = milestone ? milestone.number : undefined
-    }
-
-    return ensureIssue(
-        octokit,
-        {
-            title: trackingIssueTitle(version),
-            owner: 'sourcegraph',
-            repo: 'sourcegraph',
-            assignees,
-            body: issueBody,
-            milestone: milestoneNumber,
-            labels: ['release-tracking'],
-        },
-        dryRun
-    )
-}
-
-/**
  * Ensures a upgrade managed instances to ($MAJOR.$MINOR) tracking issue has been created with the given
  * parameters using `templates.releaseIssue`.
  */

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -37,13 +37,13 @@ const templates = {
     upgradeMangedInstanceIssue: {
         owner: 'sourceraph',
         repo: 'about',
-        path: 'handbook/engineering/releases/upgrade_managed_issue_template.md'
+        path: 'handbook/engineering/releases/upgrade_managed_issue_template.md',
     },
     releaseDockerIssue: {
         owner: 'sourcegraph',
         repo: 'about',
-        path: 'handbook/engineering/releases/release_deploy_sourcegraph_docker_template.md'
-    }
+        path: 'handbook/engineering/releases/release_deploy_sourcegraph_docker_template.md',
+    },
 }
 
 /**

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -39,11 +39,6 @@ const templates = {
         repo: 'about',
         path: 'handbook/engineering/releases/upgrade_managed_issue_template.md',
     },
-    releaseDockerIssue: {
-        owner: 'sourcegraph',
-        repo: 'about',
-        path: 'handbook/engineering/releases/release_deploy_sourcegraph_docker_template.md',
-    },
 }
 
 /**

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -5,6 +5,8 @@ import {
     listIssues,
     getTrackingIssue,
     ensureReleaseTrackingIssue,
+    ensureReleaseDockerTrackingIssue,
+    ensureUpgradeManagedTrackingIssue,
     ensurePatchReleaseIssue,
     createChangesets,
     CreatedChangeset,
@@ -27,6 +29,8 @@ export type StepID =
     | 'tracking:release-timeline'
     | 'tracking:release-issue'
     | 'tracking:patch-issue'
+    | 'tracking:release-docker-customers'
+    | 'tracking:upgrade-managed-instances'
     // branch cut
     | 'changelog:cut'
     // release
@@ -261,6 +265,44 @@ If you have changes that should go into this patch release, <${patchRequestTempl
                     slackAnnounceChannel
                 )
                 console.log(`Posted to Slack channel ${slackAnnounceChannel}`)
+            }
+        },
+    },
+    {
+        id: 'tracking:release-docker-customers',
+        description: 'Create a Github issue to track MAJOR.MINOR release of pure-docker to customers',
+        run: async config => {
+            const { captainGitHubUsername, oneWorkingDayAfterRelease, dryRun } = config
+            const { upcoming: release } = await releaseVersions(config)
+
+            // Create issue
+            const { url, created } = await ensureReleaseDockerTrackingIssue({
+                version: release,
+                assignees: [captainGitHubUsername],
+                oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
+                dryRun: dryRun.trackingIssues || false,
+            })
+            if (url) {
+                console.log(created ? `Created tracking issue ${url}` : `Tracking issue already exists: ${url}`)
+            }
+        },
+    },
+    {
+        id: 'tracking:upgrade-managed-instances',
+        description: 'Create a Github issue to track upgrade of managed instances MAJOR.MINOR release',
+        run: async config => {
+            const { captainGitHubUsername, oneWorkingDayAfterRelease, dryRun } = config
+            const { upcoming: release } = await releaseVersions(config)
+
+            // Create issue
+            const { url, created } = await ensureUpgradeManagedTrackingIssue({
+                version: release,
+                assignees: [captainGitHubUsername],
+                oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
+                dryRun: dryRun.trackingIssues || false,
+            })
+            if (url) {
+                console.log(created ? `Created tracking issue ${url}` : `Tracking issue already exists: ${url}`)
             }
         },
     },

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -177,7 +177,6 @@ const steps: Step[] = [
                 oneWorkingDayBeforeRelease,
                 fourWorkingDaysBeforeRelease,
                 fiveWorkingDaysBeforeRelease,
-
                 captainSlackUsername,
                 slackAnnounceChannel,
                 dryRun,

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -5,7 +5,6 @@ import {
     listIssues,
     getTrackingIssue,
     ensureReleaseTrackingIssue,
-    ensureReleaseDockerTrackingIssue,
     ensureUpgradeManagedTrackingIssue,
     ensurePatchReleaseIssue,
     createChangesets,
@@ -29,7 +28,6 @@ export type StepID =
     | 'tracking:release-timeline'
     | 'tracking:release-issue'
     | 'tracking:patch-issue'
-    | 'tracking:release-docker-customers'
     | 'tracking:release-managed-instances'
     // branch cut
     | 'changelog:cut'
@@ -160,14 +158,6 @@ const steps: Step[] = [
                     startDateTime: new Date(config.oneWorkingDayAfterRelease).toISOString(),
                     endDateTime: addMinutes(new Date(config.releaseDateTime), 1).toISOString(),
                 },
-                {
-                    title: `Release deploy-soucegraph-docker ${release.major}.${release.minor} for customers`,
-                    description: '(This is not an actual event to attend, just a calendar marker.)',
-                    anyoneCanAddSelf: true,
-                    attendees: [config.teamEmail],
-                    startDateTime: new Date(config.oneWorkingDayAfterRelease).toISOString(),
-                    endDateTime: addMinutes(new Date(config.releaseDateTime), 1).toISOString(),
-                },
             ]
 
             for (const event of events) {
@@ -265,25 +255,6 @@ If you have changes that should go into this patch release, <${patchRequestTempl
                     slackAnnounceChannel
                 )
                 console.log(`Posted to Slack channel ${slackAnnounceChannel}`)
-            }
-        },
-    },
-    {
-        id: 'tracking:release-docker-customers',
-        description: 'Create a Github issue to track MAJOR.MINOR release of pure-docker to customers',
-        run: async config => {
-            const { captainGitHubUsername, oneWorkingDayAfterRelease, dryRun } = config
-            const { upcoming: release } = await releaseVersions(config)
-
-            // Create issue
-            const { url, created } = await ensureReleaseDockerTrackingIssue({
-                version: release,
-                assignees: [captainGitHubUsername],
-                oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
-                dryRun: dryRun.trackingIssues || false,
-            })
-            if (url) {
-                console.log(created ? `Created tracking issue ${url}` : `Tracking issue already exists: ${url}`)
             }
         },
     },

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -195,7 +195,7 @@ const steps: Step[] = [
                 version: release,
                 assignees: [captainGitHubUsername],
                 releaseDateTime: new Date(releaseDateTime),
-                oneWorkingDayAfterRelease: new Date (oneWorkingDayAfterRelease),
+                oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
                 oneWorkingDayBeforeRelease: new Date(oneWorkingDayBeforeRelease),
                 fourWorkingDaysBeforeRelease: new Date(fourWorkingDaysBeforeRelease),
                 fiveWorkingDaysBeforeRelease: new Date(fiveWorkingDaysBeforeRelease),

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -148,6 +148,22 @@ const steps: Step[] = [
                     startDateTime: new Date(config.releaseDateTime).toISOString(),
                     endDateTime: addMinutes(new Date(config.releaseDateTime), 1).toISOString(),
                 },
+                {
+                    title: `Deploy Sourcegraph ${release.major}.${release.minor} to managed instances`,
+                    description: '(This is not an actual event to attend, just a calendar marker.)',
+                    anyoneCanAddSelf: true,
+                    attendees: [config.teamEmail],
+                    startDateTime: new Date(config.oneWorkingDayAfterRelease).toISOString(),
+                    endDateTime: addMinutes(new Date(config.releaseDateTime), 1).toISOString(),
+                },
+                {
+                    title: `Release deploy-soucegraph-docker ${release.major}.${release.minor} for customers`,
+                    description: '(This is not an actual event to attend, just a calendar marker.)',
+                    anyoneCanAddSelf: true,
+                    attendees: [config.teamEmail],
+                    startDateTime: new Date(config.oneWorkingDayAfterRelease).toISOString(),
+                    endDateTime: addMinutes(new Date(config.releaseDateTime), 1).toISOString(),
+                },
             ]
 
             for (const event of events) {
@@ -163,6 +179,7 @@ const steps: Step[] = [
             const {
                 releaseDateTime,
                 captainGitHubUsername,
+                oneWorkingDayAfterRelease,
                 oneWorkingDayBeforeRelease,
                 fourWorkingDaysBeforeRelease,
                 fiveWorkingDaysBeforeRelease,
@@ -178,6 +195,7 @@ const steps: Step[] = [
                 version: release,
                 assignees: [captainGitHubUsername],
                 releaseDateTime: new Date(releaseDateTime),
+                oneWorkingDayAfterRelease: new Date (oneWorkingDayAfterRelease),
                 oneWorkingDayBeforeRelease: new Date(oneWorkingDayBeforeRelease),
                 fourWorkingDaysBeforeRelease: new Date(fourWorkingDaysBeforeRelease),
                 fiveWorkingDaysBeforeRelease: new Date(fiveWorkingDaysBeforeRelease),

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -30,7 +30,7 @@ export type StepID =
     | 'tracking:release-issue'
     | 'tracking:patch-issue'
     | 'tracking:release-docker-customers'
-    | 'tracking:upgrade-managed-instances'
+    | 'tracking:release-managed-instances'
     // branch cut
     | 'changelog:cut'
     // release
@@ -288,7 +288,7 @@ If you have changes that should go into this patch release, <${patchRequestTempl
         },
     },
     {
-        id: 'tracking:upgrade-managed-instances',
+        id: 'tracking:release-managed-instances',
         description: 'Create a Github issue to track upgrade of managed instances MAJOR.MINOR release',
         run: async config => {
             const { captainGitHubUsername, oneWorkingDayAfterRelease, dryRun } = config


### PR DESCRIPTION
Creates two new tracking issues for upgrades and the docker customer-replica, as well as calendar entries. 

Related: sourcegraph/about#2209 