### PR TITLE
Link in sqlite3 when building libsqlite3-pcre

### DIFF
--- a/dev/libsqlite3-pcre/build.sh
+++ b/dev/libsqlite3-pcre/build.sh
@@ -74,14 +74,14 @@ function build() {
     darwin*)
       # pkg-config spits out multiple arguments and must not be quoted.
       # shellcheck disable=SC2046
-      gcc -fno-common -dynamiclib pcre.c -o "$libsqlite_path" $(pkg-config --cflags sqlite3 libpcre) $(pkg-config --libs libpcre) -fPIC
+      gcc -fno-common -dynamiclib pcre.c -o "$libsqlite_path" $(pkg-config --cflags sqlite3 libpcre) $(pkg-config --libs libpcre sqlite3) -fPIC
       exit 0
       ;;
 
     linux*)
       # pkg-config spits out multiple arguments and must not be quoted.
       # shellcheck disable=SC2046
-      gcc -shared -o "$libsqlite_path" $(pkg-config --cflags sqlite3 libpcre) -fPIC -W -Werror pcre.c $(pkg-config --libs libpcre) -Wl,-z,defs
+      gcc -shared -o "$libsqlite_path" $(pkg-config --cflags sqlite3 libpcre) -fPIC -W -Werror pcre.c $(pkg-config --libs libpcre sqlite3) -Wl,-z,defs
       exit 0
       ;;
 


### PR DESCRIPTION
Quinn Keast ran into an issue where compiling this would fail because of
missing sqlite3 symbols. This fixes that error by linking in `sqlite3`,
which I think was/is implicit if sqlite3 is installed globally, but that
might not be the case on a multi-user homebrew setup on macOS Big Sur
(which is what Quinn has).

