### PR TITLE
repo-updater: Don't lock external_services table while sourcing

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -772,7 +772,8 @@ func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.
 
 				clock := dbtesting.NewFakeClock(time.Now(), 0)
 				syncer := &repos.Syncer{
-					Now: clock.Now,
+					Store: store,
+					Now:   clock.Now,
 				}
 
 				if tc.sourcerErr != nil || tc.listRepoErr != nil {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -184,7 +184,9 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 	defer s.setOrResetLastSyncErr(externalServiceID, &err)
 
 	ids := []int64{externalServiceID}
-	svcs, err := tx.ExternalServiceStore.List(ctx, db.ExternalServicesListOptions{IDs: ids})
+	// We don't tx here as the sourcing process below can be slow and we don't want
+	// to lock the transaction for too long.
+	svcs, err := s.Store.ExternalServiceStore.List(ctx, db.ExternalServicesListOptions{IDs: ids})
 	if err != nil {
 		return errors.Wrap(err, "fetching external services")
 	}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -184,8 +184,8 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 	defer s.setOrResetLastSyncErr(externalServiceID, &err)
 
 	ids := []int64{externalServiceID}
-	// We don't tx here as the sourcing process below can be slow and we don't want
-	// to lock the transaction for too long.
+	// We don't use tx here as the sourcing process below can be slow and we don't
+	// want to hold a lock on the external_services table for too long.
 	svcs, err := s.Store.ExternalServiceStore.List(ctx, db.ExternalServicesListOptions{IDs: ids})
 	if err != nil {
 		return errors.Wrap(err, "fetching external services")


### PR DESCRIPTION
We no longer use the provided tx to fetch the external service as making
this query will hold a lock on the external_services table for the
entire duration of the sync.

Closes: https://github.com/sourcegraph/sourcegraph/issues/16070