### PR TITLE
apiworker: Set -e to trace docker command script execution

### DIFF
--- a/enterprise/internal/apiworker/handler.go
+++ b/enterprise/internal/apiworker/handler.go
@@ -171,7 +171,7 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 }
 
 func buildScript(dockerStep apiclient.DockerStep) []byte {
-	return []byte(strings.Join(dockerStep.Commands, "\n"))
+	return append([]byte("set -x\n"), []byte(strings.Join(dockerStep.Commands, "\n"))...)
 }
 
 func union(a, b map[string]string) map[string]string {


### PR DESCRIPTION
Currently we only get the straight output from the commands being executed from the shell script passed into the runtime environment. No bueno to read, where does one end and the other start? Bit of an eye sore.

So we shall fix that with this PR using the magic of the :shell: