### PR TITLE
search: enable searchFilesInRepos for streaming

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -494,7 +494,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 		return nil, err
 	}
 
-	fileResults, _, err := searchFilesInRepos(ctx, &args)
+	fileResults, _, err := searchFilesInRepos(ctx, &args, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -267,7 +267,7 @@ func paginatedSearchFilesInRepos(ctx context.Context, args *search.TextParameter
 	return plan.execute(ctx, func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *searchResultsCommon, error) {
 		batchArgs := *args
 		batchArgs.RepoPromise = (&search.Promise{}).Resolve(batch)
-		fileResults, fileCommon, err := searchFilesInRepos(ctx, &batchArgs)
+		fileResults, fileCommon, err := searchFilesInRepos(ctx, &batchArgs, nil)
 		// Timeouts are reported through searchResultsCommon so don't report an error for them
 		if err != nil && !(err == context.DeadlineExceeded || err == context.Canceled) {
 			return nil, nil, err

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -176,7 +176,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			newArgs.RepoPromise = (&search.Promise{}).Resolve(repos)
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
-			matches, _, err := searchFilesInRepos(ctx, &newArgs)
+			matches, _, err := searchFilesInRepos(ctx, &newArgs, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +204,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
-			matches, _, err := searchFilesInRepos(ctx, &newArgs)
+			matches, _, err := searchFilesInRepos(ctx, &newArgs, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1756,12 +1756,12 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 	defer func() {
 		tr.Finish()
 	}()
-	fileResults, fileCommon, err := searchFilesInRepos(ctx, args)
+	fileResults, fileCommon, err := searchFilesInRepos(ctx, args, a.resultChannel)
 	if args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == defaultMaxSearchResults && len(fileResults) == 0 && err == nil {
 		// No results for structural search? Automatically search again and force Zoekt
 		// to resolve more potential file matches by setting a higher FileMatchLimit.
 		args.PatternInfo.FileMatchLimit = 1000
-		fileResults, fileCommon, err = searchFilesInRepos(ctx, args)
+		fileResults, fileCommon, err = searchFilesInRepos(ctx, args, a.resultChannel)
 		if len(fileResults) == 0 {
 			// Still no results? Give up.
 			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
@@ -1775,7 +1775,7 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 	for i := range fileResults {
 		results[i] = fileResults[i]
 	}
-	a.report(ctx, results, fileCommon, errors.Wrap(err, "text search failed"))
+	a.collect(ctx, results, fileCommon, errors.Wrap(err, "text search failed"))
 }
 
 func (a *aggregator) doDiffSearch(ctx context.Context, tp *search.TextParameters) {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -294,7 +294,7 @@ func fileMatchResultsToSearchResults(results []*FileMatchResolver) []SearchResul
 }
 
 // searchFilesInRepos searches a set of repos for a pattern.
-// For c != nil searchFilesInRepos will send down partial results down c.
+// For c != nil searchFilesInRepos will send results down c.
 func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan<- []SearchResultResolver) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
 	if mockSearchFilesInRepos != nil {
 		return mockSearchFilesInRepos(args)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -285,8 +285,17 @@ func fileMatchURI(name api.RepoName, ref, path string) string {
 
 var mockSearchFilesInRepos func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error)
 
+func fileMatchResultsToSearchResults(results []*FileMatchResolver) []SearchResultResolver {
+	results2 := make([]SearchResultResolver, len(results))
+	for i, result := range results {
+		results2[i] = result
+	}
+	return results2
+}
+
 // searchFilesInRepos searches a set of repos for a pattern.
-func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
+// For c != nil searchFilesInRepos will send down partial results down c.
+func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan<- []SearchResultResolver) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
 	if mockSearchFilesInRepos != nil {
 		return mockSearchFilesInRepos(args)
 	}
@@ -379,6 +388,12 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters) (res [
 				return a > b
 			})
 			unflattened = append(unflattened, matches)
+
+			// Send matches down the results channel.
+			if c != nil {
+				c <- fileMatchResultsToSearchResults(matches)
+			}
+
 			flattenedSize += len(matches)
 
 			// Stop searching once we have found enough matches. This does

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -7,9 +7,11 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
 	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
@@ -113,6 +115,96 @@ func TestSearchFilesInRepos(t *testing.T) {
 	_, _, err = searchFilesInRepos(context.Background(), args, nil)
 	if !gitserver.IsRevisionNotFound(errors.Cause(err)) {
 		t.Fatalf("searching non-existent rev expected to fail with RevisionNotFoundError got: %v", err)
+	}
+}
+
+func TestSearchFilesInReposStream(t *testing.T) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo *types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+		repoName := repo.Name
+		switch repoName {
+		case "foo/one":
+			return []*FileMatchResolver{
+				{
+					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+				},
+			}, false, nil
+		case "foo/two":
+			return []*FileMatchResolver{
+				{
+					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+				},
+			}, false, nil
+		case "foo/three":
+			return []*FileMatchResolver{
+				{
+					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+				},
+			}, false, nil
+		default:
+			return nil, false, errors.New("Unexpected repo")
+		}
+	}
+	defer func() { mockSearchFilesInRepo = nil }()
+
+	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
+
+	q, err := query.ParseAndCheck("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := &search.TextParameters{
+		PatternInfo: &search.TextPatternInfo{
+			FileMatchLimit: defaultMaxSearchResults,
+			Pattern:        "foo",
+		},
+		RepoPromise:  (&search.Promise{}).Resolve(makeRepositoryRevisions("foo/one", "foo/two", "foo/three")),
+		Query:        q,
+		Zoekt:        zoekt,
+		SearcherURLs: endpoint.Static("test"),
+	}
+
+	resultChannel := make(chan []SearchResultResolver)
+	var resultsFromChannel []*FileMatchResolver
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var ok bool
+		var resultChunk []SearchResultResolver
+		for {
+			resultChunk, ok = <-resultChannel
+			if !ok {
+				break
+			}
+			for _, result := range resultChunk {
+				fm, _ := result.ToFileMatch()
+				resultsFromChannel = append(resultsFromChannel, fm)
+			}
+		}
+	}()
+
+	results, _, err := searchFilesInRepos(context.Background(), args, resultChannel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resultChannel)
+	wg.Wait()
+
+	if len(results) != 3 {
+		t.Errorf("expected three results, got %d", len(results))
+	}
+
+	// For streaming we cannot guarantee the order. Hence we use a sets to compare
+	// the slices.
+	mapForSlice := func(fms []*FileMatchResolver) map[*FileMatchResolver]struct{} {
+		m := make(map[*FileMatchResolver]struct{})
+		for _, fm := range fms {
+			m[fm] = struct{}{}
+		}
+		return m
+	}
+	if diff := cmp.Diff(mapForSlice(resultsFromChannel), mapForSlice(results)); diff != "" {
+		t.Errorf(diff)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -146,7 +146,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 	}
 	defer func() { mockSearchFilesInRepo = nil }()
 
-	zoekt := &searchbackend.Zoekt{Client: &fakeSearcher{}}
+	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
 
 	q, err := query.ParseAndCheck("foo")
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -79,7 +79,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
 	}
-	results, common, err := searchFilesInRepos(context.Background(), args)
+	results, common, err := searchFilesInRepos(context.Background(), args, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	_, _, err = searchFilesInRepos(context.Background(), args)
+	_, _, err = searchFilesInRepos(context.Background(), args, nil)
 	if !gitserver.IsRevisionNotFound(errors.Cause(err)) {
 		t.Fatalf("searching non-existent rev expected to fail with RevisionNotFoundError got: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	repos[0].ListRefs = func(context.Context, api.RepoName) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}
-	results, _, err := searchFilesInRepos(context.Background(), args)
+	results, _, err := searchFilesInRepos(context.Background(), args, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Relates to #13067

We add a result channel `c chan<- []SearchResultResolver` as the last argument to `searchFilesInRepos`. This is the first step to making file/path search stream-based.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
