### PR TITLE
docs: life-of-a-repository/scheduler: fix spacing so list items are properly displayed

### DIFF
--- a/doc/dev/background-information/architecture/life-of-a-repository.md
+++ b/doc/dev/background-information/architecture/life-of-a-repository.md
@@ -61,6 +61,7 @@ We keep a list of all repositories on Sourcegraph in the [`repo` table](https://
 We can't clone all repositories concurrently due to resource constraints in Sourcegraph and on the code host. So `repo-updater` has an [update scheduler](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.14.0/-/blob/cmd/repo-updater/repos/scheduler.go). Cloning and fetching are treated in the same way, but priority is given to newly discovered repositories.
 
 The scheduler is divided into two parts:
+
 - [`updateQueue`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.14.0/-/blob/cmd/repo-updater/repos/scheduler.go#L392:6) is a priority queue of repositories to clone/fetch on `gitserver`.
 - [`schedule`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.14.0/-/blob/cmd/repo-updater/repos/scheduler.go#L567:6) which places repositories onto the `updateQueue` when it thinks it should be updated. This is what paces out updates for a repository. It contains heuristics such that recently updated repositories are more frequently checked.
 


### PR DESCRIPTION
The list items under the "Git Update Scheduler"/"The schedule is divided into two parts:" are displayed inline [https://docs.sourcegraph.com/dev/background-information/architecture/life-of-a-repository#git-update-scheduler].  Adding a new line between the description and the actual list so it interprets the '-'s as list items and displays the list properly.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
