### PR TITLE
usagestats: remove current week from weekly retention

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -427,6 +427,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	err = db.EventLogs.Insert(ctx, &db.Event{
 		UserID:          0,
 		Name:            "ping",

--- a/internal/usagestats/retention.go
+++ b/internal/usagestats/retention.go
@@ -10,6 +10,8 @@ import (
 )
 
 func GetRetentionStatistics(ctx context.Context) (*types.RetentionStats, error) {
+	weekAgo := timeNow().AddDate(0, 0, -7)
+
 	weeklyRetentionQuery := sqlf.Sprintf(`
 		WITH
 			dates AS (
@@ -61,7 +63,7 @@ func GetRetentionStatistics(ctx context.Context) (*types.RetentionStats, error) 
 		LEFT JOIN sub     ON dates.week_start_date = sub.cohort_date
 		GROUP BY week, cohorts.cohort_size
 		ORDER BY week DESC;
-		`, timeNow().AddDate(0, 0, -7), timeNow().AddDate(0, 0, -7), timeNow().AddDate(0, 0, -7), timeNow().AddDate(0, 0, -7))
+		`, weekAgo, weekAgo, weekAgo, weekAgo)
 
 	rows, err := dbconn.Global.QueryContext(ctx, weeklyRetentionQuery.Query(sqlf.PostgresBindVar), weeklyRetentionQuery.Args()...)
 	if err != nil {

--- a/internal/usagestats/retention.go
+++ b/internal/usagestats/retention.go
@@ -61,7 +61,7 @@ func GetRetentionStatistics(ctx context.Context) (*types.RetentionStats, error) 
 		LEFT JOIN sub     ON dates.week_start_date = sub.cohort_date
 		GROUP BY week, cohorts.cohort_size
 		ORDER BY week DESC;
-		`, timeNow(), timeNow(), timeNow(), timeNow())
+		`, timeNow().AddDate(0, 0, -7), timeNow().AddDate(0, 0, -7), timeNow().AddDate(0, 0, -7), timeNow().AddDate(0, 0, -7))
 
 	rows, err := dbconn.Global.QueryContext(ctx, weeklyRetentionQuery.Query(sqlf.PostgresBindVar), weeklyRetentionQuery.Args()...)
 	if err != nil {

--- a/internal/usagestats/retention_test.go
+++ b/internal/usagestats/retention_test.go
@@ -65,22 +65,6 @@ func TestRetentionUsageStatistics(t *testing.T) {
 	zeroFloat := float64(0)
 	weekly := []*types.WeeklyRetentionStats{
 		{
-			WeekStart:  userCreationDate.Add(time.Hour * time.Duration(168)).UTC(),
-			CohortSize: nil,
-			Week0:      nil,
-			Week1:      nil,
-			Week2:      nil,
-			Week3:      nil,
-			Week4:      nil,
-			Week5:      nil,
-			Week6:      nil,
-			Week7:      nil,
-			Week8:      nil,
-			Week9:      nil,
-			Week10:     nil,
-			Week11:     nil,
-		},
-		{
 			WeekStart:  userCreationDate.UTC(),
 			CohortSize: &one,
 			Week0:      &oneFloat,
@@ -98,7 +82,7 @@ func TestRetentionUsageStatistics(t *testing.T) {
 		},
 	}
 
-	for i := 1; i < 11; i++ {
+	for i := 1; i <= 11; i++ {
 		weekly = append(weekly, &types.WeeklyRetentionStats{
 			WeekStart:  userCreationDate.Add((time.Hour * time.Duration(168*i) * -1)).UTC(),
 			CohortSize: nil,


### PR DESCRIPTION
The pings currently collect retention data for cohorts created in the last 12 weeks. The first of the 12 weeks is the current, ongoing week, which means that in each ping we'll be receiving one row of data for a week that's not yet complete. 

This PR removes the current week's cohort from the weekly retention data. Instead, we'll show the last 12 cohorts prior to the current week.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
