### PR TITLE
executor: Write scripts into workspace instead of another temporary directory

### DIFF
--- a/enterprise/internal/apiworker/command/docker.go
+++ b/enterprise/internal/apiworker/command/docker.go
@@ -5,6 +5,10 @@ import (
 	"strconv"
 )
 
+// ScriptsPath is the location relative to the executor workspace where the executor
+// will write scripts required for the execution of the job.
+const ScriptsPath = ".sourcegraph-executor"
+
 // formatRawOrDockerCommand constructs the command to run on the host in order to
 // invoke the given spec. If the spec does not specify an image, then the command
 // will be run _directly_ on the host. Otherwise, the command will be run inside
@@ -32,7 +36,7 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) com
 			dockerEnvFlags(spec.Env),
 			dockerEntrypointFlags(),
 			spec.Image,
-			spec.ScriptPath,
+			filepath.Join("/data", ScriptsPath, spec.ScriptPath),
 		),
 		Operation: spec.Operation,
 	}
@@ -46,7 +50,7 @@ func dockerResourceFlags(options ResourceOptions) []string {
 }
 
 func dockerVolumeFlags(wd, scriptPath string) []string {
-	return []string{"-v", wd + ":/data", "-v", scriptPath + ":" + scriptPath}
+	return []string{"-v", wd + ":/data"}
 }
 
 func dockerWorkingdirectoryFlags(dir string) []string {

--- a/enterprise/internal/apiworker/command/docker_test.go
+++ b/enterprise/internal/apiworker/command/docker_test.go
@@ -52,13 +52,12 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 			"--cpus", "4",
 			"--memory", "20G",
 			"-v", "/proj/src:/data",
-			"-v", "myscript.sh:myscript.sh",
 			"-w", "/data/subdir",
 			"-e", "TEST=true",
 			"--entrypoint",
 			"/bin/sh",
 			"alpine:latest",
-			"myscript.sh",
+			"/data/.sourcegraph-executor/myscript.sh",
 		},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {

--- a/enterprise/internal/apiworker/command/firecracker.go
+++ b/enterprise/internal/apiworker/command/firecracker.go
@@ -116,7 +116,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 			"ignite", "run",
 			commonFirecrackerFlags,
 			firecrackerResourceFlags(options.ResourceOptions),
-			firecrackerCopyfileFlags(repoDir, imageKeys, scriptPaths, options),
+			firecrackerCopyfileFlags(repoDir, imageKeys, options),
 			"--ssh",
 			"--name", name,
 			sanitizeImage(options.FirecrackerOptions.Image),
@@ -160,7 +160,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 			Key: fmt.Sprintf("setup.cat.%d", i),
 			Command: flatten(
 				"ignite", "exec", name, "--",
-				"cat", scriptPath,
+				"cat", filepath.Join(ScriptsPath, scriptPath),
 			),
 			Operation: operations.SetupRm,
 		}
@@ -204,19 +204,13 @@ func firecrackerResourceFlags(options ResourceOptions) []string {
 	}
 }
 
-func firecrackerCopyfileFlags(dir string, imageKeys, scriptPaths []string, options Options) []string {
-	copyfiles := make([]string, 0, len(imageKeys)+len(scriptPaths)+1)
+func firecrackerCopyfileFlags(dir string, imageKeys []string, options Options) []string {
+	copyfiles := make([]string, 0, len(imageKeys)+1)
 	for _, imageKey := range imageKeys {
 		copyfiles = append(copyfiles, fmt.Sprintf(
 			"%s:%s",
 			tarfilePathOnHost(imageKey, options),
 			tarfilePathInVM(imageKey),
-		))
-	}
-
-	for _, scriptPath := range scriptPaths {
-		copyfiles = append(copyfiles, fmt.Sprintf(
-			"%s:%s", scriptPath, scriptPath,
 		))
 	}
 

--- a/enterprise/internal/apiworker/command/firecracker.go
+++ b/enterprise/internal/apiworker/command/firecracker.go
@@ -160,7 +160,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger *Logger,
 			Key: fmt.Sprintf("setup.cat.%d", i),
 			Command: flatten(
 				"ignite", "exec", name, "--",
-				"cat", filepath.Join(ScriptsPath, scriptPath),
+				"cat", filepath.Join(firecrackerContainerDir, ScriptsPath, scriptPath),
 			),
 			Operation: operations.SetupRm,
 		}

--- a/enterprise/internal/apiworker/command/firecracker_test.go
+++ b/enterprise/internal/apiworker/command/firecracker_test.go
@@ -62,12 +62,11 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 				"--cpus", "4",
 				"--memory", "20G",
 				"-v", "/work:/data",
-				"-v", "myscript.sh:myscript.sh",
 				"-w", "/data/subdir",
 				"-e", "TEST=true",
 				"--entrypoint /bin/sh",
 				"alpine:latest",
-				"myscript.sh",
+				"/data/.sourcegraph-executor/myscript.sh",
 			}, " "),
 		},
 	}

--- a/enterprise/internal/apiworker/handler_test.go
+++ b/enterprise/internal/apiworker/handler_test.go
@@ -3,6 +3,7 @@ package apiworker
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,10 +14,11 @@ import (
 )
 
 func TestHandle(t *testing.T) {
-	makeTempDir = func() (string, error) {
-		return "/tmp/codeintel", nil
+	testDir := "/tmp/codeintel"
+	makeTempDir = func() (string, error) { return testDir, nil }
+	if err := os.MkdirAll(filepath.Join(testDir, command.ScriptsPath), os.ModePerm); err != nil {
+		t.Fatalf("unexpected error creating workspace: %s", err)
 	}
-	os.Mkdir("/tmp/codeintel", os.ModePerm)
 
 	store := NewMockStore()
 	runner := NewMockRunner()
@@ -98,8 +100,8 @@ func TestHandle(t *testing.T) {
 	}
 
 	expectedCommands := [][]string{
-		{"/bin/sh", "/tmp/codeintel/42.0_linux@deadbeef.sh"},
-		{"/bin/sh", "/tmp/codeintel/42.1_linux@deadbeef.sh"},
+		{"/bin/sh", "42.0_linux@deadbeef.sh"},
+		{"/bin/sh", "42.1_linux@deadbeef.sh"},
 		{"src", "campaigns", "help"},
 		{"src", "campaigns", "apply", "-f", "spec.yaml"},
 	}


### PR DESCRIPTION
I think this is why auto-indexing has been failing since lAsT yEaR (lol). If this doesn't fix it then at least we have a cleaner execution model: more things are now in the workspace directory so we have a minimal context area on disk for each run.

The other things we import are docker image gzip files, which we aren't currently copying into the workspace as we have a single shared directory in hopes that multiple organizations can benefit from using the same base images. We can likely do a quick on-host copy step to make things more uniform.