### PR TITLE
monitoring: fire an alert when there is any permission syncing error

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3475,7 +3475,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions:**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 1e-06+ permissions sync error rate for 1m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1+ permissions sync error rate for 1m0s
 
 **Possible solutions:**
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3475,7 +3475,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions:**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 1+ permissions sync error rate for 1m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1e-06+ permissions sync error rate for 1m0s
 
 **Possible solutions:**
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -298,7 +298,7 @@ func RepoUpdater() *monitoring.Container {
 							Description:     "permissions sync error rate",
 							Query:           `sum by (type) (rate(src_repoupdater_perms_syncer_sync_errors_total[1m]))`,
 							DataMayNotExist: true,
-							Critical:        monitoring.Alert().GreaterOrEqual(0.01).For(time.Minute),
+							Critical:        monitoring.Alert().GreaterOrEqual(0.000001).For(time.Minute),
 							PanelOptions:    monitoring.PanelOptions().LegendFormat("{{type}}").Unit(monitoring.Number),
 							Owner:           monitoring.ObservableOwnerCloud,
 							PossibleSolutions: `

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -296,9 +296,9 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:            "perms_syncer_sync_errors",
 							Description:     "permissions sync error rate",
-							Query:           `sum by (type) (rate(src_repoupdater_perms_syncer_sync_errors_total[1m]))`,
+							Query:           `sum by (type) (ceil(rate(src_repoupdater_perms_syncer_sync_errors_total[1m])))`,
 							DataMayNotExist: true,
-							Critical:        monitoring.Alert().GreaterOrEqual(0.000001).For(time.Minute),
+							Critical:        monitoring.Alert().GreaterOrEqual(1).For(time.Minute),
 							PanelOptions:    monitoring.PanelOptions().LegendFormat("{{type}}").Unit(monitoring.Number),
 							Owner:           monitoring.ObservableOwnerCloud,
 							PossibleSolutions: `

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -296,9 +296,9 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:            "perms_syncer_sync_errors",
 							Description:     "permissions sync error rate",
-							Query:           `sum by (type) (rate(src_repoupdater_perms_syncer_sync_errors_total[1m])) / sum by (type) (rate(src_repoupdater_perms_syncer_sync_duration_seconds_count[1m]))`,
+							Query:           `sum by (type) (rate(src_repoupdater_perms_syncer_sync_errors_total[1m]))`,
 							DataMayNotExist: true,
-							Critical:        monitoring.Alert().GreaterOrEqual(1).For(time.Minute),
+							Critical:        monitoring.Alert().GreaterOrEqual(0.01).For(time.Minute),
 							PanelOptions:    monitoring.PanelOptions().LegendFormat("{{type}}").Unit(monitoring.Number),
 							Owner:           monitoring.ObservableOwnerCloud,
 							PossibleSolutions: `


### PR DESCRIPTION
This PR addresses two things:

1. Measure on the "rate" of permission syncing errors instead of percentage of the former.
1. Fire a critical alert whenever there is an error. Used `ceil` function to round up.

Fixes #16698