### PR TITLE
monitoring: mark monitoring API docs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@ cmd/frontend/graphqlbackend/schema.go linguist-generated=true
 cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/__fixtures__/** linguist-generated=true
 **/bindata.go linguist-generated=true
+monitoring/monitoring/README.md linguist-generated=true
 CHANGELOG.md merge=union


### PR DESCRIPTION
I'm leaving alert_solutions and dashboards generated docs as _not_ linguist-generated for now since we still want to review those diffs

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
