### PR TITLE
repo-updater: Ensure default repos stay cloned

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -206,7 +207,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}()
 	server.Syncer = syncer
 
-	go syncCloned(ctx, scheduler, gitserver.DefaultClient, store)
+	go syncScheduler(ctx, scheduler, gitserver.DefaultClient, store)
 
 	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
 
@@ -345,6 +346,9 @@ type scheduler interface {
 
 	// SetCloned ensures uncloned repos are given priority in the scheduler.
 	SetCloned([]string)
+
+	// EnsureScheduled ensures that all the repos provided are known to the scheduler
+	EnsureScheduled([]*types.RepoName)
 }
 
 func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps *repos.GitolitePhabricatorMetadataSyncer) {
@@ -375,10 +379,21 @@ func watchSyncer(ctx context.Context, syncer *repos.Syncer, sched scheduler, gps
 	}
 }
 
-// syncCloned will periodically list the cloned repositories on gitserver and
-// update the scheduler with the list.
-func syncCloned(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store *repos.Store) {
+// syncScheduler will periodically list the cloned repositories on gitserver and
+// update the scheduler with the list. It also ensures that all our default repos
+// are known to the scheduler to ensure that they are always cloned even after a
+// gitserver rebalance.
+func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitserver.Client, store *repos.Store) {
 	doSync := func() {
+		defaultRepos, err := idb.Repos.ListDefaultRepos(ctx)
+		if err != nil {
+			log15.Error("Error fetching default repos", "error", err)
+			return
+		}
+
+		// Ensure that all default repos are known to the scheduler
+		sched.EnsureScheduled(defaultRepos)
+
 		cloned, err := gitserverClient.ListCloned(ctx)
 		if err != nil {
 			log15.Warn("failed to fetch list of cloned repositories", "error", err)

--- a/internal/db/default_repos_test.go
+++ b/internal/db/default_repos_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func Test_defaultRepos_List(t *testing.T) {
+func TestListDefaultRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -120,6 +120,56 @@ func Test_defaultRepos_List(t *testing.T) {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestListDefaultReposNotCloned(t *testing.T) {
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := context.Background()
+	_, err := dbconn.Global.ExecContext(ctx, `
+			-- insert one user-added repo, i.e. a repo added by an external service owned by a user
+			INSERT INTO users(id, username) VALUES (1, 'foo');
+			INSERT INTO repo(id, name, cloned) VALUES (10, 'github.com/foo/bar10', true);
+			INSERT INTO repo(id, name, cloned) VALUES (11, 'github.com/foo/bar11', false);
+			INSERT INTO external_services(id, kind, display_name, config, namespace_user_id) VALUES (100, 'github', 'github', '{}', 1);
+			INSERT INTO external_service_repos VALUES (100, 10, 'https://github.com/foo/bar10');
+			INSERT INTO external_service_repos VALUES (100, 11, 'https://github.com/foo/bar11');
+
+			-- insert one repo referenced in the default repo table
+			INSERT INTO repo(id, name, cloned) VALUES (12, 'github.com/foo/bar12', true);
+			INSERT INTO default_repos(repo_id) VALUES(12);
+			INSERT INTO repo(id, name, cloned) VALUES (13, 'github.com/foo/bar13', false);
+			INSERT INTO default_repos(repo_id) VALUES(13);
+
+			-- insert one repo not referenced in the default repo table;
+			INSERT INTO repo(id, name) VALUES (14, 'github.com/foo/bar14');
+		`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := Repos.ListDefaultReposNotCloned(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(repos, func(i, j int) bool {
+		return repos[i].ID < repos[j].ID
+	})
+
+	want := []*types.RepoName{
+		{
+			ID:   api.RepoID(11),
+			Name: "github.com/foo/bar11",
+		},
+		{
+			ID:   api.RepoID(13),
+			Name: "github.com/foo/bar13",
+		},
+	}
+	// expect 2 repos, the user added repo and the one that is referenced in the default repos table
+	if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func BenchmarkDefaultRepos_List_Empty(b *testing.B) {

--- a/internal/db/default_repos_test.go
+++ b/internal/db/default_repos_test.go
@@ -122,56 +122,6 @@ func TestListDefaultRepos(t *testing.T) {
 	})
 }
 
-func TestListDefaultReposNotCloned(t *testing.T) {
-	dbtesting.SetupGlobalTestDB(t)
-	ctx := context.Background()
-	_, err := dbconn.Global.ExecContext(ctx, `
-			-- insert one user-added repo, i.e. a repo added by an external service owned by a user
-			INSERT INTO users(id, username) VALUES (1, 'foo');
-			INSERT INTO repo(id, name, cloned) VALUES (10, 'github.com/foo/bar10', true);
-			INSERT INTO repo(id, name, cloned) VALUES (11, 'github.com/foo/bar11', false);
-			INSERT INTO external_services(id, kind, display_name, config, namespace_user_id) VALUES (100, 'github', 'github', '{}', 1);
-			INSERT INTO external_service_repos VALUES (100, 10, 'https://github.com/foo/bar10');
-			INSERT INTO external_service_repos VALUES (100, 11, 'https://github.com/foo/bar11');
-
-			-- insert one repo referenced in the default repo table
-			INSERT INTO repo(id, name, cloned) VALUES (12, 'github.com/foo/bar12', true);
-			INSERT INTO default_repos(repo_id) VALUES(12);
-			INSERT INTO repo(id, name, cloned) VALUES (13, 'github.com/foo/bar13', false);
-			INSERT INTO default_repos(repo_id) VALUES(13);
-
-			-- insert one repo not referenced in the default repo table;
-			INSERT INTO repo(id, name) VALUES (14, 'github.com/foo/bar14');
-		`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	repos, err := Repos.ListDefaultReposNotCloned(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	sort.Slice(repos, func(i, j int) bool {
-		return repos[i].ID < repos[j].ID
-	})
-
-	want := []*types.RepoName{
-		{
-			ID:   api.RepoID(11),
-			Name: "github.com/foo/bar11",
-		},
-		{
-			ID:   api.RepoID(13),
-			Name: "github.com/foo/bar13",
-		},
-	}
-	// expect 2 repos, the user added repo and the one that is referenced in the default repos table
-	if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
 	dbtesting.SetupGlobalTestDB(b)
 	ctx := context.Background()

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -652,6 +652,66 @@ func (s *RepoStore) list(ctx context.Context, tr *trace.Trace, minimal bool, opt
 	return s.getReposBySQL(ctx, minimal, fromClause, queryConds, querySuffix, scanRepo)
 }
 
+// ListDefaultRepos returns a list of default repos. Default repos are a union of
+// any repo in our default_repos table or any repos owned by a user.
+func (s *RepoStore) ListDefaultRepos(ctx context.Context) (results []*types.RepoName, err error) {
+	tr, ctx := trace.New(ctx, "repos.ListDefaultRepos", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+	s.ensureStore()
+
+	const q = `
+-- source: internal/db/default_repos.go:defaultRepos.List
+SELECT
+    id,
+    name
+FROM
+    repo r
+WHERE
+    EXISTS (
+        SELECT
+        FROM
+            external_service_repos sr
+            INNER JOIN external_services s ON s.id = sr.external_service_id
+        WHERE
+			s.namespace_user_id IS NOT NULL
+			AND s.deleted_at IS NULL
+			AND r.id = sr.repo_id
+            AND r.deleted_at IS NULL)
+UNION
+    SELECT
+        repo.id,
+        repo.name
+    FROM
+        default_repos
+		JOIN repo ON default_repos.repo_id = repo.id
+	WHERE
+		deleted_at IS NULL
+`
+
+	var repos []*types.RepoName
+
+	rows, err := s.Query(ctx, sqlf.Sprintf(q))
+	if err != nil {
+		return nil, errors.Wrap(err, "querying for indexed repos")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var r types.RepoName
+		if err := rows.Scan(&r.ID, &r.Name); err != nil {
+			return nil, errors.Wrap(err, "scanning row from default_repos table")
+		}
+		repos = append(repos, &r)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "scanning rows for default repos")
+	}
+
+	return repos, nil
+}
+
 // Create inserts repos and their sources, respectively in the repo and external_service_repos table.
 // Associated external services must already exist.
 func (s *RepoStore) Create(ctx context.Context, repos ...*types.Repo) (err error) {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -83,7 +83,7 @@ type Client struct {
 	// concurrent use. It may return different results at different times.
 	Addrs func(ctx context.Context) []string
 
-	// UserAgent is a string identifing who the client is. It will be logged in
+	// UserAgent is a string identifying who the client is. It will be logged in
 	// the telemetry in gitserver.
 	UserAgent string
 }


### PR DESCRIPTION
This change ensures that our default repos are always known to the scheduler
before we sync the cloned status. This will ensure that we always notice when default
repos are no longer cloned.

Closes https://github.com/sourcegraph/sourcegraph/issues/16007