### PR TITLE
Fix import of storybook hook in react component

### DIFF
--- a/client/web/src/enterprise/user/settings/UserEventLogsPage.tsx
+++ b/client/web/src/enterprise/user/settings/UserEventLogsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -9,7 +9,6 @@ import { FilteredConnection } from '../../../components/FilteredConnection'
 import { PageTitle } from '../../../components/PageTitle'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
-import { useMemo } from '@storybook/addons'
 import {
     UserEventLogFields,
     UserEventLogsConnectionFields,


### PR DESCRIPTION
Autoimport seems to have chosen the wrong import here and it throws. Found in Sentry.