### PR TITLE
Tweak code monitoring actions feedback copy

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -163,7 +163,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                 </div>
             )}
             <small className="text-muted">
-                What other actions would you like to run?{' '}
+                What other actions would you like to take?{' '}
                 <a href="mailto:feedback@sourcegraph.com" target="_blank" rel="noopener">
                     Share feedback.
                 </a>

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -163,7 +163,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                 </div>
             )}
             <small className="text-muted">
-                What other actions would you like to do?{' '}
+                What other actions would you like to run?{' '}
                 <a href="mailto:feedback@sourcegraph.com" target="_blank" rel="noopener">
                     Share feedback.
                 </a>


### PR DESCRIPTION
Nit: "to do actions" is awkward. "to run actions" is more idiomatic, and consistent with the copy above. What do you think @quinnkeast?

Existing state for reference:

![image](https://user-images.githubusercontent.com/1741180/103895526-d9b7b300-50f0-11eb-9249-21c2fe78d55f.png)


