### PR TITLE
Fix match for commit and diff merged into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Specifying a ref that doesn't exist would show an alert, but still return results [#15576](https://github.com/sourcegraph/sourcegraph/issues/15576)
 - Fixed search highlighting the wrong line. [#10468](https://github.com/sourcegraph/sourcegraph/issues/10468)
 - Fixed an issue where searches of the form `foo type:file` returned results of type `path` too. [#17076](https://github.com/sourcegraph/sourcegraph/issues/17076)
+- Fixed queries like `(type:commit or type:diff)` so that if the query matches both the commit message and the diff, both are returned as results. [#16899](https://github.com/sourcegraph/sourcegraph/issues/16899)
 
 ### Removed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -797,6 +797,11 @@ func TestSearch(t *testing.T) {
 				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) author:felix yarn`,
 			},
 			{
+				name:  `Or match on both diff and commit returns both`,
+        query: `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) subscription after:"june 11 2019" before:"june 13 2019"`,
+        exactMatchCount: 2,
+			},
+			{
 				name:            `Or distributive property on rev`,
 				query:           `repo:^github\.com/sgtest/mux$ (rev:v1.7.3 or revision:v1.7.2)`,
 				exactMatchCount: 2,

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -797,9 +797,9 @@ func TestSearch(t *testing.T) {
 				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) author:felix yarn`,
 			},
 			{
-				name:  `Or match on both diff and commit returns both`,
-        query: `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) subscription after:"june 11 2019" before:"june 13 2019"`,
-        exactMatchCount: 2,
+				name:            `Or match on both diff and commit returns both`,
+				query:           `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) subscription after:"june 11 2019" before:"june 13 2019"`,
+				exactMatchCount: 2,
 			},
 			{
 				name:            `Or distributive property on rev`,


### PR DESCRIPTION
When `(type:commit or type:diff)`, if the query matched the same commit
for both a diff and a commit message, only one result would be returned
because we merge `or` results by URL and the URL is the same for the
diff and the commit that the diff is for.

This commit merges diffs and commits separately so that if a query
matches a commit's message and a commit's diff, both will be returned.

Fixes #16899

Example result of the query `repo:^github\.com/sgtest/sourcegraph-typescript$ (type:diff or type:commit) subscription after:"june 11 2019" before:"june 13 2019"`
<img width="895" alt="Screen Shot 2021-01-07 at 13 11 07" src="https://user-images.githubusercontent.com/12631702/103939977-e1278e00-50e9-11eb-8b85-a5842aa6da39.png">
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
