### PR TITLE
Remove redundant type conversion

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -765,7 +765,7 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 			continue
 		}
 		if repoMatch, ok := r.ToRepository(); ok {
-			rightRepoMatches[string(repoMatch.URL())] = repoMatch
+			rightRepoMatches[repoMatch.URL()] = repoMatch
 			continue
 		}
 		if commitMatch, ok := r.ToCommitSearchResult(); ok {


### PR DESCRIPTION
`RepositoryResolver.URL()` returns a string, so this type conversion is
redundant.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
