### PR TITLE
graphql: Add RepoCount to ExternalServices

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -149,15 +149,5 @@ func (r *externalServiceResolver) LastSyncError(ctx context.Context) (*string, e
 }
 
 func (r *externalServiceResolver) RepoCount(ctx context.Context) (int32, error) {
-	// 🚨 SECURITY: Only site admins or the owner of the external service are allowed
-	// to query the number of repos they have synced
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		if r.externalService.NamespaceUserID == 0 {
-			return 0, err
-		} else if actor.FromContext(ctx).UID != r.externalService.NamespaceUserID {
-			return 0, errors.New("the authenticated user does not have access to this external service")
-		}
-	}
-
 	return db.ExternalServices.RepoCount(ctx, r.externalService.ID)
 }

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -147,3 +147,17 @@ func (r *externalServiceResolver) LastSyncError(ctx context.Context) (*string, e
 	}
 	return &latestError, nil
 }
+
+func (r *externalServiceResolver) RepoCount(ctx context.Context) (int32, error) {
+	// 🚨 SECURITY: Only site admins or the owner of the external service are allowed
+	// to query the number of repos they have synced
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		if r.externalService.NamespaceUserID == 0 {
+			return 0, err
+		} else if actor.FromContext(ctx).UID != r.externalService.NamespaceUserID {
+			return 0, errors.New("the authenticated user does not have access to this external service")
+		}
+	}
+
+	return db.ExternalServices.RepoCount(ctx, r.externalService.ID)
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4037,6 +4037,10 @@ type ExternalService implements Node {
     """
     namespace: ID
     """
+    The number of repos synced by the external service
+    """
+    repoCount: Int!
+    """
     An optional URL that will be populated when webhooks have been configured for the external service.
     """
     webhookURL: String
@@ -4048,7 +4052,6 @@ type ExternalService implements Node {
     not break the API and stay backwards compatible.
     """
     warning: String
-
     """
     External services are synced with code hosts in the background. This optional field
     will contain any errors that occured during the most recent completed sync.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4037,7 +4037,7 @@ type ExternalService implements Node {
     """
     namespace: ID
     """
-    The number of repos synced by the external service
+    The number of repos synced by the external service.
     """
     repoCount: Int!
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4030,6 +4030,10 @@ type ExternalService implements Node {
     """
     namespace: ID
     """
+    The number of repos synced by the external service
+    """
+    repoCount: Int!
+    """
     An optional URL that will be populated when webhooks have been configured for the external service.
     """
     webhookURL: String
@@ -4041,7 +4045,6 @@ type ExternalService implements Node {
     not break the API and stay backwards compatible.
     """
     warning: String
-
     """
     External services are synced with code hosts in the background. This optional field
     will contain any errors that occured during the most recent completed sync.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4030,7 +4030,7 @@ type ExternalService implements Node {
     """
     namespace: ID
     """
-    The number of repos synced by the external service
+    The number of repos synced by the external service.
     """
     repoCount: Int!
     """

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -906,6 +906,23 @@ func (e *ExternalServiceStore) Count(ctx context.Context, opt ExternalServicesLi
 	return count, nil
 }
 
+// RepoCount returns the number of repos synced by the external service with the
+// given id.
+//
+// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
+func (e *ExternalServiceStore) RepoCount(ctx context.Context, id int64) (int32, error) {
+	e.ensureStore()
+
+	q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_repos WHERE external_service_id = %s", id)
+	var count int32
+
+	if err := e.QueryRow(ctx, q).Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 // MockExternalServices mocks the external services store.
 type MockExternalServices struct {
 	Create           func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -434,6 +434,55 @@ func TestExternalServicesStore_Update(t *testing.T) {
 	}
 }
 
+func TestCountRepoCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	ctx := actor.WithInternalActor(context.Background())
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es1 := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := ExternalServices.Create(ctx, confGet, es1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = dbconn.Global.ExecContext(ctx, `
+INSERT INTO repo (id, name, description, fork)
+VALUES (1, 'github.com/user/repo', '', FALSE);
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert rows to `external_service_repos` table to test the trigger.
+	q := sqlf.Sprintf(`
+INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
+VALUES (%d, 1, '')
+`, es1.ID)
+	_, err = dbconn.Global.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := ExternalServices.RepoCount(ctx, es1.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count != 1 {
+		t.Fatalf("Expected 1, got %d", count)
+	}
+}
+
 func TestExternalServicesStore_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
It returns the number of repos currently synced by an
external service.

Closes: https://github.com/sourcegraph/sourcegraph/issues/16729