### PR TITLE
search: enable indexed search for streaming

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1714,7 +1714,8 @@ func (a *aggregator) collect(ctx context.Context, results []SearchResultResolver
 			continue
 		}
 
-		// Merge file matches
+		// Merge fileMatches from type symbol, path, file. For streaming search this
+		// code has no effect and the frontend should handle deduplication.
 		if m, ok := a.fileMatches[fm.uri]; ok {
 			m.appendMatches(fm)
 		} else {

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -260,13 +260,33 @@ func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPat
 	), nil
 }
 
+func zoektSearchHEADOnlyFilesStream(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent {
+	c := make(chan zoektSearchStreamEvent)
+	go func() {
+		defer close(c)
+		_, _, _, _ = zoektSearchHEADOnlyFiles(ctx, args, repos, since, c)
+	}()
+
+	return c
+}
+
 // zoektSearchHEADOnlyFiles searches repositories using zoekt, returning only the file paths containing
 // content matching the given pattern.
 //
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoID]struct{}, err error) {
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration, c chan<- zoektSearchStreamEvent) (fm []*FileMatchResolver, limitHit bool, partial map[api.RepoID]struct{}, err error) {
+	defer func() {
+		if c != nil {
+			c <- zoektSearchStreamEvent{
+				fm:       fm,
+				limitHit: limitHit,
+				partial:  partial,
+				err:      err,
+			}
+		}
+	}()
 	if len(repos.repoRevs) == 0 {
 		return nil, false, nil, nil
 	}

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -260,7 +260,7 @@ func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPat
 	), nil
 }
 
-func zoektSearchHEADOnlyFilesStream(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, since func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent {
+func zoektSearchHEADOnlyFilesStream(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, _ indexedRequestType, since func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent {
 	c := make(chan zoektSearchStreamEvent)
 	go func() {
 		defer close(c)

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -127,7 +127,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		defer run.Release()
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		for event := range indexedSearchStream(ctx, indexed) {
+		for event := range indexed.Search(ctx) {
 			func() {
 				mu.Lock()
 				defer mu.Unlock()

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -526,7 +526,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 					defer mu.Unlock()
 					common.update(&event.common)
 
-					tr.LogFields(otlog.Error(event.err), otlog.Bool("overLimitCanceled", overLimitCanceled))
+					tr.LogFields(otlog.Int("matches.len", len(event.results)), otlog.Error(event.err), otlog.Bool("overLimitCanceled", overLimitCanceled))
 					if event.err != nil && searchErr == nil && !overLimitCanceled {
 						searchErr = event.err
 						tr.LazyPrintf("cancel indexed search due to error: %v", event.err)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -520,7 +520,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 			// TODO limitHit, handleRepoSearchResult
 			defer wg.Done()
 
-			for event := range indexedSearchStream(ctx, indexed) {
+			for event := range indexed.Search(ctx) {
 				func() {
 					mu.Lock()
 					defer mu.Unlock()

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -519,55 +519,57 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 			// TODO limitHit, handleRepoSearchResult
 			defer wg.Done()
 
-			mu.Lock()
-			defer mu.Unlock()
 			for event := range indexedSearchStream(ctx, indexed) {
-				common.update(&event.common)
+				func() {
+					mu.Lock()
+					defer mu.Unlock()
+					common.update(&event.common)
 
-				err = event.err
-				tr.LogFields(otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
-				if err != nil && searchErr == nil && !overLimitCanceled {
-					searchErr = err
-					tr.LazyPrintf("cancel indexed search due to error: %v", err)
-					cancel()
-				}
-
-				if args.PatternInfo.IsStructuralPat {
-					// A partition of {repo name => file list} that we will build from Zoekt matches
-					partition := make(map[string][]string)
-					var repos []*search.RepositoryRevisions
-
-					for _, m := range event.results {
-						name := string(m.Repo.Name())
-						partition[name] = append(partition[name], m.JPath)
+					err = event.err
+					tr.LogFields(otlog.Error(err), otlog.Bool("overLimitCanceled", overLimitCanceled))
+					if err != nil && searchErr == nil && !overLimitCanceled {
+						searchErr = err
+						tr.LazyPrintf("cancel indexed search due to error: %v", err)
+						cancel()
 					}
 
-					// Filter Zoekt repos that didn't contain matches
-					for _, repo := range indexed.Repos() {
-						for key := range partition {
-							if string(repo.Repo.Name) == key {
-								repos = append(repos, repo)
+					if args.PatternInfo.IsStructuralPat {
+						// A partition of {repo name => file list} that we will build from Zoekt matches
+						partition := make(map[string][]string)
+						var repos []*search.RepositoryRevisions
+
+						for _, m := range event.results {
+							name := string(m.Repo.Name())
+							partition[name] = append(partition[name], m.JPath)
+						}
+
+						// Filter Zoekt repos that didn't contain matches
+						for _, repo := range indexed.Repos() {
+							for key := range partition {
+								if string(repo.Repo.Name) == key {
+									repos = append(repos, repo)
+								}
 							}
 						}
-					}
 
-					// For structural search, we run callSearcherOverRepos
-					// over the set of repos and files known to contain
-					// parts of the pattern as determined by Zoekt.
-					// callSearcherOverRepos must acquire the lock, so we
-					// must release the lock held by Zoekt at this point.
-					// The Zoekt part of the search is done here as far as
-					// structural search is concerned, so the lock can be
-					// freely released.
-					mu.Unlock()
-					err := callSearcherOverRepos(repos, partition)
-					mu.Lock()
-					if err != nil {
-						searchErr = err
+						// For structural search, we run callSearcherOverRepos
+						// over the set of repos and files known to contain
+						// parts of the pattern as determined by Zoekt.
+						// callSearcherOverRepos must acquire the lock, so we
+						// must release the lock held by Zoekt at this point.
+						// The Zoekt part of the search is done here as far as
+						// structural search is concerned, so the lock can be
+						// freely released.
+						mu.Unlock()
+						err := callSearcherOverRepos(repos, partition)
+						mu.Lock()
+						if err != nil {
+							searchErr = err
+						}
+					} else {
+						addMatches(event.results)
 					}
-				} else {
-					addMatches(event.results)
-				}
+				}()
 			}
 		}()
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -239,10 +239,7 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c chan<- indexedSearc
 	case textRequest, symbolRequest:
 		zoektStream = zoektSearchStream
 	case fileRequest:
-		// Wrap zoektSearchHEADOnlyFilesStream to get a common signature for the event loop.
-		zoektStream = func(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, _ indexedRequestType, since func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent {
-			return zoektSearchHEADOnlyFilesStream(ctx, args, repos, since)
-		}
+		zoektStream = zoektSearchHEADOnlyFilesStream
 	default:
 		err = fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
 		c <- indexedSearchEvent{common: searchResultsCommon{}, results: nil, err: err}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -254,6 +254,12 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c chan<- indexedSearc
 		}
 	}()
 
+	repos := make([]*types.RepoName, 0, len(s.Repos()))
+	for _, r := range s.Repos() {
+		repos = append(repos, r.Repo)
+	}
+	sort.Sort(types.RepoNames(repos))
+
 	for event := range events {
 		err := event.err
 
@@ -267,12 +273,6 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c chan<- indexedSearc
 			c <- indexedSearchEvent{common: searchResultsCommon{}, results: nil, err: err}
 			return
 		}
-
-		repos := make([]*types.RepoName, 0, len(s.Repos()))
-		for _, r := range s.Repos() {
-			repos = append(repos, r.Repo)
-		}
-		sort.Sort(types.RepoNames(repos))
 
 		var timedout []*types.RepoName
 		if noResultsInTimeout {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -232,8 +232,6 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c chan<- indexedSearc
 		since = s.since
 	}
 
-	var err error
-
 	var zoektStream streamFunc
 	switch s.typ {
 	case textRequest, symbolRequest:
@@ -241,13 +239,13 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c chan<- indexedSearc
 	case fileRequest:
 		zoektStream = zoektSearchHEADOnlyFilesStream
 	default:
-		err = fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
+		err := fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
 		c <- indexedSearchEvent{common: searchResultsCommon{}, results: nil, err: err}
 		return
 	}
 
 	for event := range zoektStream(ctx, s.args, s.repos, s.typ, since) {
-		err = event.err
+		err := event.err
 
 		noResultsInTimeout := false
 		if err == errNoResultsInTimeout {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -209,17 +209,18 @@ type indexedSearchEvent struct {
 	err     error
 }
 
-func indexedSearchStream(ctx context.Context, indexed *indexedSearchRequest) <-chan indexedSearchEvent {
+// Search returns a search event stream. Ensure you drain the stream.
+func (s *indexedSearchRequest) Search(ctx context.Context) <-chan indexedSearchEvent {
 	c := make(chan indexedSearchEvent)
 	go func() {
 		defer close(c)
-		indexed.Search(ctx, c)
+		s.doSearch(ctx, c)
 	}()
 
 	return c
 }
 
-func (s *indexedSearchRequest) Search(ctx context.Context, c chan<- indexedSearchEvent) {
+func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- indexedSearchEvent) {
 	if s.args == nil {
 		return
 	}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -304,7 +304,7 @@ func TestIndexedSearch(t *testing.T) {
 
 			indexed.since = tt.args.since
 
-			gotCommon, gotFm, err := indexed.Search(tt.args.ctx)
+			gotCommon, gotFm, err := indexed.Search(tt.args.ctx, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -304,11 +304,22 @@ func TestIndexedSearch(t *testing.T) {
 
 			indexed.since = tt.args.since
 
-			gotCommon, gotFm, err := indexed.Search(tt.args.ctx, nil)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
-				return
+			// This is a quick fix which will break once we enable the zoekt client for true streaming.
+			// Once we return more than one event we have to account for the proper order of results
+			// in the tests.
+			var (
+				gotCommon searchResultsCommon
+				gotFm     []*FileMatchResolver
+			)
+			for event := range indexedSearchStream(tt.args.ctx, indexed) {
+				if (event.err != nil) != tt.wantErr {
+					t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
+					return
+				}
+				gotCommon.update(&event.common)
+				gotFm = append(gotFm, event.results...)
 			}
+
 			if diff := cmp.Diff(&tt.wantCommon, &gotCommon, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("common mismatch (-want +got):\n%s", diff)
 			}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -311,7 +311,7 @@ func TestIndexedSearch(t *testing.T) {
 				gotCommon searchResultsCommon
 				gotFm     []*FileMatchResolver
 			)
-			for event := range indexedSearchStream(tt.args.ctx, indexed) {
+			for event := range indexed.Search(tt.args.ctx) {
 				if (event.err != nil) != tt.wantErr {
 					t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 					return


### PR DESCRIPTION
Relates to #17043

This updates the call chain for indexed search to support streaming.
For true streaming, we still have to update the zoekt client.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
