### PR TITLE
monitoring(postgres): fix panels, adjust transaction alerts

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2150,6 +2150,26 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
+## postgres: pods_available_percentage
+
+<p class="subtitle">percentage pods available (cloud)</p>
+
+**Descriptions:**
+
+- <span class="badge badge-critical">critical</span> postgres: less than 90% percentage pods available for 10m0s
+
+**Possible solutions:**
+
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_postgres_pods_available_percentage"
+]
+```
+
+<br />
+
 ## precise-code-intel-worker: upload_queue_size
 
 <p class="subtitle">queue size (code-intel)</p>

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1958,11 +1958,11 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ## postgres: connections
 
-<p class="subtitle">connections (cloud)</p>
+<p class="subtitle">active connections (cloud)</p>
 
 **Descriptions:**
 
-- <span class="badge badge-warning">warning</span> postgres: less than 5 connections for 5m0s
+- <span class="badge badge-warning">warning</span> postgres: less than 5 active connections for 5m0s
 
 **Possible solutions:**
 
@@ -1976,14 +1976,14 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## postgres: transactions
+## postgres: transaction_durations
 
-<p class="subtitle">transaction durations (cloud)</p>
+<p class="subtitle">maximum transaction durations (cloud)</p>
 
 **Descriptions:**
 
-- <span class="badge badge-warning">warning</span> postgres: 300ms+ transaction durations for 5m0s
-- <span class="badge badge-critical">critical</span> postgres: 500ms+ transaction durations for 5m0s
+- <span class="badge badge-warning">warning</span> postgres: 300ms+ maximum transaction durations for 5m0s
+- <span class="badge badge-critical">critical</span> postgres: 500ms+ maximum transaction durations for 10m0s
 
 **Possible solutions:**
 
@@ -1991,8 +1991,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_postgres_transactions",
-  "critical_postgres_transactions"
+  "warning_postgres_transaction_durations",
+  "critical_postgres_transaction_durations"
 ]
 ```
 
@@ -2000,14 +2000,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ## postgres: postgres_up
 
-<p class="subtitle">current db status (cloud)</p>
+<p class="subtitle">database availability (cloud)</p>
 
 **Descriptions:**
 
-- <span class="badge badge-critical">critical</span> postgres: less than 0 current db status for 5m0s
+- <span class="badge badge-critical">critical</span> postgres: less than 0 database availability for 5m0s
 
 **Possible solutions:**
 
+- **Refer to the [dashboards reference](./dashboards.md#postgres-postgres-up)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2028,6 +2029,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions:**
 
+- **Refer to the [dashboards reference](./dashboards.md#postgres-pg-exporter-err)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2040,15 +2042,16 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ## postgres: migration_in_progress
 
-<p class="subtitle">schema migration status (where 0 is no migration in progress) (cloud)</p>
+<p class="subtitle">active schema migration (cloud)</p>
 
 **Descriptions:**
 
-- <span class="badge badge-critical">critical</span> postgres: 1+ schema migration status (where 0 is no migration in progress) for 5m0s
+- <span class="badge badge-critical">critical</span> postgres: 1+ active schema migration for 5m0s
 
 **Possible solutions:**
 
-- The database migration has been in progress for 5 or more minutes, please contact Sourcegraph if this persists
+- The database migration has been in progress for 5 or more minutes - please contact Sourcegraph if this persists.
+- **Refer to the [dashboards reference](./dashboards.md#postgres-migration-in-progress)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2069,8 +2072,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions:**
 
-- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the pgsql service.
-- **Docker Compose:** Consider increasing `cpus:` of the pgsql container in `docker-compose.yml`.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the (pgsql|codeintel-db) service.
+- **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2091,8 +2094,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions:**
 
-- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the pgsql service.
-- **Docker Compose:** Consider increasing `memory:` of the pgsql container in `docker-compose.yml`.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the (pgsql|codeintel-db) service.
+- **Docker Compose:** Consider increasing `memory:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2114,7 +2117,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions:**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `cpus:` of the pgsql container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2136,95 +2139,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions:**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `memory:` of pgsql container in `docker-compose.yml`.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_postgres_provisioning_container_memory_usage_short_term"
-]
-```
-
-<br />
-
-## postgres: provisioning_container_cpu_usage_long_term
-
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> postgres: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
-
-**Possible solutions:**
-
-- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the codeintel-db service.
-- **Docker Compose:** Consider increasing `cpus:` of the codeintel-db container in `docker-compose.yml`.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_postgres_provisioning_container_cpu_usage_long_term"
-]
-```
-
-<br />
-
-## postgres: provisioning_container_memory_usage_long_term
-
-<p class="subtitle">container memory usage (1d maximum) by instance (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> postgres: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
-
-**Possible solutions:**
-
-- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the codeintel-db service.
-- **Docker Compose:** Consider increasing `memory:` of the codeintel-db container in `docker-compose.yml`.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_postgres_provisioning_container_memory_usage_long_term"
-]
-```
-
-<br />
-
-## postgres: provisioning_container_cpu_usage_short_term
-
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> postgres: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
-
-**Possible solutions:**
-
-- **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `cpus:` of the codeintel-db container in `docker-compose.yml`.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_postgres_provisioning_container_cpu_usage_short_term"
-]
-```
-
-<br />
-
-## postgres: provisioning_container_memory_usage_short_term
-
-<p class="subtitle">container memory usage (5m maximum) by instance (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> postgres: 90%+ container memory usage (5m maximum) by instance
-
-**Possible solutions:**
-
-- **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `memory:` of codeintel-db container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `memory:` of (pgsql|codeintel-db) container in `docker-compose.yml`.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -939,6 +939,16 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 
 <br />
 
+### Postgres: Kubernetes monitoring (ignore if using Docker Compose or server)
+
+#### postgres: pods_available_percentage
+
+This cloud panel indicates percentage pods available.
+
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage) for relevant alerts.
+
+<br />
+
 ## Precise Code Intel Worker
 
 <p class="subtitle">Handles conversion of uploaded precise code intelligence bundles.</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -855,23 +855,21 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-
 
 ## Postgres
 
-<p class="subtitle">Metrics from postgres_exporter.</p>
-
-### Postgres: Default postgres dashboard
+<p class="subtitle">Postgres metrics, exported from postgres_exporter (only available on Kubernetes).</p>
 
 #### postgres: connections
 
-This cloud panel indicates connections.
+This cloud panel indicates active connections.
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-connections) for relevant alerts.
 
 <br />
 
-#### postgres: transactions
+#### postgres: transaction_durations
 
-This cloud panel indicates transaction durations.
+This cloud panel indicates maximum transaction durations.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-transactions) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for relevant alerts.
 
 <br />
 
@@ -879,7 +877,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-transacti
 
 #### postgres: postgres_up
 
-This cloud panel indicates current db status.
+This cloud panel indicates database availability.
+
+A non-zero value indicates the database is online.
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-postgres-up) for relevant alerts.
 
@@ -889,13 +889,17 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-postgres-
 
 This cloud panel indicates errors scraping postgres exporter.
 
+This value indicates issues retrieving metrics from postgres_exporter.
+
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err) for relevant alerts.
 
 <br />
 
 #### postgres: migration_in_progress
 
-This cloud panel indicates schema migration status (where 0 is no migration in progress).
+This cloud panel indicates active schema migration.
+
+A 0 value indicates that no migration is in progress.
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress) for relevant alerts.
 
@@ -930,38 +934,6 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 #### postgres: provisioning_container_memory_usage_short_term
 
 This cloud panel indicates container memory usage (5m maximum) by instance.
-
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term) for relevant alerts.
-
-<br />
-
-#### postgres: provisioning_container_cpu_usage_long_term
-
-This code-intel panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
-
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term) for relevant alerts.
-
-<br />
-
-#### postgres: provisioning_container_memory_usage_long_term
-
-This code-intel panel indicates container memory usage (1d maximum) by instance.
-
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term) for relevant alerts.
-
-<br />
-
-#### postgres: provisioning_container_cpu_usage_short_term
-
-This code-intel panel indicates container cpu usage total (5m maximum) across all cores by instance.
-
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term) for relevant alerts.
-
-<br />
-
-#### postgres: provisioning_container_memory_usage_short_term
-
-This code-intel panel indicates container memory usage (5m maximum) by instance.
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term) for relevant alerts.
 

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -95,7 +95,6 @@ func Postgres() *monitoring.Container {
 					},
 				},
 			},
-
 			{
 				Title:  "Provisioning indicators (not available on server)",
 				Hidden: true,
@@ -108,6 +107,15 @@ func Postgres() *monitoring.Container {
 					{
 						shared.ProvisioningCPUUsageShortTerm(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
 						shared.ProvisioningMemoryUsageShortTerm(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
+					},
+				},
+			},
+			{
+				Title:  "Kubernetes monitoring (ignore if using Docker Compose or server)",
+				Hidden: true,
+				Rows: []monitoring.Row{
+					{
+						shared.KubernetesPodsAvailable(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -7,36 +7,38 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-const (
-	dbCodeIntel   = "codeintel-db"
-	dbSourcegraph = "pgsql"
-)
-
 func Postgres() *monitoring.Container {
+	// In docker-compose, codeintel-db container is called pgsql
+	// In Kubernetes, codeintel-db container is called codeintel-db
+	// Because of this, we track all database cAdvisor metrics in a single panel using this
+	// container name regex to ensure we have observability on all platforms.
+	const databaseContainerNames = "(pgsql|codeintel-db)"
+
 	return &monitoring.Container{
 		Name:        "postgres",
 		Title:       "Postgres",
-		Description: "Metrics from postgres_exporter.",
+		Description: "Postgres metrics, exported from postgres_exporter (only available on Kubernetes).",
 		Groups: []monitoring.Group{
 			{
-				Title: "Default postgres dashboard",
+				Title: "General",
 				Rows: []monitoring.Row{{
 					monitoring.Observable{
 						Name:              "connections",
-						Description:       "connections",
+						Description:       "active connections",
 						Owner:             monitoring.ObservableOwnerCloud,
 						Query:             `sum by (datname) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"})`,
+						PanelOptions:      monitoring.PanelOptions().LegendFormat("{{datname}}"),
 						Warning:           monitoring.Alert().LessOrEqual(5).For(5 * time.Minute),
 						PossibleSolutions: "none",
 					},
 					monitoring.Observable{
-						Name:              "transactions",
-						Description:       "transaction durations",
+						Name:              "transaction_durations",
+						Description:       "maximum transaction durations",
 						Owner:             monitoring.ObservableOwnerCloud,
 						Query:             `sum by (datname) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin"})`,
+						PanelOptions:      monitoring.PanelOptions().LegendFormat("{{datname}}").Unit(monitoring.Milliseconds),
 						Warning:           monitoring.Alert().GreaterOrEqual(300).For(5 * time.Minute),
-						Critical:          monitoring.Alert().GreaterOrEqual(500).For(5 * time.Minute),
-						PanelOptions:      monitoring.PanelOptions().Unit(monitoring.Milliseconds),
+						Critical:          monitoring.Alert().GreaterOrEqual(500).For(10 * time.Minute),
 						PossibleSolutions: "none",
 					},
 				},
@@ -48,31 +50,39 @@ func Postgres() *monitoring.Container {
 					{
 						monitoring.Observable{
 							Name:              "postgres_up",
-							Description:       "current db status",
+							Description:       "database availability",
 							Owner:             monitoring.ObservableOwnerCloud,
 							Query:             "pg_up",
+							PanelOptions:      monitoring.PanelOptions().LegendFormat("{{app}}"),
 							Critical:          monitoring.Alert().LessOrEqual(0).For(5 * time.Minute),
 							PossibleSolutions: "none",
+							Interpretation:    "A non-zero value indicates the database is online.",
 						},
 						monitoring.Observable{
 							Name:              "pg_exporter_err",
 							Description:       "errors scraping postgres exporter",
 							Owner:             monitoring.ObservableOwnerCloud,
 							Query:             "pg_exporter_last_scrape_error",
+							PanelOptions:      monitoring.PanelOptions().LegendFormat("{{app}}"),
 							Warning:           monitoring.Alert().GreaterOrEqual(1).For(5 * time.Minute),
-							PossibleSolutions: "none",
+							PossibleSolutions: "none", // TODO(@daxmc99): how to debug this?
+							Interpretation:    "This value indicates issues retrieving metrics from postgres_exporter.",
 						},
 						monitoring.Observable{
-							Name:        "migration_in_progress",
-							Description: "schema migration status (where 0 is no migration in progress)",
-							Owner:       monitoring.ObservableOwnerCloud,
-							Query:       "pg_sg_migration_status",
-							Critical:    monitoring.Alert().GreaterOrEqual(1).For(5 * time.Minute),
-							PossibleSolutions: "The database migration has been in progress for 5 or more minutes, " +
-								"please contact Sourcegraph if this persists",
+							Name:           "migration_in_progress",
+							Description:    "active schema migration",
+							Owner:          monitoring.ObservableOwnerCloud,
+							Query:          "pg_sg_migration_status",
+							PanelOptions:   monitoring.PanelOptions().LegendFormat("{{app}}"),
+							Critical:       monitoring.Alert().GreaterOrEqual(1).For(5 * time.Minute),
+							Interpretation: "A 0 value indicates that no migration is in progress.",
+							PossibleSolutions: `
+								The database migration has been in progress for 5 or more minutes - please contact Sourcegraph if this persists.
+							`,
 						},
-						// TODO(Dax): Blocked by https://github.com/sourcegraph/sourcegraph/issues/13300,  need to enable `pg_stat_statements` in Postgres conf
-						//monitoring.Observable{
+						// TODO(@daxmc99): Blocked by https://github.com/sourcegraph/sourcegraph/issues/13300
+						// need to enable `pg_stat_statements` in Postgres conf
+						// monitoring.Observable{
 						//	Name:            "cache_hit_ratio",
 						//	Description:     "ratio of cache hits over 5m",
 						//	Owner:           monitoring.ObservableOwnerCloud,
@@ -89,22 +99,15 @@ func Postgres() *monitoring.Container {
 			{
 				Title:  "Provisioning indicators (not available on server)",
 				Hidden: true,
+				// See docstring for databaseContainerNames
 				Rows: []monitoring.Row{
 					{
-						shared.ProvisioningCPUUsageLongTerm(dbSourcegraph, monitoring.ObservableOwnerCloud).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm(dbSourcegraph, monitoring.ObservableOwnerCloud).Observable(),
+						shared.ProvisioningCPUUsageLongTerm(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
+						shared.ProvisioningMemoryUsageLongTerm(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
 					},
 					{
-						shared.ProvisioningCPUUsageShortTerm(dbSourcegraph, monitoring.ObservableOwnerCloud).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm(dbSourcegraph, monitoring.ObservableOwnerCloud).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageLongTerm(dbCodeIntel, monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageLongTerm(dbCodeIntel, monitoring.ObservableOwnerCodeIntel).Observable(),
-					},
-					{
-						shared.ProvisioningCPUUsageShortTerm(dbCodeIntel, monitoring.ObservableOwnerCodeIntel).Observable(),
-						shared.ProvisioningMemoryUsageShortTerm(dbCodeIntel, monitoring.ObservableOwnerCodeIntel).Observable(),
+						shared.ProvisioningCPUUsageShortTerm(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
+						shared.ProvisioningMemoryUsageShortTerm(databaseContainerNames, monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},
 			},


### PR DESCRIPTION
Working on alerts and monitoring issues recently, noticed that postgres alerts are always firing in dogfood and the dashboards are a bit incomplete, this PR:

* Relaxes the transaction duration critical alert to 10m - this fires often in k8s.sgdev.org but always seems to be a spike of just around 10m. Might just be a deploy thing
* Adds my best-guess `Interpretation` to some undocumented alerts. Unsure where to go with `pg_exporter_err` right now, could use some help @daxmc99 (has been active in k8s.sgdev.org for a while it seems)
* Moves the first group of observables to the standardized `General` group (which makes it a top-level panel)
* Improve naming on some alerts
* Panel options so we don't show a bunch of `value`. However, not sure if I'm using the best label here though - currently mostly Kubernetes `app`, but not sure if postgres_exporter has a better label we should use instead. Whatever label we choose, I _think_ we should also `sum by` that label (see screenshot below, `app` is not unique atm)
* Remove per-database container monitoring (see `databaseContainerNames` docstring)
* This seems only available for k8s, so add a note in description

before:

![image](https://user-images.githubusercontent.com/23356519/104010665-d2bf9c00-51e7-11eb-9e24-116ed23758a5.png)

after:

![image](https://user-images.githubusercontent.com/23356519/104010714-e965f300-51e7-11eb-9ebd-3cb680a7d118.png)




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
