### PR TITLE
Small design adjustments and fixes for jumping content

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -4,8 +4,7 @@
     &__card {
         border-radius: 4px;
         // stylelint-disable-next-line declaration-property-unit-whitelist
-        margin-top: calc(1rem - 1px);
-        margin-bottom: calc(1rem - 1px);
+        margin: calc(1rem - 1px) 0;
 
         &-link {
             &:hover {
@@ -16,16 +15,12 @@
 
         &--button {
             // stylelint-disable-next-line declaration-property-unit-whitelist
-            margin-top: calc(1rem - 1px);
-            margin-bottom: calc(1rem - 1px);
+            margin: calc(1rem - 1px) 0;
             border-radius: 4px;
 
             &:hover {
                 // stylelint-disable-next-line declaration-property-unit-whitelist
-                margin-top: calc(1rem - 2px);
-                margin-bottom: calc(1rem - 2px);
-                margin-left: -1px;
-                margin-right: -1px;
+                margin: calc(1rem - 2px) -1px calc(1rem - 2px) -1px;
                 border: 2px solid #329af0;
             }
 

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.scss
@@ -3,6 +3,9 @@
 .code-monitor-form {
     &__card {
         border-radius: 4px;
+        // stylelint-disable-next-line declaration-property-unit-whitelist
+        margin-top: calc(1rem - 1px);
+        margin-bottom: calc(1rem - 1px);
 
         &-link {
             &:hover {
@@ -13,12 +16,16 @@
 
         &--button {
             // stylelint-disable-next-line declaration-property-unit-whitelist
-            margin: calc(16px - 1px) -1px;
+            margin-top: calc(1rem - 1px);
+            margin-bottom: calc(1rem - 1px);
             border-radius: 4px;
 
             &:hover {
                 // stylelint-disable-next-line declaration-property-unit-whitelist
-                margin: calc(16px - 2px) -2px;
+                margin-top: calc(1rem - 2px);
+                margin-bottom: calc(1rem - 2px);
+                margin-left: -1px;
+                margin-right: -1px;
                 border: 2px solid #329af0;
             }
 
@@ -40,6 +47,7 @@
 
     &__horizontal-rule {
         margin: 2rem 0;
+        border-top: 1px solid var(--border-color-2);
     }
 
     &__owner-dropdown {

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -137,7 +137,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
     return (
         <>
             <Form className="my-4 pb-5 test-monitor-form" onSubmit={requestOnSubmit}>
-                <div className="flex mb-4">
+                <div className="d-flex flex-column mb-4">
                     Name
                     <div>
                         <input
@@ -154,7 +154,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                     </div>
                     <small className="text-muted">
                         Give it a short, descriptive name to reference events on Sourcegraph and in notifications. Do
-                        not include:{' '}
+                        not include{' '}
                         <a
                             href="https://docs.sourcegraph.com/code_monitoring/explanations/best_practices#do-not-include-confidential-information-in-monitor-names"
                             target="_blank"

--- a/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.tsx
@@ -59,7 +59,7 @@ export const DeleteMonitorModal: React.FunctionComponent<DeleteModalProps> = ({
 
             <p>
                 <strong>This action cannot be undone.</strong> Code monitoring will no longer watch for trigger event
-                and all actions will immediately be removed. Event history will still be accessible.
+                and all actions will immediately be removed.
             </p>
             {(!deleteCompletedOrError || isErrorLike(deleteCompletedOrError)) && (
                 <div>

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -94,7 +94,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                 </button>
             )}
             {showEmailNotificationForm && (
-                <div className="code-monitor-form__card card p-3 my-3">
+                <div className="code-monitor-form__card card p-3">
                     <div className="font-weight-bold">Send email notifications</div>
                     <span className="text-muted">Deliver email notifications to specified recipients.</span>
                     <div className="mt-4 test-action-form">
@@ -111,12 +111,12 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                             Code monitors are currently limited to sending emails to your primary email address.
                         </small>
                     </div>
-                    <div className="flex">
+                    <div className="d-flex align-items-center my-4">
                         <Toggle
                             title="Enabled"
                             value={emailNotificationEnabled}
                             onToggle={toggleEmailNotificationEnabled}
-                            className="mr-2 my-4"
+                            className="mr-2"
                         />
                         Enabled
                     </div>
@@ -136,21 +136,19 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                 </div>
             )}
             {actionsCompleted && !showEmailNotificationForm && (
-                <div className="code-monitor-form__card card p-3 my-3">
+                <div className="code-monitor-form__card card p-3">
                     <div className="d-flex justify-content-between align-items-center">
                         <div>
                             <div className="font-weight-bold">Send email notifications</div>
                             <span className="text-muted test-existing-action-email">{authenticatedUser.email}</span>
                         </div>
-                        <div className="d-flex">
-                            <div className="flex">
-                                <Toggle
-                                    title="Enabled"
-                                    value={emailNotificationEnabled}
-                                    onToggle={toggleEmailNotificationEnabled}
-                                    className="mr-2"
-                                />
-                            </div>
+                        <div className="d-flex align-items-center">
+                            <Toggle
+                                title="Enabled"
+                                value={emailNotificationEnabled}
+                                onToggle={toggleEmailNotificationEnabled}
+                                className="mr-3"
+                            />
                             <button
                                 type="button"
                                 onClick={editForm}

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -120,7 +120,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                 </button>
             )}
             {showQueryForm && (
-                <div className="code-monitor-form__card card p-3 my-3">
+                <div className="code-monitor-form__card card p-3">
                     <div className="font-weight-bold">When there are new search results</div>
                     <span className="text-muted">
                         This trigger will fire when new search results are found for a given search query.
@@ -189,7 +189,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                 </div>
             )}
             {!showQueryForm && triggerCompleted && (
-                <div className="code-monitor-form__card card p-3 my-3">
+                <div className="code-monitor-form__card card p-3">
                     <div className="d-flex justify-content-between align-items-center">
                         <div>
                             <div className="font-weight-bold">When there are new search results</div>

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
     Trigger
   </h3>
   <div
-    className="code-monitor-form__card card p-3 my-3"
+    className="code-monitor-form__card card p-3"
   >
     <div
       className="font-weight-bold"


### PR DESCRIPTION
I've gone through the code monitoring UI implementation and made a few small adjustments for design alignment, as well as to fix a visual bug where clicking a card in the form to open the full UI would cause a visual jump. 

As I'm not fully versed on the frontend conventions with Sourcegraph, please be sure to triple-check my work!
