### PR TITLE
streaming search: log events

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -471,6 +471,28 @@ describe('StreamingSearchResults', () => {
         element.unmount()
     })
 
+    it('should log view, query, and results fetched events', () => {
+        const logSpy = sinon.spy()
+        const logViewEventSpy = sinon.spy()
+        const telemetryService = {
+            ...NOOP_TELEMETRY_SERVICE,
+            log: logSpy,
+            logViewEvent: logViewEventSpy,
+        }
+
+        const element = mount(
+            <BrowserRouter>
+                <StreamingSearchResults {...defaultProps} telemetryService={telemetryService} />
+            </BrowserRouter>
+        )
+
+        sinon.assert.calledOnceWithExactly(logViewEventSpy, 'SearchResults')
+        sinon.assert.calledWith(logSpy, 'SearchResultsQueried')
+        sinon.assert.calledWith(logSpy, 'SearchResultsFetched')
+
+        element.unmount()
+    })
+
     it('should log event when clicking on search result', () => {
         const logSpy = sinon.spy()
         const telemetryService = {
@@ -487,7 +509,6 @@ describe('StreamingSearchResults', () => {
         const item = element.find(FileMatch).first()
         act(() => item.prop('onSelect')())
 
-        sinon.assert.calledOnce(logSpy)
         sinon.assert.calledWith(logSpy, 'SearchResultClicked')
 
         element.unmount()

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -19,11 +19,14 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { isDefined } from '../../../../../shared/src/util/types'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
 import { AuthenticatedUser } from '../../../auth'
+import { ErrorAlert } from '../../../components/alerts'
 import { PageTitle } from '../../../components/PageTitle'
 import { SearchResult } from '../../../components/SearchResult'
 import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
 import { VersionContext } from '../../../schema/site.schema'
+import { eventLogger } from '../../../tracking/eventLogger'
 import { QueryState, submitSearch } from '../../helpers'
+import { queryTelemetryData } from '../../queryTelemetry'
 import { SearchAlert } from '../SearchAlert'
 import { LATEST_VERSION } from '../SearchResults'
 import { SearchResultsInfoBar } from '../SearchResultsInfoBar'
@@ -38,8 +41,7 @@ import {
     SearchStreamingProps,
     resolveVersionContext,
 } from '../..'
-import { ErrorAlert } from '../../../components/alerts'
-import { eventLogger } from '../../../tracking/eventLogger'
+import { asError } from '../../../../../shared/src/util/errors'
 
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
@@ -80,9 +82,33 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         availableVersionContexts,
         previousVersionContext,
         authenticatedUser,
+        telemetryService,
     } = props
 
-    const { query = '', patternType, caseSensitive, versionContext } = parseSearchURL(props.location.search)
+    // Log view event on first load
+    useEffect(
+        () => {
+            telemetryService.logViewEvent('SearchResults')
+        },
+        // Only log view on initial load
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []
+    )
+
+    const { query = '', patternType, caseSensitive, versionContext } = parseSearchURL(location.search)
+
+    // Log search query event when URL changes
+    useEffect(() => {
+        const query_data = queryTelemetryData(query, caseSensitive)
+        telemetryService.log('SearchResultsQueried', {
+            code_search: { query_data },
+        })
+        if (query_data.query?.field_type && query_data.query.field_type.value_diff > 0) {
+            telemetryService.log('DiffSearchResultsQueried')
+        }
+    }, [caseSensitive, location.search, query, telemetryService])
+
+    // Update patternType, caseSensitivity and versionContext based on current URL
 
     useEffect(() => {
         if (patternType && patternType !== currentPatternType) {
@@ -116,12 +142,38 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         )
     )
 
+    // Log events when search completes or fails
+    useEffect(() => {
+        if (results?.state === 'complete') {
+            telemetryService.log('SearchResultsFetched', {
+                code_search: {
+                    // 🚨 PRIVACY: never provide any private data in { code_search: { results } }.
+                    results: {
+                        results_count: results.results.length,
+                        any_cloning: results.progress.skipped.some(skipped => skipped.reason === 'repository-cloning'),
+                    },
+                },
+            })
+        } else if (results?.state === 'error') {
+            telemetryService.log('SearchResultsFetchFailed', {
+                code_search: { error_message: asError(results.error).message },
+            })
+            console.error(results.error)
+        }
+    }, [results, telemetryService])
+
     const [allExpanded, setAllExpanded] = useState(false)
-    const onExpandAllResultsToggle = useCallback(() => setAllExpanded(oldValue => !oldValue), [setAllExpanded])
+    const onExpandAllResultsToggle = useCallback(() => {
+        setAllExpanded(oldValue => !oldValue)
+        telemetryService.log(allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
+    }, [allExpanded, telemetryService])
 
     const [showSavedSearchModal, setShowSavedSearchModal] = useState(false)
     const onSaveQueryClick = useCallback(() => setShowSavedSearchModal(true), [])
-    const onSaveQueryModalClose = useCallback(() => setShowSavedSearchModal(false), [])
+    const onSaveQueryModalClose = useCallback(() => {
+        setShowSavedSearchModal(false)
+        telemetryService.log('SavedQueriesToggleCreating', { queries: { creating: false } })
+    }, [telemetryService])
 
     const [showVersionContextWarning, setShowVersionContextWarning] = useState(false)
     useEffect(

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -210,9 +210,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         () => setItemsToShow(items => Math.min(results?.results.length || 0, items + incrementalItemsToShow)),
         [results?.results.length]
     )
-    const logSearchResultClicked = useCallback(() => props.telemetryService.log('SearchResultClicked'), [
-        props.telemetryService,
-    ])
+    const logSearchResultClicked = useCallback(() => telemetryService.log('SearchResultClicked'), [telemetryService])
     const renderResult = (result: GQL.GenericSearchResultInterface | GQL.IFileMatch): JSX.Element | undefined => {
         switch (result.__typename) {
             case 'FileMatch':
@@ -241,9 +239,10 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
     const onSearchAgain = useCallback(
         (additionalFilters: string[]) => {
             const newQuery = [query, ...additionalFilters].join(' ')
+            telemetryService.log('SearchSkippedResultsAgainClicked')
             submitSearch({ ...props, query: newQuery, source: 'excludedResults' })
         },
-        [query, props]
+        [query, telemetryService, props]
     )
 
     return (


### PR DESCRIPTION
Log all events already logged by non-streaming search when using streaming search. Since streaming search was a rewrite of the search results UI, a lot of events that were logged by the old UI were not yet being logged in the new one.

Also added logging for when the user clicks the "Search again" button in the skipped results popover.