### PR TITLE
added link to requirements.md

### DIFF
--- a/doc/campaigns/references/index.md
+++ b/doc/campaigns/references/index.md
@@ -3,3 +3,4 @@
 - [Campaign spec YAML reference](campaign_spec_yaml_reference.md)
 - <span class="badge badge-experimental">Experimental</span> [Campaign spec templating](campaign_spec_templating.md)
 - [Troubleshooting](troubleshooting.md)
+- [Requirements](requirements.md)


### PR DESCRIPTION
Even though this is linked from the top campaigns doc page, I thought we should document it here, too. It is the only page not linked from the parent index.md file.