### PR TITLE
[Docs]:Upgrade minimum k8s to 1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to Sourcegraph are documented in this file.
   - link directly to the relevant Grafana panel, instead of just the service dashboard. [#17014](https://github.com/sourcegraph/sourcegraph/pull/17014)
   - link to a time frame relevant to the alert, instead of just the past few hours. [#17034](https://github.com/sourcegraph/sourcegraph/pull/17034)
 - Added `serviceKind` field of the `ExternalServiceKind` type to `Repository.externalURLs` GraphQL API, `serviceType` field is deprecated and will be removed in the future releases. [#14979](https://github.com/sourcegraph/sourcegraph/issues/14979)
+- Dashboard links included in [monitoring alerts](https://docs.sourcegraph.com/admin/observability/alerting) now link directly to the relevant Grafana panel, instead of just the service dashboard. [#17014](https://github.com/sourcegraph/sourcegraph/pull/17014)
+- The minimum Kubernetes version required to use the [Kubernetes deployment option](https://docs.sourcegraph.com/admin/install/kubernetes) is now [v1.15 (released June 2019)](https://kubernetes.io/blog/2019/06/19/kubernetes-1-15-release-announcement/).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ All notable changes to Sourcegraph are documented in this file.
   - link directly to the relevant Grafana panel, instead of just the service dashboard. [#17014](https://github.com/sourcegraph/sourcegraph/pull/17014)
   - link to a time frame relevant to the alert, instead of just the past few hours. [#17034](https://github.com/sourcegraph/sourcegraph/pull/17034)
 - Added `serviceKind` field of the `ExternalServiceKind` type to `Repository.externalURLs` GraphQL API, `serviceType` field is deprecated and will be removed in the future releases. [#14979](https://github.com/sourcegraph/sourcegraph/issues/14979)
-- Dashboard links included in [monitoring alerts](https://docs.sourcegraph.com/admin/observability/alerting) now link directly to the relevant Grafana panel, instead of just the service dashboard. [#17014](https://github.com/sourcegraph/sourcegraph/pull/17014)
 - The minimum Kubernetes version required to use the [Kubernetes deployment option](https://docs.sourcegraph.com/admin/install/kubernetes) is now [v1.15 (released June 2019)](https://kubernetes.io/blog/2019/06/19/kubernetes-1-15-release-announcement/).
 
 ### Fixed

--- a/doc/CODENOTIFY
+++ b/doc/CODENOTIFY
@@ -1,2 +1,2 @@
 **/* @christinaforney
-admin/* @sourcegraph/distribution 
+**/admin/** @sourcegraph/distribution

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -8,9 +8,9 @@ The Kubernetes manifests for a Sourcegraph on Kubernetes installation are in the
 
 ## Requirements
 
-- [Kubernetes](https://kubernetes.io/) v1.9 or later with an SSD storage class
+- [Kubernetes](https://kubernetes.io/) v1.14 or later with an SSD storage class
   - [Cluster role administrator access](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.9.7 or later
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.14 or later
 - Access to server infrastructure on which you can create a Kubernetes cluster (see
   [resource allocation guidelines](scale.md)).
 - [Sourcegraph Enterprise license](configure.md#add-license-key). You can run through these instructions without one, but you must obtain a license for instances of more than 10 users.

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -8,9 +8,9 @@ The Kubernetes manifests for a Sourcegraph on Kubernetes installation are in the
 
 ## Requirements
 
-- [Kubernetes](https://kubernetes.io/) v1.14 or later with an SSD storage class
+- [Kubernetes](https://kubernetes.io/) v1.15 or later with an SSD storage class
   - [Cluster role administrator access](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.14 or later
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.15 or later
 - Access to server infrastructure on which you can create a Kubernetes cluster (see
   [resource allocation guidelines](scale.md)).
 - [Sourcegraph Enterprise license](configure.md#add-license-key). You can run through these instructions without one, but you must obtain a license for instances of more than 10 users.
@@ -107,4 +107,4 @@ manifests that cannot be installed otherwise.
    ```
 
 We also provide an [overlay](configure.md#non-privileged-overlay) that generates a version of the manifests that does not
-require cluster-admin privileges. 
+require cluster-admin privileges.


### PR DESCRIPTION
Update minimum k8s version

We have actually had this as a minimum version for awhile since we upgraded the networking API group to `networking.k8s.io/v1beta1`. 

Part of https://github.com/sourcegraph/sourcegraph/issues/16808 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
