### PR TITLE
Fixes LoaderInput class, email validation errors are visible now

### DIFF
--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -82,7 +82,7 @@ export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, on
             {/* eslint-disable-next-line react/forbid-elements */}
             <form className="form-inline" onSubmit={onSubmit} noValidate={true}>
                 <LoaderInput
-                    className={(deriveInputClassName(emailState), 'mr-sm-2')}
+                    className={classNames(deriveInputClassName(emailState), 'mr-sm-2')}
                     loading={emailState.kind === 'LOADING'}
                 >
                     <input
@@ -104,7 +104,7 @@ export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, on
                         spellCheck={false}
                         readOnly={false}
                     />
-                </LoaderInput>{' '}
+                </LoaderInput>
                 <LoaderButton
                     loading={statusOrError === 'loading'}
                     label="Add"


### PR DESCRIPTION

### Description

Fixes missing `classNames` call that wasn't setting derived `<input/>` class.   
That resulted in validation messages with `display: none`.  
