### PR TITLE
minor fixes to docstring and error message in LSIF code

### DIFF
--- a/enterprise/internal/codeintel/lsif/correlation/correlate.go
+++ b/enterprise/internal/codeintel/lsif/correlation/correlate.go
@@ -279,7 +279,7 @@ func correlateContainsEdge(state *wrappedState, id int, edge lsif.Edge) error {
 
 	for _, inV := range edge.InVs {
 		if _, ok := state.RangeData[inV]; !ok {
-			return malformedDump(id, edge.InV, "range")
+			return malformedDump(id, inV, "range")
 		}
 		state.Contains.SetAdd(edge.OutV, inV)
 	}
@@ -305,7 +305,7 @@ func correlateItemEdge(state *wrappedState, id int, edge lsif.Edge) error {
 	if documentMap, ok := state.DefinitionData[edge.OutV]; ok {
 		for _, inV := range edge.InVs {
 			if _, ok := state.RangeData[inV]; !ok {
-				return malformedDump(id, edge.InV, "range")
+				return malformedDump(id, inV, "range")
 			}
 
 			// Link definition data to defining range
@@ -322,7 +322,7 @@ func correlateItemEdge(state *wrappedState, id int, edge lsif.Edge) error {
 				state.LinkedReferenceResults.Link(edge.OutV, inV)
 			} else {
 				if _, ok = state.RangeData[inV]; !ok {
-					return malformedDump(id, edge.InV, "range")
+					return malformedDump(id, inV, "range")
 				}
 
 				// Link reference data to a reference range

--- a/enterprise/internal/codeintel/lsif/datastructures/default_idset_map.go
+++ b/enterprise/internal/codeintel/lsif/datastructures/default_idset_map.go
@@ -94,7 +94,7 @@ func (sm *DefaultIDSetMap) SetContains(key, id int) bool {
 	return false
 }
 
-// SetEach determines if the given identifier belongs to the set at the given key.
+// SetEach invokes the given function with each identifier in the set at the given key.
 func (sm *DefaultIDSetMap) SetEach(key int, f func(id int)) {
 	if sm.key == key {
 		sm.value.Each(f)


### PR DESCRIPTION
- fix (*DefaultIDSetMap).SetEach documentation that was copied from other method. The SetEach method's documentation was accidentally copied verbatim from SetContains. The new docstring now describes what SetEach does.
- refer to correct vertex ID in error message. These edges use inVs not inV (i.e., they have multiple in-vertices), and we're looping over inVs, so `inV` contains the ID we want, not `edge.InV`.