### PR TITLE
fix issue where scrollbars appear during resizing

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -160,11 +160,6 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
       }
     >
       <div
-        className="resizable__ghost "
-        onMouseMove={[Function]}
-        onMouseUp={[Function]}
-      />
-      <div
         className="list-group list-group-flush hierarchical-locations-view__list test-hierarchical-locations-view-list"
       >
         <span

--- a/client/shared/src/components/Resizable.scss
+++ b/client/shared/src/components/Resizable.scss
@@ -44,22 +44,4 @@
             right: 0;
         }
     }
-
-    &__ghost {
-        position: absolute;
-
-        // Add buffer area so that resizables inside a position:relative will continue to receive
-        // onMouseMove events even when enlarging in a direction that causes the cursor to be on top
-        // of elements in a different position:relative context.
-        top: -100px;
-        left: -100px;
-        right: -100px;
-        bottom: -100px;
-
-        display: none;
-        z-index: 999999;
-        &--resizing {
-            display: block;
-        }
-    }
 }

--- a/client/shared/src/components/Resizable.tsx
+++ b/client/shared/src/components/Resizable.tsx
@@ -88,11 +88,6 @@ export class Resizable<C extends React.ReactElement> extends React.PureComponent
                 className={`resizable resizable--${this.props.handlePosition} ${this.props.className || ''}`}
                 ref={this.setContainerRef}
             >
-                <div
-                    className={`resizable__ghost ${this.state.resizing ? 'resizable__ghost--resizing' : ''}`}
-                    onMouseMove={this.onMouseMove}
-                    onMouseUp={this.onMouseUp}
-                />
                 {this.props.element}
                 <div
                     className={`resizable__handle resizable__handle--${this.props.handlePosition} ${
@@ -112,29 +107,36 @@ export class Resizable<C extends React.ReactElement> extends React.PureComponent
         event.preventDefault()
         if (!this.state.resizing) {
             this.setState({ resizing: true })
-        }
-    }
 
-    private onMouseUp = (event: React.MouseEvent<HTMLDivElement>): void => {
-        event.preventDefault()
-        if (this.state.resizing) {
-            this.setState({ resizing: false })
-        }
-    }
-
-    private onMouseMove = (event: React.MouseEvent<HTMLDivElement>): void => {
-        event.preventDefault()
-        if (this.state.resizing && this.containerRef) {
-            let size = isHorizontal(this.props.handlePosition)
-                ? this.props.handlePosition === 'right'
-                    ? event.pageX - this.containerRef.getBoundingClientRect().left
-                    : this.containerRef.getBoundingClientRect().right - event.pageX
-                : this.containerRef.getBoundingClientRect().bottom - event.pageY
-            if (event.shiftKey) {
-                size = Math.ceil(size / 20) * 20
+            const onMouseMove = (event: MouseEvent): void => {
+                event.preventDefault()
+                if (this.state.resizing && this.containerRef) {
+                    let size = isHorizontal(this.props.handlePosition)
+                        ? this.props.handlePosition === 'right'
+                            ? event.pageX - this.containerRef.getBoundingClientRect().left
+                            : this.containerRef.getBoundingClientRect().right - event.pageX
+                        : this.containerRef.getBoundingClientRect().bottom - event.pageY
+                    if (event.shiftKey) {
+                        size = Math.ceil(size / 20) * 20
+                    }
+                    this.setState({ size })
+                    this.sizeUpdates.next(size)
+                }
             }
-            this.setState({ size })
-            this.sizeUpdates.next(size)
+
+            const onMouseUp = (event: Event): void => {
+                event.preventDefault()
+                if (this.state.resizing) {
+                    this.setState({ resizing: false })
+                    if (event.currentTarget) {
+                        event.currentTarget.removeEventListener('mouseup', onMouseUp)
+                        event.currentTarget.removeEventListener('mousemove', onMouseMove as EventListener)
+                    }
+                }
+            }
+
+            event.currentTarget.ownerDocument.addEventListener('mousemove', onMouseMove)
+            event.currentTarget.ownerDocument.addEventListener('mouseup', onMouseUp)
         }
     }
 }


### PR DESCRIPTION
The Resizable element previously used a "ghost" element to make it so that resizing would continue (and the `mousemove` event would keep firing) even if the user's cursor moved beyond the element's bounds (which occurs because the user moves the mouse faster than the element resizes, by definition, because the latter is in response to the former). This ghost element, however, causes scrollbars to appear because it enlarges the parent element. It is possible to suppress these through complex CSS, but that's error prone because the Resizable component is used in many different places.

Instead, we solve the problem by adding the `mousemove` listener to the root DOM node, so it will continue to fire.