### PR TITLE
repo-updater: always wrap context.Background with internal actor

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -449,8 +449,6 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		return errors.Wrap(err, "set repository pending permissions")
 	}
 
-	fmt.Println(8)
-
 	log15.Debug("PermsSyncer.syncRepoPerms.synced", "repoID", repo.ID, "name", repo.Name, "count", len(extAccountIDs))
 	return nil
 }

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	codemonitorsBackground "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	ossAuthz "github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	ossDB "github.com/sourcegraph/sourcegraph/internal/db"
@@ -42,7 +43,9 @@ func enterpriseInit(
 	cf *httpcli.Factory,
 	server *repoupdater.Server,
 ) (debugDumpers []debugserver.Dumper) {
-	ctx := context.Background()
+	// NOTE: Internal actor is required to have full visibility of the repo table
+	// 	(i.e. bypass repository authorization).
+	ctx := actor.WithInternalActor(context.Background())
 
 	codemonitorsBackground.StartBackgroundJobs(ctx, db)
 


### PR DESCRIPTION
repo-updater used to have god-view of the entire repo table, but with the merge of underlying DB logic, the repoStore it is using now respecting the repository permissions, which makes the repo-updater not able to see the private repos anymore.

This causes two symptoms (maybe there are more):

1. Permissions syncing stops working because it can't see private repos (no leakage, instead non-admin could see nothing).
2. Site admin can still visit the private repo on Sourcegraph but not able to view the settings page, because the page sends a request to the repo-updater and the latter couldn't see it.

<img width="657" alt="CleanShot 2021-01-09 at 23 05 07@2x" src="https://user-images.githubusercontent.com/2946214/104094962-222cc780-52cf-11eb-816a-5c4c7e98d462.png">

_I found this bug in my personal instance, triggered by my recent update to insider version, and my friend couldn't see my repo anymore_
