### PR TITLE
force immediate sync when setting code host repos

### DIFF
--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
@@ -55,6 +56,9 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 	es.Config = string(buf)
+
+	// set to time.Zero to sync ASAP
+	es.NextSyncAt = time.Time{}
 
 	err = db.ExternalServices.Upsert(ctx, es)
 	if err != nil {


### PR DESCRIPTION
When the user updates their code host config via the manage repositories page we want to immediately sync and keep track of that sync in order to show a pending state to the user (info here https://github.com/sourcegraph/sourcegraph/issues/16948 ). In order to do this we will set this next sync field to time.Zero for the highest priority sync, and poll the externalService until the lastSyncAt field updates, which will be added in a separate PR.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
