### PR TITLE
Introduce detach operation to reconciler

### DIFF
--- a/client/web/src/enterprise/campaigns/preview/list/PreviewAction.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewAction.tsx
@@ -21,9 +21,6 @@ export const PreviewAction: React.FunctionComponent<PreviewActionProps> = ({ nod
         return <PreviewActionNoAction reason={NoActionReasonStrings[NoActionReason.NO_ACCESS]} className={className} />
     }
     if (node.operations.length === 0) {
-        if (node.targets.__typename === 'VisibleApplyPreviewTargetsDetach') {
-            return <PreviewActionDetach className={className} />
-        }
         return <PreviewActionNoAction className={className} />
     }
     if (node.operations.includes(ChangesetSpecOperation.IMPORT)) {
@@ -49,6 +46,9 @@ export const PreviewAction: React.FunctionComponent<PreviewActionProps> = ({ nod
         node.operations.includes(ChangesetSpecOperation.PUSH)
     ) {
         return <PreviewActionUpdate className={className} />
+    }
+    if (node.operations.includes(ChangesetSpecOperation.DETACH)) {
+        return <PreviewActionDetach className={className} />
     }
     return <PreviewActionUnknown operations={node.operations.join(' => ')} className={className} />
 }

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -178,6 +178,26 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
             },
         },
     },
+    'Detach changeset': {
+        __typename: 'VisibleChangesetApplyPreview',
+        operations: [ChangesetSpecOperation.DETACH],
+        delta: {
+            titleChanged: false,
+        },
+        targets: {
+            __typename: 'VisibleApplyPreviewTargetsDetach',
+            changeset: {
+                id: '123123',
+                title: 'Le open changeset',
+                repository: testRepo,
+                diffStat: {
+                    added: 2,
+                    changed: 8,
+                    deleted: 10,
+                },
+            },
+        },
+    },
 }
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -959,6 +959,10 @@ enum ChangesetSpecOperation {
     Internal operation to get around slow code host updates.
     """
     SLEEP
+    """
+    The changeset is removed from some of the associated campaigns.
+    """
+    DETACH
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -952,6 +952,10 @@ enum ChangesetSpecOperation {
     Internal operation to get around slow code host updates.
     """
     SLEEP
+    """
+    The changeset is removed from some of the associated campaigns.
+    """
+    DETACH
 }
 
 """

--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -121,6 +121,9 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 		case campaigns.ReconcilerOperationSleep:
 			e.sleep()
 
+		case campaigns.ReconcilerOperationDetach:
+			e.detachChangeset()
+
 		default:
 			err = fmt.Errorf("executor operation %q not implemented", op)
 		}
@@ -359,6 +362,14 @@ func (e *executor) reopenChangeset(ctx context.Context) (err error) {
 		return errors.Wrap(err, "updating changeset")
 	}
 	return nil
+}
+
+func (e *executor) detachChangeset() {
+	for _, assoc := range e.ch.Campaigns {
+		if assoc.Detach {
+			e.ch.RemoveCampaignID(assoc.CampaignID)
+		}
+	}
 }
 
 // closeChangeset closes the given changeset on its code host if its ExternalState is OPEN or DRAFT.

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -417,7 +417,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			// Create the changeset with correct associations.
 			changesetOpts := tc.changeset
 			changesetOpts.Repo = rs[0].ID
-			changesetOpts.CampaignIDs = []int64{campaign.ID}
+			changesetOpts.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign.ID}}
 			changesetOpts.OwnedByCampaign = campaign.ID
 			if changesetSpec != nil {
 				changesetOpts.CurrentSpec = changesetSpec.ID

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -417,7 +417,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			// Create the changeset with correct associations.
 			changesetOpts := tc.changeset
 			changesetOpts.Repo = rs[0].ID
-			changesetOpts.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign.ID}}
+			changesetOpts.Campaigns = []campaigns.CampaignAssoc{{CampaignID: campaign.ID}}
 			changesetOpts.OwnedByCampaign = campaign.ID
 			if changesetSpec != nil {
 				changesetOpts.CurrentSpec = changesetSpec.ID

--- a/enterprise/internal/campaigns/reconciler/plan_test.go
+++ b/enterprise/internal/campaigns/reconciler/plan_test.go
@@ -127,7 +127,7 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				ExternalState:    campaigns.ChangesetExternalStateClosed,
 				OwnedByCampaign:  1234,
-				CampaignIDs:      []int64{1234},
+				Campaigns:        []campaigns.CampaignChangeset{{CampaignID: 1234}},
 			},
 			wantOperations: Operations{
 				campaigns.ReconcilerOperationReopen,
@@ -141,11 +141,12 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				ExternalState:    campaigns.ChangesetExternalStateOpen,
 				OwnedByCampaign:  1234,
-				CampaignIDs:      []int64{1234},
+				Campaigns:        []campaigns.CampaignChangeset{{CampaignID: 1234, Detach: true}},
 				// Important bit:
 				Closing: true,
 			},
 			wantOperations: Operations{
+				campaigns.ReconcilerOperationDetach,
 				campaigns.ReconcilerOperationClose,
 			},
 		},
@@ -157,11 +158,12 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				ExternalState:    campaigns.ChangesetExternalStateClosed,
 				OwnedByCampaign:  1234,
-				CampaignIDs:      []int64{1234},
+				Campaigns:        []campaigns.CampaignChangeset{{CampaignID: 1234, Detach: true}},
 				// Important bit:
 				Closing: true,
 			},
 			wantOperations: Operations{
+				campaigns.ReconcilerOperationDetach,
 				// TODO: This should probably be a noop in the future
 				campaigns.ReconcilerOperationClose,
 			},

--- a/enterprise/internal/campaigns/reconciler/plan_test.go
+++ b/enterprise/internal/campaigns/reconciler/plan_test.go
@@ -127,7 +127,7 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				ExternalState:    campaigns.ChangesetExternalStateClosed,
 				OwnedByCampaign:  1234,
-				Campaigns:        []campaigns.CampaignChangeset{{CampaignID: 1234}},
+				Campaigns:        []campaigns.CampaignAssoc{{CampaignID: 1234}},
 			},
 			wantOperations: Operations{
 				campaigns.ReconcilerOperationReopen,
@@ -141,12 +141,11 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				ExternalState:    campaigns.ChangesetExternalStateOpen,
 				OwnedByCampaign:  1234,
-				Campaigns:        []campaigns.CampaignChangeset{{CampaignID: 1234, Detach: true}},
+				Campaigns:        []campaigns.CampaignAssoc{{CampaignID: 1234}},
 				// Important bit:
 				Closing: true,
 			},
 			wantOperations: Operations{
-				campaigns.ReconcilerOperationDetach,
 				campaigns.ReconcilerOperationClose,
 			},
 		},
@@ -158,14 +157,41 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				ExternalState:    campaigns.ChangesetExternalStateClosed,
 				OwnedByCampaign:  1234,
-				Campaigns:        []campaigns.CampaignChangeset{{CampaignID: 1234, Detach: true}},
+				Campaigns:        []campaigns.CampaignAssoc{{CampaignID: 1234}},
 				// Important bit:
 				Closing: true,
 			},
 			wantOperations: Operations{
-				campaigns.ReconcilerOperationDetach,
 				// TODO: This should probably be a noop in the future
 				campaigns.ReconcilerOperationClose,
+			},
+		},
+		{
+			name:         "detaching",
+			previousSpec: ct.TestSpecOpts{Published: true},
+			currentSpec:  ct.TestSpecOpts{Published: true},
+			changeset: ct.TestChangesetOpts{
+				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				ExternalState:    campaigns.ChangesetExternalStateOpen,
+				OwnedByCampaign:  1234,
+				Campaigns:        []campaigns.CampaignAssoc{{CampaignID: 1234, Detach: true}},
+			},
+			wantOperations: Operations{
+				campaigns.ReconcilerOperationDetach,
+			},
+		},
+		{
+			name:         "detaching already-detached changeset",
+			previousSpec: ct.TestSpecOpts{Published: true},
+			currentSpec:  ct.TestSpecOpts{Published: true},
+			changeset: ct.TestChangesetOpts{
+				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				ExternalState:    campaigns.ChangesetExternalStateClosed,
+				OwnedByCampaign:  1234,
+				Campaigns:        []campaigns.CampaignAssoc{},
+			},
+			wantOperations: Operations{
+				// Expect no operations.
 			},
 		},
 	}

--- a/enterprise/internal/campaigns/reconciler/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler/reconciler_test.go
@@ -110,7 +110,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 			// Create the changeset with correct associations.
 			changesetOpts := tc.changeset
 			changesetOpts.Repo = rs[0].ID
-			changesetOpts.CampaignIDs = []int64{campaign.ID}
+			changesetOpts.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign.ID}}
 			changesetOpts.OwnedByCampaign = campaign.ID
 			if changesetSpec != nil {
 				changesetOpts.CurrentSpec = changesetSpec.ID

--- a/enterprise/internal/campaigns/reconciler/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler/reconciler_test.go
@@ -110,7 +110,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 			// Create the changeset with correct associations.
 			changesetOpts := tc.changeset
 			changesetOpts.Repo = rs[0].ID
-			changesetOpts.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign.ID}}
+			changesetOpts.Campaigns = []campaigns.CampaignAssoc{{CampaignID: campaign.ID}}
 			changesetOpts.OwnedByCampaign = campaign.ID
 			if changesetSpec != nil {
 				changesetOpts.CurrentSpec = changesetSpec.ID

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
@@ -114,7 +114,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 	wantApplyPreview := []apitest.ChangesetApplyPreview{
 		{
 			Typename:   "VisibleChangesetApplyPreview",
-			Operations: []campaigns.ReconcilerOperation{},
+			Operations: []campaigns.ReconcilerOperation{campaigns.ReconcilerOperationDetach},
 			Targets: apitest.ChangesetApplyPreviewTargets{
 				Typename:  "VisibleApplyPreviewTargetsDetach",
 				Changeset: apitest.Changeset{ID: string(marshalChangesetID(closingChangeset.ID))},

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -148,14 +148,14 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 			RepoID:              githubRepo.ID,
 			ExternalID:          "5834",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			CampaignIDs:         []int64{campaign.ID},
+			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
 			PublicationState:    campaigns.ChangesetPublicationStatePublished,
 		},
 		{
 			RepoID:              githubRepo.ID,
 			ExternalID:          "5849",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			CampaignIDs:         []int64{campaign.ID},
+			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
 			PublicationState:    campaigns.ChangesetPublicationStatePublished,
 		},
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -148,14 +148,14 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 			RepoID:              githubRepo.ID,
 			ExternalID:          "5834",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
+			Campaigns:           []campaigns.CampaignAssoc{{CampaignID: campaign.ID}},
 			PublicationState:    campaigns.ChangesetPublicationStatePublished,
 		},
 		{
 			RepoID:              githubRepo.ID,
 			ExternalID:          "5849",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
+			Campaigns:           []campaigns.CampaignAssoc{{CampaignID: campaign.ID}},
 			PublicationState:    campaigns.ChangesetPublicationStatePublished,
 		},
 	}

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -222,7 +222,7 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 func addChangeset(t *testing.T, ctx context.Context, s *store.Store, c *campaigns.Changeset, campaign int64) {
 	t.Helper()
 
-	c.CampaignIDs = append(c.CampaignIDs, campaign)
+	c.Campaigns = append(c.Campaigns, campaigns.CampaignChangeset{CampaignID: campaign})
 	if err := s.UpdateChangeset(ctx, c); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -222,7 +222,7 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 func addChangeset(t *testing.T, ctx context.Context, s *store.Store, c *campaigns.Changeset, campaign int64) {
 	t.Helper()
 
-	c.Campaigns = append(c.Campaigns, campaigns.CampaignChangeset{CampaignID: campaign})
+	c.Campaigns = append(c.Campaigns, campaigns.CampaignAssoc{CampaignID: campaign})
 	if err := s.UpdateChangeset(ctx, c); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -88,7 +88,7 @@ func TestPermissionLevels(t *testing.T) {
 		}
 
 		// We attach the changeset to the campaign so we can test syncChangeset
-		changeset.CampaignIDs = append(changeset.CampaignIDs, c.ID)
+		changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignChangeset{CampaignID: c.ID})
 		if err := s.UpdateChangeset(ctx, changeset); err != nil {
 			t.Fatal(err)
 		}
@@ -614,7 +614,7 @@ func TestPermissionLevels(t *testing.T) {
 							// matter for the addChangesetsToCampaign mutation,
 							// since that is idempotent and we want to solely
 							// check for auth errors.
-							changeset.CampaignIDs = []int64{campaignID}
+							changeset.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaignID}}
 							if err := cstore.UpdateChangeset(ctx, changeset); err != nil {
 								t.Fatal(err)
 							}
@@ -836,7 +836,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		}
 		// We attach the two changesets to the campaign
 		for _, c := range changesets {
-			c.CampaignIDs = []int64{campaign.ID}
+			c.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign.ID}}
 			if err := cstore.UpdateChangeset(ctx, c); err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -88,7 +88,7 @@ func TestPermissionLevels(t *testing.T) {
 		}
 
 		// We attach the changeset to the campaign so we can test syncChangeset
-		changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignChangeset{CampaignID: c.ID})
+		changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignAssoc{CampaignID: c.ID})
 		if err := s.UpdateChangeset(ctx, changeset); err != nil {
 			t.Fatal(err)
 		}
@@ -614,7 +614,7 @@ func TestPermissionLevels(t *testing.T) {
 							// matter for the addChangesetsToCampaign mutation,
 							// since that is idempotent and we want to solely
 							// check for auth errors.
-							changeset.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaignID}}
+							changeset.Campaigns = []campaigns.CampaignAssoc{{CampaignID: campaignID}}
 							if err := cstore.UpdateChangeset(ctx, changeset); err != nil {
 								t.Fatal(err)
 							}
@@ -836,7 +836,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		}
 		// We attach the two changesets to the campaign
 		for _, c := range changesets {
-			c.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign.ID}}
+			c.Campaigns = []campaigns.CampaignAssoc{{CampaignID: campaign.ID}}
 			if err := cstore.UpdateChangeset(ctx, c); err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/rewirer/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer.go
@@ -92,7 +92,7 @@ func (r *ChangesetRewirer) createChangesetForSpec(repo *types.Repo, spec *campai
 		RepoID:              spec.RepoID,
 		ExternalServiceType: repo.ExternalRepo.ServiceType,
 
-		Campaigns:         []campaigns.CampaignChangeset{{CampaignID: r.campaignID}},
+		Campaigns:         []campaigns.CampaignAssoc{{CampaignID: r.campaignID}},
 		OwnedByCampaignID: r.campaignID,
 		CurrentSpecID:     spec.ID,
 
@@ -114,7 +114,7 @@ func (r *ChangesetRewirer) updateChangesetToNewSpec(c *campaigns.Changeset, spec
 	c.CurrentSpecID = spec.ID
 
 	// Ensure that the changeset is attached to the campaign
-	c.Campaigns = append(c.Campaigns, campaigns.CampaignChangeset{CampaignID: r.campaignID})
+	c.Campaigns = append(c.Campaigns, campaigns.CampaignAssoc{CampaignID: r.campaignID})
 
 	// We need to enqueue it for the changeset reconciler, so the
 	// reconciler wakes up, compares old and new spec and, if
@@ -127,7 +127,7 @@ func (r *ChangesetRewirer) createTrackingChangeset(repo *types.Repo, externalID 
 		RepoID:              repo.ID,
 		ExternalServiceType: repo.ExternalRepo.ServiceType,
 
-		Campaigns:  []campaigns.CampaignChangeset{{CampaignID: r.campaignID}},
+		Campaigns:  []campaigns.CampaignAssoc{{CampaignID: r.campaignID}},
 		ExternalID: externalID,
 		// Note: no CurrentSpecID, because we merely track this one
 
@@ -143,7 +143,7 @@ func (r *ChangesetRewirer) createTrackingChangeset(repo *types.Repo, externalID 
 func (r *ChangesetRewirer) attachTrackingChangeset(changeset *campaigns.Changeset) {
 	// We already have a changeset with the given repoID and
 	// externalID, so we can track it.
-	changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignChangeset{CampaignID: r.campaignID})
+	changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignAssoc{CampaignID: r.campaignID})
 
 	// If it's errored and not created by another campaign, we re-enqueue it.
 	if changeset.OwnedByCampaignID == 0 && changeset.ReconcilerState == campaigns.ReconcilerStateErrored {

--- a/enterprise/internal/campaigns/service/service_apply_campaign_test.go
+++ b/enterprise/internal/campaigns/service/service_apply_campaign_test.go
@@ -333,7 +333,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 			changeset3 := oldChangesets.Find(campaigns.WithCurrentSpecID(oldSpec3.ID))
 			ct.SetChangesetPublished(t, ctx, store, changeset3, "12345", oldSpec3.Spec.HeadRef)
 
-			// Apply and expect 5 changesets
+			// Apply and expect 6 changesets
 			campaign, cs := applyAndListChangesets(adminCtx, t, svc, campaignSpec2.RandID, 6)
 
 			// This changeset we want marked as "to be closed"
@@ -349,6 +349,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				ReconcilerState:  campaigns.ReconcilerStateQueued,
 				PublicationState: campaigns.ChangesetPublicationStatePublished,
 				DiffStat:         ct.TestChangsetSpecDiffStat,
+				DetachFrom:       []int64{campaign.ID},
 				Closing:          true,
 			})
 
@@ -459,12 +460,13 @@ func TestServiceApplyCampaign(t *testing.T) {
 				CampaignSpec: campaignSpec3.ID,
 				HeadRef:      "refs/heads/repo-0-branch-0",
 			})
-			// Apply again. This should have detached the tracked changeset but it should not be closed, since the campaign is
+			// Apply again. This should have flagged the association as detach and it should not be closed, since the campaign is
 			// not the owner.
 			trackingCampaign, cs := applyAndListChangesets(adminCtx, t, svc, campaignSpec3.RandID, 2)
 
 			trackedChangesetAssertions.Closing = false
 			trackedChangesetAssertions.ReconcilerState = campaigns.ReconcilerStateQueued
+			trackedChangesetAssertions.DetachFrom = []int64{trackingCampaign.ID}
 			ct.ReloadAndAssertChangeset(t, ctx, store, c2, trackedChangesetAssertions)
 
 			// But we do want to have a new changeset record that is going to create a new changeset on the code host.
@@ -495,8 +497,8 @@ func TestServiceApplyCampaign(t *testing.T) {
 			// And now we apply a new spec without any changesets.
 			campaignSpec2 := ct.CreateCampaignSpec(t, ctx, store, "unpublished-changesets", admin.ID)
 
-			// That should close no changesets, but leave the campaign with 0 changesets,
-			// and the unpublished changesets should be detached
+			// That should close no changesets, but set the unpublished changesets to be detached when
+			// the reconciler picks them up.
 			applyAndListChangesets(adminCtx, t, svc, campaignSpec2.RandID, 1)
 		})
 
@@ -796,7 +798,8 @@ func TestServiceApplyCampaign(t *testing.T) {
 			}
 			c = ct.ReloadAndAssertChangeset(t, ctx, store, c, assertions)
 
-			// STEP 2: Now we apply a new spec without any changesets.
+			// STEP 2: Now we apply a new spec without any changesets, but expect the changeset-to-be-detached to
+			// be left in the campaign (the reconciler would detach it, if the executor picked up the changeset).
 			campaignSpec2 := ct.CreateCampaignSpec(t, ctx, store, "detached-closed-changeset", admin.ID)
 			applyAndListChangesets(adminCtx, t, svc, campaignSpec2.RandID, 1)
 
@@ -805,11 +808,13 @@ func TestServiceApplyCampaign(t *testing.T) {
 			assertions.ReconcilerState = campaigns.ReconcilerStateQueued
 			// And the previous spec is recorded, because the previous run finished with reconcilerState completed.
 			assertions.PreviousSpec = spec1.ID
+			assertions.DetachFrom = []int64{campaign.ID}
 			c = ct.ReloadAndAssertChangeset(t, ctx, store, c, assertions)
 
 			// Now we update the changeset to make it look closed.
 			ct.SetChangesetClosed(t, ctx, store, c)
 			assertions.Closing = false
+			assertions.DetachFrom = []int64{}
 			assertions.ReconcilerState = campaigns.ReconcilerStateCompleted
 			assertions.ExternalState = campaigns.ChangesetExternalStateClosed
 			c = ct.ReloadAndAssertChangeset(t, ctx, store, c, assertions)
@@ -862,6 +867,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 
 				// Our previously published changeset should be marked as "to be closed"
 				assertions.Closing = true
+				assertions.DetachFrom = []int64{campaign.ID}
 				assertions.ReconcilerState = campaigns.ReconcilerStateQueued
 				// And the previous spec is recorded.
 				assertions.PreviousSpec = spec1.ID
@@ -870,6 +876,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				// Now we update the changeset to make it look closed.
 				ct.SetChangesetClosed(t, ctx, store, c)
 				assertions.Closing = false
+				assertions.DetachFrom = []int64{}
 				assertions.ReconcilerState = campaigns.ReconcilerStateCompleted
 				assertions.ExternalState = campaigns.ChangesetExternalStateClosed
 				ct.ReloadAndAssertChangeset(t, ctx, store, c, assertions)
@@ -935,13 +942,14 @@ func TestServiceApplyCampaign(t *testing.T) {
 
 				// Our previously published changeset should be marked as "to be closed"
 				assertions.Closing = true
+				assertions.DetachFrom = []int64{campaign.ID}
 				assertions.ReconcilerState = campaigns.ReconcilerStateQueued
 				// And the previous spec is recorded.
 				assertions.PreviousSpec = spec1.ID
 				c = ct.ReloadAndAssertChangeset(t, ctx, store, c, assertions)
 
 				if len(c.Campaigns) != 1 {
-					t.Fatal("Expected changeset to be detached from campaign, but wasn't")
+					t.Fatal("Expected changeset to be still attached to campaign, but wasn't")
 				}
 
 				// Now we update the changeset to simulate that closing failed.
@@ -977,6 +985,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				assertions.ReconcilerState = campaigns.ReconcilerStateQueued
 				assertions.FailureMessage = nil
 				assertions.NumFailures = 0
+				assertions.DetachFrom = []int64{}
 				ct.AssertChangeset(t, attachedChangeset, assertions)
 			})
 
@@ -1020,6 +1029,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 
 				// Our previously published changeset should be marked as "to be closed"
 				assertions.Closing = true
+				assertions.DetachFrom = []int64{campaign.ID}
 				assertions.ReconcilerState = campaigns.ReconcilerStateQueued
 				// And the previous spec is recorded.
 				assertions.PreviousSpec = spec1.ID
@@ -1045,6 +1055,7 @@ func TestServiceApplyCampaign(t *testing.T) {
 				// Assert that the previous spec is still spec 1
 				assertions.PreviousSpec = spec1.ID
 				assertions.ReconcilerState = campaigns.ReconcilerStateQueued
+				assertions.DetachFrom = []int64{}
 				ct.AssertChangeset(t, attachedChangeset, assertions)
 			})
 		})

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -814,7 +814,7 @@ func testChangeset(repoID api.RepoID, campaign int64, extState campaigns.Changes
 	}
 
 	if campaign != 0 {
-		changeset.CampaignIDs = []int64{campaign}
+		changeset.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign}}
 	}
 
 	return changeset

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -814,7 +814,7 @@ func testChangeset(repoID api.RepoID, campaign int64, extState campaigns.Changes
 	}
 
 	if campaign != 0 {
-		changeset.Campaigns = []campaigns.CampaignChangeset{{CampaignID: campaign}}
+		changeset.Campaigns = []campaigns.CampaignAssoc{{CampaignID: campaign}}
 	}
 
 	return changeset

--- a/enterprise/internal/campaigns/store/campaigns_test.go
+++ b/enterprise/internal/campaigns/store/campaigns_test.go
@@ -76,7 +76,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 		}
 
 		changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-			CampaignIDs: []int64{cs[0].ID},
+			Campaigns: []campaigns.CampaignChangeset{{CampaignID: cs[0].ID}},
 		})
 
 		count, err = s.CountCampaigns(ctx, CountCampaignsOpts{ChangesetID: changeset.ID})
@@ -153,7 +153,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 		t.Run("By ChangesetID", func(t *testing.T) {
 			for i := 1; i <= len(cs); i++ {
 				changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-					CampaignIDs: []int64{cs[i-1].ID},
+					Campaigns: []campaigns.CampaignChangeset{{CampaignID: cs[i-1].ID}},
 				})
 				opts := ListCampaignsOpts{ChangesetID: changeset.ID}
 

--- a/enterprise/internal/campaigns/store/campaigns_test.go
+++ b/enterprise/internal/campaigns/store/campaigns_test.go
@@ -76,7 +76,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 		}
 
 		changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-			Campaigns: []campaigns.CampaignChangeset{{CampaignID: cs[0].ID}},
+			Campaigns: []campaigns.CampaignAssoc{{CampaignID: cs[0].ID}},
 		})
 
 		count, err = s.CountCampaigns(ctx, CountCampaignsOpts{ChangesetID: changeset.ID})
@@ -153,7 +153,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 		t.Run("By ChangesetID", func(t *testing.T) {
 			for i := 1; i <= len(cs); i++ {
 				changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-					Campaigns: []campaigns.CampaignChangeset{{CampaignID: cs[i-1].ID}},
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: cs[i-1].ID}},
 				})
 				opts := ListCampaignsOpts{ChangesetID: changeset.ID}
 

--- a/enterprise/internal/campaigns/store/changesets.go
+++ b/enterprise/internal/campaigns/store/changesets.go
@@ -98,7 +98,7 @@ func (s *Store) changesetWriteQuery(q string, includeID bool, c *campaigns.Chang
 		return nil, err
 	}
 
-	assocsAsMap := make(map[int64]campaigns.CampaignChangeset, len(c.Campaigns))
+	assocsAsMap := make(map[int64]campaigns.CampaignAssoc, len(c.Campaigns))
 	for _, assoc := range c.Campaigns {
 		assocsAsMap[assoc.CampaignID] = assoc
 	}
@@ -724,12 +724,12 @@ func scanChangesets(rows *sql.Rows, queryErr error) ([]*campaigns.Changeset, err
 // It implements the sql.Scanner interface so it can be used as a scan destination,
 // similar to sql.NullString.
 type jsonCampaignChangesetSet struct {
-	Assocs *[]campaigns.CampaignChangeset
+	Assocs *[]campaigns.CampaignAssoc
 }
 
 // Scan implements the Scanner interface.
 func (n *jsonCampaignChangesetSet) Scan(value interface{}) error {
-	m := make(map[int64]campaigns.CampaignChangeset)
+	m := make(map[int64]campaigns.CampaignAssoc)
 
 	switch value := value.(type) {
 	case nil:
@@ -742,13 +742,13 @@ func (n *jsonCampaignChangesetSet) Scan(value interface{}) error {
 	}
 
 	if *n.Assocs == nil {
-		*n.Assocs = make([]campaigns.CampaignChangeset, 0, len(m))
+		*n.Assocs = make([]campaigns.CampaignAssoc, 0, len(m))
 	} else {
 		*n.Assocs = (*n.Assocs)[:0]
 	}
 
 	for id, assoc := range m {
-		*n.Assocs = append(*n.Assocs, campaigns.CampaignChangeset{CampaignID: id, Detach: assoc.Detach})
+		*n.Assocs = append(*n.Assocs, campaigns.CampaignAssoc{CampaignID: id, Detach: assoc.Detach})
 	}
 
 	return nil

--- a/enterprise/internal/campaigns/store/changesets_test.go
+++ b/enterprise/internal/campaigns/store/changesets_test.go
@@ -81,7 +81,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 				CreatedAt:           clock.Now(),
 				UpdatedAt:           clock.Now(),
 				Metadata:            githubPR,
-				Campaigns:           []campaigns.CampaignChangeset{{CampaignID: int64(i) + 1}},
+				Campaigns:           []campaigns.CampaignAssoc{{CampaignID: int64(i) + 1}},
 				ExternalID:          fmt.Sprintf("foobar-%d", i),
 				ExternalServiceType: extsvc.TypeGitHub,
 				ExternalBranch:      fmt.Sprintf("refs/heads/campaigns/test/%d", i),
@@ -161,7 +161,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			CreatedAt:           clock.Now(),
 			UpdatedAt:           clock.Now(),
 			Metadata:            githubPR,
-			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: 1}},
+			Campaigns:           []campaigns.CampaignAssoc{{CampaignID: 1}},
 			ExternalID:          "foobar-123",
 			ExternalServiceType: extsvc.TypeGitHub,
 			ExternalBranch:      "refs/heads/campaigns/test",
@@ -631,7 +631,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		cs := &campaigns.Changeset{
 			RepoID:              repo.ID,
 			Metadata:            githubPR,
-			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: 1}},
+			Campaigns:           []campaigns.CampaignAssoc{{CampaignID: 1}},
 			ExternalID:          fmt.Sprintf("foobar-%d", 42),
 			ExternalServiceType: extsvc.TypeGitHub,
 			ExternalBranch:      "refs/heads/campaigns/test",
@@ -810,8 +810,8 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 
 		for i := range have {
 			// Test we can add to the set.
-			have[i].Campaigns = append(have[i].Campaigns, campaigns.CampaignChangeset{CampaignID: 42})
-			want[i].Campaigns = append(want[i].Campaigns, campaigns.CampaignChangeset{CampaignID: 42})
+			have[i].Campaigns = append(have[i].Campaigns, campaigns.CampaignAssoc{CampaignID: 42})
+			want[i].Campaigns = append(want[i].Campaigns, campaigns.CampaignAssoc{CampaignID: 42})
 
 			if err := s.UpdateChangeset(ctx, have[i]); err != nil {
 				t.Fatal(err)
@@ -1186,7 +1186,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 			CreatedAt:           clock.Now(),
 			UpdatedAt:           clock.Now(),
 			Metadata:            githubPR,
-			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: int64(i) + 1}},
+			Campaigns:           []campaigns.CampaignAssoc{{CampaignID: int64(i) + 1}},
 			ExternalID:          fmt.Sprintf("foobar-%d", i),
 			ExternalServiceType: extsvc.TypeGitHub,
 			ExternalBranch:      "refs/heads/campaigns/test",
@@ -1225,7 +1225,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 			t.Fatal(err)
 		}
 
-		cs.Campaigns = []campaigns.CampaignChangeset{{CampaignID: c.ID}}
+		cs.Campaigns = []campaigns.CampaignAssoc{{CampaignID: c.ID}}
 
 		if err := s.UpdateChangeset(ctx, cs); err != nil {
 			t.Fatal(err)
@@ -1332,7 +1332,7 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 		// If a changeset has ANY open campaigns we should list it
 		// Attach cs1 to both an open and closed campaign
 		openCampaignID := changesets[1].Campaigns[0].CampaignID
-		changesets[0].Campaigns = []campaigns.CampaignChangeset{{CampaignID: closedCampaignID}, {CampaignID: openCampaignID}}
+		changesets[0].Campaigns = []campaigns.CampaignAssoc{{CampaignID: closedCampaignID}, {CampaignID: openCampaignID}}
 		err = s.UpdateChangeset(ctx, changesets[0])
 		if err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/campaigns/testing/changeset.go
+++ b/enterprise/internal/campaigns/testing/changeset.go
@@ -18,7 +18,7 @@ type TestChangesetOpts struct {
 	Campaign     int64
 	CurrentSpec  int64
 	PreviousSpec int64
-	CampaignIDs  []int64
+	Campaigns    []campaigns.CampaignChangeset
 
 	ExternalServiceType string
 	ExternalID          string
@@ -70,7 +70,7 @@ func BuildChangeset(opts TestChangesetOpts) *campaigns.Changeset {
 		RepoID:         opts.Repo,
 		CurrentSpecID:  opts.CurrentSpec,
 		PreviousSpecID: opts.PreviousSpec,
-		CampaignIDs:    opts.CampaignIDs,
+		Campaigns:      opts.Campaigns,
 
 		ExternalServiceType: opts.ExternalServiceType,
 		ExternalID:          opts.ExternalID,
@@ -99,7 +99,7 @@ func BuildChangeset(opts TestChangesetOpts) *campaigns.Changeset {
 	}
 
 	if opts.Campaign != 0 {
-		changeset.CampaignIDs = []int64{opts.Campaign}
+		changeset.Campaigns = []campaigns.CampaignChangeset{{CampaignID: opts.Campaign}}
 	}
 
 	return changeset
@@ -276,6 +276,15 @@ func SetChangesetClosed(t *testing.T, ctx context.Context, s UpdateChangeseter, 
 	c.ReconcilerState = campaigns.ReconcilerStateCompleted
 	c.Closing = false
 	c.ExternalState = campaigns.ChangesetExternalStateClosed
+
+	assocs := make([]campaigns.CampaignChangeset, 0)
+	for _, assoc := range c.Campaigns {
+		if !assoc.Detach {
+			assocs = append(assocs, assoc)
+		}
+	}
+
+	c.Campaigns = assocs
 
 	if err := s.UpdateChangeset(ctx, c); err != nil {
 		t.Fatalf("failed to update changeset: %s", err)

--- a/enterprise/internal/campaigns/testing/changeset.go
+++ b/enterprise/internal/campaigns/testing/changeset.go
@@ -18,7 +18,7 @@ type TestChangesetOpts struct {
 	Campaign     int64
 	CurrentSpec  int64
 	PreviousSpec int64
-	Campaigns    []campaigns.CampaignChangeset
+	Campaigns    []campaigns.CampaignAssoc
 
 	ExternalServiceType string
 	ExternalID          string
@@ -99,7 +99,7 @@ func BuildChangeset(opts TestChangesetOpts) *campaigns.Changeset {
 	}
 
 	if opts.Campaign != 0 {
-		changeset.Campaigns = []campaigns.CampaignChangeset{{CampaignID: opts.Campaign}}
+		changeset.Campaigns = []campaigns.CampaignAssoc{{CampaignID: opts.Campaign}}
 	}
 
 	return changeset
@@ -123,6 +123,8 @@ type ChangesetAssertions struct {
 
 	FailureMessage *string
 	NumFailures    int64
+
+	DetachFrom []int64
 }
 
 func AssertChangeset(t *testing.T, c *campaigns.Changeset, a ChangesetAssertions) {
@@ -178,6 +180,19 @@ func AssertChangeset(t *testing.T, c *campaigns.Changeset, a ChangesetAssertions
 
 	if diff := cmp.Diff(a.Closing, c.Closing); diff != "" {
 		t.Fatalf("changeset Closing wrong. (-want +got):\n%s", diff)
+	}
+
+	toDetach := []int64{}
+	for _, assoc := range c.Campaigns {
+		if assoc.Detach {
+			toDetach = append(toDetach, assoc.CampaignID)
+		}
+	}
+	if a.DetachFrom == nil {
+		a.DetachFrom = []int64{}
+	}
+	if diff := cmp.Diff(a.DetachFrom, toDetach); diff != "" {
+		t.Fatalf("changeset DetachFrom wrong. (-want +got):\n%s", diff)
 	}
 
 	if want := c.FailureMessage; want != nil {
@@ -277,7 +292,7 @@ func SetChangesetClosed(t *testing.T, ctx context.Context, s UpdateChangeseter, 
 	c.Closing = false
 	c.ExternalState = campaigns.ChangesetExternalStateClosed
 
-	assocs := make([]campaigns.CampaignChangeset, 0)
+	assocs := make([]campaigns.CampaignAssoc, 0)
 	for _, assoc := range c.Campaigns {
 		if !assoc.Detach {
 			assocs = append(assocs, assoc)

--- a/enterprise/internal/campaigns/webhooks/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_test.go
@@ -119,7 +119,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			RepoID:              githubRepo.ID,
 			ExternalID:          "10156",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			CampaignIDs:         []int64{campaign.ID},
+			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
 		}
 
 		err = s.CreateChangeset(ctx, changeset)
@@ -298,13 +298,13 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				RepoID:              bitbucketRepo.ID,
 				ExternalID:          "69",
 				ExternalServiceType: bitbucketRepo.ExternalRepo.ServiceType,
-				CampaignIDs:         []int64{campaign.ID},
+				Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
 			},
 			{
 				RepoID:              bitbucketRepo.ID,
 				ExternalID:          "19",
 				ExternalServiceType: bitbucketRepo.ExternalRepo.ServiceType,
-				CampaignIDs:         []int64{campaign.ID},
+				Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
 			},
 		}
 

--- a/enterprise/internal/campaigns/webhooks/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_test.go
@@ -119,7 +119,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			RepoID:              githubRepo.ID,
 			ExternalID:          "10156",
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
-			Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
+			Campaigns:           []campaigns.CampaignAssoc{{CampaignID: campaign.ID}},
 		}
 
 		err = s.CreateChangeset(ctx, changeset)
@@ -298,13 +298,13 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				RepoID:              bitbucketRepo.ID,
 				ExternalID:          "69",
 				ExternalServiceType: bitbucketRepo.ExternalRepo.ServiceType,
-				Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
+				Campaigns:           []campaigns.CampaignAssoc{{CampaignID: campaign.ID}},
 			},
 			{
 				RepoID:              bitbucketRepo.ID,
 				ExternalID:          "19",
 				ExternalServiceType: bitbucketRepo.ExternalRepo.ServiceType,
-				Campaigns:           []campaigns.CampaignChangeset{{CampaignID: campaign.ID}},
+				Campaigns:           []campaigns.CampaignAssoc{{CampaignID: campaign.ID}},
 			},
 		}
 

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -194,8 +194,8 @@ func (s ChangesetCheckState) Valid() bool {
 	}
 }
 
-// CampaignChangeset stores the details on the connection between the two.
-type CampaignChangeset struct {
+// CampaignAssoc stores the details of a association to a Campaign.
+type CampaignAssoc struct {
 	CampaignID int64 `json:"-"`
 	Detach     bool  `json:"detach"`
 }
@@ -208,7 +208,7 @@ type Changeset struct {
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 	Metadata            interface{}
-	Campaigns           []CampaignChangeset
+	Campaigns           []CampaignAssoc
 	ExternalID          string
 	ExternalServiceType string
 	// ExternalBranch should always be prefixed with refs/heads/. Call git.EnsureRefPrefix before setting this value.

--- a/internal/campaigns/changeset_test.go
+++ b/internal/campaigns/changeset_test.go
@@ -521,7 +521,7 @@ func TestChangesetMetadata(t *testing.T) {
 		CreatedAt:           now,
 		UpdatedAt:           now,
 		Metadata:            githubPR,
-		CampaignIDs:         []int64{},
+		Campaigns:           []CampaignChangeset{},
 		ExternalID:          "12345",
 		ExternalServiceType: extsvc.TypeGitHub,
 	}

--- a/internal/campaigns/changeset_test.go
+++ b/internal/campaigns/changeset_test.go
@@ -521,7 +521,7 @@ func TestChangesetMetadata(t *testing.T) {
 		CreatedAt:           now,
 		UpdatedAt:           now,
 		Metadata:            githubPR,
-		Campaigns:           []CampaignChangeset{},
+		Campaigns:           []CampaignAssoc{},
 		ExternalID:          "12345",
 		ExternalServiceType: extsvc.TypeGitHub,
 	}

--- a/internal/campaigns/reconciler.go
+++ b/internal/campaigns/reconciler.go
@@ -14,4 +14,5 @@ const (
 	ReconcilerOperationClose        ReconcilerOperation = "CLOSE"
 	ReconcilerOperationReopen       ReconcilerOperation = "REOPEN"
 	ReconcilerOperationSleep        ReconcilerOperation = "SLEEP"
+	ReconcilerOperationDetach       ReconcilerOperation = "DETACH"
 )


### PR DESCRIPTION
This makes it a first-class supported changeset operation, which makes it easier to have the stats bar as per the design, without getting all nodes and counting them.
