### PR TITLE
Don't display publish notice on empty campaigns

### DIFF
--- a/client/web/src/enterprise/campaigns/detail/UnpublishedNotice.tsx
+++ b/client/web/src/enterprise/campaigns/detail/UnpublishedNotice.tsx
@@ -14,7 +14,7 @@ export const UnpublishedNotice: React.FunctionComponent<UnpublishedNoticeProps> 
     total,
     className,
 }) => {
-    if (unpublished !== total) {
+    if (total === 0 || unpublished !== total) {
         return <></>
     }
     return (


### PR DESCRIPTION
The message was displayed for empty campaigns and that felt misleading to me.
