### PR TITLE
Added notifications for team/code-insights GitHub label 

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -15,3 +15,4 @@ jobs:
                   team/cloud=@tsenart
                   team/search=@lguychard
                   team/code-intelligence=@macraig
+                  team/code-insights=@joelkw @felixfbecker


### PR DESCRIPTION
Want to get ahead of this and doing some "how to contact the code insights team" updates today. 