### PR TITLE
Fixes links between repos and code hosts pages, minor routing cleanup.

### DIFF
--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState, useEffect } from 'react'
+import { RouteComponentProps } from 'react-router'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as H from 'history'
 
@@ -14,10 +15,11 @@ import { asError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/
 import { Scalars, ExternalServiceKind, ListExternalServiceFields } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 
-export interface UserAddCodeHostsPageProps {
+export interface UserAddCodeHostsPageProps extends RouteComponentProps {
     userID: Scalars['ID']
     codeHostExternalServices: Record<string, AddExternalServiceOptions>
     history: H.History
+    routingPrefix: string
 }
 
 type ServicesByKind = Partial<Record<ExternalServiceKind, ListExternalServiceFields>>
@@ -30,6 +32,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
     userID,
     codeHostExternalServices,
     history,
+    routingPrefix,
 }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
 
@@ -94,7 +97,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
             </div>
             <p className="text-muted mt-2">
                 Connect with providers where your source code is hosted. Then,{' '}
-                <Link className="text-primary" to="repositories">
+                <Link className="text-primary" to={`${routingPrefix}/repositories`}>
                     add repositories
                 </Link>{' '}
                 to search with Sourcegraph.

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -416,9 +416,9 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                         <h3>Your repositories</h3>
                         <p className="text-muted">
                             Repositories you own or collaborate on from{' '}
-                            <a className="text-primary" href={routingPrefix + '/external-services'}>
+                            <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
                                 connected code hosts
-                            </a>
+                            </Link>
                         </p>
                         {
                             // display radio button for 'all' or 'selected' repos

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -182,9 +182,9 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
             </div>
             <p className="text-muted pb-2">
                 All repositories synced with Sourcegraph from{' '}
-                <a className="text-primary" href={routingPrefix + '/external-services'}>
+                <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
                     connected code hosts
-                </a>
+                </Link>
             </p>
             {body}
         </div>

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -7,10 +7,7 @@ import { RouteComponentProps } from 'react-router'
 import type { UserAddCodeHostsPageContainerProps } from './UserAddCodeHostsPageContainer'
 
 const SettingsArea = lazyComponent(() => import('../../settings/SettingsArea'), 'SettingsArea')
-const ExternalServicesPage = lazyComponent(
-    () => import('../../components/externalServices/ExternalServicesPage'),
-    'ExternalServicesPage'
-)
+
 const UserSettingsRepositoriesPage = lazyComponent(
     () => import('./repositories/UserSettingsRepositoriesPage'),
     'UserSettingsRepositoriesPage'
@@ -73,23 +70,6 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         condition: () => window.context.accessTokensAllow !== 'none',
     },
     {
-        path: '/external-services',
-        render: props => (
-            <ExternalServicesPage
-                {...props}
-                userID={props.user.id}
-                routingPrefix={props.user.url + '/settings'}
-                afterDeleteRoute={props.user.url + '/settings/external-services'}
-            />
-        ),
-        exact: true,
-        condition: props =>
-            window.context.externalServicesUserModeEnabled ||
-            (props.user.id === props.authenticatedUser.id &&
-                props.authenticatedUser.tags.includes('AllowUserExternalServicePublic')) ||
-            props.user.tags?.includes('AllowUserExternalServicePublic'),
-    },
-    {
         path: '/repositories',
         render: props => (
             <UserSettingsRepositoriesPage
@@ -123,7 +103,15 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: '/code-hosts',
-        render: props => <UserAddCodeHostsPageContainer userID={props.user.id} history={props.history} />,
+        render: props => (
+            <UserAddCodeHostsPageContainer
+                userID={props.user.id}
+                routingPrefix={props.user.url + '/settings'}
+                history={props.history}
+                match={props.match}
+                location={props.location}
+            />
+        ),
         exact: true,
         condition: props =>
             window.context.externalServicesUserModeEnabled ||


### PR DESCRIPTION

### Description

- fixes links between user repos and code hosts (`external-services` -> `code-hosts`)
- replaces `a` anchors with `Link` components to avoid full page re-rendering on navigation
- minor routing cleanup