### PR TITLE
search: Fix code monitors paging

### DIFF
--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -114,9 +114,7 @@ WHERE namespace_user_id = %s
 AND id > %s;
 `
 
-// RemainingCountMonitors provides the number of unreturned code monitors after
-// a call to Monitors with the given args
-
+// RemainingCountMonitors provides the number of unreturned code monitors after the provided ID
 func (s *Store) RemainingCountMonitors(ctx context.Context, userID int32, lastID int64) (count int32, err error) {
 	err = s.QueryRow(ctx, sqlf.Sprintf(remainingCountMonitorsFmtStr, userID, lastID)).Scan(&count)
 	return count, err

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -107,19 +107,6 @@ func (s *Store) TotalCountMonitors(ctx context.Context, userID int32) (count int
 	return count, err
 }
 
-const remainingCountMonitorsFmtStr = `
-SELECT COUNT(*)
-FROM cm_monitors
-WHERE namespace_user_id = %s
-AND id > %s;
-`
-
-// RemainingCountMonitors provides the number of unreturned code monitors after the provided ID
-func (s *Store) RemainingCountMonitors(ctx context.Context, userID int32, lastID int64) (count int32, err error) {
-	err = s.QueryRow(ctx, sqlf.Sprintf(remainingCountMonitorsFmtStr, userID, lastID)).Scan(&count)
-	return count, err
-}
-
 const monitorsFmtStr = `
 SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
 FROM cm_monitors

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -116,21 +116,10 @@ AND id > %s;
 
 // RemainingCountMonitors provides the number of unreturned code monitors after
 // a call to Monitors with the given args
-func (s *Store) RemainingCountMonitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) (remaining int32, err error) {
-	after, err := unmarshalAfter(args.After)
-	if err != nil {
-		return 0, err
-	}
 
-	var count int32
-	err = s.QueryRow(ctx, sqlf.Sprintf(remainingCountMonitorsFmtStr, userID, after)).Scan(&count)
-
-	remaining = count - args.First
-	if remaining < 0 {
-		remaining = 0
-	}
-
-	return remaining, err
+func (s *Store) RemainingCountMonitors(ctx context.Context, userID int32, lastID int64) (count int32, err error) {
+	err = s.QueryRow(ctx, sqlf.Sprintf(remainingCountMonitorsFmtStr, userID, lastID)).Scan(&count)
+	return count, err
 }
 
 const monitorsFmtStr = `

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -46,9 +46,12 @@ func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlback
 		return nil, err
 	}
 
-	remaining, err := r.store.RemainingCountMonitors(ctx, userID, args)
-	if err != nil {
-		return nil, err
+	var remaining int32
+	if len(ms) != 0 {
+		remaining, err = r.store.RemainingCountMonitors(ctx, userID, ms[len(ms)-1].ID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	mrs := make([]graphqlbackend.MonitorResolver, 0, len(ms))
@@ -58,6 +61,7 @@ func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlback
 			Monitor:  m,
 		})
 	}
+
 	return &monitorConnection{Resolver: r, monitors: mrs, totalCount: total, remaining: remaining}, nil
 }
 


### PR DESCRIPTION
The PageInfo returned by the GraphQL resolver for monitors was always
indicating that there were more pages after the first query because it
simply checked if the last result was empty.

This change adds logic to query the number of remaining code monitors so
that HasNextPage is set only if asking for another page would result in
more code monitors.

Fixes #16723 