### PR TITLE
search: remove search_alert dependency on query/syntax package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -148,7 +148,7 @@ func TestAddQueryRegexpField(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := addRegexpField(parseTree, test.addField, test.addPattern)
+			got := query.AddRegexpField(parseTree, test.addField, test.addPattern)
 			if got != test.want {
 				t.Errorf("got %q, want %q", got, test.want)
 			}

--- a/internal/search/query/alert.go
+++ b/internal/search/query/alert.go
@@ -1,0 +1,46 @@
+package query
+
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
+)
+
+func OmitQueryField(p syntax.ParseTree, field string) string {
+	omitField := func(e syntax.Expr) *syntax.Expr {
+		if e.Field == field {
+			return nil
+		}
+		return &e
+	}
+	return syntax.Map(p, omitField).String()
+}
+
+// addRegexpField adds a new expr to the query with the given field
+// and pattern value. The field is assumed to be a regexp.
+//
+// It tries to remove redundancy in the result. For example, given
+// a query like "x:foo", if given a field "x" with pattern "foobar" to add,
+// it will return a query "x:foobar" instead of "x:foo x:foobar". It is not
+// guaranteed to always return the simplest query.
+func AddRegexpField(p syntax.ParseTree, field, pattern string) string {
+	var added bool
+	addRegexpField := func(e syntax.Expr) *syntax.Expr {
+		if e.Field == field && strings.Contains(pattern, e.Value) {
+			e.Value = pattern
+			added = true
+			return &e
+		}
+		return &e
+	}
+	modified := syntax.Map(p, addRegexpField)
+	if !added {
+		p = append(p, &syntax.Expr{
+			Field:     field,
+			Value:     pattern,
+			ValueType: syntax.TokenLiteral,
+		})
+		return p.String()
+	}
+	return modified.String()
+}

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -24,6 +24,9 @@ func (e *UnsupportedError) Error() string {
 	return e.Msg
 }
 
+// LegacyParseError aliases to the parse error type for the legacy parser.
+type LegacyParseError = syntax.ParseError
+
 type SearchType int
 
 const (


### PR DESCRIPTION
I want to delete the unused legacy parser code. To start I need to remove all package imports of 

`github.com/sourcegraph/sourcegraph/internal/search/query/syntax`

which is where most of the old code logic lives. This PR removes it for the uses in `graphqlbackend/search_alert.go`. To do that, I'm just pulling the dependencies into `internal/search` and aliasing the type. This way, I can have a single PR later that removes the unneeded parts in one go.