### PR TITLE
Filter LSIF dumps with an orphaned commit

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/api/exists.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/exists.go
@@ -7,6 +7,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
@@ -60,7 +61,13 @@ func (api *CodeIntelAPI) FindClosestDumps(ctx context.Context, repositoryID int,
 			}
 		}
 
-		dumps = append(dumps, dump)
+		dumpCommitExists, err := api.dbStore.HasCommit(ctx, dump.RepositoryID, dump.Commit)
+		if err != nil {
+			return nil, err
+		}
+		if dumpCommitExists {
+			dumps = append(dumps, dump)
+		}
 	}
 
 	return dumps, nil

--- a/enterprise/cmd/frontend/internal/codeintel/api/helpers_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/helpers_test.go
@@ -185,6 +185,26 @@ func setMockDBStoreHasCommit(t testing.TB, mockDBStore *MockDBStore, expectedRep
 	})
 }
 
+type commitSpec struct {
+	commit string
+	exists bool
+}
+
+func setMultiMockDBStoreHasCommit(t testing.TB, mockDBStore *MockDBStore, expectedRepositoryID int, specs []commitSpec) {
+	mockDBStore.HasCommitFunc.SetDefaultHook(func(ctx context.Context, repositoryID int, commit string) (bool, error) {
+		if repositoryID != expectedRepositoryID {
+			t.Errorf("unexpected repository id for HasCommit. want=%d have=%d", expectedRepositoryID, repositoryID)
+		}
+		for _, s := range specs {
+			if s.commit == commit {
+				return s.exists, nil
+			}
+		}
+		t.Errorf("unexpected commit for HasCommit: %s", commit)
+		return false, nil
+	})
+}
+
 func setMockReferencePagerPageFromOffset(t testing.TB, mockReferencePager *MockReferencePager, expectedOffset int, references []lsifstore.PackageReference) {
 	mockReferencePager.PageFromOffsetFunc.SetDefaultHook(func(ctx context.Context, offset int) ([]lsifstore.PackageReference, error) {
 		if offset != expectedOffset {


### PR DESCRIPTION
# Checklist

- [x] Update the main codes
- [x] Update the tests and mock methods: because current tests ignore commits for dumps, this PR causes all of the relevant tests to fail

Fixes #12588