### PR TITLE
repo-updater: Handle GitHub account suspension

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -252,8 +252,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			unauthorized := errcode.IsUnauthorized(errors.Cause(err))
 
 			// Detect GitHub account suspension error
-			ghErr, ok := err.(*github.APIError)
-			accountSuspended := ok && ghErr.AccountSuspended()
+			accountSuspended := errcode.IsAccountSuspended(errors.Cause(err))
 
 			if unauthorized || accountSuspended {
 				err = db.ExternalAccounts.TouchExpired(ctx, acct.ID)

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -122,6 +122,18 @@ func IsUnauthorized(err error) bool {
 	})
 }
 
+// IsAccountSuspended will check if err or one of its causes was due to the
+// account being suspended
+func IsAccountSuspended(err error) bool {
+	type accountSuspendeder interface {
+		AccountSuspended() bool
+	}
+	return isErrorPredicate(err, func(err error) bool {
+		e, ok := err.(accountSuspendeder)
+		return ok && e.AccountSuspended()
+	})
+}
+
 // IsBadRequest will check if err or one of its causes is a bad request.
 func IsBadRequest(err error) bool {
 	type badRequester interface {

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -319,6 +319,22 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 				err:  "bad credentials",
 			},
 			testCase{
+				// If the source account has been suspended we should treat this as if zero repos were returned as it indicates
+				// that the source no longer has access to its repos
+				name:    string(tc.repo.Name) + "/accountsuspended",
+				sourcer: repos.NewFakeSourcer(&repos.ErrAccountSuspended{}),
+				store:   s,
+				stored: types.Repos{tc.repo.With(
+					types.Opt.RepoSources(tc.svc.URN()),
+				)},
+				now: clock.Now,
+				diff: repos.Diff{Deleted: types.Repos{tc.repo.With(
+					types.Opt.RepoSources(tc.svc.URN(), svcdup.URN()),
+				)}},
+				svcs: []*types.ExternalService{tc.svc},
+				err:  "account suspended",
+			},
+			testCase{
 				// It's expected that there could be multiple stored sources but only one will ever be returned
 				// by the code host as it can't know about others.
 				name: string(tc.repo.Name) + "/source already stored",


### PR DESCRIPTION
We treat account suspensions in the same way as bad credentials. It is a non fatal sync errors and causes us to remove all synced repos for the account.

Closes: https://github.com/sourcegraph/sourcegraph/issues/17159