### PR TITLE
postgres_exporter: fix build w/o arguments, add version label

### DIFF
--- a/docker-images/postgres_exporter/Dockerfile
+++ b/docker-images/postgres_exporter/Dockerfile
@@ -1,4 +1,6 @@
+FROM wrouesnel/postgres_exporter:v0.7.0@sha256:785c919627c06f540d515aac88b7966f352403f73e931e70dc2cbf783146a98b as postgres_exporter
 FROM sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
+LABEL com.sourcegraph.postgres_exporter.version=v0.7.0
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -12,7 +14,7 @@ LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
 # hadolint ignore=DL3022
-COPY --from=wrouesnel/postgres_exporter:v0.7.0@sha256:785c919627c06f540d515aac88b7966f352403f73e931e70dc2cbf783146a98b /postgres_exporter /usr/local/bin/postgres_exporter
+COPY --from=postgres_exporter /postgres_exporter /usr/local/bin/postgres_exporter
 
 RUN addgroup -S postgres_exporter && adduser --uid 20001 -S postgres_exporter -G postgres_exporter
 

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -2,7 +2,7 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
-docker build -t "${IMAGE:-'sourcegraph/postgres_exporter'}" . \
+docker build -t "${IMAGE:-sourcegraph/postgres_exporter}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \


### PR DESCRIPTION
Was trying to get `dev/start.sh` to work, saw some postgres_exporter errors. Turns out they were unrelated, but made a few fly-by changes

* allow build to work without arguments, previously:
```
./docker-images/postgres_exporter/build.sh
+ docker build -t ''\''sourcegraph/postgres_exporter'\''' . --progress=plain --build-arg COMMIT_SHA --build-arg DATE --build-arg VERSION
invalid argument "'sourcegraph/postgres_exporter'" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```
* make dockerfile line shorter using a named `FROM`, and add a label for the upstream version (similar to the grafana/prometheus image labels)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
