### PR TITLE
streaming: show errors in skipped popover and sort by severity

### DIFF
--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -12,7 +12,10 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
     const [isOpen, setIsOpen] = useState(false)
     const toggleOpen = useCallback(() => setIsOpen(previous => !previous), [setIsOpen])
 
-    const skippedWithWarning = useMemo(() => progress.skipped.some(skipped => skipped.severity === 'warn'), [progress])
+    const skippedWithWarningOrError = useMemo(
+        () => progress.skipped.some(skipped => skipped.severity === 'warn' || skipped.severity === 'error'),
+        [progress]
+    )
 
     const onSearchAgainWithPopupClose = useCallback(
         (filters: string[]) => {
@@ -30,13 +33,13 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                         className={classNames(
                             'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none',
                             {
-                                'streaming-progress__skipped--warning': skippedWithWarning,
+                                'streaming-progress__skipped--warning': skippedWithWarningOrError,
                             }
                         )}
                         caret={true}
                         color="link"
                     >
-                        {skippedWithWarning ? (
+                        {skippedWithWarningOrError ? (
                             <AlertCircleIcon className="mr-2 icon-inline" />
                         ) : (
                             <InformationOutlineIcon className="mr-2 icon-inline" />

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -6,10 +6,9 @@ import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 import { StreamingProgressProps } from './StreamingProgress'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
-export const StreamingProgressSkippedButton: React.FunctionComponent<Pick<
-    StreamingProgressProps,
-    'progress' | 'onSearchAgain' | 'history'
->> = ({ progress, onSearchAgain, history }) => {
+export const StreamingProgressSkippedButton: React.FunctionComponent<
+    Pick<StreamingProgressProps, 'progress' | 'onSearchAgain' | 'history'>
+> = ({ progress, onSearchAgain, history }) => {
     const [isOpen, setIsOpen] = useState(false)
     const toggleOpen = useCallback(() => setIsOpen(previous => !previous), [setIsOpen])
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -6,9 +6,10 @@ import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 import { StreamingProgressProps } from './StreamingProgress'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
-export const StreamingProgressSkippedButton: React.FunctionComponent<
-    Pick<StreamingProgressProps, 'progress' | 'onSearchAgain' | 'history'>
-> = ({ progress, onSearchAgain, history }) => {
+export const StreamingProgressSkippedButton: React.FunctionComponent<Pick<
+    StreamingProgressProps,
+    'progress' | 'onSearchAgain' | 'history'
+>> = ({ progress, onSearchAgain, history }) => {
     const [isOpen, setIsOpen] = useState(false)
     const toggleOpen = useCallback(() => setIsOpen(previous => !previous), [setIsOpen])
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.story.tsx
@@ -34,6 +34,13 @@ add('popover', () => {
                 },
             },
             {
+                reason: 'error',
+                message:
+                    'There was a network error retrieving search results. Check your Internet connection and try again.',
+                severity: 'error',
+                title: 'Error loading results',
+            },
+            {
                 reason: 'excluded-archive',
                 message: '',
                 severity: 'info',

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.test.tsx
@@ -47,6 +47,13 @@ describe('StreamingProgressSkippedPopover', () => {
                     },
                 },
                 {
+                    reason: 'error',
+                    message:
+                        'There was a network error retrieving search results. Check your Internet connection and try again.',
+                    severity: 'error',
+                    title: 'Error loading results',
+                },
+                {
                     reason: 'shard-timedout',
                     message: 'Search timed out',
                     severity: 'warn',
@@ -236,6 +243,16 @@ describe('StreamingProgressSkippedPopover', () => {
             repositoriesCount: 2,
             skipped: [
                 {
+                    reason: 'shard-timedout',
+                    message: 'Search timed out',
+                    severity: 'warn',
+                    title: 'Search timed out',
+                    suggested: {
+                        title: 'timeout:2m',
+                        queryExpression: 'timeout:2m',
+                    },
+                },
+                {
                     reason: 'excluded-fork',
                     message: '10k forked repositories excluded',
                     severity: 'info',
@@ -255,16 +272,6 @@ describe('StreamingProgressSkippedPopover', () => {
                         queryExpression: 'archived:yes',
                     },
                 },
-                {
-                    reason: 'shard-timedout',
-                    message: 'Search timed out',
-                    severity: 'warn',
-                    title: 'Search timed out',
-                    suggested: {
-                        title: 'timeout:2m',
-                        queryExpression: 'timeout:2m',
-                    },
-                },
             ],
         }
 
@@ -277,7 +284,7 @@ describe('StreamingProgressSkippedPopover', () => {
         const checkboxes = element.find(Input)
 
         expect(checkboxes).toHaveLength(3)
-        const checkbox1 = checkboxes.at(1)
+        const checkbox1 = checkboxes.at(0)
         checkbox1.invoke('onChange')?.({
             currentTarget: { checked: true, value: checkbox1.props().value as string },
         } as ChangeEvent<HTMLInputElement>)
@@ -292,6 +299,6 @@ describe('StreamingProgressSkippedPopover', () => {
         form.simulate('submit')
 
         sinon.assert.calledOnce(searchAgain)
-        sinon.assert.calledWith(searchAgain, ['archived:yes', 'timeout:2m'])
+        sinon.assert.calledWith(searchAgain, ['timeout:2m', 'archived:yes'])
     })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -6,11 +6,31 @@ import { Alert, Button, Form, FormGroup, Input, Label } from 'reactstrap'
 import { Markdown } from '../../../../../../shared/src/components/Markdown'
 import { renderMarkdown } from '../../../../../../shared/src/util/markdown'
 import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighlightedSearchQuery'
+import { Skipped } from '../../../stream'
 import { StreamingProgressProps } from './StreamingProgress'
 
-export const StreamingProgressSkippedPopover: React.FunctionComponent<
-    Pick<StreamingProgressProps, 'progress' | 'onSearchAgain' | 'history'>
-> = ({ progress, onSearchAgain, history }) => {
+const sortBySeverity = (a: Skipped, b: Skipped): number => {
+    const severityToNumber = (severity: Skipped['severity']): number => {
+        switch (severity) {
+            case 'error':
+                return 1
+            case 'warn':
+                return 2
+            case 'info':
+                return 3
+        }
+    }
+
+    const aSev = severityToNumber(a.severity)
+    const bSev = severityToNumber(b.severity)
+
+    return aSev - bSev
+}
+
+export const StreamingProgressSkippedPopover: React.FunctionComponent<Pick<
+    StreamingProgressProps,
+    'progress' | 'onSearchAgain' | 'history'
+>> = ({ progress, onSearchAgain, history }) => {
     const [selectedSuggestedSearches, setSelectedSuggestedSearches] = useState(new Set<string>())
     const submitHandler = useCallback(
         (event: React.FormEvent) => {
@@ -33,15 +53,17 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
         })
     }, [])
 
+    const sortedSkippedItems = progress.skipped.sort(sortBySeverity)
+
     return (
         <>
-            {progress.skipped.map(skipped => (
-                <Alert key={skipped.reason} color={skipped.severity === 'warn' ? 'danger' : 'info'} fade={false}>
+            {sortedSkippedItems.map(skipped => (
+                <Alert key={skipped.reason} color={skipped.severity === 'info' ? 'info' : 'danger'} fade={false}>
                     <h4 className="d-flex align-items-center mb-0">
-                        {skipped.severity === 'warn' ? (
-                            <AlertCircleIcon className="icon-inline mr-2" />
-                        ) : (
+                        {skipped.severity === 'info' ? (
                             <InformationOutlineIcon className="icon-inline mr-2" />
+                        ) : (
+                            <AlertCircleIcon className="icon-inline mr-2" />
                         )}
                         <span>{skipped.title}</span>
                     </h4>
@@ -52,11 +74,11 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
                     )}
                 </Alert>
             ))}
-            {progress.skipped.some(skipped => skipped.suggested) && (
+            {sortedSkippedItems.some(skipped => skipped.suggested) && (
                 <Form onSubmit={submitHandler}>
                     <div className="mb-2">Search again:</div>
                     <FormGroup check={true}>
-                        {progress.skipped.map(
+                        {sortedSkippedItems.map(
                             skipped =>
                                 skipped.suggested && (
                                     <Label

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -27,10 +27,9 @@ const sortBySeverity = (a: Skipped, b: Skipped): number => {
     return aSev - bSev
 }
 
-export const StreamingProgressSkippedPopover: React.FunctionComponent<Pick<
-    StreamingProgressProps,
-    'progress' | 'onSearchAgain' | 'history'
->> = ({ progress, onSearchAgain, history }) => {
+export const StreamingProgressSkippedPopover: React.FunctionComponent<
+    Pick<StreamingProgressProps, 'progress' | 'onSearchAgain' | 'history'>
+> = ({ progress, onSearchAgain, history }) => {
     const [selectedSuggestedSearches, setSelectedSuggestedSearches] = useState(new Set<string>())
     const submitHandler = useCallback(
         (event: React.FormEvent) => {

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -9,18 +9,18 @@ import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighl
 import { Skipped } from '../../../stream'
 import { StreamingProgressProps } from './StreamingProgress'
 
-const sortBySeverity = (a: Skipped, b: Skipped): number => {
-    const severityToNumber = (severity: Skipped['severity']): number => {
-        switch (severity) {
-            case 'error':
-                return 1
-            case 'warn':
-                return 2
-            case 'info':
-                return 3
-        }
+const severityToNumber = (severity: Skipped['severity']): number => {
+    switch (severity) {
+        case 'error':
+            return 1
+        case 'warn':
+            return 2
+        case 'info':
+            return 3
     }
+}
 
+const sortBySeverity = (a: Skipped, b: Skipped): number => {
     const aSev = severityToNumber(a.severity)
     const bSev = severityToNumber(b.severity)
 

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -11,6 +11,22 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       "repositoriesCount": 2,
       "skipped": Array [
         Object {
+          "message": "There was a network error retrieving search results. Check your Internet connection and try again.",
+          "reason": "error",
+          "severity": "error",
+          "title": "Error loading results",
+        },
+        Object {
+          "message": "Search timed out",
+          "reason": "shard-timedout",
+          "severity": "warn",
+          "suggested": Object {
+            "queryExpression": "timeout:2m",
+            "title": "timeout:2m",
+          },
+          "title": "Search timed out",
+        },
+        Object {
           "message": "10k forked repositories excluded",
           "reason": "excluded-fork",
           "severity": "info",
@@ -40,20 +56,212 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           },
           "title": "1 archived",
         },
-        Object {
-          "message": "Search timed out",
-          "reason": "shard-timedout",
-          "severity": "warn",
-          "suggested": Object {
-            "queryExpression": "timeout:2m",
-            "title": "timeout:2m",
-          },
-          "title": "Search timed out",
-        },
       ],
     }
   }
 >
+  <Alert
+    closeAriaLabel="Close"
+    color="danger"
+    fade={false}
+    isOpen={true}
+    key="error"
+    tag="div"
+    transition={
+      Object {
+        "appear": true,
+        "baseClass": "fade",
+        "baseClassActive": "show",
+        "enter": true,
+        "exit": true,
+        "in": true,
+        "mountOnEnter": false,
+        "onEnter": [Function],
+        "onEntered": [Function],
+        "onEntering": [Function],
+        "onExit": [Function],
+        "onExited": [Function],
+        "onExiting": [Function],
+        "tag": "div",
+        "timeout": 150,
+        "unmountOnExit": true,
+      }
+    }
+  >
+    <Fade
+      appear={true}
+      baseClass=""
+      baseClassActive="show"
+      className="alert alert-danger"
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      role="alert"
+      tag="div"
+      timeout={0}
+      unmountOnExit={true}
+    >
+      <Transition
+        appear={true}
+        enter={true}
+        exit={true}
+        in={true}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={0}
+        unmountOnExit={true}
+      >
+        <div
+          className="alert alert-danger"
+          role="alert"
+        >
+          <h4
+            className="d-flex align-items-center mb-0"
+          >
+            <Memo(AlertCircleIcon)
+              className="icon-inline mr-2"
+            />
+            <span>
+              Error loading results
+            </span>
+          </h4>
+          <div
+            className="mt-2"
+          >
+            <Markdown
+              dangerousInnerHTML="<p>There was a network error retrieving search results. Check your Internet connection and try again.</p>
+"
+              history="[History]"
+            >
+              <div
+                className="markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>There was a network error retrieving search results. Check your Internet connection and try again.</p>
+",
+                  }
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </div>
+      </Transition>
+    </Fade>
+  </Alert>
+  <Alert
+    closeAriaLabel="Close"
+    color="danger"
+    fade={false}
+    isOpen={true}
+    key="shard-timedout"
+    tag="div"
+    transition={
+      Object {
+        "appear": true,
+        "baseClass": "fade",
+        "baseClassActive": "show",
+        "enter": true,
+        "exit": true,
+        "in": true,
+        "mountOnEnter": false,
+        "onEnter": [Function],
+        "onEntered": [Function],
+        "onEntering": [Function],
+        "onExit": [Function],
+        "onExited": [Function],
+        "onExiting": [Function],
+        "tag": "div",
+        "timeout": 150,
+        "unmountOnExit": true,
+      }
+    }
+  >
+    <Fade
+      appear={true}
+      baseClass=""
+      baseClassActive="show"
+      className="alert alert-danger"
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      role="alert"
+      tag="div"
+      timeout={0}
+      unmountOnExit={true}
+    >
+      <Transition
+        appear={true}
+        enter={true}
+        exit={true}
+        in={true}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={0}
+        unmountOnExit={true}
+      >
+        <div
+          className="alert alert-danger"
+          role="alert"
+        >
+          <h4
+            className="d-flex align-items-center mb-0"
+          >
+            <Memo(AlertCircleIcon)
+              className="icon-inline mr-2"
+            />
+            <span>
+              Search timed out
+            </span>
+          </h4>
+          <div
+            className="mt-2"
+          >
+            <Markdown
+              dangerousInnerHTML="<p>Search timed out</p>
+"
+              history="[History]"
+            >
+              <div
+                className="markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Search timed out</p>
+",
+                  }
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </div>
+      </Transition>
+    </Fade>
+  </Alert>
   <Alert
     closeAriaLabel="Close"
     color="info"
@@ -357,107 +565,6 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       </Transition>
     </Fade>
   </Alert>
-  <Alert
-    closeAriaLabel="Close"
-    color="danger"
-    fade={false}
-    isOpen={true}
-    key="shard-timedout"
-    tag="div"
-    transition={
-      Object {
-        "appear": true,
-        "baseClass": "fade",
-        "baseClassActive": "show",
-        "enter": true,
-        "exit": true,
-        "in": true,
-        "mountOnEnter": false,
-        "onEnter": [Function],
-        "onEntered": [Function],
-        "onEntering": [Function],
-        "onExit": [Function],
-        "onExited": [Function],
-        "onExiting": [Function],
-        "tag": "div",
-        "timeout": 150,
-        "unmountOnExit": true,
-      }
-    }
-  >
-    <Fade
-      appear={true}
-      baseClass=""
-      baseClassActive="show"
-      className="alert alert-danger"
-      enter={true}
-      exit={true}
-      in={true}
-      mountOnEnter={false}
-      onEnter={[Function]}
-      onEntered={[Function]}
-      onEntering={[Function]}
-      onExit={[Function]}
-      onExited={[Function]}
-      onExiting={[Function]}
-      role="alert"
-      tag="div"
-      timeout={0}
-      unmountOnExit={true}
-    >
-      <Transition
-        appear={true}
-        enter={true}
-        exit={true}
-        in={true}
-        mountOnEnter={false}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={0}
-        unmountOnExit={true}
-      >
-        <div
-          className="alert alert-danger"
-          role="alert"
-        >
-          <h4
-            className="d-flex align-items-center mb-0"
-          >
-            <Memo(AlertCircleIcon)
-              className="icon-inline mr-2"
-            />
-            <span>
-              Search timed out
-            </span>
-          </h4>
-          <div
-            className="mt-2"
-          >
-            <Markdown
-              dangerousInnerHTML="<p>Search timed out</p>
-"
-              history="[History]"
-            >
-              <div
-                className="markdown"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Search timed out</p>
-",
-                  }
-                }
-                onClick={[Function]}
-              />
-            </Markdown>
-          </div>
-        </div>
-      </Transition>
-    </Fade>
-  </Alert>
   <Form
     onSubmit={[Function]}
     tag="form"
@@ -478,6 +585,57 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         <div
           className="form-check"
         >
+          <Label
+            check={true}
+            className="mb-1 d-block"
+            key="timeout:2m"
+            tag="label"
+            widths={
+              Array [
+                "xs",
+                "sm",
+                "md",
+                "lg",
+                "xl",
+              ]
+            }
+          >
+            <label
+              className="mb-1 d-block form-check-label"
+            >
+              <Input
+                onChange={[Function]}
+                type="checkbox"
+                value="timeout:2m"
+              >
+                <input
+                  className="form-check-input"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="timeout:2m"
+                />
+              </Input>
+               
+              timeout:2m
+               (
+              <SyntaxHighlightedSearchQuery
+                query="timeout:2m"
+              >
+                <span
+                  className="text-monospace search-query-link"
+                >
+                  <span
+                    className="search-filter-keyword"
+                  >
+                    timeout
+                    :
+                  </span>
+                  2m
+                </span>
+              </SyntaxHighlightedSearchQuery>
+              )
+            </label>
+          </Label>
           <Label
             check={true}
             className="mb-1 d-block"
@@ -620,57 +778,6 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
                     :
                   </span>
                   yes
-                </span>
-              </SyntaxHighlightedSearchQuery>
-              )
-            </label>
-          </Label>
-          <Label
-            check={true}
-            className="mb-1 d-block"
-            key="timeout:2m"
-            tag="label"
-            widths={
-              Array [
-                "xs",
-                "sm",
-                "md",
-                "lg",
-                "xl",
-              ]
-            }
-          >
-            <label
-              className="mb-1 d-block form-check-label"
-            >
-              <Input
-                onChange={[Function]}
-                type="checkbox"
-                value="timeout:2m"
-              >
-                <input
-                  className="form-check-input"
-                  onChange={[Function]}
-                  type="checkbox"
-                  value="timeout:2m"
-                />
-              </Input>
-               
-              timeout:2m
-               (
-              <SyntaxHighlightedSearchQuery
-                query="timeout:2m"
-              >
-                <span
-                  className="text-monospace search-query-link"
-                >
-                  <span
-                    className="search-filter-keyword"
-                  >
-                    timeout
-                    :
-                  </span>
-                  2m
                 </span>
               </SyntaxHighlightedSearchQuery>
               )


### PR DESCRIPTION
- Errors (either server or client side) from streaming search are now shown in the skipped results popover with a new `error` severity
- Messages in the skipped results popover are now sorted by severity (`error` -> `warn` -> `info`)
- Renamed `stream.tsx` to `stream.ts` since it doesn't contain any JSX