### PR TITLE
codeintel: Add a feature flag for auto indexing

### DIFF
--- a/client/web/src/enterprise/repo/settings/routes.tsx
+++ b/client/web/src/enterprise/repo/settings/routes.tsx
@@ -43,6 +43,8 @@ export const enterpriseRepoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] 
         exact: true,
         render: props => <RepoSettingsPermissionsPage {...props} />,
     },
+
+    // Code intelligence upload routes
     {
         path: '/code-intelligence/uploads',
         exact: true,
@@ -53,21 +55,28 @@ export const enterpriseRepoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[] 
         exact: true,
         render: props => <CodeIntelUploadPage {...props} />,
     },
-    {
-        path: '/code-intelligence/index-configuration',
-        exact: true,
-        render: props => <CodeIntelIndexConfigurationPage {...props} />,
-    },
+
+    // Auto indexing routes
     {
         path: '/code-intelligence/indexes',
         exact: true,
         render: props => <CodeIntelIndexesPage {...props} />,
+        condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
     {
         path: '/code-intelligence/indexes/:id',
         exact: true,
         render: props => <CodeIntelIndexPage {...props} />,
+        condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
+    {
+        path: '/code-intelligence/index-configuration',
+        exact: true,
+        render: props => <CodeIntelIndexConfigurationPage {...props} />,
+        condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
+    },
+
+    // Legacy routes
     {
         path: '/code-intelligence/lsif-uploads/:id',
         exact: true,

--- a/client/web/src/enterprise/repo/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/repo/settings/sidebaritems.ts
@@ -10,14 +10,14 @@ const codeIntelSettingsGroup = {
             label: 'Uploads',
         },
         {
-            to: '/code-intelligence/index-configuration',
-            label: 'Index configuration',
-            condition: () => Boolean(window.context?.autoIndexingEnabled),
-        },
-        {
             to: '/code-intelligence/indexes',
             label: 'Auto indexing',
-            condition: () => Boolean(window.context?.autoIndexingEnabled),
+            condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
+        },
+        {
+            to: '/code-intelligence/index-configuration',
+            label: 'Index configuration',
+            condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
         },
     ],
 }

--- a/client/web/src/enterprise/repo/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/repo/settings/sidebaritems.ts
@@ -12,12 +12,12 @@ const codeIntelSettingsGroup = {
         {
             to: '/code-intelligence/index-configuration',
             label: 'Index configuration',
-            condition: () => Boolean(window.context?.sourcegraphDotComMode),
+            condition: () => Boolean(window.context?.autoIndexingEnabled),
         },
         {
             to: '/code-intelligence/indexes',
             label: 'Auto indexing',
-            condition: () => Boolean(window.context?.sourcegraphDotComMode),
+            condition: () => Boolean(window.context?.autoIndexingEnabled),
         },
     ],
 }

--- a/client/web/src/enterprise/site-admin/routes.ts
+++ b/client/web/src/enterprise/site-admin/routes.ts
@@ -70,6 +70,8 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         render: lazyComponent(() => import('./SiteAdminRegistryExtensionsPage'), 'SiteAdminRegistryExtensionsPage'),
         exact: true,
     },
+
+    // Code intelligence upload routes
     {
         path: '/code-intelligence/uploads',
         render: lazyComponent(() => import('../codeintel/list/CodeIntelUploadsPage'), 'CodeIntelUploadsPage'),
@@ -80,16 +82,22 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         render: lazyComponent(() => import('../codeintel/detail/CodeIntelUploadPage'), 'CodeIntelUploadPage'),
         exact: true,
     },
+
+    // Auto indexing routes
     {
         path: '/code-intelligence/indexes',
         render: lazyComponent(() => import('../codeintel/list/CodeIntelIndexesPage'), 'CodeIntelIndexesPage'),
         exact: true,
+        condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
     {
         path: '/code-intelligence/indexes/:id',
         render: lazyComponent(() => import('../codeintel/detail/CodeIntelIndexPage'), 'CodeIntelIndexPage'),
         exact: true,
+        condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
+
+    // Legacy routes
     {
         path: '/lsif-uploads/:id',
         render: lazyComponent(() => import('./SiteAdminLsifUploadPage'), 'SiteAdminLsifUploadPage'),

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -45,7 +45,7 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
         {
             to: '/site-admin/code-intelligence/indexes',
             label: 'Auto indexing',
-            condition: () => Boolean(window.context?.sourcegraphDotComMode),
+            condition: () => Boolean(window.context?.autoIndexingEnabled),
         },
     ],
 }

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -45,7 +45,7 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
         {
             to: '/site-admin/code-intelligence/indexes',
             label: 'Auto indexing',
-            condition: () => Boolean(window.context?.autoIndexingEnabled),
+            condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
         },
     ],
 }

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -17,6 +17,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     accessTokensAllow: 'all-users-create',
     allowSignup: false,
     campaignsEnabled: true,
+    autoIndexingEnabled: true,
     externalServicesUserModeEnabled: false,
     csrfToken: 'test-csrf-token',
     assetsRoot: new URL('/.assets', sourcegraphBaseUrl).href,

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -17,7 +17,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     accessTokensAllow: 'all-users-create',
     allowSignup: false,
     campaignsEnabled: true,
-    autoIndexingEnabled: true,
+    codeIntelAutoIndexingEnabled: true,
     externalServicesUserModeEnabled: false,
     csrfToken: 'test-csrf-token',
     assetsRoot: new URL('/.assets', sourcegraphBaseUrl).href,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -83,8 +83,8 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the campaigns feature is enabled on the site. */
     campaignsEnabled: boolean
 
-    /** Whether the auto-indexer feature is enabled on the site. */
-    autoIndexingEnabled: boolean
+    /** Whether the code intel auto-indexer feature is enabled on the site. */
+    codeIntelAutoIndexingEnabled: boolean
 
     /** Whether user is allowed to add external services. */
     externalServicesUserModeEnabled: boolean

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -83,6 +83,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the campaigns feature is enabled on the site. */
     campaignsEnabled: boolean
 
+    /** Whether the auto-indexer feature is enabled on the site. */
+    autoIndexingEnabled: boolean
+
     /** Whether user is allowed to add external services. */
     externalServicesUserModeEnabled: boolean
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -261,7 +261,10 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
 
                                 // Flipping these feature flags require a reload for the
                                 // UI to be rendered correctly in the navbar and the sidebar.
-                                const keys: (keyof SiteConfiguration)[] = ['campaigns.enabled', 'autoIndexing.enabled']
+                                const keys: (keyof SiteConfiguration)[] = [
+                                    'campaigns.enabled',
+                                    'codeIntelAutoIndexing.enabled',
+                                ]
 
                                 if (
                                     !keys.every(

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -255,18 +255,19 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                                 return []
                             }),
                             tap(() => {
-                                // Flipping the Campaigns feature flag
-                                // requires a reload for the
-                                // Campaigns UI to be correctly rendered in the navbar.
-                                const lastCampaignsEnabled =
-                                    (lastConfiguration &&
-                                        (jsonc.parse(lastConfiguration.effectiveContents) as SiteConfiguration)?.[
-                                            'campaigns.enabled'
-                                        ]) === true
-                                const newCampaignsEnabled =
-                                    (jsonc.parse(newContents) as SiteConfiguration)?.['campaigns.enabled'] === true
+                                const oldContents = lastConfiguration?.effectiveContents || ''
+                                const oldConfiguration = jsonc.parse(oldContents) as SiteConfiguration
+                                const newConfiguration = jsonc.parse(newContents) as SiteConfiguration
 
-                                if (lastCampaignsEnabled !== newCampaignsEnabled) {
+                                // Flipping these feature flags require a reload for the
+                                // UI to be rendered correctly in the navbar and the sidebar.
+                                const keys: (keyof SiteConfiguration)[] = ['campaigns.enabled', 'autoIndexing.enabled']
+
+                                if (
+                                    !keys.every(
+                                        key => Boolean(oldConfiguration?.[key]) === Boolean(newConfiguration?.[key])
+                                    )
+                                ) {
                                     window.location.reload()
                                 }
                             })

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -26,58 +26,58 @@ type CodeIntelResolver interface {
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
 }
 
-var codeIntelOnlyInEnterprise = errors.New("precise code intelligence only available in enterprise")
+var errCodeIntelOnlyInEnterprise = errors.New("precise code intelligence only available in enterprise")
 
 type defaultCodeIntelResolver struct{}
 
 var DefaultCodeIntelResolver CodeIntelResolver = defaultCodeIntelResolver{}
 
 func (defaultCodeIntelResolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (LSIFUploadResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) LSIFUploads(ctx context.Context, args *LSIFUploadsQueryArgs) (LSIFUploadConnectionResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) LSIFUploadsByRepo(ctx context.Context, args *LSIFRepositoryUploadsQueryArgs) (LSIFUploadConnectionResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) DeleteLSIFUpload(ctx context.Context, id graphql.ID) (*EmptyResponse, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (LSIFIndexResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) LSIFIndexes(ctx context.Context, args *LSIFIndexesQueryArgs) (LSIFIndexConnectionResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) LSIFIndexesByRepo(ctx context.Context, args *LSIFRepositoryIndexesQueryArgs) (LSIFIndexConnectionResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*EmptyResponse, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) IndexConfiguration(ctx context.Context, id graphql.ID) (IndexConfigurationResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args *UpdateRepositoryIndexConfigurationArgs) (*EmptyResponse, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) QueueAutoIndexJobForRepo(ctx context.Context, id graphql.ID) (*EmptyResponse, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (defaultCodeIntelResolver) GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error) {
-	return nil, codeIntelOnlyInEnterprise
+	return nil, errCodeIntelOnlyInEnterprise
 }
 
 func (r *schemaResolver) LSIFUploads(ctx context.Context, args *LSIFUploadsQueryArgs) (LSIFUploadConnectionResolver, error) {

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -86,7 +86,7 @@ type JSContext struct {
 
 	CampaignsEnabled bool `json:"campaignsEnabled"`
 
-	AutoIndexingEnabled bool `json:"autoIndexingEnabled"`
+	CodeIntelAutoIndexingEnabled bool `json:"codeIntelAutoIndexingEnabled"`
 
 	ExperimentalFeatures schema.ExperimentalFeatures `json:"experimentalFeatures"`
 }
@@ -188,7 +188,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		CampaignsEnabled: campaignsEnabled,
 
-		AutoIndexingEnabled: conf.AutoIndexingEnabled(),
+		CodeIntelAutoIndexingEnabled: conf.CodeIntelAutoIndexingEnabled(),
 
 		ExperimentalFeatures: conf.ExperimentalFeatures(),
 	}

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -86,6 +86,8 @@ type JSContext struct {
 
 	CampaignsEnabled bool `json:"campaignsEnabled"`
 
+	AutoIndexingEnabled bool `json:"autoIndexingEnabled"`
+
 	ExperimentalFeatures schema.ExperimentalFeatures `json:"experimentalFeatures"`
 }
 
@@ -185,6 +187,8 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		Branding: globals.Branding(),
 
 		CampaignsEnabled: campaignsEnabled,
+
+		AutoIndexingEnabled: conf.AutoIndexingEnabled(),
 
 		ExperimentalFeatures: conf.ExperimentalFeatures(),
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/index_scheduler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/index_scheduler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -58,6 +59,10 @@ func NewIndexScheduler(
 }
 
 func (s *IndexScheduler) Handle(ctx context.Context) error {
+	if !conf.CodeIntelAutoIndexingEnabled() {
+		return nil
+	}
+
 	configuredRepositoryIDs, err := s.dbStore.GetRepositoriesWithIndexConfiguration(ctx)
 	if err != nil {
 		return errors.Wrap(err, "store.GetRepositoriesWithIndexConfiguration")

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/index_scheduler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/index_scheduler.go
@@ -58,8 +58,11 @@ func NewIndexScheduler(
 	)
 }
 
+// For mocking in tests
+var indexSchedulerEnabled = conf.CodeIntelAutoIndexingEnabled
+
 func (s *IndexScheduler) Handle(ctx context.Context) error {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !indexSchedulerEnabled() {
 		return nil
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/index_scheduler_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/index_scheduler_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
+func init() {
+	indexSchedulerEnabled = func() bool { return true }
+}
+
 func TestIndexSchedulerUpdate(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockDBStore.GetRepositoriesWithIndexConfigurationFunc.SetDefaultReturn([]int{43, 44, 45, 46}, nil)

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/inference"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -63,6 +64,10 @@ func NewIndexabilityUpdater(
 }
 
 func (u *IndexabilityUpdater) Handle(ctx context.Context) error {
+	if !conf.CodeIntelAutoIndexingEnabled() {
+		return nil
+	}
+
 	start := time.Now().UTC()
 
 	stats, err := u.dbStore.RepoUsageStatistics(ctx)

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
@@ -63,8 +63,11 @@ func NewIndexabilityUpdater(
 	)
 }
 
+// For mocking in tests
+var indexabilityUpdaterEnabled = conf.CodeIntelAutoIndexingEnabled
+
 func (u *IndexabilityUpdater) Handle(ctx context.Context) error {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !indexabilityUpdaterEnabled() {
 		return nil
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
+func init() {
+	indexabilityUpdaterEnabled = func() bool { return true }
+}
+
 func TestIndexabilityUpdater(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockDBStore.RepoUsageStatisticsFunc.SetDefaultReturn([]store.RepoUsageStatistics{

--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	HunkCacheSize                 int
 	DataTTL                       time.Duration
 	UploadTimeout                 time.Duration
-	EnableAutoIndexing            bool
 	IndexBatchSize                int
 	MinimumTimeSinceLastEnqueue   time.Duration
 	MinimumSearchCount            int
@@ -38,7 +37,6 @@ func init() {
 	config.CommitGraphUpdateTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_COMMIT_GRAPH_UPDATE_TASK_INTERVAL", "10s", "The frequency with which to run periodic codeintel commit graph update tasks.")
 	config.CleanupTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic codeintel cleanup tasks.")
 	config.AutoIndexingTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL", "10m", "The frequency with which to run periodic codeintel auto-indexing tasks.")
-	config.EnableAutoIndexing = config.GetBool("PRECISE_CODE_INTEL_ENABLE_AUTO_INDEXING", "false", "Whether to enable scheduling of auto-indexing tasks.")
 	config.IndexBatchSize = config.GetInt("PRECISE_CODE_INTEL_INDEX_BATCH_SIZE", "100", "The number of indexable repositories to schedule at a time.")
 	config.MinimumTimeSinceLastEnqueue = config.GetInterval("PRECISE_CODE_INTEL_MINIMUM_TIME_SINCE_LAST_ENQUEUE", "24h", "The minimum time between auto-index enqueues for the same repository.")
 	config.MinimumSearchCount = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_SEARCH_COUNT", "50", "The minimum number of search-based code intel events that triggers auto-indexing on a repository.")

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -122,10 +122,6 @@ func newCommitGraphRoutines(observationContext *observation.Context) []goroutine
 }
 
 func newIndexingRoutines(observationContext *observation.Context) []goroutine.BackgroundRoutine {
-	if !config.EnableAutoIndexing {
-		return nil
-	}
-
 	return []goroutine.BackgroundRoutine{
 		indexing.NewIndexScheduler(
 			services.dbStore,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -84,8 +84,10 @@ func (r *Resolver) DeleteLSIFUpload(ctx context.Context, id graphql.ID) (*gql.Em
 	return &gql.EmptyResponse{}, nil
 }
 
+var autoIndexingEnabled = conf.CodeIntelAutoIndexingEnabled
+
 func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIndexResolver, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -103,7 +105,7 @@ func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIn
 }
 
 func (r *Resolver) LSIFIndexes(ctx context.Context, args *gql.LSIFIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -112,7 +114,7 @@ func (r *Resolver) LSIFIndexes(ctx context.Context, args *gql.LSIFIndexesQueryAr
 }
 
 func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFRepositoryIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -125,7 +127,7 @@ func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFReposito
 }
 
 func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -147,7 +149,7 @@ func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*gql.Emp
 }
 
 func (r *Resolver) IndexConfiguration(ctx context.Context, id graphql.ID) (gql.IndexConfigurationResolver, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -165,7 +167,7 @@ func (r *Resolver) IndexConfiguration(ctx context.Context, id graphql.ID) (gql.I
 }
 
 func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args *gql.UpdateRepositoryIndexConfigurationArgs) (*gql.EmptyResponse, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -187,7 +189,7 @@ func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args 
 }
 
 func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
-	if !conf.CodeIntelAutoIndexingEnabled() {
+	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -5,17 +5,21 @@ import (
 	"strings"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
 
 const (
 	DefaultUploadPageSize = 50
 	DefaultIndexPageSize  = 50
 )
+
+var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto indexing is not enabled")
 
 // Resolver is the main interface to code intel-related operations exposted to the GraphQL API. This
 // resolver concerns itself with GraphQL/API-specific behaviors (auth, validation, marshaling, etc.).
@@ -81,6 +85,10 @@ func (r *Resolver) DeleteLSIFUpload(ctx context.Context, id graphql.ID) (*gql.Em
 }
 
 func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIndexResolver, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	indexID, err := unmarshalLSIFIndexGQLID(id)
 	if err != nil {
 		return nil, err
@@ -95,11 +103,19 @@ func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIn
 }
 
 func (r *Resolver) LSIFIndexes(ctx context.Context, args *gql.LSIFIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	// Delegate behavior to LSIFIndexesByRepo with no specified repository identifier
 	return r.LSIFIndexesByRepo(ctx, &gql.LSIFRepositoryIndexesQueryArgs{LSIFIndexesQueryArgs: args})
 }
 
 func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFRepositoryIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	opts, err := makeGetIndexesOptions(ctx, args)
 	if err != nil {
 		return nil, err
@@ -109,6 +125,10 @@ func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFReposito
 }
 
 func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	// 🚨 SECURITY: Only site admins may delete LSIF data for now
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
@@ -127,6 +147,10 @@ func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*gql.Emp
 }
 
 func (r *Resolver) IndexConfiguration(ctx context.Context, id graphql.ID) (gql.IndexConfigurationResolver, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	repositoryID, err := gql.UnmarshalRepositoryID(id)
 	if err != nil {
 		return nil, err
@@ -141,6 +165,10 @@ func (r *Resolver) IndexConfiguration(ctx context.Context, id graphql.ID) (gql.I
 }
 
 func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args *gql.UpdateRepositoryIndexConfigurationArgs) (*gql.EmptyResponse, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	// 🚨 SECURITY: Only site admins may configure indexing jobs for now
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return nil, err
@@ -159,6 +187,10 @@ func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args 
 }
 
 func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
+	if !conf.AutoIndexingEnabled() {
+		return nil, errAutoIndexingNotEnabled
+	}
+
 	repositoryID, err := gql.UnmarshalRepositoryID(id)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -85,7 +85,7 @@ func (r *Resolver) DeleteLSIFUpload(ctx context.Context, id graphql.ID) (*gql.Em
 }
 
 func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIndexResolver, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -103,7 +103,7 @@ func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIn
 }
 
 func (r *Resolver) LSIFIndexes(ctx context.Context, args *gql.LSIFIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -112,7 +112,7 @@ func (r *Resolver) LSIFIndexes(ctx context.Context, args *gql.LSIFIndexesQueryAr
 }
 
 func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFRepositoryIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -125,7 +125,7 @@ func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFReposito
 }
 
 func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -147,7 +147,7 @@ func (r *Resolver) DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*gql.Emp
 }
 
 func (r *Resolver) IndexConfiguration(ctx context.Context, id graphql.ID) (gql.IndexConfigurationResolver, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -165,7 +165,7 @@ func (r *Resolver) IndexConfiguration(ctx context.Context, id graphql.ID) (gql.I
 }
 
 func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args *gql.UpdateRepositoryIndexConfigurationArgs) (*gql.EmptyResponse, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 
@@ -187,7 +187,7 @@ func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args 
 }
 
 func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
-	if !conf.AutoIndexingEnabled() {
+	if !conf.CodeIntelAutoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
+func init() {
+	autoIndexingEnabled = func() bool { return true }
+}
+
 func TestDeleteLSIFUpload(t *testing.T) {
 	t.Cleanup(func() {
 		db.Mocks.Users.GetByCurrentAuthUser = nil

--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -36,7 +36,6 @@ fi
 SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat "$DEV_PRIVATE_PATH"/enterprise/dev/test-license-generation-key.pem)
 export SOURCEGRAPH_LICENSE_GENERATION_KEY
 
-export PRECISE_CODE_INTEL_ENABLE_AUTO_INDEXING=true
 export PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT=http://localhost:9000
 export DISABLE_CNCF=notonmybox
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -226,6 +226,13 @@ func CampaignsEnabled() bool {
 	return true
 }
 
+func AutoIndexingEnabled() bool {
+	if enabled := Get().AutoIndexingEnabled; enabled != nil {
+		return *enabled
+	}
+	return false
+}
+
 func ExternalURL() string {
 	return Get().ExternalURL
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -226,8 +226,8 @@ func CampaignsEnabled() bool {
 	return true
 }
 
-func AutoIndexingEnabled() bool {
-	if enabled := Get().AutoIndexingEnabled; enabled != nil {
+func CodeIntelAutoIndexingEnabled() bool {
+	if enabled := Get().CodeIntelAutoIndexingEnabled; enabled != nil {
 		return *enabled
 	}
 	return false

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1163,8 +1163,6 @@ type SiteConfiguration struct {
 	AuthSessionExpiry string `json:"auth.sessionExpiry,omitempty"`
 	// AuthUserOrgMap description: Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
 	AuthUserOrgMap map[string][]string `json:"auth.userOrgMap,omitempty"`
-	// AutoIndexingEnabled description: Enables/disables the precise code intel auto indexing feature.
-	AutoIndexingEnabled *bool `json:"autoIndexing.enabled,omitempty"`
 	// AutomationReadAccessEnabled description: DEPRECATED: The automation feature was renamed to campaigns. Use `campaigns.readAccess.enabled` instead.
 	AutomationReadAccessEnabled *bool `json:"automation.readAccess.enabled,omitempty"`
 	// Branding description: Customize Sourcegraph homepage logo and search icon.
@@ -1177,6 +1175,8 @@ type SiteConfiguration struct {
 	CampaignsReadAccessEnabled *bool `json:"campaigns.readAccess.enabled,omitempty"`
 	// CampaignsRestrictToAdmins description: When enabled, only site admins can create and apply campaigns.
 	CampaignsRestrictToAdmins bool `json:"campaigns.restrictToAdmins,omitempty"`
+	// CodeIntelAutoIndexingEnabled description: Enables/disables the code intel auto indexing feature.
+	CodeIntelAutoIndexingEnabled *bool `json:"codeIntelAutoIndexing.enabled,omitempty"`
 	// CorsOrigin description: Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
 	CorsOrigin string `json:"corsOrigin,omitempty"`
 	// DebugSearchSymbolsParallelism description: (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1163,6 +1163,8 @@ type SiteConfiguration struct {
 	AuthSessionExpiry string `json:"auth.sessionExpiry,omitempty"`
 	// AuthUserOrgMap description: Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
 	AuthUserOrgMap map[string][]string `json:"auth.userOrgMap,omitempty"`
+	// AutoIndexingEnabled description: Enables/disables the precise code intel auto indexing feature.
+	AutoIndexingEnabled *bool `json:"autoIndexing.enabled,omitempty"`
 	// AutomationReadAccessEnabled description: DEPRECATED: The automation feature was renamed to campaigns. Use `campaigns.readAccess.enabled` instead.
 	AutomationReadAccessEnabled *bool `json:"automation.readAccess.enabled,omitempty"`
 	// Branding description: Customize Sourcegraph homepage logo and search icon.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -278,8 +278,8 @@
       "group": "Campaigns",
       "default": false
     },
-    "autoIndexing.enabled": {
-      "description": "Enables/disables the precise code intel auto indexing feature.",
+    "codeIntelAutoIndexing.enabled": {
+      "description": "Enables/disables the code intel auto indexing feature.",
       "type": "boolean",
       "!go": { "pointer": true },
       "group": "Code intelligence",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -278,6 +278,13 @@
       "group": "Campaigns",
       "default": false
     },
+    "autoIndexing.enabled": {
+      "description": "Enables/disables the precise code intel auto indexing feature.",
+      "type": "boolean",
+      "!go": { "pointer": true },
+      "group": "Code intelligence",
+      "default": false
+    },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -283,6 +283,13 @@ const SiteSchemaJSON = `{
       "group": "Campaigns",
       "default": false
     },
+    "autoIndexing.enabled": {
+      "description": "Enables/disables the precise code intel auto indexing feature.",
+      "type": "boolean",
+      "!go": { "pointer": true },
+      "group": "Code intelligence",
+      "default": false
+    },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -283,8 +283,8 @@ const SiteSchemaJSON = `{
       "group": "Campaigns",
       "default": false
     },
-    "autoIndexing.enabled": {
-      "description": "Enables/disables the precise code intel auto indexing feature.",
+    "codeIntelAutoIndexing.enabled": {
+      "description": "Enables/disables the code intel auto indexing feature.",
       "type": "boolean",
       "!go": { "pointer": true },
       "group": "Code intelligence",


### PR DESCRIPTION
Add feature flag in site settings `codeIntelAutoIndexing.enabled` which will enable or disable code intel index routes, background routines, resolvers, and UI navigation related to auto indexing.

This subsumes an envvar that enabled or disabled background routines.