### PR TITLE
Campaign preview stats bar

### DIFF
--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -9,6 +9,7 @@
 @import './enterprise/campaigns/preview/list/HiddenChangesetApplyPreviewNode';
 @import './enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode';
 @import './enterprise/campaigns/preview/CreateUpdateCampaignAlert';
+@import './enterprise/campaigns/preview/CampaignPreviewStatsBar';
 @import './enterprise/campaigns/close/CampaignCloseChangesetsList';
 @import './enterprise/campaigns/close/CampaignCloseChangesetsListEmptyElement';
 @import './enterprise/campaigns/close/CampaignCloseHeader';

--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -3,10 +3,11 @@
 @import './SourcegraphWebApp';
 
 // Enterprise styles
-@import './enterprise/campaigns/preview/list/PreviewList';
 @import './enterprise/campaigns/preview/list/ChangesetApplyPreviewNode';
 @import './enterprise/campaigns/preview/list/EmptyPreviewListElement';
 @import './enterprise/campaigns/preview/list/HiddenChangesetApplyPreviewNode';
+@import './enterprise/campaigns/preview/list/PreviewList';
+@import './enterprise/campaigns/preview/list/PreviewNodeIndicator';
 @import './enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode';
 @import './enterprise/campaigns/preview/CreateUpdateCampaignAlert';
 @import './enterprise/campaigns/preview/CampaignPreviewStatsBar';

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -92,7 +92,12 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             <span className={classNames('align-self-stretch d-none d-md-flex', node.reviewState && 'p-2')}>
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
             </span>
-            <div className={classNames('align-self-stretch d-none d-md-flex', node.diffStat && 'p-2')}>
+            <div
+                className={classNames(
+                    'align-self-stretch d-none d-md-flex justify-content-center',
+                    node.diffStat && 'p-2'
+                )}
+            >
                 {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewPage.story.tsx
@@ -61,6 +61,23 @@ const campaignSpec = (): CampaignSpecFields => ({
         totalCount: 0,
         nodes: [],
     },
+    applyPreview: {
+        stats: {
+            close: 10,
+            detach: 10,
+            import: 10,
+            publish: 10,
+            publishDraft: 10,
+            push: 10,
+            reopen: 10,
+            undraft: 10,
+            update: 10,
+
+            added: 5,
+            modified: 10,
+            removed: 3,
+        },
+    },
 })
 
 const fetchCampaignSpecCreate: typeof fetchCampaignSpecById = () => of(campaignSpec())

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewPage.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewPage.tsx
@@ -19,6 +19,7 @@ import { AuthenticatedUser } from '../../../auth'
 import { MissingCredentialsAlert } from './MissingCredentialsAlert'
 import { SupersedingCampaignSpecAlert } from '../detail/SupersedingCampaignSpecAlert'
 import { queryChangesetSpecFileDiffs, queryChangesetApplyPreview } from './list/backend'
+import { CampaignPreviewStatsBar } from './CampaignPreviewStatsBar'
 
 export interface CampaignPreviewPageProps extends ThemeProps, TelemetryProps {
     campaignSpecID: string
@@ -95,6 +96,7 @@ export const CampaignPreviewPage: React.FunctionComponent<CampaignPreviewPagePro
                 viewerCanAdminister={spec.viewerCanAdminister}
                 telemetryService={telemetryService}
             />
+            <CampaignPreviewStatsBar campaignSpec={spec} />
             <CampaignDescription history={history} description={spec.description.description} />
             <PreviewList
                 campaignSpecID={specID}

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewPage.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewPage.tsx
@@ -89,6 +89,7 @@ export const CampaignPreviewPage: React.FunctionComponent<CampaignPreviewPagePro
                 viewerCampaignsCodeHosts={spec.viewerCampaignsCodeHosts}
             />
             <SupersedingCampaignSpecAlert spec={spec.supersedingCampaignSpec} />
+            <CampaignPreviewStatsBar campaignSpec={spec} />
             <CreateUpdateCampaignAlert
                 history={history}
                 specID={spec.id}
@@ -96,7 +97,6 @@ export const CampaignPreviewPage: React.FunctionComponent<CampaignPreviewPagePro
                 viewerCanAdminister={spec.viewerCanAdminister}
                 telemetryService={telemetryService}
             />
-            <CampaignPreviewStatsBar campaignSpec={spec} />
             <CampaignDescription history={history} description={spec.description.description} />
             <PreviewList
                 campaignSpecID={specID}

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.scss
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.scss
@@ -1,0 +1,9 @@
+.campaign-preview-stats-bar {
+    &__stat {
+        color: $gray-10;
+    }
+    &__divider {
+        border: 1px solid var(--border-color);
+        height: 2rem;
+    }
+}

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.scss
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.scss
@@ -7,3 +7,39 @@
         height: 2rem;
     }
 }
+
+.preview-stats-added {
+    &__dot {
+        width: 0.25rem;
+        height: 0.25rem;
+        background-color: var(--oc-lime-6);
+    }
+    &__icon {
+        line-height: 1rem;
+        color: var(--oc-lime-9);
+    }
+}
+
+.preview-stats-modified {
+    &__dot {
+        width: 0.25rem;
+        height: 0.25rem;
+        background-color: var(--oc-yellow-5);
+    }
+    &__icon {
+        line-height: 1rem;
+        color: var(--oc-orange-9);
+    }
+}
+
+.preview-stats-removed {
+    &__dot {
+        width: 0.25rem;
+        height: 0.25rem;
+        background-color: var(--danger);
+    }
+    &__icon {
+        line-height: 1rem;
+        color: var(--oc-red-9);
+    }
+}

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.scss
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.scss
@@ -9,7 +9,7 @@
 }
 
 .preview-stats-added {
-    &__dot {
+    &__line {
         width: 0.25rem;
         height: 0.25rem;
         background-color: var(--oc-lime-6);
@@ -21,7 +21,7 @@
 }
 
 .preview-stats-modified {
-    &__dot {
+    &__line {
         width: 0.25rem;
         height: 0.25rem;
         background-color: var(--oc-yellow-5);
@@ -33,7 +33,7 @@
 }
 
 .preview-stats-removed {
-    &__dot {
+    &__line {
         width: 0.25rem;
         height: 0.25rem;
         background-color: var(--danger);

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { DiffStat } from '../../../components/diff/DiffStat'
+import { CampaignSpecFields } from '../../../graphql-operations'
+import {
+    PreviewActionClose,
+    PreviewActionImport,
+    PreviewActionPublish,
+    PreviewActionReopen,
+    PreviewActionUndraft,
+    PreviewActionUpdate,
+} from './list/PreviewAction'
+
+export interface CampaignPreviewStatsBarProps {
+    campaignSpec: CampaignSpecFields
+}
+
+export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewStatsBarProps> = ({ campaignSpec }) => (
+    <div className="d-flex mb-3">
+        <h2 className="m-0 mr-3 create-update-campaign-alert__badge">
+            <span className="badge badge-info text-uppercase mb-0">Preview</span>
+        </h2>
+        <DiffStat {...campaignSpec.diffStat} separateLines={true} expandedCounts={true} />
+        <div className="flex-grow-1 d-flex justify-content-between">
+            <PreviewStatsAdded count={campaignSpec.applyPreview.stats.added} />
+            <PreviewStatsRemoved count={campaignSpec.applyPreview.stats.removed} />
+            <PreviewStatsModified count={campaignSpec.applyPreview.stats.modified} />
+        </div>
+        <div className="flex-grow-1 d-flex justify-content-between">
+            <PreviewActionReopen label={`${campaignSpec.applyPreview.stats.reopen} reopen`} />
+            <PreviewActionClose label={`${campaignSpec.applyPreview.stats.reopen} close`} />
+            <PreviewActionUpdate label={`${campaignSpec.applyPreview.stats.update} update`} />
+            <PreviewActionUndraft label={`${campaignSpec.applyPreview.stats.undraft} undraft`} />
+            {/* <PreviewActionUnpublished label={`${campaignSpec.applyPreview.stats.reopen} close`} /> */}
+            <PreviewActionPublish
+                label={`${
+                    campaignSpec.applyPreview.stats.publish + campaignSpec.applyPreview.stats.publishDraft
+                } publish`}
+            />
+            <PreviewActionImport label={`${campaignSpec.applyPreview.stats.import} import`} />
+        </div>
+    </div>
+)
+
+export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ count }) => (
+    <div className="d-flex flex-column">
+        <div className="d-flex flex-column align-items-center">
+            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-lime-6)' }}>&nbsp;</span>
+            <span style={{ color: 'var(--oc-lime-9)' }}>+</span>
+            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-lime-6)' }}>&nbsp;</span>
+        </div>
+        {count} added
+    </div>
+)
+export const PreviewStatsModified: React.FunctionComponent<{ count: number }> = ({ count }) => (
+    <div className="d-flex flex-column">
+        <div className="d-flex flex-column align-items-center">
+            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-yellow-5)' }}>&nbsp;</span>
+            <span style={{ color: 'var(--oc-orange-9)' }}>&#9679;</span>
+            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-yellow-5)' }}>&nbsp;</span>
+        </div>
+        {count} modified
+    </div>
+)
+export const PreviewStatsRemoved: React.FunctionComponent<{ count: number }> = ({ count }) => (
+    <div className="d-flex flex-column">
+        <div className="d-flex flex-column align-items-center">
+            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--danger)' }}>&nbsp;</span>
+            <span style={{ color: 'var(--oc-red-9)' }}>-</span>
+            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--danger)' }}>&nbsp;</span>
+        </div>
+        {count} removed
+    </div>
+)

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
@@ -8,64 +8,84 @@ import {
     PreviewActionReopen,
     PreviewActionUndraft,
     PreviewActionUpdate,
-} from './list/PreviewAction'
+} from './list/PreviewActions'
+
+const actionClassNames = 'd-flex flex-column justify-content-center align-items-center campaign-preview-stats-bar__stat'
 
 export interface CampaignPreviewStatsBarProps {
     campaignSpec: CampaignSpecFields
 }
 
 export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewStatsBarProps> = ({ campaignSpec }) => (
-    <div className="d-flex mb-3">
-        <h2 className="m-0 mr-3 create-update-campaign-alert__badge">
+    <div className="d-flex mb-3 align-items-center">
+        <h2 className="m-0 create-update-campaign-alert__badge">
             <span className="badge badge-info text-uppercase mb-0">Preview</span>
         </h2>
+        <div className="campaign-preview-stats-bar__divider mx-4" />
         <DiffStat {...campaignSpec.diffStat} separateLines={true} expandedCounts={true} />
-        <div className="flex-grow-1 d-flex justify-content-between">
+        <div className="flex-grow-1 d-flex justify-content-end">
             <PreviewStatsAdded count={campaignSpec.applyPreview.stats.added} />
             <PreviewStatsRemoved count={campaignSpec.applyPreview.stats.removed} />
             <PreviewStatsModified count={campaignSpec.applyPreview.stats.modified} />
         </div>
+        <div className="campaign-preview-stats-bar__divider mx-4" />
         <div className="flex-grow-1 d-flex justify-content-between">
-            <PreviewActionReopen label={`${campaignSpec.applyPreview.stats.reopen} reopen`} />
-            <PreviewActionClose label={`${campaignSpec.applyPreview.stats.reopen} close`} />
-            <PreviewActionUpdate label={`${campaignSpec.applyPreview.stats.update} update`} />
-            <PreviewActionUndraft label={`${campaignSpec.applyPreview.stats.undraft} undraft`} />
-            {/* <PreviewActionUnpublished label={`${campaignSpec.applyPreview.stats.reopen} close`} /> */}
+            <PreviewActionReopen
+                className={actionClassNames}
+                label={`${campaignSpec.applyPreview.stats.reopen} reopen`}
+            />
+            <PreviewActionClose
+                className={actionClassNames}
+                label={`${campaignSpec.applyPreview.stats.reopen} close`}
+            />
+            <PreviewActionUpdate
+                className={actionClassNames}
+                label={`${campaignSpec.applyPreview.stats.update} update`}
+            />
+            <PreviewActionUndraft
+                className={actionClassNames}
+                label={`${campaignSpec.applyPreview.stats.undraft} undraft`}
+            />
+            {/* <PreviewActionUnpublished className={actionClassNames} label={`${campaignSpec.applyPreview.stats.reopen} close`} /> */}
             <PreviewActionPublish
+                className={actionClassNames}
                 label={`${
                     campaignSpec.applyPreview.stats.publish + campaignSpec.applyPreview.stats.publishDraft
                 } publish`}
             />
-            <PreviewActionImport label={`${campaignSpec.applyPreview.stats.import} import`} />
+            <PreviewActionImport
+                className={actionClassNames}
+                label={`${campaignSpec.applyPreview.stats.import} import`}
+            />
         </div>
     </div>
 )
 
 export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ count }) => (
-    <div className="d-flex flex-column">
-        <div className="d-flex flex-column align-items-center">
+    <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2">
+        <div className="d-flex flex-column align-items-center justify-content-center">
             <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-lime-6)' }}>&nbsp;</span>
-            <span style={{ color: 'var(--oc-lime-9)' }}>+</span>
+            <span style={{ color: 'var(--oc-lime-9)', lineHeight: '1rem' }}>+</span>
             <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-lime-6)' }}>&nbsp;</span>
         </div>
         {count} added
     </div>
 )
 export const PreviewStatsModified: React.FunctionComponent<{ count: number }> = ({ count }) => (
-    <div className="d-flex flex-column">
+    <div className="d-flex flex-column campaign-preview-stats-bar__stat">
         <div className="d-flex flex-column align-items-center">
             <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-yellow-5)' }}>&nbsp;</span>
-            <span style={{ color: 'var(--oc-orange-9)' }}>&#9679;</span>
+            <span style={{ color: 'var(--oc-orange-9)', lineHeight: '1rem' }}>&bull;</span>
             <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-yellow-5)' }}>&nbsp;</span>
         </div>
         {count} modified
     </div>
 )
 export const PreviewStatsRemoved: React.FunctionComponent<{ count: number }> = ({ count }) => (
-    <div className="d-flex flex-column">
+    <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2">
         <div className="d-flex flex-column align-items-center">
             <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--danger)' }}>&nbsp;</span>
-            <span style={{ color: 'var(--oc-red-9)' }}>-</span>
+            <span style={{ color: 'var(--oc-red-9)', lineHeight: '1rem' }}>-</span>
             <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--danger)' }}>&nbsp;</span>
         </div>
         {count} removed

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
@@ -63,9 +63,9 @@ export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewSta
 export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ count }) => (
     <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2 text-nowrap">
         <div className="d-flex flex-column align-items-center justify-content-center">
-            <span className="preview-stats-added__dot">&nbsp;</span>
+            <span className="preview-stats-added__line">&nbsp;</span>
             <span className="preview-stats-added__icon">+</span>
-            <span className="preview-stats-added__dot">&nbsp;</span>
+            <span className="preview-stats-added__line">&nbsp;</span>
         </div>
         {count} added
     </div>
@@ -73,9 +73,9 @@ export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ 
 export const PreviewStatsModified: React.FunctionComponent<{ count: number }> = ({ count }) => (
     <div className="d-flex flex-column campaign-preview-stats-bar__stat text-nowrap">
         <div className="d-flex flex-column align-items-center">
-            <span className="preview-stats-modified__dot">&nbsp;</span>
+            <span className="preview-stats-modified__line">&nbsp;</span>
             <span className="preview-stats-modified__icon">&bull;</span>
-            <span className="preview-stats-modified__dot">&nbsp;</span>
+            <span className="preview-stats-modified__line">&nbsp;</span>
         </div>
         {count} modified
     </div>
@@ -83,9 +83,9 @@ export const PreviewStatsModified: React.FunctionComponent<{ count: number }> = 
 export const PreviewStatsRemoved: React.FunctionComponent<{ count: number }> = ({ count }) => (
     <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2 text-nowrap">
         <div className="d-flex flex-column align-items-center">
-            <span className="preview-stats-removed__dot">&nbsp;</span>
+            <span className="preview-stats-removed__line">&nbsp;</span>
             <span className="preview-stats-removed__icon">-</span>
-            <span className="preview-stats-removed__dot">&nbsp;</span>
+            <span className="preview-stats-removed__line">&nbsp;</span>
         </div>
         {count} removed
     </div>

--- a/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CampaignPreviewStatsBar.tsx
@@ -17,8 +17,8 @@ export interface CampaignPreviewStatsBarProps {
 }
 
 export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewStatsBarProps> = ({ campaignSpec }) => (
-    <div className="d-flex mb-3 align-items-center">
-        <h2 className="m-0 create-update-campaign-alert__badge">
+    <div className="d-flex flex-wrap mb-3 align-items-center">
+        <h2 className="m-0 align-self-center">
             <span className="badge badge-info text-uppercase mb-0">Preview</span>
         </h2>
         <div className="campaign-preview-stats-bar__divider mx-4" />
@@ -28,8 +28,8 @@ export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewSta
             <PreviewStatsRemoved count={campaignSpec.applyPreview.stats.removed} />
             <PreviewStatsModified count={campaignSpec.applyPreview.stats.modified} />
         </div>
-        <div className="campaign-preview-stats-bar__divider mx-4" />
-        <div className="flex-grow-1 d-flex justify-content-between">
+        <div className="campaign-preview-stats-bar__divider d-none d-md-block mx-4" />
+        <div className="flex-grow-1 d-flex flex-wrap justify-content-between">
             <PreviewActionReopen
                 className={actionClassNames}
                 label={`${campaignSpec.applyPreview.stats.reopen} reopen`}
@@ -46,7 +46,6 @@ export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewSta
                 className={actionClassNames}
                 label={`${campaignSpec.applyPreview.stats.undraft} undraft`}
             />
-            {/* <PreviewActionUnpublished className={actionClassNames} label={`${campaignSpec.applyPreview.stats.reopen} close`} /> */}
             <PreviewActionPublish
                 className={actionClassNames}
                 label={`${
@@ -62,31 +61,31 @@ export const CampaignPreviewStatsBar: React.FunctionComponent<CampaignPreviewSta
 )
 
 export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ count }) => (
-    <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2">
+    <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2 text-nowrap">
         <div className="d-flex flex-column align-items-center justify-content-center">
-            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-lime-6)' }}>&nbsp;</span>
-            <span style={{ color: 'var(--oc-lime-9)', lineHeight: '1rem' }}>+</span>
-            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-lime-6)' }}>&nbsp;</span>
+            <span className="preview-stats-added__dot">&nbsp;</span>
+            <span className="preview-stats-added__icon">+</span>
+            <span className="preview-stats-added__dot">&nbsp;</span>
         </div>
         {count} added
     </div>
 )
 export const PreviewStatsModified: React.FunctionComponent<{ count: number }> = ({ count }) => (
-    <div className="d-flex flex-column campaign-preview-stats-bar__stat">
+    <div className="d-flex flex-column campaign-preview-stats-bar__stat text-nowrap">
         <div className="d-flex flex-column align-items-center">
-            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-yellow-5)' }}>&nbsp;</span>
-            <span style={{ color: 'var(--oc-orange-9)', lineHeight: '1rem' }}>&bull;</span>
-            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--oc-yellow-5)' }}>&nbsp;</span>
+            <span className="preview-stats-modified__dot">&nbsp;</span>
+            <span className="preview-stats-modified__icon">&bull;</span>
+            <span className="preview-stats-modified__dot">&nbsp;</span>
         </div>
         {count} modified
     </div>
 )
 export const PreviewStatsRemoved: React.FunctionComponent<{ count: number }> = ({ count }) => (
-    <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2">
+    <div className="d-flex flex-column campaign-preview-stats-bar__stat mr-2 text-nowrap">
         <div className="d-flex flex-column align-items-center">
-            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--danger)' }}>&nbsp;</span>
-            <span style={{ color: 'var(--oc-red-9)', lineHeight: '1rem' }}>-</span>
-            <span style={{ width: '0.25rem', height: '0.25rem', backgroundColor: 'var(--danger)' }}>&nbsp;</span>
+            <span className="preview-stats-removed__dot">&nbsp;</span>
+            <span className="preview-stats-removed__icon">-</span>
+            <span className="preview-stats-removed__dot">&nbsp;</span>
         </div>
         {count} removed
     </div>

--- a/client/web/src/enterprise/campaigns/preview/CreateUpdateCampaignAlert.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CreateUpdateCampaignAlert.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import { isErrorLike } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
+import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 
 export interface CreateUpdateCampaignAlertProps extends TelemetryProps {
     specID: string
@@ -42,20 +43,19 @@ export const CreateUpdateCampaignAlert: React.FunctionComponent<CreateUpdateCamp
     return (
         <>
             <div className="alert alert-info p-3 mb-3 d-block d-md-flex align-items-center body-lead">
-                <h2 className="m-0 mr-3 create-update-campaign-alert__badge">
-                    <span className="badge badge-info text-uppercase mb-0">Preview</span>
-                </h2>
+                <InfoCircleOutlineIcon className="icon-inline mr-2" />
                 {!campaign && (
                     <p className="mb-0 flex-grow-1 mr-3 create-update-campaign-alert__copy">
-                        Review the proposed changesets below. Click 'Apply spec' or run 'src campaigns apply' against
-                        your campaign spec to create the campaign and perform the indicated action on each changeset.
+                        Review the proposed changesets below. Click 'Apply spec' or run <code>src campaigns apply</code>{' '}
+                        against your campaign spec to create the campaign and perform the indicated action on each
+                        changeset.
                     </p>
                 )}
                 {campaign && (
                     <p className="mb-0 flex-grow-1 mr-3 create-update-campaign-alert__copy">
                         This operation will update the existing campaign <Link to={campaign.url}>{campaign.name}</Link>.
-                        Click 'Apply spec' or run 'src campaigns apply' against your campaign spec to update the
-                        campaign and perform the indicated action on each changeset.
+                        Click 'Apply spec' or run <code>src campaigns apply</code> against your campaign spec to update
+                        the campaign and perform the indicated action on each changeset.
                     </p>
                 )}
                 <div className="create-update-campaign-alert__btn">

--- a/client/web/src/enterprise/campaigns/preview/backend.ts
+++ b/client/web/src/enterprise/campaigns/preview/backend.ts
@@ -57,6 +57,23 @@ export const campaignSpecFragment = gql`
         diffStat {
             ...DiffStatFields
         }
+        applyPreview {
+            stats {
+                close
+                detach
+                import
+                publish
+                publishDraft
+                push
+                reopen
+                undraft
+                update
+
+                added
+                modified
+                removed
+            }
+        }
         supersedingCampaignSpec {
             ...SupersedingCampaignSpecFields
         }

--- a/client/web/src/enterprise/campaigns/preview/list/HiddenChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/HiddenChangesetApplyPreviewNode.tsx
@@ -4,6 +4,7 @@ import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import { PreviewActions } from './PreviewActions'
 import { ChangesetStatusCell } from '../../detail/changesets/ChangesetStatusCell'
 import { ChangesetState } from '../../../../../../shared/src/graphql-operations'
+import { PreviewNodeIndicator } from './PreviewNodeIndicator'
 
 export interface HiddenChangesetApplyPreviewNodeProps {
     node: HiddenChangesetApplyPreviewFields
@@ -18,6 +19,7 @@ export const HiddenChangesetApplyPreviewNode: React.FunctionComponent<HiddenChan
             node={node}
             className="hidden-changeset-apply-preview-node__list-cell d-block d-sm-flex hidden-changeset-apply-preview-node__current-state"
         />
+        <PreviewNodeIndicator node={node} />
         <PreviewActions
             node={node}
             className="hidden-changeset-apply-preview-node__list-cell hidden-changeset-apply-preview-node__action"

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewActions.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewActions.tsx
@@ -76,79 +76,106 @@ const PreviewAction: React.FunctionComponent<PreviewActionProps> = ({ operation,
 
 const iconClassNames = 'm-0 text-nowrap'
 
-export const PreviewActionPublish: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionPublish: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Publish',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <UploadIcon className="icon-inline mr-1" data-tooltip="This changeset will be published to its code host" />
-        <span>Publish</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionPublishDraft: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionPublishDraft: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Publish draft',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <UploadIcon
             className="text-muted mr-1 icon-inline"
             data-tooltip="This changeset will be published as a draft to its code host"
         />
-        <span>Publish draft</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionImport: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionImport: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Import',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <ImportIcon
             className="icon-inline mr-1"
             data-tooltip="This changeset will be imported and tracked in this campaign"
         />
-        <span>Import</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionClose: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionClose: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Close',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <CloseCircleOutlineIcon
             className="text-danger mr-1 icon-inline"
             data-tooltip="This changeset will be closed on the code host"
         />
-        <span>Close</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionDetach: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionDetach: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Detach',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <TrashIcon
             className="text-danger mr-1 icon-inline"
             data-tooltip="This changeset will be removed from the campaign"
         />
-        <span>Detach</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionReopen: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionReopen: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Reopen',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <SourceBranchRefreshIcon
             className="icon-inline text-success mr-1"
             data-tooltip="This changeset will be reopened on the code host"
         />
-        <span>Reopen</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionUndraft: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionUndraft: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Undraft',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <SourceBranchCheckIcon
             className="icon-inline text-success mr-1"
             data-tooltip="This changeset will be marked as ready for review on the code host"
         />
-        <span>Undraft</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionUpdate: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionUpdate: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Update',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <SourceBranchSyncIcon
             className="icon-inline mr-1"
             data-tooltip="This changeset will be updated on the code host"
         />
-        <span>Update</span>
+        <span>{label}</span>
     </div>
 )
-export const PreviewActionPush: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+export const PreviewActionPush: React.FunctionComponent<{ label?: string; className?: string }> = ({
+    label = 'Push',
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <UploadNetworkIcon className="icon-inline mr-1" data-tooltip="A new commit will be pushed to the code host" />
-        <span>Push</span>
+        <span>{label}</span>
     </div>
 )
 export const PreviewActionUnknown: React.FunctionComponent<{ className?: string; operations: string }> = ({

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewList.scss
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewList.scss
@@ -2,7 +2,10 @@
     &__grid {
         display: grid;
         grid-template-columns:
-            [caret] min-content [current_state] min-content [action] min-content [info] minmax(auto, 1fr)
+            [caret] min-content [current_state] min-content [indicator] min-content [action] min-content [info] minmax(
+                auto,
+                1fr
+            )
             [diffstat] min-content [end];
         align-items: center;
     }

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewListHeader.tsx
@@ -8,6 +8,9 @@ export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> 
     <>
         <span className="p-2 d-none d-sm-block" />
         <h5 className="p-2 d-none d-sm-block text-uppercase text-center">Current state</h5>
+        <h5 className="p-2 d-none d-sm-block text-uppercase text-center">
+            +<br />-
+        </h5>
         <h5 className="p-2 d-none d-sm-block text-uppercase text-nowrap">Actions</h5>
         <h5 className="p-2 d-none d-sm-block text-uppercase text-nowrap">Changeset information</h5>
         <h5 className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">Changes</h5>

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.scss
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.scss
@@ -1,0 +1,29 @@
+.preview-node-indicator {
+    &__attach-dot {
+        width: 0.25rem;
+        height: calc(50% - 0.5rem);
+        background-color: var(--oc-lime-6);
+    }
+    &__attach-icon {
+        color: var(--oc-lime-9);
+        line-height: 1rem;
+    }
+    &__update-dot {
+        width: 0.25rem;
+        height: calc(50% - 0.5rem);
+        background-color: var(--oc-yellow-5);
+    }
+    &__update-icon {
+        color: var(--oc-orange-9);
+        line-height: 1rem;
+    }
+    &__detach-dot {
+        width: 0.25rem;
+        height: calc(50% - 0.5rem);
+        background-color: var(--danger);
+    }
+    &__detach-icon {
+        color: var(--oc-red-9);
+        line-height: 1rem;
+    }
+}

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.tsx
@@ -20,6 +20,10 @@ export const PreviewNodeIndicator: React.FunctionComponent<PreviewNodeIndicatorP
             )
         case 'HiddenApplyPreviewTargetsUpdate':
         case 'VisibleApplyPreviewTargetsUpdate':
+            if (node.__typename === 'HiddenChangesetApplyPreview' || node.operations.length === 0) {
+                // If no operations, no update :P
+                return <div />
+            }
             return (
                 <div className={containerClassName}>
                     <span className="preview-node-indicator__update-dot">&nbsp;</span>

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { ChangesetApplyPreviewFields } from '../../../../graphql-operations'
+
+const containerClassName = 'd-flex flex-column align-items-center justify-content-center align-self-stretch'
+
+export interface PreviewNodeIndicatorProps {
+    node: ChangesetApplyPreviewFields
+}
+
+export const PreviewNodeIndicator: React.FunctionComponent<PreviewNodeIndicatorProps> = ({ node }) => {
+    switch (node.targets.__typename) {
+        case 'HiddenApplyPreviewTargetsAttach':
+        case 'VisibleApplyPreviewTargetsAttach':
+            return (
+                <div className={containerClassName}>
+                    <span className="preview-node-indicator__attach-dot">&nbsp;</span>
+                    <span className="preview-node-indicator__attach-icon">+</span>
+                    <span className="preview-node-indicator__attach-dot">&nbsp;</span>
+                </div>
+            )
+        case 'HiddenApplyPreviewTargetsUpdate':
+        case 'VisibleApplyPreviewTargetsUpdate':
+            return (
+                <div className={containerClassName}>
+                    <span className="preview-node-indicator__update-dot">&nbsp;</span>
+                    <span className="preview-node-indicator__update-icon">&bull;</span>
+                    <span className="preview-node-indicator__update-dot">&nbsp;</span>
+                </div>
+            )
+        case 'HiddenApplyPreviewTargetsDetach':
+        case 'VisibleApplyPreviewTargetsDetach':
+            return (
+                <div className={containerClassName}>
+                    <span className="preview-node-indicator__detach-dot">&nbsp;</span>
+                    <span className="preview-node-indicator__detach-icon">-</span>
+                    <span className="preview-node-indicator__detach-dot">&nbsp;</span>
+                </div>
+            )
+    }
+}

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewNodeIndicator.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ChangesetApplyPreviewFields } from '../../../../graphql-operations'
 
-const containerClassName = 'd-flex flex-column align-items-center justify-content-center align-self-stretch'
+const containerClassName = 'd-none d-sm-flex flex-column align-items-center justify-content-center align-self-stretch'
 
 export interface PreviewNodeIndicatorProps {
     node: ChangesetApplyPreviewFields

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -17,6 +17,7 @@ import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
 import { GitBranchChangesetDescriptionInfo } from './GitBranchChangesetDescriptionInfo'
 import { ChangesetStatusCell } from '../../detail/changesets/ChangesetStatusCell'
+import { PreviewNodeIndicator } from './PreviewNodeIndicator'
 
 export interface VisibleChangesetApplyPreviewNodeProps extends ThemeProps {
     node: VisibleChangesetApplyPreviewFields
@@ -65,6 +66,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<VisibleCh
                 node={node}
                 className="visible-changeset-apply-preview-node__list-cell d-block d-sm-flex visible-changeset-apply-preview-node__current-state align-self-stretch visible-changeset-apply-preview-node__status-cell"
             />
+            <PreviewNodeIndicator node={node} />
             <PreviewActions
                 node={node}
                 className="visible-changeset-apply-preview-node__list-cell visible-changeset-apply-preview-node__action align-self-stretch"

--- a/client/web/src/enterprise/campaigns/preview/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/preview/list/backend.ts
@@ -143,7 +143,6 @@ const campaignSpecApplyPreviewConnectionFieldsFragment = gql`
                 }
                 changeset {
                     id
-                    state
                     title
                     state
                     currentSpec {

--- a/client/web/src/enterprise/campaigns/preview/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/preview/list/backend.ts
@@ -143,6 +143,7 @@ const campaignSpecApplyPreviewConnectionFieldsFragment = gql`
                 }
                 changeset {
                     id
+                    state
                     title
                     state
                     currentSpec {

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -554,6 +554,23 @@ describe('Campaigns', () => {
                                       },
                             supersedingCampaignSpec: null,
                             viewerCanAdminister: true,
+                            applyPreview: {
+                                stats: {
+                                    close: 10,
+                                    detach: 10,
+                                    import: 10,
+                                    publish: 10,
+                                    publishDraft: 10,
+                                    push: 10,
+                                    reopen: 10,
+                                    undraft: 10,
+                                    update: 10,
+
+                                    added: 5,
+                                    modified: 10,
+                                    removed: 3,
+                                },
+                            },
                             viewerCampaignsCodeHosts: {
                                 totalCount: 0,
                                 nodes: [],

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -226,6 +226,10 @@ type ChangesetApplyPreviewConnectionStatsResolver interface {
 	Reopen() int32
 	Sleep() int32
 	Detach() int32
+
+	Added() int32
+	Modified() int32
+	Removed() int32
 }
 
 type ChangesetApplyPreviewConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -1467,6 +1467,19 @@ type ChangesetApplyPreviewConnectionStats {
     The changeset is removed from some of the associated campaigns.
     """
     detach: Int!
+
+    """
+    The amount of changesets that are added to the campaign in this operation.
+    """
+    added: Int!
+    """
+    The amount of changesets that are already attached to the campaign and modified in this operation.
+    """
+    modified: Int!
+    """
+    The amount of changesets that are disassociated from the campaign in this operation.
+    """
+    removed: Int!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1460,6 +1460,19 @@ type ChangesetApplyPreviewConnectionStats {
     The changeset is removed from some of the associated campaigns.
     """
     detach: Int!
+
+    """
+    The amount of changesets that are added to the campaign in this operation.
+    """
+    added: Int!
+    """
+    The amount of changesets that are already attached to the campaign and modified in this operation.
+    """
+    modified: Int!
+    """
+    The amount of changesets that are disassociated from the campaign in this operation.
+    """
+    removed: Int!
 }
 
 """

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
@@ -94,6 +94,11 @@ type changesetApplyPreviewConnectionStatsResolver struct {
 	reopen       int32
 	sleep        int32
 	detach       int32
+	unpublished  int32
+
+	added    int32
+	modified int32
+	removed  int32
 }
 
 func (r *changesetApplyPreviewConnectionStatsResolver) Push() int32 {
@@ -129,6 +134,15 @@ func (r *changesetApplyPreviewConnectionStatsResolver) Sleep() int32 {
 func (r *changesetApplyPreviewConnectionStatsResolver) Detach() int32 {
 	return r.detach
 }
+func (r *changesetApplyPreviewConnectionStatsResolver) Added() int32 {
+	return r.added
+}
+func (r *changesetApplyPreviewConnectionStatsResolver) Modified() int32 {
+	return r.modified
+}
+func (r *changesetApplyPreviewConnectionStatsResolver) Removed() int32 {
+	return r.removed
+}
 
 var _ graphqlbackend.ChangesetApplyPreviewConnectionStatsResolver = &changesetApplyPreviewConnectionStatsResolver{}
 
@@ -158,6 +172,16 @@ func (r *changesetApplyPreviewConnectionResolver) Stats(ctx context.Context) (gr
 		ops, err = visRes.Operations(ctx)
 		if err != nil {
 			return nil, err
+		}
+		targets := visRes.Targets()
+		if _, ok := targets.ToVisibleApplyPreviewTargetsAttach(); ok {
+			stats.added++
+		}
+		if _, ok := targets.ToVisibleApplyPreviewTargetsUpdate(); ok {
+			stats.modified++
+		}
+		if _, ok := targets.ToVisibleApplyPreviewTargetsDetach(); ok {
+			stats.removed++
 		}
 		for _, op := range ops {
 			switch op {

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
@@ -158,6 +158,7 @@ func (r *changesetApplyPreviewConnectionResolver) Stats(ctx context.Context) (gr
 			store:             r.store,
 			mapping:           mapping,
 			preloadedCampaign: campaign,
+			campaignSpecID:    r.campaignSpecID,
 		}
 		var ops []campaigns.ReconcilerOperation
 		if _, ok := res.ToHiddenChangesetApplyPreview(); ok {
@@ -178,7 +179,9 @@ func (r *changesetApplyPreviewConnectionResolver) Stats(ctx context.Context) (gr
 			stats.added++
 		}
 		if _, ok := targets.ToVisibleApplyPreviewTargetsUpdate(); ok {
-			stats.modified++
+			if len(ops) > 0 {
+				stats.modified++
+			}
 		}
 		if _, ok := targets.ToVisibleApplyPreviewTargetsDetach(); ok {
 			stats.removed++
@@ -247,6 +250,10 @@ func (r *changesetApplyPreviewConnectionResolver) compute(ctx context.Context) (
 			CampaignID:     opts.CampaignID,
 		}
 		r.allMappings, r.err = r.store.GetRewirerMappings(ctx, allOpts)
+		if r.err != nil {
+			return
+		}
+		r.err = r.allMappings.Hydrate(ctx, r.store)
 		if r.err != nil {
 			return
 		}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
@@ -160,6 +160,10 @@ query($campaignSpec: ID!, $first: Int!, $after: String) {
           reopen
           sleep
           detach
+
+          added
+          modified
+          removed
         }
       }
     }


### PR DESCRIPTION
This implements the new header stats bar for the preview page and also adds the added/modified/removed indicators, so the stats are also reflected on the rows.