### PR TITLE
internal/db: generate separate schema.md files for codeintel and frontend DBs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ client/browser/build
 **/package.json
 **/coverage
 internal/db/schema.md
+internal/db/schema.*.md
 cmd/xlang-python/python-langserver/
 package-lock.json
 package.json

--- a/internal/db/gen.go
+++ b/internal/db/gen.go
@@ -1,4 +1,5 @@
 package db
 
 // $PGHOST, $PGUSER, $PGPORT etc. must be set to run this generate script.
-//go:generate env GO111MODULE=on go run schemadoc/main.go schema.md
+//go:generate env GO111MODULE=on go run schemadoc/main.go frontend schema.md
+//go:generate env GO111MODULE=on go run schemadoc/main.go codeintel schema.codeintel.md

--- a/internal/db/schema.codeintel.md
+++ b/internal/db/schema.codeintel.md
@@ -1,0 +1,71 @@
+# Table "public.codeintel_schema_migrations"
+```
+ Column  |  Type   | Modifiers 
+---------+---------+-----------
+ version | bigint  | not null
+ dirty   | boolean | not null
+Indexes:
+    "codeintel_schema_migrations_pkey" PRIMARY KEY, btree (version)
+
+```
+
+# Table "public.lsif_data_definitions"
+```
+   Column   |  Type   | Modifiers 
+------------+---------+-----------
+ dump_id    | integer | not null
+ scheme     | text    | not null
+ identifier | text    | not null
+ data       | bytea   | 
+Indexes:
+    "lsif_data_definitions_pkey" PRIMARY KEY, btree (dump_id, scheme, identifier)
+
+```
+
+# Table "public.lsif_data_documents"
+```
+ Column  |  Type   | Modifiers 
+---------+---------+-----------
+ dump_id | integer | not null
+ path    | text    | not null
+ data    | bytea   | 
+Indexes:
+    "lsif_data_documents_pkey" PRIMARY KEY, btree (dump_id, path)
+
+```
+
+# Table "public.lsif_data_metadata"
+```
+      Column       |  Type   | Modifiers 
+-------------------+---------+-----------
+ dump_id           | integer | not null
+ num_result_chunks | integer | 
+Indexes:
+    "lsif_data_metadata_pkey" PRIMARY KEY, btree (dump_id)
+
+```
+
+# Table "public.lsif_data_references"
+```
+   Column   |  Type   | Modifiers 
+------------+---------+-----------
+ dump_id    | integer | not null
+ scheme     | text    | not null
+ identifier | text    | not null
+ data       | bytea   | 
+Indexes:
+    "lsif_data_references_pkey" PRIMARY KEY, btree (dump_id, scheme, identifier)
+
+```
+
+# Table "public.lsif_data_result_chunks"
+```
+ Column  |  Type   | Modifiers 
+---------+---------+-----------
+ dump_id | integer | not null
+ idx     | integer | not null
+ data    | bytea   | 
+Indexes:
+    "lsif_data_result_chunks_pkey" PRIMARY KEY, btree (dump_id, idx)
+
+```

--- a/internal/db/schema.md
+++ b/internal/db/schema.md
@@ -331,17 +331,6 @@ Referenced by:
 
 ```
 
-# Table "public.codeintel_schema_migrations"
-```
- Column  |  Type   | Modifiers 
----------+---------+-----------
- version | bigint  | not null
- dirty   | boolean | not null
-Indexes:
-    "codeintel_schema_migrations_pkey" PRIMARY KEY, btree (version)
-
-```
-
 # Table "public.critical_and_site_config"
 ```
    Column   |           Type           |                               Modifiers                               
@@ -571,67 +560,6 @@ Triggers:
  mgmt_password_bcrypt    | text    | not null default ''::text
 Indexes:
     "global_state_pkey" PRIMARY KEY, btree (site_id)
-
-```
-
-# Table "public.lsif_data_definitions"
-```
-   Column   |  Type   | Modifiers 
-------------+---------+-----------
- dump_id    | integer | not null
- scheme     | text    | not null
- identifier | text    | not null
- data       | bytea   | 
-Indexes:
-    "lsif_data_definitions_pkey" PRIMARY KEY, btree (dump_id, scheme, identifier)
-
-```
-
-# Table "public.lsif_data_documents"
-```
- Column  |  Type   | Modifiers 
----------+---------+-----------
- dump_id | integer | not null
- path    | text    | not null
- data    | bytea   | 
-Indexes:
-    "lsif_data_documents_pkey" PRIMARY KEY, btree (dump_id, path)
-
-```
-
-# Table "public.lsif_data_metadata"
-```
-      Column       |  Type   | Modifiers 
--------------------+---------+-----------
- dump_id           | integer | not null
- num_result_chunks | integer | 
-Indexes:
-    "lsif_data_metadata_pkey" PRIMARY KEY, btree (dump_id)
-
-```
-
-# Table "public.lsif_data_references"
-```
-   Column   |  Type   | Modifiers 
-------------+---------+-----------
- dump_id    | integer | not null
- scheme     | text    | not null
- identifier | text    | not null
- data       | bytea   | 
-Indexes:
-    "lsif_data_references_pkey" PRIMARY KEY, btree (dump_id, scheme, identifier)
-
-```
-
-# Table "public.lsif_data_result_chunks"
-```
- Column  |  Type   | Modifiers 
----------+---------+-----------
- dump_id | integer | not null
- idx     | integer | not null
- data    | bytea   | 
-Indexes:
-    "lsif_data_result_chunks_pkey" PRIMARY KEY, btree (dump_id, idx)
 
 ```
 


### PR DESCRIPTION
Today, schemadoc generates a single schema.md file for both the frontend and codeintel DBs. It does this by applying the migrations of both to the same DB and then extracting the info it needs, which is okay because Code Intel's Postgres DB and frontend are intentionally compatible and usable in the same Postgres instance (although not advised.)

For Code Insights (see #17217) I am introducing a separate TimescaleDB instance. It is basically just a Postgres plugin, but will be deploying it separately from our other Postgres instances and not designing it to be compatible with our frontend DB as codeintel has chosen to do. I am doing it this way because TimescaleDB lags a bit behind the official Postgres versioning (e.g. they are on v12) and don't want us to be tied to the version TimescaleDB supports. Also, installing the plugin is more tedious/annoying than just running it separately (and isolation is nice.)

Fixes #17217

Signed-off-by: Stephen Gutekanst <stephen.gutekanst@gmail.com>