### PR TITLE
Enable dynamic changesetTemplates and steps outputs

### DIFF
--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -129,10 +129,6 @@
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
             "additionalProperties": {"type": "string"}
-          },
-          "outputVariable": {
-            "type": "string",
-            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in `vars`."
           }
         }
       }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -85,11 +85,11 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["${{ step.stdout }}", "${{ repository.name }}"]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",
-                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var. If not set, 'text' is assumed to the format.",
                   "enum": ["json", "yaml", "text"]
                 }
               }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -75,6 +75,26 @@
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
           },
+          "outputs": {
+            "type": "object",
+            "description": "Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "The value of the output, which can be a template string.",
+                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "enum": ["json", "yaml", "text"]
+                }
+              }
+            }
+          },
           "env": {
             "description": "Environment variables to set in the step environment.",
             "oneOf": [
@@ -108,9 +128,11 @@
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "additionalProperties": {"type": "string"}
+          },
+          "outputVariable": {
+            "type": "string",
+            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in `vars`."
           }
         }
       }
@@ -225,9 +247,7 @@
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": {
-                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
-                },
+                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -85,7 +85,7 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                  "examples": ["${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",
@@ -128,7 +128,7 @@
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": {"type": "string"}
+            "additionalProperties": { "type": "string" }
           }
         }
       }
@@ -243,7 +243,9 @@
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
+                "additionalProperties": {
+                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
+                },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -134,10 +134,6 @@ const CampaignSpecSchemaJSON = `{
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
             "additionalProperties": {"type": "string"}
-          },
-          "outputVariable": {
-            "type": "string",
-            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in ` + "`" + `vars` + "`" + `."
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -80,6 +80,26 @@ const CampaignSpecSchemaJSON = `{
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
           },
+          "outputs": {
+            "type": "object",
+            "description": "Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "The value of the output, which can be a template string.",
+                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "enum": ["json", "yaml", "text"]
+                }
+              }
+            }
+          },
           "env": {
             "description": "Environment variables to set in the step environment.",
             "oneOf": [
@@ -113,9 +133,11 @@ const CampaignSpecSchemaJSON = `{
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "additionalProperties": {"type": "string"}
+          },
+          "outputVariable": {
+            "type": "string",
+            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in ` + "`" + `vars` + "`" + `."
           }
         }
       }
@@ -230,9 +252,7 @@ const CampaignSpecSchemaJSON = `{
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": {
-                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
-                },
+                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -90,7 +90,7 @@ const CampaignSpecSchemaJSON = `{
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                  "examples": ["${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",
@@ -133,7 +133,7 @@ const CampaignSpecSchemaJSON = `{
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": {"type": "string"}
+            "additionalProperties": { "type": "string" }
           }
         }
       }
@@ -248,7 +248,9 @@ const CampaignSpecSchemaJSON = `{
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
+                "additionalProperties": {
+                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
+                },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -90,11 +90,11 @@ const CampaignSpecSchemaJSON = `{
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["${{ step.stdout }}", "${{ repository.name }}"]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",
-                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var. If not set, 'text' is assumed to the format.",
                   "enum": ["json", "yaml", "text"]
                 }
               }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -45,6 +45,12 @@ type AWSCodeCommitGitCredentials struct {
 	// Username description: The Git username
 	Username string `json:"username"`
 }
+type AdditionalProperties struct {
+	// Format description: The expected format of the output. If set, the output is being parsed in that format before being stored in the var.
+	Format string `json:"format,omitempty"`
+	// Value description: The value of the output, which can be a template string.
+	Value string `json:"value"`
+}
 
 // AuthAccessTokens description: Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
 type AuthAccessTokens struct {
@@ -1273,6 +1279,10 @@ type Step struct {
 	Env interface{} `json:"env,omitempty"`
 	// Files description: Files that should be mounted into or be created inside the Docker container.
 	Files map[string]string `json:"files,omitempty"`
+	// OutputVariable description: The name of the variable in which to save the output of the step. The variable has to have been declared in `vars`.
+	OutputVariable string `json:"outputVariable,omitempty"`
+	// Outputs description: Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>
+	Outputs map[string]AdditionalProperties `json:"outputs,omitempty"`
 	// Run description: The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.
 	Run string `json:"run"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -46,7 +46,7 @@ type AWSCodeCommitGitCredentials struct {
 	Username string `json:"username"`
 }
 type AdditionalProperties struct {
-	// Format description: The expected format of the output. If set, the output is being parsed in that format before being stored in the var.
+	// Format description: The expected format of the output. If set, the output is being parsed in that format before being stored in the var. If not set, 'text' is assumed to the format.
 	Format string `json:"format,omitempty"`
 	// Value description: The value of the output, which can be a template string.
 	Value string `json:"value"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1279,8 +1279,6 @@ type Step struct {
 	Env interface{} `json:"env,omitempty"`
 	// Files description: Files that should be mounted into or be created inside the Docker container.
 	Files map[string]string `json:"files,omitempty"`
-	// OutputVariable description: The name of the variable in which to save the output of the step. The variable has to have been declared in `vars`.
-	OutputVariable string `json:"outputVariable,omitempty"`
 	// Outputs description: Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>
 	Outputs map[string]AdditionalProperties `json:"outputs,omitempty"`
 	// Run description: The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.


### PR DESCRIPTION
This updates the campaign spec schema to the one in https://github.com/sourcegraph/src-cli/pull/424 and should be merged before.

I'm going to add documentation in a separate PR so we don't tie these together.