### PR TITLE
db: truncate microsecond for User.CreatedAt

### DIFF
--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 	"unicode/utf8"
 
 	"github.com/hashicorp/go-multierror"
@@ -19,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/db/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -189,7 +189,7 @@ func (u *users) create(ctx context.Context, tx *sql.Tx, info NewUser) (newUser *
 		return nil, errors.New("no email verification code provided for new user with unverified email")
 	}
 
-	createdAt := time.Now()
+	createdAt := timeutil.Now()
 	updatedAt := createdAt
 	invalidatedSessionsAt := createdAt
 	var id int32


### PR DESCRIPTION
Because Postgres 9.6 - 13 in Docker do not support storing anything more precise than one microsecond, so there is a possible flaky when comparing `time.Now` from Go and time read back from the Postgres, which in turn may invalidate a valid session.