### PR TITLE
search: streaming interface for zoekt

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
@@ -27,7 +26,7 @@ func TestSearchRepositories(t *testing.T) {
 		{Repo: &types.RepoName{ID: 789, Name: "bar/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}},
 	}
 
-	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
+	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
 	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
 		repos, err := getRepos(context.Background(), args.RepoPromise)
@@ -148,7 +147,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		}
 	}
 
-	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
+	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/atomic"
 
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
-	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -840,7 +839,7 @@ func TestSearchResultsHydration(t *testing.T) {
 	}}
 
 	z := &searchbackend.Zoekt{
-		Client: &searchzoekt.FakeSearcher{
+		Client: &searchbackend.FakeSearcher{
 			Repos:  []*zoekt.RepoListEntry{zoektRepo},
 			Result: &zoekt.SearchResult{Files: zoektFileMatches},
 		},
@@ -1277,7 +1276,7 @@ func TestEvaluateAnd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			zoektFileMatches := generateZoektMatches(tt.zoektMatches)
 			z := &searchbackend.Zoekt{
-				Client: &searchzoekt.FakeSearcher{
+				Client: &searchbackend.FakeSearcher{
 					Repos:  zoektRepos,
 					Result: &zoekt.SearchResult{Files: zoektFileMatches, Stats: zoekt.Stats{FilesSkipped: tt.filesSkipped}},
 				},

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
-	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -79,7 +78,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 	}}
 
 	z := &searchbackend.Zoekt{
-		Client: &searchzoekt.FakeSearcher{
+		Client: &searchbackend.FakeSearcher{
 			Repos:  []*zoekt.RepoListEntry{zoektRepo},
 			Result: &zoekt.SearchResult{Files: zoektFileMatches},
 		},

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -69,7 +68,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	}
 	defer func() { mockSearchFilesInRepo = nil }()
 
-	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
+	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
 	q, err := query.ParseAndCheck("foo")
 	if err != nil {
@@ -155,7 +154,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 	}
 	defer func() { mockSearchFilesInRepo = nil }()
 
-	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
+	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
 	q, err := query.ParseAndCheck("foo")
 	if err != nil {
@@ -262,7 +261,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	}})
 	defer conf.Mock(nil)
 
-	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
+	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
 	q, err := query.ParseAndCheck("foo")
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
-	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -293,7 +292,7 @@ func TestIndexedSearch(t *testing.T) {
 				RepoPromise:     (&search.Promise{}).Resolve(tt.args.repos),
 				UseFullDeadline: tt.args.useFullDeadline,
 				Zoekt: &searchbackend.Zoekt{
-					Client: &searchzoekt.FakeSearcher{
+					Client: &searchbackend.FakeSearcher{
 						Result: &zoekt.SearchResult{Files: tt.args.results},
 						Repos:  zoektRepos,
 					},
@@ -710,7 +709,7 @@ func BenchmarkSearchResults(b *testing.B) {
 	zoektFileMatches := generateZoektMatches(50)
 
 	z := &searchbackend.Zoekt{
-		Client: &searchzoekt.FakeSearcher{
+		Client: &searchbackend.FakeSearcher{
 			Repos:  zoektRepos,
 			Result: &zoekt.SearchResult{Files: zoektFileMatches},
 		},
@@ -760,13 +759,13 @@ func BenchmarkIntegrationSearchResults(b *testing.B) {
 	_, repos, zoektRepos := generateRepos(5000)
 	zoektFileMatches := generateZoektMatches(50)
 
-	zoektClient, cleanup := zoektRPC(&searchzoekt.FakeSearcher{
+	zoektClient, cleanup := zoektRPC(&searchbackend.FakeSearcher{
 		Repos:  zoektRepos,
 		Result: &zoekt.SearchResult{Files: zoektFileMatches},
 	})
 	defer cleanup()
 	z := &searchbackend.Zoekt{
-		Client:       zoektClient,
+		Client:       searchbackend.AdaptStreamSearcher(zoektClient),
 		DisableCache: true,
 	}
 

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -765,7 +765,7 @@ func BenchmarkIntegrationSearchResults(b *testing.B) {
 	})
 	defer cleanup()
 	z := &searchbackend.Zoekt{
-		Client:       searchbackend.AdaptStreamSearcher(zoektClient),
+		Client:       &searchbackend.StreamSearchAdapter{zoektClient},
 		DisableCache: true,
 	}
 

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 
-	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -340,7 +339,7 @@ func TestDefaultRepositories(t *testing.T) {
 				indexed = append(indexed, &zoekt.RepoListEntry{Repository: zoekt.Repository{Name: name}})
 			}
 			z := &searchbackend.Zoekt{
-				Client:       &searchzoekt.FakeSearcher{Repos: indexed},
+				Client:       &searchbackend.FakeSearcher{Repos: indexed},
 				DisableCache: true,
 			}
 

--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -1,4 +1,4 @@
-package zoekt
+package backend
 
 import (
 	"context"
@@ -24,6 +24,10 @@ func (ss *FakeSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt.
 		return &zoekt.SearchResult{}, nil
 	}
 	return ss.Result, nil
+}
+
+func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions) <-chan StreamSearchEvent {
+	return AdaptStreamSearcher(ss).StreamSearch(ctx, q, opts)
 }
 
 func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoList, error) {

--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -27,7 +27,7 @@ func (ss *FakeSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt.
 }
 
 func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions) <-chan StreamSearchEvent {
-	return AdaptStreamSearcher(ss).StreamSearch(ctx, q, opts)
+	return (&StreamSearchAdapter{ss}).StreamSearch(ctx, q, opts)
 }
 
 func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q) (*zoekt.RepoList, error) {

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -253,24 +253,6 @@ func equalKeys(a map[string]StreamSearcher, b map[string]struct{}) bool {
 	return true
 }
 
-// dedupStream runs dedupper over c
-func dedupStream(c <-chan StreamSearchEvent) <-chan StreamSearchEvent {
-	dedupper := dedupper{}
-	c2 := make(chan StreamSearchEvent)
-
-	go func() {
-		defer close(c2)
-		for r := range c {
-			if r.SearchResult != nil {
-				r.SearchResult.Files = dedupper.Dedup(r.SearchResult.Files)
-			}
-			c2 <- r
-		}
-	}()
-
-	return c2
-}
-
 type dedupper map[string]struct{}
 
 // Dedup will in-place filter out matches on Repositories we already have

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -33,7 +33,7 @@ func TestHorizontalSearcher(t *testing.T) {
 				listResult: &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{&rle}},
 			}
 			// Return metered searcher to test that codepath
-			return NewMeteredSearcher(endpoint, AdaptStreamSearcher(client))
+			return NewMeteredSearcher(endpoint, &StreamSearchAdapter{client})
 		},
 	}
 	defer searcher.Close()

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -20,7 +20,7 @@ func TestHorizontalSearcher(t *testing.T) {
 
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
-		Dial: func(endpoint string) zoekt.Searcher {
+		Dial: func(endpoint string) StreamSearcher {
 			var rle zoekt.RepoListEntry
 			rle.Repository.Name = endpoint
 			client := &mockSearcher{
@@ -33,7 +33,7 @@ func TestHorizontalSearcher(t *testing.T) {
 				listResult: &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{&rle}},
 			}
 			// Return metered searcher to test that codepath
-			return NewMeteredSearcher(endpoint, client)
+			return NewMeteredSearcher(endpoint, AdaptStreamSearcher(client))
 		},
 	}
 	defer searcher.Close()
@@ -130,7 +130,7 @@ func TestSyncSearchers(t *testing.T) {
 	dialNumCounter := 0
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
-		Dial: func(endpoint string) zoekt.Searcher {
+		Dial: func(endpoint string) StreamSearcher {
 			dialNumCounter++
 			return &mock{
 				dialNum: dialNumCounter,
@@ -317,6 +317,10 @@ func (s *mockSearcher) Search(context.Context, query.Q, *zoekt.SearchOptions) (*
 		res = &sr
 	}
 	return res, s.searchError
+}
+
+func (s *mockSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) <-chan StreamSearchEvent {
+	return (&StreamSearchAdapter{s}).StreamSearch(ctx, q, opts)
 }
 
 func (s *mockSearcher) List(context.Context, query.Q) (*zoekt.RepoList, error) {

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -26,15 +26,15 @@ func init() {
 }
 
 type meteredSearcher struct {
-	zoekt.Searcher
+	StreamSearcher
 
 	hostname string
 }
 
-func NewMeteredSearcher(hostname string, z zoekt.Searcher) zoekt.Searcher {
+func NewMeteredSearcher(hostname string, z StreamSearcher) StreamSearcher {
 	return &meteredSearcher{
-		Searcher: z,
-		hostname: hostname,
+		StreamSearcher: z,
+		hostname:       hostname,
 	}
 }
 
@@ -98,7 +98,7 @@ func (m *meteredSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 		},
 	})
 
-	zsr, err := m.Searcher.Search(ctx, q, opts)
+	zsr, err := m.StreamSearcher.Search(ctx, q, opts)
 
 	code := "200"
 	if err != nil {
@@ -155,7 +155,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 
 	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q), tags...)
 
-	zsl, err := m.Searcher.List(ctx, q)
+	zsl, err := m.StreamSearcher.List(ctx, q)
 
 	code := "200"
 	if err != nil {

--- a/internal/search/backend/text.go
+++ b/internal/search/backend/text.go
@@ -18,7 +18,7 @@ import (
 // Note: Zoekt starts up background goroutines, so call Close when done using
 // the Client.
 type Zoekt struct {
-	Client zoekt.Searcher
+	Client StreamSearcher
 
 	// DisableCache when true prevents caching of Client.List. Useful in
 	// tests.

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -30,19 +30,13 @@ type StreamSearchEvent struct {
 	Error error
 }
 
-func AdaptStreamSearcher(s zoekt.Searcher) StreamSearcher {
-	if ss, ok := s.(StreamSearcher); ok {
-		return ss
-	}
-
-	return &streamSearchAdapter{Searcher: s}
-}
-
-type streamSearchAdapter struct {
+// StreamSearchAdapter adapts a zoekt.Searcher to conform to the StreamSearch
+// interface by calling zoekt.Searcher.Search.
+type StreamSearchAdapter struct {
 	zoekt.Searcher
 }
 
-func (s *streamSearchAdapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) <-chan StreamSearchEvent {
+func (s *StreamSearchAdapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) <-chan StreamSearchEvent {
 	c := make(chan StreamSearchEvent)
 
 	go func() {
@@ -57,6 +51,6 @@ func (s *streamSearchAdapter) StreamSearch(ctx context.Context, q query.Q, opts 
 	return c
 }
 
-func (s *streamSearchAdapter) String() string {
+func (s *StreamSearchAdapter) String() string {
 	return "streamSearchAdapter{" + s.Searcher.String() + "}"
 }

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -1,0 +1,31 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
+)
+
+// StreamSearcher is an optional interface which sends results over a channel
+// as they are found.
+//
+// This is a Sourcegraph extension.
+type StreamSearcher interface {
+	zoekt.Searcher
+
+	// StreamSearch returns a channel which needs to be read until closed.
+	StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) <-chan StreamSearchEvent
+}
+
+// StreamSearchEvent has fields optionally set representing events that happen
+// during a search.
+//
+// This is a Sourcegraph extension.
+type StreamSearchEvent struct {
+	// SearchResult is non-nil if this event is a search result. These should be
+	// combined with previous and later SearchResults.
+	SearchResult *zoekt.SearchResult
+	// Error indicates an error was encountered.
+	Error error
+}

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -43,11 +42,11 @@ func SearcherURLs() *endpoint.Map {
 
 func Indexed() *backend.Zoekt {
 	indexedSearchOnce.Do(func() {
-		dial := func(endpoint string) zoekt.Searcher {
-			return backend.NewMeteredSearcher(endpoint, rpc.Client(endpoint))
+		dial := func(endpoint string) backend.StreamSearcher {
+			return backend.NewMeteredSearcher(endpoint, backend.AdaptStreamSearcher(rpc.Client(endpoint)))
 		}
 
-		var client zoekt.Searcher
+		var client backend.StreamSearcher
 		if indexers := Indexers(); indexers.Enabled() {
 			client = backend.NewMeteredSearcher(
 				"", // no hostname means its the aggregator

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -43,7 +43,7 @@ func SearcherURLs() *endpoint.Map {
 func Indexed() *backend.Zoekt {
 	indexedSearchOnce.Do(func() {
 		dial := func(endpoint string) backend.StreamSearcher {
-			return backend.NewMeteredSearcher(endpoint, backend.AdaptStreamSearcher(rpc.Client(endpoint)))
+			return backend.NewMeteredSearcher(endpoint, &backend.StreamSearchAdapter{rpc.Client(endpoint)})
 		}
 
 		var client backend.StreamSearcher


### PR DESCRIPTION
This introduces a streaming interface for Zoekt called `StreamSearcher`. This adds an event based equivalent of zoekt's batch method `Search`. We then update HorizontalSearcher and MeteredSearcher to be stream based. Additionally we add an adapter which takes the batch interface and "upgrades" it to streaming. This allows us to update most places to instead take a `StreamSearcher`. The next PR will actually use this streaming searcher, which will allow us to stream results as we receive them from a zoekt backend to the client.

Design discussion. I am unsure about embedding `zoekt.Searcher` into `StreamSearcher`. It feels weird to keep supporting the batch interface when we shouldn't be using it going forward. WDYT of once we are using StreamSearcher in the next PR to update the interface to exclude `zoekt.Searcher.Search`?

Test plan: Unit tests as well as manual testing in my dev environment. I ran a few searches to and inspected the traces as well.

Co-authored-by: @stefanhengl 