### PR TITLE
Fix missing parameter in curl command in docs

### DIFF
--- a/doc/cli/quickstart.md
+++ b/doc/cli/quickstart.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/src
 ### Linux
 
 ```sh
-curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64
+curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src
 chmod +x /usr/local/bin/src
 ```
 


### PR DESCRIPTION
This was reported by a customer to @christinelovett.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
