### PR TITLE
search: Make URI public

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -282,7 +282,7 @@ func paginatedSearchFilesInRepos(ctx context.Context, args *search.TextParameter
 		// fileResults is not sorted so we must sort it now. fileCommon may or
 		// may not be sorted, but we do not rely on its order.
 		sort.Slice(fileResults, func(i, j int) bool {
-			return fileResults[i].uri < fileResults[j].uri
+			return fileResults[i].URI < fileResults[j].URI
 		})
 		results := make([]SearchResultResolver, 0, len(fileResults))
 		for _, r := range fileResults {

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -39,14 +39,14 @@ func TestSearchRepositories(t *testing.T) {
 		case "foo/one":
 			return []*FileMatchResolver{
 				{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
+					URI:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
 			}, &searchResultsCommon{}, nil
 		case "bar/one":
 			return []*FileMatchResolver{
 				{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
+					URI:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 789}},
 				},
 			}, &searchResultsCommon{}, nil
@@ -137,7 +137,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		case "foo/one":
 			return []*FileMatchResolver{
 				{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+					URI:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
 			}, &searchResultsCommon{}, nil
@@ -155,7 +155,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 			return []*FileMatchResolver{
 				{
-					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+					URI:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
 			}, &searchResultsCommon{}, nil
@@ -190,7 +190,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
 			return []*FileMatchResolver{
 				{
-					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+					URI:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
 			}, &searchResultsCommon{}, nil

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -763,7 +763,7 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 	// accumulate matches for the right subexpression in a lookup.
 	for _, r := range right.SearchResults {
 		if fileMatch, ok := r.ToFileMatch(); ok {
-			rightFileMatches[fileMatch.uri] = fileMatch
+			rightFileMatches[fileMatch.URI] = fileMatch
 			continue
 		}
 		if repoMatch, ok := r.ToRepository(); ok {
@@ -783,7 +783,7 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 
 	for _, leftMatch := range left.SearchResults {
 		if leftFileMatch, ok := leftMatch.ToFileMatch(); ok {
-			rightFileMatch := rightFileMatches[leftFileMatch.uri]
+			rightFileMatch := rightFileMatches[leftFileMatch.URI]
 			if rightFileMatch == nil {
 				// no overlap with existing matches.
 				merged = append(merged, leftMatch)
@@ -792,7 +792,7 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 			}
 			// merge line matches with a file match that already exists.
 			rightFileMatch.appendMatches(leftFileMatch)
-			rightFileMatches[leftFileMatch.uri] = rightFileMatch
+			rightFileMatches[leftFileMatch.URI] = rightFileMatch
 			continue
 		}
 
@@ -868,7 +868,7 @@ func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 	rightFileMatches := make(map[string]*FileMatchResolver)
 	for _, r := range right.SearchResults {
 		if fileMatch, ok := r.ToFileMatch(); ok {
-			rightFileMatches[fileMatch.uri] = fileMatch
+			rightFileMatches[fileMatch.URI] = fileMatch
 		}
 	}
 
@@ -879,7 +879,7 @@ func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 			continue
 		}
 
-		rightFileMatch := rightFileMatches[leftFileMatch.uri]
+		rightFileMatch := rightFileMatches[leftFileMatch.URI]
 		if rightFileMatch == nil {
 			continue
 		}
@@ -1732,10 +1732,10 @@ func (a *aggregator) collect(ctx context.Context, results []SearchResultResolver
 
 		// Merge fileMatches from type symbol, path, file. For streaming search this
 		// code has no effect and the frontend should handle deduplication.
-		if m, ok := a.fileMatches[fm.uri]; ok {
+		if m, ok := a.fileMatches[fm.URI]; ok {
 			m.appendMatches(fm)
 		} else {
-			a.fileMatches[fm.uri] = fm
+			a.fileMatches[fm.URI] = fm
 			a.results = append(a.results, r)
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -193,7 +193,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		matches[i] = &FileMatchResolver{
 			JPath:     file.FileName,
 			JLimitHit: fileLimitHit,
-			uri:       fileMatchURI(repoRev.Repo.Name, "", file.FileName),
+			URI:       fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 			Repo:      repoResolvers[repoRev.Repo.Name],
 			CommitID:  api.CommitID(file.Version),
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -109,7 +109,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			fm := mkFileMatch(&types.RepoName{Name: "repo"}, "dir/file")
-			fm.uri = "git://repo?rev#dir/file"
+			fm.URI = "git://repo?rev#dir/file"
 			fm.CommitID = "rev"
 			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
 		}
@@ -169,7 +169,7 @@ func TestSearchSuggestions(t *testing.T) {
 			}
 			mk := func(name api.RepoName, path string) *FileMatchResolver {
 				fm := mkFileMatch(&types.RepoName{Name: name}, path)
-				fm.uri = fileMatchURI(name, "rev", path)
+				fm.URI = fileMatchURI(name, "rev", path)
 				fm.CommitID = "rev"
 				return fm
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -107,7 +107,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		if len(matches) > 0 {
 			common.resultCount += int32(len(matches))
 			sort.Slice(matches, func(i, j int) bool {
-				a, b := matches[i].uri, matches[j].uri
+				a, b := matches[i].URI, matches[j].URI
 				return a > b
 			})
 			unflattened = append(unflattened, matches)
@@ -273,7 +273,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 			fileMatch := &FileMatchResolver{
 				JPath:   symbolRes.symbol.Path,
 				symbols: []*searchSymbolResult{symbolRes},
-				uri:     uri,
+				URI:     uri,
 				Repo:    repoResolver,
 				// Don't get commit from GitCommitResolver.OID() because we don't want to
 				// slow search results down when they are coming from zoekt.

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -590,7 +590,7 @@ func mkFileMatch(repo *types.RepoName, path string, lineNumbers ...int32) *FileM
 		lines = append(lines, &lineMatch{JLineNumber: n})
 	}
 	return &FileMatchResolver{
-		uri:          fileMatchURI(repo.Name, "", path),
+		URI:          fileMatchURI(repo.Name, "", path),
 		JPath:        path,
 		JLineMatches: lines,
 		Repo:         &RepositoryResolver{innerRepo: repo.ToRepo()},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -44,7 +44,7 @@ type FileMatchResolver struct {
 	JLimitHit    bool         `json:"LimitHit"`
 	MatchCount   int          // Number of matches. Different from len(JLineMatches), as multiple lines may correspond to one logical match.
 	symbols      []*searchSymbolResult
-	uri          string
+	URI          string `json:"-"`
 	Repo         *RepositoryResolver
 	CommitID     api.CommitID
 	// InputRev is the Git revspec that the user originally requested to search. It is used to
@@ -58,7 +58,7 @@ func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 }
 
 func (fm *FileMatchResolver) Key() string {
-	return fm.uri
+	return fm.URI
 }
 
 func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
@@ -89,7 +89,7 @@ func (fm *FileMatchResolver) RevSpec() *gitRevSpec {
 }
 
 func (fm *FileMatchResolver) Resource() string {
-	return fm.uri
+	return fm.URI
 }
 
 func (fm *FileMatchResolver) Symbols() []*symbolResolver {
@@ -218,7 +218,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 			JLimitHit:    fm.LimitHit,
 			MatchCount:   fm.MatchCount,
 
-			uri:      workspace + fm.Path,
+			URI:      workspace + fm.Path,
 			Repo:     repoResolver,
 			CommitID: commit,
 			InputRev: &rev,
@@ -385,7 +385,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 		if len(matches) > 0 {
 			common.resultCount += int32(len(matches))
 			sort.Slice(matches, func(i, j int) bool {
-				a, b := matches[i].uri, matches[j].uri
+				a, b := matches[i].URI, matches[j].URI
 				return a > b
 			})
 			unflattened = append(unflattened, matches)
@@ -626,7 +626,7 @@ func flattenFileMatches(unflattened [][]*FileMatchResolver, fileMatchLimit int) 
 	// repo. We then want to create an idempontent order of results, but
 	// ensuring every repo has atleast one result.
 	sort.Slice(unflattened, func(i, j int) bool {
-		a, b := unflattened[i][0].uri, unflattened[j][0].uri
+		a, b := unflattened[i][0].URI, unflattened[j][0].URI
 		return a > b
 	})
 	var flattened []*FileMatchResolver
@@ -652,7 +652,7 @@ func flattenFileMatches(unflattened [][]*FileMatchResolver, fileMatchLimit int) 
 	// Sort again since we constructed flattened by adding more results at the
 	// end.
 	sort.Slice(flattened, func(i, j int) bool {
-		a, b := flattened[i].uri, flattened[j].uri
+		a, b := flattened[i].URI, flattened[j].URI
 		return a > b
 	})
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -38,13 +38,13 @@ func TestSearchFilesInRepos(t *testing.T) {
 		case "foo/one":
 			return []*FileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+					URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		case "foo/two":
 			return []*FileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+					URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		case "foo/empty":
@@ -125,19 +125,19 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		case "foo/one":
 			return []*FileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+					URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		case "foo/two":
 			return []*FileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+					URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		case "foo/three":
 			return []*FileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+					URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		default:
@@ -215,7 +215,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		case "foo":
 			return []*FileMatchResolver{
 				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+					URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 				},
 			}, false, nil
 		default:
@@ -257,7 +257,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 
 	resultURIs := make([]string, len(results))
 	for i, result := range results {
-		resultURIs[i] = result.uri
+		resultURIs[i] = result.URI
 	}
 	sort.Strings(resultURIs)
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -534,7 +534,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 				JLineMatches: lines,
 				JLimitHit:    fileLimitHit,
 				MatchCount:   matchCount, // We do not use resp.MatchCount because it counts the number of lines matched, not the number of fragments.
-				uri:          fileMatchURI(repo.Name, inputRev, file.FileName),
+				URI:          fileMatchURI(repo.Name, inputRev, file.FileName),
 				symbols:      symbols,
 				Repo:         repoResolver,
 				CommitID:     api.CommitID(file.Version),


### PR DESCRIPTION
Makes the `URI` field of `FileMatchResolver` public so that it can be
used to construct a `FileMatchResolver` from outisde the
`graphqlbackend` package. This is needed so that we can run Zoekt
queries from searcher for structural search.

It's used for zoekt [here](https://k8s.sgdev.org/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_structural.go#L196:4).


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
