### PR TITLE
WIP Copy zoekt querying to searcher for structural search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -67,7 +68,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	}
 
 	k := zoektResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
-	searchOpts := zoektSearchOpts(ctx, k, args.PatternInfo)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
 
 	if args.UseFullDeadline {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
@@ -24,7 +23,6 @@ import (
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -325,49 +323,6 @@ func zoektResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch boo
 	return k
 }
 
-func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[string]string) {
-	if !ot.ShouldTrace(ctx) {
-		return false, nil
-	}
-
-	spanContext = make(map[string]string)
-	if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil {
-		log15.Warn("Error injecting span context into map: %s", err)
-		return true, nil
-	}
-	return true, spanContext
-}
-
-func zoektSearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt.SearchOptions {
-	shouldTrace, spanContext := getSpanContext(ctx)
-	searchOpts := zoekt.SearchOptions{
-		Trace:                  shouldTrace,
-		SpanContext:            spanContext,
-		MaxWallTime:            defaultTimeout,
-		ShardMaxMatchCount:     100 * k,
-		TotalMaxMatchCount:     100 * k,
-		ShardMaxImportantMatch: 15 * k,
-		TotalMaxImportantMatch: 25 * k,
-		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
-	}
-
-	// We want zoekt to return more than FileMatchLimit results since we use
-	// the extra results to populate reposLimitHit. Additionally the defaults
-	// are very low, so we always want to return at least 2000.
-	if query.FileMatchLimit > defaultMaxSearchResults {
-		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
-	}
-	if searchOpts.MaxDocDisplayCount < 2000 {
-		searchOpts.MaxDocDisplayCount = 2000
-	}
-
-	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {
-		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
-	}
-
-	return searchOpts
-}
-
 var errNoResultsInTimeout = errors.New("no results found in specified timeout")
 
 type zoektSearchStreamEvent struct {
@@ -427,7 +382,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	}
 
 	k := zoektResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
-	searchOpts := zoektSearchOpts(ctx, k, args.PatternInfo)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
 
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -1,10 +1,19 @@
 package search
 
 import (
+	"context"
+	"errors"
+	"regexp/syntax"
+	"time"
+
+	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 func HandleFilePathPatterns(query *search.TextPatternInfo) (zoektquery.Q, error) {
@@ -49,4 +58,167 @@ func HandleFilePathPatterns(query *search.TextPatternInfo) (zoektquery.Q, error)
 	}
 
 	return zoektquery.NewAnd(and...), nil
+}
+
+func buildQuery(args *search.TextParameters, repoBranches map[string][]string, filePathPatterns zoektquery.Q, shortcircuit bool) (zoektquery.Q, error) {
+	regexString := comby.StructuralPatToRegexpQuery(args.PatternInfo.Pattern, shortcircuit)
+	if len(regexString) == 0 {
+		return &zoektquery.Const{Value: true}, nil
+	}
+	re, err := syntax.Parse(regexString, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
+	if err != nil {
+		return nil, err
+	}
+	return zoektquery.NewAnd(
+		&zoektquery.RepoBranches{Set: repoBranches},
+		filePathPatterns,
+		&zoektquery.Regexp{
+			Regexp:        re,
+			CaseSensitive: true,
+			Content:       true,
+		},
+	), nil
+}
+
+type zoektSearchStreamEvent struct {
+	fm       []zoekt.FileMatch
+	limitHit bool
+	partial  map[api.RepoID]struct{}
+	err      error
+}
+
+func zoektSearchHEADOnlyFilesStream(ctx context.Context, args *search.TextParameters, repoBranches map[string][]string, since func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent {
+	c := make(chan zoektSearchStreamEvent)
+	go func() {
+		defer close(c)
+		_, _, _, _ = zoektSearchHEADOnlyFiles(ctx, args, repoBranches, since, c)
+	}()
+
+	return c
+}
+
+const defaultMaxSearchResults = 30
+
+// zoektSearchHEADOnlyFiles searches repositories using zoekt, returning only the file paths containing
+// content matching the given pattern.
+//
+// Timeouts are reported through the context, and as a special case errNoResultsInTimeout
+// is returned if no results are found in the given timeout (instead of the more common
+// case of finding partial or full results in the given timeout).
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repoBranches map[string][]string, since func(t time.Time) time.Duration, c chan<- zoektSearchStreamEvent) (fm []zoekt.FileMatch, limitHit bool, partial map[api.RepoID]struct{}, err error) {
+	defer func() {
+		if c != nil {
+			c <- zoektSearchStreamEvent{
+				fm:       fm,
+				limitHit: limitHit,
+				partial:  partial,
+				err:      err,
+			}
+		}
+	}()
+	if len(repoBranches) == 0 {
+		return nil, false, nil, nil
+	}
+
+	k := zoektutil.ResultCountFactor(len(repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
+
+	if args.UseFullDeadline {
+		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
+		deadline, _ := ctx.Deadline()
+		searchOpts.MaxWallTime = time.Until(deadline)
+
+		// We don't want our context's deadline to cut off zoekt so that we can get the results
+		// found before the deadline.
+		//
+		// We'll create a new context that gets cancelled if the other context is cancelled for any
+		// reason other than the deadline being exceeded. This essentially means the deadline for the new context
+		// will be `deadline + time for zoekt to cancel + network latency`.
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithoutDeadline(ctx)
+		defer cancel()
+	}
+
+	filePathPatterns, err := HandleFilePathPatterns(args.PatternInfo)
+	if err != nil {
+		return nil, false, nil, err
+	}
+
+	t0 := time.Now()
+	q, err := buildQuery(args, repoBranches, filePathPatterns, true)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	resp, err := args.Zoekt.Client.Search(ctx, q, &searchOpts)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if since(t0) >= searchOpts.MaxWallTime {
+		return nil, false, nil, errNoResultsInTimeout
+	}
+
+	// We always return approximate results (limitHit true) unless we run the branch to perform a more complete search.
+	limitHit = true
+	// If the previous indexed search did not return a substantial number of matching file candidates or count was
+	// manually specified, run a more complete and expensive search.
+	if resp.FileCount < 10 || args.PatternInfo.FileMatchLimit != defaultMaxSearchResults {
+		q, err = buildQuery(args, repoBranches, filePathPatterns, false)
+		if err != nil {
+			return nil, false, nil, err
+		}
+		resp, err = args.Zoekt.Client.Search(ctx, q, &searchOpts)
+		if err != nil {
+			return nil, false, nil, err
+		}
+		if since(t0) >= searchOpts.MaxWallTime {
+			return nil, false, nil, errNoResultsInTimeout
+		}
+		// This is the only place limitHit can be set false, meaning we covered everything.
+		limitHit = resp.FilesSkipped+resp.ShardsSkipped > 0
+	}
+
+	if len(resp.Files) == 0 {
+		return nil, false, nil, nil
+	}
+
+	// TODO make this work
+	// limitHit, files, partial := zoektLimitMatches(limitHit, int(args.PatternInfo.FileMatchLimit), resp.Files, func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
+	// 	repo, inputRevs := repos.GetRepoInputRev(file)
+	// 	return repo, inputRevs, true
+	// })
+	// resp.Files = files
+
+	maxLineMatches := 25 + k
+	for _, file := range resp.Files {
+		if len(file.LineMatches) > maxLineMatches {
+			file.LineMatches = file.LineMatches[:maxLineMatches]
+			limitHit = true
+		}
+	}
+
+	return resp.Files, limitHit, partial, nil
+}
+
+var errNoResultsInTimeout = errors.New("no results found in specified timeout")
+
+// contextWithoutDeadline returns a context which will cancel if the cOld is
+// canceled.
+func contextWithoutDeadline(cOld context.Context) (context.Context, context.CancelFunc) {
+	cNew, cancel := context.WithCancel(context.Background())
+
+	// Set trace context so we still get spans propagated
+	cNew = trace.CopyContext(cNew, cOld)
+
+	go func() {
+		select {
+		case <-cOld.Done():
+			// cancel the new context if the old one is done for some reason other than the deadline passing.
+			if cOld.Err() != context.DeadlineExceeded {
+				cancel()
+			}
+		case <-cNew.Done():
+		}
+	}()
+
+	return cNew, cancel
 }

--- a/cmd/searcher/search/zoekt_search_test.go
+++ b/cmd/searcher/search/zoekt_search_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
+)
+
+func TestGroupFilesByRepo(t *testing.T) {
+	testMatch := func(name, repo string) zoekt.FileMatch {
+		return zoekt.FileMatch{
+			Repository: repo,
+			FileName:   name,
+		}
+	}
+
+	cases := []struct {
+		name     string
+		input    []zoekt.FileMatch
+		expected map[string][]zoekt.FileMatch
+	}{
+		{"empty", []zoekt.FileMatch{}, map[string][]zoekt.FileMatch{}},
+		{"nil", nil, map[string][]zoekt.FileMatch{}},
+		{
+			"basic",
+			[]zoekt.FileMatch{
+				testMatch("file1", "repo1"),
+				testMatch("file2", "repo1"),
+				testMatch("file3", "repo2"),
+			},
+			map[string][]zoekt.FileMatch{
+				"repo1": {
+					testMatch("file1", "repo1"),
+					testMatch("file2", "repo1"),
+				},
+				"repo2": {
+					testMatch("file3", "repo2"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := groupFilesByRepo(tc.input)
+			if !reflect.DeepEqual(output, tc.expected) {
+				t.Fatal(cmp.Diff(output, tc.expected))
+			}
+		})
+	}
+}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -1,9 +1,17 @@
 package zoekt
 
 import (
+	"context"
 	"regexp/syntax"
+	"time"
 
+	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 func FileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
@@ -42,4 +50,85 @@ func ParseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 		Content:       contentOnly,
 		FileName:      filenameOnly,
 	}, nil
+}
+
+const defaultMaxSearchResults = 30
+
+var (
+	// The default timeout to use for queries.
+	defaultTimeout = 20 * time.Second
+)
+
+func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt.SearchOptions {
+	shouldTrace, spanContext := getSpanContext(ctx)
+	searchOpts := zoekt.SearchOptions{
+		Trace:                  shouldTrace,
+		SpanContext:            spanContext,
+		MaxWallTime:            defaultTimeout,
+		ShardMaxMatchCount:     100 * k,
+		TotalMaxMatchCount:     100 * k,
+		ShardMaxImportantMatch: 15 * k,
+		TotalMaxImportantMatch: 25 * k,
+		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
+	}
+
+	// We want zoekt to return more than FileMatchLimit results since we use
+	// the extra results to populate reposLimitHit. Additionally the defaults
+	// are very low, so we always want to return at least 2000.
+	if query.FileMatchLimit > defaultMaxSearchResults {
+		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
+	}
+	if searchOpts.MaxDocDisplayCount < 2000 {
+		searchOpts.MaxDocDisplayCount = 2000
+	}
+
+	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {
+		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
+	}
+
+	return searchOpts
+}
+
+func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[string]string) {
+	if !ot.ShouldTrace(ctx) {
+		return false, nil
+	}
+
+	spanContext = make(map[string]string)
+	if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil {
+		log15.Warn("Error injecting span context into map: %s", err)
+		return true, nil
+	}
+	return true, spanContext
+}
+
+func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k int) {
+	if globalSearch {
+		// for globalSearch, numRepos = 0, but effectively we are searching over all
+		// indexed repos, hence k should be 1
+		k = 1
+	} else {
+		// If we're only searching a small number of repositories, return more
+		// comprehensive results. This is arbitrary.
+		switch {
+		case numRepos <= 5:
+			k = 100
+		case numRepos <= 10:
+			k = 10
+		case numRepos <= 25:
+			k = 8
+		case numRepos <= 50:
+			k = 5
+		case numRepos <= 100:
+			k = 3
+		case numRepos <= 500:
+			k = 2
+		default:
+			k = 1
+		}
+	}
+	if fileMatchLimit > defaultMaxSearchResults {
+		k = int(float64(k) * 3 * float64(fileMatchLimit) / float64(defaultMaxSearchResults))
+	}
+	return k
 }


### PR DESCRIPTION
This copies zoekt query code to the `searcher` service so it can be used to find the files which will be searched by comby. Once everything is connected, there should be some deduplication effort. 

Depends on #17283 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
