### PR TITLE
Adding integrationKey to alert docs

### DIFF
--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -49,6 +49,7 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
       "type": "pagerduty",
       // Routing key for the PagerDuty Events API v2
       "routingKey": "XXXXXXXX"
+      "integrationKey": "XXXXXXXX"
     }
   }
 ]


### PR DESCRIPTION
A customer reported an issue configuring PagerDuty alerts; after looking the code they resolved it by including both `routingKey` and `integrationKey` in their site config, eg:

```
"observability.alerts": [
  {
    "level": "critical",
    "notifier": {
      "type": "pagerduty",
      "routingKey": "XXXXXXXX"
      "integrationKey": "XXXXXXXX"
    }
  }
```

What is unclear to us is whether `routingKey` actually _does_ anything—should the user actually just pass `integrationKey`? I see both referenced at https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/site.schema.json?utm_source=share#L1158

So, assigning for review to make sure that the alerts really do need both!